### PR TITLE
Lint parentheses around switch statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 * Improve performance of `TrailingNewlineRule`.  
   [Keith Smiley](https://github.com/keith)
 
+* Lint parentheses around switch statements.  
+  [Keith Smiley](https://github.com/keith)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -14,7 +14,7 @@ public struct ControlStatementRule: Rule {
     public let identifier = "control_statement"
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return ["if", "for", "while"].flatMap { statementKind in
+        return ["if", "for", "switch", "while"].flatMap { statementKind in
             let pattern = "\(statementKind)\\s*\\([^,]*\\)\\s*\\{"
             return compact(file.matchPattern(pattern).map { match, syntaxKinds in
                 if syntaxKinds.first != .Keyword {
@@ -44,7 +44,8 @@ public struct ControlStatementRule: Rule {
             "for var index = 0; index < 42; index++ {\n",
             "while condition {\n",
             "} while condition {\n",
-            "do { ; } while condition {\n"
+            "do { ; } while condition {\n",
+            "switch foo {\n",
         ],
         triggeringExamples: [
             "if (condition) {\n",
@@ -58,7 +59,8 @@ public struct ControlStatementRule: Rule {
             "} while (condition) {\n",
             "} while(condition) {\n",
             "do { ; } while(condition) {\n",
-            "do { ; } while (condition) {\n"
+            "do { ; } while (condition) {\n",
+            "switch (foo) {\n",
         ]
     )
 }


### PR DESCRIPTION
This adds `switch` to the list of things that should not have parens around their arguments.