### PR TITLE
Improve ControlStatementRule for issues #187 and #189

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,24 @@
   `OptionSetType` subclasses.  
   [Will Fleming](https://github.com/wfleming)
 
+* Add `VariableNameMaxLengthRule` and `VariableNameMinLengthRule` parameter rules. 
+  Remove length checks on `VariableNameRule`.  
+  [Mickael Morier](https://github.com/mmorier)
+
 ##### Bug Fixes
 
 * All rules now print their identifiers in reports.  
   [JP Simard](https://github.com/jpsim)
   [#180](https://github.com/realm/SwiftLint/issues/180)
+
+* `ControlStatementRule` now detects all violations.  
+  [Mickael Morier](https://github.com/mmorier)
+  [#187](https://github.com/realm/SwiftLint/issues/187)
+
+* `ControlStatementRule` no longer triggers a violation for acceptable use of 
+  parentheses.  
+  [Mickael Morier](https://github.com/mmorier)
+  [#189](https://github.com/realm/SwiftLint/issues/189)
 
 * Nesting rule no longer triggers a violation for enums nested one level deep.  
   [JP Simard](https://github.com/jpsim)

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -77,7 +77,10 @@ public struct ControlStatementRule: Rule {
             return true
         }
 
-        let lastClosingParenthesePosition = content.lastIndexOf(")")
+        guard let lastClosingParenthesePosition = content.lastIndexOf(")") else {
+            return false
+        }
+
         var depth = 0
         var index = 0
         for char in content.characters {

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -18,6 +18,8 @@ public struct ControlStatementRule: Rule {
         nonTriggeringExamples: [
             "if condition {\n",
             "if (a, b) == (0, 1) {\n",
+            "if (a || b) && (c || d) {\n",
+            "if (min...max).contains(value) {\n",
             "if renderGif(data) {\n",
             "renderGif(data)\n",
             "for item in collection {\n",
@@ -28,11 +30,13 @@ public struct ControlStatementRule: Rule {
             "while condition {\n",
             "} while condition {\n",
             "do { ; } while condition {\n",
-            "switch foo {\n",
+            "switch foo {\n"
         ],
         triggeringExamples: [
             "if (condition) {\n",
             "if(condition) {\n",
+            "if ((a || b) && (c || d)) {\n",
+            "if ((min...max).contains(value)) {\n",
             "for (item in collection) {\n",
             "for (var index = 0; index < 42; index++) {\n",
             "for(item in collection) {\n",
@@ -44,7 +48,7 @@ public struct ControlStatementRule: Rule {
             "} while(condition) {\n",
             "do { ; } while(condition) {\n",
             "do { ; } while (condition) {\n",
-            "switch (foo) {\n",
+            "switch (foo) {\n"
         ]
     )
 
@@ -52,10 +56,11 @@ public struct ControlStatementRule: Rule {
         let statements = ["if", "for", "guard", "switch", "while"]
         return statements.flatMap { statementKind -> [StyleViolation] in
             let pattern = statementKind == "guard"
-                ? "\(statementKind)\\s*\\([^,]*\\)\\s*else\\s*\\{"
-                : "\(statementKind)\\s*\\([^,]*\\)\\s*\\{"
+                ? "\(statementKind)\\s*\\([^,{]*\\)\\s*else\\s*\\{"
+                : "\(statementKind)\\s*\\([^,{]*\\)\\s*\\{"
             return file.matchPattern(pattern).flatMap { match, syntaxKinds in
-                if syntaxKinds.first != .Keyword {
+                let matchString = file.contents.substring(match.location, length: match.length)
+                if self.isFalsePositive(matchString, syntaxKind: syntaxKinds.first) {
                     return nil
                 }
                 return StyleViolation(ruleDescription: self.dynamicType.description,
@@ -64,5 +69,28 @@ public struct ControlStatementRule: Rule {
                     "parentheses.")
                 }
         }
+
+    }
+
+    private func isFalsePositive(content: String, syntaxKind: SyntaxKind?) -> Bool {
+        if syntaxKind != .Keyword {
+            return true
+        }
+
+        let lastClosingParenthesePosition = content.lastIndexOf(")")
+        var depth = 0
+        var index = 0
+        for char in content.characters {
+            if char == ")" {
+                if index != lastClosingParenthesePosition && depth == 1 {
+                    return true
+                }
+                depth--
+            } else if char == "(" {
+                depth++
+            }
+            index++
+        }
+        return false
     }
 }

--- a/Source/SwiftLintFramework/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/String+SwiftLint.swift
@@ -48,15 +48,17 @@ extension String {
     }
 
     func substring(from: Int, length: Int? = nil) -> String {
-        let length = length ?? characters.count
-        return self[from..<from + length]
+        if let length = length {
+            return self[from..<from + length]
+        }
+        return substringFromIndex(startIndex.advancedBy(from, limit: endIndex))
     }
 
-    public func lastIndexOf(search: String) -> Int {
+    public func lastIndexOf(search: String) -> Int? {
         if let range = rangeOfString(search, options: [.LiteralSearch, .BackwardsSearch]) {
             return startIndex.distanceTo(range.startIndex)
         }
-        return -1
+        return nil
     }
 }
 

--- a/Source/SwiftLintFramework/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/String+SwiftLint.swift
@@ -38,6 +38,26 @@ extension String {
         }
         return self
     }
+
+    subscript (range: Range<Int>) -> String {
+        get {
+            let subStart = startIndex.advancedBy(range.startIndex, limit: endIndex)
+            let subEnd = subStart.advancedBy(range.endIndex - range.startIndex, limit: endIndex)
+            return substringWithRange(Range(start: subStart, end: subEnd))
+        }
+    }
+
+    func substring(from: Int, length: Int? = nil) -> String {
+        let length = length ?? characters.count
+        return self[from..<from + length]
+    }
+
+    public func lastIndexOf(search: String) -> Int {
+        if let range = rangeOfString(search, options: [.LiteralSearch, .BackwardsSearch]) {
+            return startIndex.distanceTo(range.startIndex)
+        }
+        return -1
+    }
 }
 
 extension NSString {


### PR DESCRIPTION
I fix false positive for `ControlStatementRule` that we have notice in issue #189. To do that, I had to check condition's depth.

I also fix issue #187 with this PR in remove closing curly bracket from regex.

I had some function in `String+Swiftlint` to make easier substring and index search.