### PR TITLE
Improve failing log output of tests

### DIFF
--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -39,9 +39,13 @@ class IntegrationTests: XCTestCase {
 
     func testSwiftLintAutoCorrects() {
         let swiftFiles = config.lintableFilesForPath("")
-        XCTAssertEqual(swiftFiles.flatMap({
-            Linter(file: $0, configuration: config).correct()
-        }), [])
+        let corrections = swiftFiles.flatMap { Linter(file: $0, configuration: config).correct() }
+        for correction in corrections {
+            correction.location.file!.withStaticString {
+                XCTFail(correction.ruleDescription.description,
+                        file: $0, line: UInt(correction.location.line!))
+            }
+        }
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -169,7 +169,8 @@ extension XCTestCase {
 
             // Assert locations missing vaiolation
             let violatedLocations = triggerViolations.map { $0.location }
-            let locationsWithoutViolation = expectedLocations.filter { !violatedLocations.contains($0) }
+            let locationsWithoutViolation = expectedLocations
+                .filter { !violatedLocations.contains($0) }
             if !locationsWithoutViolation.isEmpty {
                 XCTFail("triggeringExample did not violate at expected location: \n" +
                     "\(render(locations: locationsWithoutViolation, in: cleanTrigger))")

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -132,6 +132,7 @@ extension XCTestCase {
             XCTFail("nonTriggeringExample violated: \n\(nonTriggerWithViolations)")
         }
 
+        // Triggering examples violate
         var violationsCount = 0
         var expectedViolationsCount = 0
         for trigger in triggers {
@@ -142,6 +143,9 @@ extension XCTestCase {
             // Triggering examples with violation markers violate at the marker's location
             let (cleanTrigger, markerOffsets) = cleanedContentsAndMarkerOffsets(from: trigger)
             if markerOffsets.isEmpty {
+                if triggerViolations.isEmpty {
+                    XCTFail("triggeringExample did not violate: \n```\n\(trigger)\n```")
+                }
                 expectedViolationsCount += 1
                 continue
             }
@@ -154,7 +158,6 @@ extension XCTestCase {
                                "'\(trigger)' violation didn't match expected location.")
             }
         }
-        // Triggering examples violate
         XCTAssertEqual(violationsCount, expectedViolationsCount)
 
         // Comment doesn't violate

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -34,7 +34,7 @@ private func cleanedContentsAndMarkerOffsets(from contents: String) -> (String, 
     return (contents as String, markerOffsets.sorted())
 }
 
-func render(violations: [StyleViolation], in contents: String) -> String {
+private func render(violations: [StyleViolation], in contents: String) -> String {
     var contents = (contents as NSString).lines().map { $0.content }
     for violation in violations.sorted(by: { $0.location > $1.location }) {
         guard let line = violation.location.line,
@@ -54,7 +54,7 @@ func render(violations: [StyleViolation], in contents: String) -> String {
     return (["```"] + contents + ["```"]).joined(separator: "\n")
 }
 
-func render(locations: [Location], in contents: String) -> String {
+private func render(locations: [Location], in contents: String) -> String {
     var contents = (contents as NSString).lines().map { $0.content }
     for location in locations.sorted(by: > ) {
         guard let line = location.line, let character = location.character else { continue }

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -152,6 +152,15 @@ extension XCTestCase {
             expectedViolationsCount += markerOffsets.count
             let file = File(contents: cleanTrigger)
             let expectedLocations = markerOffsets.map { Location(file: file, characterOffset: $0) }
+
+            // Assert violations on unexpected location
+            let violationsAtUnexpectedLocation = triggerViolations
+                .filter { !expectedLocations.contains($0.location) }
+            if !violationsAtUnexpectedLocation.isEmpty {
+                XCTFail("triggeringExample violate at unexpected location: \n" +
+                    "\(render(violations: violationsAtUnexpectedLocation, in: trigger))")
+            }
+
             XCTAssertEqual(triggerViolations.count, expectedLocations.count)
             for (triggerViolation, expectedLocation) in zip(triggerViolations, expectedLocations) {
                 XCTAssertEqual(triggerViolation.location, expectedLocation,

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -145,23 +145,17 @@ extension XCTestCase {
         }
 
         // Triggering examples violate
-        var violationsCount = 0
-        var expectedViolationsCount = 0
         for trigger in triggers {
-            let triggerViolations = violations(trigger, config: config).sorted {
-                $0.location < $1.location
-            }
-            violationsCount += triggerViolations.count
+            let triggerViolations = violations(trigger, config: config)
+
             // Triggering examples with violation markers violate at the marker's location
             let (cleanTrigger, markerOffsets) = cleanedContentsAndMarkerOffsets(from: trigger)
             if markerOffsets.isEmpty {
                 if triggerViolations.isEmpty {
                     XCTFail("triggeringExample did not violate: \n```\n\(trigger)\n```")
                 }
-                expectedViolationsCount += 1
                 continue
             }
-            expectedViolationsCount += markerOffsets.count
             let file = File(contents: cleanTrigger)
             let expectedLocations = markerOffsets.map { Location(file: file, characterOffset: $0) }
 
@@ -172,6 +166,7 @@ extension XCTestCase {
                 XCTFail("triggeringExample violate at unexpected location: \n" +
                     "\(render(violations: violationsAtUnexpectedLocation, in: trigger))")
             }
+
             // Assert locations missing vaiolation
             let violatedLocations = triggerViolations.map { $0.location }
             let locationsWithoutViolation = expectedLocations.filter { !violatedLocations.contains($0) }
@@ -186,7 +181,6 @@ extension XCTestCase {
                                "'\(trigger)' violation didn't match expected location.")
             }
         }
-        XCTAssertEqual(violationsCount, expectedViolationsCount)
 
         // Comment doesn't violate
         XCTAssertEqual(


### PR DESCRIPTION
On debugging failing tests, I did adhoc improvements sometime. But now, I think it should be implemented that properly.
## 

This depends on #832 
- Assert on each correction of `testSwiftLintAutoCorrects()`
- Produce detailed log of generated violations from `nonTriggeringExamples` : 

> /Users/norio/github/SwiftLint/Tests/SwiftLintFramework/TestHelpers.swift:136: error: -[SwiftLintFrameworkTests.RulesTests testMissingDocs] : failed - nonTriggeringExample violated:
> 
> ```
> /// docs
> public func a() {}
>        ^ warning: Missing Docs Violation: Public declarations should be documented. (missing_docs)
> ```
- Produce detailed log when triggeringExample without expected location does not violate:

> /Users/norio/github/SwiftLint/Tests/SwiftLintFramework/TestHelpers.swift:159: error: -[SwiftLintFrameworkTests.RulesTests testValidDocs] : failed - triggeringExample did not violate:
> 
> ```
> /// docs
> public func no() -> (Int, Int) {return (1, 2)}
> ```
- Produce detailed log when triggeringExample violated at unexpected location:

> /Users/norio/github/SwiftLint/Tests/SwiftLintFramework/TestHelpers.swift:173: error: -[SwiftLintFrameworkTests.RulesTests testMissingDocs] : failed - triggeringExample violate at unexpected location:
> 
> ```
> public func a↓() {}
>        ^ warning: Missing Docs Violation: Public declarations should be documented. (missing_docs)
> ```
- Produce detailed log when expected location of triggeringExample is not violated at:

> /Users/norio/github/SwiftLint/Tests/SwiftLintFramework/TestHelpers.swift:180: error: -[SwiftLintFrameworkTests.RulesTests testMissingDocs] : failed - triggeringExample did not violate at expected location:
> 
> ```
> public func a↓() {}
> ```
- Remove surplus assertions from triggeringExamples:
  - Comparing total count of violations and expected locations from all triggering examples
  - Comparing count of violations and expected locations on each triggering examples
  - Order based comparison between violations and expected locations
