### PR TITLE
Improve performance of `ColonRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   [Daniel Beard](https://github.com/daniel-beard)
   [#256](https://github.com/realm/SwiftLint/issues/256)
 
+* Improve performance of `ColonRule`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Bug Fixes
 
 * None.


### PR DESCRIPTION
The duration of `ColonRule` on linting Carthage 0.11 is reduced from 2287ms to 1581ms by Instruments.
from:
<img width="903" alt="screenshot 2016-01-30 22 07 06" src="https://cloud.githubusercontent.com/assets/33430/12695876/70820ca4-c79e-11e5-89ed-3419d85cb9f9.png">
to:
<img width="893" alt="screenshot 2016-01-30 22 07 40" src="https://cloud.githubusercontent.com/assets/33430/12695879/7af976ea-c79e-11e5-887c-397238a9bb91.png">
