### PR TITLE
Add additional "Runpath Search Paths" values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * Improve error messages for invalid configuration files.
   [Brian Hardy](https://github.com/lyricsboy)
+  
+* Add Runpath Search Paths so that `swiftlint` can find
+  `SwiftLintFramework.framework` in more places.  
+  [Isaac Greenspan](https://github.com/vokal-isaac)
 
 ##### Bug Fixes
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -1145,7 +1145,7 @@
 			baseConfigurationReference = D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "Source/swiftlint/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/SwiftLintFramework.framework/Versions/Current/Frameworks @executable_path/../Frameworks @executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1156,7 +1156,7 @@
 			baseConfigurationReference = D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "Source/swiftlint/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/SwiftLintFramework.framework/Versions/Current/Frameworks @executable_path/../Frameworks @executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1167,7 +1167,7 @@
 			baseConfigurationReference = D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "Source/swiftlint/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/SwiftLintFramework.framework/Versions/Current/Frameworks @executable_path/../Frameworks @executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1178,7 +1178,7 @@
 			baseConfigurationReference = D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "Source/swiftlint/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/SwiftLintFramework.framework/Versions/Current/Frameworks @executable_path/../Frameworks @executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
Add `@executable_path/../Frameworks` so that the `swiftlint` binary can be run while inside the Xcode-built `.app` bundle.
Add `@executable_path` and `@executable_path/SwiftLintFramework.framework/Versions/Current/Frameworks` so that putting `SwiftLintFramework.framework` in the same directory as the `swiftlint` binary will allow the binary to run.

Basically, this gives a bit more flexibility in how `swiftlint` is installed.