### PR TITLE
Per issue #709 - README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ APM.
 $ swiftlint help
 Available commands:
 
-   autocorrect  Automatically correct warnings and errors
    help         Display general or command-specific help
    lint         Print lint warnings and errors for the Swift files in the current directory (default command)
    rules        Display the list of rules and their identifiers


### PR DESCRIPTION
Either I installed `Swiftlint` incorrectly, or the README needs to be updated. Had a look at the main.swift file and it looks like the command is registered. Unsure of why I wouldn't be able to execute it from the command line though:
```
dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
    let registry = CommandRegistry<CommandantError<()>>()
    registry.register(LintCommand())
    registry.register(AutoCorrectCommand())
```
First time using the project, so I could quite easily be using it incorrectly. Either way, I thought I'd bring this up.