### PR TITLE
Optimize `File.allDeclarationsByType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Improve performance of `MissingDocsRule`.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes
 


### PR DESCRIPTION
It rebuilds `_allDeclarationsByType` incrementally.
By applying this, the duration of linting Carthage is reduced from:
```
swiftlint lint --config ~/.swiftlint-test.yml  23.05s user 1.85s system 82% cpu 30.338 total
```
to:
```
swiftlint lint --config ~/.swiftlint-test.yml  20.09s user 1.34s system 84% cpu 25.329 total
```