### PR TITLE
re-word lint command description (CommandType.function)

### DIFF
--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -17,8 +17,7 @@ let fileManager = NSFileManager.defaultManager()
 
 struct LintCommand: CommandType {
     let verb = "lint"
-    let function = "Print lint warnings and errors for the Swift files in the current directory " +
-                   "(default command)"
+    let function = "Print lint warnings and errors (default command)"
 
     func run(mode: CommandMode) -> Result<(), CommandantError<()>> {
         return LintOptions.evaluate(mode).flatMap { options in


### PR DESCRIPTION
it was simplistic & incorrect to state that only files in the current directory are linted