### PR TITLE
fold ConfigurableRule into Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
   has been renamed to a free function: `reporterFromString(_:)`.  
   [JP Simard](https://github.com/jpsim)
 
-* `_ConfigProviderRule` has been removed and its `configDescription` requirement
-  has been moved to `ConfigurableRule`.  
+* `_ConfigProviderRule` & `ConfigurableRule` have been removed and their
+  requirements have been moved to `Rule`.  
   [JP Simard](https://github.com/jpsim)
 
 ##### Enhancements

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -137,19 +137,18 @@ public struct Configuration: Equatable {
     public static func rulesFromDict(dict: [String: AnyObject]? = nil,
                                      ruleList: RuleList = masterRuleList) -> [Rule] {
         var rules = [Rule]()
-        for rule in ruleList.list.values {
-            let identifier = rule.description.identifier
-            if let ConfigurableRuleType = rule as? ConfigurableRule.Type,
-               ruleConfig = dict?[identifier] {
+        for ruleType in ruleList.list.values {
+            let identifier = ruleType.description.identifier
+            if let ruleConfig = dict?[identifier] {
                 do {
-                    let configuredRule = try ConfigurableRuleType.init(config: ruleConfig)
+                    let configuredRule = try ruleType.init(config: ruleConfig)
                     rules.append(configuredRule)
                 } catch {
                     queuedPrintError("Invalid config for '\(identifier)'. Falling back to default.")
-                    rules.append(rule.init())
+                    rules.append(ruleType.init())
                 }
             } else {
-                rules.append(rule.init())
+                rules.append(ruleType.init())
             }
         }
 

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -8,32 +8,24 @@
 
 import SourceKittenFramework
 
-public protocol OptInRule {}
-
 public protocol Rule {
     init() // Rules need to be able to be initialized with default values
+    init(config: AnyObject) throws
     static var description: RuleDescription { get }
     func validateFile(file: File) -> [StyleViolation]
+    func isEqualTo(rule: Rule) -> Bool
+    var configDescription: String { get }
 }
 
 extension Rule {
     func isEqualTo(rule: Rule) -> Bool {
-        switch (self, rule) {
-        case (let rule1 as ConfigurableRule, let rule2 as ConfigurableRule):
-            return rule1.isEqualTo(rule2)
-        default:
-            return self.dynamicType.description == rule.dynamicType.description
-        }
+        return self.dynamicType.description == rule.dynamicType.description
     }
 }
 
-public protocol ConfigurableRule: Rule {
-    init(config: AnyObject) throws
-    func isEqualTo(rule: ConfigurableRule) -> Bool
-    var configDescription: String { get }
-}
+public protocol OptInRule: Rule {}
 
-public protocol ConfigProviderRule: ConfigurableRule {
+public protocol ConfigProviderRule: Rule {
     typealias ConfigType: RuleConfig
     var config: ConfigType { get set }
 }
@@ -50,7 +42,7 @@ public extension ConfigProviderRule {
         try self.config.setConfig(config)
     }
 
-    public func isEqualTo(rule: ConfigurableRule) -> Bool {
+    public func isEqualTo(rule: Rule) -> Bool {
         if let rule = rule as? Self {
             return config.isEqualTo(rule.config)
         }

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -67,7 +67,7 @@ public enum AccessControlLevel: String {
     }
 }
 
-public struct MissingDocsRule: ConfigurableRule, OptInRule {
+public struct MissingDocsRule: OptInRule {
     public init(config: AnyObject) throws {
         guard let array = [String].arrayOf(config) else {
             throw ConfigurationError.UnknownConfiguration
@@ -138,7 +138,7 @@ public struct MissingDocsRule: ConfigurableRule, OptInRule {
         }
     }
 
-    public func isEqualTo(rule: ConfigurableRule) -> Bool {
+    public func isEqualTo(rule: Rule) -> Bool {
         if let rule = rule as? MissingDocsRule {
             return rule.parameters == self.parameters
         }

--- a/Source/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Source/SwiftLintFrameworkTests/RuleTests.swift
@@ -44,6 +44,8 @@ class RuleTests: XCTestCase {
 
     private struct RuleMock1: Rule {
         init() {}
+        init(config: AnyObject) throws { self.init() }
+        var configDescription: String { return "N/A" }
         static let description = RuleDescription(identifier: "RuleMock1", name: "", description: "")
         func validateFile(file: File) -> [StyleViolation] {
             return []
@@ -52,6 +54,8 @@ class RuleTests: XCTestCase {
 
     private struct RuleMock2: Rule {
         init() {}
+        init(config: AnyObject) throws { self.init() }
+        var configDescription: String { return "N/A" }
         static let description = RuleDescription(identifier: "RuleMock2", name: "", description: "")
         func validateFile(file: File) -> [StyleViolation] {
             return []

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -83,16 +83,21 @@ extension TextTable {
         ]
         self.init(columns: columns)
         let sortedRules = ruleList.list.sort { $0.0 < $1.0 }
-        for (ruleId, ruleType) in sortedRules {
+        for (ruleID, ruleType) in sortedRules {
             let rule = ruleType.init()
-            let configuredRule = configuration.rules.indexOf({
-                $0.dynamicType.description.identifier == ruleId
-            }).map { configuration.rules[$0] }
-            addRow(ruleId,
-                   (rule is OptInRule) ? "yes" : "no",
-                   (rule is CorrectableRule) ? "yes" : "no",
-                   configuredRule != nil ? "yes" : "no",
-                   ((configuredRule ?? rule)  as? ConfigurableRule)?.configDescription ?? "N/A")
+            let configuredRule: Rule? = {
+                for rule in configuration.rules
+                    where rule.dynamicType.description.identifier == ruleID {
+                        return rule
+                }
+                return nil
+            }()
+            addRow(ruleID,
+                (rule is OptInRule) ? "yes" : "no",
+                (rule is CorrectableRule) ? "yes" : "no",
+                configuredRule != nil ? "yes" : "no",
+                (configuredRule ?? rule).configDescription
+            )
         }
     }
 }


### PR DESCRIPTION
Depends on #508 and as mentioned there, since all rules are now configurable and that this is something we'll likely want to enforce with all rules moving forward, there's no need for a dedicated "configurable rule" protocol, it should just be folded into `Rule`. /cc @scottrhoyt @norio-nomura 