### PR TITLE
Add `NSRegularExpression.cached(pattern:)`

### DIFF
--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -14,8 +14,7 @@ internal func regex(pattern: String) -> NSRegularExpression {
     // confirmed to work, so it's ok to force-try here.
 
     // swiftlint:disable:next force_try
-    return try! NSRegularExpression(pattern: pattern,
-                                    options: [.AnchorsMatchLines, .DotMatchesLineSeparators])
+    return try! NSRegularExpression.cached(pattern: pattern)
 }
 
 extension File {

--- a/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
@@ -8,13 +8,21 @@
 
 import Foundation
 
+private var regexCache = [String: NSRegularExpression]()
+
 public extension NSRegularExpression {
-    public convenience init(pattern: String) throws {
-        try self.init(pattern: pattern,
+    public static func cached(pattern pattern: String) throws -> NSRegularExpression {
+        if let result = regexCache[pattern] {
+            return result
+        }
+
+        let result = try NSRegularExpression(pattern: pattern,
             options: [.AnchorsMatchLines, .DotMatchesLineSeparators])
+        regexCache[pattern] = result
+        return result
     }
     public static func forcePattern(pattern: String) -> NSRegularExpression {
         // swiftlint:disable:next force_try
-        return try! NSRegularExpression(pattern: pattern)
+        return try! NSRegularExpression.cached(pattern: pattern)
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigs/RegexConfig.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigs/RegexConfig.swift
@@ -37,7 +37,7 @@ public struct RegexConfig: RuleConfig, Equatable {
             throw ConfigurationError.UnknownConfiguration
         }
 
-        regex = try NSRegularExpression(pattern: regexString)
+        regex = try NSRegularExpression.cached(pattern: regexString)
 
         if let name = configDict["name"] as? String {
             self.name = name


### PR DESCRIPTION
All rules enabled linting Carthage 0.11 with this commit:
- Persistent Bytes on termination is reduced from 584.67MB to 556.62MB.
- Duration is reduced from 22sec to 21sec.

Related: #394