### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* FunctionBodyLengthRule now does not count comment lines.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#258](https://github.com/realm/SwiftLint/issues/258)
 
 ##### Bug Fixes
 
@@ -24,10 +26,6 @@
   [Scott Hoyt](https://github.com/scottrhoyt)
 
 ##### Enhancements
-
-* FunctionBodyLengthRule now does not count comment lines.  
-  [Marcelo Fabri](https://github.com/marcelofabri)
-  [#258](https://github.com/realm/SwiftLint/issues/258)
 
 * `ConfigurableRule` protocol allows for improved rule configuration. See
   `CONTRIBUTING` for more details.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Master
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* None.
+
 ## 0.6.0: Steam Cycle
 
 ##### Breaking


### PR DESCRIPTION
- Add empty first changelog section after 0.6.0
- `FunctionBodyLengthRule` was merged after 0.6.0