### PR TITLE
Validates if "return" in ConditionalReturnsOnNewline is a keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@
 * Fixed: `ConditionalReturnsOnNewline' now respects severity configuration.  
   [Rohan Dhaimade](https://github.com/HaloZero)
   [#783](https://github.com/realm/SwiftLint/issues/783)
+  
+* Fixed: `ConditionalReturnsOnNewline' now checks if `return` is a keyword,
+  avoiding false positives.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#784](https://github.com/realm/SwiftLint/issues/784)
 
 ## 0.12.0: Vertical Laundry
 

--- a/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
@@ -51,7 +51,7 @@ public struct ConditionalReturnsOnNewline: ConfigurationProviderRule, Rule, OptI
         }.map {
             StyleViolation(ruleDescription: self.dynamicType.description,
                 severity: self.configuration.severity,
-                location: Location(file: file, byteOffset: $0.0.location))
+                location: Location(file: file, characterOffset: $0.0.location))
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/784

I haven't found a better way to get a token's string than using `NSString.substringWithRange`, so I might be missing something.