### PR TITLE
Optimize `excludingPattern` in `violatingOpeningBraceRanges()`

### DIFF
--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -16,7 +16,7 @@ extension File {
         return matchPattern(
             "((?:[^( ]|[\\s(][\\s]+)\\{)",
             excludingSyntaxKinds: SyntaxKind.commentAndStringKinds(),
-            excludingPattern: "((?:if|guard|while)\\n((?:[^\\{]+)\\n)+\\s*\\{)"
+            excludingPattern: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{"
         )
     }
 }


### PR DESCRIPTION
Fix #491
By applying this, on linting KeychainAccess,
from(0.8.0):
```
swiftlint lint --config ~/.swiftlint-test.yml  29.61s user 0.18s system 98% cpu 30.175 total
```
to:
```
swiftlint lint --config ~/.swiftlint-test.yml  1.92s user 0.06s system 91% cpu 2.160 total
```