### PR TITLE
[SPM] Add `make spm_test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Carthage/Build
 SwiftLint.pkg
 SwiftLintFramework.framework.zip
 benchmark_*
+
+# SPM
+.build
+Packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
     - script: set -o pipefail && script/cibuild | xcpretty
       env: JOB=Xcode
-    - script: make spm
+    - script: make spm_test
       env: JOB=SPM
       before_install:
         - make swift_snapshot_install

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ spm:
 	) && $(SPM) $(SPMFLAGS)
 	sed -i "" "s/$(SWIFT_SNAPSHOT)/swift-latest/" Source/Clang_C/module.modulemap
 
+spm_test: spm
+	.build/Debug/SwiftLintFrameworkTests
+
 spm_clean:
 	$(SPM) --clean
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,11 +7,15 @@ let package = Package(
     Target(name: "swiftlint",
       dependencies: [
         .Target(name: "SwiftLintFramework")
-      ])
+      ]),
+    Target(name: "SwiftLintFrameworkTests",
+      dependencies: [
+        .Target(name: "SwiftLintFramework")
+      ]),
   ],
   dependencies: [
     .Package(url: "https://github.com/jpsim/SourceKitten.git", majorVersion: 0, minor: 9),
     .Package(url: "https://github.com/norio-nomura/YamlSwift.git", majorVersion: 1),
-  ],
-  exclude: ["Source/SwiftLintFrameworkTests"]
+    .Package(url: "https://github.com/norio-nomura/swift-corelibs-xctest.git", majorVersion: 0),
+  ]
 )

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SwiftLintFramework
 import SourceKittenFramework
 import XCTest
@@ -223,7 +224,11 @@ extension String {
 
 extension XCTestCase {
     var bundlePath: String {
-        return NSBundle(forClass: self.dynamicType).resourcePath!
+        #if SWIFT_PACKAGE
+            return "Source/SwiftLintFrameworkTests/Resources".absolutePathRepresentation()
+        #else
+            return NSBundle(forClass: self.dynamicType).resourcePath!
+        #endif
     }
 
     var projectMockPathLevel0: String {

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -13,6 +13,29 @@ import XCTest
 let optInRules = masterRuleList.list.filter({ $0.1.init() is OptInRule }).map({ $0.0 })
 
 class ConfigurationTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testInit", self.testInit),
+        ("testEmptyConfiguration", self.testEmptyConfiguration),
+        ("testWhitelistRules", self.testWhitelistRules),
+        ("testOtherRuleConfigurationsAlongsideWhitelistRules",
+            self.testOtherRuleConfigurationsAlongsideWhitelistRules),
+        ("testDisabledRules", self.testDisabledRules),
+        ("testDisabledRulesWithUnknownRule", self.testDisabledRulesWithUnknownRule),
+        ("testExcludedPaths", self.testExcludedPaths),
+        ("testIsEqualTo", self.testIsEqualTo),
+        ("testIsNotEqualTo", self.testIsNotEqualTo),
+        ("testMerge", self.testMerge),
+        ("testLevel0", self.testLevel0),
+        ("testLevel1", self.testLevel1),
+        ("testLevel2", self.testLevel2),
+        ("testLevel3", self.testLevel3),
+        ("testDoNotUseNestedConfigs", self.testDoNotUseNestedConfigs),
+        ("testConfiguresCorrectlyFromDict", self.testConfiguresCorrectlyFromDict),
+        ("testConfigureFallsBackCorrectly", self.testConfigureFallsBackCorrectly),
+    ]
+
     func testInit() {
         XCTAssert(Configuration(dict: [:]) != nil,
             "initializing Configuration with empty Dictionary should succeed")

--- a/Source/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Source/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Realm. All rights reserved.
 //
 
+import Foundation
 import XCTest
 import SwiftLintFramework
 import SourceKittenFramework

--- a/Source/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Source/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -12,6 +12,13 @@ import SourceKittenFramework
 
 class CustomRulesTests: XCTestCase {
 
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testCustomRuleConfigSetsCorrectly", self.testCustomRuleConfigSetsCorrectly),
+        ("testCustomRuleConfigThrows", self.testCustomRuleConfigThrows),
+        ("testCustomRules", self.testCustomRules),
+    ]
+
     func testCustomRuleConfigSetsCorrectly() {
         let configDict = ["my_custom_rule": ["name": "MyCustomRule",
             "message": "Message",

--- a/Source/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
+++ b/Source/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import XCTest
 
 class ExtendedNSStringTests: XCTestCase {

--- a/Source/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
+++ b/Source/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
@@ -9,6 +9,13 @@
 import XCTest
 
 class ExtendedNSStringTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters",
+            self.testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters)
+    ]
+
     func testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters() {
         let contents = "" +
         "import Foundation\n" +                               // 18 characters

--- a/Source/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -14,6 +14,15 @@ private func funcWithBody(body: String) -> String {
 }
 
 class FunctionBodyLengthRuleTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testFunctionBodyLengths", self.testFunctionBodyLengths),
+        ("testFunctionBodyLengthsWithComments", self.testFunctionBodyLengthsWithComments),
+        ("testFunctionBodyLengthsWithMultilineComments",
+            self.testFunctionBodyLengthsWithMultilineComments),
+    ]
+
     func testFunctionBodyLengths() {
         let longFunctionBody = funcWithBody(
             Repeat(count: 39, repeatedValue: "x = 0\n").joinWithSeparator("")

--- a/Source/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Source/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -29,7 +29,7 @@ class IntegrationTests: XCTestCase {
         let swiftFiles = config.lintableFilesForPath("")
         XCTAssert(swiftFiles.map({$0.path!}).contains(__FILE__), "current file should be included")
 
-        #if SWIFTLINT_XCODE_VERSION_0730
+        #if SWIFTLINT_XCODE_VERSION_0730 || SWIFT_PACKAGE
             XCTAssertEqual(swiftFiles.flatMap({
                 Linter(file: $0, configuration: config).styleViolations
             }), [])

--- a/Source/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Source/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -12,6 +12,12 @@ import SwiftLintFramework
 import XCTest
 
 class IntegrationTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testSwiftLintLints", self.testSwiftLintLints),
+    ]
+
     func testSwiftLintLints() {
         // This is as close as we're ever going to get to a self-hosting linter.
         let directory = (((__FILE__ as NSString)

--- a/Source/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Source/SwiftLintFrameworkTests/ReporterTests.swift
@@ -10,6 +10,15 @@ import SwiftLintFramework
 import XCTest
 
 class ReporterTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testXcodeReporter", self.testXcodeReporter),
+        ("testJSONReporter", self.testJSONReporter),
+        ("testCSVReporter", self.testCSVReporter),
+        ("testCheckstyleReporter", self.testCheckstyleReporter),
+    ]
+
     func generateViolations() -> [StyleViolation] {
         let location = Location(file: "filename", line: 1, character: 2)
         return [

--- a/Source/SwiftLintFrameworkTests/RuleConfigTests.swift
+++ b/Source/SwiftLintFrameworkTests/RuleConfigTests.swift
@@ -12,6 +12,21 @@ import SourceKittenFramework
 
 class RuleConfigurationsTests: XCTestCase {
 
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testNameConfigSetsCorrectly", self.testNameConfigSetsCorrectly),
+        ("testNameConfigThrowsOnBadConfig", self.testNameConfigThrowsOnBadConfig),
+        ("testNameConfigMinLengthThreshold", self.testNameConfigMinLengthThreshold),
+        ("testNameConfigMaxLengthThreshold", self.testNameConfigMaxLengthThreshold),
+        ("testSeverityConfigFromString", self.testSeverityConfigFromString),
+        ("testSeverityConfigFromDictionary", self.testSeverityConfigFromDictionary),
+        ("testSeverityConfigThrowsOnBadConfig", self.testSeverityConfigThrowsOnBadConfig),
+        ("testSeverityLevelConfigParams", self.testSeverityLevelConfigParams),
+        ("testSeverityLevelConfigPartialParams", self.testSeverityLevelConfigPartialParams),
+        ("testRegexConfigThrows", self.testRegexConfigThrows),
+        ("testRegexRuleDescription", self.testRegexRuleDescription),
+    ]
+
     func testNameConfigSetsCorrectly() {
         let config = [ "min_length": ["warning": 17, "error": 7],
                        "max_length": ["warning": 170, "error": 700],

--- a/Source/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/RuleTests.swift
@@ -21,6 +21,27 @@ struct RuleWithLevelsMock: ConfigProviderRule {
 
 class RuleTests: XCTestCase {
 
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testRuleIsEqualTo", self.testRuleIsEqualTo),
+        ("testRuleIsNotEqualTo", self.testRuleIsNotEqualTo),
+        ("testRuleArraysWithDifferentCountsNotEqual",
+            self.testRuleArraysWithDifferentCountsNotEqual),
+        ("testSeverityLevelRuleInitsWithConfigDictionary",
+            self.testSeverityLevelRuleInitsWithConfigDictionary),
+        ("testSeverityLevelRuleInitsWithWarningOnlyConfigDictionary",
+            self.testSeverityLevelRuleInitsWithWarningOnlyConfigDictionary),
+        ("testSeverityLevelRuleInitsWithErrorOnlyConfigDictionary",
+            self.testSeverityLevelRuleInitsWithErrorOnlyConfigDictionary),
+        ("testSeverityLevelRuleInitsWithConfigArray",
+            self.testSeverityLevelRuleInitsWithConfigArray),
+        ("testSeverityLevelRuleInitsWithSingleValueConfigArray",
+            self.testSeverityLevelRuleInitsWithSingleValueConfigArray),
+        ("testSeverityLevelRuleInitsWithLiteral", self.testSeverityLevelRuleInitsWithLiteral),
+        ("testSeverityLevelRuleNotEqual", self.testSeverityLevelRuleNotEqual),
+        ("testDifferentSeverityLevelRulesNotEqual", self.testDifferentSeverityLevelRulesNotEqual),
+    ]
+
     private struct RuleMock1: Rule {
         init() {}
         static let description = RuleDescription(identifier: "RuleMock1", name: "", description: "")

--- a/Source/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Source/SwiftLintFrameworkTests/RulesTests.swift
@@ -10,6 +10,42 @@ import SwiftLintFramework
 import XCTest
 
 class RulesTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testClosingBrace", self.testClosingBrace),
+        ("testColon", self.testColon),
+        ("testComma", self.testComma),
+        ("testConditionalBindingCascade", self.testConditionalBindingCascade),
+        ("testControlStatement", self.testControlStatement),
+        ("testCyclomaticComplexity", self.testCyclomaticComplexity),
+        ("testEmptyCount", self.testEmptyCount),
+        ("testFileLength", self.testFileLength),
+        ("testForceCast", self.testForceCast),
+        ("testForceTry", self.testForceTry),
+        ("testForceUnwrapping", self.testForceUnwrapping),
+        ("testFunctionBodyLength", self.testFunctionBodyLength),
+        ("testFunctionParameterCountRule", self.testFunctionParameterCountRule),
+        ("testLeadingWhitespace", self.testLeadingWhitespace),
+        ("testLegacyConstant", self.testLegacyConstant),
+        ("testLegacyConstructor", self.testLegacyConstructor),
+        ("testLineLength", self.testLineLength),
+        ("testMissingDocs", self.testMissingDocs),
+        ("testNesting", self.testNesting),
+        ("testOpeningBrace", self.testOpeningBrace),
+        ("testOperatorFunctionWhitespace", self.testOperatorFunctionWhitespace),
+        ("testReturnArrowWhitespace", self.testReturnArrowWhitespace),
+        ("testStatementPosition", self.testStatementPosition),
+        ("testTodo", self.testTodo),
+        ("testTrailingNewline", self.testTrailingNewline),
+        ("testTrailingSemicolon", self.testTrailingSemicolon),
+        ("testTrailingWhitespace", self.testTrailingWhitespace),
+        ("testTypeBodyLength", self.testTypeBodyLength),
+        ("testTypeName", self.testTypeName),
+        ("testValidDocs", self.testValidDocs),
+        ("testVariableName", self.testVariableName),
+    ]
+
     func testClosingBrace() {
         verifyRule(ClosingBraceRule.description)
     }

--- a/Source/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Source/SwiftLintFrameworkTests/TestHelpers.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SwiftLintFramework
 import SourceKittenFramework
 import XCTest

--- a/Source/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
+++ b/Source/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
@@ -53,11 +53,19 @@ class YamlSwiftLintTests: XCTestCase {
     }
 
     func getTestYaml() -> String {
-        let testBundle = NSBundle(forClass: self.dynamicType)
-        if let path = testBundle.pathForResource("test", ofType: "yml"),
-           let ymlString = try? String(contentsOfFile: path) {
-            return ymlString
-        }
+        #if SWIFT_PACKAGE
+            let path = "Source/SwiftLintFrameworkTests/Resources/test.yml"
+                .absolutePathRepresentation()
+            if let ymlString = try? String(contentsOfFile: path) {
+                return ymlString
+            }
+        #else
+            let testBundle = NSBundle(forClass: self.dynamicType)
+            if let path = testBundle.pathForResource("test", ofType: "yml"),
+                let ymlString = try? String(contentsOfFile: path) {
+                    return ymlString
+            }
+        #endif
         fatalError("Could not load test.yml")
     }
 

--- a/Source/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
+++ b/Source/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
@@ -6,11 +6,17 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import XCTest
 import Yaml
 @testable import SwiftLintFramework
 
 class YamlSwiftLintTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testFlattenYaml", self.testFlattenYaml),
+    ]
 
     func testFlattenYaml() {
         let yamlResult = Yaml.load(getTestYaml())

--- a/Source/SwiftLintFrameworkTests/YamlParserTests.swift
+++ b/Source/SwiftLintFrameworkTests/YamlParserTests.swift
@@ -10,6 +10,14 @@ import XCTest
 @testable import SwiftLintFramework
 
 class YamlParserTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testParseEmptyString", self.testParseEmptyString),
+        ("testParseValidString", self.testParseValidString),
+        ("testParseInvalidStringThrows", self.testParseInvalidStringThrows),
+    ]
+
     // swiftlint:disable force_try
     func testParseEmptyString() {
         XCTAssertEqual((try! YamlParser.parse("")).count, 0,

--- a/Source/SwiftLintFrameworkTests/main.swift
+++ b/Source/SwiftLintFrameworkTests/main.swift
@@ -1,0 +1,23 @@
+//
+//  main.swift
+//  SwiftLint
+//
+//  Created by 野村 憲男 on 2/3/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import XCTest
+
+XCTMain([
+    ConfigurationTests(),
+    CustomRulesTests(),
+    ExtendedNSStringTests(),
+    FunctionBodyLengthRuleTests(),
+    IntegrationTests(),
+    ReporterTests(),
+    RuleConfigurationsTests(),
+    RulesTests(),
+    RuleTests(),
+    YamlSwiftLintTests(),
+    YamlParserTests(),
+    ])

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpeningBraceRule.swift; sourceTree = "<group>"; };
 		692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionRule.swift; sourceTree = "<group>"; };
 		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
+		6CDD62CE1C6193300094A198 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
 		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
@@ -481,6 +482,7 @@
 				D0D1212219E878CC005E4BAA /* Configuration */,
 				D0D1217C19E87B05005E4BAA /* Supporting Files */,
 				3B12C9BE1C3209AC000B423F /* Resources */,
+				6CDD62CE1C6193300094A198 /* main.swift */,
 				E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */,
 				D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */,
 				E832F10C1B17E725003F265F /* IntegrationTests.swift */,


### PR DESCRIPTION
#468 

Notes:
- `swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a` contains `libswiftXCTest.dylib`. But that can not be used on building by SPM because that does not contain module. So, this PR uses `swift-corelibs-xctest` as dependency.
- Use forked [`norio-nomura/swift-corelibs-xctest`](https://github.com/norio-nomura/swift-corelibs-xctest) as dependency because original repository has no version tags yet.
- Test cases are needed conforming to `XCTestCaseProvider`.
- Add `import Foundation` explicitly.
- Change some path operation depending `NSBundle`
