### PR TITLE
Fix `CommaRule` mismatch between violations and corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Master
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* Fix `CommaRule` mismatch between violations and corrections.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#466](https://github.com/realm/SwiftLint/issues/466)
+
 ## 0.9.1: Air Duct Cleaning
 
 ##### Breaking
@@ -17,10 +33,6 @@
 * Fix issues with nested `.swiftlint.yml` file resolution.  
   [Norio Nomura](https://github.com/norio-nomura)
   [#543](https://github.com/realm/SwiftLint/issues/543)
-
-* Fix `CommaRule` mismatch between violations and corrections.  
-  [Norio Nomura](https://github.com/norio-nomura)
-  [#466](https://github.com/realm/SwiftLint/issues/466)
 
 ## 0.9.0: Appliance Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#543](https://github.com/realm/SwiftLint/issues/543)
 
+* Fix `CommaRule` did not match between violations and corrections.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#466](https://github.com/realm/SwiftLint/issues/466)
+
 ## 0.9.0: Appliance Maintenance
 
 ##### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#543](https://github.com/realm/SwiftLint/issues/543)
 
-* Fix `CommaRule` did not match between violations and corrections.  
+* Fix `CommaRule` mismatch between violations and corrections.  
   [Norio Nomura](https://github.com/norio-nomura)
   [#466](https://github.com/realm/SwiftLint/issues/466)
 

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -88,7 +88,7 @@ extension File {
             let tokensInRange = syntax.tokens.filter { token in
                 let tokenByteRange = NSRange(location: token.offset, length: token.length)
                 return NSIntersectionRange(matchByteRange, tokenByteRange).length > 0
-            }.map({ $0 })
+            }
             return (match.range, tokensInRange)
         }
     }

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -85,10 +85,7 @@ extension File {
         return regex.matchesInString(self.contents, options: [], range: range).map { match in
             let matchByteRange = contents.NSRangeToByteRange(start: match.range.location,
                 length: match.range.length) ?? match.range
-            let tokensInRange = syntax.tokens.filter { token in
-                let tokenByteRange = NSRange(location: token.offset, length: token.length)
-                return NSIntersectionRange(matchByteRange, tokenByteRange).length > 0
-            }
+            let tokensInRange = syntax.tokensIn(matchByteRange)
             return (match.range, tokensInRange)
         }
     }

--- a/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
@@ -14,9 +14,22 @@ extension SyntaxMap {
     ///
     /// - Parameter byteRange: byte based NSRange
     internal func tokensIn(byteRange: NSRange) -> [SyntaxToken] {
-        return tokens.filter { token in
-            let tokenByteRange = NSRange(location: token.offset, length: token.length)
-            return NSIntersectionRange(byteRange, tokenByteRange).length > 0
+        func intersect(token: SyntaxToken) -> Bool {
+            return NSRange(location: token.offset, length: token.length)
+                .intersectsRange(byteRange)
         }
+
+        func notIntersect(token: SyntaxToken) -> Bool {
+            return !intersect(token)
+        }
+
+        guard let startIndex = tokens.indexOf(intersect) else {
+            return []
+        }
+        let tokensBeginningIntersect = tokens.lazy.suffixFrom(startIndex)
+        if let endIndex = tokensBeginningIntersect.indexOf(notIntersect) {
+            return Array(tokensBeginningIntersect.prefixUpTo(endIndex))
+        }
+        return Array(tokensBeginningIntersect)
     }
 }

--- a/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
@@ -14,6 +14,7 @@ extension SyntaxMap {
     ///
     /// - Parameter byteRange: byte based NSRange
     internal func tokensIn(byteRange: NSRange) -> [SyntaxToken] {
+
         func intersect(token: SyntaxToken) -> Bool {
             return NSRange(location: token.offset, length: token.length)
                 .intersectsRange(byteRange)

--- a/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
@@ -1,0 +1,22 @@
+//
+//  SyntaxMap+SwiftLint.swift
+//  SwiftLint
+//
+//  Created by Norio Nomura on 2/19/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+extension SyntaxMap {
+    /// Returns array of SyntaxTokens intersecting with byte range
+    ///
+    /// - Parameter byteRange: byte based NSRange
+    internal func tokensIn(byteRange: NSRange) -> [SyntaxToken] {
+        return tokens.filter { token in
+            let tokenByteRange = NSRange(location: token.offset, length: token.length)
+            return NSIntersectionRange(byteRange, tokenByteRange).length > 0
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -39,7 +39,7 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let pattern = "(\\,[^\\s])|(\\s\\,)"
+        let pattern = ",\\S|\\s,"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
 
         return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -33,7 +33,8 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
             "func abc(a: String,b: String) {}\n": "func abc(a: String, b: String) {}\n",
             "abc(a: \"string\",b: \"string\"\n": "abc(a: \"string\", b: \"string\"\n",
             "abc(a: \"string\"  ,  b: \"string\"\n": "abc(a: \"string\", b: \"string\"\n",
-            "enum a { case a  ,b }\n": "enum a { case a, b }\n"
+            "enum a { case a  ,b }\n": "enum a { case a, b }\n",
+            "let a = [1,1]\nlet b = 1\nf(1, b)\n": "let a = [1, 1]\nlet b = 1\nf(1, b)\n",
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -66,15 +66,17 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
     }
 
     // captures spaces and comma only
+    // http://userguide.icu-project.org/strings/regexp
     private static let pattern =
         "\\S" +                // not whitespace
         "(" +                  // start first capure
         "\\s+" +               // followed by whitespace
         "," +                  // to the left of a comma
-        "\\s*" +               // followed by any amount of whitespace.
+        "[\\t\\p{Z}]*" +       // followed by any amount of tab or space.
         "|" +                  // or
         "," +                  // immediately followed by a comma
-        "(?:\\s{0}|\\s{2,})" + // followed by 0 or 2+ whitespace characters.
+        "(?:[\\t\\p{Z}]{0}|" + // followed by 0
+        "[\\t\\p{Z}]{2,})" +   // or 2+ tab or space characters.
         ")" +                  // end capture
         "(\\S)"                // second capture is not whitespace.
 

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -24,6 +24,7 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
             "abc(a: \"string\", b: \"string\"",
             "enum a { case a, b, c }",
             "func abc(\n  a: String,  // comment\n  bcd: String // comment\n) {\n}\n",
+            "func abc(\n  a: String,\n  bcd: String\n) {\n}\n",
         ],
         triggeringExamples: [
             "func abc(a: String↓ ,b: String) { }",

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -22,7 +22,8 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
         nonTriggeringExamples: [
             "func abc(a: String, b: String) { }",
             "abc(a: \"string\", b: \"string\"",
-            "enum a { case a, b, c }"
+            "enum a { case a, b, c }",
+            "func abc(\n  a: String,  // comment\n  bcd: String // comment\n) {\n}\n",
         ],
         triggeringExamples: [
             "func abc(a: String↓ ,b: String) { }",

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -90,7 +90,7 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
     private func violationRangesInFile(file: File) -> [NSRange] {
         let contents = file.contents
         let range = NSRange(location: 0, length: contents.utf16.count)
-        let tokens = file.syntaxMap.tokens
+        let syntaxMap = file.syntaxMap
         return CommaRule.regularExpression
             .matchesInString(contents, options: [], range: range)
             .flatMap { match -> NSRange? in
@@ -103,10 +103,8 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
                     else { return nil }
 
                 // first captured range won't match tokens if it is not comment neither string
-                let tokensInFirstRange = tokens.filter { token in
-                    let tokenByteRange = NSRange(location: token.offset, length: token.length)
-                    return NSIntersectionRange(matchByteFirstRange, tokenByteRange).length > 0
-                    }.filter { CommaRule.excludingSyntaxKindsForFirstCapture.contains($0.type) }
+                let tokensInFirstRange = syntaxMap.tokensIn(matchByteFirstRange)
+                    .filter { CommaRule.excludingSyntaxKindsForFirstCapture.contains($0.type) }
 
                 // If not empty, first captured range is comment or string
                 if !tokensInFirstRange.isEmpty {
@@ -120,10 +118,8 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
                     else { return nil }
 
                 // second captured range won't match tokens if it is not comment
-                let tokensInSecondRange = tokens.filter { token in
-                    let tokenByteRange = NSRange(location: token.offset, length: token.length)
-                    return NSIntersectionRange(matchByteSecondRange, tokenByteRange).length > 0
-                    }.filter { CommaRule.excludingSyntaxKindsForSecondCapture.contains($0.type) }
+                let tokensInSecondRange = syntaxMap.tokensIn(matchByteSecondRange)
+                    .filter { CommaRule.excludingSyntaxKindsForSecondCapture.contains($0.type) }
 
                 // If not empty, second captured range is comment
                 if !tokensInSecondRange.isEmpty {

--- a/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Source/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -133,7 +133,7 @@ class ConfigurationTests: XCTestCase {
         private override func filesToLintAtPath(path: String) -> [String] {
             switch path {
             case "directory": return ["directory/File1.swift", "directory/File2.swift",
-                "directory/excluded/Excluded.swift",  "directory/ExcludedFile.swift"]
+                "directory/excluded/Excluded.swift", "directory/ExcludedFile.swift"]
             case "directory/excluded" : return ["directory/excluded/Excluded.swift"]
             case "directory/ExcludedFile.swift" : return ["directory/ExcludedFile.swift"]
             default: break
@@ -145,7 +145,7 @@ class ConfigurationTests: XCTestCase {
 
     func testExcludedPaths() {
         let configuration = Configuration(included: ["directory"],
-            excluded: ["directory/excluded",  "directory/ExcludedFile.swift"])!
+            excluded: ["directory/excluded", "directory/ExcludedFile.swift"])!
         let paths = configuration.lintablePathsForPath("", fileManager: TestFileManager())
         XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
     }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */; };
 		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
+		6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
 		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
@@ -198,6 +199,7 @@
 		692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpeningBraceRule.swift; sourceTree = "<group>"; };
 		692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionRule.swift; sourceTree = "<group>"; };
 		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
+		6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxMap+SwiftLint.swift"; sourceTree = "<group>"; };
 		6CDD62CE1C6193300094A198 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
@@ -628,6 +630,7 @@
 				E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */,
 				E816194B1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift */,
 				E87E4A081BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift */,
+				6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */,
 				3B1150C91C31FC3F00D83B1E /* Yaml+SwiftLint.swift */,
 				3B5B9FE01C444DA20009AD27 /* Array+SwiftLint.swift */,
 				3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */,
@@ -819,6 +822,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */,
 				E881985C1BEA978500333A11 /* TrailingNewlineRule.swift in Sources */,
 				E881985E1BEA982100333A11 /* TypeBodyLengthRule.swift in Sources */,
 				69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */,


### PR DESCRIPTION
- Add failing correction example from #466 to `CommaRule`  
https://github.com/realm/SwiftLint/issues/466#issuecomment-184474925
- Rewrite `CommaRule.correctFile(_:)`  
Now corrections happen only on violations.
Because `assertCorrection(_:expected:)` expects one correction for each `corrections`,
and the rule added by 93e8e12 causes two corrections on previous logic.
Fix #466
- Simplify the regular expression in `CommaRule.validateFile(_:)`  
- Remove surplus `map` calls in `rangesAndTokensMatching(_:)`  