### PR TITLE
make all rule descriptions follow a consistent format

### DIFF
--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -14,7 +14,7 @@ public struct ColonRule: Rule {
     public static let description = RuleDescription(
         identifier: "colon",
         name: "Colon",
-        description: "This rule checks whether you associate the colon with the identifier.",
+        description: "Colons should be next to the identifier when specifying a type.",
         nonTriggeringExamples: [
             "let abc: Void\n",
             "let abc: [Void: Void]\n",

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -25,7 +25,7 @@ public struct FileLengthRule: ParameterizedRule {
     public static let description = RuleDescription(
         identifier: "file_length",
         name: "File Line Length",
-        description: "Enforce maximum file length"
+        description: "Files should not span too many lines."
     )
 
     public func validateFile(file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -14,7 +14,7 @@ public struct ForceCastRule: Rule {
     public static let description = RuleDescription(
         identifier: "force_cast",
         name: "Force Cast",
-        description: "This rule checks whether you don't do force casts.",
+        description: "Force casts should be avoided.",
         nonTriggeringExamples: [
             "NSNumber() as? Int\n"
         ],

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -26,7 +26,7 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
     public static let description = RuleDescription(
         identifier: "function_body_length",
         name: "Function Body Length",
-        description: "Enforce maximum function length"
+        description: "Functions bodies should not span too many lines."
     )
 
     public func validateFile(file: File,

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -14,7 +14,7 @@ public struct LeadingWhitespaceRule: Rule {
     public static let description = RuleDescription(
         identifier: "leading_whitespace",
         name: "Leading Whitespace",
-        description: "This rule checks that there's no leading whitespace in your file.",
+        description: "Files should not contain leading whitespace.",
         nonTriggeringExamples: [ "//\n" ],
         triggeringExamples: [ "\n", " //\n" ]
     )

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -25,7 +25,7 @@ public struct LineLengthRule: ParameterizedRule {
     public static let description = RuleDescription(
         identifier: "line_length",
         name: "Line Length",
-        description: "Enforce maximum line length"
+        description: "Lines should not span too many characters."
     )
 
     public func validateFile(file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -15,8 +15,8 @@ public struct OpeningBraceRule: Rule {
     public static let description = RuleDescription(
         identifier: "opening_brace",
         name: "Opening Brace Spacing",
-        description: "Check whether there is a space before opening brace and it is on the same " +
-        "line.",
+        description: "Opening braces should be preceded by a single space and on the same line " +
+                     "as the declaration.",
         nonTriggeringExamples: [
             "func abc() {\n}",
             "[].map() { $0 }",

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -14,8 +14,7 @@ public struct OperatorFunctionWhitespaceRule: Rule {
     public static let description = RuleDescription(
         identifier: "operator_whitespace",
         name: "Operator Function Whitespace",
-        description: "Use a single whitespace around operators when " +
-        "defining them.",
+        description: "Operators should be surrounded by a single whitespace when defining them.",
         nonTriggeringExamples: [
             "func <| (lhs: Int, rhs: Int) -> Int {}\n",
             "func <|< <A>(lhs: A, rhs: A) -> A {}\n",

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -15,8 +15,8 @@ public struct ReturnArrowWhitespaceRule: Rule {
     public static let description = RuleDescription(
         identifier: "return_arrow_whitespace",
         name: "Returning Whitespace",
-        description: "This rule checks whether you have 1 space before " +
-        "return arrow and return type. Newlines are also acceptable.",
+        description: "Return arrow and return type should be separated by a single space or on a " +
+                     "separate line.",
         nonTriggeringExamples: [
             "func abc() -> Int {}\n",
             "func abc() -> [Int] {}\n",

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -15,8 +15,8 @@ public struct StatementPositionRule: Rule {
     public static let description = RuleDescription(
         identifier: "statement_position",
         name: "Statement Position",
-        description: "This rule checks whether statements are correctly " +
-        "positioned.",
+        description: "Else and catch should be on the same line, one space after the previous " +
+                     "declaration.",
         nonTriggeringExamples: [
             "} else if {",
             "} else {",

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -21,7 +21,7 @@ public struct TodoRule: Rule {
     public static let description = RuleDescription(
         identifier: "todo",
         name: "Todo",
-        description: "This rule checks whether you removed all TODOs and FIXMEs.",
+        description: "TODOs and FIXMEs should be avoided.",
         nonTriggeringExamples: [
             "// notaTODO:\n",
             "// notaFIXME:\n"

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -14,7 +14,7 @@ public struct TrailingWhitespaceRule: Rule {
     public static let description = RuleDescription(
         identifier: "trailing_whitespace",
         name: "Trailing Whitespace",
-        description: "This rule checks whether you don't have any trailing whitespace.",
+        description: "Lines should not have trailing whitespace.",
         nonTriggeringExamples: [ "//\n" ],
         triggeringExamples: [ "// \n" ]
     )

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -25,8 +25,8 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
 
     public static let description = RuleDescription(
         identifier: "type_body_length",
-        name: "Type body Length",
-        description: "Enforce maximum type body length"
+        name: "Type Body Length",
+        description: "Type bodies should not span too many lines."
     )
 
     public func validateFile(file: File,

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -15,8 +15,8 @@ public struct TypeNameRule: ASTRule {
     public static let description = RuleDescription(
         identifier: "type_name",
         name: "Type Name",
-        description: "Type name should only contain alphanumeric characters, " +
-        "start with an uppercase character and between 3 and 40 characters in length.",
+        description: "Type name should only contain alphanumeric characters, start with an " +
+                     "uppercase character and span between 3 and 40 characters in length.",
         nonTriggeringExamples: [
             "struct MyStruct {}",
             "private struct _MyStruct {}"

--- a/Source/SwiftLintFramework/Rules/VariableNameMaxLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameMaxLengthRule.swift
@@ -26,7 +26,7 @@ public struct VariableNameMaxLengthRule: ASTRule, ParameterizedRule {
     public static let description = RuleDescription(
         identifier: "variable_name_max_length",
         name: "Variable Name Max Length Rule",
-        description: "Variable name should be 40 characters or less.",
+        description: "Variable name should not be too long.",
         nonTriggeringExamples: [
             "let myLet = 0",
             "var myVar = 0",

--- a/Source/SwiftLintFramework/Rules/VariableNameMinLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameMinLengthRule.swift
@@ -26,7 +26,7 @@ public struct VariableNameMinLengthRule: ASTRule, ParameterizedRule {
     public static let description = RuleDescription(
         identifier: "variable_name_min_length",
         name: "Variable Name Min Length Rule",
-        description: "Variable name should be 3 characters or more.",
+        description: "Variable name should not be too short.",
         nonTriggeringExamples: [
             "let myLet = 0",
             "var myVar = 0",


### PR DESCRIPTION
These were all over the place. Now all rules describe the encouraged behavior in the form of "$THING should $DO_THIS.".