### PR TITLE
add an integration test to ensure SwiftLint autocorrects successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@
   [JP Simard](https://github.com/jpsim)
   [#120](https://github.com/realm/SwiftLint/issues/120)
 
+* Fixed `LegacyConstructorRule` from correcting legacy constructors in string
+  literals.  
+  [JP Simard](https://github.com/jpsim)
+  [#466](https://github.com/realm/SwiftLint/issues/466)
+
 ## 0.8.0: High Heat
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Models/Correction.swift
+++ b/Source/SwiftLintFramework/Models/Correction.swift
@@ -6,11 +6,18 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
-public struct Correction {
+public struct Correction: Equatable {
     public let ruleDescription: RuleDescription
     public let location: Location
 
     public var consoleDescription: String {
         return "\(location) Corrected \(ruleDescription.name)"
     }
+}
+
+// MARK: Equatable
+
+public func == (lhs: Correction, rhs: Correction) -> Bool {
+    return lhs.ruleDescription == rhs.ruleDescription &&
+        lhs.location == rhs.location
 }

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -71,7 +71,9 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigProviderRule {
         var contents = file.contents
 
         for (pattern, template) in patterns {
-            let matches = file.matchPattern(pattern, excludingSyntaxKinds: [.Comment])
+            let matches = file.matchPattern(pattern)
+                .filter({ $0.1.first == .Identifier })
+                .map({ $0.0 })
 
             let regularExpression = regex(pattern)
             for range in matches.reverse() {

--- a/Source/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Source/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -11,6 +11,15 @@ import SourceKittenFramework
 import SwiftLintFramework
 import XCTest
 
+let config: Configuration = {
+    let directory = (((__FILE__ as NSString)
+        .stringByDeletingLastPathComponent as NSString)
+        .stringByDeletingLastPathComponent as NSString)
+        .stringByDeletingLastPathComponent
+    NSFileManager.defaultManager().changeCurrentDirectoryPath(directory)
+    return Configuration(path: Configuration.fileName)
+}()
+
 class IntegrationTests: XCTestCase {
 
     // protocol XCTestCaseProvider
@@ -20,12 +29,6 @@ class IntegrationTests: XCTestCase {
 
     func testSwiftLintLints() {
         // This is as close as we're ever going to get to a self-hosting linter.
-        let directory = (((__FILE__ as NSString)
-            .stringByDeletingLastPathComponent as NSString)
-            .stringByDeletingLastPathComponent as NSString)
-            .stringByDeletingLastPathComponent
-        NSFileManager.defaultManager().changeCurrentDirectoryPath(directory)
-        let config = Configuration(path: Configuration.fileName)
         let swiftFiles = config.lintableFilesForPath("")
         XCTAssert(swiftFiles.map({$0.path!}).contains(__FILE__), "current file should be included")
 
@@ -41,5 +44,12 @@ class IntegrationTests: XCTestCase {
                 XCTFail($0.reason, file: $0.location.file!, line: UInt($0.location.line!))
             }
         #endif
+    }
+
+    func testSwiftLintAutoCorrects() {
+        let swiftFiles = config.lintableFilesForPath("")
+        XCTAssertEqual(swiftFiles.flatMap({
+            Linter(file: $0, configuration: config).correct()
+        }), [])
     }
 }


### PR DESCRIPTION
This depends on #499 and #501, and should help minimize issues with autocorrect in the future by making sure `autocorrect` succeeds on SwiftLint's codebase. /cc @scottrhoyt @norio-nomura 