### PR TITLE
[New Rule] Conditional Returns on Newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
   [woodhamgh](https://github.com/woodhamgh)
   [696](https://github.com/realm/SwiftLint/issues/696)
 
-* Adds 'GuardReturnsOnNewLineRule' rule.
+* Adds 'ConditionalReturnsOnNewLineRule' rule.  
   [Rohan Dhaimade](https://github.com/HaloZero)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
   [woodhamgh](https://github.com/woodhamgh)
   [696](https://github.com/realm/SwiftLint/issues/696)
 
+* Adds 'GuardReturnsOnNewLineRule' rule.
+  [Rohan Dhaimade](https://github.com/HaloZero)
+
 ##### Bug Fixes
 
 * Fixed CustomRule Regex.  

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -43,8 +43,8 @@ public struct RuleList {
 public let masterRuleList = RuleList(rules:
     ClosingBraceRule.self,
     ColonRule.self,
-    ConditionalReturnsOnNewline.self,
     CommaRule.self,
+    ConditionalReturnsOnNewline.self,
     ControlStatementRule.self,
     CustomRules.self,
     CyclomaticComplexityRule.self,

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -43,12 +43,12 @@ public struct RuleList {
 public let masterRuleList = RuleList(rules:
     ClosingBraceRule.self,
     ColonRule.self,
+    ConditionalReturnsOnNewline.self,
     CommaRule.self,
     ControlStatementRule.self,
     CustomRules.self,
     CyclomaticComplexityRule.self,
     EmptyCountRule.self,
-    GuardReturnsOnNewline.self,
     FileLengthRule.self,
     ForceCastRule.self,
     ForceTryRule.self,

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -48,6 +48,7 @@ public let masterRuleList = RuleList(rules:
     CustomRules.self,
     CyclomaticComplexityRule.self,
     EmptyCountRule.self,
+    GuardReturnsOnNewline.self,
     FileLengthRule.self,
     ForceCastRule.self,
     ForceTryRule.self,

--- a/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
@@ -9,12 +9,11 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ConditionalReturnsOnNewline: Rule, OptInRule {
+public struct ConditionalReturnsOnNewline: ConfigurationProviderRule, Rule, OptInRule {
     public let configurationDescription = "N/A"
+    public var configuration = SeverityConfiguration(.Warning)
 
     public init() { }
-
-    public init(configuration: AnyObject) { }
 
     public static let description = RuleDescription(
         identifier: "conditional_returns_on_newline",

--- a/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
@@ -1,5 +1,5 @@
 //
-//  GuardReturnsOnNewline.swift
+//  ConditionalReturnsOnNewline.swift
 //  SwiftLint
 //
 //  Created by Rohan Dhaimade on 12/08/2016.
@@ -9,7 +9,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct GuardReturnsOnNewline: Rule, OptInRule {
+public struct ConditionalReturnsOnNewline: Rule, OptInRule {
     public let configurationDescription = "N/A"
 
     public init() { }
@@ -17,20 +17,24 @@ public struct GuardReturnsOnNewline: Rule, OptInRule {
     public init(configuration: AnyObject) { }
 
     public static let description = RuleDescription(
-        identifier: "guard_returns_on_newline",
-        name: "Guard Returns on Newline",
-        description: "Guards should always return on the next line",
+        identifier: "conditional_returns_on_newline",
+        name: "Conditional Returns on Newline",
+        description: "Conditional statements should always return on the next line",
         nonTriggeringExamples: [
             "guard true else {\n return true\n}",
-            "guard true,\n let x = true else {\n return true\n}"
+            "guard true,\n let x = true else {\n return true\n}",
+            "if true else {\n return true\n}",
+            "if true,\n let x = true else {\n return true\n}"
         ],
         triggeringExamples: [
             "guard true else { return }",
+            "if true { return }",
+            "if true { break } else { return }",
         ]
     )
 
     public func validateFile(file: File) -> [StyleViolation] {
-        let pattern = "guard[^\n]*return[^\n]\n*"
+        let pattern = "(guard|if)[^\n]*return[^\n]\n*"
         let excludingKinds = SyntaxKind.commentAndStringKinds()
         return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: self.dynamicType.description,

--- a/Source/SwiftLintFramework/Rules/GuardReturnsOnNewline.swift
+++ b/Source/SwiftLintFramework/Rules/GuardReturnsOnNewline.swift
@@ -1,0 +1,40 @@
+//
+//  GuardReturnsOnNewline.swift
+//  SwiftLint
+//
+//  Created by Rohan Dhaimade on 12/08/2016.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct GuardReturnsOnNewline: Rule, OptInRule {
+    public let configurationDescription = "N/A"
+
+    public init() { }
+
+    public init(configuration: AnyObject) { }
+
+    public static let description = RuleDescription(
+        identifier: "guard_returns_on_newline",
+        name: "Guard Returns on Newline",
+        description: "Guards should always return on the next line",
+        nonTriggeringExamples: [
+            "guard true else {\n return true\n}",
+            "guard true,\n let x = true else {\n return true\n}"
+        ],
+        triggeringExamples: [
+            "guard true else { return }",
+        ]
+    )
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        let pattern = "guard[^\n]*return[^\n]\n*"
+        let excludingKinds = SyntaxKind.commentAndStringKinds()
+        return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                location: Location(file: file, byteOffset: $0.location))
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
+		DAD3BE481D66DF9200660239 /* GuardReturnsOnNewline.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE471D66DF9200660239 /* GuardReturnsOnNewline.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
 		E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA01B8A71DF00399043 /* Configuration.swift */; };
@@ -243,6 +244,7 @@
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
+		DAD3BE471D66DF9200660239 /* GuardReturnsOnNewline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GuardReturnsOnNewline.swift; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
 		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
@@ -593,6 +595,7 @@
 				B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */,
 				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
 				2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */,
+				DAD3BE471D66DF9200660239 /* GuardReturnsOnNewline.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */,
 				006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */,
@@ -873,6 +876,7 @@
 				4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */,
 				6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */,
 				E881985C1BEA978500333A11 /* TrailingNewlineRule.swift in Sources */,
+				DAD3BE481D66DF9200660239 /* GuardReturnsOnNewline.swift in Sources */,
 				E881985E1BEA982100333A11 /* TypeBodyLengthRule.swift in Sources */,
 				69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */,
 				E849FF281BF9481A009AE999 /* MissingDocsRule.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		7250948A1D0859260039B353 /* StatementPositionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725094881D0855760039B353 /* StatementPositionConfiguration.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
+		93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift */; };
 		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
 		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -61,7 +62,6 @@
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
-		DAD3BE481D66DF9200660239 /* GuardReturnsOnNewline.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE471D66DF9200660239 /* GuardReturnsOnNewline.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
 		E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA01B8A71DF00399043 /* Configuration.swift */; };
@@ -216,6 +216,7 @@
 		725094881D0855760039B353 /* StatementPositionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionConfiguration.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
+		93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewline.swift; sourceTree = "<group>"; };
 		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
 		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -244,7 +245,6 @@
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
-		DAD3BE471D66DF9200660239 /* GuardReturnsOnNewline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GuardReturnsOnNewline.swift; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
 		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
@@ -585,6 +585,7 @@
 				1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */,
 				E88DEA831B0990F500A66CB0 /* ColonRule.swift */,
 				695BE9CE1BDFD92B0071E985 /* CommaRule.swift */,
+				93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift */,
 				65454F451B14D73800319A6C /* ControlStatementRule.swift */,
 				3B1DF0111C5148140011BCED /* CustomRules.swift */,
 				2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */,
@@ -595,7 +596,6 @@
 				B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */,
 				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
 				2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */,
-				DAD3BE471D66DF9200660239 /* GuardReturnsOnNewline.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */,
 				006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */,
@@ -876,7 +876,6 @@
 				4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */,
 				6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */,
 				E881985C1BEA978500333A11 /* TrailingNewlineRule.swift in Sources */,
-				DAD3BE481D66DF9200660239 /* GuardReturnsOnNewline.swift in Sources */,
 				E881985E1BEA982100333A11 /* TypeBodyLengthRule.swift in Sources */,
 				69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */,
 				E849FF281BF9481A009AE999 /* MissingDocsRule.swift in Sources */,
@@ -924,6 +923,7 @@
 				E881985A1BEA96EA00333A11 /* OperatorFunctionWhitespaceRule.swift in Sources */,
 				3BCC04D21C4F56D3006073C3 /* NameConfiguration.swift in Sources */,
 				E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */,
+				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift in Sources */,
 				E88DEA771B098D0C00A66CB0 /* Rule.swift in Sources */,
 				7250948A1D0859260039B353 /* StatementPositionConfiguration.swift in Sources */,
 				E81619531BFC162C00946723 /* QueuedPrint.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -105,6 +105,10 @@ class RulesTests: XCTestCase {
         verifyRule(EmptyCountRule.description)
     }
 
+    func testGuardReturnsOnNewLines() {
+        verifyRule(GuardReturnsOnNewline.description)
+    }
+
     func testFileLength() {
         verifyRule(FileLengthRule.description, commentDoesntViolate: false)
     }

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -93,6 +93,10 @@ class RulesTests: XCTestCase {
         verifyRule(CommaRule.description)
     }
 
+    func testConditionalReturnsOnNewline() {
+        verifyRule(ConditionalReturnsOnNewline.description)
+    }
+
     func testControlStatement() {
         verifyRule(ControlStatementRule.description)
     }
@@ -103,10 +107,6 @@ class RulesTests: XCTestCase {
 
     func testEmptyCount() {
         verifyRule(EmptyCountRule.description)
-    }
-
-    func testGuardReturnsOnNewLines() {
-        verifyRule(GuardReturnsOnNewline.description)
     }
 
     func testFileLength() {


### PR DESCRIPTION
Added an opt-in rule to enforce that guard's must return on new lines separate from guard statement. Opt-in as it's purely stylistic but enforced at my place of work and seems to also follow Github's style convention as well. 