### PR TITLE
Refine `ForceUnwrappingRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Master
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* Fix force unwrap rule missed cases with quotes.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#535](https://github.com/realm/SwiftLint/issues/535)
+
 ## 0.9.0: Appliance Maintenance
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
@@ -17,6 +17,10 @@ extension SyntaxKind {
         self = kind
     }
 
+    static func commentKeywordStringAndTypeidentifierKinds() -> [SyntaxKind] {
+        return commentAndStringKinds() + [.Keyword, .Typeidentifier]
+    }
+
     static func commentAndStringKinds() -> [SyntaxKind] {
         return commentKinds() + [.String]
     }

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -21,7 +21,10 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
         description: "Force unwrapping should be avoided.",
         nonTriggeringExamples: [
             "if let url = NSURL(string: query)",
-            "navigationController?.pushViewController(viewController, animated: true)"
+            "navigationController?.pushViewController(viewController, animated: true)",
+            "let s as! Test",
+            "try! canThrowErrors()",
+            "let object: AnyObject!",
         ],
         triggeringExamples: [
             "let url = NSURL(string: query)↓!",

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -27,7 +27,8 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
             "let url = NSURL(string: query)↓!",
             "navigationController↓!.pushViewController(viewController, animated: true)",
             "let unwrapped = optional↓!",
-            "return cell↓!"
+            "return cell↓!",
+            "let url = NSURL(string: \"http://www.google.com\")↓!"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -36,7 +36,8 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return file.matchPattern("[\\w)]+!", withSyntaxKinds: [.Identifier]).map {
+        return file.matchPattern("\\S!",
+            excludingSyntaxKinds: SyntaxKind.commentKeywordStringAndTypeidentifierKinds()).map {
             StyleViolation(ruleDescription: self.dynamicType.description,
                 severity: configuration.severity,
                 location: Location(file: file, characterOffset: NSMaxRange($0) - 1))

--- a/Source/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Source/SwiftLintFrameworkTests/TestHelpers.swift
@@ -76,7 +76,7 @@ extension XCTestCase {
             if markerLocation == NSNotFound { continue }
             let cleanTrigger = trigger.stringByReplacingOccurrencesOfString(violationMarker,
                 withString: "")
-            XCTAssertEqual(triggerViolations.first!.location,
+            XCTAssertEqual(triggerViolations.first?.location,
                 Location(file: File(contents: cleanTrigger), characterOffset: markerLocation))
         }
         // Triggering examples violate


### PR DESCRIPTION
Fix #535 
The duration of `ForceUnwrappingRule` on linting Carthage 0.14 is reduced from 1415ms to 339ms by Instruments.
from:
<img width="1039" alt="screenshot 2016-02-14 23 04 21" src="https://cloud.githubusercontent.com/assets/33430/13034285/d01d4f34-d374-11e5-8a9a-994c7975bec2.png">
to:
<img width="1039" alt="screenshot 2016-02-14 23 04 58" src="https://cloud.githubusercontent.com/assets/33430/13034287/dd01e836-d374-11e5-83dd-23f7e29cd58f.png">
