### PR TITLE
Improve performance of `FunctionParameterCountRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
   [JP Simard](https://github.com/jpsim)
   [#120](https://github.com/realm/SwiftLint/issues/120)
 
+* Improve performance of `FunctionParameterCountRule`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Bug Fixes
 
 * Fix case sensitivity of keywords for `valid_docs`.  


### PR DESCRIPTION
The duration of `FunctionParameterCountRule` on linting Carthage 0.13 is reduced from 787ms to 208ms by Instruments.
from:
<img width="1039" alt="screenshot 2016-02-11 00 45 21" src="https://cloud.githubusercontent.com/assets/33430/12952265/3b22759e-d059-11e5-8e0d-110e09dd2552.png">
to:
<img width="1039" alt="screenshot 2016-02-11 00 44 41" src="https://cloud.githubusercontent.com/assets/33430/12952276/40cb95d4-d059-11e5-9293-236e1faa4f0e.png">
