### PR TITLE
Only validate examples produce their own violations

### DIFF
--- a/Source/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Source/SwiftLintFrameworkTests/TestHelpers.swift
@@ -14,16 +14,20 @@ func violations(string: String) -> [StyleViolation] {
     return Linter(file: File(contents: string)).styleViolations
 }
 
+private func violations(string: String, type: StyleViolationType) -> [StyleViolation] {
+    return violations(string).filter { $0.type == type }
+}
+
 extension XCTestCase {
     func verifyRule(rule: RuleExample,
         type: StyleViolationType,
         commentDoesntViolate: Bool = true) {
-        XCTAssertEqual(rule.nonTriggeringExamples.flatMap({violations($0)}), [])
-        XCTAssertEqual(rule.triggeringExamples.flatMap({violations($0).map({$0.type})}),
+        XCTAssertEqual(rule.nonTriggeringExamples.flatMap({violations($0, type)}), [])
+        XCTAssertEqual(rule.triggeringExamples.flatMap({violations($0, type).map({$0.type})}),
             Array(count: rule.triggeringExamples.count, repeatedValue: type))
 
         if commentDoesntViolate {
-            XCTAssertEqual(rule.triggeringExamples.flatMap({violations("// " + $0)}), [])
+            XCTAssertEqual(rule.triggeringExamples.flatMap({violations("// " + $0, type)}), [])
         }
     }
 }


### PR DESCRIPTION
When adding new general rules, examples from other rules could violate your new rule. Since we're already testing rules practically through the integration tests we should only validate that examples produce the expected violation types.

This became an issue when I was working on https://github.com/realm/SwiftLint/issues/66 since all the current examples don't have docstrings (since they're not relevant to the rules they're testing).