### PR TITLE
Print violations to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   warnings.  
   [Keith Smiley](https://github.com/keith)
 
+* Violations are now printed to stderr.  
+  [Keith Smiley](https://github.com/keith)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/swiftlint/LintCommand.swift
+++ b/Source/swiftlint/LintCommand.swift
@@ -58,7 +58,7 @@ struct LintCommand: CommandType {
                 print("Linting '\(filename)' (\(index + 1)/\(filesToLint.count))")
                 let file = File(path: path)!
                 for violation in Linter(file: file, configuration: configuration).styleViolations {
-                    print(violation)
+                    fputs("\(violation)\n", stderr)
                     numberOfViolations++
                     if violation.severity == .Error {
                         numberOfSeriousViolations++


### PR DESCRIPTION
This means you can do something like:

```sh
swiftlint lint 1>/dev/null
```

If you want to hide the progress output, such as on CI.