### PR TITLE
Optimize `File.matchPattern(_:) -> [(NSRange, [SyntaxKind])]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Make linting faster than 0.5.0, but slower than 0.4.0  
   [Norio Nomura](https://github.com/norio-nomura)
-  [#263](https://github.com/realm/SwiftLint/pull/263)
+  [#119](https://github.com/jpsim/SourceKitten/issues/119)
 
 ## 0.5.0: Downy™
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Master
+
+##### Bug Fixes
+
+* Make linting faster than 0.5.0, but slower than 0.4.0  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#263](https://github.com/realm/SwiftLint/pull/263)
+
 ## 0.5.0: Downy™
 
 ##### Breaking
@@ -24,7 +32,7 @@
 
 * Allow to exclude files from `included` directory with `excluded`.  
   [Michal Laskowski](https://github.com/michallaskowski)
-  
+
 ##### Bug Fixes
 
 * Statement position rule no longer triggers for non-keyword uses of `catch` and
@@ -78,7 +86,7 @@
   [Mickael Morier](https://github.com/mmorier)
   [#187](https://github.com/realm/SwiftLint/issues/187)
 
-* `ControlStatementRule` no longer triggers a violation for acceptable use of 
+* `ControlStatementRule` no longer triggers a violation for acceptable use of
   parentheses.  
   [Mickael Morier](https://github.com/mmorier)
   [#189](https://github.com/realm/SwiftLint/issues/189)

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -61,11 +61,11 @@ extension File {
         let syntax = syntaxMap
         let matches = regex(pattern).matchesInString(self.contents, options: [], range: range)
         return matches.map { match in
-            let matchRangeInByte = contents.NSRangeToByteRange(start: match.range.location,
+            let matchByteRange = contents.NSRangeToByteRange(start: match.range.location,
                 length: match.range.length) ?? match.range
             let kindsInRange = syntax.tokens.filter { token in
-                let tokenRange = NSRange(location: token.offset, length: token.length)
-                return NSIntersectionRange(matchRangeInByte, tokenRange).length > 0
+                let tokenByteRange = NSRange(location: token.offset, length: token.length)
+                return NSIntersectionRange(matchByteRange, tokenByteRange).length > 0
             }.map({ $0.type }).flatMap(SyntaxKind.init)
             return (match.range, kindsInRange)
         }

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -61,11 +61,11 @@ extension File {
         let syntax = syntaxMap
         let matches = regex(pattern).matchesInString(self.contents, options: [], range: range)
         return matches.map { match in
+            let matchRangeInByte = contents.NSRangeToByteRange(start: match.range.location,
+                length: match.range.length) ?? match.range
             let kindsInRange = syntax.tokens.filter { token in
-                let tokenRange = contents
-                    .byteRangeToNSRange(start: token.offset, length: token.length) ??
-                    NSRange(location: token.offset, length: token.length)
-                return NSIntersectionRange(match.range, tokenRange).length > 0
+                let tokenRange = NSRange(location: token.offset, length: token.length)
+                return NSIntersectionRange(matchRangeInByte, tokenRange).length > 0
             }.map({ $0.type }).flatMap(SyntaxKind.init)
             return (match.range, kindsInRange)
         }


### PR DESCRIPTION
Change from converting match's position to converting token's position.
By applying this, duration of linting KeychainAccess is reduced from 752+sec(I can't wait completion) to 27sec, but still slower that 0.4.0 (7 sec).

Related: https://github.com/jpsim/SourceKitten/issues/119