### PR TITLE
Update rule descriptions to not include specifics

### DIFF
--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -40,7 +40,7 @@ public struct FileLengthRule: ParameterizedRule {
 
     public let example = RuleExample(
         ruleName: "File Line Length Rule",
-        ruleDescription: "Files should be less than 400 lines.",
+        ruleDescription: "Enforce maximum file length",
         nonTriggeringExamples: [],
         triggeringExamples: [],
         showExamples: false

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -89,7 +89,7 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
 
     public let example = RuleExample(
         ruleName: "Function Body Length Rule",
-        ruleDescription: "This rule checks whether your function bodies are less than 40 lines.",
+        ruleDescription: "Enforce maximum function length",
         nonTriggeringExamples: [],
         triggeringExamples: [],
         showExamples: false

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -41,7 +41,7 @@ public struct LineLengthRule: ParameterizedRule {
 
     public let example = RuleExample(
         ruleName: "Line Length Rule",
-        ruleDescription: "Lines should be less than 100 characters.",
+        ruleDescription: "Enforce maximum line length",
         nonTriggeringExamples: [],
         triggeringExamples: [],
         showExamples: false

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -78,7 +78,7 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
 
     public let example = RuleExample(
         ruleName: "Type body Length Rule",
-        ruleDescription: "Type body should span 200 lines or less.",
+        ruleDescription: "Enforce maximum type body length",
         nonTriggeringExamples: [],
         triggeringExamples: [],
         showExamples: false


### PR DESCRIPTION
Now that configuration of rules has been added, having these hard coded lengths is no longer valid.