### PR TITLE
Fixed trailingNewlineCount() returning wrong count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Bug Fixes
 
-* None.
+* AutoCorrect for TrailingNewlineRule only removes at most one line.
+  [John Estropia](https://github.com/JohnEstropia)
 
 
 ## 0.5.5: Magic Drying Fluff Balls™

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ##### Bug Fixes
 
-* AutoCorrect for TrailingNewlineRule only removes at most one line.
+* AutoCorrect for TrailingNewlineRule only removes at most one line.  
   [John Estropia](https://github.com/JohnEstropia)
 
 

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -10,11 +10,8 @@ import SourceKittenFramework
 
 extension String {
     private func trailingNewlineCount() -> Int? {
-        let start = endIndex.advancedBy(-2, limit: startIndex)
-        let range = Range(start: start, end: endIndex)
-        let substring = self[range].utf16
         let newLineSet = NSCharacterSet.newlineCharacterSet()
-        let slices = substring.split(allowEmptySlices: true) { !newLineSet.characterIsMember($0) }
+        let slices = self.utf16.split(allowEmptySlices: true) { !newLineSet.characterIsMember($0) }
 
         return slices.last?.count
     }
@@ -34,7 +31,8 @@ public struct TrailingNewlineRule: CorrectableRule {
         ],
         corrections: [
             "let a = 0": "let a = 0\n",
-            "let a = 0\n\n": "let a = 0\n"
+            "let b = 0\n\n": "let b = 0\n",
+            "let c = 0\n\n\n\n": "let c = 0\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -9,11 +9,19 @@
 import SourceKittenFramework
 
 extension String {
+    private func countOfTrailingCharactersInSet(characterSet: NSCharacterSet) -> Int {
+        var count = 0
+        for char in utf16.lazy.reverse() {
+            if !characterSet.characterIsMember(char) {
+                break
+            }
+            count++
+        }
+        return count
+    }
+    
     private func trailingNewlineCount() -> Int? {
-        let newLineSet = NSCharacterSet.newlineCharacterSet()
-        let slices = self.utf16.split(allowEmptySlices: true) { !newLineSet.characterIsMember($0) }
-
-        return slices.last?.count
+        return countOfTrailingCharactersInSet(NSCharacterSet.newlineCharacterSet())
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -19,7 +19,7 @@ extension String {
         }
         return count
     }
-    
+
     private func trailingNewlineCount() -> Int? {
         return countOfTrailingCharactersInSet(NSCharacterSet.newlineCharacterSet())
     }


### PR DESCRIPTION
`let start = endIndex.advancedBy(-2, limit: startIndex)` 
basically limited this method to count only up to 2 lines...