### PR TITLE
Excluding Pods files by default (fix #6)

### DIFF
--- a/Source/swiftlint/LintCommand.swift
+++ b/Source/swiftlint/LintCommand.swift
@@ -54,7 +54,10 @@ struct LintCommand: CommandType {
 
 func recursivelyFindSwiftFilesInDirectory(directory: String) -> [String] {
     let subPaths = fileManager.subpathsOfDirectoryAtPath(directory, error: nil) as? [String]
-    return map(subPaths) { subPaths in
+    let filteredSubPaths = subPaths?.filter {
+        return !$0.hasPrefix("Pods")
+    }
+    return map(filteredSubPaths) { subPaths in
         return reduce(compact((["."] + subPaths).map { dirPath in
             let files = fileManager.contentsOfDirectoryAtPath(dirPath, error: nil) as? [String]
             return map(files) { files in


### PR DESCRIPTION
A start point to make SwiftLint configurable to chose which folders to scan.