### PR TITLE
Add `-configuration` options to `clean` target in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ test: clean bootstrap
 clean:
 	rm -f "$(OUTPUT_PACKAGE)"
 	rm -rf "$(TEMPORARY_FOLDER)"
-	$(BUILD_TOOL) $(XCODEFLAGS) clean
+	$(BUILD_TOOL) $(XCODEFLAGS) -configuration Debug clean
+	$(BUILD_TOOL) $(XCODEFLAGS) -configuration Release clean
+	$(BUILD_TOOL) $(XCODEFLAGS) -configuration Test clean
 
 install: uninstall package
 	sudo installer -pkg SwiftLint.pkg -target /


### PR DESCRIPTION
`xcodebuild clean` uses `Debug` configuration without `-configuration`
option, and cleans directories that used by `Debug` configuration. But
`make install` uses `-configuration Release` by scheme of project.  

By this change, `clean` cleans all directories that used by `Debug`,
`Release` and `Test` configurations.