### PR TITLE
Add type function count rule 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ##### Enhancements
 
+* Add TypeFunctionCountRule.  
+  [Brandon Kobilansky](https://github.com/bkobilansky)
+  [#53](https://github.com/realm/SwiftLint/issues/53)
+
 * Add AutoCorrect for StatementPositionRule.  
   [Raphael Randschau](https://github.com/nicolai86)
 

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -21,6 +21,7 @@ extension Yaml {
     }
 }
 
+// swiftlint:disable type_function_count
 public struct Configuration: Equatable {
     public let disabledRules: [String] // disabled_rules
     public let included: [String]      // included
@@ -185,6 +186,7 @@ public struct Configuration: Equatable {
             intParams(FunctionBodyLengthRule).map(FunctionBodyLengthRule.init) ?? FunctionBodyLengthRule(),
             intParams(LineLengthRule).map(LineLengthRule.init) ?? LineLengthRule(),
             intParams(TypeBodyLengthRule).map(TypeBodyLengthRule.init) ?? TypeBodyLengthRule(),
+            intParams(TypeFunctionCountRule).map(TypeFunctionCountRule.init) ?? TypeFunctionCountRule(),
             intParams(VariableNameMaxLengthRule).map(VariableNameMaxLengthRule.init) ?? VariableNameMaxLengthRule(),
             intParams(VariableNameMinLengthRule).map(VariableNameMinLengthRule.init) ?? VariableNameMinLengthRule(),
         ]
@@ -216,6 +218,7 @@ public struct Configuration: Equatable {
         return self
     }
 }
+// swiftlint:enable type_function_count
 
 // MARK: - Nested Configurations Extension
 

--- a/Source/SwiftLintFramework/Rules/TypeFunctionCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeFunctionCountRule.swift
@@ -1,0 +1,84 @@
+//
+//  TypeFunctionCountRule.swift
+//  SwiftLint
+//
+//  Created by Brandon Kobilansky on 1/11/16.
+//  Copyright (c) 2016 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+import SwiftXPC
+
+public struct TypeFunctionCountRule: ASTRule, ParameterizedRule {
+    public init() {
+        self.init(parameters: [
+            RuleParameter(severity: .Warning, value: 8),
+            RuleParameter(severity: .Error, value: 10)
+            ])
+    }
+
+    public init(parameters: [RuleParameter<Int>]) {
+        self.parameters = parameters
+    }
+
+    public let parameters: [RuleParameter<Int>]
+
+    public static let description = RuleDescription(
+        identifier: "type_function_count",
+        name: "Type Function Count",
+        description: "Types should not contain too many functions.",
+        nonTriggeringExamples: [
+            "struct Foo { static func foo() {} }",
+            "class Foo { class func foo() {} }",
+            "enum Foo { func foo() {} }",
+        ],
+        triggeringExamples: TypeFunctionCountRule.triggeringExamples()
+    )
+
+    public func validateFile(file: File,
+        kind: SwiftDeclarationKind,
+        dictionary: XPCDictionary) -> [StyleViolation] {
+            let typeKinds: [SwiftDeclarationKind] = [.Class, .Struct, .Enum]
+
+            if !typeKinds.contains(kind) {
+                return []
+            }
+
+            let functionKinds: [SwiftDeclarationKind] = [
+                .FunctionMethodInstance,
+                .FunctionMethodClass,
+                .FunctionMethodStatic
+            ]
+
+            if let substructure = dictionary["key.substructure"] as? XPCArray {
+                let functions = substructure.filter { xpcItem in
+                    if let item = xpcItem as? XPCDictionary,
+                        keyKind = item["key.kind"] as? String,
+                        functionKind = SwiftDeclarationKind(rawValue: keyKind) {
+                            return functionKinds.contains(functionKind)
+                    }
+                    return false
+                }
+
+                for parameter in parameters.reverse() where functions.count > parameter.value {
+                    let offset = (dictionary["key.nameoffset"] as? Int64).flatMap({Int($0)}) ?? 0
+                    return [StyleViolation(ruleDescription: self.dynamicType.description,
+                        severity: parameter.severity,
+                        location: Location(file: file, characterOffset: offset),
+                        reason: "Type should contain \(parameter.value) functions or less: " +
+                        "currently contains \(functions.count)")]
+                }
+            }
+            return []
+    }
+
+    // MARK: - Private Methods
+
+    private static func triggeringExamples() -> [String] {
+        let functions = "static func foo() {} class func foo() {} func foo() {}"
+        let repeatedFunctions = Repeat(count: 10, repeatedValue: functions).joinWithSeparator("")
+        return ["struct", "class", "enum"].map {
+            return "\($0) Foo { \(repeatedFunctions) }"
+        }
+    }
+}

--- a/Source/SwiftLintFrameworkTests/ASTRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/ASTRuleTests.swift
@@ -9,6 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
+// swiftlint:disable type_function_count
 class ASTRuleTests: XCTestCase {
     func testTypeNames() {
         for kind in ["class", "struct", "enum"] {
@@ -166,6 +167,10 @@ class ASTRuleTests: XCTestCase {
         }
     }
 
+    func testTypeFunctionCountRule() {
+        verifyRule(TypeFunctionCountRule.description)
+    }
+
     func testTypeNamesVerifyRule() {
         verifyRule(TypeNameRule.description)
     }
@@ -190,3 +195,4 @@ class ASTRuleTests: XCTestCase {
         verifyRule(ControlStatementRule.description)
     }
 }
+// swiftlint:enable type_function_count

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -10,6 +10,7 @@ import SwiftLintFramework
 import SourceKittenFramework
 import XCTest
 
+// swiftlint:disable type_function_count
 class ConfigurationTests: XCTestCase {
     func testInit() {
         XCTAssert(Configuration(yaml: "") != nil,
@@ -198,3 +199,4 @@ extension XCTestCase {
         return projectMockPathLevel3.stringByAppendingPathComponent("Level3.swift")
     }
 }
+// swiftlint:enable type_function_count

--- a/Source/SwiftLintFrameworkTests/StringRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/StringRuleTests.swift
@@ -9,6 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
+// swiftlint:disable type_function_count
 class StringRuleTests: XCTestCase {
     func testLineLengths() {
         let longLine = Repeat(count: 100, repeatedValue: "/").joinWithSeparator("") + "\n"
@@ -114,3 +115,4 @@ class StringRuleTests: XCTestCase {
         verifyRule(ConditionalBindingCascadeRule.description)
     }
 }
+// swiftlint:enable type_function_count

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
+		CAB5D8791C44ABAB0021D23F /* TypeFunctionCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5D8781C44ABAB0021D23F /* TypeFunctionCountRule.swift */; };
 		CAF900141BED8B17006A371D /* VariableNameMaxLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF900121BED8B17006A371D /* VariableNameMaxLengthRule.swift */; };
 		CAF900151BED8B17006A371D /* VariableNameMinLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF900131BED8B17006A371D /* VariableNameMinLengthRule.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -157,6 +158,7 @@
 		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
+		CAB5D8781C44ABAB0021D23F /* TypeFunctionCountRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeFunctionCountRule.swift; sourceTree = "<group>"; };
 		CAF900121BED8B17006A371D /* VariableNameMaxLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableNameMaxLengthRule.swift; sourceTree = "<group>"; };
 		CAF900131BED8B17006A371D /* VariableNameMinLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableNameMinLengthRule.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -501,6 +503,7 @@
 				E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */,
 				E88DEA851B0991BF00A66CB0 /* TrailingWhitespaceRule.swift */,
 				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
+				CAB5D8781C44ABAB0021D23F /* TypeFunctionCountRule.swift */,
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
 				E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */,
 				CAF900121BED8B17006A371D /* VariableNameMaxLengthRule.swift */,
@@ -772,6 +775,7 @@
 				E88DEA771B098D0C00A66CB0 /* Rule.swift in Sources */,
 				CAF900141BED8B17006A371D /* VariableNameMaxLengthRule.swift in Sources */,
 				E81619531BFC162C00946723 /* QueuedPrint.swift in Sources */,
+				CAB5D8791C44ABAB0021D23F /* TypeFunctionCountRule.swift in Sources */,
 				E87E4A051BFB927C00FCFE46 /* TrailingSemicolonRule.swift in Sources */,
 				E88198421BEA929F00333A11 /* NestingRule.swift in Sources */,
 				E881985B1BEA974E00333A11 /* StatementPositionRule.swift in Sources */,


### PR DESCRIPTION
Initial work on #53

Howdy folks, I have a couple of questions. First, I assumed this should be parameterized. What's our take on the default values? 8 for a warning, 10 for an error? 

Adding this also rule caused several lint failures around the codebase. How do we want to deal with that? For now, I disabled the rule for the failing types.