### PR TITLE
Deduplicate files in the current directory. Fixes #154.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   [JP Simard](https://github.com/jpsim)
   [#151](https://github.com/realm/SwiftLint/issues/151)
 
+* Deduplicate files in the current directory.  
+  [JP Simard](https://github.com/jpsim)
+  [#154](https://github.com/realm/SwiftLint/issues/154)
+
 
 ## 0.2.0: Tumble Dry
 

--- a/Source/SwiftLintFramework/NSFileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/NSFileManager+SwiftLint.swift
@@ -10,8 +10,7 @@ import Foundation
 
 extension NSFileManager {
     public func allFilesRecursively(directory directory: String) -> [String] {
-        let relativeFiles = (try! contentsOfDirectoryAtPath(directory)) +
-            (try! subpathsOfDirectoryAtPath(directory))
-        return relativeFiles.map((directory as NSString).stringByAppendingPathComponent)
+        return try! subpathsOfDirectoryAtPath(directory)
+            .map((directory as NSString).stringByAppendingPathComponent)
     }
 }


### PR DESCRIPTION
Turns out that `subpathsOfDirectoryAtPath` includes files in that directory.