### PR TITLE
Allow private(set) on IBOutlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   [Daniel Beard](https://github.com/daniel-beard)
   [#764](https://github.com/realm/SwiftLint/issues/764)
 
+* Adds `allow_private_set` configuration for the `private_outlet` rule.  
+  [Rohan Dhaimade](https://github.com/HaloZero)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
@@ -10,7 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.Warning)
+    public var configuration = PrivateOutletRuleConfiguration(allowPrivateSet: false)
 
     public init() {}
 
@@ -47,8 +47,13 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
         // Check if private
         let accessibility = (dictionary["key.accessibility"] as? String) ?? ""
+        let setterAccesiblity = (dictionary["key.setter_accessibility"] as? String) ?? ""
         let isPrivate = accessibility == "source.lang.swift.accessibility.private"
-        guard !isPrivate else { return [] }
+        let isPrivateSet = setterAccesiblity == "source.lang.swift.accessibility.private"
+
+        if isPrivate || (self.configuration.allowPrivateSet && isPrivateSet) {
+            return []
+        }
 
         // Violation found!
         let location: Location
@@ -60,7 +65,7 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
         return [
             StyleViolation(ruleDescription: self.dynamicType.description,
-                severity: configuration.severity,
+                severity: configuration.severityConfiguration.severity,
                 location: location
             )
         ]

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -1,0 +1,39 @@
+//
+//  PrivateOutletRuleConfiguration
+//  SwiftLint
+//
+//  Created by Rohan Dhaimade on 24/08/2016.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+
+public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.Warning)
+    var allowPrivateSet = false
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription + ", allow_private_set: \(allowPrivateSet)"
+    }
+
+    public init(allowPrivateSet: Bool) {
+        self.allowPrivateSet = allowPrivateSet
+    }
+
+    public mutating func applyConfiguration(configuration: AnyObject) throws {
+        guard let configuration = configuration as? [String: AnyObject] else {
+            throw ConfigurationError.UnknownConfiguration
+        }
+
+        allowPrivateSet = (configuration["allow_private_set"] as? Bool == true)
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.applyConfiguration(severityString)
+        }
+    }
+}
+
+public func == (lhs: PrivateOutletRuleConfiguration,
+                rhs: PrivateOutletRuleConfiguration) -> Bool {
+    return lhs.allowPrivateSet == rhs.allowPrivateSet
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
+		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
 		E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA01B8A71DF00399043 /* Configuration.swift */; };
@@ -255,6 +256,7 @@
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
+		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
 		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
@@ -366,6 +368,7 @@
 			isa = PBXGroup;
 			children = (
 				3BCC04D01C4F56D3006073C3 /* NameConfiguration.swift */,
+				DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */,
 				B2902A0D1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift */,
 				3BB47D821C514E8100AE6A10 /* RegexConfiguration.swift */,
 				3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */,
@@ -904,6 +907,7 @@
 				E812249C1B04FADC001783D2 /* Linter.swift in Sources */,
 				1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */,
 				E81CDE711C00FEAA00B430F6 /* ValidDocsRule.swift in Sources */,
+				DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */,
 				2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */,
 				E87E4A091BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift in Sources */,
 				3B0B14541C505D6300BE82F7 /* SeverityConfiguration.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -184,6 +184,20 @@ class RulesTests: XCTestCase {
 
     func testPrivateOutlet() {
         verifyRule(PrivateOutletRule.description)
+
+        let baseDescription = PrivateOutletRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
+            "class Foo {\n  @IBOutlet private(set) var label: UILabel?\n}\n",
+            "class Foo {\n  @IBOutlet private(set) var label: UILabel!\n}\n",
+            "class Foo {\n  @IBOutlet weak private(set) var label: UILabel?\n}\n",
+            "class Foo {\n  @IBOutlet private(set) weak var label: UILabel?\n}\n"
+        ]
+        let description = RuleDescription(identifier: baseDescription.identifier,
+                                          name: baseDescription.name,
+                                          description: baseDescription.description,
+                                          nonTriggeringExamples: nonTriggeringExamples,
+                                          triggeringExamples: baseDescription.triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["allow_private_set": true])
     }
 
     func testPrivateUnitTest() {

--- a/Tests/SwiftLintFramework/TestHelpers.swift
+++ b/Tests/SwiftLintFramework/TestHelpers.swift
@@ -85,7 +85,7 @@ func makeConfig(ruleConfiguration: AnyObject?, _ identifier: String) -> Configur
     if let ruleConfiguration = ruleConfiguration, ruleType = masterRuleList.list[identifier] {
         // The caller has provided a custom configuration for the rule under test
         return (try? ruleType.init(configuration: ruleConfiguration)).flatMap { configuredRule in
-            return Configuration(configuredRules: [configuredRule])
+            return Configuration(whitelistRules: [identifier], configuredRules: [configuredRule])
         }
     }
     return Configuration(whitelistRules: [identifier])


### PR DESCRIPTION
Added a configuration to the ```private_outlet``` rule to allow for ```private(set)```. 

```private(set)``` can be useful. Sometimes you can have components that can expose their views for information retrieval, modification of components (say alpha transparency), or maybe setting callbacks on view components for later reuse but shouldn't allow their full write modification. 

I made it a configuration to allow people to control it or not, by default false as the rule is more specifically geared toward private outlets.

