### PR TITLE
Allow lowercase enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ##### Breaking
 
-* None.
+* Now `type_name` allows lowercase enum values to match the Swift API Design
+  Guidelines.
+  [Jorge Bernal](https://github.com/koke)
+  [#654](https://github.com/realm/SwiftLint/issues/654)
 
 ##### Enhancements
 

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -27,6 +27,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
             [
                 "\(type) MyType {}",
                 "private \(type) _MyType {}",
+                "enum MyType {\ncase value\n}",
                 "\(type) " + Repeat(count: 40, repeatedValue: "A").joinWithSeparator("") + " {}"
             ]
         }),
@@ -48,8 +49,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
             .Class,
             .Struct,
             .Typealias,
-            .Enum,
-            .Enumelement
+            .Enum
         ]
         if !typeKinds.contains(kind) {
             return []


### PR DESCRIPTION
The Swift API Design Guidelines states that:

> Names of types and protocols are UpperCamelCase. Everything else is
> lowerCamelCase.

https://swift.org/documentation/api-design-guidelines/#follow-case-conventions

This PR changes `type_name` so it doesn't force enum values to UpperCamelCase.