### PR TITLE
only correct legacy constructors if they're tokenized as identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@
   [JP Simard](https://github.com/jpsim)
   [#120](https://github.com/realm/SwiftLint/issues/120)
 
+* Fixed `LegacyConstructorRule` from correcting legacy constructors in string
+  literals.  
+  [JP Simard](https://github.com/jpsim)
+  [#466](https://github.com/realm/SwiftLint/issues/466)
+
 ## 0.8.0: High Heat
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -71,7 +71,9 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigProviderRule {
         var contents = file.contents
 
         for (pattern, template) in patterns {
-            let matches = file.matchPattern(pattern, excludingSyntaxKinds: [.Comment])
+            let matches = file.matchPattern(pattern)
+                .filter({ $0.1.first == .Identifier })
+                .map({ $0.0 })
 
             let regularExpression = regex(pattern)
             for range in matches.reverse() {


### PR DESCRIPTION
This is the counterpart to #499, fixing the other half of #466.