### PR TITLE
remove Curry dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "Carthage/Checkouts/SourceKitten"]
 	path = Carthage/Checkouts/SourceKitten
 	url = https://github.com/jpsim/SourceKitten.git
-[submodule "Carthage/Checkouts/Curry"]
-	path = Carthage/Checkouts/Curry
-	url = https://github.com/thoughtbot/Curry.git

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,3 @@
 github "Carthage/Commandant"
-github "thoughtbot/Curry"
 github "jspahrsummers/xcconfigs"
 github "behrang/YamlSwift"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
-github "thoughtbot/Curry" "v1.4.0"
 github "antitypical/Result" "1.0.1"
 github "drmohundro/SWXMLHash" "2.0.6"
 github "jpsim/SwiftXPC" "1.1.1"

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -7,7 +7,6 @@
 //
 
 import Commandant
-import Curry
 import Foundation
 import Result
 import SourceKittenFramework
@@ -40,8 +39,16 @@ struct AutoCorrectOptions: OptionsType {
     let useScriptInputFiles: Bool
 
     // swiftlint:disable:next line_length
+    static func create(path: String) -> (configurationFile: String) -> (useScriptInputFiles: Bool) -> AutoCorrectOptions {
+        return { configurationFile in { useScriptInputFiles in
+            self.init(path: path, configurationFile: configurationFile,
+                      useScriptInputFiles: useScriptInputFiles)
+        }}
+    }
+
+    // swiftlint:disable:next line_length
     static func evaluate(mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
-        return curry(self.init)
+        return create
             <*> mode <| Option(key: "path",
                 defaultValue: "",
                 usage: "the path to the file or directory to correct")

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -7,7 +7,6 @@
 //
 
 import Commandant
-import Curry
 import Foundation
 import Result
 import SourceKittenFramework
@@ -64,9 +63,16 @@ struct LintOptions: OptionsType {
     let useScriptInputFiles: Bool
 
     // swiftlint:disable:next line_length
+    static func create(path: String) -> (useSTDIN: Bool) -> (configurationFile: String) -> (strict: Bool) -> (useScriptInputFiles: Bool) -> LintOptions {
+        return { useSTDIN in { configurationFile in { strict in { useScriptInputFiles in
+            self.init(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile,
+                      strict: strict, useScriptInputFiles: useScriptInputFiles)
+        }}}}
+    }
+
+    // swiftlint:disable:next line_length
     static func evaluate(mode: CommandMode) -> Result<LintOptions, CommandantError<CommandantError<()>>> {
-        let curriedInitializer = curry(self.init)
-        return curriedInitializer
+        return create
             <*> mode <| Option(key: "path",
                 defaultValue: "",
                 usage: "the path to the file or directory to lint")

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -43,8 +43,6 @@
 		E816194E1BFBFEAB00946723 /* ForceTryRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E816194D1BFBFEAB00946723 /* ForceTryRule.swift */; };
 		E81619531BFC162C00946723 /* QueuedPrint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81619521BFC162C00946723 /* QueuedPrint.swift */; };
 		E81CDE711C00FEAA00B430F6 /* ValidDocsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */; };
-		E82161421C138DA900E0CF4F /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E82161411C138DA900E0CF4F /* Curry.framework */; };
-		E82161431C138DB200E0CF4F /* Curry.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E82161411C138DA900E0CF4F /* Curry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E832F10B1B17E2F5003F265F /* NSFileManager+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E832F10A1B17E2F5003F265F /* NSFileManager+SwiftLint.swift */; };
 		E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E832F10C1B17E725003F265F /* IntegrationTests.swift */; };
 		E83A0B351A5D382B0041A60A /* VersionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83A0B341A5D382B0041A60A /* VersionCommand.swift */; };
@@ -129,7 +127,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				E82161431C138DB200E0CF4F /* Curry.framework in Copy Frameworks */,
 				E89376AE1B8A70400025708E /* Yaml.framework in Copy Frameworks */,
 				E8BA7E141B07A400003E02D0 /* Result.framework in Copy Frameworks */,
 				E8BA7E151B07A400003E02D0 /* Commandant.framework in Copy Frameworks */,
@@ -216,7 +213,6 @@
 		E816194D1BFBFEAB00946723 /* ForceTryRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceTryRule.swift; sourceTree = "<group>"; };
 		E81619521BFC162C00946723 /* QueuedPrint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueuedPrint.swift; sourceTree = "<group>"; };
 		E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidDocsRule.swift; sourceTree = "<group>"; };
-		E82161411C138DA900E0CF4F /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Curry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E832F10A1B17E2F5003F265F /* NSFileManager+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSFileManager+SwiftLint.swift"; sourceTree = "<group>"; };
 		E832F10C1B17E725003F265F /* IntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		E83A0B341A5D382B0041A60A /* VersionCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionCommand.swift; sourceTree = "<group>"; };
@@ -272,7 +268,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E82161421C138DA900E0CF4F /* Curry.framework in Frameworks */,
 				E89376AD1B8A701E0025708E /* Yaml.framework in Frameworks */,
 				E8BA7E131B07A3F3003E02D0 /* Result.framework in Frameworks */,
 				E8BA7E111B07A3EC003E02D0 /* Commandant.framework in Frameworks */,

--- a/SwiftLint.xcworkspace/contents.xcworkspacedata
+++ b/SwiftLint.xcworkspace/contents.xcworkspacedata
@@ -14,9 +14,6 @@
       location = "group:Carthage/Checkouts/Commandant/Commandant.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Carthage/Checkouts/Curry/Curry.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:Carthage/Checkouts/Commandant/Carthage/Checkouts/Result/Result.xcodeproj">
    </FileRef>
    <FileRef


### PR DESCRIPTION
The syntax is going away in Swift 3, and it's not that hard to do ourselves.