### PR TITLE
[New Rule] weak_delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   instance variables to be `private`.  
   [Olivier Halligon](https://github.com/AliSoftware)
 
-* Add `WeakDelegateRule` Opt-In rule to enforce delegate instance
+* Add `WeakDelegateRule` rule to enforce delegate instance
   variables to be `weak`.  
   [Olivier Halligon](https://github.com/AliSoftware)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   instance variables to be `private`.  
   [Olivier Halligon](https://github.com/AliSoftware)
 
+* Add `WeakDelegateRule` Opt-In rule to enforce delegate instance
+  variables to be `weak`.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+
 * Add `LegacyNSGeometryFunctionsRule` rule. Add `NSSize`, `NSPoint`, and 
   `NSRect` constants and constructors to existing rules.  
   [David Rönnqvist](https://github.com/d-ronnqvist)

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -74,5 +74,6 @@ public let masterRuleList = RuleList(rules:
     TypeBodyLengthRule.self,
     TypeNameRule.self,
     ValidDocsRule.self,
-    VariableNameRule.self
+    VariableNameRule.self,
+    WeakDelegateRule.self
 )

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -42,9 +42,10 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
         }
 
         // Check if name contains "delegate"
-        let name = (dictionary["key.name"] as? String) ?? ""
-        let isDelegate = name.lowercaseString.rangeOfString("delegate") != nil
-        guard isDelegate else { return [] }
+        guard let name = (dictionary["key.name"] as? String) where
+            name.lowercaseString.containsString("delegate") else {
+                return []
+        }
 
         // Check if non-weak
         let attributes = (dictionary["key.attributes"] as? [SourceKitRepresentable])?

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -22,7 +22,9 @@ public struct WeakDelegateRule: ASTRule, OptInRule, ConfigurationProviderRule {
             "class Foo {\n  weak var delegate: SomeProtocol?\n}\n",
             "class Foo {\n  weak var someDelegate: SomeDelegateProtocol?\n}\n",
             "class Foo {\n  weak var delegateScroll: ScrollDelegate?\n}\n",
+            // We only consider properties to be a delegate if it has "delegate" in its name
             "class Foo {\n  var scrollHandler: ScrollDelegate?\n}\n",
+            // Only trigger on instance variables, not local variables
             "func foo() {\n  var delegate: SomeDelegate\n}\n"
         ],
         triggeringExamples: [

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct WeakDelegateRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.Warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -1,0 +1,69 @@
+//
+//  WeakDelegate.swift
+//  SwiftLint
+//
+//  Created by Olivier Halligon on 11/08/2016.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct WeakDelegateRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.Warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "weak_delegate",
+        name: "Weak Delegate",
+        description: "Delegates should be weak to avoid reference cycles.",
+        nonTriggeringExamples: [
+            "class Foo {\n  weak var delegate: SomeProtocol?\n}\n",
+            "class Foo {\n  weak var someDelegate: SomeDelegateProtocol?\n}\n",
+            "class Foo {\n  weak var delegateScroll: ScrollDelegate?\n}\n",
+            "class Foo {\n  var scrollHandler: ScrollDelegate?\n}\n",
+            "func foo() {\n  var delegate: SomeDelegate\n}\n"
+        ],
+        triggeringExamples: [
+            "class Foo {\n  var delegate: SomeProtocol?\n}\n",
+            "class Foo {\n  var scrollDelegate: ScrollDelegate?\n}\n",
+            "class Foo {\n  var delegateScroll: ScrollDelegate?\n}\n",
+        ]
+    )
+
+    public func validateFile(file: File,
+                             kind: SwiftDeclarationKind,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .VarInstance else {
+            return []
+        }
+
+        // Check if name contains "delegate"
+        let name = (dictionary["key.name"] as? String) ?? ""
+        let isDelegate = name.lowercaseString.rangeOfString("delegate") != nil
+        guard isDelegate else { return [] }
+
+        // Check if non-weak
+        let attributes = (dictionary["key.attributes"] as? [SourceKitRepresentable])?
+            .flatMap({ ($0 as? [String: SourceKitRepresentable]) as? [String: String] })
+            .flatMap({ $0["key.attribute"] }) ?? []
+        let isWeak = attributes.contains("source.decl.attribute.weak")
+        guard !isWeak else { return [] }
+
+        // Violation found!
+        let location: Location
+        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+            location = Location(file: file, byteOffset: offset)
+        } else {
+            location = Location(file: file.path)
+        }
+
+        return [
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: configuration.severity,
+                location: location
+            )
+        ]
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		006ECFC41C44E99E00EF6364 /* LegacyConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */; };
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
 		094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094385021D5D4F78009168CF /* PrivateOutletRule.swift */; };
+		094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094384FF1D5D2382009168CF /* WeakDelegateRule.swift */; };
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
 		2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */; };
@@ -175,6 +176,7 @@
 		006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRule.swift; sourceTree = "<group>"; };
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
 		094385021D5D4F78009168CF /* PrivateOutletRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
+		094384FF1D5D2382009168CF /* WeakDelegateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
 		2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityRule.swift; sourceTree = "<group>"; };
@@ -615,6 +617,7 @@
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
 				E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */,
 				E88DEA931B099C0900A66CB0 /* VariableNameRule.swift */,
+				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -914,6 +917,7 @@
 				3BCC04D11C4F56D3006073C3 /* SeverityLevelsConfiguration.swift in Sources */,
 				6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */,
 				E86396C51BADAC15002C9E88 /* XcodeReporter.swift in Sources */,
+				094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */,
 				3B1DF0121C5148140011BCED /* CustomRules.swift in Sources */,
 				2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */,
 				E86396C91BADB2B9002C9E88 /* JSONReporter.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -232,4 +232,8 @@ class RulesTests: XCTestCase {
     func testVariableName() {
         verifyRule(VariableNameRule.description)
     }
+
+    func testWeakDelegate() {
+        verifyRule(WeakDelegateRule.description)
+    }
 }


### PR DESCRIPTION
Added a rule to enforce `delegate` instance variables to be declared as `weak` to avoid reference cycles.
