### PR TITLE
Option to ignore one or all rules for a file by adding a comment

### DIFF
--- a/Source/SwiftLintFramework/Linter.swift
+++ b/Source/SwiftLintFramework/Linter.swift
@@ -31,7 +31,14 @@ public struct Linter {
     ]
 
     public var styleViolations: [StyleViolation] {
-        return rules.flatMap { $0.validateFile(file) }
+        return rules.flatMap {
+            if !(file.contents as NSString).containsString("// SwiftLint ignore \($0.identifier)")
+                && !(file.contents as NSString).containsString("// SwiftLint ignore all") {
+                return $0.validateFile(file)
+            } else {
+                return []
+            }
+        }
     }
 
     public var ruleExamples: [RuleExample] {


### PR DESCRIPTION
With this change you can disable all rules for a file by adding the following line to your swift file:
// SwiftLint ignore all
or you can disable a specific rule by adding something like:
// SwiftLint ignore variable_name
Where variable_name is the identifier of the rule