### PR TITLE
`LegacyConstantRule` and `LegacyConstructorRule` failed to `autocorrect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   [Josh Friend](https://github.com/joshfriend)
   [#592](https://github.com/realm/SwiftLint/issues/592)
 
+* `LegacyConstantRule` and `LegacyConstructorRule` failed to `autocorrect`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#623](https://github.com/realm/SwiftLint/issues/623)
+
 ## 0.9.2: Multiple Exhaust Codes
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
@@ -67,16 +67,19 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule {
         var corrections = [Correction]()
         var contents = file.contents
 
-        for (pattern, template) in patterns {
-            let matches = file.matchPattern(pattern, withSyntaxKinds: [.Identifier])
-
-            let regularExpression = regex(pattern)
-            for range in matches.reverse() {
-                contents = regularExpression.stringByReplacingMatchesInString(contents,
-                    options: [], range: range, withTemplate: template)
-                let location = Location(file: file, characterOffset: range.location)
-                corrections.append(Correction(ruleDescription: description, location: location))
+        let matches = patterns.map {
+                (pattern, template) -> [(NSRange, String, String)] in
+                let matches = file.matchPattern(pattern, withSyntaxKinds: [.Identifier])
+                return matches.map { ($0, pattern, template) }
             }
+            .flatten()
+            .sort { $0.0.location > $1.0.location } // reversed
+
+        for (range, pattern, template) in matches {
+            contents = regex(pattern).stringByReplacingMatchesInString(contents,
+                options: [], range: range, withTemplate: template)
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: description, location: location))
         }
 
         file.write(contents)

--- a/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
@@ -33,11 +33,11 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule {
             "↓CGRectNull"
         ],
         corrections: [
-            "CGRectInfinite\n": "CGRect.infinite\n",
-            "CGPointZero\n": "CGPoint.zero\n",
-            "CGRectZero\n": "CGRect.zero\n",
-            "CGSizeZero\n": "CGSize.zero\n",
-            "CGRectNull\n": "CGRect.null\n"
+            "↓CGRectInfinite\n": "CGRect.infinite\n",
+            "↓CGPointZero\n": "CGPoint.zero\n",
+            "↓CGRectZero\n": "CGRect.zero\n",
+            "↓CGSizeZero\n": "CGSize.zero\n",
+            "↓CGRectInfinite\n↓CGRectNull\n": "CGRect.infinite\nCGRect.null\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -72,18 +72,21 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
         var corrections = [Correction]()
         var contents = file.contents
 
-        for (pattern, template) in patterns {
-            let matches = file.matchPattern(pattern)
-                .filter({ $0.1.first == .Identifier })
-                .map({ $0.0 })
-
-            let regularExpression = regex(pattern)
-            for range in matches.reverse() {
-                contents = regularExpression.stringByReplacingMatchesInString(contents,
-                    options: [], range: range, withTemplate: template)
-                let location = Location(file: file, characterOffset: range.location)
-                corrections.append(Correction(ruleDescription: description, location: location))
+        let matches = patterns.map {
+                (pattern, template) -> [(NSRange, String, String)] in
+                let matches = file.matchPattern(pattern)
+                    .filter { $0.1.first == .Identifier }
+                    .map { ($0.0, pattern, template) }
+                return matches
             }
+            .flatten()
+            .sort { $0.0.location > $1.0.location } // reversed
+
+        for (range, pattern, template) in matches {
+            contents = regex(pattern).stringByReplacingMatchesInString(contents,
+                options: [], range: range, withTemplate: template)
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: description, location: location))
         }
 
         file.write(contents)

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -33,11 +33,13 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
             "↓NSMakeRange(10, 1)",
         ],
         corrections: [
-            "CGPointMake(10,  10   )\n": "CGPoint(x: 10, y: 10)\n",
-            "CGSizeMake(10, 10)\n": "CGSize(width: 10, height: 10)\n",
-            "CGRectMake(0, 0, 10, 10)\n": "CGRect(x: 0, y: 0, width: 10, height: 10)\n",
-            "CGVectorMake(10, 10)\n": "CGVector(dx: 10, dy: 10)\n",
-            "NSMakeRange(10, 1)\n": "NSRange(location: 10, length: 1)\n",
+            "↓CGPointMake(10,  10   )\n": "CGPoint(x: 10, y: 10)\n",
+            "↓CGSizeMake(10, 10)\n": "CGSize(width: 10, height: 10)\n",
+            "↓CGRectMake(0, 0, 10, 10)\n": "CGRect(x: 0, y: 0, width: 10, height: 10)\n",
+            "↓CGVectorMake(10, 10)\n": "CGVector(dx: 10, dy: 10)\n",
+            "↓NSMakeRange(10, 1)\n": "NSRange(location: 10, length: 1)\n",
+            "↓CGVectorMake(10, 10)\n↓NSMakeRange(10, 1)\n": "CGVector(dx: 10, dy: 10)\n" +
+                "NSRange(location: 10, length: 1)\n",
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule {


### PR DESCRIPTION
Fix #623
- Enhance marker support in `verifyRule()`  
  - Support multiple marker in trigger
  - Support marker in `assertCorrection()`
- Fix `LegacyConstantRule`
- Fix `LegacyConstructorRule`