### PR TITLE
add --benchmark option to LintCommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Carthage/Build
 
 SwiftLint.pkg
 SwiftLintFramework.framework.zip
+benchmark_*

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -10,7 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct Linter {
-    private let file: File
+    public let file: File
     private let rules: [Rule]
     public let reporter: Reporter.Type
 

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -49,15 +49,8 @@ struct LintCommand: CommandType {
                 queuedPrint(reporter.generateReport(violations))
             }
             let numberOfSeriousViolations = violations.filter({ $0.severity == .Error }).count
-            let violationSuffix = (violations.count != 1 ? "s" : "")
-            let fileCount = files.count
-            let filesSuffix = (fileCount != 1 ? "s." : ".")
-            queuedPrintError(
-                "Done linting!" +
-                " Found \(violations.count) violation\(violationSuffix)," +
-                " \(numberOfSeriousViolations) serious" +
-                " in \(fileCount) file\(filesSuffix)"
-            )
+            LintCommand.printStatus(violations: violations, files: files,
+                numberOfSeriousViolations: numberOfSeriousViolations)
             if options.benchmark {
                 saveBenchmark("files", times: fileTimes)
                 saveBenchmark("rules", times: ruleTimes)
@@ -67,6 +60,16 @@ struct LintCommand: CommandType {
             }
             return .Success()
         }
+    }
+
+    static func printStatus(violations violations: [StyleViolation], files: [File],
+        numberOfSeriousViolations: Int) {
+        let violationSuffix = (violations.count != 1 ? "s" : "")
+        let fileCount = files.count
+        let filesSuffix = (fileCount != 1 ? "s." : ".")
+        let message = "Done linting! Found \(violations.count) violation\(violationSuffix), " +
+            "\(numberOfSeriousViolations) serious in \(fileCount) file\(filesSuffix)"
+        queuedPrintError(message)
     }
 }
 

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -12,34 +12,6 @@ import Result
 import SourceKittenFramework
 import SwiftLintFramework
 
-private let numberFormatter: NSNumberFormatter = {
-    let formatter = NSNumberFormatter()
-    formatter.numberStyle = .DecimalStyle
-    formatter.minimumFractionDigits = 3
-    return formatter
-}()
-
-private let timestamp: String = {
-    let formatter = NSDateFormatter()
-    formatter.dateFormat = "yyyy_MM_dd_HH_mm_ss"
-    return formatter.stringFromDate(NSDate())
-}()
-
-private func saveBenchmark(name: String, times: [(id: String, time: Double)]) {
-    let string = times
-        .reduce([String: Double](), combine: { accu, idAndTime in
-            var accu = accu
-            accu[idAndTime.id] = (accu[idAndTime.id] ?? 0) + idAndTime.time
-            return accu
-        })
-        .sort({ $0.1 < $1.1 })
-        .map({ "\(numberFormatter.stringFromNumber($0.1)!): \($0.0)" })
-        .joinWithSeparator("\n")
-        + "\n"
-    let data = string.dataUsingEncoding(NSUTF8StringEncoding)
-    data?.writeToFile("benchmark_\(name)_\(timestamp).txt", atomically: true)
-}
-
 struct LintCommand: CommandType {
     let verb = "lint"
     let function = "Print lint warnings and errors (default command)"

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -19,6 +19,12 @@ private let numberFormatter: NSNumberFormatter = {
     return formatter
 }()
 
+private let timestamp: String = {
+    let formatter = NSDateFormatter()
+    formatter.dateFormat = "yyyy_MM_dd_HH_mm_ss"
+    return formatter.stringFromDate(NSDate())
+}()
+
 private func saveBenchmark(name: String, times: [(id: String, time: Double)]) {
     let string = times
         .reduce([String: Double](), combine: { accu, idAndTime in
@@ -31,7 +37,7 @@ private func saveBenchmark(name: String, times: [(id: String, time: Double)]) {
         .joinWithSeparator("\n")
         + "\n"
     let data = string.dataUsingEncoding(NSUTF8StringEncoding)
-    data?.writeToFile("benchmark_\(name).txt", atomically: true)
+    data?.writeToFile("benchmark_\(name)_\(timestamp).txt", atomically: true)
 }
 
 struct LintCommand: CommandType {

--- a/Source/swiftlint/Helpers/Benchmark.swift
+++ b/Source/swiftlint/Helpers/Benchmark.swift
@@ -1,0 +1,37 @@
+//
+//  Benchmark.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 1/25/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+
+private let numberFormatter: NSNumberFormatter = {
+    let formatter = NSNumberFormatter()
+    formatter.numberStyle = .DecimalStyle
+    formatter.minimumFractionDigits = 3
+    return formatter
+}()
+
+private let timestamp: String = {
+    let formatter = NSDateFormatter()
+    formatter.dateFormat = "yyyy_MM_dd_HH_mm_ss"
+    return formatter.stringFromDate(NSDate())
+}()
+
+internal func saveBenchmark(name: String, times: [(id: String, time: Double)]) {
+    let string = times
+        .reduce([String: Double](), combine: { accu, idAndTime in
+            var accu = accu
+            accu[idAndTime.id] = (accu[idAndTime.id] ?? 0) + idAndTime.time
+            return accu
+        })
+        .sort({ $0.1 < $1.1 })
+        .map({ "\(numberFormatter.stringFromNumber($0.1)!): \($0.0)" })
+        .joinWithSeparator("\n")
+        + "\n"
+    let data = string.dataUsingEncoding(NSUTF8StringEncoding)
+    data?.writeToFile("benchmark_\(name)_\(timestamp).txt", atomically: true)
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
+		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
 		E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA01B8A71DF00399043 /* Configuration.swift */; };
 		E809EDA31B8A73FB00399043 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */; };
 		E80E018D1B92C0F60078EB70 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80E018C1B92C0F60078EB70 /* Command.swift */; };
@@ -218,6 +219,7 @@
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
+		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
 		E809EDA01B8A71DF00399043 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		E80E018C1B92C0F60078EB70 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
@@ -363,6 +365,7 @@
 		D0D1211A19E87861005E4BAA /* swiftlint */ = {
 			isa = PBXGroup;
 			children = (
+				E802ECFE1C56A54600A35AE1 /* Helpers */,
 				E8B0677F1C13E48100E9E13F /* Extensions */,
 				E85FF9921C13E35400714267 /* Commands */,
 				D0D1211B19E87861005E4BAA /* main.swift */,
@@ -496,6 +499,14 @@
 				D0D1217D19E87B05005E4BAA /* Info.plist */,
 			);
 			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E802ECFE1C56A54600A35AE1 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				E802ECFF1C56A56000A35AE1 /* Benchmark.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		E85FF9921C13E35400714267 /* Commands */ = {
@@ -881,6 +892,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E8B067811C13E49600E9E13F /* Configuration+CommandLine.swift in Sources */,
+				E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */,
 				E83A0B351A5D382B0041A60A /* VersionCommand.swift in Sources */,
 				E861519B1B0573B900C54AC0 /* LintCommand.swift in Sources */,
 				D0E7B65619E9C76900EDBA4D /* main.swift in Sources */,


### PR DESCRIPTION
I'm not sure how useful this is yet, but this might help getting more informative numbers for #376. /cc @scottrhoyt @norio-nomura 

Generates the following when running `swiftlint lint --benchmark` on SwiftLint:

**benchmark_rules.txt**
```
0.000: file_length
0.000: leading_whitespace
0.002: trailing_newline
0.004: trailing_semicolon
0.005: force_cast
0.005: force_try
0.005: todo
0.005: closing_brace
0.006: empty_count
0.007: conditional_binding_cascade
0.007: legacy_constant
0.008: return_arrow_whitespace
0.008: legacy_constructor
0.009: trailing_whitespace
0.012: operator_whitespace
0.017: statement_position
0.021: comma
0.021: control_statement
0.026: type_body_length
0.029: type_name
0.034: opening_brace
0.041: variable_name
0.047: cyclomatic_complexity
0.059: function_body_length
0.060: nesting
0.104: line_length
0.143: colon
0.304: valid_docs
```

**benchmark_files.txt**
```
0.002: /Users/jp/Projects/SwiftLint/Source/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/Level3/Level3.swift
0.002: /Users/jp/Projects/SwiftLint/Source/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level1.swift
0.002: /Users/jp/Projects/SwiftLint/Source/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/Level2.swift
0.003: /Users/jp/Projects/SwiftLint/Source/SwiftLintFrameworkTests/Resources/ProjectMock/Level0.swift
0.004: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Models/ConfigurationError.swift
0.004: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
0.004: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Protocols/Reporter.swift
0.004: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Models/Correction.swift
0.004: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
0.005: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
0.005: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Models/ViolationSeverity.swift
0.005: /Users/jp/Projects/SwiftLint/Source/swiftlint/Commands/RulesCommand.swift
0.006: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Protocols/RuleConfig.swift
0.006: /Users/jp/Projects/SwiftLint/Source/swiftlint/main.swift
...
truncated for comment
...
0.046: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
0.049: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Rules/ColonRule.swift
0.064: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
0.068: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Rules/RuleConfigs/NameConfig.swift
0.072: /Users/jp/Projects/SwiftLint/Source/swiftlint/Commands/LintCommand.swift
0.079: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Models/Configuration.swift
0.083: /Users/jp/Projects/SwiftLint/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
0.115: /Users/jp/Projects/SwiftLint/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
```