### PR TITLE
Variable name violation should be ignored if the entire name is in capitals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ##### Enhancements
 
-* None.
+* The `VariableNameRule` now allows variable names when the entire
+name is capitalized. This allows stylistic usage common in cases like
+`URL` and other acronyms.
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#161](https://github.com/realm/SwiftLint/issues/161)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -16,13 +16,15 @@ public struct VariableNameRule: ASTRule {
         identifier: "variable_name",
         name: "Variable Name",
         description: "Variable name should only contain alphanumeric characters and " +
-          "start with a a lowercase character. In an exception to the above, variable " +
-          "names may start with a capital letter when they are declared static and immutable.",
+          "start with a a lowercase character or should only contain capital letters. " +
+          "In an exception to the above, variable names may start with a capital letter " +
+          "when they are declared static and immutable.",
         nonTriggeringExamples: [
             "let myLet = 0",
             "var myVar = 0",
             "private let _myLet = 0",
-            "class Abc { static let MyLet = 0 }"
+            "class Abc { static let MyLet = 0 }",
+            "let URL: NSURL? = nil"
         ],
         triggeringExamples: [
             "let MyLet = 0",
@@ -31,11 +33,15 @@ public struct VariableNameRule: ASTRule {
         ]
     )
 
+    private func nameIsViolatingCase(name: String) -> Bool {
+        let firstCharacter = name.substringToIndex(name.startIndex.successor())
+        return firstCharacter.isUppercase() && !name.isUppercase()
+    }
+
     public func validateFile(file: File, kind: SwiftDeclarationKind,
                              dictionary: XPCDictionary) -> [StyleViolation] {
         return file.validateVariableName(dictionary, kind: kind).map { name, offset in
             let nameCharacterSet = NSCharacterSet(charactersInString: name)
-            let firstCharacter = name.substringToIndex(name.startIndex.successor())
             let description = self.dynamicType.description
             let location = Location(file: file, offset: offset)
             if !NSCharacterSet.alphanumericCharacterSet().isSupersetOfSet(nameCharacterSet) {
@@ -43,7 +49,7 @@ public struct VariableNameRule: ASTRule {
                     severity: .Error,
                     location: location,
                     reason: "Variable name should only contain alphanumeric characters: '\(name)'")]
-            } else if kind != SwiftDeclarationKind.VarStatic && firstCharacter.isUppercase() {
+            } else if kind != SwiftDeclarationKind.VarStatic && nameIsViolatingCase(name) {
                 return [StyleViolation(ruleDescription: description,
                     severity: .Error,
                     location: location,

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -16,7 +16,7 @@ public struct VariableNameRule: ASTRule {
         identifier: "variable_name",
         name: "Variable Name",
         description: "Variable name should only contain alphanumeric characters and " +
-          "start with a a lowercase character or should only contain capital letters. " +
+          "start with a lowercase character or should only contain capital letters. " +
           "In an exception to the above, variable names may start with a capital letter " +
           "when they are declared static and immutable.",
         nonTriggeringExamples: [


### PR DESCRIPTION
Fixes #161.