### PR TITLE
make RulesCommand show a configuration description for all rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   has been renamed to a free function: `reporterFromString(_:)`.  
   [JP Simard](https://github.com/jpsim)
 
+* `_ConfigProviderRule` has been removed and its `configDescription` requirement
+  has been moved to `ConfigurableRule`.  
+  [JP Simard](https://github.com/jpsim)
+
 ##### Enhancements
 
 * `swiftlint lint` now accepts an optional `--reporter` parameter which
@@ -13,6 +17,9 @@
   `xcode` (default), `json`, `csv` or `checkstyle`.  
   [JP Simard](https://github.com/jpsim)
   [#440](https://github.com/realm/SwiftLint/issues/440)
+
+* `swiftlint rules` now shows a configuration description for all rules.  
+  [JP Simard](https://github.com/jpsim)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -30,13 +30,10 @@ extension Rule {
 public protocol ConfigurableRule: Rule {
     init(config: AnyObject) throws
     func isEqualTo(rule: ConfigurableRule) -> Bool
-}
-
-public protocol _ConfigProviderRule: ConfigurableRule {
     var configDescription: String { get }
 }
 
-public protocol ConfigProviderRule: _ConfigProviderRule {
+public protocol ConfigProviderRule: ConfigurableRule {
     typealias ConfigType: RuleConfig
     var config: ConfigType { get set }
 }

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -12,7 +12,7 @@ import SourceKittenFramework
 // MARK: - CustomRulesConfig
 
 public struct CustomRulesConfig: RuleConfig, Equatable {
-    public var consoleDescription: String { return "N/A" }
+    public var consoleDescription: String { return "user-defined" }
     public var customRuleConfigs = [RegexConfig]()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -76,6 +76,12 @@ public struct MissingDocsRule: ConfigurableRule, OptInRule {
         parameters = zip([.Warning, .Error], acl).map(RuleParameter<AccessControlLevel>.init)
     }
 
+    public var configDescription: String {
+        return parameters.map({
+            "\($0.severity.rawValue.lowercaseString): \($0.value.rawValue)"
+        }).joinWithSeparator(", ")
+    }
+
     public init() {
         parameters = [RuleParameter(severity: .Warning, value: .Public)]
     }

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -92,7 +92,7 @@ extension TextTable {
                    (rule is OptInRule) ? "yes" : "no",
                    (rule is CorrectableRule) ? "yes" : "no",
                    configuredRule != nil ? "yes" : "no",
-                   ((configuredRule ?? rule)  as? _ConfigProviderRule)?.configDescription ?? "N/A")
+                   ((configuredRule ?? rule)  as? ConfigurableRule)?.configDescription ?? "N/A")
         }
     }
 }


### PR DESCRIPTION
Now that all rules are configurable, I think it'd be nice to fold `ConfigurableRule` into `Rule` and get rid of `ConfigurableRule` altogether. /cc @scottrhoyt @norio-nomura 