### PR TITLE
Trailing whitespace rule optionally ignore empty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#167](https://github.com/jpsim/SourceKitten/issues/167)
 
+* Added the user-configurable option `ignores_empty_lines` to the
+  `trailing_whitespace` rule. It can be used to control whether the
+  `TrailingWhitespaceRule` should report and correct whitespace-indented empty
+  lines. Defaults to `false`. Added unit tests.  
+  [Reimar Twelker](https://github.com/raginmari)
+
 ##### Bug Fixes
 
 * Failed to launch swiftlint when Xcode.app was placed at non standard path.  

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -13,7 +13,8 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
     var ignoresEmptyLines = false
 
     public var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", ignores_empty_lines: \(ignoresEmptyLines ? "true" : "false")"
+        return severityConfiguration.consoleDescription +
+            ", ignores_empty_lines: \(ignoresEmptyLines ? "true" : "false")"
     }
 
     public init(ignoresEmptyLines: Bool) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -13,11 +13,7 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
     var ignoresEmptyLines = false
 
     public var consoleDescription: String {
-        return "ignores empty lines: \(ignoresEmptyLines ? "true" : "false")"
-    }
-
-    public init() {
-        self.init(ignoresEmptyLines: false)
+        return "ignores_empty_lines: \(ignoresEmptyLines ? "true" : "false")"
     }
 
     public init(ignoresEmptyLines: Bool) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -25,10 +25,8 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
             throw ConfigurationError.UnknownConfiguration
         }
 
-        if let ignoresEmptyLinesString = configuration["ignores_empty_lines"] as? String {
-            ignoresEmptyLines = (ignoresEmptyLinesString == "true")
-        } else {
-            ignoresEmptyLines = false
+        if let ignoresEmptyLinesString = configuration["ignores_empty_lines"] as? Bool {
+            ignoresEmptyLines = ignoresEmptyLinesString
         }
 
         if let severityString = configuration["severity"] as? String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.Warning)
     var ignoresEmptyLines = false
-    
+
     public var consoleDescription: String {
         return "ignores empty lines: \(ignoresEmptyLines ? "true" : "false")"
     }
@@ -34,13 +34,14 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
         } else {
             ignoresEmptyLines = false
         }
-        
+
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.applyConfiguration(severityString)
         }
     }
 }
 
-public func == (lhs: TrailingWhitespaceConfiguration, rhs: TrailingWhitespaceConfiguration) -> Bool {
+public func == (lhs: TrailingWhitespaceConfiguration,
+                rhs: TrailingWhitespaceConfiguration) -> Bool {
     return lhs.ignoresEmptyLines == rhs.ignoresEmptyLines
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -1,0 +1,46 @@
+//
+//  TrailingWhitespaceConfiguration.swift
+//  SwiftLint
+//
+//  Created by Reimar Twelker on 12.04.16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+
+public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.Warning)
+    var ignoresEmptyLines = false
+    
+    public var consoleDescription: String {
+        return "ignores empty lines: \(ignoresEmptyLines ? "true" : "false")"
+    }
+
+    public init() {
+        self.init(ignoresEmptyLines: false)
+    }
+
+    public init(ignoresEmptyLines: Bool) {
+        self.ignoresEmptyLines = ignoresEmptyLines
+    }
+
+    public mutating func applyConfiguration(configuration: AnyObject) throws {
+        guard let configuration = configuration as? [String: AnyObject] else {
+            throw ConfigurationError.UnknownConfiguration
+        }
+
+        if let ignoresEmptyLinesString = configuration["ignores_empty_lines"] as? String {
+            ignoresEmptyLines = (ignoresEmptyLinesString == "true")
+        } else {
+            ignoresEmptyLines = false
+        }
+        
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.applyConfiguration(severityString)
+        }
+    }
+}
+
+public func == (lhs: TrailingWhitespaceConfiguration, rhs: TrailingWhitespaceConfiguration) -> Bool {
+    return lhs.ignoresEmptyLines == rhs.ignoresEmptyLines
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -26,9 +26,7 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
             throw ConfigurationError.UnknownConfiguration
         }
 
-        if let ignoresEmptyLinesString = configuration["ignores_empty_lines"] as? Bool {
-            ignoresEmptyLines = ignoresEmptyLinesString
-        }
+        ignoresEmptyLines = (configuration["ignores_empty_lines"] as? Bool == true)
 
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.applyConfiguration(severityString)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -13,7 +13,7 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
     var ignoresEmptyLines = false
 
     public var consoleDescription: String {
-        return "ignores_empty_lines: \(ignoresEmptyLines ? "true" : "false")"
+        return severityConfiguration.consoleDescription + ", ignores_empty_lines: \(ignoresEmptyLines ? "true" : "false")"
     }
 
     public init(ignoresEmptyLines: Bool) {

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -10,8 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
-
-    public var configuration = SeverityConfiguration(.Warning)
+    public var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
 
     public init() {}
 
@@ -25,11 +24,21 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return file.lines.filter {
-            $0.content.hasTrailingWhitespace()
-        }.map {
+        var filteredLines: [Line]
+        if configuration.ignoresEmptyLines {
+            filteredLines = file.lines.filter {
+                // Ignores lines that contain nothing but whitespace = empty lines
+                $0.content.hasTrailingWhitespace() && !$0.content.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()).isEmpty
+            }
+        } else {
+            filteredLines = file.lines.filter {
+                $0.content.hasTrailingWhitespace()
+            }
+        }
+
+        return filteredLines.map {
             StyleViolation(ruleDescription: self.dynamicType.description,
-                severity: configuration.severity,
+                severity: configuration.severityConfiguration.severity,
                 location: Location(file: file.path, line: $0.index))
         }
     }
@@ -42,6 +51,12 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         for line in file.lines {
             let correctedLine = (line.content as NSString)
                 .stringByTrimmingTrailingCharactersInSet(whitespaceCharacterSet)
+
+            if configuration.ignoresEmptyLines && correctedLine.characters.isEmpty {
+                correctedLines.append(line.content)
+                continue
+            }
+
             let region = fileRegions.filter {
                 $0.contains(Location(file: file.path, line: line.index, character: 0))
             }.first
@@ -49,6 +64,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
                 correctedLines.append(line.content)
                 continue
             }
+
             if line.content != correctedLine {
                 let description = self.dynamicType.description
                 let location = Location(file: file.path, line: line.index)

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -24,7 +24,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        var filteredLines: [Line]
+        let filteredLines: [Line]
         if configuration.ignoresEmptyLines {
             filteredLines = file.lines.filter {
                 // Ignores lines that contain nothing but whitespace = empty lines

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -28,7 +28,8 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         if configuration.ignoresEmptyLines {
             filteredLines = file.lines.filter {
                 // Ignores lines that contain nothing but whitespace = empty lines
-                $0.content.hasTrailingWhitespace() && !$0.content.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()).isEmpty
+                $0.content.hasTrailingWhitespace() && !$0.content.stringByTrimmingCharactersInSet(
+                    NSCharacterSet.whitespaceCharacterSet()).isEmpty
             }
         } else {
             filteredLines = file.lines.filter {

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
 		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
+		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
@@ -203,6 +204,7 @@
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
 		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
+		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D0D1212619E878CC005E4BAA /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -340,6 +342,7 @@
 				3BB47D821C514E8100AE6A10 /* RegexConfiguration.swift */,
 				3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */,
 				3BCC04CF1C4F56D3006073C3 /* SeverityLevelsConfiguration.swift */,
+				BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */,
 			);
 			path = RuleConfigurations;
 			sourceTree = "<group>";
@@ -828,6 +831,7 @@
 				E88198571BEA953300333A11 /* ForceCastRule.swift in Sources */,
 				D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */,
 				3BCC04CD1C4F5694006073C3 /* ConfigurationError.swift in Sources */,
+				BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */,
 				83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */,
 				3B12C9C51C322032000B423F /* MasterRuleList.swift in Sources */,
 				E812249C1B04FADC001783D2 /* Linter.swift in Sources */,

--- a/Tests/SwiftLintFramework/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFramework/RuleConfigurationTests.swift
@@ -129,4 +129,56 @@ class RuleConfigurationsTests: XCTestCase {
                                                                 name: "name",
                                                                 description: ""))
     }
+
+    func testTrailingWhitespaceConfigurationThrowsOnBadConfig() {
+        let config = "unknown"
+        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        checkError(ConfigurationError.UnknownConfiguration) {
+            try configuration.applyConfiguration(config)
+        }
+    }
+
+    func testTrailingWhitespaceConfigurationInitializerSetsIgnoresEmptyLines() {
+        let configuration1 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        XCTAssertFalse(configuration1.ignoresEmptyLines)
+
+        let configuration2 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true)
+        XCTAssertTrue(configuration2.ignoresEmptyLines)
+    }
+
+    func testTrailingWhitespaceConfigurationApplyConfigurationSetsIgnoresEmptyLines() {
+        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        do {
+            let config1 = ["ignores_empty_lines": true]
+            try configuration.applyConfiguration(config1)
+            XCTAssertTrue(configuration.ignoresEmptyLines)
+
+            let config2 = ["ignores_empty_lines": false]
+            try configuration.applyConfiguration(config2)
+            XCTAssertFalse(configuration.ignoresEmptyLines)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testTrailingWhitespaceConfigurationCompares() {
+        let configuration1 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        let configuration2 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true)
+        XCTAssertFalse(configuration1 == configuration2)
+
+        let configuration3 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true)
+        XCTAssertTrue(configuration2 == configuration3)
+    }
+
+    func testTrailingWhitespaceConfigurationApplyConfigurationUpdatesSeverityConfiguration() {
+        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        configuration.severityConfiguration.severity = .Warning
+
+        do {
+            try configuration.applyConfiguration(["severity": "error"])
+            XCTAssert(configuration.severityConfiguration.severity == .Error)
+        } catch {
+            XCTFail()
+        }
+    }
 }

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -130,7 +130,7 @@ class RulesTests: XCTestCase {
                                nonTriggeringExamples: nonTriggeringExamples,
                                   triggeringExamples: baseDescription.triggeringExamples,
                                          corrections: baseDescription.corrections)
-        verifyRule(description, ruleConfiguration: ["ignores_empty_lines": "true"],
+        verifyRule(description, ruleConfiguration: ["ignores_empty_lines": true],
                    commentDoesntViolate: false)
     }
 

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -119,6 +119,18 @@ class RulesTests: XCTestCase {
 
     func testTrailingWhitespace() {
         verifyRule(TrailingWhitespaceRule.description, commentDoesntViolate: false)
+
+        // Perform additional tests with the ignores_empty_lines setting enabled.
+        // The set of non-triggering examples is extended by a whitespace-indented empty line
+        let baseDescription = TrailingWhitespaceRule.description
+        let description = RuleDescription(identifier: baseDescription.identifier,
+                                                name: baseDescription.name,
+                                         description: baseDescription.description,
+                               nonTriggeringExamples: baseDescription.nonTriggeringExamples + [" \n"],
+                                  triggeringExamples: baseDescription.triggeringExamples,
+                                         corrections: baseDescription.corrections)
+        verifyRule(description, ruleConfiguration: ["ignores_empty_lines": "true"],
+                   commentDoesntViolate: false)
     }
 
     func testTypeBodyLength() {

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -123,10 +123,11 @@ class RulesTests: XCTestCase {
         // Perform additional tests with the ignores_empty_lines setting enabled.
         // The set of non-triggering examples is extended by a whitespace-indented empty line
         let baseDescription = TrailingWhitespaceRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [" \n"]
         let description = RuleDescription(identifier: baseDescription.identifier,
                                                 name: baseDescription.name,
                                          description: baseDescription.description,
-                               nonTriggeringExamples: baseDescription.nonTriggeringExamples + [" \n"],
+                               nonTriggeringExamples: nonTriggeringExamples,
                                   triggeringExamples: baseDescription.triggeringExamples,
                                          corrections: baseDescription.corrections)
         verifyRule(description, ruleConfiguration: ["ignores_empty_lines": "true"],

--- a/Tests/SwiftLintFramework/TestHelpers.swift
+++ b/Tests/SwiftLintFramework/TestHelpers.swift
@@ -58,9 +58,25 @@ extension String {
 }
 
 extension XCTestCase {
-    func verifyRule(ruleDescription: RuleDescription, commentDoesntViolate: Bool = true,
+    func verifyRule(ruleDescription: RuleDescription,
+                    ruleConfiguration: AnyObject? = nil,
+                    commentDoesntViolate: Bool = true,
                     stringDoesntViolate: Bool = true) {
-        let config = Configuration(whitelistRules: [ruleDescription.identifier])!
+        var config: Configuration
+        if let ruleConfiguration = ruleConfiguration,
+            ruleType = masterRuleList.list[ruleDescription.identifier] {
+            // The caller has provided a custom configuration for the rule under test
+            do {
+                let configuredRule = try ruleType.init(configuration: ruleConfiguration)
+                config = Configuration(configuredRules: [configuredRule])!
+            } catch {
+                XCTFail()
+                return
+            }
+        } else {
+            config = Configuration(whitelistRules: [ruleDescription.identifier])!
+        }
+
         let triggers = ruleDescription.triggeringExamples
         let nonTriggers = ruleDescription.nonTriggeringExamples
 

--- a/Tests/SwiftLintFramework/TestHelpers.swift
+++ b/Tests/SwiftLintFramework/TestHelpers.swift
@@ -62,7 +62,7 @@ extension XCTestCase {
                     ruleConfiguration: AnyObject? = nil,
                     commentDoesntViolate: Bool = true,
                     stringDoesntViolate: Bool = true) {
-        var config: Configuration
+        let config: Configuration
         if let ruleConfiguration = ruleConfiguration,
             ruleType = masterRuleList.list[ruleDescription.identifier] {
             // The caller has provided a custom configuration for the rule under test


### PR DESCRIPTION
Modified the `TrailingWhitespaceRule`.

Added the user-configurable option `ignores_empty_lines` which can be used to make the rule ignore whitespace-indented empty lines. By default, the option is `false`.

Added unit tests.