### PR TITLE
Add `--config` option to `rules` command

### DIFF
--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -26,7 +26,8 @@ struct RulesCommand: CommandType {
             return .Success()
         }
 
-        print(TextTable(ruleList: masterRuleList).render())
+        let configuration = Configuration(commandLinePath: options.configurationFile)
+        print(TextTable(ruleList: masterRuleList, configuration: configuration).render())
         return .Success()
     }
 
@@ -49,14 +50,20 @@ struct RulesCommand: CommandType {
 
 struct RulesOptions: OptionsType {
     private let ruleID: String?
+    private let configurationFile: String
 
-    private init(ruleID: String) {
-        self.ruleID = ruleID.isEmpty ? nil : ruleID
+    static func create(configurationFile: String) -> (ruleID: String) -> RulesOptions {
+        return { ruleID in
+            self.init(ruleID: (ruleID.isEmpty ? nil : ruleID), configurationFile: configurationFile)
+        }
     }
 
     // swiftlint:disable:next line_length
     static func evaluate(mode: CommandMode) -> Result<RulesOptions, CommandantError<CommandantError<()>>> {
-        return self.init
+        return create
+            <*> mode <| Option(key: "config",
+                defaultValue: Configuration.fileName,
+                usage: "the path to SwiftLint's configuration file")
             <*> mode <| Argument(defaultValue: "",
                 usage: "the rule identifier to display description for")
     }

--- a/Source/swiftlint/Helpers/TextTable.swift
+++ b/Source/swiftlint/Helpers/TextTable.swift
@@ -37,6 +37,7 @@ struct TextTable {
 
     init(ruleList: RuleList) {
         let sortedRules = masterRuleList.list.sort { $0.0 < $1.0 }
+        let configuration: Configuration = Configuration()
         columns = [
             TextTableColumn(header: "identifier", values: sortedRules.map({ $0.0 })),
             TextTableColumn(header: "opt-in",
@@ -45,7 +46,7 @@ struct TextTable {
                 values: sortedRules.map({ ($0.1.init() is CorrectableRule) ? "yes" : "no" })),
             TextTableColumn(header: "enabled in your config",
                 values: sortedRules.map({
-                    Configuration().rules.map({
+                    configuration.rules.map({
                         $0.dynamicType.description.identifier
                     }).contains($0.0) ? "yes" : "no"
                 })),

--- a/Source/swiftlint/Helpers/TextTable.swift
+++ b/Source/swiftlint/Helpers/TextTable.swift
@@ -35,9 +35,8 @@ private struct TextTableColumn {
 struct TextTable {
     private let columns: [TextTableColumn]
 
-    init(ruleList: RuleList) {
-        let sortedRules = masterRuleList.list.sort { $0.0 < $1.0 }
-        let configuration: Configuration = Configuration()
+    init(ruleList: RuleList, configuration: Configuration) {
+        let sortedRules = ruleList.list.sort { $0.0 < $1.0 }
         columns = [
             TextTableColumn(header: "identifier", values: sortedRules.map({ $0.0 })),
             TextTableColumn(header: "opt-in",


### PR DESCRIPTION
- Add `--config` option to `rules` command
```sh
% swiftlint help rules
Display the list of rules and their identifiers

[--config .swiftlint.yml]
	the path to SwiftLint's configuration file

[(string)]
	the rule identifier to display description for
```
- Fix multiple "Loading configuration from …" message on `swiftlint rules`
```sh
% swiftlint rules
Loading configuration from '.swiftlint.yml'
Loading configuration from '.swiftlint.yml'
…
Loading configuration from '.swiftlint.yml'
Loading configuration from '.swiftlint.yml'
+-----------------------------+--------+-------------+------------------------+--------------------------------------------------+
| identifier                  | opt-in | correctable | enabled in your config | configuration                                    |
+-----------------------------+--------+-------------+------------------------+--------------------------------------------------+
| closing_brace               | no     | yes         | yes                    | warning                                          |
```