### PR TITLE
fix false violation report when `error` is nil for NameConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@
   [JP Simard](https://github.com/jpsim)
   [#466](https://github.com/realm/SwiftLint/issues/466)
 
+* Fixed an issue where `variable_name` or `type_name` would always report a
+  violation when configured with only a `warning` value on either `min_length`
+  or `max_length`.  
+  [JP Simard](https://github.com/jpsim)
+  [#522](https://github.com/realm/SwiftLint/issues/522)
+
 ## 0.8.0: High Heat
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/RuleConfigs/NameConfig.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigs/NameConfig.swift
@@ -63,14 +63,13 @@ public func == (lhs: NameConfig, rhs: NameConfig) -> Bool {
 
 public extension ConfigProviderRule where ConfigType == NameConfig {
     public func severity(forLength length: Int) -> ViolationSeverity? {
-        if length < config.minLength.error ||
-           length > config.maxLength.error {
-                return .Error
-        } else if length < config.minLength.warning ||
-                  length > config.maxLength.warning {
-                return .Warning
-        } else {
-            return .None
+        if let minError = config.minLength.error where length < minError {
+            return .Error
+        } else if let maxError = config.maxLength.error where length > maxError {
+            return .Error
+        } else if length < config.minLength.warning || length > config.maxLength.warning {
+            return .Warning
         }
+        return nil
     }
 }


### PR DESCRIPTION
fix #522