### PR TITLE
Add autocorrect for CommaRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Add AutoCorrect for StatementPositionRule.  
   [Raphael Randschau](https://github.com/nicolai86)
+* Add AutoCorrect for CommaRule.  
+  [Raphael Randschau](https://github.com/nicolai86)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct CommaRule: Rule {
+public struct CommaRule: CorrectableRule {
     public static let description = RuleDescription(
         identifier: "comma",
         name: "Comma Spacing",
@@ -23,6 +23,12 @@ public struct CommaRule: Rule {
             "func abc(a: String↓ ,b: String) { }",
             "abc(a: \"string\"↓,b: \"string\"",
             "enum a { case a↓ ,b }"
+        ],
+        corrections: [
+            "func abc(a: String,b: String) {}\n": "func abc(a: String, b: String) {}\n",
+            "abc(a: \"string\",b: \"string\"\n": "abc(a: \"string\", b: \"string\"\n",
+            "abc(a: \"string\"  ,  b: \"string\"\n": "abc(a: \"string\", b: \"string\"\n",
+            "enum a { case a  ,b }\n": "enum a { case a, b }\n"
         ]
     )
 
@@ -34,5 +40,27 @@ public struct CommaRule: Rule {
             StyleViolation(ruleDescription: self.dynamicType.description,
                 location: Location(file: file, characterOffset: $0.location))
         }
+    }
+
+    public func correctFile(file: File) -> [Correction] {
+        guard validateFile(file).count > 0 else { return [] }
+        let pattern = "\\s*\\,\\s*([^\\s])"
+
+        let description = self.dynamicType.description
+        var corrections = [Correction]()
+        var contents = file.contents
+
+        let matches = file.matchPattern(pattern, withSyntaxKinds: [.Identifier])
+
+        let regularExpression = regex(pattern)
+        for range in matches.reverse() {
+            contents = regularExpression.stringByReplacingMatchesInString(contents,
+                options: [], range: range, withTemplate: ", $1")
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: description, location: location))
+        }
+
+        file.write(contents)
+        return corrections
     }
 }


### PR DESCRIPTION
Another tiny addition to make `autocorrect` more useful for existing codebases.