### PR TITLE
[Tests] Split LinterTests into 3 files

### DIFF
--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -1,0 +1,84 @@
+//
+//  StringRuleTests.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 5/28/15.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+import XCTest
+
+class StringRuleTests: XCTestCase {
+    func testLineLengths() {
+        let longLine = join("", Array(count: 100, repeatedValue: "/")) + "\n"
+        XCTAssertEqual(violations(longLine), [])
+        let testCases: [(String, Int, ViolationSeverity)] = [
+            ("/", 101, .VeryLow),
+            (join("", Array(count: 21, repeatedValue: "/")), 121, .Low),
+            (join("", Array(count: 51, repeatedValue: "/")), 151, .Medium),
+            (join("", Array(count: 101, repeatedValue: "/")), 201, .High),
+            (join("", Array(count: 151, repeatedValue: "/")), 251, .VeryHigh)
+        ]
+        for testCase in testCases {
+            XCTAssertEqual(violations(testCase.0 + longLine), [StyleViolation(type: .Length,
+                location: Location(file: nil, line: 1),
+                severity: testCase.2,
+                reason: "Line should be 100 characters or less: " +
+                "currently \(testCase.1) characters")])
+        }
+    }
+
+    func testTrailingNewlineAtEndOfFile() {
+        XCTAssertEqual(violations("//\n"), [])
+        XCTAssertEqual(violations(""), [StyleViolation(type: .TrailingNewline,
+            location: Location(file: nil, line: 1),
+            severity: .Medium,
+            reason: "File should have a single trailing newline: currently has 0")])
+        XCTAssertEqual(violations("//\n\n"), [StyleViolation(type: .TrailingNewline,
+            location: Location(file: nil, line: 3),
+            severity: .Medium,
+            reason: "File should have a single trailing newline: currently has 2")])
+    }
+
+    func testFileLengths() {
+        XCTAssertEqual(violations(join("", Array(count: 400, repeatedValue: "//\n"))), [])
+        let testCases: [(String, Int, ViolationSeverity)] = [
+            (join("", Array(count: 401, repeatedValue: "//\n")), 401, .VeryLow),
+            (join("", Array(count: 501, repeatedValue: "//\n")), 501, .Low),
+            (join("", Array(count: 751, repeatedValue: "//\n")), 751, .Medium),
+            (join("", Array(count: 1001, repeatedValue: "//\n")), 1001, .High),
+            (join("", Array(count: 2001, repeatedValue: "//\n")), 2001, .VeryHigh)
+        ]
+        for testCase in testCases {
+            XCTAssertEqual(violations(testCase.0), [StyleViolation(type: .Length,
+                location: Location(file: nil, line: testCase.1),
+                severity: testCase.2,
+                reason: "File should contain 400 lines or less: currently contains \(testCase.1)")])
+        }
+    }
+
+    func testFileShouldntStartWithWhitespace() {
+        verifyRule(LeadingWhitespaceRule().example,
+            type: .LeadingWhitespace,
+            commentDoesntViolate: false)
+    }
+
+    func testLinesShouldntContainTrailingWhitespace() {
+        verifyRule(TrailingWhitespaceRule().example,
+            type: .TrailingWhitespace,
+            commentDoesntViolate: false)
+    }
+
+    func testForceCasting() {
+        verifyRule(ForceCastRule().example, type: .ForceCast)
+    }
+
+    func testTodoOrFIXME() {
+        verifyRule(TodoRule().example, type: .TODO)
+    }
+
+    func testColon() {
+        verifyRule(ColonRule().example, type: .Colon)
+    }
+}

--- a/Source/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Source/SwiftLintFrameworkTests/TestHelpers.swift
@@ -1,0 +1,29 @@
+//
+//  TestHelpers.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 2015-05-16.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+import SourceKittenFramework
+import XCTest
+
+func violations(string: String) -> [StyleViolation] {
+    return Linter(file: File(contents: string)).styleViolations
+}
+
+extension XCTestCase {
+    func verifyRule(rule: RuleExample,
+        type: StyleViolationType,
+        commentDoesntViolate: Bool = true) {
+        XCTAssertEqual(rule.nonTriggeringExamples.flatMap({violations($0)}), [])
+        XCTAssertEqual(rule.triggeringExamples.flatMap({violations($0).map({$0.type})}),
+            Array(count: rule.triggeringExamples.count, repeatedValue: type))
+
+        if commentDoesntViolate {
+            XCTAssertEqual(rule.triggeringExamples.flatMap({violations("// " + $0)}), [])
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
-		E812249A1B04F85B001783D2 /* LinterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81224991B04F85B001783D2 /* LinterTests.swift */; };
+		E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81224991B04F85B001783D2 /* TestHelpers.swift */; };
 		E812249C1B04FADC001783D2 /* Linter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E812249B1B04FADC001783D2 /* Linter.swift */; };
 		E83A0B351A5D382B0041A60A /* VersionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83A0B341A5D382B0041A60A /* VersionCommand.swift */; };
 		E861519B1B0573B900C54AC0 /* LintCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E861519A1B0573B900C54AC0 /* LintCommand.swift */; };
@@ -53,6 +53,8 @@
 		E8BA7E131B07A3F3003E02D0 /* LlamaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8BA7E121B07A3F3003E02D0 /* LlamaKit.framework */; };
 		E8BA7E141B07A400003E02D0 /* LlamaKit.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E8BA7E121B07A3F3003E02D0 /* LlamaKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E8BA7E151B07A400003E02D0 /* Commandant.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E8BA7E101B07A3EC003E02D0 /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E8BB8F9A1B17DDB200199606 /* ASTRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BB8F991B17DDB200199606 /* ASTRuleTests.swift */; };
+		E8BB8F9C1B17DE3B00199606 /* StringRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BB8F9B1B17DE3B00199606 /* StringRuleTests.swift */; };
 		E8C0DFCD1AD349DB007EE3D4 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */; };
 		E8C0DFCE1AD349E5007EE3D4 /* SWXMLHash.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -137,7 +139,7 @@
 		D0D1217D19E87B05005E4BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0E7B65819E9CA0800EDBA4D /* swiftlint */ = {isa = PBXFileReference; lastKnownFileType = text; path = swiftlint; sourceTree = BUILT_PRODUCTS_DIR; };
-		E81224991B04F85B001783D2 /* LinterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinterTests.swift; sourceTree = "<group>"; };
+		E81224991B04F85B001783D2 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		E812249B1B04FADC001783D2 /* Linter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Linter.swift; sourceTree = "<group>"; };
 		E83A0B341A5D382B0041A60A /* VersionCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionCommand.swift; sourceTree = "<group>"; };
 		E861519A1B0573B900C54AC0 /* LintCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LintCommand.swift; sourceTree = "<group>"; };
@@ -169,6 +171,8 @@
 		E8AB1A2D1A649F2100452012 /* libclang.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libclang.dylib; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib; sourceTree = DEVELOPER_DIR; };
 		E8BA7E101B07A3EC003E02D0 /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8BA7E121B07A3F3003E02D0 /* LlamaKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = LlamaKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E8BB8F991B17DDB200199606 /* ASTRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASTRuleTests.swift; sourceTree = "<group>"; };
+		E8BB8F9B1B17DE3B00199606 /* StringRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringRuleTests.swift; sourceTree = "<group>"; };
 		E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -331,8 +335,8 @@
 			isa = PBXGroup;
 			children = (
 				E88DEA8B1B0999A000A66CB0 /* ASTRule.swift */,
-				E88DEA741B09852000A66CB0 /* File+SwiftLint.swift */,
 				24E17F701B1481FF008195BE /* File+Cache.swift */,
+				E88DEA741B09852000A66CB0 /* File+SwiftLint.swift */,
 				E812249B1B04FADC001783D2 /* Linter.swift */,
 				E88DEA6E1B09843F00A66CB0 /* Location.swift */,
 				E88DEA761B098D0C00A66CB0 /* Rule.swift */,
@@ -367,7 +371,9 @@
 		D0D1217B19E87B05005E4BAA /* SwiftLintFrameworkTests */ = {
 			isa = PBXGroup;
 			children = (
-				E81224991B04F85B001783D2 /* LinterTests.swift */,
+				E8BB8F991B17DDB200199606 /* ASTRuleTests.swift */,
+				E8BB8F9B1B17DE3B00199606 /* StringRuleTests.swift */,
+				E81224991B04F85B001783D2 /* TestHelpers.swift */,
 				D0D1212219E878CC005E4BAA /* Configuration */,
 				D0D1217C19E87B05005E4BAA /* Supporting Files */,
 			);
@@ -598,7 +604,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E812249A1B04F85B001783D2 /* LinterTests.swift in Sources */,
+				E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */,
+				E8BB8F9C1B17DE3B00199606 /* StringRuleTests.swift in Sources */,
+				E8BB8F9A1B17DDB200199606 /* ASTRuleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Given that the `LinterTests` class was sitting in at 200 lines and we have a rule for that, this is probably the time to split this monolith into multiple files.