### PR TITLE
Added rule reference on command output to enable batch processing

### DIFF
--- a/Source/SwiftLintFramework/Reporters/CSVReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CSVReporter.swift
@@ -23,7 +23,8 @@ public struct CSVReporter: Reporter {
             "character",
             "severity",
             "type",
-            "reason"
+            "reason",
+            "rule_id"
         ]
         return (keys + violations.flatMap(arrayForViolation)).joinWithSeparator(",")
     }
@@ -35,7 +36,8 @@ public struct CSVReporter: Reporter {
             violation.location.character,
             violation.severity.rawValue,
             violation.type.description,
-            violation.reason
+            violation.reason,
+            violation.rule?.identifier
         ]
         return values.map({ $0?.description ?? "" })
     }

--- a/Source/SwiftLintFramework/Reporters/CSVReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CSVReporter.swift
@@ -37,7 +37,7 @@ public struct CSVReporter: Reporter {
             violation.severity.rawValue,
             violation.type.description,
             violation.reason,
-            violation.rule?.identifier
+            violation.ruleId
         ]
         return values.map({ $0?.description ?? "" })
     }

--- a/Source/SwiftLintFramework/Reporters/JSONReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JSONReporter.swift
@@ -28,6 +28,7 @@ public struct JSONReporter: Reporter {
             "character": violation.location.character ?? NSNull(),
             "severity": violation.severity.rawValue,
             "type": violation.type.description,
+            "rule_id": violation.rule?.identifier ?? NSNull(),
             "reason": violation.reason ?? NSNull()
         ]
     }

--- a/Source/SwiftLintFramework/Reporters/JSONReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JSONReporter.swift
@@ -28,7 +28,7 @@ public struct JSONReporter: Reporter {
             "character": violation.location.character ?? NSNull(),
             "severity": violation.severity.rawValue,
             "type": violation.type.description,
-            "rule_id": violation.rule?.identifier ?? NSNull(),
+            "rule_id": violation.ruleId ?? NSNull(),
             "reason": violation.reason ?? NSNull()
         ]
     }

--- a/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
@@ -23,6 +23,7 @@ public struct XcodeReporter: Reporter {
         return "\(violation.location): " +
             "\(violation.severity.rawValue.lowercaseString): " +
             "\(violation.type) Violation: " +
-            (violation.reason ?? "")
+            (violation.reason ?? "") + " " +
+            "(\(violation.rule?.identifier ?? ""))"
     }
 }

--- a/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
@@ -24,6 +24,6 @@ public struct XcodeReporter: Reporter {
             "\(violation.severity.rawValue.lowercaseString): " +
             "\(violation.type) Violation: " +
             (violation.reason ?? "") + " " +
-            "(\(violation.rule?.identifier ?? ""))"
+            "(" + (violation.rule?.identifier ?? "") + ")"
     }
 }

--- a/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
@@ -24,6 +24,6 @@ public struct XcodeReporter: Reporter {
             "\(violation.severity.rawValue.lowercaseString): " +
             "\(violation.type) Violation: " +
             (violation.reason ?? "") + " " +
-            "(" + (violation.rule?.identifier ?? "") + ")"
+            "(" + (violation.ruleId ?? "") + ")"
     }
 }

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -23,7 +23,7 @@ public struct ColonRule: Rule {
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
                 reason: "When specifying a type, always associate the colon with the identifier",
-                rule: self)
+                ruleId: self.identifier)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -22,7 +22,8 @@ public struct ColonRule: Rule {
             return StyleViolation(type: .Colon,
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
-                reason: "When specifying a type, always associate the colon with the identifier")
+                reason: "When specifying a type, always associate the colon with the identifier",
+                rule: self)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -24,7 +24,8 @@ public struct ControlStatementRule: Rule {
                     location: Location(file: file, offset: match.location),
                     severity: .Warning,
                     reason: "\(statementKind) statements shouldn't wrap their conditionals in " +
-                    "parentheses.")
+                    "parentheses.",
+                    rule: self)
                 }
         }
     }

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -25,7 +25,7 @@ public struct ControlStatementRule: Rule {
                     severity: .Warning,
                     reason: "\(statementKind) statements shouldn't wrap their conditionals in " +
                     "parentheses.",
-                    rule: self)
+                    ruleId: self.identifier)
                 }
         }
     }

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -32,7 +32,8 @@ public struct FileLengthRule: ParameterizedRule {
                     location: Location(file: file.path, line: lineCount),
                     severity: parameter.severity,
                     reason: "File should contain \(parameters.first!.value) lines or less: " +
-                    "currently contains \(lineCount)")]
+                    "currently contains \(lineCount)",
+                    rule: self)]
             }
         }
         return []

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -33,7 +33,7 @@ public struct FileLengthRule: ParameterizedRule {
                     severity: parameter.severity,
                     reason: "File should contain \(parameters.first!.value) lines or less: " +
                     "currently contains \(lineCount)",
-                    rule: self)]
+                    ruleId: self.identifier)]
             }
         }
         return []

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -18,7 +18,8 @@ public struct ForceCastRule: Rule {
             return StyleViolation(type: .ForceCast,
                 location: Location(file: file, offset: range.location),
                 severity: .Error,
-                reason: "Force casts should be avoided")
+                reason: "Force casts should be avoided",
+                rule: self)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -19,7 +19,7 @@ public struct ForceCastRule: Rule {
                 location: Location(file: file, offset: range.location),
                 severity: .Error,
                 reason: "Force casts should be avoided",
-                rule: self)
+                ruleId: self.identifier)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -81,7 +81,7 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
                         severity: parameter.severity,
                         reason: "Function body should be span \(parameters.first!.value) lines " +
                         "or less: currently spans \(endLine - startLine) lines",
-                        rule: self)]
+                        ruleId: self.identifier)]
                 }
             }
         }

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -80,7 +80,8 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
                         location: location,
                         severity: parameter.severity,
                         reason: "Function body should be span \(parameters.first!.value) lines " +
-                        "or less: currently spans \(endLine - startLine) lines")]
+                        "or less: currently spans \(endLine - startLine) lines",
+                        rule: self)]
                 }
             }
         }

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -23,7 +23,7 @@ public struct LeadingWhitespaceRule: Rule {
                 severity: .Warning,
                 reason: "File shouldn't start with whitespace: " +
                 "currently starts with \(countOfLeadingWhitespace) whitespace characters",
-                rule: self)]
+                ruleId: self.identifier)]
         }
         return []
     }

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -22,7 +22,8 @@ public struct LeadingWhitespaceRule: Rule {
                 location: Location(file: file.path, line: 1),
                 severity: .Warning,
                 reason: "File shouldn't start with whitespace: " +
-                "currently starts with \(countOfLeadingWhitespace) whitespace characters")]
+                "currently starts with \(countOfLeadingWhitespace) whitespace characters",
+                rule: self)]
         }
         return []
     }

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -33,7 +33,7 @@ public struct LineLengthRule: ParameterizedRule {
                         severity: parameter.severity,
                         reason: "Line should be \(parameters.first!.value) characters or less: " +
                         "currently \(line.content.characters.count) characters",
-                        rule: self)
+                        ruleId: self.identifier)
                 }
             }
             return nil

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -32,7 +32,8 @@ public struct LineLengthRule: ParameterizedRule {
                         location: Location(file: file.path, line: line.index),
                         severity: parameter.severity,
                         reason: "Line should be \(parameters.first!.value) characters or less: " +
-                        "currently \(line.content.characters.count) characters")
+                        "currently \(line.content.characters.count) characters",
+                        rule: self)
                 }
             }
             return nil

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -56,16 +56,16 @@ public struct NestingRule: ASTRule {
             if level > 1 && typeKinds.contains(kind) {
                 violations.append(StyleViolation(type: .Nesting,
                     location: Location(file: file, offset: offset),
-                    reason: "Types should be nested at most 1 level deep"))
+                    reason: "Types should be nested at most 1 level deep", rule: self))
             } else if level > 2 && kind == .Enumelement {
                 // Enum elements are implicitly wrapped in an .Enumcase
                 violations.append(StyleViolation(type: .Nesting,
                     location: Location(file: file, offset: offset),
-                    reason: "Types should be nested at most 1 level deep"))
+                    reason: "Types should be nested at most 1 level deep", rule: self))
             } else if level > 5 {
                 violations.append(StyleViolation(type: .Nesting,
                     location: Location(file: file, offset: offset),
-                    reason: "Statements should be nested at most 5 levels deep"))
+                    reason: "Statements should be nested at most 5 levels deep", rule: self))
             }
         }
         let substructure = dictionary["key.substructure"] as? XPCArray ?? []

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -53,19 +53,18 @@ public struct NestingRule: ASTRule {
             .Enumcase
         ]
         if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+            let location = Location(file: file, offset: offset)
             if level > 1 && typeKinds.contains(kind) {
-                violations.append(StyleViolation(type: .Nesting,
-                    location: Location(file: file, offset: offset),
-                    reason: "Types should be nested at most 1 level deep", rule: self))
+                violations.append(StyleViolation(type: .Nesting, location: location,
+                    reason: "Types should be nested at most 1 level deep", ruleId: self.identifier))
             } else if level > 2 && kind == .Enumelement {
                 // Enum elements are implicitly wrapped in an .Enumcase
-                violations.append(StyleViolation(type: .Nesting,
-                    location: Location(file: file, offset: offset),
-                    reason: "Types should be nested at most 1 level deep", rule: self))
+                violations.append(StyleViolation(type: .Nesting, location: location,
+                    reason: "Types should be nested at most 1 level deep", ruleId: self.identifier))
             } else if level > 5 {
-                violations.append(StyleViolation(type: .Nesting,
-                    location: Location(file: file, offset: offset),
-                    reason: "Statements should be nested at most 5 levels deep", rule: self))
+                violations.append(StyleViolation(type: .Nesting, location: location,
+                    reason: "Statements should be nested at most 5 levels deep",
+                    ruleId: self.identifier))
             }
         }
         let substructure = dictionary["key.substructure"] as? XPCArray ?? []

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -29,7 +29,8 @@ public struct OperatorFunctionWhitespaceRule: Rule {
             return StyleViolation(type: .OperatorFunctionWhitespace,
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
-                reason: example.ruleDescription)
+                reason: example.ruleDescription,
+                rule: self)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -30,7 +30,7 @@ public struct OperatorFunctionWhitespaceRule: Rule {
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
                 reason: example.ruleDescription,
-                rule: self)
+                ruleId: self.identifier)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -31,7 +31,8 @@ public struct ReturnArrowWhitespaceRule: Rule {
             return StyleViolation(type: .ReturnArrowWhitespace,
                 location: Location(file: file, offset: match.location),
                 severity: .Warning,
-                reason: "File should have 1 space before return arrow and return type")
+                reason: "File should have 1 space before return arrow and return type",
+                rule: self)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -32,7 +32,7 @@ public struct ReturnArrowWhitespaceRule: Rule {
                 location: Location(file: file, offset: match.location),
                 severity: .Warning,
                 reason: "File should have 1 space before return arrow and return type",
-                rule: self)
+                ruleId: self.identifier)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -29,7 +29,7 @@ public struct TodoRule: Rule {
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
                 reason: "TODOs and FIXMEs should be avoided",
-                rule: self)
+                ruleId: self.identifier)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -28,7 +28,8 @@ public struct TodoRule: Rule {
             return StyleViolation(type: .TODO,
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
-                reason: "TODOs and FIXMEs should be avoided")
+                reason: "TODOs and FIXMEs should be avoided",
+                rule: self)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -26,7 +26,7 @@ public struct TrailingNewlineRule: Rule {
                 location: Location(file: file.path, line: max(file.lines.count, 1)),
                 severity: .Warning,
                 reason: "File should have a single trailing newline",
-                rule: self)]
+                ruleId: self.identifier)]
         }
 
         return []

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -25,7 +25,8 @@ public struct TrailingNewlineRule: Rule {
             return [StyleViolation(type: .TrailingNewline,
                 location: Location(file: file.path, line: max(file.lines.count, 1)),
                 severity: .Warning,
-                reason: "File should have a single trailing newline")]
+                reason: "File should have a single trailing newline",
+                rule: self)]
         }
 
         return []

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -20,7 +20,8 @@ public struct TrailingWhitespaceRule: Rule {
             StyleViolation(type: .TrailingWhitespace,
                 location: Location(file: file.path, line: $0.index),
                 severity: .Warning,
-                reason: "Line #\($0.index) should have no trailing whitespace")
+                reason: "Line #\($0.index) should have no trailing whitespace",
+                rule: self)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -21,7 +21,7 @@ public struct TrailingWhitespaceRule: Rule {
                 location: Location(file: file.path, line: $0.index),
                 severity: .Warning,
                 reason: "Line #\($0.index) should have no trailing whitespace",
-                rule: self)
+                ruleId: self.identifier)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -70,7 +70,7 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
                         severity: parameter.severity,
                         reason: "Type body should be span \(parameters.first!.value) lines " +
                         "or less: currently spans \(endLine - startLine) lines",
-                        rule: self)]
+                        ruleId: self.identifier)]
                 }
             }
         }

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -69,7 +69,8 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
                         location: location,
                         severity: parameter.severity,
                         reason: "Type body should be span \(parameters.first!.value) lines " +
-                        "or less: currently spans \(endLine - startLine) lines")]
+                        "or less: currently spans \(endLine - startLine) lines",
+                        rule: self)]
                 }
             }
         }

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -58,20 +58,20 @@ public struct TypeNameRule: ASTRule {
                     location: location,
                     severity: .Error,
                     reason: "Type name should only contain alphanumeric characters: '\(name)'",
-                    rule: self))
+                    ruleId: self.identifier))
             } else if !name.substringToIndex(name.startIndex.successor()).isUppercase() {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Error,
                     reason: "Type name should start with an uppercase character: '\(name)'",
-                    rule: self))
+                    ruleId: self.identifier))
             } else if name.characters.count < 3 || name.characters.count > 40 {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Warning,
                     reason: "Type name should be between 3 and 40 characters in length: " +
                     "'\(name)'",
-                    rule: self))
+                    ruleId: self.identifier))
             }
         }
         return violations

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -57,18 +57,21 @@ public struct TypeNameRule: ASTRule {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Error,
-                    reason: "Type name should only contain alphanumeric characters: '\(name)'"))
+                    reason: "Type name should only contain alphanumeric characters: '\(name)'",
+                    rule: self))
             } else if !name.substringToIndex(name.startIndex.successor()).isUppercase() {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Error,
-                    reason: "Type name should start with an uppercase character: '\(name)'"))
+                    reason: "Type name should start with an uppercase character: '\(name)'",
+                    rule: self))
             } else if name.characters.count < 3 || name.characters.count > 40 {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Warning,
                     reason: "Type name should be between 3 and 40 characters in length: " +
-                    "'\(name)'"))
+                    "'\(name)'",
+                    rule: self))
             }
         }
         return violations

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -59,20 +59,20 @@ public struct VariableNameRule: ASTRule {
                     location: location,
                     severity: .Error,
                     reason: "Variable name should only contain alphanumeric characters: '\(name)'",
-                    rule: self))
+                    ruleId: self.identifier))
             } else if name.substringToIndex(name.startIndex.successor()).isUppercase() {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Error,
                     reason: "Variable name should start with a lowercase character: '\(name)'",
-                    rule: self))
+                    ruleId: self.identifier))
             } else if name.characters.count < 3 || name.characters.count > 40 {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Warning,
                     reason: "Variable name should be between 3 and 40 characters in length: " +
                     "'\(name)'",
-                    rule: self))
+                    ruleId: self.identifier))
             }
         }
         return violations

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -58,18 +58,21 @@ public struct VariableNameRule: ASTRule {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Error,
-                    reason: "Variable name should only contain alphanumeric characters: '\(name)'"))
+                    reason: "Variable name should only contain alphanumeric characters: '\(name)'",
+                    rule: self))
             } else if name.substringToIndex(name.startIndex.successor()).isUppercase() {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Error,
-                    reason: "Variable name should start with a lowercase character: '\(name)'"))
+                    reason: "Variable name should start with a lowercase character: '\(name)'",
+                    rule: self))
             } else if name.characters.count < 3 || name.characters.count > 40 {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Warning,
                     reason: "Variable name should be between 3 and 40 characters in length: " +
-                    "'\(name)'"))
+                    "'\(name)'",
+                    rule: self))
             }
         }
         return violations

--- a/Source/SwiftLintFramework/StyleViolation.swift
+++ b/Source/SwiftLintFramework/StyleViolation.swift
@@ -10,23 +10,27 @@ public struct StyleViolation: CustomStringConvertible, Equatable {
     public let type: StyleViolationType
     public let severity: ViolationSeverity
     public let location: Location
+    public let rule: Rule?
     public let reason: String?
     public var description: String {
         return XcodeReporter.generateForSingleViolation(self)
     }
 
-    public init(type: StyleViolationType, location: Location, reason: String? = nil) {
-        self.init(type: type, location: location, severity: .Warning, reason: reason)
+    public init(type: StyleViolationType, location: Location,
+        reason: String? = nil, rule: Rule? = nil) {
+        self.init(type: type, location: location, severity: .Warning, reason: reason, rule: rule)
     }
 
     public init(type: StyleViolationType,
         location: Location,
         severity: ViolationSeverity,
-        reason: String? = nil) {
+        reason: String? = nil,
+        rule: Rule? = nil) {
         self.severity = severity
         self.type = type
         self.location = location
         self.reason = reason
+        self.rule = rule
     }
 }
 

--- a/Source/SwiftLintFramework/StyleViolation.swift
+++ b/Source/SwiftLintFramework/StyleViolation.swift
@@ -10,27 +10,28 @@ public struct StyleViolation: CustomStringConvertible, Equatable {
     public let type: StyleViolationType
     public let severity: ViolationSeverity
     public let location: Location
-    public let rule: Rule?
+    public let ruleId: String?
     public let reason: String?
     public var description: String {
         return XcodeReporter.generateForSingleViolation(self)
     }
 
     public init(type: StyleViolationType, location: Location,
-        reason: String? = nil, rule: Rule? = nil) {
-        self.init(type: type, location: location, severity: .Warning, reason: reason, rule: rule)
+        reason: String? = nil, ruleId: String? = nil) {
+        self.init(type: type, location: location, severity: .Warning,
+            reason: reason, ruleId: ruleId)
     }
 
     public init(type: StyleViolationType,
         location: Location,
         severity: ViolationSeverity,
         reason: String? = nil,
-        rule: Rule? = nil) {
+        ruleId: String? = nil) {
         self.severity = severity
         self.type = type
         self.location = location
         self.reason = reason
-        self.rule = rule
+        self.ruleId = ruleId
     }
 }
 

--- a/Source/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Source/SwiftLintFrameworkTests/ReporterTests.swift
@@ -29,8 +29,8 @@ class ReporterTests: XCTestCase {
     func testXcodeReporter() {
         XCTAssertEqual(
             XcodeReporter.generateReport(generateViolations()),
-            "filename:1:2: warning: Length Violation: Violation Reason.\n" +
-            "filename:1:2: error: Length Violation: Violation Reason."
+            "filename:1:2: warning: Length Violation: Violation Reason. (line_length)\n" +
+            "filename:1:2: error: Length Violation: Violation Reason. (line_length)"
         )
     }
 

--- a/Source/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Source/SwiftLintFrameworkTests/ReporterTests.swift
@@ -11,15 +11,18 @@ import XCTest
 
 class ReporterTests: XCTestCase {
     func generateViolations() -> [StyleViolation] {
+        let rule: Rule = LineLengthRule()
         return [
             StyleViolation(type: .Length,
                 location: Location(file: "filename", line: 1, character: 2),
                 severity: .Warning,
-                reason: "Violation Reason."),
+                reason: "Violation Reason.",
+                rule: rule),
             StyleViolation(type: .Length,
                 location: Location(file: "filename", line: 1, character: 2),
                 severity: .Error,
-                reason: "Violation Reason.")
+                reason: "Violation Reason.",
+                rule: rule)
         ]
     }
 
@@ -36,20 +39,22 @@ class ReporterTests: XCTestCase {
             JSONReporter.generateReport(generateViolations()),
             "[\n" +
                 "  {\n" +
-                "    \"type\" : \"Length\",\n" +
-                "    \"line\" : 1,\n" +
                 "    \"reason\" : \"Violation Reason.\",\n" +
-                "    \"file\" : \"filename\",\n" +
                 "    \"character\" : 2,\n" +
-                "    \"severity\" : \"Warning\"\n" +
+                "    \"file\" : \"filename\",\n" +
+                "    \"rule_id\" : \"line_length\",\n" +
+                "    \"line\" : 1,\n" +
+                "    \"severity\" : \"Warning\",\n" +
+                "    \"type\" : \"Length\"\n" +
                 "  },\n" +
                 "  {\n" +
-                "    \"type\" : \"Length\",\n" +
-                "    \"line\" : 1,\n" +
                 "    \"reason\" : \"Violation Reason.\",\n" +
-                "    \"file\" : \"filename\",\n" +
                 "    \"character\" : 2,\n" +
-                "    \"severity\" : \"Error\"\n" +
+                "    \"file\" : \"filename\",\n" +
+                "    \"rule_id\" : \"line_length\",\n" +
+                "    \"line\" : 1,\n" +
+                "    \"severity\" : \"Error\",\n" +
+                "    \"type\" : \"Length\"\n" +
                 "  }\n" +
             "]"
         )
@@ -58,9 +63,9 @@ class ReporterTests: XCTestCase {
     func testCSVReporter() {
         XCTAssertEqual(
             CSVReporter.generateReport(generateViolations()),
-            "file,line,character,severity,type,reason," +
-            "filename,1,2,Warning,Length,Violation Reason.," +
-            "filename,1,2,Error,Length,Violation Reason."
+            "file,line,character,severity,type,reason,rule_id," +
+            "filename,1,2,Warning,Length,Violation Reason.,line_length," +
+            "filename,1,2,Error,Length,Violation Reason.,line_length"
         )
     }
 }

--- a/Source/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Source/SwiftLintFrameworkTests/ReporterTests.swift
@@ -17,12 +17,12 @@ class ReporterTests: XCTestCase {
                 location: Location(file: "filename", line: 1, character: 2),
                 severity: .Warning,
                 reason: "Violation Reason.",
-                rule: rule),
+                ruleId: rule.identifier),
             StyleViolation(type: .Length,
                 location: Location(file: "filename", line: 1, character: 2),
                 severity: .Error,
                 reason: "Violation Reason.",
-                rule: rule)
+                ruleId: rule.identifier)
         ]
     }
 

--- a/Source/swiftlint/RulesCommand.swift
+++ b/Source/swiftlint/RulesCommand.swift
@@ -16,7 +16,7 @@ struct RulesCommand: CommandType {
 
     func run(mode: CommandMode) -> Result<(), CommandantError<()>> {
         let ruleDescriptions = Configuration.rulesFromYAML(nil)
-            .map({ "\($0.example.ruleName) (\($0.identifier))" })
+            .map({ "\($0.example.ruleName) (\($0.identifier)): \($0.example.ruleDescription)"})
             .joinWithSeparator("\n")
         print(ruleDescriptions)
         return .Success()


### PR DESCRIPTION
Hi,

In this pull request I added a Rule reference to StyleViolation in order to be able to retrieve the rule matching a violation when generating a report.

I also added a rule id field on the 3 reporters.

Finally: I slightly modified the 'rules' command output in order to make it easier to process as well.

My goal is to integrate SwiftLint to a SonarQube plugin for Swift