### PR TITLE
Remove Location's comparison of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
 * Allow newlines in function return arrow.  
   [JP Simard](https://github.com/jpsim)
 
+* Don't compare text when comparing `Location`s.  
+  [Keith Smiley](https://github.com/keith)
+
 
 ## 0.1.2: FabricSoftenerRule
 

--- a/Source/SwiftLintFramework/Location.swift
+++ b/Source/SwiftLintFramework/Location.swift
@@ -47,9 +47,6 @@ public func == (lhs: Location, rhs: Location) -> Bool {
 }
 
 public func < (lhs: Location, rhs: Location) -> Bool {
-    if lhs.file != rhs.file {
-        return lhs.file < rhs.file
-    }
     if lhs.line != rhs.line {
         return lhs.line < rhs.line
     }


### PR DESCRIPTION
This fixes an issue with tests and regions where comparing the start and
end would return incorrect results. Really the locations just need to
compare the line and character numbers to be useful.