### PR TITLE
Change `included` of `custom_rules` to  regular expression in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ following syntax:
 ```yaml
 custom_rules:
   pirates_beat_ninjas: # rule identifier
-    include: "*.swift" # regex that defines paths to include during linting. optional.
+    included: ".*.swift" # regex that defines paths to include during linting. optional.
     name: "Pirates Beat Ninjas" # rule name. optional.
     regex: "([n,N]inja)" # matching pattern
     match_kinds: # SyntaxKinds to match. optional.


### PR DESCRIPTION
Fix #794 and #795