### PR TITLE
fix Xcode 7.3 compilation

### DIFF
--- a/Source/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Source/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -22,11 +22,18 @@ class IntegrationTests: XCTestCase {
         let config = Configuration(path: Configuration.fileName)
         let swiftFiles = config.lintableFilesForPath("")
         XCTAssert(swiftFiles.map({$0.path!}).contains(__FILE__), "current file should be included")
-        let violations = swiftFiles.flatMap {
-            Linter(file: $0, configuration: config).styleViolations
-        }
-        violations.forEach {
-            XCTFail($0.reason, file: $0.location.file!, line: UInt($0.location.line!))
-        }
+
+        #if SWIFTLINT_XCODE_VERSION_0730
+            XCTAssertEqual(swiftFiles.flatMap({
+                Linter(file: $0, configuration: config).styleViolations
+            }), [])
+        #else
+            let violations = swiftFiles.flatMap {
+                Linter(file: $0, configuration: config).styleViolations
+            }
+            violations.forEach {
+                XCTFail($0.reason, file: $0.location.file!, line: UInt($0.location.line!))
+            }
+        #endif
     }
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -1016,6 +1016,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Source/SwiftLintFrameworkTests/Supporting Files/Info.plist";
+				OTHER_SWIFT_FLAGS = "-D SWIFTLINT_XCODE_VERSION_$(XCODE_VERSION_MINOR)";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftLintFrameworkTests;
 			};
@@ -1030,6 +1031,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Source/SwiftLintFrameworkTests/Supporting Files/Info.plist";
+				OTHER_SWIFT_FLAGS = "-D SWIFTLINT_XCODE_VERSION_$(XCODE_VERSION_MINOR)";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftLintFrameworkTests;
 			};
@@ -1086,6 +1088,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Source/SwiftLintFrameworkTests/Supporting Files/Info.plist";
+				OTHER_SWIFT_FLAGS = "-D SWIFTLINT_XCODE_VERSION_$(XCODE_VERSION_MINOR)";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftLintFrameworkTests;
 			};
@@ -1142,6 +1145,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Source/SwiftLintFrameworkTests/Supporting Files/Info.plist";
+				OTHER_SWIFT_FLAGS = "-D SWIFTLINT_XCODE_VERSION_$(XCODE_VERSION_MINOR)";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftLintFrameworkTests;
 			};


### PR DESCRIPTION
Fixes #425. XCTest APIs now use StaticString instead of String for file names and we can't create a StaticString for violation file names, so just revert to the old XCTest check.

/cc @norio-nomura 