### PR TITLE
Add note about specifying reporter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ variable_name_max_length:
 variable_name_min_length:
   - 3 # warning
   - 2 # error
+reporter: "csv" # reporter type (xcode, json, csv)
 ```
 
 ### Auto-correct


### PR DESCRIPTION
Didn't even know there are other types of reporters until I browsed some issues and code itself