### PR TITLE
Fix typo in FunctionBodyLengthRule and TypeBodyLengthRule

### DIFF
--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -63,7 +63,7 @@ public struct FunctionBodyLengthRule: ASTRule, ParameterizedRule {
                     return [StyleViolation(ruleDescription: self.dynamicType.description,
                         severity: parameter.severity,
                         location: location,
-                        reason: "Function body should be span \(parameters.first!.value) lines " +
+                        reason: "Function body should span \(parameters.first!.value) lines " +
                         "or less: currently spans \(endLine - startLine) lines")]
                 }
             }

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -47,7 +47,7 @@ public struct TypeBodyLengthRule: ASTRule, ParameterizedRule {
                     where endLine - startLine > parameter.value {
                         return [StyleViolation(ruleDescription: self.dynamicType.description,
                             severity: parameter.severity, location: location,
-                            reason: "Type body should be span \(parameters.first!.value) lines " +
+                            reason: "Type body should span \(parameters.first!.value) lines " +
                             "or less: currently spans \(endLine - startLine) lines")]
                 }
             }

--- a/Source/SwiftLintFrameworkTests/ASTRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/ASTRuleTests.swift
@@ -147,7 +147,7 @@ class ASTRuleTests: XCTestCase {
         XCTAssertEqual(violations(longerFunctionBody), [StyleViolation(
             ruleDescription: FunctionBodyLengthRule.description,
             location: Location(file: nil, line: 1, character: 1),
-            reason: "Function body should be span 40 lines or less: currently spans 41 lines")])
+            reason: "Function body should span 40 lines or less: currently spans 41 lines")])
     }
 
     func testTypeBodyLengths() {
@@ -162,7 +162,7 @@ class ASTRuleTests: XCTestCase {
             XCTAssertEqual(violations(longerTypeBody), [StyleViolation(
                 ruleDescription: TypeBodyLengthRule.description,
                 location: Location(file: nil, line: 1, character: 1),
-                reason: "Type body should be span 200 lines or less: currently spans 201 lines")])
+                reason: "Type body should span 200 lines or less: currently spans 201 lines")])
         }
     }
 


### PR DESCRIPTION
Just a small typo. I assume this is not relevant enough to go into the change log, otherwise I'm happy to add it.