### PR TITLE
Fix typo in CommaRule.swift

### DIFF
--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -13,7 +13,7 @@ public struct CommaRule: CorrectableRule {
     public static let description = RuleDescription(
         identifier: "comma",
         name: "Comma Spacing",
-        description: "One space before and no after must be present next to any comma.",
+        description: "One space after and no before must be present next to any comma.",
         nonTriggeringExamples: [
             "func abc(a: String, b: String) { }",
             "abc(a: \"string\", b: \"string\"",

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -13,7 +13,7 @@ public struct CommaRule: CorrectableRule {
     public static let description = RuleDescription(
         identifier: "comma",
         name: "Comma Spacing",
-        description: "One space after and no before must be present next to any comma.",
+        description: "There should be no space before and one after any comma.",
         nonTriggeringExamples: [
             "func abc(a: String, b: String) { }",
             "abc(a: \"string\", b: \"string\"",


### PR DESCRIPTION
The description implied the opposite of the rule.