### PR TITLE
Fixing a minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - Pods
   - Source/ExcludedFolder
-  - Source/EcludedFile.swift
+  - Source/ExcludedFile.swift
 # parameterized rules can be customized from this configuration file
 line_length: 110
 # parameterized rules are first parameterized as a warning level, then error level.


### PR DESCRIPTION
At least, I think it's a typo. I would probably want to exclude a file names ```EcludedFile.swift```, too.