### PR TITLE
Disable SeverityLevelsConfig error ruleParam if only warning is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ##### Breaking
 
-* None.
+* Setting only warning on `SeverityLevelsConfig` now
+  disables error ruleParameter.  
+  [Robin Kunde](https://github.com/robinkunde)
+  [#409](https://github.com/realm/SwiftLint/issues/409)
 
 ##### Enhancements
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigs/NameConfig.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigs/NameConfig.swift
@@ -14,11 +14,11 @@ public struct NameConfig: RuleConfig, Equatable {
     var excluded: Set<String>
 
     var minLengthThreshold: Int {
-        return max(minLength.warning, minLength.error)
+        return max(minLength.warning, minLength.error ?? minLength.warning)
     }
 
     var maxLengthThreshold: Int {
-        return min(maxLength.warning, maxLength.error)
+        return min(maxLength.warning, maxLength.error ?? maxLength.warning)
     }
 
     public init(minLengthWarning: Int,

--- a/Source/SwiftLintFramework/Rules/RuleConfigs/SeverityLevelsConfig.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigs/SeverityLevelsConfig.swift
@@ -10,24 +10,25 @@ import Foundation
 
 public struct SeverityLevelsConfig: RuleConfig, Equatable {
     var warning: Int
-    var error: Int
+    var error: Int?
 
     var params: [RuleParameter<Int>] {
-        return [RuleParameter(severity: .Error, value: error),
+        if let error = error {
+            return [RuleParameter(severity: .Error, value: error),
                 RuleParameter(severity: .Warning, value: warning)]
+        }
+        return [RuleParameter(severity: .Warning, value: warning)]
     }
 
     mutating public func setConfig(config: AnyObject) throws {
         if let config = [Int].arrayOf(config) where !config.isEmpty {
             warning = config[0]
-            if config.count > 1 {
-                error = config[1]
-            }
+            error = (config.count > 1) ? config[1] : nil
         } else if let config = config as? [String: AnyObject] {
             if let warningNumber = config["warning"] as? Int {
                 warning = warningNumber
-            }
-            if let errorNumber = config["error"] as? Int {
+                error = config["error"] as? Int
+            } else if let errorNumber = config["error"] as? Int {
                 error = errorNumber
             }
         } else {

--- a/Source/SwiftLintFrameworkTests/RuleConfigTests.swift
+++ b/Source/SwiftLintFrameworkTests/RuleConfigTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import SourceKittenFramework
 
 class RuleConfigurationsTests: XCTestCase {
@@ -44,6 +44,30 @@ class RuleConfigurationsTests: XCTestCase {
         }
     }
 
+    func testNameConfigMinLengthThreshold() {
+        var nameConfig = NameConfig(minLengthWarning: 7,
+                                    minLengthError: 17,
+                                    maxLengthWarning: 0,
+                                    maxLengthError: 0,
+                                    excluded: [])
+        XCTAssertEqual(nameConfig.minLengthThreshold, 17)
+
+        nameConfig.minLength.error = nil
+        XCTAssertEqual(nameConfig.minLengthThreshold, 7)
+    }
+
+    func testNameConfigMaxLengthThreshold() {
+        var nameConfig = NameConfig(minLengthWarning: 0,
+                                    minLengthError: 0,
+                                    maxLengthWarning: 17,
+                                    maxLengthError: 7,
+                                    excluded: [])
+        XCTAssertEqual(nameConfig.maxLengthThreshold, 7)
+
+        nameConfig.maxLength.error = nil
+        XCTAssertEqual(nameConfig.maxLengthThreshold, 17)
+    }
+
     func testSeverityConfigFromString() {
         let config = "Warning"
         let comp = SeverityConfig(.Warning)
@@ -74,6 +98,17 @@ class RuleConfigurationsTests: XCTestCase {
         checkError(ConfigurationError.UnknownConfiguration) {
             try severityConfig.setConfig(config)
         }
+    }
+
+    func testSeverityLevelConfigParams() {
+        let severityConfig = SeverityLevelsConfig(warning: 17, error: 7)
+        XCTAssertEqual(severityConfig.params, [RuleParameter(severity: .Error, value: 7),
+            RuleParameter(severity: .Warning, value: 17)])
+    }
+
+    func testSeverityLevelConfigPartialParams() {
+        let severityConfig = SeverityLevelsConfig(warning: 17, error: nil)
+        XCTAssertEqual(severityConfig.params, [RuleParameter(severity: .Warning, value: 17)])
     }
 
     func testRegexConfigThrows() {

--- a/Source/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/RuleTests.swift
@@ -13,7 +13,7 @@ import SourceKittenFramework
 struct RuleWithLevelsMock: ConfigProviderRule {
     var config = SeverityLevelsConfig(warning: 2, error: 3)
 
-    static let description = RuleDescription(identifier: "violation_level_mock",
+    static let description = RuleDescription(identifier: "severity_level_mock",
         name: "",
         description: "")
     func validateFile(file: File) -> [StyleViolation] { return [] }
@@ -58,7 +58,7 @@ class RuleTests: XCTestCase {
         XCTAssertFalse([RuleMock1(), RuleMock2()] == [RuleMock1()])
     }
 
-    func testViolationLevelRuleInitsWithConfigDictionary() {
+    func testSeverityLevelRuleInitsWithConfigDictionary() {
         let config = ["warning": 17, "error": 7]
         let rule = try? RuleWithLevelsMock(config: config)
         var comp = RuleWithLevelsMock()
@@ -67,7 +67,24 @@ class RuleTests: XCTestCase {
         XCTAssertEqual(rule?.isEqualTo(comp), true)
     }
 
-    func testViolationLevelRuleInitsWithConfigArray() {
+    func testSeverityLevelRuleInitsWithWarningOnlyConfigDictionary() {
+        let config = ["warning": 17]
+        let rule = try? RuleWithLevelsMock(config: config)
+        var comp = RuleWithLevelsMock()
+        comp.config.warning = 17
+        comp.config.error = nil
+        XCTAssertEqual(rule?.isEqualTo(comp), true)
+    }
+
+    func testSeverityLevelRuleInitsWithErrorOnlyConfigDictionary() {
+        let config = ["error": 17]
+        let rule = try? RuleWithLevelsMock(config: config)
+        var comp = RuleWithLevelsMock()
+        comp.config.error = 17
+        XCTAssertEqual(rule?.isEqualTo(comp), true)
+    }
+
+    func testSeverityLevelRuleInitsWithConfigArray() {
         let config = [17, 7] as AnyObject
         let rule = try? RuleWithLevelsMock(config: config)
         var comp = RuleWithLevelsMock()
@@ -76,21 +93,31 @@ class RuleTests: XCTestCase {
         XCTAssertEqual(rule?.isEqualTo(comp), true)
     }
 
-    func testViolationLevelRuleInitsWithLiteral() {
+    func testSeverityLevelRuleInitsWithSingleValueConfigArray() {
+        let config = [17] as AnyObject
+        let rule = try? RuleWithLevelsMock(config: config)
+        var comp = RuleWithLevelsMock()
+        comp.config.warning = 17
+        comp.config.error = nil
+        XCTAssertEqual(rule?.isEqualTo(comp), true)
+    }
+
+    func testSeverityLevelRuleInitsWithLiteral() {
         let config = 17 as AnyObject
         let rule = try? RuleWithLevelsMock(config: config)
         var comp = RuleWithLevelsMock()
         comp.config.warning = 17
+        comp.config.error = nil
         XCTAssertEqual(rule?.isEqualTo(comp), true)
     }
 
-    func testViolationLevelRuleNotEqual() {
+    func testSeverityLevelRuleNotEqual() {
         let config = 17 as AnyObject
         let rule = try? RuleWithLevelsMock(config: config)
         XCTAssertEqual(rule?.isEqualTo(RuleWithLevelsMock()), false)
     }
 
-    func testDifferentViolationLevelRulesNotEqual() {
+    func testDifferentSeverityLevelRulesNotEqual() {
         XCTAssertFalse(RuleWithLevelsMock().isEqualTo(RuleWithLevelsMock2()))
     }
 }


### PR DESCRIPTION
SeverityLevelsConfig is used for both rules where the warning threshold must logically be lower than the error threshold and vice versa.

In order to prevent the generation of invalid configs via implicit definition in yaml, the error ruleParameter should be disable in such cases. For example, the README contains this code right now:

```yaml
# rules that have both warning and error levels, can set just the warning level
# implicitly
line_length: 110
```

If 110 is larger than whatever default value SwiftLint define for error, this would be an invalid config.

This commit also updates the test names since ViolationLevel is no more.