### PR TITLE
Fix trailing_semicolon autocorrect to handle more than one violation per line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
   [diogoguimaraes](https://github.com/diogoguimaraes)
   [#451](https://github.com/realm/SwiftLint/issues/451)
 
+* Fix `trailing_newline` autocorrect to handle more than one violation per line.
+    [daniel-beard](https://github.com/daniel-beard)
+    [#465](https://github.com/realm/SwiftLint/issues/465)
+
 ## 0.7.2: Appliance Manual
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 
 extension File {
     private func violatingTrailingSemicolonRanges() -> [NSRange] {
-        return matchPattern(";*([^\\S\\n]?)*;+$",
+        return matchPattern("(;+([^\\S\\n]?)*)+;?$",
                             excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
     }
 }
@@ -31,13 +31,15 @@ public struct TrailingSemicolonRule: CorrectableRule, ConfigProviderRule {
             "let a = 0↓;\n",
             "let a = 0↓;\nlet b = 1\n",
             "let a = 0↓;;\n",
-            "let a = 0↓;    ;;\n"
+            "let a = 0↓;    ;;\n",
+            "let a = 0↓; ; ;\n"
         ],
         corrections: [
             "let a = 0;\n": "let a = 0\n",
             "let a = 0;\nlet b = 1\n": "let a = 0\nlet b = 1\n",
             "let a = 0;;\n": "let a = 0\n",
-            "let a = 0;    ;;\n": "let a = 0\n"
+            "let a = 0;    ;;\n": "let a = 0\n",
+            "let a = 0; ; ;\n": "let a = 0\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -11,7 +11,8 @@ import SourceKittenFramework
 
 extension File {
     private func violatingTrailingSemicolonRanges() -> [NSRange] {
-        return matchPattern(";$", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
+        return matchPattern(";*([^\\S\\n]?)*;+$",
+                            excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
     }
 }
 
@@ -28,11 +29,15 @@ public struct TrailingSemicolonRule: CorrectableRule, ConfigProviderRule {
         nonTriggeringExamples: [ "let a = 0\n" ],
         triggeringExamples: [
             "let a = 0↓;\n",
-            "let a = 0↓;\nlet b = 1\n"
+            "let a = 0↓;\nlet b = 1\n",
+            "let a = 0↓;;\n",
+            "let a = 0↓;    ;;\n"
         ],
         corrections: [
             "let a = 0;\n": "let a = 0\n",
-            "let a = 0;\nlet b = 1\n": "let a = 0\nlet b = 1\n"
+            "let a = 0;\nlet b = 1\n": "let a = 0\nlet b = 1\n",
+            "let a = 0;;\n": "let a = 0\n",
+            "let a = 0;    ;;\n": "let a = 0\n"
         ]
     )
 


### PR DESCRIPTION
- Handle multiple violations that may also contain whitespace (excluding newlines) on a single line.
- Fixes #465 