### PR TITLE
Generate assertion on every violations in `testSwiftLintLints()`

### DIFF
--- a/Source/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Source/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -22,8 +22,11 @@ class IntegrationTests: XCTestCase {
         let config = Configuration(path: Configuration.fileName)
         let swiftFiles = config.lintableFilesForPath("")
         XCTAssert(swiftFiles.map({$0.path!}).contains(__FILE__), "current file should be included")
-        XCTAssertEqual(swiftFiles.flatMap({
+        let violations = swiftFiles.flatMap {
             Linter(file: $0, configuration: config).styleViolations
-        }), [])
+        }
+        violations.forEach {
+            XCTFail($0.reason, file: $0.location.file!, line: UInt($0.location.line!))
+        }
     }
 }


### PR DESCRIPTION
It makes violations browsable on Xcode's Issue Navigator.
e.g:
<img width="1039" alt="screenshot 2016-01-24 18 09 14" src="https://cloud.githubusercontent.com/assets/33430/12535416/f4146c98-c2c5-11e5-9ce3-bf546db8f4dc.png">