### PR TITLE
Allow capitalized var names for OptionSetType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
 
 ##### Enhancements
 
-* None.
+* The `VariableNameRule` now allows capitalized variable names when they are
+  declared static. This allows stylistic usage common in cases like
+  `OptionSetType` subclasses.
+  [Will Fleming](https://github.com/wfleming)
 
 ##### Bug Fixes
 


### PR DESCRIPTION
There is at least one semi-common case new to Swift 2 where capitalized names should probably be allowed: in [OptionSetType](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Reference/Swift_OptionSetType_Protocol/index.html) classes, the standard pattern is to use `static let = Foo` to declare each option for the type.

I don't know of any common usages outside of `OptionSetType` where this is expected, since for anything like this you're probably either using `OptionSetType` or `enum`. But the context of the enclosing class isn't easily available in the rule right now, as far as I could tell, and I feel like keeping the rule a bit more general is probably better anyway.

One downside of this implementation is that it would *also* pass a capitalized "static var Foo", which is probably not desirable. It's not clear to me how feasible addressing this is: it seems like SourceKitten might need to be updated to be more precise with `SwiftDeclarationKind` values? Using `static var` at all is an anti-pattern as far as I'm concerned, though, so hopefully this isn't a huge deal. Perhaps there should be a rule identifying `static var` and considering it a violation? (I'd be happy to take a look at that either on top of this PR or separately if you think that's worthwhile.)