### PR TITLE
Reduce calls to `String.characters.count` in `LineLengthRule.validateFile(_:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * Improve performance by reducing calls to SourceKit.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Improve performance of `LineLengthRule`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Bug Fixes
 
 * AutoCorrect for TrailingNewlineRule only removes at most one line.  

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -30,12 +30,13 @@ public struct LineLengthRule: ParameterizedRule {
 
     public func validateFile(file: File) -> [StyleViolation] {
         return file.lines.flatMap { line in
-            for param in parameters.reverse() where line.content.characters.count > param.value {
+            let length = line.content.characters.count
+            for param in parameters.reverse() where length > param.value {
                 return StyleViolation(ruleDescription: self.dynamicType.description,
                     severity: param.severity,
                     location: Location(file: file.path, line: line.index),
                     reason: "Line should be \(parameters.first!.value) characters or less: " +
-                    "currently \(line.content.characters.count) characters")
+                    "currently \(length) characters")
             }
             return nil
         }


### PR DESCRIPTION
By applying this, the duration of linting Carthage is reduced from:
```
swiftlint lint  20.07s user 1.10s system 84% cpu 25.023 total
```
to:
```
swiftlint lint  18.27s user 1.05s system 84% cpu 22.769 total
```