### PR TITLE
Fix a bug in EmptyCountRule when using a variable named count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Fix LegacyConstructorRule when using variables instead of numbers.  
   [Sarr Blaise](https://github.com/bsarr007) 
   [#646](https://github.com/realm/SwiftLint/issues/646) 
+* Fix EmptyCountRule when using a variable named count.
+  [Pierre-Yves Lebecq](https://github.com/pylebecq)
 
 ## 0.11.1: Cuddles... Or Else!
 

--- a/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
@@ -21,7 +21,8 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
             "var count = 0\n",
             "[Int]().isEmpty\n",
             "[Int]().count > 1\n",
-            "[Int]().count == 1\n"
+            "[Int]().count == 1\n",
+            "func abc(count: Int) -> Bool { return count <= 0 }"
         ],
         triggeringExamples: [
             "[Int]().count == 0\n",
@@ -31,7 +32,7 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let pattern = "count\\s*(==|!=|<|<=|>|>=)\\s*0"
+        let pattern = "\\.count\\s*(==|!=|<|<=|>|>=)\\s*0"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
         return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: self.dynamicType.description,


### PR DESCRIPTION
Hello guys, I found out the empty count rule is triggered when declaring this king of method:

```
func testEmptyCount(count: Int) -> Bool {
    return count <= 0
}
```

I tried to fix it.