### PR TITLE
Build with swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,18 @@ git:
 branches:
   only:
     - master
-script: set -o pipefail && script/cibuild | xcpretty
+script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
+matrix:
+  include:
+    - script: set -o pipefail && script/cibuild | xcpretty
+      env: JOB=Xcode
+    - script: make spm
+      env: JOB=SPM
+      before_install:
+        - make swift_snapshot_install
+  exclude:
+    - script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
+
 notifications:
   email: false
   slack: realmio:vPdpsG9NLDo2DNlbqtcMAQuE

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,20 @@ OUTPUT_PACKAGE=SwiftLint.pkg
 VERSION_STRING=$(shell agvtool what-marketing-version -terse1)
 COMPONENTS_PLIST=Source/swiftlint/Supporting Files/Components.plist
 
+SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a
+
+SPM=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/bin/swift build
+SPM_INCLUDE=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/local/include
+SPM_LIB=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib
+
+SPMFLAGS=--configuration debug
+# for including "clang-c"
+SPMFLAGS+=-Xcc -ISource/Clang_C -Xcc -I$(SPM_INCLUDE)
+# for linking sourcekitd and clang-c
+SPMFLAGS+= -Xcc -F$(SPM_LIB) -Xlinker -F$(SPM_LIB) -Xlinker -L$(SPM_LIB)
+# for loading sourcekitd and clang-c
+SPMFLAGS+= -Xlinker -rpath -Xlinker $(SPM_LIB)
+
 .PHONY: all bootstrap clean install package test uninstall
 
 all: bootstrap
@@ -73,3 +87,24 @@ release: package archive
 # http://irace.me/swift-profiling/
 display_compilation_time:
 	$(BUILD_TOOL) $(XCODEFLAGS) OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build test | grep -E ^[1-9]{1}[0-9]*.[0-9]ms | sort -n
+
+swift_snapshot_install:
+	curl https://swift.org/builds/development/xcode/$(SWIFT_SNAPSHOT)/$(SWIFT_SNAPSHOT)-osx.pkg -o swift.pkg
+	sudo installer -pkg swift.pkg -target /
+
+spm:
+	sed -i "" "s/swift-latest/$(SWIFT_SNAPSHOT)/" Source/Clang_C/module.modulemap
+	$(SPM) $(SPMFLAGS) || (\
+		echo "SPM does not use Package.swift. So now removing unnecesory directories in 'Packages/*' that cause build error.";\
+		rm -rf Packages/SourceKitten-*/Source/sourcekitten;\
+		rm -rf Packages/SourceKitten-*/Source/SourceKittenFrameworkTests;\
+		rm -rf Packages/YamlSwift-*/YamlTests;\
+		echo "Runs SPM again.";\
+	) && $(SPM) $(SPMFLAGS)
+	sed -i "" "s/$(SWIFT_SNAPSHOT)/swift-latest/" Source/Clang_C/module.modulemap
+
+spm_clean:
+	$(SPM) --clean
+
+spm_clean_dist:
+	$(SPM) --clean=dist

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+import PackageDescription
+
+let package = Package(
+  name: "SwiftLint",
+  targets: [
+    Target(name: "SwiftLintFramework"),
+    Target(name: "swiftlint",
+      dependencies: [
+        .Target(name: "SwiftLintFramework")
+      ])
+  ],
+  dependencies: [
+    .Package(url: "https://github.com/norio-nomura/SourceKitten.git", majorVersion: 0, minor: 8),
+    .Package(url: "https://github.com/norio-nomura/Commandant.git", majorVersion: 0, minor: 8),
+    .Package(url: "https://github.com/norio-nomura/YamlSwift.git", majorVersion: 1),
+  ],
+  exclude: ["Source/SwiftLintFrameworkTests"]
+)

--- a/Source/Clang_C/module.modulemap
+++ b/Source/Clang_C/module.modulemap
@@ -1,0 +1,5 @@
+module Clang_C [system] {
+  header "/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a.xctoolchain/usr/local/include/clang-c/Documentation.h"
+  link "clang"
+  export *
+}

--- a/Source/Clang_C/module.modulemap
+++ b/Source/Clang_C/module.modulemap
@@ -1,5 +1,5 @@
 module Clang_C [system] {
-  header "/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a.xctoolchain/usr/local/include/clang-c/Documentation.h"
+  header "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/local/include/clang-c/Documentation.h"
   link "clang"
   export *
 }

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -18,14 +18,14 @@ public struct Linter {
         return getStyleViolations().0
     }
 
-    public var styleViolationsAndRuleTimes: ([StyleViolation], [(rule: String, time: Double)]) {
+    public var styleViolationsAndRuleTimes: ([StyleViolation], [(id: String, time: Double)]) {
         return getStyleViolations(true)
     }
 
     private func getStyleViolations(benchmark: Bool = false) ->
-        ([StyleViolation], [(rule: String, time: Double)]) {
+        ([StyleViolation], [(id: String, time: Double)]) {
         let regions = file.regions()
-        var ruleTimes = [(rule: String, time: Double)]()
+        var ruleTimes = [(id: String, time: Double)]()
         let violations = rules.flatMap { rule -> [StyleViolation] in
             let start: NSDate! = benchmark ? NSDate() : nil
             let violations = rule.validateFile(self.file)

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct ForceUnwrappingRule: OptInRule, ConfigProviderRule {


### PR DESCRIPTION
Notes:
- SPM does not use Package.swift in dependencies. So it removes unnecessary directories in `Packages/*` that cause build error.
- Using `--configuration release` crashes compiler.
- Using forked dependencies:

Uses forked dependencies:
- https://github.com/norio-nomura/SourceKitten/  
  Updated Package.swift  
  Added `0.8.1-test` tag for fetching  
- https://github.com/norio-nomura/Commandant/  
  Added `0.8.3-test` tag for fetching  
- https://github.com/norio-nomura/YamlSwift/  
  Added Package.swift  
  Fixed build error on swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a  
  Added `1.4.0-test` tag for fetching  
