### PR TITLE
Accept variable names starting with more than one capital letter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   [JP Simard](https://github.com/jpsim)
   [#166](https://github.com/realm/SwiftLint/issues/166)
 
+
+* `VariableNameRule` now accepts symbols starting with more than one uppercase
+  letter to allow for names like XMLString or MIMEType.  
+  [Erik Aigner](https://github.com/eaigner)
+  [#566](https://github.com/realm/SwiftLint/issues/566)
+
 ##### Bug Fixes
 
 * Avoid overwriting files whose contents have not changed.  

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -26,6 +26,10 @@ extension String {
         return self == uppercaseString
     }
 
+    internal func isLowercase() -> Bool {
+        return self == lowercaseString
+    }
+
     internal func nameStrippingLeadingUnderscoreIfPrivate(dict: [String: SourceKitRepresentable]) ->
                                                         String {
         let privateACL = "source.lang.swift.accessibility.private"

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -31,7 +31,8 @@ public struct VariableNameRule: ASTRule, ConfigurationProviderRule {
             "var myVar = 0",
             "private let _myLet = 0",
             "class Abc { static let MyLet = 0 }",
-            "let URL: NSURL? = nil"
+            "let URL: NSURL? = nil",
+            "let XMLString: String? = nil"
         ],
         triggeringExamples: [
             "↓let MyLet = 0",
@@ -47,8 +48,17 @@ public struct VariableNameRule: ASTRule, ConfigurationProviderRule {
     )
 
     private func nameIsViolatingCase(name: String) -> Bool {
-        let firstCharacter = name.substringToIndex(name.startIndex.successor())
-        return firstCharacter.isUppercase() && !name.isUppercase()
+        let secondIndex = name.startIndex.successor()
+        let firstCharacter = name.substringToIndex(secondIndex)
+        if firstCharacter.isUppercase() {
+            if name.characters.count > 1 {
+                let range = Range(start: secondIndex, end: secondIndex.successor())
+                let secondCharacter = name.substringWithRange(range)
+                return secondCharacter.isLowercase()
+            }
+            return true
+        }
+        return false
     }
 
     public func validateFile(file: File, kind: SwiftDeclarationKind,


### PR DESCRIPTION
The rule was modified to allow for names that start with multiple uppercase letters like XMLString or MIMEType.

Closes #566