### PR TITLE
Improve performance of `ColonRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 * Improve performance of `FunctionParameterCountRule`.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Improve performance of `ColonRule`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Bug Fixes
 
 * Fix case sensitivity of keywords for `valid_docs`.  

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -73,22 +73,22 @@ extension File {
         }.map { $0.0 }
     }
 
-    internal func matchAndTokensPattern(pattern: String) -> [(NSRange, [SyntaxToken])] {
-        return matchAndTokensPattern(regex(pattern))
+    internal func rangesAndTokensMatching(pattern: String) -> [(NSRange, [SyntaxToken])] {
+        return rangesAndTokensMatching(regex(pattern))
     }
 
-    internal func matchAndTokensPattern(regex: NSRegularExpression) -> [(NSRange, [SyntaxToken])] {
+    internal func rangesAndTokensMatching(regex: NSRegularExpression) ->
+        [(NSRange, [SyntaxToken])] {
         let contents = self.contents as NSString
         let range = NSRange(location: 0, length: contents.length)
         let syntax = syntaxMap
-        let matches = regex.matchesInString(self.contents, options: [], range: range)
-        return matches.map { match in
+        return regex.matchesInString(self.contents, options: [], range: range).map { match in
             let matchByteRange = contents.NSRangeToByteRange(start: match.range.location,
                 length: match.range.length) ?? match.range
             let tokensInRange = syntax.tokens.filter { token in
                 let tokenByteRange = NSRange(location: token.offset, length: token.length)
                 return NSIntersectionRange(matchByteRange, tokenByteRange).length > 0
-                }.map({ $0 })
+            }.map({ $0 })
             return (match.range, tokensInRange)
         }
     }
@@ -98,7 +98,7 @@ extension File {
     }
 
     public func matchPattern(regex: NSRegularExpression) -> [(NSRange, [SyntaxKind])] {
-        return matchAndTokensPattern(regex).map { range, tokens in
+        return rangesAndTokensMatching(regex).map { range, tokens in
             (range, tokens.map({ $0.type }).flatMap(SyntaxKind.init))
         }
     }

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -73,11 +73,11 @@ extension File {
         }.map { $0.0 }
     }
 
-    public func matchPattern(pattern: String) -> [(NSRange, [SyntaxKind])] {
-        return matchPattern(regex(pattern))
+    internal func matchAndTokensPattern(pattern: String) -> [(NSRange, [SyntaxToken])] {
+        return matchAndTokensPattern(regex(pattern))
     }
 
-    public func matchPattern(regex: NSRegularExpression) -> [(NSRange, [SyntaxKind])] {
+    internal func matchAndTokensPattern(regex: NSRegularExpression) -> [(NSRange, [SyntaxToken])] {
         let contents = self.contents as NSString
         let range = NSRange(location: 0, length: contents.length)
         let syntax = syntaxMap
@@ -85,11 +85,21 @@ extension File {
         return matches.map { match in
             let matchByteRange = contents.NSRangeToByteRange(start: match.range.location,
                 length: match.range.length) ?? match.range
-            let kindsInRange = syntax.tokens.filter { token in
+            let tokensInRange = syntax.tokens.filter { token in
                 let tokenByteRange = NSRange(location: token.offset, length: token.length)
                 return NSIntersectionRange(matchByteRange, tokenByteRange).length > 0
-            }.map({ $0.type }).flatMap(SyntaxKind.init)
-            return (match.range, kindsInRange)
+                }.map({ $0 })
+            return (match.range, tokensInRange)
+        }
+    }
+
+    public func matchPattern(pattern: String) -> [(NSRange, [SyntaxKind])] {
+        return matchPattern(regex(pattern))
+    }
+
+    public func matchPattern(regex: NSRegularExpression) -> [(NSRange, [SyntaxKind])] {
+        return matchAndTokensPattern(regex).map { range, tokens in
+            (range, tokens.map({ $0.type }).flatMap(SyntaxKind.init))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -111,23 +111,23 @@ public struct ColonRule: CorrectableRule, ConfigProviderRule {
     // MARK: - Private
 
     private let pattern =
-        "(\\w)" + // Capture an identifier
-        "(?:" +    // start group
-        "\\s+" +   // followed by whitespace
-        ":" +      // to the left of a colon
-        "\\s*" +   // followed by any amount of whitespace.
-        "|" +      // or
-        ":" +      // immediately followed by a colon
+        "(\\w)" +              // Capture an identifier
+        "(?:" +                // start group
+        "\\s+" +               // followed by whitespace
+        ":" +                  // to the left of a colon
+        "\\s*" +               // followed by any amount of whitespace.
+        "|" +                  // or
+        ":" +                  // immediately followed by a colon
         "(?:\\s{0}|\\s{2,})" + // followed by 0 or 2+ whitespace characters.
-        ")" +      // end group
-        "(" +      // Capture a type identifier
-        "[\\[|\\(]*" + // which may begin with a series of nested parenthesis or brackets
-        "\\S)"   // lazily to the first non-whitespace character.
+        ")" +                  // end group
+        "(" +                  // Capture a type identifier
+        "[\\[|\\(]*" +         // which may begin with a series of nested parenthesis or brackets
+        "\\S)"                 // lazily to the first non-whitespace character.
 
     private func violationRangesInFile(file: File, withPattern pattern: String) -> [NSRange] {
         let nsstring = file.contents as NSString
         let commentAndStringKindsSet = Set(SyntaxKind.commentAndStringKinds())
-        return file.matchAndTokensPattern(pattern).filter { range, syntaxTokens in
+        return file.rangesAndTokensMatching(pattern).filter { range, syntaxTokens in
             let syntaxKinds = syntaxTokens.map({ $0.type }).flatMap(SyntaxKind.init)
             if !syntaxKinds.startsWith([.Identifier, .Typeidentifier]) {
                 return false

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -111,7 +111,7 @@ public struct ColonRule: CorrectableRule, ConfigProviderRule {
     // MARK: - Private
 
     private let pattern =
-        "(\\w+)" + // Capture an identifier
+        "(\\w)" + // Capture an identifier
         "(?:" +    // start group
         "\\s+" +   // followed by whitespace
         ":" +      // to the left of a colon
@@ -121,15 +121,22 @@ public struct ColonRule: CorrectableRule, ConfigProviderRule {
         "(?:\\s{0}|\\s{2,})" + // followed by 0 or 2+ whitespace characters.
         ")" +      // end group
         "(" +      // Capture a type identifier
-        "(?:\\[|\\()*" + // which may begin with a series of nested parenthesis or brackets
-        "\\S+?)"   // lazily to the first non-whitespace character.
+        "[\\[|\\(]*" + // which may begin with a series of nested parenthesis or brackets
+        "\\S)"   // lazily to the first non-whitespace character.
 
     private func violationRangesInFile(file: File, withPattern pattern: String) -> [NSRange] {
-        return file.matchPattern(pattern).filter { range, syntaxKinds in
+        let nsstring = file.contents as NSString
+        let commentAndStringKindsSet = Set(SyntaxKind.commentAndStringKinds())
+        return file.matchAndTokensPattern(pattern).filter { range, syntaxTokens in
+            let syntaxKinds = syntaxTokens.map({ $0.type }).flatMap(SyntaxKind.init)
             if !syntaxKinds.startsWith([.Identifier, .Typeidentifier]) {
                 return false
             }
-            return Set(syntaxKinds).intersect(Set(SyntaxKind.commentAndStringKinds())).isEmpty
-        }.flatMap { $0.0 }
+            return Set(syntaxKinds).intersect(commentAndStringKindsSet).isEmpty
+        }.flatMap { range, syntaxTokens in
+            let identifierRange = nsstring // swiftlint:disable:next force_unwrapping
+                .byteRangeToNSRange(start: syntaxTokens.first!.offset, length: 0)
+            return identifierRange.map { NSUnionRange($0, range) }
+        }
     }
 }


### PR DESCRIPTION
The duration of `ColonRule` on linting Carthage 0.13 is reduced from 1673ms to 515ms by Instruments.
from:
<img width="1039" alt="screenshot 2016-02-11 00 23 02" src="https://cloud.githubusercontent.com/assets/33430/12951465/cba00e50-d055-11e5-83b9-30f3c0070b9a.png">
to:
<img width="1039" alt="screenshot 2016-02-11 00 21 44" src="https://cloud.githubusercontent.com/assets/33430/12951468/d2a3b882-d055-11e5-9e13-f755c7131c22.png">
