### PR TITLE
autocorrect fix of locally disabled rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ##### Enhancements
 
 * LeadingWhitespaceRule is now auto correctable.  
-  [masters3d](https://github.com/masters3d)
+  [J. Cheyo Jimenez](https://github.com/masters3d)
 
 * Add included regex for custom rules to control what files are processed.  
   [bootstraponline](https://github.com/bootstraponline)
@@ -15,6 +15,10 @@
 
 ##### Bug Fixes
 
+* Fix locally disabled comma rule autocorrect.  
+  [J. Cheyo Jimenez](https://github.com/masters3d)  
+  [#601](https://github.com/realm/SwiftLint/issues/601)  
+  
 * Fix LegacyConstructorRule when using variables instead of numbers.  
   [Sarr Blaise](https://github.com/bsarr007) 
   [#646](https://github.com/realm/SwiftLint/issues/646) 

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -34,6 +34,19 @@ public protocol CorrectableRule: Rule {
     func correctFile(file: File) -> [Correction]
 }
 
+extension CorrectableRule {
+    func isRuleDisabled(file: File) -> Bool {
+        let region = file.regions().filter {
+            $0.contains(Location(file: file.path, line: max(file.lines.count, 1)))
+        }.first
+        if region?.isRuleDisabled(self) == true {
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
 public protocol SourceKitFreeRule: Rule {}
 
 // MARK: - ConfigurationProviderRule conformance to Configurable

--- a/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
@@ -54,6 +54,9 @@ public struct ClosingBraceRule: CorrectableRule, ConfigurationProviderRule {
     }
 
     public func correctFile(file: File) -> [Correction] {
+        if isRuleDisabled(file) {
+            return []
+        }
         let violatingRanges = file.ruleEnabledViolatingRanges(
             file.violatingClosingBraceRanges(),
             forRule: self

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -91,6 +91,9 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
     }
 
     public func correctFile(file: File) -> [Correction] {
+        if isRuleDisabled(file) {
+            return []
+        }
         let matches = violationRangesInFile(file, withPattern: pattern)
         guard !matches.isEmpty else { return [] }
 

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -52,6 +52,12 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
     public func correctFile(file: File) -> [Correction] {
         let matches = violationRangesInFile(file)
         if matches.isEmpty { return [] }
+        let region = file.regions().filter {
+            $0.contains(Location(file: file.path, line: max(file.lines.count, 1)))
+        }.first
+        if region?.isRuleDisabled(self) == true {
+            return []
+        }
 
         var contents = file.contents as NSString
         let description = self.dynamicType.description

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -52,13 +52,9 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
     public func correctFile(file: File) -> [Correction] {
         let matches = violationRangesInFile(file)
         if matches.isEmpty { return [] }
-        let region = file.regions().filter {
-            $0.contains(Location(file: file.path, line: max(file.lines.count, 1)))
-        }.first
-        if region?.isRuleDisabled(self) == true {
+        if isRuleDisabled(file) {
             return []
         }
-
         var contents = file.contents as NSString
         let description = self.dynamicType.description
         var corrections = [Correction]()

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -44,10 +44,7 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
         if spaceCount == 0 {
             return []
         }
-        let region = file.regions().filter {
-            $0.contains(Location(file: file.path, line: max(file.lines.count, 1)))
-        }.first
-        if region?.isRuleDisabled(self) == true {
+        if isRuleDisabled(file) {
             return []
         }
         let indexEnd = file.contents.startIndex.advancedBy(spaceCount)

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -107,10 +107,10 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
     }
 
     public func correctFile(file: File) -> [Correction] {
+        if isRuleDisabled(file) { return [] }
         let varName = RegexHelpers.varNameGroup
         let twoVars = RegexHelpers.twoVars
         let twoVariableOrNumber = RegexHelpers.twoVariableOrNumber
-
         let patterns = [
             "CGRectGetWidth\\(\(varName)\\)": "$1.width",
             "CGRectGetHeight\\(\(varName)\\)": "$1.height",
@@ -133,7 +133,6 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
             "CGRectContainsPoint\\(\(twoVars)\\)": "$1.contains($2)",
             "CGRectIntersectsRect\\(\(twoVars)\\)": "$1.intersects($2)"
         ]
-
         let description = self.dynamicType.description
         var corrections = [Correction]()
         var contents = file.contents

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -105,9 +105,11 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
                 location: Location(file: file, characterOffset: $0.location))
         }
     }
-
+// swiftlint:disable function_body_length
     public func correctFile(file: File) -> [Correction] {
-        if isRuleDisabled(file) { return [] }
+        if isRuleDisabled(file) {
+            return []
+        }
         let varName = RegexHelpers.varNameGroup
         let twoVars = RegexHelpers.twoVars
         let twoVariableOrNumber = RegexHelpers.twoVariableOrNumber

--- a/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
@@ -56,6 +56,9 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule {
     }
 
     public func correctFile(file: File) -> [Correction] {
+        if isRuleDisabled(file) {
+            return []
+        }
         let patterns = [
             "CGRectInfinite": "CGRect.infinite",
             "CGPointZero": "CGPoint.zero",

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -84,6 +84,9 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
     }
 
     public func correctFile(file: File) -> [Correction] {
+        if isRuleDisabled(file) {
+            return []
+        }
         let twoVarsOrNum = RegexHelpers.twoVariableOrNumber
 
         let patterns = [

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -77,6 +77,9 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
     }
 
     public func correctFile(file: File) -> [Correction] {
+        if isRuleDisabled(file) {
+            return []
+        }
         let violatingRanges = file.ruleEnabledViolatingRanges(
             file.violatingOpeningBraceRanges(),
             forRule: self

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -59,6 +59,9 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
     }
 
     public func correctFile(file: File) -> [Correction] {
+        if isRuleDisabled(file) {
+            return []
+        }
         let matches = violationRangesInFile(file)
         guard !matches.isEmpty else { return [] }
 

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -81,6 +81,9 @@ public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule 
     }
 
     public func correctFile(file: File) -> [Correction] {
+        if isRuleDisabled(file) {
+            return []
+        }
         switch configuration.statementMode {
         case .Default:
             return defaultCorrectFile(file)

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -63,10 +63,7 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, S
         guard let count = file.contents.trailingNewlineCount() where count != 1 else {
             return []
         }
-        let region = file.regions().filter {
-            $0.contains(Location(file: file.path, line: max(file.lines.count, 1)))
-        }.first
-        if region?.isRuleDisabled(self) == true {
+        if isRuleDisabled(file) {
             return []
         }
         if count < 1 {

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -64,6 +64,9 @@ public struct TrailingSemicolonRule: CorrectableRule, ConfigurationProviderRule 
         if adjustedRanges.isEmpty {
             return []
         }
+        if isRuleDisabled(file) {
+            return []
+        }
         var correctedContents = file.contents
         for range in adjustedRanges {
             if let indexRange = correctedContents.nsrangeToIndexRange(range) {


### PR DESCRIPTION
This code needs to be added to all the correctable rules that don't have it, but I think we should probably add this to the File type  or Correctable protocol so that we could just say
```
if currentRuleIsDisabled{
   return []
}
```
closes #601