### PR TITLE
Update yaml parsing to allow single value configurations

### DIFF
--- a/Source/SwiftLintFramework/Configuration.swift
+++ b/Source/SwiftLintFramework/Configuration.swift
@@ -10,10 +10,10 @@ import Yaml
 
 extension Yaml {
     var arrayOfStrings: [Swift.String]? {
-        return array?.flatMap { $0.string }
+        return array?.flatMap { $0.string } ?? string.map { [$0] }
     }
     var arrayOfInts: [Swift.Int]? {
-        return array?.flatMap { $0.int }
+        return array?.flatMap { $0.int } ?? int.map { [$0] }
     }
 }
 


### PR DESCRIPTION
This updates the `arrayOfStrings` and `arrayOfInts` methods to also
accept a single value if they are not parsed as an array. This lets us
do this for our configuration:

    line_length: 110

Instead of:

    line_length:
      - 110

If we only actually need a single value. The same goes for source
directories and other string keys.