### PR TITLE
Add path or file based exclusion to the linter

### DIFF
--- a/Source/swiftlint/LintCommand.swift
+++ b/Source/swiftlint/LintCommand.swift
@@ -123,6 +123,7 @@ struct LintOptions: OptionsType {
             <*> m <| Option(key: "path", defaultValue: "", usage: "the path to the file or" +
                         " directory to lint")
             <*> m <| Option(key: "use-stdin", defaultValue: false, usage: "lint standard input")
-            <*> m <| Option(key: "exclude", defaultValue: "", usage: "comma separated files or folders to exclude")
+            <*> m <| Option(key: "exclude", defaultValue: "", usage: "comma separated files" +
+                        "or folders to exclude")
     }
 }


### PR DESCRIPTION
Taking a stab at #6.

It would be pretty easy to add regex based exclusion too.