### PR TITLE
Improves error messaging for Configuration, particularly with YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Improve error messages for invalid configuration files.
+  [Brian Hardy](https://github.com/lyricsboy)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -150,7 +150,9 @@ public struct Configuration: Equatable {
     public init(path: String = Configuration.fileName, rootPath: String? = nil,
                 optional: Bool = true, quiet: Bool = false) {
         let fullPath = (path as NSString).absolutePathRepresentation()
-        let fail = { (msg: String) in fatalError("Could not read configuration file at path '\(fullPath)': \(msg)") }
+        let fail = { (msg: String) in
+            fatalError("Could not read configuration file at path '\(fullPath)': \(msg)")
+        }
         if path.isEmpty || !NSFileManager.defaultManager().fileExistsAtPath(fullPath) {
             if !optional { fail("File not found.") }
             self.init()!

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -150,9 +150,9 @@ public struct Configuration: Equatable {
     public init(path: String = Configuration.fileName, rootPath: String? = nil,
                 optional: Bool = true, quiet: Bool = false) {
         let fullPath = (path as NSString).absolutePathRepresentation()
-        let fail = { fatalError("Could not read configuration file at path '\(fullPath)'") }
+        let fail = { (msg: String) in fatalError("Could not read configuration file at path '\(fullPath)': \(msg)") }
         if path.isEmpty || !NSFileManager.defaultManager().fileExistsAtPath(fullPath) {
-            if !optional { fail() }
+            if !optional { fail("File not found.") }
             self.init()!
             self.rootPath = rootPath
             return
@@ -168,8 +168,10 @@ public struct Configuration: Equatable {
             configurationPath = fullPath
             self.rootPath = rootPath
             return
+        } catch YamlParserError.YamlParsing(let message) {
+            fail("Error parsing YAML: \(message)")
         } catch {
-            fail()
+            fail("\(error)")
         }
         self.init()!
     }


### PR DESCRIPTION
Like a noob, I created a new `.swiftlint.yml` using tabs instead of spaces. The error message from SwiftLint was not super helpful:

```
fatal error: Could not read configuration file at path '.../.swiftlint.yml': file .../SwiftLint/Source/SwiftLintFramework/Models/Configuration.swift, line 153
```

With these changes, various error conditions when loading a Configuration are logged more verbosely. In my example, the new output is:

```
fatal error: Could not read configuration file at path '.../.swiftlint.yml': Error parsing YAML: expected colon, near "included:\n- Something\nline_length:\n- 150\n- 250\n": file .../SwiftLint/Source/SwiftLintFramework/Models/Configuration.swift, line 153
```