### PR TITLE
Rewrite `ConditionalBindingCascadeRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 * SwiftLint no longer crashes when SourceKitService crashes.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Rewrite `conditional_binding_cascade` rule.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#617](https://github.com/jpsim/SwiftLint/issues/617)
+
 ##### Bug Fixes
 
 * Failed to launch swiftlint when Xcode.app was placed at non standard path.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Rewrite `conditional_binding_cascade` rule.  
   [Norio Nomura](https://github.com/norio-nomura)
-  [#617](https://github.com/jpsim/SwiftLint/issues/617)
+  [#617](https://github.com/realm/SwiftLint/issues/617)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -29,7 +29,7 @@ public struct Linter {
         let regions = file.regions()
         var ruleTimes = [(id: String, time: Double)]()
         let violations = rules.flatMap { rule -> [StyleViolation] in
-            if (rule.dynamicType.description.needsSourceKit || rule is ASTRule) &&
+            if (rule.dynamicType.description.needsSourceKit || rule is ASTBaseRule) &&
                 self.file.sourcekitdFailed {
                 return []
             }

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -23,7 +23,7 @@ extension ASTBaseRule {
         let substructure = dictionary["key.substructure"] as? [SourceKitRepresentable] ?? []
         return substructure.flatMap { subItem -> [StyleViolation] in
             guard let subDict = subItem as? [String: SourceKitRepresentable],
-                let kindString = subDict["key.kind"] as? String else {
+                kindString = subDict["key.kind"] as? String else {
                     return []
             }
             return self.validateFile(file, dictionary: subDict) +

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -8,12 +8,12 @@
 
 import SourceKittenFramework
 
-public protocol ASTRule: Rule {
-    func validateFile(file: File, kind: SwiftDeclarationKind,
+public protocol ASTBaseRule: Rule {
+    func validateFile(file: File, kind: String,
                       dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]
 }
 
-extension ASTRule {
+extension ASTBaseRule {
     public func validateFile(file: File) -> [StyleViolation] {
         return validateFile(file, dictionary: file.structure.dictionary)
     }
@@ -23,12 +23,27 @@ extension ASTRule {
         let substructure = dictionary["key.substructure"] as? [SourceKitRepresentable] ?? []
         return substructure.flatMap { subItem -> [StyleViolation] in
             guard let subDict = subItem as? [String: SourceKitRepresentable],
-                let kindString = subDict["key.kind"] as? String,
-                let kind = SwiftDeclarationKind(rawValue: kindString) else {
+                let kindString = subDict["key.kind"] as? String else {
                     return []
             }
             return self.validateFile(file, dictionary: subDict) +
-                self.validateFile(file, kind: kind, dictionary: subDict)
+                self.validateFile(file, kind: kindString, dictionary: subDict)
         }
     }
+}
+
+public protocol ASTRule: ASTBaseRule {
+    func validateFile(file: File, kind: SwiftDeclarationKind,
+                      dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]
+}
+
+extension ASTRule {
+    public func validateFile(file: File, kind: String,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard let kind = SwiftDeclarationKind(rawValue: kind) else {
+            return []
+        }
+        return self.validateFile(file, kind: kind, dictionary: dictionary)
+    }
+
 }

--- a/Source/SwiftLintFramework/Rules/ConditionalBindingCascadeRule.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalBindingCascadeRule.swift
@@ -35,7 +35,8 @@ public struct ConditionalBindingCascadeRule: ConfigurationProviderRule {
             "if let a = b, let c = d \n {",
             "if \n let a = b, let c = d {",
             "if let a = b, c = d.indexOf({$0 == e}), let f = g {",
-            "guard let a = b, let c = d else {"
+            "guard let a = b, let c = d else {",
+            "if let a = a, b = b {\ndebugPrint(\"\")\n}\nif let c = a, let d = b {\n}",
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -42,12 +42,12 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
             return []
         }
         if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
+            bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
+            bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
             let startLine = file.contents.lineAndCharacterForByteOffset(bodyOffset)
             let endLine = file.contents.lineAndCharacterForByteOffset(bodyOffset + bodyLength)
 
-            if let startLine = startLine?.line, let endLine = endLine?.line {
+            if let startLine = startLine?.line, endLine = endLine?.line {
                 for parameter in configuration.params {
                     let (exceeds, lineCount) = file.exceedsLineCountExcludingCommentsAndWhitespace(
                                                                 startLine, endLine, parameter.value)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -37,7 +37,7 @@ public struct RegexConfiguration: RuleConfiguration, Equatable {
 
     public mutating func applyConfiguration(configuration: AnyObject) throws {
         guard let configurationDict = configuration as? [String: AnyObject],
-              let regexString = configurationDict["regex"] as? String else {
+            regexString = configurationDict["regex"] as? String else {
             throw ConfigurationError.UnknownConfiguration
         }
 

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -43,12 +43,12 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
             return []
         }
         if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
+            bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
+            bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
             let startLine = file.contents.lineAndCharacterForByteOffset(bodyOffset)
             let endLine = file.contents.lineAndCharacterForByteOffset(bodyOffset + bodyLength)
 
-            if let startLine = startLine?.line, let endLine = endLine?.line {
+            if let startLine = startLine?.line, endLine = endLine?.line {
                 for parameter in configuration.params {
                     let (exceeds, lineCount) = file.exceedsLineCountExcludingCommentsAndWhitespace(
                                                                 startLine, endLine, parameter.value)

--- a/Tests/SwiftLintFramework/IntegrationTests.swift
+++ b/Tests/SwiftLintFramework/IntegrationTests.swift
@@ -51,7 +51,6 @@ extension String {
             let rawPointer = $0._rawValue
             let byteSize = lengthOfBytesUsingEncoding(NSUTF8StringEncoding)._builtinWordValue
             let isASCII = true._getBuiltinLogicValue()
-            // swiftlint:disable:next variable_name
             let staticString = StaticString(_builtinStringLiteral: rawPointer, byteSize: byteSize,
                 isASCII: isASCII)
             closure(staticString)

--- a/Tests/SwiftLintFramework/IntegrationTests.swift
+++ b/Tests/SwiftLintFramework/IntegrationTests.swift
@@ -51,6 +51,7 @@ extension String {
             let rawPointer = $0._rawValue
             let byteSize = lengthOfBytesUsingEncoding(NSUTF8StringEncoding)._builtinWordValue
             let isASCII = true._getBuiltinLogicValue()
+            // swiftlint:disable:next variable_name
             let staticString = StaticString(_builtinStringLiteral: rawPointer, byteSize: byteSize,
                 isASCII: isASCII)
             closure(staticString)

--- a/Tests/SwiftLintFramework/Yaml+SwiftLintTests.swift
+++ b/Tests/SwiftLintFramework/Yaml+SwiftLintTests.swift
@@ -57,7 +57,7 @@ class YamlSwiftLintTests: XCTestCase {
         #else
             let testBundle = NSBundle(forClass: self.dynamicType)
             if let path = testBundle.pathForResource("test", ofType: "yml"),
-                let ymlString = try? String(contentsOfFile: path) {
+                ymlString = try? String(contentsOfFile: path) {
                     return ymlString
             }
         #endif


### PR DESCRIPTION
- Fix #617
- Add `ASTBaseRule`  
`ASTBaseRule` takes kind as `String` for supporting other than `SwiftDeclarationKind`.
`ASTRule` inherits `ASTBaseRule`.