### PR TITLE
Use `cp -Rf` instead of `cp -rf` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ installables: clean bootstrap
 
 prefix_install: installables
 	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
-	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SwiftLintFramework.framework" "$(PREFIX)/Frameworks/"
+	cp -Rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SwiftLintFramework.framework" "$(PREFIX)/Frameworks/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/swiftlint" "$(PREFIX)/bin/"
 	install_name_tool -add_rpath "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks/" "$(PREFIX)/bin/swiftlint"
 	install_name_tool -add_rpath "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks/SourceKittenFramework.framework/Versions/Current/Frameworks/" "$(PREFIX)/bin/swiftlint"


### PR DESCRIPTION
`-r` option of `cp` copies symbolic links as normal files.
As the result of that, `SwiftLintFramework.framework` that distributed by Homebrew contains a lot of duplicated files inside that.
`-R` option copies symbolic links as symbolic links.

On my testing, this fix reduces the size of `swiftlint-0.4.0.el_capitan.bottle.tar.gz` from 17.2MB to 4.3MB.