### PR TITLE
Change approach for SPM support, requiring no llbuild flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: JOB=SPM
       before_install:
         - make swift_snapshot_install
+        - make spm_bootstrap
   exclude:
     - script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
 

--- a/Makefile
+++ b/Makefile
@@ -17,18 +17,7 @@ VERSION_STRING=$(shell agvtool what-marketing-version -terse1)
 COMPONENTS_PLIST=Source/swiftlint/Supporting Files/Components.plist
 
 SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2016-02-03-a
-
-SPM=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/bin/swift build
-SPM_INCLUDE=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/local/include
-SPM_LIB=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib
-
-SPMFLAGS=--configuration debug
-# for including "clang-c"
-SPMFLAGS+=-Xcc -ISource/Clang_C -Xcc -I$(SPM_INCLUDE)
-# for linking sourcekitd and clang-c
-SPMFLAGS+= -Xcc -F$(SPM_LIB) -Xlinker -F$(SPM_LIB) -Xlinker -L$(SPM_LIB)
-# for loading sourcekitd and clang-c
-SPMFLAGS+= -Xlinker -rpath -Xlinker $(SPM_LIB)
+SWIFT_BUILD_COMMAND=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/bin/swift build
 
 .PHONY: all bootstrap clean install package test uninstall
 
@@ -92,21 +81,26 @@ swift_snapshot_install:
 	curl https://swift.org/builds/development/xcode/$(SWIFT_SNAPSHOT)/$(SWIFT_SNAPSHOT)-osx.pkg -o swift.pkg
 	sudo installer -pkg swift.pkg -target /
 
+spm_bootstrap: spm_teardown
+	cp -r /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/local/include/clang-c /usr/local/include/clang-c
+	cp Source/Clang_C/module.modulemap /usr/local/include/clang-c/module.modulemap
+	ln -s /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib/libclang.dylib /usr/local/lib/libclang.dylib
+	mkdir -p /usr/local/include/sourcekitdInProc
+	ln -s /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib/sourcekitd.framework/Headers/sourcekitd.h /usr/local/include/sourcekitdInProc/sourcekitd.h
+	curl https://static.realm.io/libsourcekitdInProc/$(SWIFT_SNAPSHOT)/libsourcekitdInProc.dylib -o /usr/local/lib/libsourcekitdInProc.dylib
+
+spm_teardown:
+	rm -rf /usr/local/include/clang-c /usr/local/lib/libclang.dylib
+	rm -rf /usr/local/include/sourcekitdInProc /usr/local/lib/libsourcekitdInProc.dylib
+
 spm:
-	sed -i "" "s/swift-latest/$(SWIFT_SNAPSHOT)/" Source/Clang_C/module.modulemap
-	$(SPM) $(SPMFLAGS) || (\
-		echo "SPM does not use Package.swift. So now removing unnecesory directories in 'Packages/*' that cause build error.";\
-		rm -rf Packages/SourceKitten-*/Source/sourcekitten;\
-		rm -rf Packages/SourceKitten-*/Source/SourceKittenFrameworkTests;\
-		echo "Runs SPM again.";\
-	) && $(SPM) $(SPMFLAGS)
-	sed -i "" "s/$(SWIFT_SNAPSHOT)/swift-latest/" Source/Clang_C/module.modulemap
+	$(SWIFT_BUILD_COMMAND)
 
 spm_test: spm
 	.build/Debug/SwiftLintFrameworkTests
 
 spm_clean:
-	$(SPM) --clean
+	$(SWIFT_BUILD_COMMAND) --clean
 
 spm_clean_dist:
-	$(SPM) --clean=dist
+	$(SWIFT_BUILD_COMMAND) --clean=dist

--- a/Makefile
+++ b/Makefile
@@ -82,16 +82,10 @@ swift_snapshot_install:
 	sudo installer -pkg swift.pkg -target /
 
 spm_bootstrap: spm_teardown
-	cp -r /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/local/include/clang-c /usr/local/include/clang-c
-	cp Source/Clang_C/module.modulemap /usr/local/include/clang-c/module.modulemap
-	ln -s /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib/libclang.dylib /usr/local/lib/libclang.dylib
-	mkdir -p /usr/local/include/sourcekitdInProc
-	ln -s /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib/sourcekitd.framework/Headers/sourcekitd.h /usr/local/include/sourcekitdInProc/sourcekitd.h
-	curl https://static.realm.io/libsourcekitdInProc/$(SWIFT_SNAPSHOT)/libsourcekitdInProc.dylib -o /usr/local/lib/libsourcekitdInProc.dylib
+	curl https://raw.githubusercontent.com/jpsim/SourceKitten/master/script/spm_bootstrap | bash -s $(SWIFT_SNAPSHOT)
 
 spm_teardown:
-	rm -rf /usr/local/include/clang-c /usr/local/lib/libclang.dylib
-	rm -rf /usr/local/include/sourcekitdInProc /usr/local/lib/libsourcekitdInProc.dylib
+	curl https://raw.githubusercontent.com/jpsim/SourceKitten/master/script/spm_teardown | bash
 
 spm:
 	$(SWIFT_BUILD_COMMAND)

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
       ]),
   ],
   dependencies: [
-    .Package(url: "https://github.com/jpsim/SourceKitten.git", majorVersion: 0, minor: 9),
+    .Package(url: "https://github.com/norio-nomura/SourceKitten.git", majorVersion: 0, minor: 9),
     .Package(url: "https://github.com/behrang/YamlSwift.git", majorVersion: 1),
     .Package(url: "https://github.com/norio-nomura/swift-corelibs-xctest.git", majorVersion: 0),
     .Package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", majorVersion: 0, minor: 2),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
       ]),
   ],
   dependencies: [
-    .Package(url: "https://github.com/jpsim/SourceKitten.git", majorVersion: 0, minor: 9),
+    .Package(url: "https://github.com/jpsim/SourceKitten.git", majorVersion: 0, minor: 10),
     .Package(url: "https://github.com/behrang/YamlSwift.git", majorVersion: 1),
     .Package(url: "https://github.com/norio-nomura/swift-corelibs-xctest.git", majorVersion: 0),
     .Package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", majorVersion: 0, minor: 2),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
       ]),
   ],
   dependencies: [
-    .Package(url: "https://github.com/norio-nomura/SourceKitten.git", majorVersion: 0, minor: 9),
+    .Package(url: "https://github.com/jpsim/SourceKitten.git", majorVersion: 0, minor: 9),
     .Package(url: "https://github.com/behrang/YamlSwift.git", majorVersion: 1),
     .Package(url: "https://github.com/norio-nomura/swift-corelibs-xctest.git", majorVersion: 0),
     .Package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", majorVersion: 0, minor: 2),

--- a/Source/Clang_C/module.modulemap
+++ b/Source/Clang_C/module.modulemap
@@ -1,5 +1,0 @@
-module Clang_C {
-  umbrella "."
-  link "clang"
-  module * { export * }
-}

--- a/Source/Clang_C/module.modulemap
+++ b/Source/Clang_C/module.modulemap
@@ -1,5 +1,5 @@
-module Clang_C [system] {
-  header "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/local/include/clang-c/Documentation.h"
+module Clang_C {
+  umbrella "."
   link "clang"
-  export *
+  module * { export * }
 }


### PR DESCRIPTION
- Same approach as https://github.com/jpsim/SourceKitten/pull/168
- Switch dependency to my fork for testing without build-delete-build approach.