### PR TITLE
Fixed disable/enable rules documentation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ directory to see the currently implemented rules.
 
 Rules can be disabled with a comment inside a source file with the following format: 
 
-`/// swiftlint:disable <rule>`
+`// swiftlint:disable <rule>`
 
 The rule will be disabled until the end of the file or until the linter sees a matching enable comment:
 
-`/// swiftlint:enable <rule>`
+`// swiftlint:enable <rule>`
 
 For example:
 


### PR DESCRIPTION
The disable/enabled documentation in the README was incorrect, it should have 2 slashes instead of 3.