### PR TITLE
Skip checking existence of trailing comment in `CommaRule` if already violating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
   [Andrew Rahn](https://github.com/paddlefish)
   [#667](https://github.com/realm/SwiftLint/issues/667)
 
-* Fix `CommaRule` ignored some violations when trailing comment exists.  
+* Fix regression in CommaRule ignoring violations when the comma is followed
+  by a comment.  
   [Norio Nomura](https://github.com/norio-nomura)
   [#683](https://github.com/realm/SwiftLint/issues/683)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   [Andrew Rahn](https://github.com/paddlefish)
   [#667](https://github.com/realm/SwiftLint/issues/667)
 
+* Fix `CommaRule` ignored some violations when trailing comment exists.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#683](https://github.com/realm/SwiftLint/issues/683)
+
 ## 0.10.0: `laundry-select` edition
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -29,7 +29,8 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
         triggeringExamples: [
             "func abc(a: String↓ ,b: String) { }",
             "abc(a: \"string\"↓,b: \"string\"",
-            "enum a { case a↓ ,b }"
+            "enum a { case a↓ ,b }",
+            "let result = plus(\n    first: 3↓ , // #683\n    second: 4\n)\n",
         ],
         corrections: [
             "func abc(a: String,b: String) {}\n": "func abc(a: String, b: String) {}\n",

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -112,6 +112,12 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
                     return nil
                 }
 
+                // If the first range does not start with comma, it already violates this rule
+                // whatever is contained in the second range.
+                if !(contents as NSString).substringWithRange(firstRange).hasPrefix(",") {
+                    return firstRange
+                }
+
                 // check second captured range
                 let secondRange = match.rangeAtIndex(2)
                 guard let matchByteSecondRange = contents

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -113,7 +113,7 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
                 }
 
                 // If the first range does not start with comma, it already violates this rule
-                // whatever is contained in the second range.
+                // no matter what is contained in the second range.
                 if !(contents as NSString).substringWithRange(firstRange).hasPrefix(",") {
                     return firstRange
                 }


### PR DESCRIPTION
Fix #683