### PR TITLE
Add command to display rule description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Improve performance of `ColonRule`.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Add command to display rule description.
+  [Tony Li](https://github.com/crazytonyli)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -10,12 +10,59 @@ import Commandant
 import Result
 import SwiftLintFramework
 
+private let violationMarker = "↓"
+
 struct RulesCommand: CommandType {
     let verb = "rules"
     let function = "Display the list of rules and their identifiers"
 
-    func run(options: NoOptions<CommandantError<()>>) -> Result<(), CommandantError<()>> {
+    func run(options: RulesOptions) -> Result<(), CommandantError<()>> {
+        if let ruleID = options.ruleID {
+            guard let rule = masterRuleList.list[ruleID] else {
+                return .Failure(CommandantError<()>
+                    .UsageError(description: "No rule with identifier: \(ruleID)"))
+            }
+
+            printRuleDescript(rule.description)
+            return .Success()
+        }
+
         print(masterRuleList.list.keys.joinWithSeparator("\n"))
         return .Success()
     }
+
+    private func printRuleDescript(desc: RuleDescription) {
+        print("\(desc.consoleDescription)")
+
+        func indent(string: String) -> String {
+            return string.componentsSeparatedByString("\n")
+                .map { "    \($0)" }
+                .joinWithSeparator("\n")
+        }
+
+        if !desc.triggeringExamples.isEmpty {
+            print("\nTriggering Examples (violation is marked with '\(violationMarker)'):")
+            for idx in 0..<desc.triggeringExamples.count {
+                print("\nExample #\(idx + 1)\n")
+                print("\(indent(desc.triggeringExamples[idx]))")
+            }
+        }
+    }
+}
+
+struct RulesOptions: OptionsType {
+
+    private let ruleID: String?
+
+    private init(ruleID: String) {
+        self.ruleID = ruleID == "" ? nil : ruleID
+    }
+
+    // swiftlint:disable:next line_length
+    static func evaluate(mode: CommandMode) -> Result<RulesOptions, CommandantError<CommandantError<()>>> {
+        return self.init
+            <*> mode <| Argument(defaultValue: "",
+                usage: "the rule identifier to display description for")
+    }
+
 }


### PR DESCRIPTION
Add command `swiftlint rules <rule identifier>` to display detailed description.

For example:

```
$ swiftlint rules comma
Comma Spacing (comma): There should be no space before and one after any comma.

Triggering Examples (violation is marked with '↓'):

Example #1

    func abc(a: String↓ ,b: String) { }

Example #2

    abc(a: "string"↓,b: "string"

Example #3

    enum a { case a↓ ,b }
```