### PR TITLE
verify that triggering examples in a string literal don't trigger violations

### DIFF
--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -90,7 +90,8 @@ class StringRuleTests: XCTestCase {
     }
 
     func testTrailingNewline() {
-        verifyRule(TrailingNewlineRule.description, commentDoesntViolate: false)
+        verifyRule(TrailingNewlineRule.description, commentDoesntViolate: false,
+                   stringDoesntViolate: false)
     }
 
     func testTrailingSemicolon() {


### PR DESCRIPTION
Addresses #214.