### PR TITLE
Revert "fix escaped double quote character"

### DIFF
--- a/Source/SwiftLintFramework/Reporters/CSVReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CSVReporter.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension String {
     private func escapedForCSV() -> String {
-        let escapedString = stringByReplacingOccurrencesOfString("\"", withString: "\\\"")
+        let escapedString = stringByReplacingOccurrencesOfString("\"", withString: "\"\"")
         if escapedString.containsString(",") || escapedString.containsString("\n") {
             return "\"\(escapedString)\""
         }


### PR DESCRIPTION
This reverts commit a0a76d898f61221fbdfe3f448e916047b4202b3d.

Turns out that the previous version was correct.
See https://en.wikipedia.org/wiki/Comma-separated_values