### PR TITLE
[New Rule] private_outlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ##### Enhancements
 
+* Add `PrivateOutletRule` Opt-In rule to enforce `@IBOutlet`
+  instance variables to be `private`.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#754](https://github.com/realm/SwiftLint/pull/754)
+
 * Add `LegacyNSGeometryFunctionsRule` rule. Add `NSSize`, `NSPoint`, and 
   `NSRect` constants and constructors to existing rules.  
   [David Rönnqvist](https://github.com/d-ronnqvist)

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -73,5 +73,6 @@ public let masterRuleList = RuleList(rules:
     TypeBodyLengthRule.self,
     TypeNameRule.self,
     ValidDocsRule.self,
-    VariableNameRule.self
+    VariableNameRule.self,
+    PrivateOutletRule.self
 )

--- a/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
@@ -1,0 +1,68 @@
+//
+//  PrivateOutletRule.swift
+//  SwiftLint
+//
+//  Created by Olivier Halligon on 12/08/2016.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.Warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "private_outlet",
+        name: "Private Outlets",
+        description: "IBOutlets should be private to avoid leaking UIKit to higher layers.",
+        nonTriggeringExamples: [
+            "class Foo {\n  @IBOutlet private var label: UILabel?\n}\n",
+            "class Foo {\n  @IBOutlet private var label: UILabel!\n}\n",
+            "class Foo {\n  var notAnOutlet: UILabel\n}\n",
+            "class Foo {\n  @IBOutlet weak private var label: UILabel?\n}\n",
+            "class Foo {\n  @IBOutlet private weak var label: UILabel?\n}\n",
+        ],
+        triggeringExamples: [
+            "class Foo {\n  @IBOutlet var label: UILabel?\n}\n",
+            "class Foo {\n  @IBOutlet var label: UILabel!\n}\n",
+        ]
+    )
+
+    public func validateFile(file: File,
+                             kind: SwiftDeclarationKind,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .VarInstance else {
+            return []
+        }
+
+        // Check if IBOutlet
+        let attributes = (dictionary["key.attributes"] as? [SourceKitRepresentable])?
+            .flatMap({ ($0 as? [String: SourceKitRepresentable]) as? [String: String] })
+            .flatMap({ $0["key.attribute"] }) ?? []
+        let isOutlet = attributes.contains("source.decl.attribute.iboutlet")
+        guard isOutlet else { return [] }
+
+        // Check if private
+        let accessibility = (dictionary["key.accessibility"] as? String) ?? ""
+        let isPrivate = accessibility == "source.lang.swift.accessibility.private"
+        guard !isPrivate else { return [] }
+
+        // Violation found!
+        let location: Location
+        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+            location = Location(file: file, byteOffset: offset)
+        } else {
+            location = Location(file: file.path)
+        }
+
+        return [
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: configuration.severity,
+                location: location
+            )
+        ]
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		006ECFC41C44E99E00EF6364 /* LegacyConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */; };
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
+		094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094385021D5D4F78009168CF /* PrivateOutletRule.swift */; };
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
 		2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */; };
@@ -173,6 +174,7 @@
 /* Begin PBXFileReference section */
 		006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRule.swift; sourceTree = "<group>"; };
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
+		094385021D5D4F78009168CF /* PrivateOutletRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
 		2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityRule.swift; sourceTree = "<group>"; };
@@ -388,7 +390,9 @@
 				D0D1216E19E87B05005E4BAA /* SwiftLintFramework */,
 				D0D1217B19E87B05005E4BAA /* SwiftLintFrameworkTests */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 			usesTabs = 0;
 		};
 		D0D1211919E87861005E4BAA /* Products */ = {
@@ -599,6 +603,7 @@
 				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
 				692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */,
 				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
+				094385021D5D4F78009168CF /* PrivateOutletRule.swift */,
 				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
 				3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */,
 				692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */,
@@ -927,6 +932,7 @@
 				3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */,
 				F22314B01D4FA4D7009AD165 /* LegacyNSGeometryFunctionsRule.swift in Sources */,
 				E88DEA8C1B0999A000A66CB0 /* ASTRule.swift in Sources */,
+				094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */,
 				E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */,
 				3BB47D831C514E8100AE6A10 /* RegexConfiguration.swift in Sources */,
 				3B1150CA1C31FC3F00D83B1E /* Yaml+SwiftLint.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -170,6 +170,10 @@ class RulesTests: XCTestCase {
         verifyRule(OperatorFunctionWhitespaceRule.description)
     }
 
+    func testPrivateOutlet() {
+        verifyRule(PrivateOutletRule.description)
+    }
+
     func testReturnArrowWhitespace() {
         verifyRule(ReturnArrowWhitespaceRule.description)
     }


### PR DESCRIPTION
Added an Opt-In rule to enforce `@IBOutlet` instance variables to be declared `private`.

Some teams (including mine) want to enforce that `@IBOutlet` are not exposed outside of the declaring type because for separation of concerns principles one might not want to leak UI details to the outside of a class.

### Rationale

I personally find it more clean to expose a `String` property to the outside — even if that property implement a `set` and `get` which in fact link to the internal `label.text` — rather than exposing the `UILabel` itself — because if some time later we change that UILabel to a non-editing UITextField or some other custom UI component for design reasons, the consumer of the class shouldn't bother (that's implementation details of the UI layer not to be exposed to the higher abstraction layer)

### Opt-In rule

That being said, knowing that this rationale depends on each team's policy and that other teams might not have similar policies regarding IBOutlets, and that this rule is debatable depending on how strict you want your team to separate the various layers, I think that this rule should be Opt-In.