### PR TITLE
Deallocate memory after every linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
   [JP Simard](https://github.com/jpsim)
   [#392](https://github.com/realm/SwiftLint/issues/392)
 
+* Reduce maximum memory usage.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Bug Fixes
 
 * Fix more false positives in `ValidDocsRule`.  

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -27,14 +27,17 @@ struct LintCommand: CommandType {
             useSTDIN: options.useSTDIN,
             useScriptInputFiles: options.useScriptInputFiles) { linter in
             let start: NSDate! = options.benchmark ? NSDate() : nil
-            let currentViolations: [StyleViolation]
-            if options.benchmark {
-                let (_currentViolations, currentRuleTimes) = linter.styleViolationsAndRuleTimes
-                currentViolations = _currentViolations
-                fileTimes.append((linter.file.path ?? "<nopath>", -start.timeIntervalSinceNow))
-                ruleTimes.appendContentsOf(currentRuleTimes)
-            } else {
-                currentViolations = linter.styleViolations
+            var currentViolations: [StyleViolation] = []
+            autoreleasepool {
+                if options.benchmark {
+                    let (_currentViolations, currentRuleTimes) = linter.styleViolationsAndRuleTimes
+                    currentViolations = _currentViolations
+                    fileTimes.append((linter.file.path ?? "<nopath>", -start.timeIntervalSinceNow))
+                    ruleTimes.appendContentsOf(currentRuleTimes)
+                } else {
+                    currentViolations = linter.styleViolations
+                }
+                linter.file.invalidateCache()
             }
             violations += currentViolations
             if reporter == nil { reporter = linter.reporter }


### PR DESCRIPTION
- Use `autoreleasepool(_:)`
- Call `File.invalidateCache()`

Instruments on linting Carthage 0.12,
maximum Persistent Bytes is reduced from 508.49MB to 170.74MB.
From:
<img width="1039" alt="screenshot 2016-02-05 19 21 17" src="https://cloud.githubusercontent.com/assets/33430/12847983/4d155b48-cc5a-11e5-8cdb-b82d204e7c1d.png">
To:
<img width="1039" alt="screenshot 2016-02-05 22 30 32" src="https://cloud.githubusercontent.com/assets/33430/12847991/595eae72-cc5a-11e5-8657-8ce589c06df5.png">

Total number of allocation does not increase. (If disposed memory was reused, it increases.)

Running Time of calling: `File.invalidateCache()` is 381ms, `autoreleasepool(_:)` is 45ms.
<img width="780" alt="screenshot 2016-02-05 22 26 16" src="https://cloud.githubusercontent.com/assets/33430/12847999/641cce2a-cc5a-11e5-9d5c-3eb749e8bcb4.png">
