### PR TITLE
fix inconsistencies between violations & corrections in StatementPositionRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   [Ankit Aggarwal](https://github.com/aciidb0mb3r)
   [#298](https://github.com/realm/SwiftLint/issues/298)
 
+* Fixed inconsistencies between violations & corrections in
+  `StatementPositionRule`.  
+  [JP Simard](https://github.com/jpsim)
+  [#466](https://github.com/realm/SwiftLint/issues/466)
+
 ## 0.8.0: High Heat
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -30,9 +30,9 @@ public struct StatementPositionRule: CorrectableRule, ConfigProviderRule {
         ],
         triggeringExamples: [
             "↓}else if {",
-            "}↓  else {",
-            "}↓\ncatch {",
-            "}\n\t↓  catch {"
+            "↓}  else {",
+            "↓}\ncatch {",
+            "↓}\n\t  catch {"
         ],
         corrections: [
             "}\n else {\n": "} else {\n",
@@ -42,8 +42,6 @@ public struct StatementPositionRule: CorrectableRule, ConfigProviderRule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let pattern = "(?:\\}|[\\s] |[\\n\\t\\r])\\b(?:else|catch)\\b"
-
         return violationRangesInFile(file, withPattern: pattern).flatMap { range in
             return StyleViolation(ruleDescription: self.dynamicType.description,
                 severity: config.severity,
@@ -52,8 +50,6 @@ public struct StatementPositionRule: CorrectableRule, ConfigProviderRule {
     }
 
     public func correctFile(file: File) -> [Correction] {
-        let pattern = "\\}\\s+((?:else|catch))\\b"
-
         let matches = violationRangesInFile(file, withPattern: pattern)
         guard !matches.isEmpty else { return [] }
 
@@ -71,7 +67,12 @@ public struct StatementPositionRule: CorrectableRule, ConfigProviderRule {
         return corrections
     }
 
-    // MARK: - Private Methods
+    // MARK: - Private
+
+    // match literal '}'
+    // followed by 1) nothing, 2) two+ whitespace/newlines or 3) newlines or tabs
+    // followed by 'else' or 'catch' literals
+    private let pattern = "\\}(?:[\\s\\n\\r]{2,}|[\\n\\t\\r]+)?\\b(else|catch)\\b"
 
     private func violationRangesInFile(file: File, withPattern pattern: String) -> [NSRange] {
         return file.matchPattern(pattern).filter { range, syntaxKinds in

--- a/Source/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Source/SwiftLintFrameworkTests/TestHelpers.swift
@@ -23,6 +23,34 @@ func violations(string: String, config: Configuration = Configuration()) -> [Sty
     return Linter(file: file, configuration: config).styleViolations
 }
 
+extension Configuration {
+    private func assertCorrection(before: String, expected: String) {
+        guard let path = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .URLByAppendingPathComponent(NSUUID().UUIDString + ".swift").path else {
+                XCTFail("couldn't generate temporary path for assertCorrection()")
+                return
+        }
+        if before.dataUsingEncoding(NSUTF8StringEncoding)?
+            .writeToFile(path, atomically: true) != true {
+                XCTFail("couldn't write to file for assertCorrection()")
+                return
+        }
+        guard let file = File(path: path) else {
+            XCTFail("couldn't read file at path '\(path)' for assertCorrection()")
+            return
+        }
+        let corrections = Linter(file: file, configuration: self).correct()
+        XCTAssertEqual(corrections.count, Int(before != expected))
+        XCTAssertEqual(file.contents, expected)
+        do {
+            let corrected = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding)
+            XCTAssertEqual(corrected as String, expected)
+        } catch {
+            XCTFail("couldn't read file at path '\(path)': \(error)")
+        }
+    }
+}
+
 extension String {
     private func toStringLiteral() -> String {
         return "\"" + stringByReplacingOccurrencesOfString("\n", withString: "\\n") + "\""
@@ -33,33 +61,6 @@ extension XCTestCase {
     func verifyRule(ruleDescription: RuleDescription, commentDoesntViolate: Bool = true,
                     stringDoesntViolate: Bool = true) {
         let config = Configuration(whitelistRules: [ruleDescription.identifier])!
-
-        func assertCorrection(before: String, expected: String) {
-            guard let path = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-                .URLByAppendingPathComponent(NSUUID().UUIDString + ".swift").path else {
-                    XCTFail("couldn't generate temporary path for assertCorrection()")
-                    return
-            }
-            if before.dataUsingEncoding(NSUTF8StringEncoding)?
-                .writeToFile(path, atomically: true) != true {
-                XCTFail("couldn't write to file for assertCorrection()")
-                return
-            }
-            guard let file = File(path: path) else {
-                XCTFail("couldn't read file at path '\(path)' for assertCorrection()")
-                return
-            }
-            let corrections = Linter(file: file, configuration: config).correct()
-            XCTAssertEqual(corrections.count, Int(before != expected))
-            XCTAssertEqual(file.contents, expected)
-            do {
-                let corrected = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding)
-                XCTAssertEqual(corrected as String, expected)
-            } catch {
-                XCTFail("couldn't read file at path '\(path)': \(error)")
-            }
-        }
-
         let triggers = ruleDescription.triggeringExamples
         let nonTriggers = ruleDescription.nonTriggeringExamples
 
@@ -98,9 +99,9 @@ extension XCTestCase {
         XCTAssert(triggers.flatMap({ violations(command + $0, config: config) }).isEmpty)
 
         // corrections
-        ruleDescription.corrections.forEach(assertCorrection)
+        ruleDescription.corrections.forEach(config.assertCorrection)
         // make sure strings that don't trigger aren't corrected
-        zip(nonTriggers, nonTriggers).forEach(assertCorrection)
+        zip(nonTriggers, nonTriggers).forEach(config.assertCorrection)
     }
 
     func checkError<T: protocol<ErrorType, Equatable>>(error: T, closure: () throws -> () ) {


### PR DESCRIPTION
Partly fixes #466. /cc @tkohout @scottrhoyt @norio-nomura 

All rules that share a different regular expression or codepath for detecting violations and snippets to correct are at risk of having this issue, so moving forward, we should take extra care to make sure they're consistent.