### PR TITLE
Optimize trailing whitespace rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Improve performance of `TrailingWhitespaceRule`.  
+  [Keith Smiley](https://github.com/keith)
 
 
 ## 0.1.2: FabricSoftenerRule

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -14,21 +14,13 @@ public struct TrailingWhitespaceRule: Rule {
     public let identifier = "trailing_whitespace"
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return file.lines.map { line in
-            (
-                index: line.index,
-                trailingWhitespaceCount: line.content.countOfTailingCharactersInSet(
-                    NSCharacterSet.whitespaceCharacterSet()
-                )
-            )
-        }.filter {
-            $0.trailingWhitespaceCount > 0
+        return file.lines.filter {
+            $0.content.hasTrailingWhitespace()
         }.map {
             StyleViolation(type: .TrailingWhitespace,
                 location: Location(file: file.path, line: $0.index),
                 severity: .Warning,
-                reason: "Line #\($0.index) should have no trailing whitespace: " +
-                "current has \($0.trailingWhitespaceCount) trailing whitespace characters")
+                reason: "Line #\($0.index) should have no trailing whitespace")
         }
     }
 

--- a/Source/SwiftLintFramework/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/String+SwiftLint.swift
@@ -11,6 +11,18 @@ import SourceKittenFramework
 import SwiftXPC
 
 extension String {
+    func hasTrailingWhitespace() -> Bool {
+        if isEmpty {
+            return false
+        }
+
+        if let character = utf16.suffix(1).first {
+            return NSCharacterSet.whitespaceCharacterSet().characterIsMember(character)
+        }
+
+        return false
+    }
+
     func isUppercase() -> Bool {
         return self == uppercaseString
     }

--- a/Source/SwiftLintFramework/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/String+SwiftLint.swift
@@ -27,10 +27,6 @@ extension String {
         return self == uppercaseString
     }
 
-    func countOfTailingCharactersInSet(characterSet: NSCharacterSet) -> Int {
-        return String(characters.reverse()).countOfLeadingCharactersInSet(characterSet)
-    }
-
     public var chomped: String {
         return stringByTrimmingCharactersInSet(NSCharacterSet.newlineCharacterSet())
     }


### PR DESCRIPTION
This updates the rule to no longer reverse each line in each file.
Instead the last character in each line is individually checked for
whitespace.

Before:

![before](https://cloud.githubusercontent.com/assets/283886/9668191/12976e42-5235-11e5-859a-7b2cbca68a5d.png)

After:

![after](https://cloud.githubusercontent.com/assets/283886/9668193/162d922a-5235-11e5-8bad-babcfd208e2b.png)
