### PR TITLE
add ReturnArrowWhitespaceRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Added `ReturnArrowWhitespaceRule` to make sure that
+  you have 1 space before return arrow and return type
+  [Akira Hirakawa](https://github.com/akirahrkw)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Linter.swift
+++ b/Source/SwiftLintFramework/Linter.swift
@@ -17,6 +17,7 @@ public struct Linter {
         LineLengthRule(),
         LeadingWhitespaceRule(),
         TrailingWhitespaceRule(),
+        ReturnArrowWhitespaceRule(),
         TrailingNewlineRule(),
         ForceCastRule(),
         FileLengthRule(),

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -1,0 +1,58 @@
+//
+//  ReturningWhitespaceRule.swift
+//  SwiftLint
+//
+//  Created by Akira Hirakawa on 2/6/15.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct ReturnArrowWhitespaceRule: Rule {
+    public init() {}
+
+    public let identifier = "return_arrow_whitespace"
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        // space doesn't include \n so that "func abc()->\n" can pass validation
+        let space = "[ \\f\\r\\t\\v]"
+        let spaceRegex = "(\(space){0}|\(space){2,})"
+
+        // ex: func abc()-> Int {
+        let pattern1 = file.matchPattern("\\)\(spaceRegex)\\->\\s*\\S+",
+            withSyntaxKinds: [.Typeidentifier])
+
+        // ex: func abc() ->Int {
+        let pattern2 = file.matchPattern("\\)\\s\\->\(spaceRegex)\\S+",
+            withSyntaxKinds: [.Typeidentifier])
+
+        return (pattern1 + pattern2).map { match in
+            return StyleViolation(type: .ReturnArrowWhitespace,
+                location: Location(file: file, offset: match.location),
+                severity: .Low,
+                reason: "File should have 1 space before return arrow and return type")
+        }
+    }
+
+    public let example = RuleExample(
+        ruleName: "Returning Whitespace Rule",
+        ruleDescription: "This rule checks whether you have 1 space before " +
+        "return arrow and return type",
+        nonTriggeringExamples: [
+            "func abc() -> Int {}\n",
+            "func abc() -> [Int] {}\n",
+            "var abc = {(param: Int) -> Void in }\n",
+            "func abc() ->\n"
+        ],
+        triggeringExamples: [
+            "func abc()->Int {}\n",
+            "func abc()->[Int] {}\n",
+            "func abc()-> Int {}\n",
+            "func abc() ->Int {}\n",
+            "func abc()  ->  Int {}\n",
+            "var abc = {(param: Int) ->Bool in }\n",
+            "var abc = {(param: Int)->Bool in }\n"
+        ],
+        showExamples: false
+    )
+}

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -52,7 +52,6 @@ public struct ReturnArrowWhitespaceRule: Rule {
             "func abc()  ->  Int {}\n",
             "var abc = {(param: Int) ->Bool in }\n",
             "var abc = {(param: Int)->Bool in }\n"
-        ],
-        showExamples: false
+        ]
     )
 }

--- a/Source/SwiftLintFramework/StyleViolationType.swift
+++ b/Source/SwiftLintFramework/StyleViolationType.swift
@@ -7,16 +7,17 @@
 //
 
 public enum StyleViolationType: String, Printable {
-    case NameFormat         = "Name Format"
-    case Length             = "Length"
-    case TrailingNewline    = "Trailing Newline"
-    case LeadingWhitespace  = "Leading Whitespace"
-    case TrailingWhitespace = "Trailing Whitespace"
-    case ForceCast          = "Force Cast"
-    case TODO               = "TODO or FIXME"
-    case Colon              = "Colon"
-    case Nesting            = "Nesting"
-    case ControlStatement   = "Control Statement Parentheses"
+    case NameFormat            = "Name Format"
+    case Length                = "Length"
+    case TrailingNewline       = "Trailing Newline"
+    case LeadingWhitespace     = "Leading Whitespace"
+    case TrailingWhitespace    = "Trailing Whitespace"
+    case ReturnArrowWhitespace = "Return Arrow Whitespace"
+    case ForceCast             = "Force Cast"
+    case TODO                  = "TODO or FIXME"
+    case Colon                 = "Colon"
+    case Nesting               = "Nesting"
+    case ControlStatement      = "Control Statement Parentheses"
 
     public var description: String { return rawValue }
 }

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -72,8 +72,7 @@ class StringRuleTests: XCTestCase {
 
     func testLinesShouldContainReturnArrowWhitespace() {
         verifyRule(ReturnArrowWhitespaceRule().example,
-            type: .ReturnArrowWhitespace,
-            commentDoesntViolate: false)
+            type: .ReturnArrowWhitespace)
     }
 
     func testForceCasting() {

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -70,6 +70,12 @@ class StringRuleTests: XCTestCase {
             commentDoesntViolate: false)
     }
 
+    func testLinesShouldContainReturnArrowWhitespace() {
+        verifyRule(ReturnArrowWhitespaceRule().example,
+            type: .ReturnArrowWhitespace,
+            commentDoesntViolate: false)
+    }
+
     func testForceCasting() {
         verifyRule(ForceCastRule().example, type: .ForceCast)
     }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
+		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81224991B04F85B001783D2 /* TestHelpers.swift */; };
 		E812249C1B04FADC001783D2 /* Linter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E812249B1B04FADC001783D2 /* Linter.swift */; };
 		E832F10B1B17E2F5003F265F /* NSFileManager+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E832F10A1B17E2F5003F265F /* NSFileManager+SwiftLint.swift */; };
@@ -141,6 +142,7 @@
 		D0D1217D19E87B05005E4BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0E7B65819E9CA0800EDBA4D /* swiftlint */ = {isa = PBXFileReference; lastKnownFileType = text; path = swiftlint; sourceTree = BUILT_PRODUCTS_DIR; };
+		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E81224991B04F85B001783D2 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		E812249B1B04FADC001783D2 /* Linter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Linter.swift; sourceTree = "<group>"; };
 		E832F10A1B17E2F5003F265F /* NSFileManager+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSFileManager+SwiftLint.swift"; sourceTree = "<group>"; };
@@ -412,6 +414,7 @@
 				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
 				E88DEA931B099C0900A66CB0 /* VariableNameRule.swift */,
+				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -580,6 +583,7 @@
 				83D71E281B131ECE000395DE /* RuleExample.swift in Sources */,
 				E812249C1B04FADC001783D2 /* Linter.swift in Sources */,
 				E88DEA861B0991BF00A66CB0 /* TrailingWhitespaceRule.swift in Sources */,
+				E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */,
 				E88DEA841B0990F500A66CB0 /* ColonRule.swift in Sources */,
 				E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */,
 				E88DEA731B0984C400A66CB0 /* String+SwiftLint.swift in Sources */,


### PR DESCRIPTION
Hi @jpsim and everyone
I've added a rule which checks whether you have 1 space before return arrow and return type or not
ex:
 Good: func abc() -> Int {}
 Bad:  func abc()->Int {}

But I'm not sure whether this rule makes sense for you or not. 
and I think this rule is not on github's swift style guide though, we have our own swift style guide for our dev team, https://github.com/burpple/swift-style-guide (which is not completed yet:) )
so that would be nice if I can contribute and apply some of our rules to this project.

thanks:)