### PR TITLE
Optimize `invalidDocOffsets(_:)`

### DIFF
--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -14,11 +14,12 @@ extension File {
         let substructure = (dictionary["key.substructure"] as? XPCArray)?
             .flatMap { $0 as? XPCDictionary } ?? []
         let substructureOffsets = substructure.flatMap(invalidDocOffsets)
-        guard let kind = (dictionary["key.kind"] as? String).flatMap(SwiftDeclarationKind.init),
-            offset = dictionary["key.offset"] as? Int64,
+        guard let kind = (dictionary["key.kind"] as? String).flatMap(SwiftDeclarationKind.init)
+            where kind != .VarParameter,
+            let offset = dictionary["key.offset"] as? Int64,
             bodyOffset = dictionary["key.bodyoffset"] as? Int64,
             comment = getDocumentationCommentBody(dictionary, syntaxMap: syntaxMap)
-            where kind != .VarParameter && !comment.containsString(":nodoc:") else {
+            where !comment.containsString(":nodoc:") else {
                 return substructureOffsets
         }
         let declaration = contents[Int(offset)..<Int(bodyOffset)]


### PR DESCRIPTION
Change guard condition to fails earlier

This commit reduces the duration of linting KeychainAccess from:
```
swiftlint lint  5.37s user 0.14s system 93% cpu 5.889 total
```
to:
```
swiftlint lint  3.74s user 0.13s system 91% cpu 4.238 total
```

the duration of linting Carthage is reduced from:
```
swiftlint lint  33.48s user 1.86s system 82% cpu 42.645 total
```
to:
```
swiftlint lint  29.61s user 1.81s system 79% cpu 39.377 total
```