### PR TITLE
Passing in severity configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fixed: `ConditionalReturnsOnNewline' now respects severity configuration.  
+  [Rohan Dhaimade](https://github.com/HaloZero)
+  [#783](https://github.com/realm/SwiftLint/issues/783)
 
 ## 0.12.0: Vertical Laundry
 

--- a/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
@@ -37,6 +37,7 @@ public struct ConditionalReturnsOnNewline: ConfigurationProviderRule, Rule, OptI
         let excludingKinds = SyntaxKind.commentAndStringKinds()
         return file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: self.configuration.severity,
                 location: Location(file: file, byteOffset: $0.location))
         }
     }


### PR DESCRIPTION
Just passing in the severity configuration for ConditionalReturnsOnNewline. 

I figure it might be useful to have a generic test rule for this but that might take a bit more work. 