### PR TITLE
Add ClosingBraceRule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Improve autocorrect for OpeningBraceRule.  
   [Yasuhiro Inami](https://github.com/inamiy)
 
+* Add ClosingBraceRule.  
+  [Yasuhiro Inami](https://github.com/inamiy)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -125,6 +125,7 @@ public struct Configuration {
 
     public static func rulesFromYAML(yaml: Yaml? = nil) -> [Rule] {
         return [
+            ClosingBraceRule(),
             ColonRule(),
             CommaRule(),
             ControlStatementRule(),

--- a/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
@@ -1,0 +1,74 @@
+//
+//  ClosingBraceRule.swift
+//  SwiftLint
+//
+//  Created by Yasuhiro Inami on 2015-12-19.
+//  Copyright © 2015 Yasuhiro Inami. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+private let whitespaceAndNewlineCharacterSet = NSCharacterSet.whitespaceAndNewlineCharacterSet()
+
+extension File {
+    private func violatingClosingBraceRanges() -> [NSRange] {
+        return matchPattern(
+            "(\\}\\s+\\))",
+            excludingSyntaxKinds: SyntaxKind.commentAndStringKinds()
+        )
+    }
+}
+
+public struct ClosingBraceRule: CorrectableRule {
+    public static let description = RuleDescription(
+        identifier: "closing_brace",
+        name: "Closing Brace Spacing",
+        description: "Closing brace with closing parenthesis" +
+                     "should not have any whitespaces in the middle.",
+        nonTriggeringExamples: [
+            "[].map({ })"
+        ],
+        triggeringExamples: [
+            "[].map({ } )"
+        ],
+        corrections: [
+            "[].map({ } )\n": "[].map({ })\n"
+        ]
+    )
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        return file.violatingClosingBraceRanges().map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: $0.location))
+        }
+    }
+
+    public func correctFile(file: File) -> [Correction] {
+        let violatingRanges = file.ruleEnabledViolatingRanges(
+            file.violatingClosingBraceRanges(),
+            forRule: self
+        )
+        return writeToFile(file, violatingRanges: violatingRanges)
+    }
+
+    private func writeToFile(file: File, violatingRanges: [NSRange]) -> [Correction] {
+        var correctedContents = file.contents
+        var adjustedLocations = [Int]()
+
+        for violatingRange in violatingRanges.reverse() {
+            if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
+                correctedContents = correctedContents
+                    .stringByReplacingCharactersInRange(indexRange, withString: "})")
+                adjustedLocations.insert(violatingRange.location, atIndex: 0)
+            }
+        }
+
+        file.write(correctedContents)
+
+        return adjustedLocations.map {
+            Correction(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, offset: $0))
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -44,7 +44,7 @@ public struct OpeningBraceRule: CorrectableRule {
             "struct Parent {\n\tstruct Child\n\t{\n\t\tlet foo: Int\n\t}\n}\n":
                 "struct Parent {\n\tstruct Child {\n\t\tlet foo: Int\n\t}\n}\n",
             "[].map(){ $0 }\n": "[].map() { $0 }\n",
-            "[].map( { } )\n": "[].map({ } )\n",
+            "[].map( { })\n": "[].map({ })\n",
         ]
     )
 
@@ -65,7 +65,7 @@ public struct OpeningBraceRule: CorrectableRule {
 
     private func writeToFile(file: File, violatingRanges: [NSRange]) -> [Correction] {
         var correctedContents = file.contents
-        var adjustedOffsets = [Int]()
+        var adjustedLocations = [Int]()
 
         for violatingRange in violatingRanges.reverse() {
             let (contents, adjustedRange) =
@@ -73,13 +73,13 @@ public struct OpeningBraceRule: CorrectableRule {
 
             correctedContents = contents
             if let adjustedRange = adjustedRange {
-                adjustedOffsets.insert(adjustedRange.location, atIndex: 0)
+                adjustedLocations.insert(adjustedRange.location, atIndex: 0)
             }
         }
 
         file.write(correctedContents)
 
-        return adjustedOffsets.map {
+        return adjustedLocations.map {
             Correction(ruleDescription: self.dynamicType.description,
                 location: Location(file: file, offset: $0))
         }

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -81,6 +81,10 @@ class StringRuleTests: XCTestCase {
         verifyRule(OpeningBraceRule.description)
 	}
 
+    func testClosingBrace() {
+        verifyRule(ClosingBraceRule.description)
+    }
+
     func testComma() {
         verifyRule(CommaRule.description)
     }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
+		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
@@ -139,6 +140,7 @@
 
 /* Begin PBXFileReference section */
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
+		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -458,6 +460,7 @@
 		E88DEA7A1B098D7300A66CB0 /* Rules */ = {
 			isa = PBXGroup;
 			children = (
+				1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */,
 				E88DEA831B0990F500A66CB0 /* ColonRule.swift */,
 				695BE9CE1BDFD92B0071E985 /* CommaRule.swift */,
 				65454F451B14D73800319A6C /* ControlStatementRule.swift */,
@@ -706,6 +709,7 @@
 				D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */,
 				83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */,
 				E812249C1B04FADC001783D2 /* Linter.swift in Sources */,
+				1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */,
 				CAF900151BED8B17006A371D /* VariableNameMinLengthRule.swift in Sources */,
 				E81CDE711C00FEAA00B430F6 /* ValidDocsRule.swift in Sources */,
 				E87E4A091BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift in Sources */,


### PR DESCRIPTION
This is an improvement for #274 to support closing-brace rule.

`[].map({ } )` will be autocorrected to `[].map({ })`.