### PR TITLE
[Configuration] allow configuring parameterized rules from the configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@
 ##### Enhancements
 
 * Configure SwiftLint via a YAML file:
-  Supports `disabled_rules`, `included` and `excluded`.
+  Supports `disabled_rules`, `included`, `excluded` and passing parameters to
+  parameterized rules.
   Pass a configuration file path to `--config`, defaults to `.swiftlint.yml`.  
   [JP Simard](https://github.com/jpsim)
+  [#1](https://github.com/realm/SwiftLint/issues/1)
   [#3](https://github.com/realm/SwiftLint/issues/3)
+  [#20](https://github.com/realm/SwiftLint/issues/20)
+  [#26](https://github.com/realm/SwiftLint/issues/26)
 
 * Updated `TypeNameRule` and `VariableNameRule` to allow private type & variable
   names to start with an underscore.

--- a/Source/SwiftLintFramework/Configuration.swift
+++ b/Source/SwiftLintFramework/Configuration.swift
@@ -12,6 +12,9 @@ extension Yaml {
     var arrayOfStrings: [Swift.String]? {
         return array?.flatMap { $0.string }
     }
+    var arrayOfInts: [Swift.Int]? {
+        return array?.flatMap { $0.int }
+    }
 }
 
 public struct Configuration {
@@ -19,10 +22,7 @@ public struct Configuration {
     public let included: [String]      // included
     public let excluded: [String]      // excluded
     public let reporter: String        // reporter (xcode, json, csv)
-
-    public var rules: [Rule] {
-        return allRules.filter { !disabledRules.contains($0.identifier) }
-    }
+    public let rules: [Rule]
 
     public var reporterFromString: Reporter.Type {
         switch reporter {
@@ -40,7 +40,8 @@ public struct Configuration {
     public init?(disabledRules: [String] = [],
                  included: [String] = [],
                  excluded: [String] = [],
-                 reporter: String = "xcode") {
+                 reporter: String = "xcode",
+                 rules: [Rule] = allRules) {
         self.disabledRules = disabledRules
         self.included = included
         self.excluded = excluded
@@ -76,6 +77,8 @@ public struct Configuration {
             }
             return nil
         }
+
+        self.rules = rules.filter { !disabledRules.contains($0.identifier) }
     }
 
     public init?(yaml: String) {
@@ -86,7 +89,8 @@ public struct Configuration {
             disabledRules: yamlConfig["disabled_rules"].arrayOfStrings ?? [],
             included: yamlConfig["included"].arrayOfStrings ?? [],
             excluded: yamlConfig["excluded"].arrayOfStrings ?? [],
-            reporter: yamlConfig["reporter"].string ?? XcodeReporter.identifier
+            reporter: yamlConfig["reporter"].string ?? XcodeReporter.identifier,
+            rules: Configuration.rulesFromYAML(yamlConfig)
         )
     }
 
@@ -118,5 +122,51 @@ public struct Configuration {
                 self.init()!
             }
         }
+    }
+
+    public static func rulesFromYAML(yaml: Yaml?) -> [Rule] {
+        var rules = [Rule]()
+        if let params = yaml?[.String(LineLengthRule().identifier)].arrayOfInts {
+            rules.append(LineLengthRule(parameters: ruleParametersFromArray(params)))
+        } else {
+            rules.append(LineLengthRule())
+        }
+        rules.append(LeadingWhitespaceRule())
+        rules.append(TrailingWhitespaceRule())
+        rules.append(ReturnArrowWhitespaceRule())
+        rules.append(TrailingNewlineRule())
+        rules.append(OperatorFunctionWhitespaceRule())
+        rules.append(ForceCastRule())
+        if let params = yaml?[.String(FileLengthRule().identifier)].arrayOfInts {
+            rules.append(FileLengthRule(parameters: ruleParametersFromArray(params)))
+        } else {
+            rules.append(FileLengthRule())
+        }
+        rules.append(TodoRule())
+        rules.append(ColonRule())
+        rules.append(TypeNameRule())
+        rules.append(VariableNameRule())
+        if let params = yaml?[.String(TypeBodyLengthRule().identifier)].arrayOfInts {
+            rules.append(TypeBodyLengthRule(parameters: ruleParametersFromArray(params)))
+        } else {
+            rules.append(TypeBodyLengthRule())
+        }
+        if let params = yaml?[.String(FunctionBodyLengthRule().identifier)].arrayOfInts {
+            rules.append(FunctionBodyLengthRule(parameters: ruleParametersFromArray(params)))
+        } else {
+            rules.append(FunctionBodyLengthRule())
+        }
+        rules.append(NestingRule())
+        rules.append(ControlStatementRule())
+        return rules
+    }
+
+    public static func ruleParametersFromArray<T>(array: [T]) -> [RuleParameter<T>] {
+        let severities: [ViolationSeverity] = [.Warning, .Error]
+        var parameters = [RuleParameter<T>]()
+        for (index, value) in array.enumerate() {
+            parameters.append(RuleParameter(severity: severities[index], value: value))
+        }
+        return parameters
     }
 }

--- a/Source/SwiftLintFramework/Configuration.swift
+++ b/Source/SwiftLintFramework/Configuration.swift
@@ -162,11 +162,6 @@ public struct Configuration {
     }
 
     public static func ruleParametersFromArray<T>(array: [T]) -> [RuleParameter<T>] {
-        let severities: [ViolationSeverity] = [.Warning, .Error]
-        var parameters = [RuleParameter<T>]()
-        for (index, value) in array.enumerate() {
-            parameters.append(RuleParameter(severity: severities[index], value: value))
-        }
-        return parameters
+        return zip([.Warning, .Error], array).map(RuleParameter.init)
     }
 }

--- a/Source/SwiftLintFramework/Rule.swift
+++ b/Source/SwiftLintFramework/Rule.swift
@@ -9,6 +9,7 @@
 import SourceKittenFramework
 
 public protocol Rule {
+    init()
     var identifier: String { get }
     func validateFile(file: File) -> [StyleViolation]
     var example: RuleExample { get }
@@ -16,6 +17,7 @@ public protocol Rule {
 
 public protocol ParameterizedRule: Rule {
     typealias ParameterType
+    init(parameters: [RuleParameter<ParameterType>])
     var parameters: [RuleParameter<ParameterType>] { get }
 }
 

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -9,14 +9,20 @@
 import SourceKittenFramework
 
 public struct FileLengthRule: ParameterizedRule {
-    public init() {}
+    public init() {
+        self.init(parameters: [
+            RuleParameter(severity: .Warning, value: 400),
+            RuleParameter(severity: .Error, value: 1000)
+        ])
+    }
+
+    public init(parameters: [RuleParameter<Int>]) {
+        self.parameters = parameters
+    }
 
     public let identifier = "file_length"
 
-    public let parameters = [
-        RuleParameter(severity: .Warning, value: 400),
-        RuleParameter(severity: .Error, value: 1000)
-    ]
+    public let parameters: [RuleParameter<Int>]
 
     public func validateFile(file: File) -> [StyleViolation] {
         let lineCount = file.lines.count
@@ -25,8 +31,8 @@ public struct FileLengthRule: ParameterizedRule {
                 return [StyleViolation(type: .Length,
                     location: Location(file: file.path, line: lineCount),
                     severity: parameter.severity,
-                    reason: "File should contain 400 lines or less: currently contains " +
-                    "\(lineCount)")]
+                    reason: "File should contain \(parameters.first!.value) lines or less: " +
+                    "currently contains \(lineCount)")]
             }
         }
         return []

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -10,14 +10,20 @@ import SourceKittenFramework
 import SwiftXPC
 
 public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
-    public init() {}
+    public init() {
+        self.init(parameters: [
+            RuleParameter(severity: .Warning, value: 40),
+            RuleParameter(severity: .Error, value: 100)
+        ])
+    }
+
+    public init(parameters: [RuleParameter<Int>]) {
+        self.parameters = parameters
+    }
 
     public let identifier = "function_body_length"
 
-    public let parameters = [
-        RuleParameter(severity: .Warning, value: 40),
-        RuleParameter(severity: .Error, value: 100)
-    ]
+    public let parameters: [RuleParameter<Int>]
 
     public func validateFile(file: File) -> [StyleViolation] {
         return validateFile(file, dictionary: file.structure.dictionary)
@@ -73,8 +79,8 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
                     return [StyleViolation(type: .Length,
                         location: location,
                         severity: parameter.severity,
-                        reason: "Function body should be span 40 lines or less: currently spans " +
-                        "\(endLine - startLine) lines")]
+                        reason: "Function body should be span \(parameters.first!.value) lines " +
+                        "or less: currently spans \(endLine - startLine) lines")]
                 }
             }
         }

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -9,14 +9,20 @@
 import SourceKittenFramework
 
 public struct LineLengthRule: ParameterizedRule {
-    public init() {}
+    public init() {
+        self.init(parameters: [
+            RuleParameter(severity: .Warning, value: 100),
+            RuleParameter(severity: .Error, value: 200)
+        ])
+    }
+
+    public init(parameters: [RuleParameter<Int>]) {
+        self.parameters = parameters
+    }
 
     public let identifier = "line_length"
 
-    public let parameters = [
-        RuleParameter(severity: .Warning, value: 100),
-        RuleParameter(severity: .Error, value: 200)
-    ]
+    public let parameters: [RuleParameter<Int>]
 
     public func validateFile(file: File) -> [StyleViolation] {
         return file.lines.flatMap { line in
@@ -25,8 +31,8 @@ public struct LineLengthRule: ParameterizedRule {
                     return StyleViolation(type: .Length,
                         location: Location(file: file.path, line: line.index),
                         severity: parameter.severity,
-                        reason: "Line should be 100 characters or less: currently " +
-                        "\(line.content.characters.count) characters")
+                        reason: "Line should be \(parameters.first!.value) characters or less: " +
+                        "currently \(line.content.characters.count) characters")
                 }
             }
             return nil

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -10,14 +10,20 @@ import SourceKittenFramework
 import SwiftXPC
 
 public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
-    public init() {}
+    public init() {
+        self.init(parameters: [
+            RuleParameter(severity: .Warning, value: 200),
+            RuleParameter(severity: .Error, value: 350)
+        ])
+    }
+
+    public init(parameters: [RuleParameter<Int>]) {
+        self.parameters = parameters
+    }
 
     public let identifier = "type_body_length"
 
-    public let parameters = [
-        RuleParameter(severity: .Warning, value: 200),
-        RuleParameter(severity: .Error, value: 350)
-    ]
+    public let parameters: [RuleParameter<Int>]
 
     public func validateFile(file: File) -> [StyleViolation] {
         return validateFile(file, dictionary: file.structure.dictionary)
@@ -62,8 +68,8 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
                     return [StyleViolation(type: .Length,
                         location: location,
                         severity: parameter.severity,
-                        reason: "Type body should be span 200 lines or less: currently spans " +
-                        "\(endLine - startLine) lines")]
+                        reason: "Type body should be span \(parameters.first!.value) lines " +
+                        "or less: currently spans \(endLine - startLine) lines")]
                 }
             }
         }


### PR DESCRIPTION
This is awkwardly implemented at the moment because we're starting to duplicate the set of rules in quite a few places, but this works for now.

```ruby
line_length:
  - 120 # Very Low
  - 140 # Low
  - 160 # Medium
  - 180 # High
  - 200 # Very High
```

Thoughts @segiddins @keith ?