### PR TITLE
add Valid Docs rule

### DIFF
--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -9,7 +9,7 @@
 import SourceKittenFramework
 import SwiftXPC
 
-private func regex(pattern: String) -> NSRegularExpression {
+internal func regex(pattern: String) -> NSRegularExpression {
     // all patterns used for regular expressions in SwiftLint are string literals which have
     // been confirmed to work, so it's ok to force-try here.
     // swiftlint:disable force_try

--- a/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
+++ b/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
@@ -19,14 +19,22 @@ private let outputQueue: dispatch_queue_t = {
     return queue
 }()
 
-/// A thread-safe version of Swift's standard print().
+/**
+ A thread-safe version of Swift's standard print().
+
+ - parameter object: Object to print.
+*/
 public func queuedPrint<T>(object: T) {
     dispatch_async(outputQueue) {
         print(object)
     }
 }
 
-/// A thread-safe, newline-terminated version of fputs(..., stderr).
+/**
+A thread-safe, newline-terminated version of fputs(..., stderr).
+
+- parameter string: String to print.
+*/
 public func queuedPrintError(string: String) {
     dispatch_async(outputQueue) {
         fputs(string + "\n", stderr)

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -61,20 +61,3 @@ extension String {
         return nil
     }
 }
-
-extension NSString {
-    public func lineAndCharacterForCharacterOffset(offset: Int) -> (line: Int, character: Int)? {
-        let range = NSRange(location: offset, length: 0)
-        var numberOfLines = 0, index = 0, lineRangeStart = 0, previousIndex = 0
-        while index < length {
-            numberOfLines++
-            if index > range.location {
-                break
-            }
-            lineRangeStart = numberOfLines
-            previousIndex = index
-            index = NSMaxRange(lineRangeForRange(NSRange(location: index, length: 1)))
-        }
-        return (lineRangeStart, range.location - previousIndex + 1)
-    }
-}

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -139,6 +139,7 @@ public struct Configuration {
             TrailingSemicolonRule(),
             TrailingWhitespaceRule(),
             TypeNameRule(),
+            ValidDocsRule(),
             VariableNameRule(),
         ] + parameterRulesFromYAML(yaml)
     }

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -12,45 +12,72 @@ import SwiftXPC
 extension File {
     private func invalidDocOffsets(dictionary: XPCDictionary) -> [Int] {
         let substructure = (dictionary["key.substructure"] as? XPCArray)?
-            .flatMap { $0 as? XPCDictionary }
-        let substructureOffsets = substructure?.flatMap(invalidDocOffsets) ?? []
+            .flatMap { $0 as? XPCDictionary } ?? []
+        let substructureOffsets = substructure.flatMap(invalidDocOffsets)
         guard let kind = (dictionary["key.kind"] as? String).flatMap(SwiftDeclarationKind.init),
             offset = dictionary["key.offset"] as? Int64,
-            bodyOffset = dictionary["key.bodyoffset"] as? Int64
-            where kind != .VarParameter else {
+            bodyOffset = dictionary["key.bodyoffset"] as? Int64,
+            comment = getDocumentationCommentBody(dictionary, syntaxMap: syntaxMap)
+            where kind != .VarParameter && !comment.containsString(":nodoc:") else {
                 return substructureOffsets
         }
         let declaration = contents[Int(offset)..<Int(bodyOffset)]
-        if let comment = getDocumentationCommentBody(dictionary, syntaxMap: syntaxMap)
-            where !comment.containsString(":nodoc:") {
-            let parameterNames = substructure?.filter {
-                ($0["key.kind"] as? String).flatMap(SwiftDeclarationKind.init) == .VarParameter
-            }.filter { subDict in
-                return (subDict["key.offset"] as? Int64).map({ $0 < bodyOffset }) ?? false
-            }.flatMap {
-                $0["key.name"] as? String
-            } ?? []
-            typealias LabelAndParameter = (label: String, parameter: String)
-            let labelsAndParameters = parameterNames.map { parameter -> LabelAndParameter in
-                let fullRange = NSRange(location: 0, length: Int(bodyOffset - offset))
-                let firstMatch = regex("([^,\\s(]+)\\s+\(parameter)\\s*:")
-                    .firstMatchInString(declaration, options: [], range: fullRange)
-                if let match = firstMatch {
-                    let label = (declaration as NSString).substringWithRange(match.rangeAtIndex(1))
-                    return (label, parameter)
-                }
-                return (parameter, parameter)
-            }
-            let undocumentedParameters = labelsAndParameters.filter {
-                !comment.containsString("- parameter \($0.label):") &&
-                    !comment.containsString("- parameter \($0.parameter):")
-            }
-            if !undocumentedParameters.isEmpty {
-                return substructureOffsets + [Int(offset)]
-            }
+        if missingReturnDocumentation(declaration, comment: comment) {
+            return substructureOffsets + [Int(offset)]
+        }
+        if superfluousReturnDocumentation(declaration, comment: comment, kind: kind) {
+            return substructureOffsets + [Int(offset)]
+        }
+        if missingParameterDocumentation(declaration, substructure: substructure, offset: offset,
+            bodyOffset: bodyOffset, comment: comment) {
+            return substructureOffsets + [Int(offset)]
         }
         return substructureOffsets
     }
+}
+
+func delcarationReturns(declaration: String, kind: SwiftDeclarationKind) -> Bool {
+    return declaration.containsString("->") || SwiftDeclarationKind.variableKinds().contains(kind)
+}
+
+func commentReturns(comment: String) -> Bool {
+    return comment.containsString("- returns:") ||
+        comment.rangeOfString("Returns")?.startIndex == comment.startIndex
+}
+
+func missingReturnDocumentation(declaration: String, comment: String) -> Bool {
+    return declaration.containsString("->") && !commentReturns(comment)
+}
+
+func superfluousReturnDocumentation(declaration: String, comment: String,
+                                    kind: SwiftDeclarationKind) -> Bool {
+    return !delcarationReturns(declaration, kind: kind) && commentReturns(comment)
+}
+
+func missingParameterDocumentation(declaration: String, substructure: [XPCDictionary],
+                                   offset: Int64, bodyOffset: Int64, comment: String) -> Bool {
+    let parameterNames = substructure.filter {
+        ($0["key.kind"] as? String).flatMap(SwiftDeclarationKind.init) == .VarParameter
+    }.filter { subDict in
+        return (subDict["key.offset"] as? Int64).map({ $0 < bodyOffset }) ?? false
+    }.flatMap {
+        $0["key.name"] as? String
+    } ?? []
+    let labelsAndParams = parameterNames.map { parameter -> (label: String, parameter: String) in
+        let fullRange = NSRange(location: 0, length: Int(bodyOffset - offset))
+        let firstMatch = regex("([^,\\s(]+)\\s+\(parameter)\\s*:")
+            .firstMatchInString(declaration, options: [], range: fullRange)
+        if let match = firstMatch {
+            let label = (declaration as NSString).substringWithRange(match.rangeAtIndex(1))
+            return (label, parameter)
+        }
+        return (parameter, parameter)
+    }
+    let undocumentedParameters = labelsAndParams.filter {
+        !comment.containsString("- parameter \($0.label):") &&
+            !comment.containsString("- parameter \($0.parameter):")
+    }
+    return !undocumentedParameters.isEmpty
 }
 
 public struct ValidDocsRule: Rule {
@@ -63,10 +90,16 @@ public struct ValidDocsRule: Rule {
             "/// docs\n/// - parameter param: this is void\npublic func a(param: Void) {}\n",
             "/// docs\n/// - parameter label: this is void\npublic func a(label param: Void) {}",
             "/// docs\n/// - parameter param: this is void\npublic func a(label param: Void) {}",
+            "/// docs\n/// - returns: false\npublic func no() -> Bool { return false }",
+            "/// Returns false\npublic func no() -> Bool { return false }",
+            "/// Returns false\nvar no: Bool { return false }",
+            "/// docs\nvar no: Bool { return false }",
         ],
         triggeringExamples: [
             "/// docs\npublic func a(param: Void) {}\n",
             "/// docs\n/// - parameter invalid: this is void\npublic func a(label param: Void) {}",
+            "/// docs\npublic func no() -> Bool { return false }",
+            "/// Returns false\npublic func a() {}",
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -30,7 +30,8 @@ extension File {
             }.flatMap {
                 $0["key.name"] as? String
             } ?? []
-            let parameters = parameterNames.map { parameter -> (label: String, parameter: String) in
+            typealias LabelAndParameter = (label: String, parameter: String)
+            let labelsAndParameters = parameterNames.map { parameter -> LabelAndParameter in
                 let fullRange = NSRange(location: 0, length: Int(bodyOffset - offset))
                 let firstMatch = regex("([^,\\s(]+)\\s+\(parameter)\\s*:")
                     .firstMatchInString(declaration, options: [], range: fullRange)
@@ -40,7 +41,7 @@ extension File {
                 }
                 return (parameter, parameter)
             }
-            let undocumentedParameters = parameters.filter {
+            let undocumentedParameters = labelsAndParameters.filter {
                 !comment.containsString("- parameter \($0.label):") &&
                     !comment.containsString("- parameter \($0.parameter):")
             }

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -1,0 +1,71 @@
+//
+//  ValidDocsRule.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 2015-11-21.
+//  Copyright © 2015 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+import SwiftXPC
+
+extension File {
+    private func invalidDocOffsets(dictionary: XPCDictionary) -> [Int] {
+        let substructure = (dictionary["key.substructure"] as? XPCArray)?
+            .flatMap { $0 as? XPCDictionary }
+        let substructureOffsets = substructure?.flatMap(invalidDocOffsets) ?? []
+        guard let kind = (dictionary["key.kind"] as? String).flatMap(SwiftDeclarationKind.init),
+            offset = dictionary["key.offset"] as? Int64,
+            bodyOffset = dictionary["key.bodyoffset"] as? Int64
+            where kind != .VarParameter else {
+                return substructureOffsets
+        }
+        let declaration = contents[Int(offset)..<Int(bodyOffset)]
+        if let comment = getDocumentationCommentBody(dictionary, syntaxMap: syntaxMap) {
+            let parameterNames = substructure?.filter {
+                ($0["key.kind"] as? String).flatMap(SwiftDeclarationKind.init) == .VarParameter
+            }.filter { subDict in
+                return (subDict["key.offset"] as? Int64).map({ $0 < bodyOffset }) ?? false
+            }.flatMap {
+                $0["key.name"] as? String
+            } ?? []
+            let parameterLabels = parameterNames.map { parameter -> String in
+                let fullRange = NSRange(location: 0, length: Int(bodyOffset - offset))
+                let firstMatch = regex("([^,\\s(]+)\\s+\(parameter)\\s*:")
+                    .firstMatchInString(declaration, options: [], range: fullRange)
+                if let match = firstMatch {
+                    return (declaration as NSString).substringWithRange(match.rangeAtIndex(1))
+                }
+                return parameter
+            }
+            if !parameterLabels.filter({ !comment.containsString("- parameter \($0):") }).isEmpty {
+                return substructureOffsets + [Int(offset)]
+            }
+        }
+        return substructureOffsets
+    }
+}
+
+public struct ValidDocsRule: Rule {
+    public static let description = RuleDescription(
+        identifier: "valid_docs",
+        name: "Valid Docs",
+        description: "Documented declarations should be valid.",
+        nonTriggeringExamples: [
+            "/// docs\npublic func a() {}\n",
+            "/// docs\n/// - parameter param: this is void\npublic func a(param: Void) {}\n",
+            "/// docs\n/// - parameter label: this is void\npublic func a(label param: Void) {}",
+        ],
+        triggeringExamples: [
+            "/// docs\npublic func a(param: Void) {}\n",
+            "/// docs\n/// - parameter param: this is void\npublic func a(label param: Void) {}",
+        ]
+    )
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        return file.invalidDocOffsets(file.structure.dictionary).map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: $0))
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -41,6 +41,10 @@ func delcarationReturns(declaration: String, kind: SwiftDeclarationKind) -> Bool
     return declaration.containsString("->") || SwiftDeclarationKind.variableKinds().contains(kind)
 }
 
+func commentHasBatchedParameters(comment: String) -> Bool {
+    return comment.lowercaseString.containsString("- parameters:")
+}
+
 func commentReturns(comment: String) -> Bool {
     return comment.containsString("- returns:") ||
         comment.rangeOfString("Returns")?.startIndex == comment.startIndex
@@ -58,6 +62,8 @@ func superfluousReturnDocumentation(declaration: String, comment: String,
 func superfluousOrMissingParameterDocumentation(declaration: String, substructure: [XPCDictionary],
                                                 offset: Int64, bodyOffset: Int64,
                                                 comment: String) -> Bool {
+    // This function doesn't handle batched parameters, so skip those.
+    if commentHasBatchedParameters(comment) { return false }
     let parameterNames = substructure.filter {
         ($0["key.kind"] as? String).flatMap(SwiftDeclarationKind.init) == .VarParameter
     }.filter { subDict in

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -22,20 +22,13 @@ extension File {
                 return substructureOffsets
         }
         let declaration = contents[Int(offset)..<Int(bodyOffset)]
-        if missingReturnDocumentation(declaration, comment: comment) {
-            return substructureOffsets + [Int(offset)]
-        }
-        if superfluousReturnDocumentation(declaration, comment: comment, kind: kind) {
-            return substructureOffsets + [Int(offset)]
-        }
-        if superfluousOrMissingThrowsDocumentation(declaration, comment: comment) {
-            return substructureOffsets + [Int(offset)]
-        }
-        if missingParameterDocumentation(declaration, substructure: substructure, offset: offset,
-            bodyOffset: bodyOffset, comment: comment) {
-            return substructureOffsets + [Int(offset)]
-        }
-        return substructureOffsets
+        let hasViolation = missingReturnDocumentation(declaration, comment: comment) ||
+            superfluousReturnDocumentation(declaration, comment: comment, kind: kind) ||
+            superfluousOrMissingThrowsDocumentation(declaration, comment: comment) ||
+            missingParameterDocumentation(declaration, substructure: substructure, offset: offset,
+                                          bodyOffset: bodyOffset, comment: comment)
+
+        return substructureOffsets + (hasViolation ? [Int(offset)] : [])
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -21,7 +21,8 @@ extension File {
                 return substructureOffsets
         }
         let declaration = contents[Int(offset)..<Int(bodyOffset)]
-        if let comment = getDocumentationCommentBody(dictionary, syntaxMap: syntaxMap) {
+        if let comment = getDocumentationCommentBody(dictionary, syntaxMap: syntaxMap)
+            where !comment.containsString(":nodoc:") {
             let parameterNames = substructure?.filter {
                 ($0["key.kind"] as? String).flatMap(SwiftDeclarationKind.init) == .VarParameter
             }.filter { subDict in
@@ -29,16 +30,21 @@ extension File {
             }.flatMap {
                 $0["key.name"] as? String
             } ?? []
-            let parameterLabels = parameterNames.map { parameter -> String in
+            let parameters = parameterNames.map { parameter -> (label: String, parameter: String) in
                 let fullRange = NSRange(location: 0, length: Int(bodyOffset - offset))
                 let firstMatch = regex("([^,\\s(]+)\\s+\(parameter)\\s*:")
                     .firstMatchInString(declaration, options: [], range: fullRange)
                 if let match = firstMatch {
-                    return (declaration as NSString).substringWithRange(match.rangeAtIndex(1))
+                    let label = (declaration as NSString).substringWithRange(match.rangeAtIndex(1))
+                    return (label, parameter)
                 }
-                return parameter
+                return (parameter, parameter)
             }
-            if !parameterLabels.filter({ !comment.containsString("- parameter \($0):") }).isEmpty {
+            let undocumentedParameters = parameters.filter {
+                !comment.containsString("- parameter \($0.label):") &&
+                    !comment.containsString("- parameter \($0.parameter):")
+            }
+            if !undocumentedParameters.isEmpty {
                 return substructureOffsets + [Int(offset)]
             }
         }
@@ -55,10 +61,11 @@ public struct ValidDocsRule: Rule {
             "/// docs\npublic func a() {}\n",
             "/// docs\n/// - parameter param: this is void\npublic func a(param: Void) {}\n",
             "/// docs\n/// - parameter label: this is void\npublic func a(label param: Void) {}",
+            "/// docs\n/// - parameter param: this is void\npublic func a(label param: Void) {}",
         ],
         triggeringExamples: [
             "/// docs\npublic func a(param: Void) {}\n",
-            "/// docs\n/// - parameter param: this is void\npublic func a(label param: Void) {}",
+            "/// docs\n/// - parameter invalid: this is void\npublic func a(label param: Void) {}",
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -28,12 +28,19 @@ extension File {
         if superfluousReturnDocumentation(declaration, comment: comment, kind: kind) {
             return substructureOffsets + [Int(offset)]
         }
+        if superfluousOrMissingThrowsDocumentation(declaration, comment: comment) {
+            return substructureOffsets + [Int(offset)]
+        }
         if missingParameterDocumentation(declaration, substructure: substructure, offset: offset,
             bodyOffset: bodyOffset, comment: comment) {
             return substructureOffsets + [Int(offset)]
         }
         return substructureOffsets
     }
+}
+
+func superfluousOrMissingThrowsDocumentation(declaration: String, comment: String) -> Bool {
+    return declaration.containsString(" throws ") == !comment.containsString("- throws:")
 }
 
 func delcarationReturns(declaration: String, kind: SwiftDeclarationKind) -> Bool {
@@ -94,12 +101,15 @@ public struct ValidDocsRule: Rule {
             "/// Returns false\npublic func no() -> Bool { return false }",
             "/// Returns false\nvar no: Bool { return false }",
             "/// docs\nvar no: Bool { return false }",
+            "/// docs\n/// - throws: NSError\nfunc a() throws {}",
         ],
         triggeringExamples: [
             "/// docs\npublic func a(param: Void) {}\n",
             "/// docs\n/// - parameter invalid: this is void\npublic func a(label param: Void) {}",
             "/// docs\npublic func no() -> Bool { return false }",
             "/// Returns false\npublic func a() {}",
+            "/// docs\n/// - throws: NSError\nfunc a() {}",
+            "/// docs\nfunc a() throws {}",
         ]
     )
 

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -94,6 +94,10 @@ class StringRuleTests: XCTestCase {
                    stringDoesntViolate: false)
     }
 
+    func testValidDocs() {
+        verifyRule(ValidDocsRule.description)
+    }
+
     func testTrailingSemicolon() {
         verifyRule(TrailingSemicolonRule.description)
     }

--- a/Source/swiftlint/LintCommand.swift
+++ b/Source/swiftlint/LintCommand.swift
@@ -145,7 +145,7 @@ struct LintCommand: CommandType {
 
         return count.flatMap { count in
             let variables = (0..<count)
-                .map { return getEnvironmentVariable("SCRIPT_INPUT_FILE_\($0)") }
+                .map { getEnvironmentVariable("SCRIPT_INPUT_FILE_\($0)") }
                 .flatMap { path -> String? in
                     switch path {
                     case let .Success(path):

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		E816194C1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E816194B1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift */; };
 		E816194E1BFBFEAB00946723 /* ForceTryRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E816194D1BFBFEAB00946723 /* ForceTryRule.swift */; };
 		E81619531BFC162C00946723 /* QueuedPrint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81619521BFC162C00946723 /* QueuedPrint.swift */; };
+		E81CDE711C00FEAA00B430F6 /* ValidDocsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */; };
 		E832F10B1B17E2F5003F265F /* NSFileManager+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E832F10A1B17E2F5003F265F /* NSFileManager+SwiftLint.swift */; };
 		E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E832F10C1B17E725003F265F /* IntegrationTests.swift */; };
 		E83A0B351A5D382B0041A60A /* VersionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83A0B341A5D382B0041A60A /* VersionCommand.swift */; };
@@ -179,6 +180,7 @@
 		E816194B1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftDeclarationKind+SwiftLint.swift"; sourceTree = "<group>"; };
 		E816194D1BFBFEAB00946723 /* ForceTryRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceTryRule.swift; sourceTree = "<group>"; };
 		E81619521BFC162C00946723 /* QueuedPrint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueuedPrint.swift; sourceTree = "<group>"; };
+		E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidDocsRule.swift; sourceTree = "<group>"; };
 		E832F10A1B17E2F5003F265F /* NSFileManager+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSFileManager+SwiftLint.swift"; sourceTree = "<group>"; };
 		E832F10C1B17E725003F265F /* IntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		E83A0B341A5D382B0041A60A /* VersionCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionCommand.swift; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 				E88DEA851B0991BF00A66CB0 /* TrailingWhitespaceRule.swift */,
 				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
+				E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */,
 				CAF900121BED8B17006A371D /* VariableNameMaxLengthRule.swift */,
 				CAF900131BED8B17006A371D /* VariableNameMinLengthRule.swift */,
 				E88DEA931B099C0900A66CB0 /* VariableNameRule.swift */,
@@ -674,6 +677,7 @@
 				83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */,
 				E812249C1B04FADC001783D2 /* Linter.swift in Sources */,
 				CAF900151BED8B17006A371D /* VariableNameMinLengthRule.swift in Sources */,
+				E81CDE711C00FEAA00B430F6 /* ValidDocsRule.swift in Sources */,
 				E87E4A091BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift in Sources */,
 				E88198551BEA949A00333A11 /* ControlStatementRule.swift in Sources */,
 				E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */,


### PR DESCRIPTION
I've been meaning to write a rule like this for a while, to prevent doc comments from getting out of sync with their declarations, or preventing typos.

This rule aims to validate that documentation comments correctly reflect the declaration.

This currently only checks if all function parameters are present in the docs as `- parameter ...:`, but this rule could be expanded to validate the following things:

- [x] if a function `throws`, that this be marked in the comment as `- Throws:`.
- [x] if a function returns something, that the comment either start with the word "Returns" or that `- returns:` be present.
- [x] the opposite of all the above in the absence of those things in the declaration.

/cc @keith 