### PR TITLE
Trim API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
   `configuredRules`.  
   [JP Simard](https://github.com/jpsim)
 
+* Removed a large number of declarations from the public SwiftLintFramework API.
+  This is being done to minimize the API surface area in preparation of a 1.0
+  release. See [#507](https://github.com/realm/SwiftLint/pull/507) for a
+  complete record of this change.  
+  [JP Simard](https://github.com/jpsim)
+  [#479](https://github.com/realm/SwiftLint/issues/479)
+
 ##### Enhancements
 
 * `swiftlint lint` now accepts an optional `--reporter` parameter which

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -50,17 +50,17 @@ private struct Cache<T> {
     }
 }
 
-public extension File {
+extension File {
 
-    public var structure: Structure {
+    internal var structure: Structure {
         return structureCache.get(self)
     }
 
-    public var syntaxMap: SyntaxMap {
+    internal var syntaxMap: SyntaxMap {
         return syntaxMapCache.get(self)
     }
 
-    public var syntaxKindsByLines: [[SyntaxKind]] {
+    internal var syntaxKindsByLines: [[SyntaxKind]] {
         return syntaxKindsByLinesCache.get(self)
     }
 
@@ -71,7 +71,7 @@ public extension File {
         syntaxKindsByLinesCache.invalidate(self)
     }
 
-    public static func clearCaches() {
+    internal static func clearCaches() {
         queueForRebuild = []
         _allDeclarationsByType = [:]
         responseCache.clear()
@@ -80,7 +80,7 @@ public extension File {
         syntaxKindsByLinesCache.clear()
     }
 
-    public static var allDeclarationsByType: [String: [String]] {
+    internal static var allDeclarationsByType: [String: [String]] {
         if !queueForRebuild.isEmpty {
             rebuildAllDeclarationsByType()
         }

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -18,7 +18,7 @@ internal func regex(pattern: String) -> NSRegularExpression {
 }
 
 extension File {
-    public func regions() -> [Region] {
+    internal func regions() -> [Region] {
         var regions = [Region]()
         var disabledRules = Set<String>()
         let commands = self.commands()
@@ -65,7 +65,7 @@ extension File {
         return Location(file: path, line: nextLine, character: nextCharacter)
     }
 
-    public func matchPattern(pattern: String,
+    internal func matchPattern(pattern: String,
                              withSyntaxKinds syntaxKinds: [SyntaxKind]) -> [NSRange] {
         return matchPattern(pattern).filter { _, kindsInRange in
             return kindsInRange.count == syntaxKinds.count &&
@@ -93,11 +93,11 @@ extension File {
         }
     }
 
-    public func matchPattern(pattern: String) -> [(NSRange, [SyntaxKind])] {
+    internal func matchPattern(pattern: String) -> [(NSRange, [SyntaxKind])] {
         return matchPattern(regex(pattern))
     }
 
-    public func matchPattern(regex: NSRegularExpression) -> [(NSRange, [SyntaxKind])] {
+    internal func matchPattern(regex: NSRegularExpression) -> [(NSRange, [SyntaxKind])] {
         return rangesAndTokensMatching(regex).map { range, tokens in
             (range, tokens.map({ $0.type }).flatMap(SyntaxKind.init))
         }
@@ -141,7 +141,7 @@ extension File {
     - returns: An array of [NSRange] objects consisting of regex matches inside
     file contents.
     */
-    public func matchPattern(pattern: String,
+    internal func matchPattern(pattern: String,
                              excludingSyntaxKinds syntaxKinds: [SyntaxKind]) -> [NSRange] {
         return matchPattern(pattern).filter {
             $0.1.filter(syntaxKinds.contains).isEmpty
@@ -164,7 +164,7 @@ extension File {
         return matches.filter { !$0.intersectsRanges(exclusionRanges) }
     }
 
-    public func validateVariableName(dictionary: [String: SourceKitRepresentable],
+    internal func validateVariableName(dictionary: [String: SourceKitRepresentable],
                                      kind: SwiftDeclarationKind) -> (name: String, offset: Int)? {
         guard let name = dictionary["key.name"] as? String,
             offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) where
@@ -174,7 +174,7 @@ extension File {
         return (name.nameStrippingLeadingUnderscoreIfPrivate(dictionary), offset)
     }
 
-    public func append(string: String) {
+    internal func append(string: String) {
         guard let stringData = string.dataUsingEncoding(NSUTF8StringEncoding) else {
             fatalError("can't encode '\(string)' with UTF8")
         }
@@ -188,7 +188,7 @@ extension File {
         lines = contents.lines()
     }
 
-    public func write(string: String) {
+    internal func write(string: String) {
         guard let path = path else {
             fatalError("file needs a path to call write(_:)")
         }

--- a/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
@@ -9,12 +9,7 @@
 import Foundation
 
 extension NSFileManager {
-    public func allFilesRecursively(directory directory: String) throws -> [String] {
-        return try subpathsOfDirectoryAtPath(directory)
-            .map((directory as NSString).stringByAppendingPathComponent)
-    }
-
-    public func filesToLintAtPath(path: String) -> [String] {
+    internal func filesToLintAtPath(path: String) -> [String] {
         let absolutePath = path.absolutePathStandardized()
         var isDirectory: ObjCBool = false
         guard fileExistsAtPath(absolutePath, isDirectory: &isDirectory) else {
@@ -22,8 +17,9 @@ extension NSFileManager {
         }
         if isDirectory {
             do {
-                return try allFilesRecursively(directory: absolutePath).filter {
-                    $0.isSwiftFile()
+                return try subpathsOfDirectoryAtPath(absolutePath)
+                    .map((absolutePath as NSString).stringByAppendingPathComponent).filter {
+                        $0.isSwiftFile()
                 }
             } catch {
                 fatalError("Couldn't find files in \(absolutePath): \(error)")

--- a/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
@@ -10,8 +10,8 @@ import Foundation
 
 private var regexCache = [String: NSRegularExpression]()
 
-public extension NSRegularExpression {
-    public static func cached(pattern pattern: String) throws -> NSRegularExpression {
+extension NSRegularExpression {
+    internal static func cached(pattern pattern: String) throws -> NSRegularExpression {
         if let result = regexCache[pattern] {
             return result
         }
@@ -21,7 +21,7 @@ public extension NSRegularExpression {
         regexCache[pattern] = result
         return result
     }
-    public static func forcePattern(pattern: String) -> NSRegularExpression {
+    internal static func forcePattern(pattern: String) -> NSRegularExpression {
         // swiftlint:disable:next force_try
         return try! NSRegularExpression.cached(pattern: pattern)
     }

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -10,7 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 extension String {
-    func hasTrailingWhitespace() -> Bool {
+    internal func hasTrailingWhitespace() -> Bool {
         if isEmpty {
             return false
         }
@@ -22,15 +22,11 @@ extension String {
         return false
     }
 
-    func isUppercase() -> Bool {
+    internal func isUppercase() -> Bool {
         return self == uppercaseString
     }
 
-    public var chomped: String {
-        return stringByTrimmingCharactersInSet(NSCharacterSet.newlineCharacterSet())
-    }
-
-    public func nameStrippingLeadingUnderscoreIfPrivate(dict: [String: SourceKitRepresentable]) ->
+    internal func nameStrippingLeadingUnderscoreIfPrivate(dict: [String: SourceKitRepresentable]) ->
                                                         String {
         let privateACL = "source.lang.swift.accessibility.private"
         if dict["key.accessibility"] as? String == privateACL && characters.first == "_" {
@@ -47,14 +43,14 @@ extension String {
         fatalError("invalid range")
     }
 
-    func substring(from: Int, length: Int? = nil) -> String {
+    internal func substring(from: Int, length: Int? = nil) -> String {
         if let length = length {
             return self[from..<from + length]
         }
         return substringFromIndex(startIndex.advancedBy(from, limit: endIndex))
     }
 
-    public func lastIndexOf(search: String) -> Int? {
+    internal func lastIndexOf(search: String) -> Int? {
         if let range = rangeOfString(search, options: [.LiteralSearch, .BackwardsSearch]) {
             return startIndex.distanceTo(range.startIndex)
         }

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -30,7 +30,7 @@ public struct Configuration: Equatable {
     public let rules: [Rule]
     public let useNestedConfigs: Bool  // process nested configs, will default to false
     public var rootPath: String?       // the root path of the lint to search for nested configs
-    private var configPath: String?    // if successfully loaded from a path
+    public var configPath: String?     // if successfully loaded from a path
 
     public init?(disabledRules: [String] = [],
                  optInRules: [String] = [],

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -24,7 +24,6 @@ private enum ConfigurationKey: String {
 
 public struct Configuration: Equatable {
     public static let fileName = ".swiftlint.yml"
-    public let disabledRules: [String] // disabled_rules
     public let included: [String]      // included
     public let excluded: [String]      // excluded
     public let reporter: String        // reporter (xcode, json, csv, checkstyle)
@@ -73,7 +72,6 @@ public struct Configuration: Equatable {
             }.joinWithSeparator("\n"))
             return nil
         }
-        self.disabledRules = validDisabledRules
 
         // white_list rules take precendence over all else.
         if !whitelistRules.isEmpty {
@@ -223,8 +221,7 @@ extension Configuration {
 // Mark - == Implementation
 
 public func == (lhs: Configuration, rhs: Configuration) -> Bool {
-    return (lhs.disabledRules == rhs.disabledRules) &&
-           (lhs.excluded == rhs.excluded) &&
+    return (lhs.excluded == rhs.excluded) &&
            (lhs.included == rhs.included) &&
            (lhs.reporter == rhs.reporter) &&
            (lhs.useNestedConfigs == rhs.useNestedConfigs) &&

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -31,7 +31,7 @@ public struct Configuration: Equatable {
     public let rules: [Rule]
     public let useNestedConfigs: Bool  // process nested configs, will default to false
     public var rootPath: String?       // the root path of the lint to search for nested configs
-    private var configPath: String?    // if successfully load from a path
+    private var configPath: String?    // if successfully loaded from a path
 
     public init?(disabledRules: [String] = [],
                  optInRules: [String] = [],
@@ -192,8 +192,8 @@ public struct Configuration: Equatable {
 
 // MARK: - Nested Configurations Extension
 
-public extension Configuration {
-    func configForPath(path: String) -> Configuration {
+extension Configuration {
+    private func configForPath(path: String) -> Configuration {
         let path = path as NSString
         let configSearchPath = path.stringByAppendingPathComponent(Configuration.fileName)
 
@@ -215,7 +215,7 @@ public extension Configuration {
     // Currently merge simply overrides the current configuration with the new configuration.
     // This requires that all config files be fully specified. In the future this will be changed
     // to do a more intelligent merge allowing for partial nested configs.
-    func merge(config: Configuration) -> Configuration {
+    internal func merge(config: Configuration) -> Configuration {
         return config
     }
 }

--- a/Source/SwiftLintFramework/Models/YamlParser.swift
+++ b/Source/SwiftLintFramework/Models/YamlParser.swift
@@ -10,12 +10,12 @@ import Yaml
 
 // MARK: - YamlParsingError
 
-public enum YamlParserError: ErrorType, Equatable {
+internal enum YamlParserError: ErrorType, Equatable {
     case YamlParsing(String)
     case YamlFlattening
 }
 
-public func == (lhs: YamlParserError, rhs: YamlParserError) -> Bool {
+internal func == (lhs: YamlParserError, rhs: YamlParserError) -> Bool {
     switch (lhs, rhs) {
     case (.YamlFlattening, .YamlFlattening):
         return true

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -18,7 +18,7 @@ public protocol Rule {
 }
 
 extension Rule {
-    func isEqualTo(rule: Rule) -> Bool {
+    public func isEqualTo(rule: Rule) -> Bool {
         return self.dynamicType.description == rule.dynamicType.description
     }
 }

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -13,6 +13,16 @@ import XCTest
 
 let optInRules = masterRuleList.list.filter({ $0.1.init() is OptInRule }).map({ $0.0 })
 
+extension Configuration {
+    var disabledRules: [String] {
+        let configuredRuleIDs = rules.map({ $0.dynamicType.description.identifier })
+        let defaultRuleIDs = Set(masterRuleList.list.values.filter({
+            !($0.init() is OptInRule)
+        }).map({ $0.description.identifier }))
+        return defaultRuleIDs.subtract(configuredRuleIDs).sort(<)
+    }
+}
+
 class ConfigurationTests: XCTestCase {
 
     // protocol XCTestCaseProvider

--- a/Source/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Source/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import SourceKittenFramework
 
 class CustomRulesTests: XCTestCase {

--- a/Source/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Source/SwiftLintFrameworkTests/TestHelpers.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import SourceKittenFramework
 import XCTest
 


### PR DESCRIPTION
this is done in an effort to stabilize the API for SwiftLint 1.0 (#479).

Still needs:

- [x] **discussion:** It occurred to me as I was marking more APIs as `internal` that anything used by rule implementations in this framework would benefit external consumers of SwiftLintFramework if they're also writing their own rules. However, since we haven't focused on that experience so far, maybe extensibility should explicitly be a non-goal for 1.0, since it inherently collides directly with stability. Hence the need for discussion around this.
- [x] **changelog entry:** Pending discussion to see what we actually want to do here.