### PR TITLE
Gw add warning threshold rule

### DIFF
--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -28,9 +28,13 @@ public struct Linter {
         }
         let regions = file.regions()
         var ruleTimes = [(id: String, time: Double)]()
+        var warningRule: WarningThresholdRule?
         let violations = rules.flatMap { rule -> [StyleViolation] in
             if !(rule is SourceKitFreeRule) && self.file.sourcekitdFailed {
                 return []
+            }
+            if rule is WarningThresholdRule {
+                warningRule = rule as? WarningThresholdRule
             }
             let start: NSDate! = benchmark ? NSDate() : nil
             let violations = rule.validateFile(self.file)
@@ -45,6 +49,9 @@ public struct Linter {
                 }
                 return violationRegion.isRuleEnabled(rule)
             }
+        }
+        if let warningRule = warningRule {
+            return (warningRule.validate(violations), ruleTimes)
         }
         return (violations, ruleTimes)
     }

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -73,5 +73,6 @@ public let masterRuleList = RuleList(rules:
     TypeBodyLengthRule.self,
     TypeNameRule.self,
     ValidDocsRule.self,
-    VariableNameRule.self
+    VariableNameRule.self,
+    WarningThresholdRule.self
 )

--- a/Source/SwiftLintFramework/Rules/WarningThresholdRule.swift
+++ b/Source/SwiftLintFramework/Rules/WarningThresholdRule.swift
@@ -1,0 +1,48 @@
+//
+//  WarningThresholdRule.swift
+//  SwiftLint
+//
+//  Created by George Woodham on 6/07/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct WarningThresholdRule: ConfigurationProviderRule, SourceKitFreeRule {
+    public var configuration = SeverityLevelsConfiguration(warning: 10, error: 0)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "warning_threshold",
+        name: "Warning Threshold",
+        description: "Number of warnings thrown is above the threshold."
+    )
+
+    public func validate(violations: [StyleViolation]) -> [StyleViolation] {
+        let value = configuration.params.map({$0.value}).maxElement(<) ?? 10
+        var count = 0
+        for violation in violations {
+            if violation.severity == ViolationSeverity.Warning {
+                count += 1
+            }
+            if count >= value {
+                return violations + createError(value)
+            }
+        }
+        return violations
+    }
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        return []
+    }
+
+    func createError(value: Int) -> [StyleViolation] {
+        let location = Location(file: "filename", line: 1, character: 2)
+        return [StyleViolation(
+            ruleDescription: self.dynamicType.description,
+            severity: ViolationSeverity.Error,
+            location: location,
+            reason: "Number of warnings exceeded threshold of \(value)")]
+    }
+}

--- a/Source/SwiftLintFramework/Rules/WarningThresholdRule.swift
+++ b/Source/SwiftLintFramework/Rules/WarningThresholdRule.swift
@@ -38,7 +38,7 @@ public struct WarningThresholdRule: ConfigurationProviderRule, SourceKitFreeRule
     }
 
     func createError(value: Int) -> [StyleViolation] {
-        let location = Location(file: "filename", line: 1, character: 2)
+        let location = Location(file: "", line: 0, character: 0)
         return [StyleViolation(
             ruleDescription: self.dynamicType.description,
             severity: ViolationSeverity.Error,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
 		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
 		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
+		52FF5A521D2CA0A000DEF2FD /* WarningThresholdRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FF5A501D2C9B1200DEF2FD /* WarningThresholdRule.swift */; };
+		52FF5A541D2DCCD700DEF2FD /* WarningThresholdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FF5A531D2DCCD700DEF2FD /* WarningThresholdTests.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */; };
 		6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */; };
@@ -200,6 +202,8 @@
 		3BDB224A1C345B4900473680 /* ProjectMock */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ProjectMock; sourceTree = "<group>"; };
 		4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
 		4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
+		52FF5A501D2C9B1200DEF2FD /* WarningThresholdRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WarningThresholdRule.swift; sourceTree = "<group>"; };
+		52FF5A531D2DCCD700DEF2FD /* WarningThresholdTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WarningThresholdTests.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		65454F451B14D73800319A6C /* ControlStatementRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlStatementRule.swift; sourceTree = "<group>"; };
@@ -526,6 +530,7 @@
 				3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */,
 				3BB47D861C51DE6E00AE6A10 /* CustomRulesTests.swift */,
 				6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */,
+				52FF5A531D2DCCD700DEF2FD /* WarningThresholdTests.swift */,
 			);
 			name = SwiftLintFrameworkTests;
 			path = Tests/SwiftLintFramework;
@@ -607,6 +612,7 @@
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
 				E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */,
 				E88DEA931B099C0900A66CB0 /* VariableNameRule.swift */,
+				52FF5A501D2C9B1200DEF2FD /* WarningThresholdRule.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -924,6 +930,7 @@
 				3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */,
 				E88DEA8C1B0999A000A66CB0 /* ASTRule.swift in Sources */,
 				E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */,
+				52FF5A521D2CA0A000DEF2FD /* WarningThresholdRule.swift in Sources */,
 				3BB47D831C514E8100AE6A10 /* RegexConfiguration.swift in Sources */,
 				3B1150CA1C31FC3F00D83B1E /* Yaml+SwiftLint.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
@@ -947,6 +954,7 @@
 				E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */,
 				02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */,
 				D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */,
+				52FF5A541D2DCCD700DEF2FD /* WarningThresholdTests.swift in Sources */,
 				6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */,
 				3BB47D871C51DE6E00AE6A10 /* CustomRulesTests.swift in Sources */,
 				E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */,

--- a/Tests/SwiftLintFramework/WarningThresholdTests.swift
+++ b/Tests/SwiftLintFramework/WarningThresholdTests.swift
@@ -1,0 +1,67 @@
+//
+//  WarningThresholdTests.swift
+//  SwiftLint
+//
+//  Created by George Woodham on 7/07/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import XCTest
+import SourceKittenFramework
+@testable import SwiftLintFramework
+
+class WarningThresholdTests: XCTestCase {
+
+    func generateViolations() -> [StyleViolation] {
+        let location = Location(file: "filename", line: 1, character: 2)
+        return [
+            StyleViolation(ruleDescription: LineLengthRule.description,
+                severity: .Warning,
+                location: location,
+                reason: "Violation Reason.1"),
+            StyleViolation(ruleDescription: LineLengthRule.description,
+                severity: .Warning,
+                location: location,
+                reason: "Violation Reason.2")
+        ]
+    }
+
+    func testWarningThresholdChangedThreshold() {
+        let violations = generateViolations()
+        do {
+            let warningThreshold = try WarningThresholdRule(configuration: ["warning": 1])
+            XCTAssertEqual(warningThreshold.validate(violations).count, 3)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testWarningThresholdDefaultThreshold() {
+        let violations = generateViolations()
+        let warningThreshold = WarningThresholdRule()
+        XCTAssertEqual(warningThreshold.validate(violations).count, 2)
+    }
+
+    func testWarningThresholdChangedErrorThreshold() {
+        let violations = generateViolations()
+        do {
+            let warningThreshold = try WarningThresholdRule(configuration: ["error": 1])
+            XCTAssertEqual(warningThreshold.validate(violations).count, 2)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testWarningThresholdChangedErrorThresholdToBeHigherThanWarning() {
+        let violations = generateViolations()
+        do {
+            // swiftlint:disable line_length
+            let warningThreshold = try WarningThresholdRule(configuration: ["warning":1, "error": 2])
+            // swiftlint:enable line_length
+            XCTAssertEqual(warningThreshold.validate(violations).count, 3)
+        } catch {
+            XCTFail()
+        }
+    }
+
+}

--- a/Tests/SwiftLintFramework/WarningThresholdTests.swift
+++ b/Tests/SwiftLintFramework/WarningThresholdTests.swift
@@ -35,7 +35,7 @@ class WarningThresholdTests: XCTestCase {
             XCTFail()
         }
     }
-    
+
     func testWarningThresholdNoViolations() {
         let violations: [StyleViolation] = []
         do {

--- a/Tests/SwiftLintFramework/WarningThresholdTests.swift
+++ b/Tests/SwiftLintFramework/WarningThresholdTests.swift
@@ -35,6 +35,16 @@ class WarningThresholdTests: XCTestCase {
             XCTFail()
         }
     }
+    
+    func testWarningThresholdNoViolations() {
+        let violations: [StyleViolation] = []
+        do {
+            let warningThreshold = try WarningThresholdRule(configuration: ["warning": 1])
+            XCTAssertEqual(warningThreshold.validate(violations).count, 0)
+        } catch {
+            XCTFail()
+        }
+    }
 
     func testWarningThresholdDefaultThreshold() {
         let violations = generateViolations()


### PR DESCRIPTION
# What <h3> 
Rule to check the number of warnings thrown by Swiftlint and to throw an error if the number of warnings is greater than the threshold.

# How <h3> 
After all the checks have been run the the list of violations is passed to this rule which adds a new entry if the number of warnings is above the set threshold.

Can be configured in the config file with
 `warning_threshold: 5`
otherwise the default of 10 is used.

# Who <h3>
https://github.com/woodhamgh

# Why <h3> 
This allows for some warnings to go through without causing build failures but limits the number of warnings within the project. Some workplaces might have their own reasons for this or for how many they are happy to allow through.

Issue where request was made:
https://github.com/realm/SwiftLint/issues/696