### PR TITLE
Trailing newline & file length violations are now displayed in Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   with examples.  
   [Chris Eidhof](https://github.com/chriseidhof)
 
-* Cache parsing to reduce execution time by more than 50%.
+* Cache parsing to reduce execution time by more than 50%.  
   [Nikolaj Schumacher](https://github.com/nschum)
 
 * Added `ControlStatementRule` to make sure that if/for/while/do statements
@@ -33,7 +33,9 @@
 
 ##### Bug Fixes
 
-None.
+* Trailing newline and file length violations are now displayed in Xcode.  
+  [JP Simard](https://github.com/jpsim)
+  [#43](https://github.com/realm/SwiftLint/issues/43)
 
 
 ## 0.1.0

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -56,4 +56,3 @@ public struct ControlStatementRule: Rule {
         ]
     )
 }
-

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -26,7 +26,7 @@ public struct FileLengthRule: ParameterizedRule {
         for parameter in reverse(parameters) {
             if lines.count > parameter.value {
                 return [StyleViolation(type: .Length,
-                    location: Location(file: file.path),
+                    location: Location(file: file.path, line: lines.count),
                     severity: parameter.severity,
                     reason: "File should contain 400 lines or less: currently contains " +
                     "\(lines.count)")]

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -19,7 +19,7 @@ public struct TrailingNewlineRule: Rule {
         )
         if countOfTrailingNewlines != 1 {
             return [StyleViolation(type: .TrailingNewline,
-                location: Location(file: file.path),
+                location: Location(file: file.path, line: file.contents.lines().count + 1),
                 severity: .Medium,
                 reason: "File should have a single trailing newline: " +
                 "currently has \(countOfTrailingNewlines)")]

--- a/Source/SwiftLintFrameworkTests/LinterTests.swift
+++ b/Source/SwiftLintFrameworkTests/LinterTests.swift
@@ -54,14 +54,14 @@ class LinterTests: XCTestCase {
         // TODO: Uncomment this once rdar://18845613 is fixed.
 //        XCTAssertEqual(violations("typealias Abc = Void\n"), [])
 //        XCTAssertEqual(violations("typealias abc = Void\n"), [StyleViolation(type: .NameFormat,
-//            location: Location(file: nil),
+//            location: Location(file: nil, line: 1),
 //            reason: "Type name should start with an uppercase character: 'abc'")])
 
         // Test enum element
         // TODO: Uncomment this once rdar://18845613 is fixed.
 //        XCTAssertEqual(violations("enum Abc { case Def }\n"), [])
 //        XCTAssertEqual(violations("enum Abc { case def }\n"), [StyleViolation(type: .NameFormat,
-//            location: Location(file: nil),
+//            location: Location(file: nil, line: 1),
 //            reason: "Type name should start with an uppercase character: 'def'")])
 
         // Test nested type
@@ -221,11 +221,11 @@ class LinterTests: XCTestCase {
     func testTrailingNewlineAtEndOfFile() {
         XCTAssertEqual(violations("//\n"), [])
         XCTAssertEqual(violations(""), [StyleViolation(type: .TrailingNewline,
-            location: Location(file: nil),
+            location: Location(file: nil, line: 1),
             severity: .Medium,
             reason: "File should have a single trailing newline: currently has 0")])
         XCTAssertEqual(violations("//\n\n"), [StyleViolation(type: .TrailingNewline,
-            location: Location(file: nil),
+            location: Location(file: nil, line: 3),
             severity: .Medium,
             reason: "File should have a single trailing newline: currently has 2")])
     }
@@ -241,7 +241,7 @@ class LinterTests: XCTestCase {
         ]
         for testCase in testCases {
             XCTAssertEqual(violations(testCase.0), [StyleViolation(type: .Length,
-                location: Location(file: nil),
+                location: Location(file: nil, line: testCase.1),
                 severity: testCase.2,
                 reason: "File should contain 400 lines or less: currently contains \(testCase.1)")])
         }


### PR DESCRIPTION
fixes #43.