### PR TITLE
Fix an issue: wrong line number and/or index is reported

### DIFF
--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -63,7 +63,7 @@ extension String {
 }
 
 extension NSString {
-    public func lineAndCharacterForByteOffset(offset: Int) -> (line: Int, character: Int)? {
+    public func lineAndCharacterForCharacterOffset(offset: Int) -> (line: Int, character: Int)? {
         let range = NSRange(location: offset, length: 0)
         var numberOfLines = 0, index = 0, lineRangeStart = 0, previousIndex = 0
         while index < length {

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -64,18 +64,17 @@ extension String {
 
 extension NSString {
     public func lineAndCharacterForByteOffset(offset: Int) -> (line: Int, character: Int)? {
-        return byteRangeToNSRange(start: offset, length: 0).flatMap { range in
-            var numberOfLines = 0, index = 0, lineRangeStart = 0, previousIndex = 0
-            while index < length {
-                numberOfLines++
-                if index > range.location {
-                    break
-                }
-                lineRangeStart = numberOfLines
-                previousIndex = index
-                index = NSMaxRange(lineRangeForRange(NSRange(location: index, length: 1)))
+        let range = NSRange(location: offset, length: 0)
+        var numberOfLines = 0, index = 0, lineRangeStart = 0, previousIndex = 0
+        while index < length {
+            numberOfLines++
+            if index > range.location {
+                break
             }
-            return (lineRangeStart, range.location - previousIndex + 1)
+            lineRangeStart = numberOfLines
+            previousIndex = index
+            index = NSMaxRange(lineRangeForRange(NSRange(location: index, length: 1)))
         }
+        return (lineRangeStart, range.location - previousIndex + 1)
     }
 }

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -33,7 +33,7 @@ public struct Command {
         scanner.scanUpToString(" ", intoString: &actionNSString)
         guard let actionString = actionNSString as String?,
             action = CommandAction(rawValue: actionString),
-            lineAndCharacter = string.lineAndCharacterForByteOffset(NSMaxRange(range)) else {
+            lineAndCharacter = string.lineAndCharacterForCharacterOffset(NSMaxRange(range)) else {
                 return nil
         }
         self.action = action

--- a/Source/SwiftLintFramework/Models/Location.swift
+++ b/Source/SwiftLintFramework/Models/Location.swift
@@ -28,7 +28,7 @@ public struct Location: CustomStringConvertible, Comparable {
 
     public init(file: File, offset: Int) {
         self.file = file.path
-        if let lineAndCharacter = file.contents.lineAndCharacterForByteOffset(offset) {
+        if let lineAndCharacter = file.contents.lineAndCharacterForCharacterOffset(offset) {
             line = lineAndCharacter.line
             character = lineAndCharacter.character
         } else {

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -55,8 +55,8 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
             let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
             let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
             let location = Location(file: file, offset: offset)
-            let startLine = file.contents.lineAndCharacterForByteOffset(bodyOffset)
-            let endLine = file.contents.lineAndCharacterForByteOffset(bodyOffset + bodyLength)
+            let startLine = file.contents.lineAndCharacterForCharacterOffset(bodyOffset)
+            let endLine = file.contents.lineAndCharacterForCharacterOffset(bodyOffset + bodyLength)
             for parameter in parameters.reverse() {
                 if let startLine = startLine?.line, let endLine = endLine?.line
                     where endLine - startLine > parameter.value {

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -40,8 +40,8 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
             let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
             let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
             let location = Location(file: file, offset: offset)
-            let startLine = file.contents.lineAndCharacterForByteOffset(bodyOffset)
-            let endLine = file.contents.lineAndCharacterForByteOffset(bodyOffset + bodyLength)
+            let startLine = file.contents.lineAndCharacterForCharacterOffset(bodyOffset)
+            let endLine = file.contents.lineAndCharacterForCharacterOffset(bodyOffset + bodyLength)
             for parameter in parameters.reverse() {
                 if let startLine = startLine?.line, let endLine = endLine?.line
                     where endLine - startLine > parameter.value {

--- a/Source/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
+++ b/Source/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
@@ -1,0 +1,30 @@
+//
+//  ExtendedNSStringTests.swift
+//  SwiftLint
+//
+//  Created by crimsonwoods on 2015/11/18.
+//  Copyright © 2015 Realm. All rights reserved.
+//
+
+import XCTest
+
+class ExtendedNSStringTests: XCTestCase {
+    func testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters() {
+        let contents = "" +
+        "import Foundation\n" +                               // 18 characters
+        "class Test {\n" +                                    // 13 characters
+            "func test() {\n" +                               // 14 characters
+                "// 日本語コメント : comment in Japanese\n" + // 33 characters
+                "// do something\n"                           // 16 characters
+            "}\n" +
+        "}"
+        let string = NSString(string: contents)
+        // A character placed on 80 offset indicates a white-space before 'do' at 5th line.
+        if let lineAndCharacter = string.lineAndCharacterForCharacterOffset(80) {
+            XCTAssertEqual(lineAndCharacter.line, 5)
+            XCTAssertEqual(lineAndCharacter.character, 3)
+        } else {
+            XCTFail("NSString.lineAndCharacterForByteOffset should return non-nil tuple.")
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
@@ -124,6 +125,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -394,6 +396,7 @@
 				E86396C61BADAFE6002C9E88 /* ReporterTests.swift */,
 				E8BB8F9B1B17DE3B00199606 /* StringRuleTests.swift */,
 				E81224991B04F85B001783D2 /* TestHelpers.swift */,
+				02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */,
 			);
 			name = SwiftLintFrameworkTests;
 			path = Source/SwiftLintFrameworkTests;
@@ -693,6 +696,7 @@
 			files = (
 				E8C164C21BEA9EDA00177258 /* ASTRuleTests.swift in Sources */,
 				E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */,
+				02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */,
 				E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */,
 				E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */,
 				E88198631BEA9A5400333A11 /* StringRuleTests.swift in Sources */,


### PR DESCRIPTION
This PR will fix issue #213.

For a file containing multi-byte-characters (like Japanese-Hiragana, Kanji and more), `offset` parameter supplied to `NSString.lineAndCharacterForByteOffset` should be handled as a character-offset.