### PR TITLE
Fix `SourceKitCrashTests` randomly failed

### DIFF
--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -68,7 +68,7 @@ private struct Cache<T> {
 extension File {
 
     private var cacheKey: String {
-        return path ?? "\(ObjectIdentifier(self).hashValue)"
+        return path ?? contents
     }
 
     internal var sourcekitdFailed: Bool {


### PR DESCRIPTION
Sometime `ObjectIdentifier(self)` might collide between tests in `SourceKitCrashTests`.
The collision caused fail on `testAssertHandlerIsNotCalledOnNormalFile`.

Reproduced log with printing `cacheKey`:
```terminal.session
Test Suite 'SourceKitCrashTests' started at 2016-10-11 20:54:42.627
Test Case '-[SwiftLintFrameworkTests.SourceKitCrashTests testAssertHandlerIsCalledOnFileThatCrashedSourceKitService]' started.
set: cacheKey: 140575074796400
get: cacheKey: 140575074796400
get: cacheKey: 140575074796400
get: cacheKey: 140575074796400
Test Case '-[SwiftLintFrameworkTests.SourceKitCrashTests testAssertHandlerIsCalledOnFileThatCrashedSourceKitService]' passed (0.003 seconds).
Test Case '-[SwiftLintFrameworkTests.SourceKitCrashTests testAssertHandlerIsNotCalledOnNormalFile]' started.
set: cacheKey: 140575074796400
get: cacheKey: 140575074796400
/Users/norio/github/SwiftLint/Tests/SwiftLintFramework/SourceKitCrashTests.swift:24: error: -[SwiftLintFrameworkTests.SourceKitCrashTests testAssertHandlerIsNotCalledOnNormalFile] : XCTAssertFalse failed - Expects assert handler was not called on accessing File.structure
get: cacheKey: 140575074796400
/Users/norio/github/SwiftLint/Tests/SwiftLintFramework/SourceKitCrashTests.swift:29: error: -[SwiftLintFrameworkTests.SourceKitCrashTests testAssertHandlerIsNotCalledOnNormalFile] : XCTAssertFalse failed - Expects assert handler was not called on accessing File.syntaxMap
get: cacheKey: 140575074796400
/Users/norio/github/SwiftLint/Tests/SwiftLintFramework/SourceKitCrashTests.swift:34: error: -[SwiftLintFrameworkTests.SourceKitCrashTests testAssertHandlerIsNotCalledOnNormalFile] : XCTAssertFalse failed - Expects assert handler was not called on accessing File.syntaxKindsByLines
Test Case '-[SwiftLintFrameworkTests.SourceKitCrashTests testAssertHandlerIsNotCalledOnNormalFile]' failed (0.007 seconds).
Test Case '-[SwiftLintFrameworkTests.SourceKitCrashTests testRulesWithFileThatCrashedSourceKitService]' started.
set: cacheKey: /Users/norio/github/SwiftLint/Tests/SwiftLintFramework/SourceKitCrashTests.swift
Most of rules are skipped because sourcekitd fails.
Test Case '-[SwiftLintFrameworkTests.SourceKitCrashTests testRulesWithFileThatCrashedSourceKitService]' passed (0.002 seconds).
Test Suite 'SourceKitCrashTests' failed at 2016-10-11 20:54:42.646.
	 Executed 3 tests, with 3 failures (0 unexpected) in 0.012 (0.018) seconds
```