### PR TITLE
Stop `make` if working tree does not have git repository

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,7 +8,7 @@ export SCRIPT_DIR=$(dirname "$0")
 
 main ()
 {
-    local submodules=$(git submodule status)
+    submodules=$(git submodule status)
     local result=$?
 
     if [ "$result" -ne "0" ]


### PR DESCRIPTION
Fix https://github.com/jpsim/SourceKitten/issues/262
See also: https://github.com/jspahrsummers/objc-build-scripts/issues/13