### PR TITLE
Remove allRules

### DIFF
--- a/Source/SwiftLintFramework/Configuration.swift
+++ b/Source/SwiftLintFramework/Configuration.swift
@@ -41,7 +41,7 @@ public struct Configuration {
                  included: [String] = [],
                  excluded: [String] = [],
                  reporter: String = "xcode",
-                 rules: [Rule] = allRules) {
+                 rules: [Rule] = Configuration.rulesFromYAML(nil)) {
         self.disabledRules = disabledRules
         self.included = included
         self.excluded = excluded
@@ -49,7 +49,7 @@ public struct Configuration {
 
         // Validate that all rule identifiers map to a defined rule
 
-        let validRuleIdentifiers = allRules.map { $0.identifier }
+        let validRuleIdentifiers = Configuration.rulesFromYAML(nil).map { $0.identifier }
 
         let ruleSet = Set(disabledRules)
         let invalidRules = ruleSet.filter({ !validRuleIdentifiers.contains($0) })

--- a/Source/SwiftLintFramework/Rule.swift
+++ b/Source/SwiftLintFramework/Rule.swift
@@ -20,22 +20,3 @@ public protocol ParameterizedRule: Rule {
     init(parameters: [RuleParameter<ParameterType>])
     var parameters: [RuleParameter<ParameterType>] { get }
 }
-
-public let allRules: [Rule] = [
-    LineLengthRule(),
-    LeadingWhitespaceRule(),
-    TrailingWhitespaceRule(),
-    ReturnArrowWhitespaceRule(),
-    TrailingNewlineRule(),
-    OperatorFunctionWhitespaceRule(),
-    ForceCastRule(),
-    FileLengthRule(),
-    TodoRule(),
-    ColonRule(),
-    TypeNameRule(),
-    VariableNameRule(),
-    TypeBodyLengthRule(),
-    FunctionBodyLengthRule(),
-    NestingRule(),
-    ControlStatementRule()
-]

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -38,7 +38,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(disabledConfig.disabledRules,
             ["nesting", "todo"],
             "initializing Configuration with valid rules in YAML string should succeed")
-        let expectedIdentifiers = allRules
+        let expectedIdentifiers = Configuration.rulesFromYAML(nil)
             .map({ $0.identifier })
             .filter({ !["nesting", "todo"].contains($0) })
         let configuredIdentifiers = disabledConfig.rules.map({ $0.identifier })


### PR DESCRIPTION
Now that the Configuration struct is creating a list of rules based on optional yaml, this list duplicates the same behavior. By removing it you no longer have to maintain duplicate lists of rules.

Passing nil as yaml isn't my favorite. If anyone has a better suggestion I'd love to hear it.