### PR TITLE
Fixes custom rule regex and allow disable in code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
 
 ##### Bug Fixes
 
+* Fixed CustomRule Regex.  
+  [J. Cheyo Jimenez](https://github.com/masters3d)
+  [#717](https://github.com/realm/SwiftLint/issues/717)
+  [#726](https://github.com/realm/SwiftLint/issues/726)
+
 * Fix LegacyConstructorRule when using variables instead of numbers.  
   [Sarr Blaise](https://github.com/bsarr007) 
   [#646](https://github.com/realm/SwiftLint/issues/646) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
   [#717](https://github.com/realm/SwiftLint/issues/717)
   [#726](https://github.com/realm/SwiftLint/issues/726)
 
+* Allow disabling custom rules in code.  
+  [J. Cheyo Jimenez](https://github.com/masters3d)
+  [#515](https://github.com/realm/SwiftLint/issues/515)
+
 * Fix LegacyConstructorRule when using variables instead of numbers.  
   [Sarr Blaise](https://github.com/bsarr007) 
   [#646](https://github.com/realm/SwiftLint/issues/646) 

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -74,12 +74,12 @@ public struct CustomRules: Rule, ConfigurationProviderRule {
     }
 
     private func validate(file: File, configuration: RegexConfiguration) -> [StyleViolation] {
-        return file.matchPattern(configuration.regex).filter {
-            !configuration.matchKinds.intersect($0.1).isEmpty
-        }.map {
+        let pattern = configuration.regex.pattern
+        let excludingKinds = Array(Set(SyntaxKind.allKinds()).subtract(configuration.matchKinds))
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: configuration.description,
                 severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.0.location),
+                location: Location(file: file, characterOffset: $0.location),
                 reason: configuration.message)
         }
     }

--- a/Tests/SwiftLintFramework/CustomRulesTests.swift
+++ b/Tests/SwiftLintFramework/CustomRulesTests.swift
@@ -55,6 +55,13 @@ class CustomRulesTests: XCTestCase {
                         reason: regexConfig.message)])
     }
 
+    func testLocalDisableCustomRule() {
+        let (_, customRules) = getCustomRules()
+        let file = File(contents: "//swiftlint:disable custom \n// file with a pattern")
+        XCTAssertEqual(customRules.validateFile(file),
+                       [])
+    }
+
     func testCustomRulesIncludedDefault() {
         // Violation detected when included is omitted.
         let (_, customRules) = getCustomRules()


### PR DESCRIPTION
closes https://github.com/realm/SwiftLint/issues/717
closes https://github.com/realm/SwiftLint/issues/726
closes #515 
Testing files:

```yml
custom_rules:
  void_as_return:
    name: "Void as Parameter"
    message: "Use Void as return type instead of ()."
    regex: "(->[ ]?\(\))"
  parenthesis_spacing:
    name: "Parenthesis Spacing"
    message: "Don't put a space inside a parenthesis."
    regex: "\(\s|\s\)"

```

```swift
func hey() -> () {
    return
}
/// space(  ) ( sd) (dd )
func space( ) {
    return
}

func space2( ) {
    return ( )
}

let abc: () -> () = {}

```
