### PR TITLE
All rules now print their identifiers in reports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Master
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* All rules now print their identifiers in reports.  
+  [JP Simard](https://github.com/jpsim)
+  [#180](https://github.com/realm/SwiftLint/issues/180)
+
+
 ## 0.3.0: Wrinkly Rules
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -22,8 +22,8 @@ public struct ColonRule: Rule {
             return StyleViolation(type: .Colon,
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
-                reason: "When specifying a type, always associate the colon with the identifier",
-                ruleId: self.identifier)
+                ruleId: self.identifier,
+                reason: "When specifying a type, always associate the colon with the identifier")
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -22,6 +22,7 @@ public struct CommaRule: Rule {
             return StyleViolation(type: .Comma,
                 location: Location(file: file, offset: match.location),
                 severity: .Warning,
+                ruleId: self.identifier,
                 reason: "One space before and no after must be present next to " +
                 "commas")
         }

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -26,9 +26,9 @@ public struct ControlStatementRule: Rule {
                 return StyleViolation(type: .ControlStatement,
                     location: Location(file: file, offset: match.location),
                     severity: .Warning,
+                    ruleId: self.identifier,
                     reason: "\(statementKind) statements shouldn't wrap their conditionals in " +
-                    "parentheses.",
-                    ruleId: self.identifier)
+                    "parentheses.")
                 }
         }
     }

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -31,9 +31,9 @@ public struct FileLengthRule: ParameterizedRule {
                 return [StyleViolation(type: .Length,
                     location: Location(file: file.path, line: lineCount),
                     severity: parameter.severity,
+                    ruleId: self.identifier,
                     reason: "File should contain \(parameters.first!.value) lines or less: " +
-                    "currently contains \(lineCount)",
-                    ruleId: self.identifier)]
+                    "currently contains \(lineCount)")]
             }
         }
         return []

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -18,8 +18,8 @@ public struct ForceCastRule: Rule {
             return StyleViolation(type: .ForceCast,
                 location: Location(file: file, offset: range.location),
                 severity: .Error,
-                reason: "Force casts should be avoided",
-                ruleId: self.identifier)
+                ruleId: self.identifier,
+                reason: "Force casts should be avoided")
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -79,9 +79,9 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
                     return [StyleViolation(type: .Length,
                         location: location,
                         severity: parameter.severity,
+                        ruleId: self.identifier,
                         reason: "Function body should be span \(parameters.first!.value) lines " +
-                        "or less: currently spans \(endLine - startLine) lines",
-                        ruleId: self.identifier)]
+                        "or less: currently spans \(endLine - startLine) lines")]
                 }
             }
         }

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -21,9 +21,9 @@ public struct LeadingWhitespaceRule: Rule {
             return [StyleViolation(type: .LeadingWhitespace,
                 location: Location(file: file.path, line: 1),
                 severity: .Warning,
+                ruleId: self.identifier,
                 reason: "File shouldn't start with whitespace: " +
-                "currently starts with \(countOfLeadingWhitespace) whitespace characters",
-                ruleId: self.identifier)]
+                "currently starts with \(countOfLeadingWhitespace) whitespace characters")]
         }
         return []
     }

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -31,9 +31,9 @@ public struct LineLengthRule: ParameterizedRule {
                     return StyleViolation(type: .Length,
                         location: Location(file: file.path, line: line.index),
                         severity: parameter.severity,
+                        ruleId: self.identifier,
                         reason: "Line should be \(parameters.first!.value) characters or less: " +
-                        "currently \(line.content.characters.count) characters",
-                        ruleId: self.identifier)
+                        "currently \(line.content.characters.count) characters")
                 }
             }
             return nil

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -56,15 +56,15 @@ public struct NestingRule: ASTRule {
             let location = Location(file: file, offset: offset)
             if level > 1 && typeKinds.contains(kind) {
                 violations.append(StyleViolation(type: .Nesting, location: location,
-                    reason: "Types should be nested at most 1 level deep", ruleId: self.identifier))
+                    ruleId: self.identifier, reason: "Types should be nested at most 1 level deep"))
             } else if level > 2 && kind == .Enumelement {
                 // Enum elements are implicitly wrapped in an .Enumcase
                 violations.append(StyleViolation(type: .Nesting, location: location,
-                    reason: "Types should be nested at most 1 level deep", ruleId: self.identifier))
+                    ruleId: self.identifier, reason: "Types should be nested at most 1 level deep"))
             } else if level > 5 {
                 violations.append(StyleViolation(type: .Nesting, location: location,
-                    reason: "Statements should be nested at most 5 levels deep",
-                    ruleId: self.identifier))
+                    ruleId: self.identifier,
+                    reason: "Statements should be nested at most 5 levels deep"))
             }
         }
         let substructure = dictionary["key.substructure"] as? XPCArray ?? []

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -22,6 +22,7 @@ public struct OpeningBraceRule: Rule {
             return StyleViolation(type: StyleViolationType.OpeningBrace,
                 location: Location(file: file, offset: match.location),
                 severity: .Warning,
+                ruleId: self.identifier,
                 reason: "Opening brace after a space and on same line " +
                 "as declaration")
         }

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -29,8 +29,8 @@ public struct OperatorFunctionWhitespaceRule: Rule {
             return StyleViolation(type: .OperatorFunctionWhitespace,
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
-                reason: example.ruleDescription,
-                ruleId: self.identifier)
+                ruleId: self.identifier,
+                reason: example.ruleDescription)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -31,8 +31,8 @@ public struct ReturnArrowWhitespaceRule: Rule {
             return StyleViolation(type: .ReturnArrowWhitespace,
                 location: Location(file: file, offset: match.location),
                 severity: .Warning,
-                reason: "File should have 1 space before return arrow and return type",
-                ruleId: self.identifier)
+                ruleId: self.identifier,
+                reason: "File should have 1 space before return arrow and return type")
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -22,6 +22,7 @@ public struct StatementPositionRule: Rule {
             return StyleViolation(type: .StatementPosition,
                 location: Location(file: file, offset: match.location),
                 severity: .Warning,
+                ruleId: self.identifier,
                 reason: "Else and catch must be on the same line and one space " +
                     "after previous declaration")
         }

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -28,8 +28,8 @@ public struct TodoRule: Rule {
             return StyleViolation(type: .TODO,
                 location: Location(file: file, offset: range.location),
                 severity: .Warning,
-                reason: "TODOs and FIXMEs should be avoided",
-                ruleId: self.identifier)
+                ruleId: self.identifier,
+                reason: "TODOs and FIXMEs should be avoided")
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -25,8 +25,8 @@ public struct TrailingNewlineRule: Rule {
             return [StyleViolation(type: .TrailingNewline,
                 location: Location(file: file.path, line: max(file.lines.count, 1)),
                 severity: .Warning,
-                reason: "File should have a single trailing newline",
-                ruleId: self.identifier)]
+                ruleId: self.identifier,
+                reason: "File should have a single trailing newline")]
         }
 
         return []

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -20,8 +20,8 @@ public struct TrailingWhitespaceRule: Rule {
             StyleViolation(type: .TrailingWhitespace,
                 location: Location(file: file.path, line: $0.index),
                 severity: .Warning,
-                reason: "Line #\($0.index) should have no trailing whitespace",
-                ruleId: self.identifier)
+                ruleId: self.identifier,
+                reason: "Line #\($0.index) should have no trailing whitespace")
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -68,9 +68,9 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
                     return [StyleViolation(type: .Length,
                         location: location,
                         severity: parameter.severity,
+                        ruleId: self.identifier,
                         reason: "Type body should be span \(parameters.first!.value) lines " +
-                        "or less: currently spans \(endLine - startLine) lines",
-                        ruleId: self.identifier)]
+                        "or less: currently spans \(endLine - startLine) lines")]
                 }
             }
         }

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -57,21 +57,21 @@ public struct TypeNameRule: ASTRule {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Error,
-                    reason: "Type name should only contain alphanumeric characters: '\(name)'",
-                    ruleId: self.identifier))
+                    ruleId: self.identifier,
+                    reason: "Type name should only contain alphanumeric characters: '\(name)'"))
             } else if !name.substringToIndex(name.startIndex.successor()).isUppercase() {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Error,
-                    reason: "Type name should start with an uppercase character: '\(name)'",
-                    ruleId: self.identifier))
+                    ruleId: self.identifier,
+                    reason: "Type name should start with an uppercase character: '\(name)'"))
             } else if name.characters.count < 3 || name.characters.count > 40 {
                 violations.append(StyleViolation(type: .NameFormat,
                     location: location,
                     severity: .Warning,
+                    ruleId: self.identifier,
                     reason: "Type name should be between 3 and 40 characters in length: " +
-                    "'\(name)'",
-                    ruleId: self.identifier))
+                    "'\(name)'"))
             }
         }
         return violations

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -90,21 +90,21 @@ extension String {
             violations.append(StyleViolation(type: .NameFormat,
                 location: location,
                 severity: .Error,
-                reason: "Variable name should only contain alphanumeric characters: '\(name)'",
-                ruleId: identifier))
+                ruleId: identifier,
+                reason: "Variable name should only contain alphanumeric characters: '\(name)'"))
         } else if name.substringToIndex(name.startIndex.successor()).isUppercase() {
             violations.append(StyleViolation(type: .NameFormat,
                 location: location,
                 severity: .Error,
-                reason: "Variable name should start with a lowercase character: '\(name)'",
-                ruleId: identifier))
+                ruleId: identifier,
+                reason: "Variable name should start with a lowercase character: '\(name)'"))
         } else if name.characters.count < 3 || name.characters.count > 40 {
             violations.append(StyleViolation(type: .NameFormat,
                 location: location,
                 severity: .Warning,
+                ruleId: identifier,
                 reason: "Variable name should be between 3 and 40 characters in length: " +
-                "'\(name)'",
-                ruleId: identifier))
+                "'\(name)'"))
         }
         return violations
     }

--- a/Source/SwiftLintFramework/StyleViolation.swift
+++ b/Source/SwiftLintFramework/StyleViolation.swift
@@ -10,23 +10,23 @@ public struct StyleViolation: CustomStringConvertible, Equatable {
     public let type: StyleViolationType
     public let severity: ViolationSeverity
     public let location: Location
-    public let ruleId: String?
+    public let ruleId: String
     public let reason: String?
     public var description: String {
         return XcodeReporter.generateForSingleViolation(self)
     }
 
-    public init(type: StyleViolationType, location: Location,
-        reason: String? = nil, ruleId: String? = nil) {
-        self.init(type: type, location: location, severity: .Warning,
-            reason: reason, ruleId: ruleId)
+    public init(type: StyleViolationType, location: Location, ruleId: String,
+        reason: String? = nil) {
+        self.init(type: type, location: location, severity: .Warning, ruleId: ruleId,
+            reason: reason)
     }
 
     public init(type: StyleViolationType,
         location: Location,
         severity: ViolationSeverity,
-        reason: String? = nil,
-        ruleId: String? = nil) {
+        ruleId: String,
+        reason: String? = nil) {
         self.severity = severity
         self.type = type
         self.location = location

--- a/Source/SwiftLintFrameworkTests/ASTRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/ASTRuleTests.swift
@@ -17,16 +17,19 @@ class ASTRuleTests: XCTestCase {
             XCTAssertEqual(violations("\(kind) Ab_ {}\n"), [StyleViolation(type: .NameFormat,
                 location: Location(file: nil, line: 1, character: 1),
                 severity: .Error,
+                ruleId: "type_name",
                 reason: "Type name should only contain alphanumeric characters: 'Ab_'")])
 
             XCTAssertEqual(violations("\(kind) abc {}\n"), [StyleViolation(type: .NameFormat,
                 location: Location(file: nil, line: 1, character: 1),
                 severity: .Error,
+                ruleId: "type_name",
                 reason: "Type name should start with an uppercase character: 'abc'")])
 
             XCTAssertEqual(violations("\(kind) Ab {}\n"), [StyleViolation(type: .NameFormat,
                 location: Location(file: nil, line: 1, character: 1),
                 severity: .Warning,
+                ruleId: "type_name",
                 reason: "Type name should be between 3 and 40 characters in length: 'Ab'")])
 
             let longName = Repeat(count: 40, repeatedValue: "A").joinWithSeparator("")
@@ -36,6 +39,7 @@ class ASTRuleTests: XCTestCase {
                 StyleViolation(type: .NameFormat,
                     location: Location(file: nil, line: 1, character: 1),
                     severity: .Warning,
+                    ruleId: "type_name",
                     reason: "Type name should be between 3 and 40 characters in length: " +
                     "'\(longerName)'")
                 ])
@@ -49,6 +53,7 @@ class ASTRuleTests: XCTestCase {
                 StyleViolation(type: .NameFormat,
                     location: Location(file: nil, line: 2, character: 5),
                     severity: .Error,
+                    ruleId: "type_name",
                     reason: "Type name should start with an uppercase character: 'def'")
             ]
         )
@@ -59,29 +64,28 @@ class ASTRuleTests: XCTestCase {
             for varType in ["var", "let"] {
                 let characterOffset = 8 + kind.characters.count
                 XCTAssertEqual(violations("\(kind) Abc { \(varType) def: Void }\n"), [])
-
                 XCTAssertEqual(violations("\(kind) Abc { \(varType) de_: Void }\n"), [
                     StyleViolation(type: .NameFormat,
                         location: Location(file: nil, line: 1, character: characterOffset),
                         severity: .Error,
+                        ruleId: "variable_name",
                         reason: "Variable name should only contain alphanumeric characters: 'de_'")
                     ])
-
                 XCTAssertEqual(violations("\(kind) Abc { \(varType) Def: Void }\n"), [
                     StyleViolation(type: .NameFormat,
                         location: Location(file: nil, line: 1, character: characterOffset),
                         severity: .Error,
+                        ruleId: "variable_name",
                         reason: "Variable name should start with a lowercase character: 'Def'")
                     ])
-
                 XCTAssertEqual(violations("\(kind) Abc { \(varType) de: Void }\n"), [
                     StyleViolation(type: .NameFormat,
                         location: Location(file: nil, line: 1, character: characterOffset),
                         severity: .Warning,
+                        ruleId: "variable_name",
                         reason: "Variable name should be between 3 and 40 characters in length: " +
                         "'de'")
                     ])
-
                 let longName = Repeat(count: 40, repeatedValue: "d").joinWithSeparator("")
                 XCTAssertEqual(violations("\(kind) Abc { \(varType) \(longName): Void }\n"), [])
                 let longerName = longName + "d"
@@ -89,6 +93,7 @@ class ASTRuleTests: XCTestCase {
                     StyleViolation(type: .NameFormat,
                         location: Location(file: nil, line: 1, character: characterOffset),
                         severity: .Warning,
+                        ruleId: "variable_name",
                         reason: "Variable name should be between 3 and 40 characters in length: " +
                         "'\(longerName)'")
                     ])
@@ -107,6 +112,7 @@ class ASTRuleTests: XCTestCase {
         XCTAssertEqual(violations(longerFunctionBody), [StyleViolation(type: .Length,
             location: Location(file: nil, line: 1, character: 1),
             severity: .Warning,
+            ruleId: "function_body_length",
             reason: "Function body should be span 40 lines or less: currently spans 41 lines")])
     }
 
@@ -122,6 +128,7 @@ class ASTRuleTests: XCTestCase {
             XCTAssertEqual(violations(longerTypeBody), [StyleViolation(type: .Length,
                 location: Location(file: nil, line: 1, character: 1),
                 severity: .Warning,
+                ruleId: "type_body_length",
                 reason: "Type body should be span 200 lines or less: currently spans 201 lines")])
         }
     }

--- a/Source/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Source/SwiftLintFrameworkTests/ReporterTests.swift
@@ -16,13 +16,13 @@ class ReporterTests: XCTestCase {
             StyleViolation(type: .Length,
                 location: Location(file: "filename", line: 1, character: 2),
                 severity: .Warning,
-                reason: "Violation Reason.",
-                ruleId: rule.identifier),
+                ruleId: rule.identifier,
+                reason: "Violation Reason."),
             StyleViolation(type: .Length,
                 location: Location(file: "filename", line: 1, character: 2),
                 severity: .Error,
-                reason: "Violation Reason.",
-                ruleId: rule.identifier)
+                ruleId: rule.identifier,
+                reason: "Violation Reason.")
         ]
     }
 

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -21,6 +21,7 @@ class StringRuleTests: XCTestCase {
             XCTAssertEqual(violations(testCase.0 + longLine), [StyleViolation(type: .Length,
                 location: Location(file: nil, line: 1),
                 severity: testCase.2,
+                ruleId: "line_length",
                 reason: "Line should be 100 characters or less: " +
                 "currently \(testCase.1) characters")])
         }
@@ -31,10 +32,12 @@ class StringRuleTests: XCTestCase {
         XCTAssertEqual(violations(""), [StyleViolation(type: .TrailingNewline,
             location: Location(file: nil, line: 1),
             severity: .Warning,
+            ruleId: "trailing_newline",
             reason: "File should have a single trailing newline")])
         XCTAssertEqual(violations("//\n\n"), [StyleViolation(type: .TrailingNewline,
             location: Location(file: nil, line: 2),
             severity: .Warning,
+            ruleId: "trailing_newline",
             reason: "File should have a single trailing newline")])
     }
 
@@ -51,6 +54,7 @@ class StringRuleTests: XCTestCase {
             XCTAssertEqual(violations(testCase.0), [StyleViolation(type: .Length,
                 location: Location(file: nil, line: testCase.1),
                 severity: testCase.2,
+                ruleId: "file_length",
                 reason: "File should contain 400 lines or less: currently contains \(testCase.1)")])
         }
     }


### PR DESCRIPTION
Fixes #180. It's super obvious that there's a lot of duplicated information at the moment between style violations and rules, where they mostly map 1-to-1. We should definitely refactor that.