### PR TITLE
re-introduce use-script-input-files option for lint & autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
 ## Master
 
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
 ##### Bug Fixes
 
 * Make linting faster than 0.5.0, but slower than 0.4.0  
   [Norio Nomura](https://github.com/norio-nomura)
   [#119](https://github.com/jpsim/SourceKitten/issues/119)
+
+* Re-introduce `--use-script-input-files` option for `lint` & `autocorrect`
+  commands. Should also fix some issues when running SwiftLint from an Xcode
+  build phase.  
+  [JP Simard](https://github.com/jpsim)
+  [#264](https://github.com/realm/SwiftLint/issues/264)
 
 ## 0.5.0: Downy™
 
@@ -72,7 +86,7 @@
   [JP Simard](https://github.com/jpsim)
 
 * Support linting from Input Files provided by Run Script Phase of Xcode with
-   `--use-script-input-files`.  
+  `--use-script-input-files`.  
   [Norio Nomura](https://github.com/norio-nomura)
   [#193](https://github.com/realm/SwiftLint/pull/193)
 

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -20,7 +20,8 @@ struct AutoCorrectCommand: CommandType {
     func run(mode: CommandMode) -> Result<(), CommandantError<()>> {
         return AutoCorrectOptions.evaluate(mode).flatMap { options in
             let configuration = Configuration(commandLinePath: options.configurationFile)
-            return configuration.visitLintableFiles(options.path, action: "Correcting") { linter in
+            return configuration.visitLintableFiles(options.path, action: "Correcting",
+                useScriptInputFiles: options.useScriptInputFiles) { linter in
                 let corrections = linter.correct()
                 if !corrections.isEmpty {
                     let correctionLogs = corrections.map({ $0.consoleDescription })
@@ -37,6 +38,7 @@ struct AutoCorrectCommand: CommandType {
 struct AutoCorrectOptions: OptionsType {
     let path: String
     let configurationFile: String
+    let useScriptInputFiles: Bool
 
     static func evaluate(mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<()>> {
         return curry(self.init)
@@ -46,5 +48,8 @@ struct AutoCorrectOptions: OptionsType {
             <*> mode <| Option(key: "config",
                 defaultValue: ".swiftlint.yml",
                 usage: "the path to SwiftLint's configuration file")
+            <*> mode <| Option(key: "use-script-input-files",
+                defaultValue: false,
+                usage: "read SCRIPT_INPUT_FILE* environment variables as files")
     }
 }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -23,7 +23,8 @@ struct LintCommand: CommandType {
             var reporter: Reporter.Type!
             let configuration = Configuration(commandLinePath: options.configurationFile)
             return configuration.visitLintableFiles(options.path, action: "Linting",
-                useSTDIN: options.useSTDIN) { linter in
+                useSTDIN: options.useSTDIN,
+                useScriptInputFiles: options.useScriptInputFiles) { linter in
                 let currentViolations = linter.styleViolations
                 violations += currentViolations
                 if reporter == nil { reporter = linter.reporter }
@@ -61,9 +62,11 @@ struct LintOptions: OptionsType {
     let useSTDIN: Bool
     let configurationFile: String
     let strict: Bool
+    let useScriptInputFiles: Bool
 
     static func evaluate(mode: CommandMode) -> Result<LintOptions, CommandantError<()>> {
-        return curry(self.init)
+        let curriedInitializer = curry(self.init)
+        return curriedInitializer
             <*> mode <| Option(key: "path",
                 defaultValue: "",
                 usage: "the path to the file or directory to lint")
@@ -76,5 +79,8 @@ struct LintOptions: OptionsType {
             <*> mode <| Option(key: "strict",
                 defaultValue: false,
                 usage: "fail on warnings")
+            <*> mode <| Option(key: "use-script-input-files",
+                defaultValue: false,
+                usage: "read SCRIPT_INPUT_FILE* environment variables as files")
     }
 }


### PR DESCRIPTION
I removed it because I'm a dummy. Fixes #264.