### PR TITLE
Better failing on yaml parser error

### DIFF
--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -120,6 +120,8 @@ public struct Configuration {
                 queuedPrintError("Loading configuration from '\(path)'")
                 self.init(yaml: yamlContents)!
                 return
+            } else {
+                failIfRequired()
             }
         } catch {
             failIfRequired()

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -87,7 +87,11 @@ public struct Configuration {
     }
 
     public init?(yaml: String) {
-        guard let yamlConfig = Yaml.load(yaml).value else {
+        let yamlResult = Yaml.load(yaml)
+        guard let yamlConfig = yamlResult.value else {
+            if let error = yamlResult.error {
+                queuedPrint(error)
+            }
             return nil
         }
         self.init(


### PR DESCRIPTION
- Add printing error when `Yaml.load(_:)` returns error
This will help finding error from YAML parser without using third-party YAML validator.

- Change to fail on YAML parser error if configuration file is required
This will help user to noticing YAML parser error.

This will reduce issues such as #249 