### PR TITLE
Add Function Naming Case Rule

### DIFF
--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -130,6 +130,7 @@ public struct Configuration {
             ControlStatementRule(),
             ForceCastRule(),
             ForceTryRule(),
+            FunctionNamingCaseRule(),
             LeadingWhitespaceRule(),
             LegacyConstructorRule(),
             NestingRule(),

--- a/Source/SwiftLintFramework/Rules/FunctionNamingCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionNamingCaseRule.swift
@@ -1,0 +1,33 @@
+//
+//  FunctionNamingCaseRule.swift
+//  SwiftLint
+//
+//  Created by Paul Williamson on 18/12/2015.
+//  Copyright © 2015 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct FunctionNamingCaseRule: Rule {
+    public static let description = RuleDescription(
+        identifier: "function_naming_case",
+        name: "Function Naming Case",
+        description: "Function names should begin with a lower case letter.",
+        nonTriggeringExamples: [
+            "func doSomething() { }"
+        ],
+        triggeringExamples: [
+            "func DoSomething() { }"
+        ]
+    )
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        let pattern = "func\\s+[A-Z]"
+        let excludingKinds = SyntaxKind.commentAndStringKinds()
+
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: $0.location))
+        }
+    }
+}

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -105,4 +105,8 @@ class StringRuleTests: XCTestCase {
     func testLegacyConstructor() {
         verifyRule(LegacyConstructorRule.description)
     }
+
+    func testFunctionNamingCase() {
+        verifyRule(FunctionNamingCaseRule.description)
+    }
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
+		0E3BC8661C242DCF00BC1F25 /* FunctionNamingCaseRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3BC8651C242DCF00BC1F25 /* FunctionNamingCaseRule.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
@@ -139,6 +140,7 @@
 
 /* Begin PBXFileReference section */
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
+		0E3BC8651C242DCF00BC1F25 /* FunctionNamingCaseRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionNamingCaseRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -465,6 +467,7 @@
 				E88DEA7F1B09903300A66CB0 /* ForceCastRule.swift */,
 				E816194D1BFBFEAB00946723 /* ForceTryRule.swift */,
 				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
+				0E3BC8651C242DCF00BC1F25 /* FunctionNamingCaseRule.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */,
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
@@ -715,6 +718,7 @@
 				E88198541BEA945100333A11 /* CommaRule.swift in Sources */,
 				E88198601BEA98F000333A11 /* VariableNameRule.swift in Sources */,
 				E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */,
+				0E3BC8661C242DCF00BC1F25 /* FunctionNamingCaseRule.swift in Sources */,
 				E86396CB1BADB519002C9E88 /* CSVReporter.swift in Sources */,
 				E88198561BEA94D800333A11 /* FileLengthRule.swift in Sources */,
 				E8B67C3E1C095E6300FDED8E /* Correction.swift in Sources */,


### PR DESCRIPTION
This commit adds a new rule for ensuring method names start with a lower case letter.

I'm unsure where new contributions should be added to the `CHANGELOG.md` as there is no `Master` heading anymore.

I hope this is useful.