### PR TITLE
Hierarchical Linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@
   FunctionBodyLength, Nesting, TypeBodyLength, TypeName, VariableName.  
   [JP Simard](https://github.com/jpsim)
 
+* Add RuleEnabler, a struct that controls which rules are enabled and which are disabled.
+  [Aaron Daub](https://github.com/aarondaub)
+
 ##### Bug Fixes
 
 None.
 
 
 ## 0.1.0
+
 
 First Version!

--- a/Source/SwiftLintFramework/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Array+SwiftLint.swift
@@ -1,0 +1,22 @@
+//
+//  Array+SwiftLint.swift
+//  SwiftLint
+//
+//  Created by Aaron Daub on 2015-05-20.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import Foundation
+
+func flatten<T>(array: [T?]) -> [T] {
+  return array.reduce([]){
+    if let e = $1 {
+      return $0 + [e]
+    }
+    return $0
+  }
+}
+
+func flatten<T>(nestedArray: [[T]]) -> [T] {
+  return reduce(nestedArray, [], +)
+}

--- a/Source/SwiftLintFramework/Linter.swift
+++ b/Source/SwiftLintFramework/Linter.swift
@@ -39,16 +39,19 @@ public struct Linter {
     
     var regions: [LinterRegion] = flatten(self.context.file.contents.lines().map { (line: Line) -> (LinterRegion)? in
       if line.content == linterContextBegin {
-        if inContext { // starting a new context, so we need the region for the code BEFORE this
-          return (contextEndingLineNumber, currentLineNumber - 1)
-        }
-      
+        let startingNewContext = !inContext
+        
         inContext = true
         contextDepth += 1
         contextStartingLineNumber = currentLineNumber + 1
+        
+        if startingNewContext { // starting a new context, so we need the region for the code BEFORE this
+          return (contextEndingLineNumber, currentLineNumber - 1)
+        }
+        
       } else if line.content == linterContextEnd && inContext {
         contextDepth -= 1
-        inContext = contextDepth == 0
+        inContext = contextDepth != 0
         
         contextEndingLineNumber = currentLineNumber - 1
         if !inContext {
@@ -64,6 +67,7 @@ public struct Linter {
     // let's add that region to regions
     let lastRegion: LinterRegion = (contextEndingLineNumber, max(self.context.file.contents.lines().count - 1, 0))
     regions.append(lastRegion)
+    
     
     let linters = regions.map { (region: LinterRegion) -> Linter in
       let file = File(contents: (self.context.file.contents as NSString).substringWithRange(NSMakeRange(region.start, region.end - region.start)))

--- a/Source/SwiftLintFramework/Linter.swift
+++ b/Source/SwiftLintFramework/Linter.swift
@@ -51,7 +51,7 @@ public struct Linter {
         }
         
       } else if line.content.trim() == linterContextEnd && inContext {
-        contexxtDepth -= 1
+        contextDepth -= 1
         inContext = contextDepth != 0
         
         contextEndingLineNumber = currentLineNumber
@@ -78,7 +78,9 @@ public struct Linter {
       
       let substring = "\n".join(sublines + [""]) // postpend the empty string to keep trailing newlines
       let file = File(contents: substring)
-      return Linter(file: file)
+      var context = self.context
+      context.file = file
+      return Linter(context: context)
     }
     
     return linters
@@ -91,5 +93,16 @@ public struct Linter {
     */
     public init(file: File) {
         self.context = LinterContext(file: file)
+    }
+  
+    /**
+    Initialize a Linter by passing in a LinterContext.
+    This is for having a child Linter inherit properties
+    from their parent.
+  
+    :param: context LinterContext to inherit from
+    */
+  private init(context: LinterContext) {
+      self.context = context
     }
 }

--- a/Source/SwiftLintFramework/Linter.swift
+++ b/Source/SwiftLintFramework/Linter.swift
@@ -11,26 +11,67 @@ import SwiftXPC
 import SourceKittenFramework
 
 public struct Linter {
-    private let file: File
+  private let context: LinterContext
 
     public var styleViolations: [StyleViolation] {
-        return reduce(
-            [
-                LineLengthRule().validateFile(file),
-                LeadingWhitespaceRule().validateFile(file),
-                TrailingWhitespaceRule().validateFile(file),
-                TrailingNewlineRule().validateFile(file),
-                ForceCastRule().validateFile(file),
-                FileLengthRule().validateFile(file),
-                TodoRule().validateFile(file),
-                ColonRule().validateFile(file),
-                TypeNameRule().validateFile(file),
-                VariableNameRule().validateFile(file),
-                TypeBodyLengthRule().validateFile(file),
-                FunctionBodyLengthRule().validateFile(file),
-                NestingRule().validateFile(file)
-            ], [], +)
+      if self.linters.count == 1 { // Terminal case
+        return context.enabledRules.flatMap {
+          $0.validateFile(self.context.file)
+        }
+      }
+      
+      return self.linters.flatMap {
+        $0.styleViolations
+      }
     }
+  
+  private var linters: [Linter] {
+    let linterContextBegin = "// swift-lint:begin-context"
+    let linterContextEnd = "// swift-lint:end-context"
+  
+  
+    var contextDepth = 0
+    var (contextStartingLineNumber, contextEndingLineNumber) = (0, 0)
+    var currentLineNumber = 0
+    var inContext = false
+    
+    typealias LinterRegion = (start: Int, end: Int)
+    
+    var regions: [LinterRegion] = flatten(self.context.file.contents.lines().map { (line: Line) -> (LinterRegion)? in
+      if line.content == linterContextBegin {
+        if inContext { // starting a new context, so we need the region for the code BEFORE this
+          return (contextEndingLineNumber, currentLineNumber - 1)
+        }
+      
+        inContext = true
+        contextDepth += 1
+        contextStartingLineNumber = currentLineNumber + 1
+      } else if line.content == linterContextEnd && inContext {
+        contextDepth -= 1
+        inContext = contextDepth == 0
+        
+        contextEndingLineNumber = currentLineNumber - 1
+        if !inContext {
+          return (contextStartingLineNumber, contextEndingLineNumber)
+        }
+      }
+      currentLineNumber += 1
+      return nil
+    })
+    
+    // regions now contains all the regions except
+    // potentially the last, if there is code after the last linterContextEnd
+    // let's add that region to regions
+    let lastRegion: LinterRegion = (contextEndingLineNumber, max(self.context.file.contents.lines().count - 1, 0))
+    regions.append(lastRegion)
+    
+    let linters = regions.map { (region: LinterRegion) -> Linter in
+      let file = File(contents: (self.context.file.contents as NSString).substringWithRange(NSMakeRange(region.start, region.end - region.start)))
+      return Linter(file: file)
+    }
+    
+    return linters
+  }
 
     /**
     Initialize a Linter by passing in a File.
@@ -38,6 +79,6 @@ public struct Linter {
     :param: file File to lint.
     */
     public init(file: File) {
-        self.file = file
+        self.context = LinterContext(file: file)
     }
 }

--- a/Source/SwiftLintFramework/Linter.swift
+++ b/Source/SwiftLintFramework/Linter.swift
@@ -39,7 +39,7 @@ public struct Linter {
     let lines = self.context.file.contents.lines()
     
     var regions: [LinterRegion] = flatten(lines.map { (line: Line) -> (LinterRegion)? in
-      if line.content == linterContextBegin {
+      if line.content.trim() == linterContextBegin {
         let startingNewContext = !inContext
         
         inContext = true
@@ -50,8 +50,8 @@ public struct Linter {
           return (contextEndingLineNumber, currentLineNumber)
         }
         
-      } else if line.content == linterContextEnd && inContext {
-        contextDepth -= 1
+      } else if line.content.trim() == linterContextEnd && inContext {
+        contexxtDepth -= 1
         inContext = contextDepth != 0
         
         contextEndingLineNumber = currentLineNumber

--- a/Source/SwiftLintFramework/Linter.swift
+++ b/Source/SwiftLintFramework/Linter.swift
@@ -12,16 +12,14 @@ import SourceKittenFramework
 
 public struct Linter {
   private let context: LinterContext
+  private let file: File
 
-    public var styleViolations: [StyleViolation] {
-      if self.linters.count == 1 { // Terminal case
-        return context.enabledRules.flatMap {
-          $0.validateFile(self.context.file)
-        }
-      }
-      
-      return self.linters.flatMap {
+  public var styleViolations: [StyleViolation] {
+    let linters = self.linters
+      return linters.flatMap {
         $0.styleViolations
+      } + context.enabledRules().flatMap {
+        $0.validateFile(self.file)
       }
     }
   
@@ -36,20 +34,13 @@ public struct Linter {
     var inContext = false
     
     typealias LinterRegion = (start: Int, exclusiveEnd: Int)
-    let lines = self.context.file.contents.lines()
+    let lines = self.context.region.contents.lines()
     
     var regions: [LinterRegion] = flatten(lines.map { (line: Line) -> (LinterRegion)? in
       if line.content.trim() == linterContextBegin {
-        let startingNewContext = !inContext
-        
         inContext = true
         contextDepth += 1
         contextStartingLineNumber = currentLineNumber + 1
-        
-        if startingNewContext { // starting a new context, so we need the region for the code BEFORE this
-          return (contextEndingLineNumber, currentLineNumber)
-        }
-        
       } else if line.content.trim() == linterContextEnd && inContext {
         contextDepth -= 1
         inContext = contextDepth != 0
@@ -62,14 +53,6 @@ public struct Linter {
       currentLineNumber += 1
       return nil
     })
-    
-    // regions now contains all the regions except
-    // potentially the last, if there is code after the last linterContextEnd
-    // let's add that region to regions
-    if contextEndingLineNumber <= lines.count {
-      regions.append((start: contextEndingLineNumber,
-                      exclusiveEnd: lines.count))
-    }
 
     let linters = regions.map { (region: LinterRegion) -> Linter in
       let sublines: [String] = map((lines[region.start ..< region.exclusiveEnd])) {
@@ -77,10 +60,9 @@ public struct Linter {
       }
       
       let substring = "\n".join(sublines + [""]) // postpend the empty string to keep trailing newlines
-      let file = File(contents: substring)
-      var context = self.context
-      context.file = file
-      return Linter(context: context)
+      let region = File(contents: substring)
+      let context = LinterContext(insideOf: self.context, file: region)
+      return Linter(file: self.file, context: context)
     }
     
     return linters
@@ -92,6 +74,7 @@ public struct Linter {
     :param: file File to lint.
     */
     public init(file: File) {
+        self.file = file
         self.context = LinterContext(file: file)
     }
   
@@ -102,7 +85,8 @@ public struct Linter {
   
     :param: context LinterContext to inherit from
     */
-  private init(context: LinterContext) {
+  private init(file: File, context: LinterContext) {
+      self.file = file
       self.context = context
     }
 }

--- a/Source/SwiftLintFramework/LinterContext.swift
+++ b/Source/SwiftLintFramework/LinterContext.swift
@@ -10,7 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct LinterContext {
-  let file: File
+  var file: File
   var enabledRules: [Rule] = [LineLengthRule(),
     LeadingWhitespaceRule(),
     TrailingWhitespaceRule(),

--- a/Source/SwiftLintFramework/LinterContext.swift
+++ b/Source/SwiftLintFramework/LinterContext.swift
@@ -1,0 +1,70 @@
+//
+//  LinterContext.swift
+//  SwiftLint
+//
+//  Created by Aaron Daub on 2015-05-21.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct LinterContext {
+  let file: File
+  var enabledRules: [Rule] = [LineLengthRule(),
+    LeadingWhitespaceRule(),
+    TrailingWhitespaceRule(),
+    TrailingNewlineRule(),
+    ForceCastRule(),
+    FileLengthRule(),
+    TodoRule(),
+    ColonRule(),
+    TypeNameRule(),
+    VariableNameRule(),
+    TypeBodyLengthRule(),
+    FunctionBodyLengthRule(),
+    NestingRule()]
+  var disabledRules: [Rule] = []
+  
+  public init(file: File) {
+    self.file = file
+  }
+  
+  func ruleWith(identifier: String, enabled: Bool) -> Rule? {
+    let arrayToSearch = enabled ? self.enabledRules : self.disabledRules
+    
+    return filter(arrayToSearch) {
+      return $0.identifier == identifier
+      }.first
+  }
+  
+  public mutating func enableRule(identifier: String) -> Bool {
+    return changeRule(identifier, enabled: true)
+  }
+  
+  public mutating func disableRule(identifier: String) -> Bool {
+    return changeRule(identifier, enabled: false)
+  }
+  
+  private mutating func changeRule(identifier: String, enabled: Bool) -> Bool {
+    var (rulesToAddTo, rulesToRemoveFrom) = enabled ? (self.enabledRules, self.disabledRules) : (self.disabledRules, self.enabledRules)
+    
+    if let rule = ruleWith(identifier, enabled: !enabled) {
+      moveRule(rule, enabled: enabled)
+      return true
+    }
+    return false
+  }
+  
+  private mutating func moveRule(rule: Rule, enabled: Bool) {
+    let rulesTuple = enabled ? (self.enabledRules, self.disabledRules) : (self.disabledRules, self.enabledRules)
+    var (rulesToAddTo, rulesToRemoveFrom): ([Rule], [Rule]) = rulesTuple
+    
+    rulesToAddTo.append(rule)
+    rulesToRemoveFrom = filter(rulesToRemoveFrom) { (candidateRule: Rule) -> Bool in
+      return candidateRule.identifier != rule.identifier
+    }
+    
+    (self.enabledRules, self.disabledRules) = enabled ? (rulesToAddTo, rulesToRemoveFrom) : (rulesToRemoveFrom, rulesToAddTo)
+  }
+}

--- a/Source/SwiftLintFramework/Rule.swift
+++ b/Source/SwiftLintFramework/Rule.swift
@@ -8,7 +8,7 @@
 
 import SourceKittenFramework
 
-protocol Rule {
+public protocol Rule {
     var identifier: String { get }
     func validateFile(file: File) -> [StyleViolation]
 }

--- a/Source/SwiftLintFramework/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/String+SwiftLint.swift
@@ -18,6 +18,10 @@ extension String {
         }
         return lines
     }
+  
+  func trim(characterSet: NSCharacterSet = NSCharacterSet.whitespaceCharacterSet()) -> String {
+      return stringByTrimmingCharactersInSet(characterSet)
+    }
 
     func isUppercase() -> Bool {
         return self == uppercaseString

--- a/Source/SwiftLintFrameworkTests/LinterTests.swift
+++ b/Source/SwiftLintFrameworkTests/LinterTests.swift
@@ -17,6 +17,17 @@ func violations(string: String) -> [StyleViolation] {
 
 class LinterTests: XCTestCase {
 
+    // MARK: Nesting
+  
+    func testNestingEquivalentToNoNesting() {
+      let lines = ["1", "2", "\n"]
+      let linesWithNesting = ["1", "// swift-lint:begin-context", "2", "// swift-lint:end-context", "\n"]
+      let (contents, contentsWithNesting) = ("\n".join(lines), "\n".join(linesWithNesting))
+      let (file, fileWithNesting) = (File(contents: contents), File(contents: contentsWithNesting))
+      let (linter, linterWithNesting) = (Linter(file: file), Linter(file: fileWithNesting))
+      XCTAssertEqual(linter.styleViolations, linterWithNesting.styleViolations, "Nesting shouldn't impact styleViolations")
+    }
+  
     // MARK: AST Violations
 
     func testTypeNames() {

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		345D0CA01B0D3A5A00EF7A41 /* Array+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345D0C9F1B0D3A5A00EF7A41 /* Array+SwiftLint.swift */; };
+		345D0CA21B0D3EC100EF7A41 /* LinterContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345D0CA11B0D3EC100EF7A41 /* LinterContext.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
@@ -98,6 +100,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		345D0C9F1B0D3A5A00EF7A41 /* Array+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+SwiftLint.swift"; sourceTree = "<group>"; };
+		345D0CA11B0D3EC100EF7A41 /* LinterContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinterContext.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -310,10 +314,12 @@
 				E88DEA8B1B0999A000A66CB0 /* ASTRule.swift */,
 				E88DEA741B09852000A66CB0 /* File+SwiftLint.swift */,
 				E812249B1B04FADC001783D2 /* Linter.swift */,
+				345D0CA11B0D3EC100EF7A41 /* LinterContext.swift */,
 				E88DEA6E1B09843F00A66CB0 /* Location.swift */,
 				E88DEA761B098D0C00A66CB0 /* Rule.swift */,
 				E88DEA781B098D4400A66CB0 /* RuleParameter.swift */,
 				E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */,
+				345D0C9F1B0D3A5A00EF7A41 /* Array+SwiftLint.swift */,
 				E88DEA6A1B0983FE00A66CB0 /* StyleViolation.swift */,
 				E88DEA6C1B09842200A66CB0 /* StyleViolationType.swift */,
 				E88DEA701B09847500A66CB0 /* ViolationSeverity.swift */,
@@ -540,6 +546,7 @@
 			files = (
 				E812249C1B04FADC001783D2 /* Linter.swift in Sources */,
 				E88DEA861B0991BF00A66CB0 /* TrailingWhitespaceRule.swift in Sources */,
+				345D0CA01B0D3A5A00EF7A41 /* Array+SwiftLint.swift in Sources */,
 				E88DEA841B0990F500A66CB0 /* ColonRule.swift in Sources */,
 				E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */,
 				E88DEA731B0984C400A66CB0 /* String+SwiftLint.swift in Sources */,
@@ -559,6 +566,7 @@
 				E88DEA8C1B0999A000A66CB0 /* ASTRule.swift in Sources */,
 				E88DEA821B0990A700A66CB0 /* TodoRule.swift in Sources */,
 				E88DEA901B099A3100A66CB0 /* FunctionBodyLengthRule.swift in Sources */,
+				345D0CA21B0D3EC100EF7A41 /* LinterContext.swift in Sources */,
 				E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */,
 				E88DEA7E1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift in Sources */,
 			);


### PR DESCRIPTION
@jpsim – I think this is a good way to handle the linting. I don't currently like how I build the child linters from lines, it's very imperative. I'd LOVE suggestions on improvements there.

This'll work with an arbitrary depth of "linter context comments" (see discussion on #4). 

This addresses #1 and #23 

TODO:

- [x] Allow linter context beginning and ending to be less strict (e.g. different whitespace)
- [x] Perhaps move the LinterRegion to be a property on LinterContext and then pass the file to each sublinter without modification
- [x] Add unit tests 
- [x] Fix issues with linter so that children don't Lint using rules that don't apply to them and we don't get false negatives for Rules that require the whole file because we're linting in chunks
- [ ] Add ability for a child linter to invalidate a style violation if it occurred in a region that the child linter was responsible and that child linter's LinterContext had that rule disabled.
