### PR TITLE
Exclude files from included folders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   [JP Simard](https://github.com/jpsim)
   [#5](https://github.com/realm/SwiftLint/issues/5)
 
+* Allow to exclude files from `included` directory with `excluded`.  
+  [Michal Laskowski](https://github.com/michallaskowski)
+  
 ##### Bug Fixes
 
 * Statement position rule no longer triggers for non-keyword uses of `catch` and

--- a/README.md
+++ b/README.md
@@ -121,11 +121,13 @@ disabled_rules: # rule identifiers to exclude from running
   - type_body_length
   - type_name
   - variable_name
-included: # paths to include during linting. `--path` is ignored if present. takes precendence over `excluded`.
+included: # paths to include during linting. `--path` is ignored if present.
   - Source
-excluded: # paths to ignore during linting. overridden by `included`.
+excluded: # paths to ignore during linting.
   - Carthage
   - Pods
+  - Source/ExcludedFolder
+  - Source/EcludedFile.swift
 # parameterized rules can be customized from this configuration file
 line_length: 110
 # parameterized rules are first parameterized as a warning level, then error level.

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -167,11 +167,16 @@ public struct Configuration {
         return zip([.Warning, .Error], array).map(RuleParameter.init)
     }
 
-    public func lintableFilesForPath(path: String) -> [File] {
+    public func lintablePathsForPath(path: String,
+                                     fileManager: NSFileManager = fileManager) -> [String] {
         let pathsForPath = included.isEmpty ? fileManager.filesToLintAtPath(path) : []
         let excludedPaths = excluded.flatMap(fileManager.filesToLintAtPath)
         let includedPaths = included.flatMap(fileManager.filesToLintAtPath)
-        let allPaths = pathsForPath.filter(excludedPaths.contains) + includedPaths
+        return (pathsForPath + includedPaths).filter({ !excludedPaths.contains($0) })
+    }
+
+    public func lintableFilesForPath(path: String) -> [File] {
+        let allPaths = self.lintablePathsForPath(path)
         return allPaths.flatMap { File(path: $0) }
     }
 }

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -67,4 +67,26 @@ class ConfigurationTests: XCTestCase {
         }
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
     }
+
+    private class TestFileManager: NSFileManager {
+        private override func filesToLintAtPath(path: String) -> [String] {
+            switch path {
+            case "directory": return ["directory/File1.swift", "directory/File2.swift",
+                "directory/excluded/Excluded.swift",  "directory/ExcludedFile.swift"]
+            case "directory/excluded" : return ["directory/excluded/Excluded.swift"]
+            case "directory/ExcludedFile.swift" : return ["directory/ExcludedFile.swift"]
+            default: break
+            }
+            XCTFail("Should not be called with path \(path)")
+            return []
+        }
+    }
+
+    func testExcludedPaths() {
+        let configuration = Configuration(disabledRules: [], included: ["directory"],
+            excluded: ["directory/excluded",  "directory/ExcludedFile.swift"],
+            reporter: "json", rules: [])!
+        let paths = configuration.lintablePathsForPath("", fileManager: TestFileManager())
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
+    }
 }


### PR DESCRIPTION
Allows to exclude specific files and folders via `excluded` from `included` paths.

Reason behind this:
In one of my projects I use [sbconstants](https://github.com/paulsamuels/SBConstants), which produces a file that does not pass lint. I would like to store the generated file in the same directory with my Storyboards, for example `Source/Interface`, and to be able to exclude the `Source/Interface` directory while linting other files in `Source`.