### PR TITLE
Add support for the guard statement to ControlStatementRule.

### DIFF
--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -14,8 +14,9 @@ public struct ControlStatementRule: Rule {
     public let identifier = "control_statement"
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return ["if", "for", "switch", "while"].flatMap { statementKind -> [StyleViolation] in
-            let pattern = "\(statementKind)\\s*\\([^,]*\\)\\s*\\{"
+        return ["if", "for", "guard", "switch", "while"].flatMap { statementKind -> [StyleViolation] in
+            let pattern = statementKind == "guard" ?
+                "\(statementKind)\\s*\\([^,]*\\)\\s*else\\s*\\{" : "\(statementKind)\\s*\\([^,]*\\)\\s*\\{"
             return file.matchPattern(pattern).flatMap { match, syntaxKinds in
                 if syntaxKinds.first != .Keyword {
                     return nil

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -14,9 +14,11 @@ public struct ControlStatementRule: Rule {
     public let identifier = "control_statement"
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return ["if", "for", "guard", "switch", "while"].flatMap { statementKind -> [StyleViolation] in
-            let pattern = statementKind == "guard" ?
-                "\(statementKind)\\s*\\([^,]*\\)\\s*else\\s*\\{" : "\(statementKind)\\s*\\([^,]*\\)\\s*\\{"
+        let statements = ["if", "for", "guard", "switch", "while"]
+        return statements.flatMap { statementKind -> [StyleViolation] in
+            let pattern = statementKind == "guard"
+                ? "\(statementKind)\\s*\\([^,]*\\)\\s*else\\s*\\{"
+                : "\(statementKind)\\s*\\([^,]*\\)\\s*\\{"
             return file.matchPattern(pattern).flatMap { match, syntaxKinds in
                 if syntaxKinds.first != .Keyword {
                     return nil
@@ -43,6 +45,7 @@ public struct ControlStatementRule: Rule {
             "for (key, value) in dictionary {\n",
             "for (index, value) in enumerate(array) {\n",
             "for var index = 0; index < 42; index++ {\n",
+            "guard condition else {\n",
             "while condition {\n",
             "} while condition {\n",
             "do { ; } while condition {\n",
@@ -55,6 +58,8 @@ public struct ControlStatementRule: Rule {
             "for (var index = 0; index < 42; index++) {\n",
             "for(item in collection) {\n",
             "for(var index = 0; index < 42; index++) {\n",
+            "guard (condition) else {\n",
+            "guard (condition) else {\n",
             "while (condition) {\n",
             "while(condition) {\n",
             "} while (condition) {\n",


### PR DESCRIPTION
This change allows SwiftLint to catch parentheses around conditions in guard statements which were added in Swift 2.