### PR TITLE
Add whitelist only rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
 included:
   - Source
-enabled_rules:
+opt_in_rules:
   - empty_count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 
 ##### Enhancements
 
-* None.
+* Add `whitelist_rules` rule whitelists in config files  
+  [Daniel Beard](https://github.com/daniel-beard)
+  [#256](https://github.com/realm/SwiftLint/issues/256)
 
 ##### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -134,12 +134,18 @@ identifiers.
 Configure SwiftLint by adding a `.swiftlint.yml` file from the directory you'll
 run SwiftLint from. The following parameters can be configured:
 
+Rule inclusion:
+- `disabled_rules`: Disable rules from the default enabled set.
+- `opt_in_rules`: Some rules are opt-in.
+- `whitelist_rules`: Can not be specified alongside `disabled_rules` or
+`opt_in_rules`. Acts as a whitelist, only the rules specified in this list will be enabled.
+
 ```yaml
 disabled_rules: # rule identifiers to exclude from running
   - colon
   - comma
   - control_statement
-enabled_rules: # some rules are only opt-in
+opt_in_rules: # some rules are only opt-in
   - empty_count
   - missing_docs
   # Find all the available rules by running:

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -32,6 +32,36 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.reporterFromString.identifier, "xcode")
     }
 
+    func testWhitelistRules() {
+        let whitelist = ["nesting", "todo"]
+        let config = Configuration(dict: ["whitelist_rules":  whitelist])!
+        let configuredIdentifiers = config.rules.map {
+            $0.dynamicType.description.identifier
+        }
+        XCTAssertEqual(whitelist, configuredIdentifiers)
+    }
+
+    func testOtherRuleConfigurationsAlongsideWhitelistRules() {
+        let whitelist = ["nesting", "todo"]
+        let enabledRulesConfigDict = [
+            "opt_in_rules": ["line_length"],
+            "whitelist_rules": whitelist
+        ]
+        let disabledRulesConfigDict = [
+            "disabled_rules": ["variable_name"],
+            "whitelist_rules": whitelist
+        ]
+        let combinedRulesConfigDict = enabledRulesConfigDict.reduce(disabledRulesConfigDict) {
+            var d = $0; d[$1.0] = $1.1; return d
+        }
+        var config = Configuration(dict: enabledRulesConfigDict)
+        XCTAssertNil(config)
+        config = Configuration(dict: disabledRulesConfigDict)
+        XCTAssertNil(config)
+        config = Configuration(dict: combinedRulesConfigDict)
+        XCTAssertNil(config)
+    }
+
     func testDisabledRules() {
         let disabledConfig = Configuration(dict: ["disabled_rules":  ["nesting", "todo"]])!
         XCTAssertEqual(disabledConfig.disabledRules,


### PR DESCRIPTION
- This is my proposal for adding a `whitelist_rules` option to the `.swiftlint.yml` configuration.
- The idea is that if the `whitelist_rules` option appears, it overrides all other rule configurations, and *only* the rules specified in the `whitelist_rules` array are enabled.
- This is intended for environments that have very specific Swift style guide rules, and where updating SwiftLint currently introduces a number of rules (that may not have been agreed on) and breaks the CI process.
- This is a proposal, I'm open to other ideas for naming or implementation, thanks!