### PR TITLE
Improve performance of `syntaxKindsByLine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   [Daniel Beard](https://github.com/daniel-beard)
   [#256](https://github.com/realm/SwiftLint/issues/256)
 
-* Improve performance of `ColonRule`.  
+* Improve performance of `ColonRule` & `syntaxKindsByLine`.  
   [Norio Nomura](https://github.com/norio-nomura)
 
 * Add command to display rule description.
@@ -34,8 +34,7 @@
 
 ##### Enhancements
 
-* Improve performance of `syntaxKindsByLine`.  
-  [Norio Nomura](https://github.com/norio-nomura)
+* None.
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@
 
 ##### Enhancements
 
-* None.
+* Improve performance of `syntaxKindsByLine`.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -60,7 +60,7 @@ public extension File {
         return syntaxMapCache.get(self)
     }
 
-    public var syntaxKindsByLines: [(Int, [SyntaxKind])] {
+    public var syntaxKindsByLines: [[SyntaxKind]] {
         return syntaxKindsByLinesCache.get(self)
     }
 


### PR DESCRIPTION
This depends on https://github.com/jpsim/SourceKitten/pull/152
The duration of linting Carthage 0.11 is reduced from 17sec to 16sec
SwiftLint(32b325b) with SourceKitten(0f54e19):
```
swiftlint lint --config ~/.swiftlint-test.yml  17.48s user 1.12s system 83% cpu 22.182 total
```
SwiftLint(this) with SourceKitten(d7f9266):
```
swiftlint lint --config ~/.swiftlint-test.yml  16.05s user 1.05s system 85% cpu 20.051 total
```
On Instruments, `*BodyLengthRule`s are reduced from:
<img width="900" alt="screenshot 2016-01-30 13 42 20" src="https://cloud.githubusercontent.com/assets/33430/12693747/a944ddc4-c757-11e5-9f0b-1c947bffe8f2.png">
to:
<img width="901" alt="screenshot 2016-01-30 13 43 46" src="https://cloud.githubusercontent.com/assets/33430/12693748/b2dfbfb6-c757-11e5-9db2-45c4f3e30ae3.png">
