### PR TITLE
Prevent EmptyCountRule from triggering on variables named "count"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#617](https://github.com/realm/SwiftLint/issues/617)
 
+* `EmptyCountRule` no longer triggers when `count` is a variable.  
+  [Josh Friend](https://github.com/joshfriend)
+
 ##### Bug Fixes
 
 * Failed to launch swiftlint when Xcode.app was placed at non standard path.  

--- a/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
@@ -21,7 +21,8 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
             "var count = 0\n",
             "[Int]().isEmpty\n",
             "[Int]().count > 1\n",
-            "[Int]().count == 1\n"
+            "[Int]().count == 1\n",
+            "if count == 0"
         ],
         triggeringExamples: [
             "[Int]().count == 0\n",
@@ -31,7 +32,7 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let pattern = "count\\s*(==|!=|<|<=|>|>=)\\s*0"
+        let pattern = "\\.count\\s*(==|!=|<|<=|>|>=)\\s*0"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
         return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: self.dynamicType.description,


### PR DESCRIPTION
With this change, `count` must be a property for the rule to trigger:

```swift
if someArray.count == 0 {
    // This case triggers the rule
}
```

```swift
var count = 0
// Do things to count...
if count == 0 {
    // This case no longer triggers the rule
}
```

This would fix the first false positive mentioned in #206:

> 1. `Int` variable named `count`. In this case, it'd be fine to check `count` against zero.