### PR TITLE
Return an error status code if serious violations found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   FunctionBodyLength, Nesting, TypeBodyLength, TypeName, VariableName.  
   [JP Simard](https://github.com/jpsim)
 
+* swiftlint returns a non-zero error code when a warning of high-severity
+  or above is found in the source files being linted.
+ [Pat Wallace](https://github.com/pawrsccouk)
+ [#30](https://github.com/realm/SwiftLint/issues/30)
+
 ##### Bug Fixes
 
 None.

--- a/Source/SwiftLintFramework/ViolationSeverity.swift
+++ b/Source/SwiftLintFramework/ViolationSeverity.swift
@@ -28,8 +28,12 @@ public enum ViolationSeverity: Int, Printable, Comparable {
         }
     }
 
+    public var isError: Bool {
+        return self > Medium
+    }
+
     public var xcodeSeverityDescription: String {
-        return self <= Medium ? "warning" : "error"
+        return self.isError ? "error" : "warning"
     }
 }
 

--- a/Source/SwiftLintFramework/ViolationSeverity.swift
+++ b/Source/SwiftLintFramework/ViolationSeverity.swift
@@ -33,7 +33,7 @@ public enum ViolationSeverity: Int, Printable, Comparable {
     }
 
     public var xcodeSeverityDescription: String {
-        return self.isError ? "error" : "warning"
+        return isError ? "error" : "warning"
     }
 }
 


### PR DESCRIPTION
To fix issue #30 

This mingles errors due to swiftlint issues with errors in the files swiftlint is auditing. We lose information doing that, but otherwise we'd need to re-architect the Command structure and I don't think that's possible right now.

This is my first go at creating GitHub pull requests, so please let me know if I'm doing anything wrong.