### PR TITLE
uninstall before `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 	rm -rf "$(TEMPORARY_FOLDER)"
 	$(BUILD_TOOL) $(XCODEFLAGS) clean
 
-install: package
+install: uninstall package
 	sudo installer -pkg SwiftLint.pkg -target /
 
 uninstall:
@@ -51,8 +51,8 @@ prefix_install: installables
 	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
 	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SwiftLintFramework.framework" "$(PREFIX)/Frameworks/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/swiftlint" "$(PREFIX)/bin/"
-	install_name_tool -add_rpath "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks/"  "$(PREFIX)/bin/swiftlint"
-	install_name_tool -add_rpath "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks/SourceKittenFramework.framework/Versions/Current/Frameworks/"  "$(PREFIX)/bin/swiftlint"
+	install_name_tool -add_rpath "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks/" "$(PREFIX)/bin/swiftlint"
+	install_name_tool -add_rpath "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks/SourceKittenFramework.framework/Versions/Current/Frameworks/" "$(PREFIX)/bin/swiftlint"
 
 package: installables
 	pkgbuild \


### PR DESCRIPTION
Fixes #134 & #158. Will only uninstall SwiftLint from the `FRAMEWORKS_FOLDER` and `BINARIES_FOLDER` folders, so if SwiftLint was installed to a different location, it won't be uninstalled.