### PR TITLE
move ASTRule function implementations into a protocol extension

### DIFF
--- a/Source/SwiftLintFramework/ASTRule.swift
+++ b/Source/SwiftLintFramework/ASTRule.swift
@@ -10,9 +10,25 @@ import SourceKittenFramework
 import SwiftXPC
 
 public protocol ASTRule: Rule {
-    func validateFile(file: File, dictionary: XPCDictionary) -> [StyleViolation]
-
     func validateFile(file: File,
-        kind: SwiftDeclarationKind,
-        dictionary: XPCDictionary) -> [StyleViolation]
+        kind: SwiftDeclarationKind, dictionary: XPCDictionary) -> [StyleViolation]
+}
+
+extension ASTRule {
+    public func validateFile(file: File) -> [StyleViolation] {
+        return validateFile(file, dictionary: file.structure.dictionary)
+    }
+
+    public func validateFile(file: File, dictionary: XPCDictionary) -> [StyleViolation] {
+        let substructure = dictionary["key.substructure"] as? XPCArray ?? []
+        return substructure.flatMap { subItem -> [StyleViolation] in
+            guard let subDict = subItem as? XPCDictionary,
+                let kindString = subDict["key.kind"] as? String,
+                let kind = SwiftDeclarationKind(rawValue: kindString) else {
+                    return []
+            }
+            return self.validateFile(file, dictionary: subDict) +
+                self.validateFile(file, kind: kind, dictionary: subDict)
+        }
+    }
 }

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -29,26 +29,6 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
         description: "Enforce maximum function length"
     )
 
-    public func validateFile(file: File) -> [StyleViolation] {
-        return validateFile(file, dictionary: file.structure.dictionary)
-    }
-
-    public func validateFile(file: File, dictionary: XPCDictionary) -> [StyleViolation] {
-        let substructure = dictionary["key.substructure"] as? XPCArray ?? []
-        return substructure.flatMap { subItem -> [StyleViolation] in
-            var violations = [StyleViolation]()
-            if let subDict = subItem as? XPCDictionary,
-                let kindString = subDict["key.kind"] as? String,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
-                violations.appendContentsOf(
-                    self.validateFile(file, dictionary: subDict) +
-                    self.validateFile(file, kind: kind, dictionary: subDict)
-                )
-            }
-            return violations
-        }
-    }
-
     public func validateFile(file: File,
         kind: SwiftDeclarationKind,
         dictionary: XPCDictionary) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -30,26 +30,6 @@ public struct NestingRule: ASTRule {
         ]
     )
 
-    public func validateFile(file: File) -> [StyleViolation] {
-        return validateFile(file, dictionary: file.structure.dictionary)
-    }
-
-    public func validateFile(file: File, dictionary: XPCDictionary) -> [StyleViolation] {
-        let substructure = dictionary["key.substructure"] as? XPCArray ?? []
-        return substructure.flatMap { subItem -> [StyleViolation] in
-            var violations = [StyleViolation]()
-            if let subDict = subItem as? XPCDictionary,
-                let kindString = subDict["key.kind"] as? String,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
-                violations.appendContentsOf(
-                    self.validateFile(file, dictionary: subDict) +
-                    self.validateFile(file, kind: kind, dictionary: subDict)
-                )
-            }
-            return violations
-        }
-    }
-
     public func validateFile(file: File, kind: SwiftDeclarationKind,
         dictionary: XPCDictionary) -> [StyleViolation] {
         return validateFile(file, kind: kind, dictionary: dictionary, level: 0)

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -29,26 +29,6 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
         description: "Enforce maximum type body length"
     )
 
-    public func validateFile(file: File) -> [StyleViolation] {
-        return validateFile(file, dictionary: file.structure.dictionary)
-    }
-
-    public func validateFile(file: File, dictionary: XPCDictionary) -> [StyleViolation] {
-        let substructure = dictionary["key.substructure"] as? XPCArray ?? []
-        return substructure.flatMap { subItem -> [StyleViolation] in
-            var violations = [StyleViolation]()
-            if let subDict = subItem as? XPCDictionary,
-                let kindString = subDict["key.kind"] as? String,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
-                violations.appendContentsOf(
-                    self.validateFile(file, dictionary: subDict) +
-                    self.validateFile(file, kind: kind, dictionary: subDict)
-                )
-            }
-            return violations
-        }
-    }
-
     public func validateFile(file: File,
         kind: SwiftDeclarationKind,
         dictionary: XPCDictionary) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -29,26 +29,6 @@ public struct TypeNameRule: ASTRule {
         ]
     )
 
-    public func validateFile(file: File) -> [StyleViolation] {
-        return validateFile(file, dictionary: file.structure.dictionary)
-    }
-
-    public func validateFile(file: File, dictionary: XPCDictionary) -> [StyleViolation] {
-        let substructure = dictionary["key.substructure"] as? XPCArray ?? []
-        return substructure.flatMap { subItem -> [StyleViolation] in
-            var violations = [StyleViolation]()
-            if let subDict = subItem as? XPCDictionary,
-                let kindString = subDict["key.kind"] as? String,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
-                violations.appendContentsOf(
-                    self.validateFile(file, dictionary: subDict) +
-                    self.validateFile(file, kind: kind, dictionary: subDict)
-                )
-            }
-            return violations
-        }
-    }
-
     public func validateFile(file: File,
         kind: SwiftDeclarationKind,
         dictionary: XPCDictionary) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -30,26 +30,6 @@ public struct VariableNameRule: ASTRule {
         ]
     )
 
-    public func validateFile(file: File) -> [StyleViolation] {
-        return validateFile(file, dictionary: file.structure.dictionary)
-    }
-
-    public func validateFile(file: File, dictionary: XPCDictionary) -> [StyleViolation] {
-        let substructure = dictionary["key.substructure"] as? XPCArray ?? []
-        return substructure.flatMap { subItem -> [StyleViolation] in
-            var violations = [StyleViolation]()
-            if let subDict = subItem as? XPCDictionary,
-                let kindString = subDict["key.kind"] as? String,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
-                violations.appendContentsOf(
-                    self.validateFile(file, dictionary: subDict) +
-                    self.validateFile(file, kind: kind, dictionary: subDict)
-                )
-            }
-            return violations
-        }
-    }
-
     public func validateFile(file: File,
         kind: SwiftDeclarationKind,
         dictionary: XPCDictionary) -> [StyleViolation] {


### PR DESCRIPTION
I should have done this when moving to Swift 2.0.