### PR TITLE
Add `make display_compilation_time`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,7 @@ archive:
 	carthage archive SwiftLintFramework
 
 release: package archive
+
+# http://irace.me/swift-profiling/
+display_compilation_time:
+	$(BUILD_TOOL) $(XCODEFLAGS) OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build | grep [1-9].[0-9]ms | sort -n

--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,4 @@ release: package archive
 
 # http://irace.me/swift-profiling/
 display_compilation_time:
-	$(BUILD_TOOL) $(XCODEFLAGS) OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build | grep [1-9].[0-9]ms | sort -n
+	$(BUILD_TOOL) $(XCODEFLAGS) OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build test | grep [1-9].[0-9]ms | sort -n


### PR DESCRIPTION
#382
SeeAlso: http://irace.me/swift-profiling/

e.g.
```sh
➜  9:37:33 git:(nn-add-make-display_compilation_time) ✗ make display_compilation_time
xcodebuild -xcconfig settings-for-all-projects.xcconfig -workspace 'SwiftLint.xcworkspace' -scheme 'swiftlint' DSTROOT=/tmp/SwiftLint.dst OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build | grep [1-9].[0-9]ms | sort -n
1.0ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result/Result/Result.swift:132:13	public func !=<T : Equatable, Error : Equatable>(left: Result<T, Error>, right: Result<T, Error>) -> Bool
1.0ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/Commandant/Commandant/Command.swift:93:14	public final func register<C : CommandType where C.ClientError == ClientError, C.Options.ClientError == ClientError>(command: C)
1.0ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/String+SourceKitten.swift:378:17	public func substringWithSourceRange(start: SourceLocation, end: SourceLocation) -> String?
1.0ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SwiftXPC/SwiftXPC/SwiftXPC.swift:359:13	public func toXPC(uuid: NSUUID) -> xpc_object_t?
1.0ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/YamlSwift/Yaml/Parser.swift:541:6	func unwrapQuotedString(s: String) -> String
1.0ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/YamlSwift/Yaml/Parser.swift:76:6	func ignoreDocEnd(context: Context) -> Context
…
85.8ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/OffsetMap.swift:51:18	private final func mapOffsets(dictionary: XPCDictionary, offsetMap: OffsetMap) -> OffsetMap
92.8ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/CodeCompletionItem.swift:82:24	public static func parseItems(data: NSData) -> [CodeCompletionItem]
95.5ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/File.swift:373:61	(closure)
98.1ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/File.swift:368:13	public func parseFullXMLDocs(xmlDocs: String) -> XPCDictionary?
107.5ms	/Users/norio/Documents/workspace/github/SwiftLint/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift:19:24	public static func generateReport(violations: [StyleViolation]) -> String
132.9ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/YamlSwift/Yaml/Tokenizer.swift:118:6	func tokenize(text: String) -> Result<[TokenMatch]>
194.8ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/Documentation.swift:13:5	init(comment: CXComment)
291.3ms	/Users/norio/Documents/workspace/github/SwiftLint/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift:34:17	public func validateFile(file: File) -> [StyleViolation]
293.5ms	/Users/norio/Documents/workspace/github/SwiftLint/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift:94:19	internal final func syntaxKindsByLine(startLine: Int? = default, endLine: Int? = default) -> [(Int, [SyntaxKind])]
757.0ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/SyntaxMap.swift:74:17	public func commentRangeBeforeOffset(offset: Int) -> Range<Int>?
1379.4ms	/Users/norio/Documents/workspace/github/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/JSONOutput.swift:9:13	public func declarationsToJSON(decl: [String : [SourceDeclaration]]) -> String
make display_compilation_time  40.77s user 10.40s system 137% cpu 37.294 total
➜  9:38:13 git:(nn-add-make-display_compilation_time) ✗ 
```