### PR TITLE
Fix ValidDocs rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix more false positives in `ValidDocsRule`.
+  [diogoguimaraes](https://github.com/diogoguimaraes)
+  [#451](https://github.com/realm/SwiftLint/issues/451)
 
 ## 0.7.2: Appliance Manual
 


### PR DESCRIPTION
This pull request fixes another false positive in the `ValidDocsRule`: 
* `func a() throws -> Bool { return true }`