### PR TITLE
handle sourcekitd error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#167](https://github.com/jpsim/SourceKitten/issues/167)
 
+* SwiftLint no longer crashes when SourceKitService crashes.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Bug Fixes
 
 * Failed to launch swiftlint when Xcode.app was placed at non standard path.  
@@ -43,9 +46,6 @@
   letter to allow for names like XMLString or MIMEType.  
   [Erik Aigner](https://github.com/eaigner)
   [#566](https://github.com/realm/SwiftLint/issues/566)
-
-* `LintCommand` does not stop when SourceKitService crashes.  
-  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
   [Erik Aigner](https://github.com/eaigner)
   [#566](https://github.com/realm/SwiftLint/issues/566)
 
+* `LintCommand` does not stop when SourceKitService crashes.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Bug Fixes
 
 * Avoid overwriting files whose contents have not changed.  

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -68,8 +68,17 @@ extension File {
         return path ?? "\(ObjectIdentifier(self).hashValue)"
     }
 
-    public var sourcekitdFailed: Bool {
-        return responseCache.get(self) == nil
+    internal var sourcekitdFailed: Bool {
+        get {
+            return responseCache.get(self) == nil
+        }
+        set {
+            if newValue {
+                responseCache.values[cacheKey] = Optional<[String: SourceKitRepresentable]>.None
+            } else {
+                responseCache.values.removeValueForKey(cacheKey)
+            }
+        }
     }
 
     internal var structure: Structure {

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -42,7 +42,7 @@ private struct Cache<T> {
     }
 
     private mutating func get(file: File) -> T {
-        let key = file.path ?? NSUUID().UUIDString
+        let key = file.cacheKey
         if let value = values[key] {
             return value
         }
@@ -63,6 +63,10 @@ private struct Cache<T> {
 }
 
 extension File {
+
+    private var cacheKey: String {
+        return path ?? "\(ObjectIdentifier(self).hashValue)"
+    }
 
     public var sourcekitdFailed: Bool {
         return responseCache.get(self) == nil

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -19,7 +19,13 @@ private var responseCache = Cache({file -> [String: SourceKitRepresentable]? in
         return nil
     }
 })
-private var structureCache = Cache({file in responseCache.get(file).map(Structure.init)})
+private var structureCache = Cache({file -> Structure? in
+    if let structure = responseCache.get(file).map(Structure.init) {
+        queueForRebuild.append(structure)
+        return structure
+    }
+    return nil
+})
 private var syntaxMapCache = Cache({file in responseCache.get(file).map(SyntaxMap.init)})
 private var syntaxKindsByLinesCache = Cache({file in file.syntaxKindsByLine()})
 
@@ -42,9 +48,6 @@ private struct Cache<T> {
         }
         let value = factory(file)
         values[key] = value
-        if let structure = value as? Structure {
-            queueForRebuild.append(structure)
-        }
         return value
     }
 

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 
 private var responseCache = Cache({file -> [String: SourceKitRepresentable]? in
     do {
-        return try Request.EditorOpen(file).sendMayThrow()
+        return try Request.EditorOpen(file).failableSend()
     } catch let error as Request.Error {
         queuedPrintError(error.description)
         return nil

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -100,7 +100,7 @@ extension File {
         }
     }
 
-    internal func syntaxKindsByLine() -> [[SyntaxKind]] {
+    internal func syntaxKindsByLine() -> [[SyntaxKind]]? {
         var results = [[SyntaxKind]](count: lines.count + 1, repeatedValue: [])
         var tokenGenerator = syntaxMap.tokens.generate()
         var lineGenerator = lines.generate()

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -36,6 +36,9 @@ extension File {
     }
 
     private func commands() -> [Command] {
+        if sourcekitdFailed {
+            return []
+        }
         let contents = self.contents as NSString
         return matchPattern("swiftlint:(enable|disable)(:previous|:this|:next)?\\ [^\\s]+",
             withSyntaxKinds: [.Comment]).flatMap { range in
@@ -101,6 +104,9 @@ extension File {
     }
 
     internal func syntaxKindsByLine() -> [[SyntaxKind]]? {
+        if sourcekitdFailed {
+            return nil
+        }
         var results = [[SyntaxKind]](count: lines.count + 1, repeatedValue: [])
         var tokenGenerator = syntaxMap.tokens.generate()
         var lineGenerator = lines.generate()

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -23,9 +23,16 @@ public struct Linter {
 
     private func getStyleViolations(benchmark: Bool = false) ->
         ([StyleViolation], [(id: String, time: Double)]) {
+        if file.sourcekitdFailed {
+            queuedPrintError("Most of rules are skipped because sourcekitd fails.")
+        }
         let regions = file.regions()
         var ruleTimes = [(id: String, time: Double)]()
         let violations = rules.flatMap { rule -> [StyleViolation] in
+            if (rule.dynamicType.description.needsSourceKit || rule is ASTRule) &&
+                self.file.sourcekitdFailed {
+                return []
+            }
             let start: NSDate! = benchmark ? NSDate() : nil
             let violations = rule.validateFile(self.file)
             if benchmark {

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -13,18 +13,20 @@ public struct RuleDescription: Equatable {
     public let nonTriggeringExamples: [String]
     public let triggeringExamples: [String]
     public let corrections: [String: String]
+    public let needsSourceKit: Bool
 
     public var consoleDescription: String { return "\(name) (\(identifier)): \(description)" }
 
     public init(identifier: String, name: String, description: String,
         nonTriggeringExamples: [String] = [], triggeringExamples: [String] = [],
-        corrections: [String: String] = [:]) {
+        corrections: [String: String] = [:], needsSourceKit: Bool = true) {
         self.identifier = identifier
         self.name = name
         self.description = description
         self.nonTriggeringExamples = nonTriggeringExamples
         self.triggeringExamples = triggeringExamples
         self.corrections = corrections
+        self.needsSourceKit = needsSourceKit
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -22,7 +22,8 @@ public struct FileLengthRule: ConfigurationProviderRule {
         ],
         triggeringExamples: [
             Repeat(count: 401, repeatedValue: "//\n").joinWithSeparator("")
-        ]
+        ],
+        needsSourceKit: false
     )
 
     public func validateFile(file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -20,7 +20,8 @@ public struct LeadingWhitespaceRule: ConfigurationProviderRule {
         name: "Leading Whitespace",
         description: "Files should not contain leading whitespace.",
         nonTriggeringExamples: [ "//\n" ],
-        triggeringExamples: [ "\n", " //\n" ]
+        triggeringExamples: [ "\n", " //\n" ],
+        needsSourceKit: false
     )
 
     public func validateFile(file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -22,7 +22,8 @@ public struct LineLengthRule: ConfigurationProviderRule {
         ],
         triggeringExamples: [
             Repeat(count: 101, repeatedValue: "/").joinWithSeparator("") + "\n"
-        ]
+        ],
+        needsSourceKit: false
     )
 
     public func validateFile(file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -47,7 +47,8 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule {
             "let a = 0": "let a = 0\n",
             "let b = 0\n\n": "let b = 0\n",
             "let c = 0\n\n\n\n": "let c = 0\n"
-        ]
+        ],
+        needsSourceKit: false
     )
 
     public func validateFile(file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -21,7 +21,8 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         description: "Lines should not have trailing whitespace.",
         nonTriggeringExamples: [ "//\n" ],
         triggeringExamples: [ "// \n" ],
-        corrections: [ "// \n": "//\n" ]
+        corrections: [ "// \n": "//\n" ],
+        needsSourceKit: false
     )
 
     public func validateFile(file: File) -> [StyleViolation] {

--- a/Source/swiftlint/main.swift
+++ b/Source/swiftlint/main.swift
@@ -6,16 +6,21 @@
 //  Copyright (c) 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import Commandant
 import SwiftLintFramework
 
-let registry = CommandRegistry<CommandantError<()>>()
-registry.register(LintCommand())
-registry.register(AutoCorrectCommand())
-registry.register(VersionCommand())
-registry.register(RulesCommand())
-registry.register(HelpCommand(registry: registry))
+dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+    let registry = CommandRegistry<CommandantError<()>>()
+    registry.register(LintCommand())
+    registry.register(AutoCorrectCommand())
+    registry.register(VersionCommand())
+    registry.register(RulesCommand())
+    registry.register(HelpCommand(registry: registry))
 
-registry.main(defaultVerb: LintCommand().verb) { error in
-    queuedPrintError(String(error))
+    registry.main(defaultVerb: LintCommand().verb) { error in
+        queuedPrintError(String(error))
+    }
 }
+
+dispatch_main()

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */; };
 		6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */; };
+		6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
 		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
@@ -200,6 +201,7 @@
 		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
 		6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Structure+SwiftLint.swift"; sourceTree = "<group>"; };
 		6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxMap+SwiftLint.swift"; sourceTree = "<group>"; };
+		6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceKitCrashTests.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
 		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
@@ -501,6 +503,7 @@
 				3B30C4A01C3785B300E04027 /* YamlParserTests.swift */,
 				3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */,
 				3BB47D861C51DE6E00AE6A10 /* CustomRulesTests.swift */,
+				6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */,
 			);
 			name = SwiftLintFrameworkTests;
 			path = Tests/SwiftLintFramework;
@@ -900,6 +903,7 @@
 				E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */,
 				02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */,
 				D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */,
+				6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */,
 				3BB47D871C51DE6E00AE6A10 /* CustomRulesTests.swift in Sources */,
 				E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */,
 				E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */,

--- a/Tests/SwiftLintFramework/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFramework/SourceKitCrashTests.swift
@@ -1,0 +1,88 @@
+//
+//  SourceKitCrashTests.swift
+//  SwiftLint
+//
+//  Created by 野村 憲男 on 2/10/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftLintFramework
+import SourceKittenFramework
+
+class SourceKitCrashTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testAssertHandlerIsNotCalledOnNormalFile", self.testAssertHandlerIsNotCalledOnNormalFile),
+        ("testAssertHandlerIsCalledOnFileThatCrashedSourceKitService",
+            self.testAssertHandlerIsCalledOnFileThatCrashedSourceKitService),
+        ("testRulesWithFileThatCrashedSourceKitService",
+            self.testRulesWithFileThatCrashedSourceKitService),
+    ]
+
+
+    let sourcekitFailedFile = { () -> File in
+        let file = File(contents: "trigger")
+        file.sourcekitdFailed = true
+        return file
+    }()
+
+    func testAssertHandlerIsNotCalledOnNormalFile() {
+        let file = File(contents: "A file didn't crash SourceKitService.")
+        file.sourcekitdFailed = false
+
+        var assertHandlerCalled = false
+        file.assertHandler = { assertHandlerCalled = true }
+
+        _ = file.structure
+        XCTAssertFalse(assertHandlerCalled,
+            "Expects assert handler was not called on accessing File.structure.")
+
+        assertHandlerCalled = false
+        _ = file.syntaxMap
+        XCTAssertFalse(assertHandlerCalled,
+            "Expects assert handler was not called on accessing File.syntaxMap.")
+
+        assertHandlerCalled = false
+        _ = file.syntaxKindsByLines
+        XCTAssertFalse(assertHandlerCalled,
+            "Expects assert handler was not called on accessing File.syntaxKindsByLines.")
+    }
+
+    func testAssertHandlerIsCalledOnFileThatCrashedSourceKitService() {
+        let file = File(contents: "A file crashed SourceKitService.")
+        file.sourcekitdFailed = true
+
+        var assertHandlerCalled = false
+        file.assertHandler = { assertHandlerCalled = true }
+
+        _ = file.structure
+        XCTAssertTrue(assertHandlerCalled,
+            "Expects assert handler was called on accessing File.structure.")
+
+        assertHandlerCalled = false
+        _ = file.syntaxMap
+        XCTAssertTrue(assertHandlerCalled,
+            "Expects assert handler was called on accessing File.syntaxMap.")
+
+        assertHandlerCalled = false
+        _ = file.syntaxKindsByLines
+        XCTAssertTrue(assertHandlerCalled,
+            "Expects assert handler was called on accessing File.syntaxKindsByLines.")
+    }
+
+    func testRulesWithFileThatCrashedSourceKitService() {
+        // swiftlint:disable:next force_unwrapping
+        let file = File(path: #file)!
+        file.sourcekitdFailed = true
+        file.assertHandler = {
+            XCTFail("If this called, rule's description.needsSourceKit is not properly configured.")
+        }
+        let allRuleIdentifiers = Array(masterRuleList.list.keys)
+        // swiftlint:disable:next force_unwrapping
+        let configuration = Configuration(whitelistRules: allRuleIdentifiers)!
+        Linter(file: file, configuration: configuration).styleViolations
+    }
+}


### PR DESCRIPTION
This depends on https://github.com/jpsim/SourceKitten/pull/169

By applying this, SourceKitService crashes do not cause SwiftLint crashes.

Notes:
- Use `Request.sendMayThrow()` in SourceKittenFramework.  
For gaining advantage of using `sourcekitd_set_notification_handler()`,
we need to vacate main thread to `dispatch_main()`. Without that, SourceKittenFramework waits 10 seconds for SourceKitService restored.
- On SourceKitd failed, continue linting the file by limited rules that does not use SourceKitd.  
Add `RuleDescription.needsSourceKit` indicating the rule needs SourceKit.
If `ASTRule` or `needsSourceKit` is true, skip them linting if SourceKitd fails.
- For crashing test, we can use following from apple/swift:
```
validation-test/compiler_crashers_fixed/04592-swift-constraints-constraintsystem-simplifyconstraint.swift
validation-test/compiler_crashers_fixed/24947-swift-lexer-leximpl.swift
validation-test/compiler_crashers_fixed/26018-swift-parser-skipsingle.swift
validation-test/compiler_crashers_fixed/26830-swift-printingdiagnosticconsumer-handlediagnostic.swift
validation-test/compiler_crashers_fixed/27433-std-function-func-swift-parser-parsenominaldeclmembers.swift
validation-test/compiler_crashers_fixed/27757-swift-parser-parsebraceitems.swift
validation-test/compiler_crashers_fixed/27947-swift-parser-parsebraceitems.swift
```
Those files can crash sourcekitd in Xcode 7.2.1, but not newer version of sourcekitd.
- On SourceKitd crash, logs are following:
```sh
% cd /path/to/github/apple/swift
% swiftlint lint --config .swiftlint.yml --benchmark --path validation-test > /dev/null
…
Linting '02327-swift-clangimporter-lookupvalue.swift' (2297/5277)
Linting '03204-swift-type-transform.swift' (2298/5277)
Linting '03326-swift-archetypetype-setnestedtypes.swift' (2299/5277)
sourcekit: [1:connection-event-handler:3843: 0.0000] Connection interrupt
sourcekit: [1:pingService:3843: 0.0010] pinging service
sourcekit: [1:ping-event-handler:615: 0.0167] service restored
sourcekitten: connection to SourceKitService restored!
Connection interrupted
Most of rules are skipped because sourcekitd fails.
Linting '04450-swift-typebase-getcanonicaltype.swift' (2300/5277)
Linting '04592-swift-constraints-constraintsystem-simplifyconstraint.swift' (2301/5277)
sourcekit: [1:connection-event-handler:1299: 0.0286] Connection interrupt
sourcekit: [1:updateSemanticEditorDelay:1299: 0.0287] disabling semantic editor for 1 seconds
sourcekit: [1:pingService:1299: 0.0288] pinging service
sourcekitten: connection to SourceKitService restored!
Connection interrupted
Most of rules are skipped because sourcekitd fails.
Linting '05045-swift-typebase-getcanonicaltype.swift' (2302/5277)
sourcekit: [1:sourcekitd_send_request_sync:3331: 0.0300] request dropped while restoring service
sourcekit: [1:ping-event-handler:3843: 0.0423] service restored
sourcekitten: connection to SourceKitService restored!
restoring service
Most of rules are skipped because sourcekitd fails.
Linting '05431-swift-declname-printpretty.swift' (2303/5277)
Linting '06207-swift-diagnosticengine-flushactivediagnostic.swift' (2304/5277)
Linting '06252-swift-typechecker-conformstoprotocol.swift' (2305/5277)
…
```

- `make spm_test` fails because https://github.com/jpsim/SourceKitten/pull/169 is not yet merged.