### PR TITLE
Add strict linting flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   [JP Simard](https://github.com/jpsim)
   [#4](https://github.com/realm/SwiftLint/issues/4)
 
+* Add `--strict` lint flag which makes the lint fail if there are any
+  warnings.  
+  [Keith Smiley](https://github.com/keith)
+
 ##### Bug Fixes
 
 * None.


### PR DESCRIPTION
This flag makes SwiftLint exit with 1 even if there are only warnings. This is useful for CI to make sure that nothing was introduced in the current build.