### PR TITLE
add `--quiet` flag to `lint` and `autocorrect` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   requirements have been moved to `Rule`.  
   [JP Simard](https://github.com/jpsim)
 
+* `Configuration(path:optional:silent)` has been changed to
+  `Configuration(path:rootPath:optional:quiet:)`.  
+  [JP Simard](https://github.com/jpsim)
+
 ##### Enhancements
 
 * `swiftlint lint` now accepts an optional `--reporter` parameter which
@@ -20,6 +24,11 @@
 
 * `swiftlint rules` now shows a configuration description for all rules.  
   [JP Simard](https://github.com/jpsim)
+
+* `lint` and `autocorrect` commands now accept a `--quiet` flag that prevents
+  status messages like 'Linting <file>' & 'Done linting' from being logged.  
+  [JP Simard](https://github.com/jpsim)
+  [#386](https://github.com/realm/SwiftLint/issues/386)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -110,7 +110,8 @@ public struct Configuration: Equatable {
         )
     }
 
-    public init(path: String = ".swiftlint.yml", optional: Bool = true, silent: Bool = false) {
+    public init(path: String = ".swiftlint.yml", rootPath: String? = nil, optional: Bool = true,
+                quiet: Bool = false) {
         let fullPath = (path as NSString).absolutePathRepresentation()
         let fail = { fatalError("Could not read configuration file at path '\(fullPath)'") }
         if path.isEmpty || !NSFileManager.defaultManager().fileExistsAtPath(fullPath) {
@@ -122,7 +123,7 @@ public struct Configuration: Equatable {
             let yamlContents = try NSString(contentsOfFile: fullPath,
                 encoding: NSUTF8StringEncoding) as String
             let dict = try YamlParser.parse(yamlContents)
-            if !silent {
+            if !quiet {
                 queuedPrintError("Loading configuration from '\(path)'")
             }
             self.init(dict: dict)!
@@ -186,7 +187,7 @@ public extension Configuration {
         // If a config exists and it isn't us, load and merge the configs
         if configSearchPath != configPath &&
             NSFileManager.defaultManager().fileExistsAtPath(configSearchPath) {
-            return merge(Configuration(path: configSearchPath, optional: false, silent: true))
+            return merge(Configuration(path: configSearchPath, optional: false, quiet: true))
         }
 
         // If we are not at the root path, continue down the tree

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -145,8 +145,9 @@ class ConfigurationTests: XCTestCase {
     // MARK: - Testing Configuration Equality
 
     private var projectMockConfig0: Configuration {
-        return Configuration(path: projectMockYAML0, optional: false, quiet: true,
-            rootPath: projectMockPathLevel0)
+        var config = Configuration(path: projectMockYAML0, optional: false, quiet: true)
+        config.rootPath = projectMockPathLevel0
+        return config
     }
 
     private var projectMockConfig2: Configuration {

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -145,13 +145,12 @@ class ConfigurationTests: XCTestCase {
     // MARK: - Testing Configuration Equality
 
     private var projectMockConfig0: Configuration {
-        var config = Configuration(path: projectMockYAML0, optional: false, silent: true)
-        config.rootPath = projectMockPathLevel0
-        return config
+        return Configuration(path: projectMockYAML0, optional: false, quiet: true,
+            rootPath: projectMockPathLevel0)
     }
 
     private var projectMockConfig2: Configuration {
-        return Configuration(path: projectMockYAML2, optional: false, silent: true)
+        return Configuration(path: projectMockYAML2, optional: false, quiet: true)
     }
 
     func testIsEqualTo() {


### PR DESCRIPTION
addresses #386.

depends on #495. /cc @scottrhoyt @norio-nomura 

**update:** no longer depends on #495 since that's since been merged.