### PR TITLE
Remove SourceKittenFramework through Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ install: package
 
 uninstall:
 	rm -rf "$(FRAMEWORKS_FOLDER)/SwiftLintFramework.framework"
+	rm -rf "$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework"
 	rm -f "$(BINARIES_FOLDER)/swiftlint"
 
 installables: clean bootstrap


### PR DESCRIPTION
While working on SwiftLint, if you ended up editing the SourceKitten
framework you end up getting really cryptic errors about missing types
from both sides. Since we're building this framework when we build this
project and we're installing it on `make install` we should remove it
with the uninstall.