### PR TITLE
Fix colon rule issue #135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   [JP Simard](https://github.com/jpsim)
   [#190](https://github.com/realm/SwiftLint/issues/190)
 
+* `ColonRule` now triggers a violation even if equal operator is collapse to type 
+   and value  
+  [Mickael Morier](https://github.com/mmorier)
+  [#135](https://github.com/realm/SwiftLint/issues/135)
+
 
 ## 0.3.0: Wrinkly Rules
 

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -19,7 +19,11 @@ public struct ColonRule: Rule {
             "let abc: Void\n",
             "let abc: [Void: Void]\n",
             "let abc: (Void, Void)\n",
-            "func abc(def: Void) {}\n"
+            "let abc: String=\"def\"\n",
+            "let abc: Int=0\n",
+            "let abc: Enum=Enum.Value\n",
+            "func abc(def: Void) {}\n",
+            "func abc(def: Void, ghi: Void) {}\n"
         ],
         triggeringExamples: [
             "let abc:Void\n",
@@ -27,19 +31,28 @@ public struct ColonRule: Rule {
             "let abc :Void\n",
             "let abc : Void\n",
             "let abc : [Void: Void]\n",
+            "let abc :String=\"def\"\n",
+            "let abc :Int=0\n",
+            "let abc :Int = 0\n",
+            "let abc:Int=0\n",
+            "let abc:Int = 0\n",
+            "let abc:Enum=Enum.Value\n",
             "func abc(def:Void) {}\n",
             "func abc(def:  Void) {}\n",
             "func abc(def :Void) {}\n",
-            "func abc(def : Void) {}\n"
+            "func abc(def : Void) {}\n",
+            "func abc(def: Void, ghi :Void) {}\n"
         ]
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let pattern1 = file.matchPattern("\\w+\\s+:\\s*\\S+",
-            withSyntaxKinds: [.Identifier, .Typeidentifier])
-        let pattern2 = file.matchPattern("\\w+:(?:\\s{0}|\\s{2,})\\S+",
-            withSyntaxKinds: [.Identifier, .Typeidentifier])
-        return (pattern1 + pattern2).map { range in
+        let pattern = "\\w+\\s+:\\s*\\S+|\\w+:(?:\\s{0}|\\s{2,})\\S+"
+
+        return file.matchPattern(pattern).flatMap { range, syntaxKinds in
+            if !syntaxKinds.startsWith([.Identifier, .Typeidentifier]) {
+                return nil
+            }
+
             return StyleViolation(ruleDescription: self.dynamicType.description,
                 location: Location(file: file, offset: range.location),
                 reason: "When specifying a type, always associate the colon with the identifier")


### PR DESCRIPTION
`ColonRule` does not trigger all colon bad format especially when no spaces surround `=` operator.

Regex was good but there are too much restrictions on SyntaxKind. Only [.Identifier, .Typeidentifier] was accepted instead of all array begin with these kinds such as:
* [.Identifier, .Typeidentifier, .String] for string value assignment
* [.Identifier, .Typeidentifier, .Number] for number value assignment
* [.Identifier, .Typeidentifier, .Identifier, .Identifier] for enumeration assignment
