### PR TITLE
Add autocorrect for ColonRule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Improve autocorrect for OpeningBraceRule.  
   [Yasuhiro Inami](https://github.com/inamiy)
+* Add autocorrect for ColonRule.  
+  [Brian Partridge](https://github.com/brianpartridge)
 
 ##### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ variable_name_min_length:
 ### Auto-correct
 
 SwiftLint can automatically correct certain violations (currently only
-`trailing_newline`, `trailing_semicolon` & `trailing_whitespace`). Files on disk
+`trailing_newline`, `trailing_semicolon`, `trailing_whitespace`, `colon`). Files on disk
 are overwritten with a corrected version.
 
 Please make sure to have backups of these files before running

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -77,7 +77,7 @@ public struct ColonRule: CorrectableRule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let pattern = (patterns() as NSArray).componentsJoinedByString("|")
+        let pattern = patterns().joinWithSeparator("|")
 
         return validMatchesInFile(file, withPattern: pattern).flatMap { range in
             return StyleViolation(ruleDescription: self.dynamicType.description,


### PR DESCRIPTION
This change adds autocorrect support for ColonRule so now all your colons will be properly positioned.  The changes include:
- Improved regular expressions (support for more type identifiers, lazy evaluation of type identifiers).
- More tests for new type identifier support.
- Improved support for rejecting strings and comments.

The only thing I dislike about this is that we need to take 2 passes over the file (once for each regex). I'm not sure if there is a way to avoid this without adding false positives to the validation step though.

:rainbow: 