### PR TITLE
Reduce creation of `Location`

### DIFF
--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -46,7 +46,6 @@ public struct FunctionBodyLengthRule: ASTRule, ViolationLevelRule {
         if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
             let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
             let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
-            let location = Location(file: file, byteOffset: offset)
             let startLine = file.contents.lineAndCharacterForByteOffset(bodyOffset)
             let endLine = file.contents.lineAndCharacterForByteOffset(bodyOffset + bodyLength)
 
@@ -57,7 +56,7 @@ public struct FunctionBodyLengthRule: ASTRule, ViolationLevelRule {
                     if exceeds {
                         return [StyleViolation(ruleDescription: self.dynamicType.description,
                             severity: parameter.severity,
-                            location: location,
+                            location: Location(file: file, byteOffset: offset),
                             reason: "Function body should span \(parameter.value) lines or less " +
                             "excluding comments and whitespace: currently spans \(lineCount) " +
                             "lines")]

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -41,13 +41,13 @@ public struct NestingRule: ASTRule {
         var violations = [StyleViolation]()
         let typeKinds: [SwiftDeclarationKind] = [.Class, .Struct, .Typealias, .Enum]
         if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
-            let location = Location(file: file, byteOffset: offset)
             if level > 1 && typeKinds.contains(kind) {
                 violations.append(StyleViolation(ruleDescription: self.dynamicType.description,
-                    location: location, reason: "Types should be nested at most 1 level deep"))
+                    location: Location(file: file, byteOffset: offset),
+                    reason: "Types should be nested at most 1 level deep"))
             } else if level > 5 {
                 violations.append(StyleViolation(ruleDescription: self.dynamicType.description,
-                    location: location,
+                    location: Location(file: file, byteOffset: offset),
                     reason: "Statements should be nested at most 5 levels deep"))
             }
         }

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -31,7 +31,6 @@ public struct TypeBodyLengthRule: ASTRule, ViolationLevelRule {
         if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
             let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
             let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
-            let location = Location(file: file, byteOffset: offset)
             let startLine = file.contents.lineAndCharacterForByteOffset(bodyOffset)
             let endLine = file.contents.lineAndCharacterForByteOffset(bodyOffset + bodyLength)
 
@@ -42,7 +41,7 @@ public struct TypeBodyLengthRule: ASTRule, ViolationLevelRule {
                     if exceeds {
                         return [StyleViolation(ruleDescription: self.dynamicType.description,
                             severity: parameter.severity,
-                            location: location,
+                            location: Location(file: file, byteOffset: offset),
                             reason: "Type body should span \(parameter.value) lines or less " +
                             "excluding comments and whitespace: currently spans \(lineCount) " +
                             "lines")]

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -45,22 +45,21 @@ public struct TypeNameRule: ASTRule {
         }
         if let name = dictionary["key.name"] as? String,
             let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
-            let location = Location(file: file, byteOffset: offset)
             let name = name.nameStrippingLeadingUnderscoreIfPrivate(dictionary)
             let nameCharacterSet = NSCharacterSet(charactersInString: name)
             if !NSCharacterSet.alphanumericCharacterSet().isSupersetOfSet(nameCharacterSet) {
                 return [StyleViolation(ruleDescription: self.dynamicType.description,
                     severity: .Error,
-                    location: location,
+                    location: Location(file: file, byteOffset: offset),
                     reason: "Type name should only contain alphanumeric characters: '\(name)'")]
             } else if !name.substringToIndex(name.startIndex.successor()).isUppercase() {
                 return [StyleViolation(ruleDescription: self.dynamicType.description,
                     severity: .Error,
-                    location: location,
+                    location: Location(file: file, byteOffset: offset),
                     reason: "Type name should start with an uppercase character: '\(name)'")]
             } else if name.characters.count < 3 || name.characters.count > 40 {
                 return [StyleViolation(ruleDescription: self.dynamicType.description,
-                    location: location,
+                    location: Location(file: file, byteOffset: offset),
                     reason: "Type name should be between 3 and 40 characters in length: '\(name)'")]
             }
         }

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -44,16 +44,15 @@ public struct VariableNameRule: ASTRule {
         return file.validateVariableName(dictionary, kind: kind).map { name, offset in
             let nameCharacterSet = NSCharacterSet(charactersInString: name)
             let description = self.dynamicType.description
-            let location = Location(file: file, byteOffset: offset)
             if !NSCharacterSet.alphanumericCharacterSet().isSupersetOfSet(nameCharacterSet) {
                 return [StyleViolation(ruleDescription: description,
                     severity: .Error,
-                    location: location,
+                    location: Location(file: file, byteOffset: offset),
                     reason: "Variable name should only contain alphanumeric characters: '\(name)'")]
             } else if kind != SwiftDeclarationKind.VarStatic && nameIsViolatingCase(name) {
                 return [StyleViolation(ruleDescription: description,
                     severity: .Error,
-                    location: location,
+                    location: Location(file: file, byteOffset: offset),
                     reason: "Variable name should start with a lowercase character: '\(name)'")]
             }
             return []


### PR DESCRIPTION
Performance improvement is small on real usage.
But, it reduces the duration of `make test`
from:
```
…
✓ testTypeBodyLengths (15.942 seconds)
…
Executed 70 tests, with 0 failures (0 unexpected) in 22.355 (22.393) seconds
```
to:
```
…
✓ testTypeBodyLengths (8.197 seconds)
…
Executed 70 tests, with 0 failures (0 unexpected) in 14.455 (14.500) seconds
```

This is that I mentioned on https://github.com/realm/SwiftLint/pull/377#issuecomment-174112575.