### PR TITLE
fix infinite recursion when using nested config files. Fixes #368

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix crash caused by infinite recursion when using nested config files.  
+  [JP Simard](https://github.com/jpsim)
+  [#368](https://github.com/realm/SwiftLint/issues/368)
 
 ## 0.6.0: Steam Cycle
 

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -12,6 +12,7 @@ import SourceKittenFramework
 private let fileManager = NSFileManager.defaultManager()
 
 public struct Configuration: Equatable {
+    public static let fileName = ".swiftlint.yml"
     public let disabledRules: [String] // disabled_rules
     public let included: [String]      // included
     public let excluded: [String]      // excluded
@@ -166,7 +167,7 @@ public struct Configuration: Equatable {
 public extension Configuration {
     func configForPath(path: String) -> Configuration {
         let path = path as NSString
-        let configSearchPath = path.stringByAppendingPathComponent(".swiftlint.yml")
+        let configSearchPath = path.stringByAppendingPathComponent(Configuration.fileName)
 
         // If a config exists and it isn't us, load and merge the configs
         if configSearchPath != configPath &&
@@ -175,7 +176,7 @@ public extension Configuration {
         }
 
         // If we are not at the root path, continue down the tree
-        if path != rootPath {
+        if path != rootPath && path != "/" {
             return configForPath(path.stringByDeletingLastPathComponent)
         }
 

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -189,11 +189,11 @@ extension XCTestCase {
     }
 
     var projectMockYAML0: String {
-        return projectMockPathLevel0.stringByAppendingPathComponent(".swiftlint.yml")
+        return projectMockPathLevel0.stringByAppendingPathComponent(Configuration.fileName)
     }
 
     var projectMockYAML2: String {
-        return projectMockPathLevel2.stringByAppendingPathComponent(".swiftlint.yml")
+        return projectMockPathLevel2.stringByAppendingPathComponent(Configuration.fileName)
     }
 
     var projectMockSwift0: String {

--- a/Source/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Source/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -19,7 +19,7 @@ class IntegrationTests: XCTestCase {
             .stringByDeletingLastPathComponent as NSString)
             .stringByDeletingLastPathComponent
         NSFileManager.defaultManager().changeCurrentDirectoryPath(directory)
-        let config = Configuration(path: ".swiftlint.yml")
+        let config = Configuration(path: Configuration.fileName)
         let swiftFiles = config.lintableFilesForPath("")
         XCTAssert(swiftFiles.map({$0.path!}).contains(__FILE__), "current file should be included")
         XCTAssertEqual(swiftFiles.flatMap({

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -18,7 +18,8 @@ struct AutoCorrectCommand: CommandType {
     let function = "Automatically correct warnings and errors"
 
     func run(options: AutoCorrectOptions) -> Result<(), CommandantError<()>> {
-        let configuration = Configuration(commandLinePath: options.configurationFile)
+        var configuration = Configuration(commandLinePath: options.configurationFile)
+        configuration.rootPath = options.path.absolutePathStandardized()
         return configuration.visitLintableFiles(options.path, action: "Correcting",
             useScriptInputFiles: options.useScriptInputFiles) { linter in
             let corrections = linter.correct()
@@ -38,7 +39,7 @@ struct AutoCorrectOptions: OptionsType {
     let configurationFile: String
     let useScriptInputFiles: Bool
 
-    // swiftlint:disable line_length
+    // swiftlint:disable:next line_length
     static func evaluate(mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
         return curry(self.init)
             <*> mode <| Option(key: "path",
@@ -51,5 +52,4 @@ struct AutoCorrectOptions: OptionsType {
                 defaultValue: false,
                 usage: "read SCRIPT_INPUT_FILE* environment variables as files")
     }
-    // swiftlint:enable line_length
 }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -63,7 +63,7 @@ struct LintOptions: OptionsType {
     let strict: Bool
     let useScriptInputFiles: Bool
 
-    // swiftlint:disable line_length
+    // swiftlint:disable:next line_length
     static func evaluate(mode: CommandMode) -> Result<LintOptions, CommandantError<CommandantError<()>>> {
         let curriedInitializer = curry(self.init)
         return curriedInitializer
@@ -83,5 +83,4 @@ struct LintOptions: OptionsType {
                 defaultValue: false,
                 usage: "read SCRIPT_INPUT_FILE* environment variables as files")
     }
-    // swiftlint:enable line_length
 }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -74,7 +74,7 @@ struct LintOptions: OptionsType {
                 defaultValue: false,
                 usage: "lint standard input")
             <*> mode <| Option(key: "config",
-                defaultValue: ".swiftlint.yml",
+                defaultValue: Configuration.fileName,
                 usage: "the path to SwiftLint's configuration file")
             <*> mode <| Option(key: "strict",
                 defaultValue: false,


### PR DESCRIPTION
/cc @scottrhoyt 

Also replaced all the hardcoded `.swiftlint.yml` strings while I was in there.