### PR TITLE
tabular rules command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
   [Scott Hoyt](https://github.com/scottrhoyt)
   [#355](https://github.com/realm/SwiftLint/issues/355)
 
+* The `rules` command now prints a table containing values for: `identifier`,
+  `opt-in`, `correctable`, `enabled in your config` & `configuration`.  
+  [JP Simard](https://github.com/jpsim)
+  [#392](https://github.com/realm/SwiftLint/issues/392)
+
 ##### Bug Fixes
 
 * Fix more false positives in `ValidDocsRule`.  

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -32,7 +32,11 @@ public protocol ConfigurableRule: Rule {
     func isEqualTo(rule: ConfigurableRule) -> Bool
 }
 
-public protocol ConfigProviderRule: ConfigurableRule {
+public protocol _ConfigProviderRule: ConfigurableRule {
+    var configDescription: String { get }
+}
+
+public protocol ConfigProviderRule: _ConfigProviderRule {
     typealias ConfigType: RuleConfig
     var config: ConfigType { get set }
 }
@@ -54,6 +58,10 @@ public extension ConfigProviderRule {
             return config.isEqualTo(rule.config)
         }
         return false
+    }
+
+    public var configDescription: String {
+        return config.consoleDescription
     }
 }
 

--- a/Source/SwiftLintFramework/Protocols/RuleConfig.swift
+++ b/Source/SwiftLintFramework/Protocols/RuleConfig.swift
@@ -11,6 +11,7 @@ import Foundation
 public protocol RuleConfig {
     mutating func setConfig(config: AnyObject) throws
     func isEqualTo(ruleConfig: RuleConfig) -> Bool
+    var consoleDescription: String { get }
 }
 
 extension RuleConfig where Self: Equatable {

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -12,6 +12,7 @@ import SourceKittenFramework
 // MARK: - CustomRulesConfig
 
 public struct CustomRulesConfig: RuleConfig, Equatable {
+    public var consoleDescription: String { return "N/A" }
     public var customRuleConfigs = [RegexConfig]()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/RuleConfigs/NameConfig.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigs/NameConfig.swift
@@ -9,6 +9,11 @@
 import Foundation
 
 public struct NameConfig: RuleConfig, Equatable {
+    public var consoleDescription: String {
+        return "(min_length) \(minLength.shortConsoleDescription), " +
+            "(max_length) \(maxLength.shortConsoleDescription)"
+    }
+
     var minLength: SeverityLevelsConfig
     var maxLength: SeverityLevelsConfig
     var excluded: Set<String>

--- a/Source/SwiftLintFramework/Rules/RuleConfigs/RegexConfig.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigs/RegexConfig.swift
@@ -21,6 +21,10 @@ public struct RegexConfig: RuleConfig, Equatable {
         return severityConfig.severity
     }
 
+    public var consoleDescription: String {
+        return "\(severity.rawValue.lowercaseString): \(regex.pattern)"
+    }
+
     public var description: RuleDescription {
         return RuleDescription(identifier: identifier,
             name: name ?? identifier,

--- a/Source/SwiftLintFramework/Rules/RuleConfigs/SeverityConfig.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigs/SeverityConfig.swift
@@ -9,6 +9,10 @@
 import Foundation
 
 public struct SeverityConfig: RuleConfig, Equatable {
+    public var consoleDescription: String {
+        return severity.rawValue.lowercaseString
+    }
+
     var severity: ViolationSeverity
 
     public init(_ severity: ViolationSeverity) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigs/SeverityLevelsConfig.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigs/SeverityLevelsConfig.swift
@@ -9,6 +9,23 @@
 import Foundation
 
 public struct SeverityLevelsConfig: RuleConfig, Equatable {
+    public var consoleDescription: String {
+        let errorString: String
+        if let errorValue = error {
+            errorString = ", error: \(errorValue)"
+        } else {
+            errorString = ""
+        }
+        return "warning: \(warning)" + errorString
+    }
+
+    public var shortConsoleDescription: String {
+        if let errorValue = error {
+            return "w/e: \(warning)/\(errorValue)"
+        }
+        return "w: \(warning)"
+    }
+
     var warning: Int
     var error: Int?
 

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -30,24 +30,29 @@ private struct TextTableColumn {
     }
 }
 
+private func fence(strings: [String], separator: String) -> String {
+    return separator + strings.joinWithSeparator(separator) + separator
+}
+
 private struct TextTable {
     let columns: [TextTableColumn]
 
     func render() -> String {
-        let widths = columns.map({ $0.width })
-        let separator = "+" + widths.map({ width in
-            return Repeat(count: width + 2, repeatedValue: "-").joinWithSeparator("")
-        }).joinWithSeparator("+") + "+"
-        let header = "|" + columns.map({
-            " \($0.header.withPadding($0.width)) "
-        }).joinWithSeparator("|") + "|"
-        let result = separator + "\n\(header)\n" + separator + "\n"
+        let joint = "+"
+        let verticalSeparator = "|"
+        let horizontalSeparator = "-"
+        let separator = fence(columns.map({ column in
+            Repeat(count: column.width + 2, repeatedValue: horizontalSeparator)
+                .joinWithSeparator("")
+        }), separator: joint)
+        let header = fence(columns.map({ " \($0.header.withPadding($0.width)) " }),
+            separator: verticalSeparator)
         let values = (0..<columns.first!.values.count).map({ rowIndex in
-            return "|" + columns.map({ column in
-                return " \(column.values[rowIndex].withPadding(column.width)) "
-            }).joinWithSeparator("|") + "|"
+            fence(columns.map({ column in
+                " \(column.values[rowIndex].withPadding(column.width)) "
+            }), separator: verticalSeparator)
         }).joinWithSeparator("\n")
-        return result + values + "\n" + separator
+        return [separator, header, separator, values, separator].joinWithSeparator("\n")
     }
 }
 

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -10,48 +10,6 @@ import Commandant
 import Result
 import SwiftLintFramework
 
-extension String {
-    private func withPadding(count: Int) -> String {
-        let length = characters.count
-        if length < count {
-            return self +
-                Repeat(count: count - length, repeatedValue: " ").joinWithSeparator("")
-        }
-        return self
-    }
-}
-
-private struct TextTableColumn {
-    let header: String
-    let values: [String]
-
-    var width: Int {
-        return max(header.characters.count, values.reduce(0) { max($0, $1.characters.count) })
-    }
-}
-
-private func fence(strings: [String], separator: String) -> String {
-    return separator + strings.joinWithSeparator(separator) + separator
-}
-
-private struct TextTable {
-    let columns: [TextTableColumn]
-
-    func render() -> String {
-        let separator = fence(columns.map({ column in
-            Repeat(count: column.width + 2, repeatedValue: "-").joinWithSeparator("")
-        }), separator: "+")
-        let header = fence(columns.map({ " \($0.header.withPadding($0.width)) " }),
-            separator: "|")
-        let values = (0..<columns.first!.values.count).map({ rowIndex in
-            fence(columns.map({ column in
-                " \(column.values[rowIndex].withPadding(column.width)) "
-            }), separator: "|")
-        }).joinWithSeparator("\n")
-        return [separator, header, separator, values, separator].joinWithSeparator("\n")
-    }
-}
-
 private let violationMarker = "↓"
 
 struct RulesCommand: CommandType {
@@ -68,25 +26,7 @@ struct RulesCommand: CommandType {
             return .Success()
         }
 
-        let sortedRules = masterRuleList.list.sort { $0.0 < $1.0 }
-        let table = TextTable(columns: [
-            TextTableColumn(header: "identifier", values: sortedRules.map({ $0.0 })),
-            TextTableColumn(header: "opt-in",
-                values: sortedRules.map({ ($0.1.init() is OptInRule) ? "yes" : "no" })),
-            TextTableColumn(header: "correctable",
-                values: sortedRules.map({ ($0.1.init() is CorrectableRule) ? "yes" : "no" })),
-            TextTableColumn(header: "enabled in your config",
-                values: sortedRules.map({
-                    Configuration().rules.map({
-                        $0.dynamicType.description.identifier
-                    }).contains($0.0) ? "yes" : "no"
-                })),
-            TextTableColumn(header: "configuration",
-                values: sortedRules.map({ _, ruleType in
-                    return (ruleType.init() as? _ConfigProviderRule)?.configDescription ?? "N/A"
-                }))
-        ])
-        print(table.render())
+        print(TextTable(ruleList: masterRuleList).render())
         return .Success()
     }
 

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -10,6 +10,47 @@ import Commandant
 import Result
 import SwiftLintFramework
 
+extension String {
+    private func withPadding(count: Int, character: String = " ") -> String {
+        let length = characters.count
+        if length < count {
+            return self +
+                Repeat(count: count - length, repeatedValue: character).joinWithSeparator("")
+        }
+        return self
+    }
+}
+
+private struct TextTableColumn {
+    let header: String
+    let values: [String]
+
+    var width: Int {
+        return max(header.characters.count, values.reduce(0) { max($0, $1.characters.count) })
+    }
+}
+
+private struct TextTable {
+    let columns: [TextTableColumn]
+
+    func render() -> String {
+        let widths = columns.map({ $0.width })
+        let separator = "+" + widths.map({ width in
+            return Repeat(count: width + 2, repeatedValue: "-").joinWithSeparator("")
+        }).joinWithSeparator("+") + "+"
+        let header = "|" + columns.map({
+            " \($0.header.withPadding($0.width)) "
+        }).joinWithSeparator("|") + "|"
+        let result = separator + "\n\(header)\n" + separator + "\n"
+        let values = (0..<columns.first!.values.count).map({ rowIndex in
+            return "|" + columns.map({ column in
+                return " \(column.values[rowIndex].withPadding(column.width)) "
+            }).joinWithSeparator("|") + "|"
+        }).joinWithSeparator("\n")
+        return result + values + "\n" + separator
+    }
+}
+
 private let violationMarker = "↓"
 
 struct RulesCommand: CommandType {
@@ -26,7 +67,23 @@ struct RulesCommand: CommandType {
             return .Success()
         }
 
-        print(masterRuleList.list.keys.joinWithSeparator("\n"))
+        let sortedRules = masterRuleList.list.sort { $0.0 < $1.0 }
+        let table = TextTable(columns: [
+            TextTableColumn(header: "identifier", values: sortedRules.map({ $0.0 })),
+            TextTableColumn(header: "opt-in", values: sortedRules.map({ _, rule in
+                return (rule.init() is OptInRule) ? "yes" : "no"
+            })),
+            TextTableColumn(header: "description", values: sortedRules.map({ _, rule in
+                let maxLength = 100
+                let description = rule.description.description
+                if description.characters.count < maxLength {
+                    return description
+                }
+                return description
+                    .substringToIndex(description.startIndex.advancedBy(maxLength)) + "..."
+            }))
+        ])
+        print(table.render())
         return .Success()
     }
 

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -80,6 +80,10 @@ struct RulesCommand: CommandType {
                     Configuration().rules.map({
                         $0.dynamicType.description.identifier
                     }).contains($0.0) ? "yes" : "no"
+                })),
+            TextTableColumn(header: "configuration",
+                values: sortedRules.map({ _, ruleType in
+                    return (ruleType.init() as? _ConfigProviderRule)?.configDescription ?? "N/A"
                 }))
         ])
         print(table.render())

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -11,11 +11,11 @@ import Result
 import SwiftLintFramework
 
 extension String {
-    private func withPadding(count: Int, character: String = " ") -> String {
+    private func withPadding(count: Int) -> String {
         let length = characters.count
         if length < count {
             return self +
-                Repeat(count: count - length, repeatedValue: character).joinWithSeparator("")
+                Repeat(count: count - length, repeatedValue: " ").joinWithSeparator("")
         }
         return self
     }

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -24,18 +24,9 @@ extension String {
 private struct TextTableColumn {
     let header: String
     let values: [String]
-    let maxWidth: Int?
-
-    init(header: String, values: [String], maxWidth: Int? = nil) {
-        self.header = header
-        self.values = values
-        self.maxWidth = maxWidth
-    }
 
     var width: Int {
-        let maxValuesWidth = values.reduce(0) { max($0, $1.characters.count) }
-        let maxContentWidth = max(header.characters.count, maxValuesWidth)
-        return min(maxWidth ?? maxContentWidth, maxContentWidth)
+        return max(header.characters.count, values.reduce(0) { max($0, $1.characters.count) })
     }
 }
 
@@ -43,68 +34,19 @@ private func fence(strings: [String], separator: String) -> String {
     return separator + strings.joinWithSeparator(separator) + separator
 }
 
-// HELP! This function is extremely brittle.
-// It only works with 3 columns, and only allows maxWidth to be set on the last column.
-private func transformColumns(columns: [TextTableColumn]) -> [[String]] {
-    return (0..<columns.first!.values.count).flatMap({ rowIndex -> [[String]] in
-        var rowsOfValues = [[String]]()
-        for column in columns {
-            func setOrAppendToFirst(values: [String]) {
-                let first = (rowsOfValues.first ?? []) + values
-                if rowsOfValues.isEmpty {
-                    rowsOfValues.append(first)
-                } else {
-                    rowsOfValues[0] = first
-                }
-            }
-            func pad(string: String) -> String {
-                return string.withPadding(column.width)
-            }
-            let value = column.values[rowIndex]
-            guard let maxWidth = column.maxWidth where value.characters.count > maxWidth else {
-                setOrAppendToFirst([pad(value)])
-                continue
-            }
-            func split(string: String) -> (before: String, after: String) {
-                let splitPoint = string.startIndex.advancedBy(string.substringToIndex(
-                    string.startIndex.advancedBy(maxWidth)
-                ).lastIndexOf(" ")! + 1)
-                return (string.substringToIndex(splitPoint), string.substringFromIndex(splitPoint))
-            }
-            var (before, after) = split(value)
-            setOrAppendToFirst([pad(before)])
-            func append(string: String) {
-                if string.isEmpty { return }
-                rowsOfValues.append([
-                    "".withPadding(columns[0].width),
-                    "".withPadding(columns[1].width),
-                    pad(string)
-                ])
-            }
-            while after.characters.count > maxWidth {
-                (before, after) = split(after)
-                append(before)
-            }
-            append(after)
-        }
-        return rowsOfValues
-    })
-}
-
 private struct TextTable {
     let columns: [TextTableColumn]
 
     func render() -> String {
-        let joint = "+", verticalSeparator = "|", horizontalSeparator = "-"
         let separator = fence(columns.map({ column in
-            Repeat(count: column.width + 2, repeatedValue: horizontalSeparator)
-                .joinWithSeparator("")
-        }), separator: joint)
+            Repeat(count: column.width + 2, repeatedValue: "-").joinWithSeparator("")
+        }), separator: "+")
         let header = fence(columns.map({ " \($0.header.withPadding($0.width)) " }),
-            separator: verticalSeparator)
-        let values = transformColumns(columns).flatMap({ values in
-            if values.isEmpty { return nil }
-            return fence(values.map({ " \($0) " }), separator: verticalSeparator)
+            separator: "|")
+        let values = (0..<columns.first!.values.count).map({ rowIndex in
+            fence(columns.map({ column in
+                " \(column.values[rowIndex].withPadding(column.width)) "
+            }), separator: "|")
         }).joinWithSeparator("\n")
         return [separator, header, separator, values, separator].joinWithSeparator("\n")
     }
@@ -131,8 +73,14 @@ struct RulesCommand: CommandType {
             TextTableColumn(header: "identifier", values: sortedRules.map({ $0.0 })),
             TextTableColumn(header: "opt-in",
                 values: sortedRules.map({ ($0.1.init() is OptInRule) ? "yes" : "no" })),
-            TextTableColumn(header: "description",
-                values: sortedRules.map({ $0.1.description.description }), maxWidth: 100)
+            TextTableColumn(header: "correctable",
+                values: sortedRules.map({ ($0.1.init() is CorrectableRule) ? "yes" : "no" })),
+            TextTableColumn(header: "enabled in your config",
+                values: sortedRules.map({
+                    Configuration().rules.map({
+                        $0.dynamicType.description.identifier
+                    }).contains($0.0) ? "yes" : "no"
+                }))
         ])
         print(table.render())
         return .Success()

--- a/Source/swiftlint/Helpers/TextTable.swift
+++ b/Source/swiftlint/Helpers/TextTable.swift
@@ -1,0 +1,69 @@
+//
+//  TextTable.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 1/31/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+
+extension String {
+    private func withPadding(count: Int) -> String {
+        let length = characters.count
+        if length < count {
+            return self +
+                Repeat(count: count - length, repeatedValue: " ").joinWithSeparator("")
+        }
+        return self
+    }
+}
+
+private func fence(strings: [String], separator: String) -> String {
+    return separator + strings.joinWithSeparator(separator) + separator
+}
+
+struct TextTableColumn {
+    let header: String
+    let values: [String]
+
+    var width: Int {
+        return max(header.characters.count, values.reduce(0) { max($0, $1.characters.count) })
+    }
+}
+
+struct TextTable {
+    private let columns: [TextTableColumn]
+
+    init(ruleList: RuleList) {
+        let sortedRules = masterRuleList.list.sort { $0.0 < $1.0 }
+        columns = [
+            TextTableColumn(header: "identifier", values: sortedRules.map({ $0.0 })),
+            TextTableColumn(header: "opt-in",
+                values: sortedRules.map({ ($0.1.init() is OptInRule) ? "yes" : "no" })),
+            TextTableColumn(header: "correctable",
+                values: sortedRules.map({ ($0.1.init() is CorrectableRule) ? "yes" : "no" })),
+            TextTableColumn(header: "enabled in your config",
+                values: sortedRules.map({
+                    Configuration().rules.map({
+                        $0.dynamicType.description.identifier
+                    }).contains($0.0) ? "yes" : "no"
+                })),
+            TextTableColumn(header: "configuration",
+                values: sortedRules.map({ _, ruleType in
+                    return (ruleType.init() as? _ConfigProviderRule)?.configDescription ?? "N/A"
+                }))
+        ]
+    }
+
+    func render() -> String {
+        let separator = fence(columns.map({ column in
+            Repeat(count: column.width + 2, repeatedValue: "-").joinWithSeparator("")
+        }), separator: "+")
+        let header = fence(columns.map({ " \($0.header.withPadding($0.width)) " }), separator: "|")
+        let values = (0..<columns.first!.values.count).map({ rowIndex in
+            fence(columns.map({ " \($0.values[rowIndex].withPadding($0.width)) " }), separator: "|")
+        }).joinWithSeparator("\n")
+        return [separator, header, separator, values, separator].joinWithSeparator("\n")
+    }
+}

--- a/Source/swiftlint/Helpers/TextTable.swift
+++ b/Source/swiftlint/Helpers/TextTable.swift
@@ -23,7 +23,7 @@ private func fence(strings: [String], separator: String) -> String {
     return separator + strings.joinWithSeparator(separator) + separator
 }
 
-struct TextTableColumn {
+private struct TextTableColumn {
     let header: String
     let values: [String]
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
+		E805382E1C5ECB4500B7846A /* TextTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805382D1C5ECB4500B7846A /* TextTable.swift */; };
 		E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA01B8A71DF00399043 /* Configuration.swift */; };
 		E809EDA31B8A73FB00399043 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */; };
 		E80E018D1B92C0F60078EB70 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80E018C1B92C0F60078EB70 /* Command.swift */; };
@@ -226,6 +227,7 @@
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
 		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
+		E805382D1C5ECB4500B7846A /* TextTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextTable.swift; sourceTree = "<group>"; };
 		E809EDA01B8A71DF00399043 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		E80E018C1B92C0F60078EB70 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
@@ -512,6 +514,7 @@
 			isa = PBXGroup;
 			children = (
 				E802ECFF1C56A56000A35AE1 /* Benchmark.swift */,
+				E805382D1C5ECB4500B7846A /* TextTable.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -911,6 +914,7 @@
 				D0E7B65619E9C76900EDBA4D /* main.swift in Sources */,
 				83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */,
 				E84E07471C13F95300F11122 /* AutoCorrectCommand.swift in Sources */,
+				E805382E1C5ECB4500B7846A /* TextTable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Just an early proof of concept to discuss what we want out of #392. Currently outputs this:

```
+-----------------------------+--------+---------------------------------------------------------------------------------------------------------+
| identifier                  | opt-in | description                                                                                             |
+-----------------------------+--------+---------------------------------------------------------------------------------------------------------+
| closing_brace               | no     | Closing brace with closing parenthesis should not have any whitespaces in the middle.                   |
| colon                       | no     | Colons should be next to the identifier when specifying a type.                                         |
| comma                       | no     | There should be no space before and one after any comma.                                                |
| conditional_binding_cascade | no     | Repeated `let` statements in conditional binding cascade should be avoided.                             |
| control_statement           | no     | if,for,while,do statements shouldn't wrap their conditionals in parentheses.                            |
| custom_rules                | no     | Create custom rules by providing a regex string. Optionally specify what syntax kinds to match again... |
| cyclomatic_complexity       | no     | Complexity of function bodies should be limited.                                                        |
| empty_count                 | yes    | Prefer checking `isEmpty` over comparing `count` to zero.                                               |
| file_length                 | no     | Files should not span too many lines.                                                                   |
| force_cast                  | no     | Force casts should be avoided.                                                                          |
| force_try                   | no     | Force tries should be avoided.                                                                          |
| force_unwrapping            | yes    | Force unwrapping should be avoided.                                                                     |
| function_body_length        | no     | Functions bodies should not span too many lines.                                                        |
| leading_whitespace          | no     | Files should not contain leading whitespace.                                                            |
| legacy_constant             | no     | Struct-scoped constants are preferred over legacy global constants.                                     |
| legacy_constructor          | no     | Swift constructors are preferred over legacy convenience functions.                                     |
| line_length                 | no     | Lines should not span too many characters.                                                              |
| missing_docs                | yes    | Public declarations should be documented.                                                               |
| nesting                     | no     | Types should be nested at most 1 level deep, and statements should be nested at most 5 levels deep.     |
| opening_brace               | no     | Opening braces should be preceded by a single space and on the same line as the declaration.            |
| operator_whitespace         | no     | Operators should be surrounded by a single whitespace when defining them.                               |
| return_arrow_whitespace     | no     | Return arrow and return type should be separated by a single space or on a separate line.               |
| statement_position          | no     | Else and catch should be on the same line, one space after the previous declaration.                    |
| todo                        | no     | TODOs and FIXMEs should be avoided.                                                                     |
| trailing_newline            | no     | Files should have a single trailing newline.                                                            |
| trailing_semicolon          | no     | Lines should not have trailing semicolons.                                                              |
| trailing_whitespace         | no     | Lines should not have trailing whitespace.                                                              |
| type_body_length            | no     | Type bodies should not span too many lines.                                                             |
| type_name                   | no     | Type name should only contain alphanumeric characters, start with an uppercase character and span be... |
| valid_docs                  | no     | Documented declarations should be valid.                                                                |
| variable_name               | no     | Variable names should only contain alphanumeric characters and start with a lowercase character or s... |
+-----------------------------+--------+---------------------------------------------------------------------------------------------------------+
```

I'm putting this up so we can discuss the direction of what we want this to look like. It's too early to review the implementation, so please don't comment on that :grimacing:.

A few open questions:

1. How should we render the configurability of rules, if at all?
2. How should we take into account the `.swiftlint.yml` configuration, if at all?
3. What columns are missing from this table?
4. Should we allow CLI flags to be passed to the `rules` command, if so which ones?
5. Is a table the right format for displaying this information, if so is this styling appropriate?
6. Should the output adapt to the width of the user's console? It currently doesn't.