### PR TITLE
Warning threshold rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   [bootstraponline](https://github.com/bootstraponline)
   [#689](https://github.com/realm/SwiftLint/issues/689)
 
+* Add configuration for setting a warning threshold.  
+  [woodhamgh](https://github.com/woodhamgh)
+  [696](https://github.com/realm/SwiftLint/issues/696)
+
 ##### Bug Fixes
 
 * Fix LegacyConstructorRule when using variables instead of numbers.  

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -76,9 +76,7 @@ public struct Configuration: Equatable {
         }
 
         // set the config threshold to the threshold provided in the config file
-        if let warningThreshold = warningThreshold {
-            self.warningThreshold = warningThreshold
-        }
+        self.warningThreshold = warningThreshold
 
         // white_list rules take precendence over all else.
         if !whitelistRules.isEmpty {
@@ -150,7 +148,7 @@ public struct Configuration: Equatable {
             whitelistRules: defaultStringArray(dict[ConfigurationKey.WhitelistRules.rawValue]),
             included: defaultStringArray(dict[ConfigurationKey.Included.rawValue]),
             excluded: defaultStringArray(dict[ConfigurationKey.Excluded.rawValue]),
-            warningThreshold: dict[ConfigurationKey.WarningThreshold.rawValue] as? Int ?? nil,
+            warningThreshold: dict[ConfigurationKey.WarningThreshold.rawValue] as? Int,
             reporter: dict[ConfigurationKey.Reporter.rawValue] as? String ??
                 XcodeReporter.identifier,
             configuredRules: masterRuleList.configuredRulesWithDictionary(dict)

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -74,7 +74,7 @@ public struct Configuration: Equatable {
             }.joinWithSeparator("\n"))
             return nil
         }
-        
+
         // set the config threshold to the threshold provided in the config file
         if let warningThreshold = warningThreshold {
             self.warningThreshold = warningThreshold

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -59,7 +59,7 @@ struct LintCommand: CommandType {
             let numberOfWarningViolations = violations.filter({ $0.severity == .Warning}).count
             if let warningThreshold = configuration.warningThreshold {
                 if numberOfWarningViolations >= warningThreshold {
-                    exit(2)
+                    violations.append(createThresholdViolation(warningThreshold))
                 }
             }
             let numberOfSeriousViolations = violations.filter({ $0.severity == .Error }).count
@@ -124,4 +124,18 @@ struct LintOptions: OptionsType {
                                usage: "the reporter used to log errors and warnings")
             <*> mode <| quietOption(action: "linting")
     }
+}
+
+func createThresholdViolation(threshold: Int) -> StyleViolation {
+    let description = RuleDescription(
+        identifier: "warning_threshold",
+        name: "Warning Threshold",
+        description: "Number of warnings thrown is above the threshold."
+    )
+    let location = Location(file: "", line: 0, character: 0)
+    return StyleViolation(
+        ruleDescription: description,
+        severity: ViolationSeverity.Error,
+        location: location,
+        reason: "Number of warnings exceeded threshold of \(threshold)")
 }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -56,6 +56,12 @@ struct LintCommand: CommandType {
             reporter.reportViolations(currentViolations, realtimeCondition: true)
         }.flatMap { files in
             reporter.reportViolations(violations, realtimeCondition: false)
+            let numberOfWarningViolations = violations.filter({ $0.severity == .Warning}).count
+            if let warningThreshold = configuration.warningThreshold {
+                if numberOfWarningViolations >= warningThreshold {
+                    exit(2)
+                }
+            }
             let numberOfSeriousViolations = violations.filter({ $0.severity == .Error }).count
             if !options.quiet {
                 LintCommand.printStatus(violations: violations, files: files,

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -26,7 +26,7 @@ extension Reporter {
 struct LintCommand: CommandType {
     let verb = "lint"
     let function = "Print lint warnings and errors (default command)"
-    
+
     func run(options: LintOptions) -> Result<(), CommandantError<()>> {
         var fileTimes = [(id: String, time: Double)]()
         var ruleTimes = [(id: String, time: Double)]()

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -57,8 +57,9 @@ struct LintCommand: CommandType {
         }.flatMap { files in
             if isWarningThresholdBroken(configuration, violations: violations) {
                 violations.append(createThresholdViolation(configuration.warningThreshold!))
+                reporter.reportViolations([violations.last!], realtimeCondition: true)
             }
-            reporter.reportViolations(violations, realtimeCondition: true)
+            reporter.reportViolations(violations, realtimeCondition: false)
             let numberOfSeriousViolations = violations.filter({ $0.severity == .Error }).count
             if !options.quiet {
                 LintCommand.printStatus(violations: violations, files: files,
@@ -127,10 +128,7 @@ private func isWarningThresholdBroken(configuration: Configuration,
                                       violations: [StyleViolation]) -> Bool {
     guard let warningThreshold = configuration.warningThreshold else { return false }
     let numberOfWarningViolations = violations.filter({ $0.severity == .Warning}).count
-    if numberOfWarningViolations >= warningThreshold {
-        return true
-    }
-    return false
+    return numberOfWarningViolations >= warningThreshold
 }
 
 private func createThresholdViolation(threshold: Int) -> StyleViolation {
@@ -142,7 +140,7 @@ private func createThresholdViolation(threshold: Int) -> StyleViolation {
     let location = Location(file: "", line: 0, character: 0)
     return StyleViolation(
         ruleDescription: description,
-        severity: ViolationSeverity.Error,
+        severity: .Error,
         location: location,
-        reason: "Number of warnings exceeded threshold of \(threshold)")
+        reason: "Number of warnings exceeded threshold of \(threshold).")
 }

--- a/Tests/SwiftLintFramework/ConfigurationTests.swift
+++ b/Tests/SwiftLintFramework/ConfigurationTests.swift
@@ -52,12 +52,12 @@ class ConfigurationTests: XCTestCase {
         }
         XCTAssertEqual(whitelist, configuredIdentifiers)
     }
-    
+
     func testWarningThreshold_value() {
         let config = Configuration(dict: ["warning_threshold": 5])!
         XCTAssertEqual(config.warningThreshold, 5)
     }
-    
+
     func testWarningThreshold_nil() {
         let config = Configuration(dict: [:])!
         XCTAssertEqual(config.warningThreshold, nil)

--- a/Tests/SwiftLintFramework/ConfigurationTests.swift
+++ b/Tests/SwiftLintFramework/ConfigurationTests.swift
@@ -52,6 +52,16 @@ class ConfigurationTests: XCTestCase {
         }
         XCTAssertEqual(whitelist, configuredIdentifiers)
     }
+    
+    func testWarningThreshold_value() {
+        let config = Configuration(dict: ["warning_threshold": 5])!
+        XCTAssertEqual(config.warningThreshold, 5)
+    }
+    
+    func testWarningThreshold_nil() {
+        let config = Configuration(dict: [:])!
+        XCTAssertEqual(config.warningThreshold, nil)
+    }
 
     func testOtherRuleConfigurationsAlongsideWhitelistRules() {
         let whitelist = ["nesting", "todo"]


### PR DESCRIPTION
# What <h3> 
Rule to check the number of warnings thrown by Swiftlint and to throw an error if the number of warnings is greater than the threshold.

# How <h3> 
New configuration parameter which adds and error into the list of violations if the threshold is broken. Done in the lint command 

Can be configured in the config file with
 `warning_threshold: 5`

# Who <h3>
https://github.com/woodhamgh

# Why <h3> 
This allows for some warnings to go through without causing build failures but limits the number of warnings within the project. Some workplaces might have their own reasons for this or for how many they are happy to allow through.

Issue where request was made:
https://github.com/realm/SwiftLint/issues/696