### PR TITLE
rewrite a few functions to shed ~10s off compile times

### DIFF
--- a/Source/SwiftLintFramework/Models/Location.swift
+++ b/Source/SwiftLintFramework/Models/Location.swift
@@ -15,9 +15,11 @@ public struct Location: CustomStringConvertible, Comparable {
     public var description: String {
         // Xcode likes warnings and errors in the following format:
         // {full_path_to_file}{:line}{:character}: {error,warning}: {content}
-        return (file ?? "<nopath>") +
-            (line.map({ ":\($0)" }) ?? "") +
-            (character.map({ ":\($0)" }) ?? "")
+        return [
+            file ?? "<nopath>",
+            line.map({ ":\($0)" }) ?? "",
+            character.map({ ":\($0)" }) ?? ""
+        ].joinWithSeparator("")
     }
 
     public init(file: String?, line: Int? = nil, character: Int? = nil) {

--- a/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
@@ -17,17 +17,15 @@ public struct CheckstyleReporter: Reporter {
     }
 
     public static func generateReport(violations: [StyleViolation]) -> String {
-        var report = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">"
-        report += violations.map { violation in
-            let fileName = violation.location.file ?? "<nopath>"
-            return "\n\t<file name=\"\(fileName)\">\n" +
-                "\t\t<error line=\"\(violation.location.line ?? 0)\" " +
-                "column=\"\(violation.location.character ?? 0)\" " +
-                "severity=\"\(violation.severity.rawValue.lowercaseString)\" " +
-                "message=\"\(violation.reason)\"/>\n" +
-                "\t</file>"
-        }.joinWithSeparator("")
-        report += "\n</checkstyle>"
-        return report
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">" +
+            violations.map({ violation in
+                let fileName = violation.location.file ?? "<nopath>"
+                return ["\n\t<file name=\"\(fileName)\">\n",
+                    "\t\t<error line=\"\(violation.location.line ?? 0)\" ",
+                    "column=\"\(violation.location.character ?? 0)\" ",
+                    "severity=\"\(violation.severity.rawValue.lowercaseString)\" ",
+                    "message=\"\(violation.reason)\"/>\n",
+                    "\t</file>"].joinWithSeparator("")
+            }).joinWithSeparator("") + "\n</checkstyle>"
     }
 }

--- a/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
@@ -20,10 +20,12 @@ public struct XcodeReporter: Reporter {
 
     internal static func generateForSingleViolation(violation: StyleViolation) -> String {
         // {full_path_to_file}{:line}{:character}: {error,warning}: {content}
-        return "\(violation.location): " +
-            "\(violation.severity.rawValue.lowercaseString): " +
-            "\(violation.ruleDescription.name) Violation: " +
-            (violation.reason ?? "") + " " +
-            "(" + (violation.ruleDescription.identifier) + ")"
+        return [
+            "\(violation.location): ",
+            "\(violation.severity.rawValue.lowercaseString): ",
+            "\(violation.ruleDescription.name) Violation: ",
+            (violation.reason ?? ""),
+            " (\(violation.ruleDescription.identifier))"
+        ].joinWithSeparator("")
     }
 }

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -9,22 +9,21 @@
 import SourceKittenFramework
 import SwiftXPC
 
-private func dictArrayForDictionary(dictionary: XPCDictionary, key: String) -> [[String: String]]? {
-    return (dictionary[key] as? XPCArray)?.flatMap {
+private func mappedDictValues(dictionary: XPCDictionary, key: String, subKey: String) -> [String] {
+    return (dictionary[key] as? XPCArray)?.flatMap({
         ($0 as? XPCDictionary) as? [String: String]
-    }
+    }).flatMap({ $0[subKey] }) ?? []
 }
 
 private func declarationOverrides(dictionary: XPCDictionary) -> Bool {
-    return dictArrayForDictionary(dictionary, key: "key.attributes")?.flatMap {
-        $0["key.attribute"]
-    }.contains("source.decl.attribute.override") ?? false
+    return mappedDictValues(dictionary, key: "key.attributes", subKey: "key.attribute")
+        .contains("source.decl.attribute.override")
 }
 
 private func inheritedMembersForDictionary(dictionary: XPCDictionary) -> [String] {
-    return dictArrayForDictionary(dictionary, key: "key.inheritedtypes")?.flatMap {
-        $0["key.name"]
-    }.flatMap { File.allDeclarationsByType[$0] ?? [] } ?? []
+    return mappedDictValues(dictionary, key: "key.inheritedtypes", subKey: "key.name").flatMap {
+        File.allDeclarationsByType[$0] ?? []
+    }
 }
 
 extension File {

--- a/Source/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -9,43 +9,43 @@
 import SwiftLintFramework
 import XCTest
 
+private func funcWithBody(body: String) -> String {
+    return "func abc() {\nvar x = 0\n\(body)}\n"
+}
+
 class FunctionBodyLengthRuleTests: XCTestCase {
     func testFunctionBodyLengths() {
-        let longFunctionBody = "func abc() {\n" +
-            "var x = 0\n" +
-            Repeat(count: 39, repeatedValue: "x = 0\n").joinWithSeparator("") +
-        "}\n"
+        let longFunctionBody = funcWithBody(
+            Repeat(count: 39, repeatedValue: "x = 0\n").joinWithSeparator("")
+        )
         XCTAssertEqual(violations(longFunctionBody), [])
 
-        let longerFunctionBody = "func abc() {\n" +
-            "var x = 0\n" +
-            Repeat(count: 40, repeatedValue: "x = 0\n").joinWithSeparator("") +
-        "}\n"
+        let longerFunctionBody = funcWithBody(
+            Repeat(count: 40, repeatedValue: "x = 0\n").joinWithSeparator("")
+        )
         XCTAssertEqual(violations(longerFunctionBody), [StyleViolation(
             ruleDescription: FunctionBodyLengthRule.description,
             location: Location(file: nil, line: 1, character: 1),
             reason: "Function body should span 40 lines or less excluding comments and " +
             "whitespace: currently spans 41 lines")])
 
-        let longerFunctionBodyWithEmptyLines = "func abc() {" +
-            Repeat(count: 100, repeatedValue: "\n").joinWithSeparator("") +
-        "}\n"
+        let longerFunctionBodyWithEmptyLines = funcWithBody(
+            Repeat(count: 100, repeatedValue: "\n").joinWithSeparator("")
+        )
         XCTAssertEqual(violations(longerFunctionBodyWithEmptyLines), [])
     }
 
     func testFunctionBodyLengthsWithComments() {
-        let longFunctionBodyWithComments = "func abc() {\n" +
-            "var x = 0\n" +
+        let longFunctionBodyWithComments = funcWithBody(
             Repeat(count: 39, repeatedValue: "x = 0\n").joinWithSeparator("") +
-            "// comment only line should be ignored.\n" +
-        "}\n"
+            "// comment only line should be ignored.\n"
+        )
         XCTAssertEqual(violations(longFunctionBodyWithComments), [])
 
-        let longerFunctionBodyWithComments = "func abc() {\n" +
-            "var x = 0\n" +
+        let longerFunctionBodyWithComments = funcWithBody(
             Repeat(count: 40, repeatedValue: "x = 0\n").joinWithSeparator("") +
-            "// comment only line should be ignored.\n" +
-        "}\n"
+            "// comment only line should be ignored.\n"
+        )
         XCTAssertEqual(violations(longerFunctionBodyWithComments), [StyleViolation(
             ruleDescription: FunctionBodyLengthRule.description,
             location: Location(file: nil, line: 1, character: 1),
@@ -54,18 +54,16 @@ class FunctionBodyLengthRuleTests: XCTestCase {
     }
 
     func testFunctionBodyLengthsWithMultilineComments() {
-        let longFunctionBodyWithMultilineComments = "func abc() {\n" +
-            "var x = 0\n" +
+        let longFunctionBodyWithMultilineComments = funcWithBody(
             Repeat(count: 39, repeatedValue: "x = 0\n").joinWithSeparator("") +
-            "/* multi line comment only line should be ignored.\n*/\n" +
-        "}\n"
+            "/* multi line comment only line should be ignored.\n*/\n"
+        )
         XCTAssertEqual(violations(longFunctionBodyWithMultilineComments), [])
 
-        let longerFunctionBodyWithMultilineComments = "func abc() {\n" +
-            "var x = 0\n" +
+        let longerFunctionBodyWithMultilineComments = funcWithBody(
             Repeat(count: 40, repeatedValue: "x = 0\n").joinWithSeparator("") +
-            "/* multi line comment only line should be ignored.\n*/\n" +
-        "}\n"
+            "/* multi line comment only line should be ignored.\n*/\n"
+        )
         XCTAssertEqual(violations(longerFunctionBodyWithMultilineComments), [StyleViolation(
             ruleDescription: FunctionBodyLengthRule.description,
             location: Location(file: nil, line: 1, character: 1),


### PR DESCRIPTION
It turns out that operators are expensive!

Running `xcodebuild -workspace SwiftLint.xcworkspace -scheme SwiftLintFramework clean build`:

before: 64.43s user 7.17s system 237% cpu 30.142 total
after: 39.46s user 6.94s system 236% cpu 19.615 total

Big thanks to @irace for writing up http://irace.me/swift-profiling which motivated me to do this :)