### PR TITLE
Add rule for header comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 * Violations are now printed to stderr.  
   [Keith Smiley](https://github.com/keith)
 
+* Add rule for header comment boilerplate.  
+  [Keith Smiley](https://github.com/keith)
+
 ##### Bug Fixes
 
 * Improve performance of `TrailingWhitespaceRule`.  

--- a/Source/SwiftLintFramework/Rule.swift
+++ b/Source/SwiftLintFramework/Rule.swift
@@ -35,5 +35,6 @@ public let allRules: [Rule] = [
     TypeBodyLengthRule(),
     FunctionBodyLengthRule(),
     NestingRule(),
-    ControlStatementRule()
+    ControlStatementRule(),
+    HeaderCommentRule(),
 ]

--- a/Source/SwiftLintFramework/Rules/HeaderCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/HeaderCommentRule.swift
@@ -1,0 +1,46 @@
+//
+//  HeaderCommentRule.swift
+//  SwiftLint
+//
+//  Created by Keith Smiley on 8/18/15.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct HeaderCommentRule: Rule {
+    public init() {}
+
+    public let identifier = "header_comment"
+
+    private static let regex = try! NSRegularExpression(pattern: "//\\s*Copyright", options: [])
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        for line in file.lines {
+            let content = line.content
+            if !content.hasPrefix("//") {
+                break
+            }
+
+            let range = NSRange(location: 0, length: content.utf16.count)
+            let matches = HeaderCommentRule.regex.matchesInString(content, options: [],
+                range: range)
+            if matches.count > 0 {
+                return [StyleViolation(type: .HeaderComment,
+                    location: Location(file: file.path, line: line.index, character: 0),
+                    reason: "Files should not have header comments")]
+            }
+        }
+
+        return []
+    }
+
+    public let example = RuleExample(ruleName: "Header Comment",
+        ruleDescription: "Files should not have header comments",
+        nonTriggeringExamples: [],
+        triggeringExamples: [
+            "// Copyright\n",
+            "//\n// Copyright",
+        ]
+    )
+}

--- a/Source/SwiftLintFramework/StyleViolationType.swift
+++ b/Source/SwiftLintFramework/StyleViolationType.swift
@@ -19,6 +19,7 @@ public enum StyleViolationType: String, CustomStringConvertible {
     case Colon                      = "Colon"
     case Nesting                    = "Nesting"
     case ControlStatement           = "Control Statement Parentheses"
+    case HeaderComment              = "Header Comment"
 
     public var description: String { return rawValue }
 }

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -87,4 +87,8 @@ class StringRuleTests: XCTestCase {
     func testColon() {
         verifyRule(ColonRule(), type: .Colon)
     }
+
+    func testHeaderComment() {
+        verifyRule(HeaderCommentRule(), type: .HeaderComment, commentDoesntViolate: false)
+    }
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		83D71E281B131ECE000395DE /* RuleExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleExample.swift */; };
 		83D71E2B1B131EED000395DE /* AnsiCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E231B131C11000395DE /* AnsiCode.swift */; };
 		83D71E2C1B131EF0000395DE /* StructuredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F231B0CAD41006214E1 /* StructuredText.swift */; };
+		C25642F51B9A100600F8540C /* HeaderCommentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25642F41B9A100600F8540C /* HeaderCommentRule.swift */; settings = {ASSET_TAGS = (); }; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
@@ -125,6 +126,7 @@
 		83894F231B0CAD41006214E1 /* StructuredText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StructuredText.swift; path = ../swiftlint/StructuredText.swift; sourceTree = "<group>"; };
 		83D71E231B131C11000395DE /* AnsiCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnsiCode.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleExample.swift; sourceTree = "<group>"; };
+		C25642F41B9A100600F8540C /* HeaderCommentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderCommentRule.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D0D1212619E878CC005E4BAA /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				E88DEA891B0992B300A66CB0 /* FileLengthRule.swift */,
 				E88DEA7F1B09903300A66CB0 /* ForceCastRule.swift */,
 				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
+				C25642F41B9A100600F8540C /* HeaderCommentRule.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
 				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
@@ -607,6 +610,7 @@
 				E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */,
 				E88DEA841B0990F500A66CB0 /* ColonRule.swift in Sources */,
 				E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */,
+				C25642F51B9A100600F8540C /* HeaderCommentRule.swift in Sources */,
 				E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */,
 				E88DEA731B0984C400A66CB0 /* String+SwiftLint.swift in Sources */,
 				24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */,


### PR DESCRIPTION
This adds a rule to warn when files have copyright boilerplate comments. This depends on https://github.com/realm/SwiftLint/pull/124 for the tests to run successfully. There's also the issue that the integration tests for SwiftLint don't work with this. Maybe this would need to wait for the new defaults to disable this rule by default.