### PR TITLE
Hue lint rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SwiftLint
 
+Note: We have modified this to be a little less strict on whitespace and line length.
+
 An experimental tool to enforce Swift style and conventions, loosely based on
 [GitHub's Swift Style Guide](https://github.com/github/swift-style-guide).
 

--- a/Source/SwiftLintFramework/Linter.swift
+++ b/Source/SwiftLintFramework/Linter.swift
@@ -16,7 +16,7 @@ public struct Linter {
     private let rules: [Rule] = [
         LineLengthRule(),
         LeadingWhitespaceRule(),
-        TrailingWhitespaceRule(),
+//        TrailingWhitespaceRule(),
         ReturnArrowWhitespaceRule(),
         TrailingNewlineRule(),
         OperatorFunctionWhitespaceRule(),

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -14,8 +14,8 @@ public struct LineLengthRule: ParameterizedRule {
     public let identifier = "line_length"
 
     public let parameters = [
-        RuleParameter(severity: .VeryLow, value: 100),
-        RuleParameter(severity: .Low, value: 120),
+//        RuleParameter(severity: .VeryLow, value: 100),
+//        RuleParameter(severity: .Low, value: 120),
         RuleParameter(severity: .Medium, value: 150),
         RuleParameter(severity: .High, value: 200),
         RuleParameter(severity: .VeryHigh, value: 250)


### PR DESCRIPTION
I have removed the trailing whitespace rule and made the line length rule less strict.

Feel free to add other changes to fit the style better!