### PR TITLE
Prepare codebase for Swift Package Manager support

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Yaml+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Yaml+SwiftLint.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import Yaml
 
 extension Yaml {

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -66,7 +66,8 @@ public struct Configuration: Equatable {
 
         // Validate that rule identifiers aren't listed multiple times
         if Set(validDisabledRules).count != validDisabledRules.count {
-            let duplicateRules = validDisabledRules.reduce([String: Int]()) { (var accu, element) in
+            let duplicateRules = validDisabledRules.reduce([String: Int]()) { accu, element in
+                var accu = accu
                 accu[element] = accu[element]?.successor() ?? 1
                 return accu
             }.filter { $0.1 > 1 }

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct ColonRule: CorrectableRule {

--- a/Source/SwiftLintFramework/Rules/ConditionalBindingCascadeRule.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalBindingCascadeRule.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct ConditionalBindingCascadeRule: Rule {

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -87,11 +87,11 @@ public struct ControlStatementRule: Rule {
                 if index != lastClosingParenthesePosition && depth == 1 {
                     return true
                 }
-                depth--
+                depth -= 1
             } else if char == "(" {
-                depth++
+                depth += 1
             }
-            index++
+            index += 1
         }
         return false
     }

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct LeadingWhitespaceRule: Rule {

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 extension String {

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -15,7 +15,7 @@ extension String {
             if !characterSet.characterIsMember(char) {
                 break
             }
-            count++
+            count += 1
         }
         return count
     }

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 extension File {

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct TrailingWhitespaceRule: CorrectableRule {

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct TypeNameRule: ASTRule {

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 extension File {

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct VariableNameRule: ASTRule {


### PR DESCRIPTION
Avoids Swift 2.2 deprecations and adds missing imports needed by SPM.