### PR TITLE
Color literals count as single character towards line count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [Syo Ikeda](https://github.com/ikesyo)
 
+* Color literals count as single characters to avoid unintentional line length violations.
+  [Jonas](https://github.com/VFUC)
+  [#742](https://github.com/realm/SwiftLint/issues/742)
+
 ##### Bug Fixes
 
 * Fixed whitespace being added to TODO messages.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [Syo Ikeda](https://github.com/ikesyo)
 
-* Color literals count as single characters to avoid unintentional line length violations.
+* Color literals count as single characters to avoid unintentional line length violations.  
   [Jonas](https://github.com/VFUC)
   [#742](https://github.com/realm/SwiftLint/issues/742)
 

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -34,7 +34,24 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
             if line.range.length < minValue {
                 return nil
             }
-            let length = line.content.characters.count
+                        
+            var length = line.content.characters.count
+            
+            // Check if a color literal exists in the line by trying to get range
+            if let colorLiteralRangeStart = line.content.rangeOfString("#colorLiteral("),
+                let colorLiteralRangeEnd = line.content.rangeOfString(")",
+                    options: .LiteralSearch,
+                    range: colorLiteralRangeStart.startIndex..<line.content.endIndex,
+                    locale: nil) {
+                
+                // Range was found, get substring of color literal range
+                let colorLiteralContent = line.content.substringWithRange(colorLiteralRangeStart.startIndex..<colorLiteralRangeEnd.endIndex)
+                
+                // Reduce length so that literal only counts as one character
+                length = length - (colorLiteralContent.characters.count - 1)
+            }
+            
+            
             for param in configuration.params where length > param.value {
                 return StyleViolation(ruleDescription: self.dynamicType.description,
                     severity: param.severity,

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -34,24 +34,24 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
             if line.range.length < minValue {
                 return nil
             }
-                        
+
             var length = line.content.characters.count
-            
+
             // Check if a color literal exists in the line by trying to get range
-            if let colorLiteralRangeStart = line.content.rangeOfString("#colorLiteral("),
-                let colorLiteralRangeEnd = line.content.rangeOfString(")",
+            if let rangeStart = line.content.rangeOfString("#colorLiteral("),
+                let rangeEnd = line.content.rangeOfString(")",
                     options: .LiteralSearch,
-                    range: colorLiteralRangeStart.startIndex..<line.content.endIndex,
+                    range: rangeStart.startIndex..<line.content.endIndex,
                     locale: nil) {
-                
+
                 // Range was found, get substring of color literal range
-                let colorLiteralContent = line.content.substringWithRange(colorLiteralRangeStart.startIndex..<colorLiteralRangeEnd.endIndex)
-                
+                let range = rangeStart.startIndex..<rangeEnd.endIndex
+                let content = line.content.substringWithRange(range)
+
                 // Reduce length so that literal only counts as one character
-                length = length - (colorLiteralContent.characters.count - 1)
+                length = length - (content.characters.count - 1)
             }
-            
-            
+
             for param in configuration.params where length > param.value {
                 return StyleViolation(ruleDescription: self.dynamicType.description,
                     severity: param.severity,

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -83,8 +83,8 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
                 break
             }
         }
-        
+
         return modifiedString
     }
-    
+
 }

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -18,10 +18,12 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
         name: "Line Length",
         description: "Lines should not span too many characters.",
         nonTriggeringExamples: [
-            Repeat(count: 100, repeatedValue: "/").joinWithSeparator("") + "\n"
+            Repeat(count: 100, repeatedValue: "/").joinWithSeparator("") + "\n",
+            Repeat(count: 100, repeatedValue: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)").joinWithSeparator("") + "\n"
         ],
         triggeringExamples: [
-            Repeat(count: 101, repeatedValue: "/").joinWithSeparator("") + "\n"
+            Repeat(count: 101, repeatedValue: "/").joinWithSeparator("") + "\n",
+            Repeat(count: 101, repeatedValue: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)").joinWithSeparator("") + "\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -41,17 +41,17 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
             // While copy of content contains color literal, replace with a single character
             while string.containsString("#colorLiteral(") {
                 if let rangeStart = string.rangeOfString("#colorLiteral("),
-                let rangeEnd = string.rangeOfString(")",
-                    options: .LiteralSearch,
-                    range: rangeStart.startIndex..<string.endIndex,
-                    locale: nil) {
+                    let rangeEnd = string.rangeOfString(")",
+                        options: .LiteralSearch,
+                        range: rangeStart.startIndex..<string.endIndex,
+                        locale: nil) {
                     string.replaceRange(rangeStart.startIndex..<rangeEnd.endIndex, with: "#")
 
                 } else { // Should never be the case, but break to avoid accidental infinity loop
                     break
                 }
             }
-
+            
             let length = string.characters.count
 
             for param in configuration.params where length > param.value {

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -19,11 +19,13 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
         description: "Lines should not span too many characters.",
         nonTriggeringExamples: [
             Repeat(count: 100, repeatedValue: "/").joinWithSeparator("") + "\n",
-            Repeat(count: 100, repeatedValue: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)").joinWithSeparator("") + "\n"
+            Repeat(count: 100, repeatedValue: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)").joinWithSeparator("") + "\n",
+            Repeat(count: 100, repeatedValue: "#imageLiteral(resourceName: \"image.jpg\")").joinWithSeparator("") + "\n"
         ],
         triggeringExamples: [
             Repeat(count: 101, repeatedValue: "/").joinWithSeparator("") + "\n",
-            Repeat(count: 101, repeatedValue: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)").joinWithSeparator("") + "\n"
+            Repeat(count: 101, repeatedValue: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)").joinWithSeparator("") + "\n",
+            Repeat(count: 101, repeatedValue: "#imageLiteral(resourceName: \"image.jpg\")").joinWithSeparator("") + "\n"
         ]
     )
 
@@ -37,22 +39,13 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
                 return nil
             }
 
-            var string = line.content //Mutable copy of content string
-            // While copy of content contains color literal, replace with a single character
-            while string.containsString("#colorLiteral(") {
-                if let rangeStart = string.rangeOfString("#colorLiteral("),
-                    let rangeEnd = string.rangeOfString(")",
-                        options: .LiteralSearch,
-                        range: rangeStart.startIndex..<string.endIndex,
-                        locale: nil) {
-                    string.replaceRange(rangeStart.startIndex..<rangeEnd.endIndex, with: "#")
+            var strippedString = line.content
+            strippedString = stripLiterals(fromSourceString: strippedString,
+                withDelimiter: "#colorLiteral")
+            strippedString = stripLiterals(fromSourceString: strippedString,
+                withDelimiter: "#imageLiteral")
 
-                } else { // Should never be the case, but break to avoid accidental infinity loop
-                    break
-                }
-            }
-            
-            let length = string.characters.count
+            let length = strippedString.characters.count
 
             for param in configuration.params where length > param.value {
                 return StyleViolation(ruleDescription: self.dynamicType.description,
@@ -64,4 +57,34 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
             return nil
         }
     }
+
+    /// Takes a string and replaces any literals specified by the `delimiter` parameter with `#`
+    ///
+    /// - parameter sourceString: Original string, possibly containing literals
+    /// - parameter delimiter:    Delimiter of the literal
+    ///     (characters before the parentheses, e.g. `#colorLiteral`)
+    ///
+    /// - returns: sourceString with the given literals replaced by `#`
+    private func stripLiterals(fromSourceString sourceString: String,
+                                                withDelimiter delimiter: String) -> String {
+        var modifiedString = sourceString
+
+        // While copy of content contains literal, replace with a single character
+        while modifiedString.containsString("\(delimiter)(") {
+            if let rangeStart = modifiedString.rangeOfString("\(delimiter)("),
+                let rangeEnd = modifiedString.rangeOfString(")",
+                                                            options: .LiteralSearch,
+                                                            range:
+                    rangeStart.startIndex..<modifiedString.endIndex,
+                                                            locale: nil) {
+                modifiedString.replaceRange(rangeStart.startIndex..<rangeEnd.endIndex, with: "#")
+
+            } else { // Should never be the case, but break to avoid accidental infinity loop
+                break
+            }
+        }
+        
+        return modifiedString
+    }
+    
 }


### PR DESCRIPTION
Hey! Trying to work on issue #742 - I've added a check for an expanded color literal substring when counting line characters. If found, it subtracts the length of the substring (-1) from the total line length, so that a color literal only counts as a single character towards the line count rule. Feedback welcome 🙂 