### PR TITLE
Xcode reporter on Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ variable_name:
     - id
     - URL
     - GlobalAPIKey
-reporter: "csv" # reporter type (xcode, json, csv, checkstyle)
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)
 ```
 
 #### Defining Custom Rules


### PR DESCRIPTION
The excellent documentation for this project makes it easy to get up and running in seconds. An exception that I found is that the reporter setup shown on the Readme makes warnings go silent (csv), so a naive copy-paste won't give the expected xcode highlights. I propose setting xcode reporting on this example, while leaving the other options on the comment