### PR TITLE
remove `init()` from `Rule`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##### Breaking
 
-* None.
+* `init()` is no longer a member of the `Rule` protocol.
 
 ##### Enhancements
 

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -9,7 +9,6 @@
 import SourceKittenFramework
 
 public protocol Rule {
-    init()
     static var description: RuleDescription { get }
     func validateFile(file: File) -> [StyleViolation]
 }

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct ColonRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "colon",
         name: "Colon",

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -10,8 +10,6 @@ import Foundation
 import SourceKittenFramework
 
 public struct CommaRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "comma",
         name: "Comma Spacing",

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct ControlStatementRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "control_statement",
         name: "Control Statement",

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct ForceCastRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "force_cast",
         name: "Force Cast",

--- a/Source/SwiftLintFramework/Rules/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceTryRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct ForceTryRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "force_try",
         name: "Force Try",

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct LeadingWhitespaceRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "leading_whitespace",
         name: "Leading Whitespace",

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct LegacyConstructorRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "legacy_constructor",
         name: "Legacy Constructor",

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -10,8 +10,6 @@ import SourceKittenFramework
 import SwiftXPC
 
 public struct NestingRule: ASTRule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "nesting",
         name: "Nesting",

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -10,8 +10,6 @@ import Foundation
 import SourceKittenFramework
 
 public struct OpeningBraceRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "opening_brace",
         name: "Opening Brace Spacing",

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct OperatorFunctionWhitespaceRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "operator_whitespace",
         name: "Operator Function Whitespace",

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -10,8 +10,6 @@ import Foundation
 import SourceKittenFramework
 
 public struct ReturnArrowWhitespaceRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "return_arrow_whitespace",
         name: "Returning Whitespace",

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -10,8 +10,6 @@ import Foundation
 import SourceKittenFramework
 
 public struct StatementPositionRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "statement_position",
         name: "Statement Position",

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -16,8 +16,6 @@ extension SyntaxKind {
 }
 
 public struct TodoRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "todo",
         name: "Todo",

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct TrailingNewlineRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "trailing_newline",
         name: "Trailing Newline",

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct TrailingSemicolonRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "trailing_semicolon",
         name: "Trailing Semicolon",

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -9,8 +9,6 @@
 import SourceKittenFramework
 
 public struct TrailingWhitespaceRule: Rule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "trailing_whitespace",
         name: "Trailing Whitespace",

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -10,8 +10,6 @@ import SourceKittenFramework
 import SwiftXPC
 
 public struct TypeNameRule: ASTRule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "type_name",
         name: "Type Name",

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -10,8 +10,6 @@ import SourceKittenFramework
 import SwiftXPC
 
 public struct VariableNameRule: ASTRule {
-    public init() {}
-
     public static let description = RuleDescription(
         identifier: "variable_name",
         name: "Variable Name",


### PR DESCRIPTION
Can anyone think of a good reason not to do this? /cc @keith 