### PR TITLE
Add JUnit reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ##### Enhancements
 
+* Add Junit reporter.
+  [Matthew Ellis](https://github.com/matthewellis)
+
 * LeadingWhitespaceRule is now auto correctable.  
   [masters3d](https://github.com/masters3d)
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ variable_name:
     - id
     - URL
     - GlobalAPIKey
-reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 ```
 
 #### Defining Custom Rules

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -22,6 +22,8 @@ public func reporterFromString(string: String) -> Reporter.Type {
         return CSVReporter.self
     case CheckstyleReporter.identifier:
         return CheckstyleReporter.self
+    case JUnitReporter.identifier:
+        return JUnitReporter.self
     default:
         fatalError("no reporter with identifier '\(string)' available.")
     }

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -1,0 +1,30 @@
+//
+//  JUnitReporter.swift
+//  SwiftLint
+//
+//  Created by Matthew Ellis on 25/05/2016.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+
+public struct JUnitReporter: Reporter {
+    public static let identifier = "junit"
+    public static let isRealtime = false
+
+    public var description: String {
+        return "Reports violations as JUnit XML."
+    }
+
+    public static func generateReport(violations: [StyleViolation]) -> String {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +
+            violations.map({ violation in
+                let fileName = violation.location.file ?? "<nopath>"
+                let severity = violation.severity.rawValue.lowercaseString + ":\n"
+                let message = severity + "Line:" + String(violation.location.line ?? 0) + " "
+                return ["\n\t<testcase classname='Formatting Test' name='\(fileName)\'>\n",
+                    "<failure message='\(violation.reason)\'>" + message + "</failure>",
+                    "\t</testcase>"].joinWithSeparator("")
+            }).joinWithSeparator("") + "\n</testsuite></testsuites>"
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
 		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
 		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
+		57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED82791CF65183002B3513 /* JUnitReporter.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */; };
 		6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */; };
@@ -202,6 +203,7 @@
 		4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		57ED82791CF65183002B3513 /* JUnitReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JUnitReporter.swift; sourceTree = "<group>"; };
 		65454F451B14D73800319A6C /* ControlStatementRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlStatementRule.swift; sourceTree = "<group>"; };
 		692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpeningBraceRule.swift; sourceTree = "<group>"; };
 		692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionRule.swift; sourceTree = "<group>"; };
@@ -563,6 +565,7 @@
 			isa = PBXGroup;
 			children = (
 				E8EA41161C2D1DBE004F9930 /* CheckstyleReporter.swift */,
+				57ED82791CF65183002B3513 /* JUnitReporter.swift */,
 				E86396CA1BADB519002C9E88 /* CSVReporter.swift */,
 				E86396C81BADB2B9002C9E88 /* JSONReporter.swift */,
 				E86396C41BADAC15002C9E88 /* XcodeReporter.swift */,
@@ -899,6 +902,7 @@
 				006ECFC41C44E99E00EF6364 /* LegacyConstantRule.swift in Sources */,
 				E88DEA731B0984C400A66CB0 /* String+SwiftLint.swift in Sources */,
 				E88198591BEA95F100333A11 /* LeadingWhitespaceRule.swift in Sources */,
+				57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */,
 				24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */,
 				E80E018F1B92C1350078EB70 /* Region.swift in Sources */,
 				E88198581BEA956C00333A11 /* FunctionBodyLengthRule.swift in Sources */,

--- a/Tests/SwiftLintFramework/ReporterTests.swift
+++ b/Tests/SwiftLintFramework/ReporterTests.swift
@@ -78,4 +78,17 @@ class ReporterTests: XCTestCase {
             "</checkstyle>"
         )
     }
+
+    func testJunitReporter() {
+        XCTAssertEqual(
+            JUnitReporter.generateReport(generateViolations()),
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>\n" +
+                "\t<testcase classname=\'Formatting Test\' name=\'filename\'>\n" +
+                    "<failure message=\'Violation Reason.\'>warning:\nLine:1 </failure>" +
+                "\t</testcase>\n" +
+                "\t<testcase classname=\'Formatting Test\' name=\'filename\'>\n" +
+                    "<failure message=\'Violation Reason.\'>error:\nLine:1 </failure>" +
+                "\t</testcase>\n</testsuite></testsuites>"
+        )
+    }
 }


### PR DESCRIPTION
I needed to pull test results from SwiftLint into Bamboo CI but the current reporters where not compatible with the parsers available, JUnit seems to be a common format for a few tools so i thought i would put in a pull request to add this to the project. 