### PR TITLE
Add CGGeometry legacy functions rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ##### Enhancements
 
+* Add `LegacyCGGeometryFunctionsRule` rule.  
+  [Sarr Blaise](https://github.com/bsarr007)
+  [#625](https://github.com/realm/SwiftLint/issues/625)
+
 * Now `libclang.dylib` and `sourcekitd.framework` are dynamically loaded at
   runtime by SourceKittenFramework to use the versions included in the Xcode
   version specified by `xcode-select -p` or custom toolchains.  

--- a/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
+++ b/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
@@ -1,0 +1,27 @@
+//
+//  RegexHelpers.swift
+//  SwiftLint
+//
+//  Created by Blaise Sarr on 13/04/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+struct RegexHelpers {
+    // A single variable
+    static let varName = "[a-zA-Z_][a-zA-Z0-9_]+"
+
+    // A single variable in a group (capturable)
+    static let varNameGroup = "\\s*(\(varName))\\s*"
+
+    // Two variables (capturables)
+    static let twoVars = "\(varNameGroup),\(varNameGroup)"
+
+    // A number
+    static let number = "[\\-0-9\\.]+"
+
+    // A variable or a number (capturable)
+    static let variableOrNumber = "\\s*(\(varName)|\(number))\\s*"
+
+    // Two 'variable or number'
+    static let twoVariableOrNumber = "\(variableOrNumber),\(variableOrNumber)"
+}

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -56,6 +56,7 @@ public let masterRuleList = RuleList(rules:
     FunctionBodyLengthRule.self,
     FunctionParameterCountRule.self,
     LeadingWhitespaceRule.self,
+    LegacyCGGeometryFunctionsRule.self,
     LegacyConstantRule.self,
     LegacyConstructorRule.self,
     LineLengthRule.self,

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -1,0 +1,96 @@
+//
+//  LegacyCGGeometryFunctionsRule.swift
+//  SwiftLint
+//
+//  Created by Blaise Sarr on 31/03/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.Warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "legacy_cggeometry_functions",
+        name: "Legacy CGGeometry Functions",
+        description: "Struct extension properties and methods are preferred over legacy functions",
+        nonTriggeringExamples: [
+            "rect.width",
+            "rect.height",
+            "rect.minX",
+            "rect.midX",
+            "rect.maxX",
+            "rect.minY",
+            "rect.midY",
+            "rect.maxY",
+            "rect.isNull",
+            "rect.isEmpty",
+            "rect.isInfinite",
+            "rect.standardized",
+            "rect.integral",
+            "rect.insetBy(dx: 5.0, dy: -7.0)",
+            "rect.offsetBy(dx: 5.0, dy: -7.0)",
+            "rect1.union(rect: rect2)",
+            "rect1.intersect(rect: rect2)",
+            // "rect.divide(atDistance: 10.2, fromEdge: edge)", No correction available for divide
+            "rect1.contains(rect: rect2)",
+            "rect.contains(point: point)",
+            "rect1.intersects(rect: rect2)",
+        ],
+        triggeringExamples: [
+            "↓CGRectGetWidth(rect)",
+            "↓CGRectGetHeight(rect)",
+            "↓CGRectGetMinX(rect)",
+            "↓CGRectGetMidX(rect)",
+            "↓CGRectGetMaxX(rect)",
+            "↓CGRectGetMinY(rect)",
+            "↓CGRectGetMidY(rect)",
+            "↓CGRectGetMaxY(rect)",
+            "↓CGRectIsNull(rect)",
+            "↓CGRectIsEmpty(rect)",
+            "↓CGRectIsInfinite(rect)",
+            "↓CGRectStandardize(rect)",
+            "↓CGRectIntegral(rect)",
+            "↓CGRectInset(rect, 10, 5)",
+            "↓CGRectOffset(rect, -2, 8.3)",
+            "↓CGRectUnion(rect1, rect2)",
+            "↓CGRectIntersection(rect1, rect2)",
+            "↓CGRectContainsRect(rect1, rect2)",
+            "↓CGRectContainsPoint(rect, point)",
+            "↓CGRectIntersectsRect(rect1, rect2)"
+        ],
+        corrections: [
+            "CGRectGetWidth( rect  )\n": "rect.width\n",
+            "CGRectGetHeight(rect )\n": "rect.height\n",
+            "CGRectGetMinX( rect)\n": "rect.minX\n",
+            "CGRectGetMidX(  rect)\n": "rect.midX\n",
+            "CGRectGetMaxX( rect)\n": "rect.maxX\n",
+            "CGRectGetMinY(rect   )\n": "rect.minY\n",
+            "CGRectGetMidY(rect )\n": "rect.midY\n",
+            "CGRectGetMaxY( rect     )\n": "rect.maxY\n",
+            "CGRectIsNull(  rect    )\n": "rect.isNull\n",
+            "CGRectIsEmpty( rect )\n": "rect.isEmpty\n",
+            "CGRectIsInfinite( rect )\n": "rect.isInfinite\n",
+            "CGRectStandardize( rect)\n": "rect.standardized\n",
+            "CGRectIntegral(rect )\n": "rect.integral\n",
+            "CGRectInset(rect, 5.0, -7.0)\n": "rect.insetBy(dx: 5.0, dy: -7.0)\n",
+            "CGRectOffset(rect, -2, 8.3)\n": "rect.offsetBy(dx: -2, dy: 8.3)\n",
+            "CGRectUnion(rect1, rect2)\n": "rect1.union(rect: rect2)\n",
+            "CGRectIntersection( rect1 ,rect2)\n": "rect1.intersect(rect: rect2)\n",
+            "CGRectContainsRect( rect1,rect2     )\n": "rect1.contains(rect: rect2)\n",
+            "CGRectContainsPoint(rect  ,point)\n": "rect.contains(point: point)\n",
+            "CGRectIntersectsRect(  rect1,rect2 )\n": "rect1.intersects(rect: rect2)\n"
+        ]
+    )
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        return []
+    }
+
+    public func correctFile(file: File) -> [Correction] {
+        return []
+    }
+}

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -63,26 +63,28 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
             "↓CGRectIntersectsRect(rect1, rect2)"
         ],
         corrections: [
-            "CGRectGetWidth( rect  )\n": "rect.width\n",
-            "CGRectGetHeight(rect )\n": "rect.height\n",
-            "CGRectGetMinX( rect)\n": "rect.minX\n",
-            "CGRectGetMidX(  rect)\n": "rect.midX\n",
-            "CGRectGetMaxX( rect)\n": "rect.maxX\n",
-            "CGRectGetMinY(rect   )\n": "rect.minY\n",
-            "CGRectGetMidY(rect )\n": "rect.midY\n",
-            "CGRectGetMaxY( rect     )\n": "rect.maxY\n",
-            "CGRectIsNull(  rect    )\n": "rect.isNull\n",
-            "CGRectIsEmpty( rect )\n": "rect.isEmpty\n",
-            "CGRectIsInfinite( rect )\n": "rect.isInfinite\n",
-            "CGRectStandardize( rect)\n": "rect.standardized\n",
-            "CGRectIntegral(rect )\n": "rect.integral\n",
-            "CGRectInset(rect, 5.0, -7.0)\n": "rect.insetBy(dx: 5.0, dy: -7.0)\n",
-            "CGRectOffset(rect, -2, 8.3)\n": "rect.offsetBy(dx: -2, dy: 8.3)\n",
-            "CGRectUnion(rect1, rect2)\n": "rect1.union(rect: rect2)\n",
-            "CGRectIntersection( rect1 ,rect2)\n": "rect1.intersect(rect: rect2)\n",
-            "CGRectContainsRect( rect1,rect2     )\n": "rect1.contains(rect: rect2)\n",
-            "CGRectContainsPoint(rect  ,point)\n": "rect.contains(point: point)\n",
-            "CGRectIntersectsRect(  rect1,rect2 )\n": "rect1.intersects(rect: rect2)\n"
+            "↓CGRectGetWidth( rect  )\n": "rect.width\n",
+            "↓CGRectGetHeight(rect )\n": "rect.height\n",
+            "↓CGRectGetMinX( rect)\n": "rect.minX\n",
+            "↓CGRectGetMidX(  rect)\n": "rect.midX\n",
+            "↓CGRectGetMaxX( rect)\n": "rect.maxX\n",
+            "↓CGRectGetMinY(rect   )\n": "rect.minY\n",
+            "↓CGRectGetMidY(rect )\n": "rect.midY\n",
+            "↓CGRectGetMaxY( rect     )\n": "rect.maxY\n",
+            "↓CGRectIsNull(  rect    )\n": "rect.isNull\n",
+            "↓CGRectIsEmpty( rect )\n": "rect.isEmpty\n",
+            "↓CGRectIsInfinite( rect )\n": "rect.isInfinite\n",
+            "↓CGRectStandardize( rect)\n": "rect.standardized\n",
+            "↓CGRectIntegral(rect )\n": "rect.integral\n",
+            "↓CGRectInset(rect, 5.0, -7.0)\n": "rect.insetBy(dx: 5.0, dy: -7.0)\n",
+            "↓CGRectOffset(rect, -2, 8.3)\n": "rect.offsetBy(dx: -2, dy: 8.3)\n",
+            "↓CGRectUnion(rect1, rect2)\n": "rect1.union(rect: rect2)\n",
+            "↓CGRectIntersection( rect1 ,rect2)\n": "rect1.intersect(rect: rect2)\n",
+            "↓CGRectContainsRect( rect1,rect2     )\n": "rect1.contains(rect: rect2)\n",
+            "↓CGRectContainsPoint(rect  ,point)\n": "rect.contains(point: point)\n",
+            "↓CGRectIntersectsRect(  rect1,rect2 )\n": "rect1.intersects(rect: rect2)\n",
+            "↓CGRectIntersectsRect(rect1, rect2 )\n↓CGRectGetWidth(rect  )\n":
+            "rect1.intersects(rect: rect2)\nrect.width\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -137,18 +137,19 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         var corrections = [Correction]()
         var contents = file.contents
 
-        for (pattern, template) in patterns {
+        let matches = patterns.map {
+            (pattern, template) -> [(NSRange, String, String)] in
             let matches = file.matchPattern(pattern)
-                .filter({ $0.1.first == .Identifier })
-                .map({ $0.0 })
-
-            let regularExpression = regex(pattern)
-            for range in matches.reverse() {
-                contents = regularExpression.stringByReplacingMatchesInString(contents,
-                                options: [], range: range, withTemplate: template)
-                let location = Location(file: file, characterOffset: range.location)
-                corrections.append(Correction(ruleDescription: description, location: location))
+                .filter { $0.1.first == .Identifier }.map { ($0.0, pattern, template) }
+            return matches
             }
+            .flatten().sort { $0.0.location > $1.0.location } // reversed
+
+        for (range, pattern, template) in matches {
+            contents = regex(pattern).stringByReplacingMatchesInString(contents,
+                                options: [], range: range, withTemplate: template)
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: description, location: location))
         }
 
         file.write(contents)

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -87,7 +87,20 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        return []
+        let functions = ["CGRectGetWidth", "CGRectGetHeight", "CGRectGetMinX", "CGRectGetMidX",
+                         "CGRectGetMaxX", "CGRectGetMinY", "CGRectGetMidY", "CGRectGetMaxY",
+                         "CGRectIsNull", "CGRectIsEmpty", "CGRectIsInfinite", "CGRectStandardize",
+                         "CGRectIntegral", "CGRectInset", "CGRectOffset", "CGRectUnion",
+                         "CGRectIntersection", "CGRectContainsRect", "CGRectContainsPoint",
+                         "CGRectIntersectsRect"]
+
+        let pattern = "\\b(" + functions.joinWithSeparator("|") + ")\\b"
+
+        return file.matchPattern(pattern, withSyntaxKinds: [.Identifier]).map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: configuration.severity,
+                location: Location(file: file, characterOffset: $0.location))
+        }
     }
 
     public func correctFile(file: File) -> [Correction] {

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -7,6 +7,7 @@
 //
 
 import SourceKittenFramework
+import Foundation
 
 public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.Warning)

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */; };
 		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
 		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
+		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */; };
 		6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */; };
@@ -195,6 +196,7 @@
 		3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlParser.swift; sourceTree = "<group>"; };
 		3BDB224A1C345B4900473680 /* ProjectMock */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ProjectMock; sourceTree = "<group>"; };
 		4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
+		4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		65454F451B14D73800319A6C /* ControlStatementRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlStatementRule.swift; sourceTree = "<group>"; };
@@ -348,6 +350,14 @@
 			path = RuleConfigurations;
 			sourceTree = "<group>";
 		};
+		4DCB8E7C1CBE43530070FCF0 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		5499CA981A2394BD00783309 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -460,6 +470,7 @@
 		D0D1216E19E87B05005E4BAA /* SwiftLintFramework */ = {
 			isa = PBXGroup;
 			children = (
+				4DCB8E7C1CBE43530070FCF0 /* Helpers */,
 				E8A541811BF94604006BA322 /* Extensions */,
 				E8A541801BF945FF006BA322 /* Models */,
 				E8A5417F1BF945F9006BA322 /* Protocols */,
@@ -892,6 +903,7 @@
 				E832F10B1B17E2F5003F265F /* NSFileManager+SwiftLint.swift in Sources */,
 				E816194C1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift in Sources */,
 				3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */,
+				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
 				E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */,
 				E881985F1BEA987C00333A11 /* TypeNameRule.swift in Sources */,
 				E88198521BEA941300333A11 /* TodoRule.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */; };
 		3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */; };
 		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
+		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */; };
 		6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */; };
@@ -193,6 +194,7 @@
 		3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleConfigurationTests.swift; sourceTree = "<group>"; };
 		3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlParser.swift; sourceTree = "<group>"; };
 		3BDB224A1C345B4900473680 /* ProjectMock */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ProjectMock; sourceTree = "<group>"; };
+		4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		65454F451B14D73800319A6C /* ControlStatementRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlStatementRule.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */,
 				D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */,
+				4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */,
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
 				E849FF271BF9481A009AE999 /* MissingDocsRule.swift */,
 				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
@@ -822,6 +825,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */,
 				6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */,
 				E881985C1BEA978500333A11 /* TrailingNewlineRule.swift in Sources */,
 				E881985E1BEA982100333A11 /* TypeBodyLengthRule.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -67,6 +67,10 @@ class RulesTests: XCTestCase {
         verifyRule(LeadingWhitespaceRule.description)
     }
 
+    func testLegacyCGGeometryFunctions() {
+        verifyRule(LegacyCGGeometryFunctionsRule.description)
+    }
+
     func testLegacyConstant() {
         verifyRule(LegacyConstantRule.description)
     }


### PR DESCRIPTION
This PR add new `LegacyCGGeometryFunctionsRule` rule

This rule enforce the use of new Swift CGGeometry methods and properties(like `rect.width`) instead of legacy CGGeometry functions(like `CGRectGetWidth(rect)`)

This closes #625 