### PR TITLE
Add "portable_zip" target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,14 @@ prefix_install: installables
 	install_name_tool -rpath "/Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks" "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks" "$(PREFIX)/bin/swiftlint"
 	install_name_tool -rpath "/Library/Frameworks" "@executable_path/../Frameworks" "$(PREFIX)/bin/swiftlint"
 
+portable_zip: installables
+	cp -Rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SwiftLintFramework.framework" "$(TEMPORARY_FOLDER)"
+	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/swiftlint" "$(TEMPORARY_FOLDER)"
+	install_name_tool -rpath "/Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks" "@executable_path/SwiftLintFramework.framework/Versions/Current/Frameworks" "$(TEMPORARY_FOLDER)/swiftlint"
+	install_name_tool -rpath "/Library/Frameworks" "@executable_path" "$(TEMPORARY_FOLDER)/swiftlint"
+	rm -f "./portable_swiftlint.zip"
+	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "swiftlint" "SwiftLintFramework.framework") > "./portable_swiftlint.zip"
+
 package: installables
 	pkgbuild \
 		--component-plist "$(COMPONENTS_PLIST)" \


### PR DESCRIPTION
This adds an additional target, `portable_zip`, to the Makefile that creates a zip file containing the `swiftlint` binary and `SwiftLintFramework.framework`, with the binary modified to find the framework in the same directory as the binary.