### PR TITLE
Allow newlines in function return arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 * Improve performance of `TrailingWhitespaceRule`.  
   [Keith Smiley](https://github.com/keith)
 
+* Allow newlines in function return arrow.  
+  [JP Simard](https://github.com/jpsim)
+
 
 ## 0.1.2: FabricSoftenerRule
 

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -15,7 +15,9 @@ public struct ReturnArrowWhitespaceRule: Rule {
     public let identifier = "return_arrow_whitespace"
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let spaceRegex = "(\\h{0}|\\h{2,})"
+        // just horizontal spacing so that "func abc()->\n" can pass validation
+        let space = "[ \\f\\r\\t]"
+        let spaceRegex = "(\(space){0}|\(space){2,})"
 
         // ex: func abc()-> Int {
         let pattern1 = file.matchPattern("\\)\(spaceRegex)\\->\\s*\\S+",

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -15,9 +15,7 @@ public struct ReturnArrowWhitespaceRule: Rule {
     public let identifier = "return_arrow_whitespace"
 
     public func validateFile(file: File) -> [StyleViolation] {
-        // space doesn't include \n so that "func abc()->\n" can pass validation
-        let space = "[ \\f\\r\\t\\v]"
-        let spaceRegex = "(\(space){0}|\(space){2,})"
+        let spaceRegex = "(\\h{0}|\\h{2,})"
 
         // ex: func abc()-> Int {
         let pattern1 = file.matchPattern("\\)\(spaceRegex)\\->\\s*\\S+",
@@ -38,13 +36,14 @@ public struct ReturnArrowWhitespaceRule: Rule {
     public let example = RuleExample(
         ruleName: "Returning Whitespace Rule",
         ruleDescription: "This rule checks whether you have 1 space before " +
-        "return arrow and return type",
+        "return arrow and return type. Newlines are also acceptable.",
         nonTriggeringExamples: [
             "func abc() -> Int {}\n",
             "func abc() -> [Int] {}\n",
             "func abc() -> (Int, Int) {}\n",
             "var abc = {(param: Int) -> Void in }\n",
-            "func abc() ->\n"
+            "func abc() ->\n    Int {}\n",
+            "func abc()\n    -> Int {}\n"
         ],
         triggeringExamples: [
             "func abc()->Int {}\n",

--- a/Source/swiftlint/LintCommand.swift
+++ b/Source/swiftlint/LintCommand.swift
@@ -107,8 +107,7 @@ struct LintOptions: OptionsType {
     let strict: Bool
 
     static func create(path: String)(useSTDIN: Bool)(configurationFile: String)(strict: Bool)
-        -> LintOptions
-    {
+        -> LintOptions {
         return LintOptions(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile,
             strict: strict)
     }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -427,13 +427,13 @@
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
 				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
 				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
+				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
 				E88DEA811B0990A700A66CB0 /* TodoRule.swift */,
 				E88DEA871B09924C00A66CB0 /* TrailingNewlineRule.swift */,
 				E88DEA851B0991BF00A66CB0 /* TrailingWhitespaceRule.swift */,
 				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
 				E88DEA931B099C0900A66CB0 /* VariableNameRule.swift */,
-				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";


### PR DESCRIPTION
This prevented SwiftLint from linting as of #118. /cc @keith 