### PR TITLE
Add multiline closure argument rule

### DIFF
--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -59,10 +59,10 @@ extension File {
         let syntax = syntaxMap
         let matches = regex(pattern).matchesInString(contents, options: [], range: range)
         return matches.map { match in
-            let tokensInRange = syntax.tokens.filter {
-                NSLocationInRange($0.offset, match.range) ||
+            let tokensInRange = syntax.tokens.filter { token in
+                NSLocationInRange(token.offset, match.range) ||
                     NSLocationInRange(match.range.location,
-                        NSRange(location: $0.offset, length: $0.length))
+                        NSRange(location: token.offset, length: token.length))
             }.map { $0.type }
             let kindsInRange = tokensInRange.flatMap(SyntaxKind.init)
             return (match.range, kindsInRange)
@@ -87,10 +87,10 @@ extension File {
         let syntax = syntaxMap
         let matches = regex(pattern).matchesInString(contents, options: [], range: range)
         return matches.filter { match in
-            let tokensInRange = syntax.tokens.filter {
-                NSLocationInRange($0.offset, match.range) ||
+            let tokensInRange = syntax.tokens.filter { token in
+                NSLocationInRange(token.offset, match.range) ||
                     NSLocationInRange(match.range.location,
-                        NSRange(location: $0.offset, length: $0.length))
+                        NSRange(location: token.offset, length: token.length))
             }
             for token in tokensInRange {
                 if NSIntersectionRange(NSRange(location: token.offset,

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -129,6 +129,7 @@ public struct Configuration {
             ForceCastRule(),
             ForceTryRule(),
             LeadingWhitespaceRule(),
+            MultilineClosureArgumentRule(),
             NestingRule(),
             OpeningBraceRule(),
             OperatorFunctionWhitespaceRule(),

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -49,8 +49,8 @@ public struct Configuration {
 
         // Validate that all rule identifiers map to a defined rule
 
-        let validRuleIdentifiers = Configuration.rulesFromYAML().map {
-            $0.dynamicType.description.identifier
+        let validRuleIdentifiers = Configuration.rulesFromYAML().map { rule in
+            rule.dynamicType.description.identifier
         }
 
         let validDisabledRules = disabledRules.filter({ validRuleIdentifiers.contains($0)})
@@ -79,8 +79,8 @@ public struct Configuration {
         }
         self.disabledRules = validDisabledRules
 
-        self.rules = rules.filter {
-            !validDisabledRules.contains($0.dynamicType.description.identifier)
+        self.rules = rules.filter { rule in
+            !validDisabledRules.contains(rule.dynamicType.description.identifier)
         }
     }
 
@@ -145,8 +145,9 @@ public struct Configuration {
     }
 
     private static func parameterRulesFromYAML(yaml: Yaml? = nil) -> [Rule] {
-        let intParams: (Rule.Type) -> [RuleParameter<Int>]? = {
-            (yaml?[.String($0.description.identifier)].arrayOfInts).map(ruleParametersFromArray)
+        let intParams: (Rule.Type) -> [RuleParameter<Int>]? = { ruleType in
+            (yaml?[.String(ruleType.description.identifier)].arrayOfInts)
+                .map(ruleParametersFromArray)
         }
         // swiftlint:disable line_length
         return [

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -32,9 +32,9 @@ public struct CommaRule: Rule {
         let pattern = "(\\,[^\\s])|(\\s\\,)"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
 
-        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).flatMap {
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).flatMap { range in
             StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: $0.location))
+                location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -22,9 +22,9 @@ public struct ForceCastRule: Rule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return file.matchPattern("as!", withSyntaxKinds: [.Keyword]).map {
+        return file.matchPattern("as!", withSyntaxKinds: [.Keyword]).map { range in
             StyleViolation(ruleDescription: self.dynamicType.description,
-                severity: .Error, location: Location(file: file, offset: $0.location))
+                severity: .Error, location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceTryRule.swift
@@ -24,9 +24,9 @@ public struct ForceTryRule: Rule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return file.matchPattern("try!", withSyntaxKinds: [.Keyword]).map {
+        return file.matchPattern("try!", withSyntaxKinds: [.Keyword]).map { range in
             StyleViolation(ruleDescription: self.dynamicType.description,
-                severity: .Error, location: Location(file: file, offset: $0.location))
+                severity: .Error, location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/MultilineClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineClosureArgumentRule.swift
@@ -1,0 +1,44 @@
+//
+//  TrailingClosureArgumentRule.swift
+//  SwiftLint
+//
+//  Created by Keith Smiley on 8/20/15.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct MultilineClosureArgumentRule: Rule {
+    public init() {}
+
+    private static let regex = try! NSRegularExpression(pattern:
+        "(^[^\\{\\n]*\\$0|\\$0[^\\}\\n]*$)", options: .AnchorsMatchLines)
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        let range = NSRange(location: 0, length: file.contents.utf16.count)
+        let matches = MultilineClosureArgumentRule.regex.matchesInString(file.contents,
+            options: [], range: range)
+
+        return matches.map { match in
+            return StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: match.range.location))
+        }
+    }
+
+    public static let description = RuleDescription(
+        identifier: "closure_argument",
+        name: "Multi-line closure argument",
+        description: "Multi-line closures should not use $0",
+        nonTriggeringExamples: [
+            "foo.map { $0.toString() }\n",
+            "foo.map { $0.something($1) }\n",
+            "foo.map(self.something)\n",
+            "foo.map{ foo in\nfoo.toString()\n}",
+        ],
+        triggeringExamples: [
+            "foo.map {\n$0\n}",
+            "$0",
+            "foo($0).map { $0.toString() }",
+        ]
+    )
+}

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -34,9 +34,9 @@ public struct OpeningBraceRule: Rule {
         let pattern = "((?:[^( ]|[\\t\\n\\f\\r (] )\\{)"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
 
-        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map { range in
             StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: $0.location))
+                location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -44,9 +44,9 @@ public struct ReturnArrowWhitespaceRule: Rule {
 
         // ex: `func abc()-> Int {` & `func abc() ->Int {`
         let pattern = "\\)(\(spaceRegex)\\->\\s*|\\s\\->\(spaceRegex))\\S+"
-        return file.matchPattern(pattern, withSyntaxKinds: [.Typeidentifier]).map {
+        return file.matchPattern(pattern, withSyntaxKinds: [.Typeidentifier]).map { range in
             StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: $0.location))
+                location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -35,9 +35,9 @@ public struct StatementPositionRule: Rule {
         let pattern = "((?:\\}|[\\s] |[\\n\\t\\r])(?:else|catch))"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
 
-        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).flatMap {
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).flatMap { range in
             StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: $0.location))
+                location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -24,9 +24,9 @@ public struct TrailingSemicolonRule: Rule {
 
     public func validateFile(file: File) -> [StyleViolation] {
         let excludingKinds = SyntaxKind.commentAndStringKinds()
-        return file.matchPattern(";$", excludingSyntaxKinds: excludingKinds).flatMap {
+        return file.matchPattern(";$", excludingSyntaxKinds: excludingKinds).flatMap { range in
             StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file, offset: $0.location))
+                location: Location(file: file, offset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -20,11 +20,11 @@ public struct TrailingWhitespaceRule: Rule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return file.lines.filter {
-            $0.content.hasTrailingWhitespace()
-        }.map {
+        return file.lines.filter { line in
+            line.content.hasTrailingWhitespace()
+        }.map { line in
             StyleViolation(ruleDescription: self.dynamicType.description,
-                location: Location(file: file.path, line: $0.index))
+                location: Location(file: file.path, line: line.index))
         }
     }
 }

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -39,8 +39,8 @@ class ConfigurationTests: XCTestCase {
         let expectedIdentifiers = Configuration.rulesFromYAML()
             .map({ $0.dynamicType.description.identifier })
             .filter({ !["nesting", "todo"].contains($0) })
-        let configuredIdentifiers = disabledConfig.rules.map {
-            $0.dynamicType.description.identifier
+        let configuredIdentifiers = disabledConfig.rules.map { rule in
+            rule.dynamicType.description.identifier
         }
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
 
@@ -62,8 +62,8 @@ class ConfigurationTests: XCTestCase {
         let expectedIdentifiers = Configuration.rulesFromYAML()
             .map({ $0.dynamicType.description.identifier })
             .filter({ ![validRule].contains($0) })
-        let configuredIdentifiers = configuration.rules.map {
-            $0.dynamicType.description.identifier
+        let configuredIdentifiers = configuration.rules.map { rule in
+            rule.dynamicType.description.identifier
         }
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
     }

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -89,6 +89,10 @@ class StringRuleTests: XCTestCase {
         verifyRule(StatementPositionRule.description)
     }
 
+    func testMultilineClosureArgument() {
+        verifyRule(MultilineClosureArgumentRule.description, commentDoesntViolate: false)
+    }
+
     func testTrailingNewline() {
         verifyRule(TrailingNewlineRule.description, commentDoesntViolate: false)
     }

--- a/Source/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Source/SwiftLintFrameworkTests/TestHelpers.swift
@@ -25,14 +25,14 @@ extension XCTestCase {
             []
         )
         XCTAssertEqual(
-            ruleDescription.triggeringExamples.flatMap({
-                violations($0, ruleDescription).map({$0.ruleDescription})
+            ruleDescription.triggeringExamples.flatMap({ example in
+                violations(example, ruleDescription).map({$0.ruleDescription})
             }),
             Array(count: ruleDescription.triggeringExamples.count, repeatedValue: ruleDescription)
         )
 
-        let commentedViolations = ruleDescription.triggeringExamples.flatMap {
-            violations("/**\n  " + $0 + "\n */", ruleDescription)
+        let commentedViolations = ruleDescription.triggeringExamples.flatMap { example in
+            violations("/**\n  " + example + "\n */", ruleDescription)
         }.map({$0.ruleDescription})
         XCTAssertEqual(
             commentedViolations,

--- a/Source/swiftlint/LintCommand.swift
+++ b/Source/swiftlint/LintCommand.swift
@@ -110,9 +110,8 @@ struct LintCommand: CommandType {
         if fileManager.fileExistsAtPath(absolutePath, isDirectory: &isDirectory) {
             if isDirectory {
                 do {
-                    return try fileManager.allFilesRecursively(directory: absolutePath).filter {
-                        $0.isSwiftFile()
-                    }
+                    return try fileManager.allFilesRecursively(directory: absolutePath)
+                        .filter { $0.isSwiftFile() }
                 } catch {
                     fatalError("Couldn't find files in \(absolutePath): \(error)")
                 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
+		C2A03B611BFC28B50037C91D /* MultilineClosureArgumentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A03B601BFC28B50037C91D /* MultilineClosureArgumentRule.swift */; };
 		CAF900141BED8B17006A371D /* VariableNameMaxLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF900121BED8B17006A371D /* VariableNameMaxLengthRule.swift */; };
 		CAF900151BED8B17006A371D /* VariableNameMinLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF900131BED8B17006A371D /* VariableNameMinLengthRule.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -139,6 +140,7 @@
 		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
+		C2A03B601BFC28B50037C91D /* MultilineClosureArgumentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineClosureArgumentRule.swift; sourceTree = "<group>"; };
 		CAF900121BED8B17006A371D /* VariableNameMaxLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableNameMaxLengthRule.swift; sourceTree = "<group>"; };
 		CAF900131BED8B17006A371D /* VariableNameMinLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableNameMinLengthRule.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -440,6 +442,7 @@
 				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
+				C2A03B601BFC28B50037C91D /* MultilineClosureArgumentRule.swift */,
 				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
 				692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */,
 				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
@@ -697,6 +700,7 @@
 				E88DEA711B09847500A66CB0 /* ViolationSeverity.swift in Sources */,
 				E88DEA8C1B0999A000A66CB0 /* ASTRule.swift in Sources */,
 				E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */,
+				C2A03B611BFC28B50037C91D /* MultilineClosureArgumentRule.swift in Sources */,
 				E881985D1BEA97EB00333A11 /* TrailingWhitespaceRule.swift in Sources */,
 				E832F10B1B17E2F5003F265F /* NSFileManager+SwiftLint.swift in Sources */,
 				E816194C1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift in Sources */,


### PR DESCRIPTION
This rule forces users to name arguments for multiline closures.

This is the first draft of https://github.com/realm/SwiftLint/issues/70

See the first commit for the rule. The second is just fixes for it.