### PR TITLE
Avoid mixing strings in console from stdout and stderr

### DIFF
--- a/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
+++ b/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
@@ -37,6 +37,7 @@ A thread-safe, newline-terminated version of fputs(..., stderr).
 */
 public func queuedPrintError(string: String) {
     dispatch_async(outputQueue) {
+        fflush(stdout)
         fputs(string + "\n", stderr)
     }
 }


### PR DESCRIPTION
`Swift.print()` uses buffered stdout by calling `putchar(_:)`.
This avoids mixing strings in console from stdout and stderr.

fix #432