### PR TITLE
Improve trailing newline performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   [JP Simard](https://github.com/jpsim)
   [#78](https://github.com/realm/SwiftLint/issues/78)
 
+* Improve performance of `TrailingNewlineRule`  
+  [Keith Smiley](https://github.com/keith)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -14,16 +14,20 @@ public struct TrailingNewlineRule: Rule {
     public let identifier = "trailing_newline"
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let countOfTrailingNewlines = file.contents.countOfTailingCharactersInSet(
-            NSCharacterSet.newlineCharacterSet()
-        )
-        if countOfTrailingNewlines != 1 {
+        let string = file.contents
+        let start = advance(string.endIndex, -2, string.startIndex)
+        let range = Range(start: start, end: string.endIndex)
+        let substring = string[range].utf16
+        let newLineSet = NSCharacterSet.newlineCharacterSet()
+        let slices = split(substring, allowEmptySlices: true) { !newLineSet.characterIsMember($0) }
+
+        if let slice = slices.last where count(slice) != 1 {
             return [StyleViolation(type: .TrailingNewline,
                 location: Location(file: file.path, line: file.contents.lines().count + 1),
                 severity: .Medium,
-                reason: "File should have a single trailing newline: " +
-                "currently has \(countOfTrailingNewlines)")]
+                reason: "File should have a single trailing newline")]
         }
+
         return []
     }
 

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -34,11 +34,11 @@ class StringRuleTests: XCTestCase {
         XCTAssertEqual(violations(""), [StyleViolation(type: .TrailingNewline,
             location: Location(file: nil, line: 1),
             severity: .Medium,
-            reason: "File should have a single trailing newline: currently has 0")])
+            reason: "File should have a single trailing newline")])
         XCTAssertEqual(violations("//\n\n"), [StyleViolation(type: .TrailingNewline,
             location: Location(file: nil, line: 3),
             severity: .Medium,
-            reason: "File should have a single trailing newline: currently has 2")])
+            reason: "File should have a single trailing newline")])
     }
 
     func testFileLengths() {


### PR DESCRIPTION
This sidesteps the previous method of reversing the entire string from every file by only checking the minimum necessary number of trailing characters for each file.

In our tests linting of our entire project with ~400 files using only this rule, (I disabled the others for testing) the lint time went from minutes to seconds.

Before:

![screen shot 2015-08-14 at 14 03 08](https://cloud.githubusercontent.com/assets/283886/9287313/2a62ebc2-42c3-11e5-95eb-42eff68444ae.png)

After:

![screen shot 2015-08-14 at 14 05 31](https://cloud.githubusercontent.com/assets/283886/9287314/31a71bf6-42c3-11e5-9c01-7cad9a9fe569.png)

