### PR TITLE
Remove duplicated Line declaration

### DIFF
--- a/Source/SwiftLintFramework/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/File+SwiftLint.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 import SwiftXPC
 
-internal typealias Line = (index: Int, content: String)
-
 extension File {
     public func regions() -> [Region] {
         let nsStringContents = contents as NSString


### PR DESCRIPTION
This typealias is public from sourcekitten, so we don't need to redeclare it here.