### PR TITLE
[StyleViolation] use RuleDescription's description when reason is nil

### DIFF
--- a/Source/SwiftLintFramework/Models/StyleViolation.swift
+++ b/Source/SwiftLintFramework/Models/StyleViolation.swift
@@ -10,7 +10,7 @@ public struct StyleViolation: CustomStringConvertible, Equatable {
     public let ruleDescription: RuleDescription
     public let severity: ViolationSeverity
     public let location: Location
-    public let reason: String?
+    public let reason: String
     public var description: String {
         return XcodeReporter.generateForSingleViolation(self)
     }
@@ -20,7 +20,7 @@ public struct StyleViolation: CustomStringConvertible, Equatable {
             self.ruleDescription = ruleDescription
             self.severity = severity
             self.location = location
-            self.reason = reason
+            self.reason = reason ?? ruleDescription.description
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -54,8 +54,7 @@ public struct ColonRule: Rule {
             }
 
             return StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: range.location),
-                reason: "When specifying a type, always associate the colon with the identifier")
+                location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -32,10 +32,9 @@ public struct CommaRule: Rule {
         let pattern = "(\\,[^\\s])|(\\s\\,)"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
 
-        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).flatMap { match in
-            return StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: match.location),
-                reason: "One space before and no after must be present next to commas")
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).flatMap {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -64,9 +64,7 @@ public struct ControlStatementRule: Rule {
                     return nil
                 }
                 return StyleViolation(ruleDescription: self.dynamicType.description,
-                    location: Location(file: file, offset: match.location),
-                    reason: "\(statementKind) statements shouldn't wrap their conditionals in " +
-                    "parentheses.")
+                    location: Location(file: file, offset: match.location))
                 }
         }
 

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -35,7 +35,7 @@ public struct FileLengthRule: ParameterizedRule {
                 severity: parameter.severity,
                 location: Location(file: file.path, line: lineCount),
                 reason: "File should contain \(parameters.first!.value) lines or less: " +
-                "currently contains \(lineCount)")]
+                        "currently contains \(lineCount)")]
         }
         return []
     }

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -22,10 +22,9 @@ public struct ForceCastRule: Rule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return file.matchPattern("as!", withSyntaxKinds: [.Keyword]).map { range in
-            return StyleViolation(ruleDescription: self.dynamicType.description,
-                severity: .Error, location: Location(file: file, offset: range.location),
-                reason: "Force casts should be avoided")
+        return file.matchPattern("as!", withSyntaxKinds: [.Keyword]).map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: .Error, location: Location(file: file, offset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -34,10 +34,9 @@ public struct OpeningBraceRule: Rule {
         let pattern = "((?:[^( ]|[\\t\\n\\f\\r (] )\\{)"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
 
-        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map { match in
-            return StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: match.location),
-                reason: "Opening brace after a space and on same line as declaration")
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -42,8 +42,7 @@ public struct OperatorFunctionWhitespaceRule: Rule {
             return syntaxKinds.first == .Keyword
         }.map { range, _ in
             return StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: range.location),
-                reason: self.dynamicType.description.description)
+                location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -44,10 +44,9 @@ public struct ReturnArrowWhitespaceRule: Rule {
 
         // ex: `func abc()-> Int {` & `func abc() ->Int {`
         let pattern = "\\)(\(spaceRegex)\\->\\s*|\\s\\->\(spaceRegex))\\S+"
-        return file.matchPattern(pattern, withSyntaxKinds: [.Typeidentifier]).map { match in
-            return StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: match.location),
-                reason: "File should have 1 space before return arrow and return type")
+        return file.matchPattern(pattern, withSyntaxKinds: [.Typeidentifier]).map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -35,11 +35,9 @@ public struct StatementPositionRule: Rule {
         let pattern = "((?:\\}|[\\s] |[\\n\\t\\r])(?:else|catch))"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
 
-        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).flatMap { match in
-            return StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: match.location),
-                reason: "Else and catch must be on the same line and one space " +
-                "after previous declaration")
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).flatMap {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -44,8 +44,7 @@ public struct TodoRule: Rule {
                 return nil
             }
             return StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: range.location),
-                reason: "TODOs and FIXMEs should be avoided")
+                location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -28,7 +28,6 @@ public struct TrailingNewlineRule: Rule {
         guard let slice = slices.last where slice.count != 1 else { return [] }
 
         return [StyleViolation(ruleDescription: self.dynamicType.description,
-            location: Location(file: file.path, line: max(file.lines.count, 1)),
-            reason: "File should have a single trailing newline")]
+            location: Location(file: file.path, line: max(file.lines.count, 1)))]
     }
 }

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -24,8 +24,7 @@ public struct TrailingWhitespaceRule: Rule {
             $0.content.hasTrailingWhitespace()
         }.map {
             StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file.path, line: $0.index),
-                reason: "Line #\($0.index) should have no trailing whitespace")
+                location: Location(file: file.path, line: $0.index))
         }
     }
 }


### PR DESCRIPTION
Many cases just used a static string that was nearly identical to the rule description as the `reason` parameter when initializing a StyleViolation.