### PR TITLE
Fix regex to grep compilation time output correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,4 @@ release: package archive
 
 # http://irace.me/swift-profiling/
 display_compilation_time:
-	$(BUILD_TOOL) $(XCODEFLAGS) OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build test | grep [1-9].[0-9]ms | sort -n
+	$(BUILD_TOOL) $(XCODEFLAGS) OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build test | grep -E ^[1-9]{1}[0-9]*.[0-9]ms | sort -n


### PR DESCRIPTION
Now we can catch "10.0ms", but not "0.0ms".

This was continued from #433.