### PR TITLE
[CONTRIBUTING.md] Small addendum about submodules & tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,9 @@ Whenever possible, prefer adding tests via the `triggeringExamples` and
 `nonTriggeringExamples` properties of a rule's `description` rather than adding
 those test cases in the unit tests directly. This makes it easier to understand
 what rules do by reading their source, and simplifies adding more test cases
-over time.
+over time. This way adding a unit test for your new Rule is just a matter of
+adding a test case in `RulesTests.swift` which simply calls
+`verifyRule(YourNewRule.description)`.
 
 ### `ConfigurationProviderRule`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,20 @@
 ## Pull Requests
 
 All changes, no matter how trivial, must be done via pull request. Commits
-should never be made directly on the `master` branch. If you have commit access
-to SwiftLint and believe your change to be trivial and not worth waiting for
-review, you may open a pull request and merge immediately, but this should be
-the exception, not the norm.
+should never be made directly on the `master` branch.
+
+_If you have commit access to SwiftLint and believe your change to be trivial
+and not worth waiting for review, you may open a pull request and merge
+immediately, but this should be the exception, not the norm._
+
+### Submodules
+
+This SwiftLint repository uses submodules for its dependencies. 
+This means that if you decide to fork this repository to contribute to SwiftLint,
+don't forget to checkout the submodules as well when cloning, by running
+`git submodule update --init --recursive` after cloning.
+
+See more info [in the README](https://github.com/realm/SwiftLint#installation)
 
 ## Rules
 


### PR DESCRIPTION
### Submodules

Starting to want to contribute so read the `CONTRIBUTING.md` then forked, but saw the `xcworkspace` were showing some xcodeproj projects in red… until I realized I forgot to clone the submodules.

### Unit Tests

Another thing I wondered when implementing my first rule is wether I should write a Unit Test explicitly myself or not.

Especially, given the paragraph about providing Unit Tests via the `triggeringExamples` and `nonTriggeringExamples`, and the fact that there's a `masterRuleList` list containing all the rules already, I wondered if the Unit Tests code weren't already auto-executing the tests for all the rules without me having to write anything additional.

That's only when seeing that my `validateFile` wasn't executed during the Rules Unit Tests that I figured I had to explicitly add one myself, which would explicitly call `verifyRule(MyNewRule.description)`

That's a small question and I quickly figured the answer myself by looking at the code, but still when opening a unknown project for the first time, every pointer & explicit doc helps.

---

So I figured a little reminder in the `CONTRIBUTING.md` might help others avoid the same mistakes :wink: