### PR TITLE
Improve performance of `LineLengthRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   [Daniel Beard](https://github.com/daniel-beard)
   [#256](https://github.com/realm/SwiftLint/issues/256)
 
-* Improve performance of `ColonRule` & `syntaxKindsByLine`.  
+* Improve performance of `ColonRule`, `LineLengthRule` & `syntaxKindsByLine`.  
   [Norio Nomura](https://github.com/norio-nomura)
 
 * Add command to display rule description:

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -26,7 +26,14 @@ public struct LineLengthRule: ConfigProviderRule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
+        let minValue = config.params.map({$0.value}).minElement(<)
         return file.lines.flatMap { line in
+            // `line.content.characters.count` <= `line.range.length` is true.
+            // So, `check line.range.length` is larger than minimum parameter value.
+            // for avoiding using heavy `line.content.characters.count`.
+            if line.range.length < minValue {
+                return nil
+            }
             let length = line.content.characters.count
             for param in config.params where length > param.value {
                 return StyleViolation(ruleDescription: self.dynamicType.description,


### PR DESCRIPTION
This depends on https://github.com/jpsim/SourceKitten/pull/152
The duration of linting Carthage 0.11 is reduced from 17sec to 16sec
SwiftLint(32b325b) with SourceKitten(0f54e19):
```
swiftlint lint --config ~/.swiftlint-test.yml  17.48s user 1.12s system 83% cpu 22.182 total
```
SwiftLint(this) with SourceKitten(d7f9266):
```
swiftlint lint --config ~/.swiftlint-test.yml  16.31s user 1.05s system 85% cpu 20.313 total
```
On Instruments, `LineLengthRule` are reduced from:
<img width="781" alt="screenshot 2016-01-30 14 12 44" src="https://cloud.githubusercontent.com/assets/33430/12693843/f836afee-c75b-11e5-985f-e1c85614ca53.png">
to:
<img width="781" alt="screenshot 2016-01-30 14 13 35" src="https://cloud.githubusercontent.com/assets/33430/12693845/fff9824c-c75b-11e5-90c9-5642bf072e8e.png">
