### PR TITLE
Make TypeNameRule Parameterized

### DIFF
--- a/Source/SwiftLintFramework/Configuration.swift
+++ b/Source/SwiftLintFramework/Configuration.swift
@@ -145,7 +145,11 @@ public struct Configuration {
         }
         rules.append(TodoRule())
         rules.append(ColonRule())
-        rules.append(TypeNameRule())
+        if let params = yaml?[.String(TypeNameRule().identifier)].arrayOfInts {
+            rules.append(TypeNameRule(parameters: ruleParametersFromArray(params)))
+        } else {
+            rules.append(TypeNameRule())
+        }
         rules.append(VariableNameRule())
         if let params = yaml?[.String(TypeBodyLengthRule().identifier)].arrayOfInts {
             rules.append(TypeBodyLengthRule(parameters: ruleParametersFromArray(params)))

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -9,10 +9,21 @@
 import SourceKittenFramework
 import SwiftXPC
 
-public struct TypeNameRule: ASTRule {
-    public init() {}
+public struct TypeNameRule: ASTRule, ParameterizedRule {
+    public init() {
+        self.init(parameters: [
+            RuleParameter(severity: .Warning, value: 3),
+            RuleParameter(severity: .Warning, value: 40)
+            ])
+    }
+
+    public init(parameters: [RuleParameter<Int>]) {
+        self.parameters = parameters
+    }
 
     public let identifier = "type_name"
+
+    public let parameters: [RuleParameter<Int>]
 
     public func validateFile(file: File) -> [StyleViolation] {
         return validateFile(file, dictionary: file.structure.dictionary)
@@ -63,11 +74,11 @@ public struct TypeNameRule: ASTRule {
                     location: location,
                     severity: .Error,
                     reason: "Type name should start with an uppercase character: '\(name)'"))
-            } else if name.characters.count < 3 || name.characters.count > 40 {
+            } else if name.characters.count < parameters[0].value || name.characters.count > parameters[1].value {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Warning,
-                    reason: "Type name should be between 3 and 40 characters in length: " +
+                    reason: "Type name should be between \(parameters[0].value) and \(parameters[1].value) characters in length: " +
                     "'\(name)'"))
             }
         }
@@ -77,7 +88,7 @@ public struct TypeNameRule: ASTRule {
     public let example = RuleExample(
         ruleName: "Type Name Rule",
         ruleDescription: "Type name should only contain alphanumeric characters, " +
-        "start with an uppercase character and between 3 and 40 characters in length.",
+        "start with an uppercase character and have character length within specified range (default: 3-40).",
         nonTriggeringExamples: [
             "struct MyStruct {}",
             "private struct _MyStruct {}"

--- a/Source/SwiftLintFrameworkTests/ASTRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/ASTRuleTests.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftLintFramework
+import SourceKittenFramework
 import XCTest
 
 class ASTRuleTests: XCTestCase {
@@ -128,6 +129,31 @@ class ASTRuleTests: XCTestCase {
 
     func testTypeNamesVerifyRule() {
         verifyRule(TypeNameRule(), type: .NameFormat)
+    }
+
+    func testParameterizedTypeNameRule() {
+        let rule = TypeNameRule(parameters: [
+            RuleParameter(severity: .Warning, value: 2),
+            RuleParameter(severity: .Warning, value: 4)
+            ])
+
+        let tooShortViolations = rule.validateFile(File(contents: "struct A{}"))
+        XCTAssert(tooShortViolations.count == 1, "Should have single violation")
+        if let violation = tooShortViolations.first {
+            XCTAssert(violation.type == .NameFormat, "Unexpected type")
+            XCTAssert(violation.severity == .Warning, "Unexpected severity")
+            XCTAssert(violation.location == Location(file: nil, line: 1, character: 1),
+                "Unexpected location")
+        }
+
+        let tooLongViolations = rule.validateFile(File(contents: "struct Abcde{}"))
+        XCTAssert(tooLongViolations.count == 1, "Should have single violation")
+        if let violation = tooLongViolations.first {
+            XCTAssert(violation.type == .NameFormat, "Unexpected type")
+            XCTAssert(violation.severity == .Warning, "Unexpected severity")
+            XCTAssert(violation.location == Location(file: nil, line: 1, character: 1),
+                "Unexpected location")
+        }
     }
 
     func testVariableNamesVerifyRule() {

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -49,4 +49,18 @@ class ConfigurationTests: XCTestCase {
         XCTAssert(duplicateConfig == nil, "initializing Configuration with duplicate rules in " +
             " YAML string should fail")
     }
+
+    func testTypeNameRuleConfiguration() {
+        let configYaml = "type_name:\n  - 2\n - 4\n";
+        guard let config = Configuration(yaml: configYaml) else {
+            XCTFail("initializing Configuration should not fail")
+            return
+        }
+        guard let rule = config.rules.filter({ $0.identifier == "type_name" }).first
+            as? TypeNameRule else {
+                XCTFail("Should parse type_name rule")
+                return
+        }
+        XCTAssertEqual(rule.parameters.flatMap({ $0.value }), [2,4])
+    }
 }


### PR DESCRIPTION
TypeNameRule now accepts configuration for minimum and maximum type name length.
Example yml configuration:
```
type_name:
 - 2
 - 100
```