### PR TITLE
Invalidate caches after correct file

### DIFF
--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -74,6 +74,7 @@ public extension File {
     public static func clearCaches() {
         queueForRebuild = []
         _allDeclarationsByType = [:]
+        responseCache.clear()
         structureCache.clear()
         syntaxMapCache.clear()
         syntaxKindsByLinesCache.clear()

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -39,6 +39,12 @@ private struct Cache<T> {
         return value
     }
 
+    private mutating func invalidate(file: File) {
+        if let key = file.path {
+            values.removeValueForKey(key)
+        }
+    }
+
     private mutating func clear() {
         values.removeAll(keepCapacity: false)
     }
@@ -56,6 +62,13 @@ public extension File {
 
     public var syntaxKindsByLines: [(Int, [SyntaxKind])] {
         return syntaxKindsByLinesCache.get(self)
+    }
+
+    public func invalidateCache() {
+        responseCache.invalidate(self)
+        structureCache.invalidate(self)
+        syntaxMapCache.invalidate(self)
+        syntaxKindsByLinesCache.invalidate(self)
     }
 
     public static func clearCaches() {

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -53,7 +53,11 @@ public struct Linter {
     public func correct() -> [Correction] {
         var corrections = [Correction]()
         for rule in rules.flatMap({ $0 as? CorrectableRule }) {
-            corrections += rule.correctFile(file)
+            let newCorrections = rule.correctFile(file)
+            corrections += newCorrections
+            if !newCorrections.isEmpty {
+                file.invalidateCache()
+            }
         }
         return corrections
     }


### PR DESCRIPTION
Cache entry should be invalidate on every corrections, because caches and content may not match after corrections.