### PR TITLE
Add SwitchCaseOnNewline rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   violations.  
   [Jonas](https://github.com/VFUC)
   [#742](https://github.com/realm/SwiftLint/issues/742)
+  
+* Add `SwitchCaseOnNewlineRule' opt-in rule that enforces a newline after
+  `case pattern:` in a `switch`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#681](https://github.com/realm/SwiftLint/issues/681)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -71,6 +71,7 @@ public let masterRuleList = RuleList(rules:
     RedundantNilCoalesingRule.self,
     ReturnArrowWhitespaceRule.self,
     StatementPositionRule.self,
+    SwitchCaseOnNewlineRule.self,
     TodoRule.self,
     TrailingNewlineRule.self,
     TrailingSemicolonRule.self,

--- a/Source/SwiftLintFramework/Rules/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseOnNewlineRule.swift
@@ -1,0 +1,60 @@
+//
+//  SwitchCaseOnNewlineRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 10/15/2016.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct SwitchCaseOnNewlineRule: ConfigurationProviderRule, Rule, OptInRule {
+    public let configurationDescription = "N/A"
+    public var configuration = SeverityConfiguration(.Warning)
+
+    public init() { }
+
+    public static let description = RuleDescription(
+        identifier: "switch_case_on_newline",
+        name: "Switch Case on Newline",
+        description: "Cases inside a switch should always be on a newline",
+        nonTriggeringExamples: [
+            "case 1:\n return true",
+            "default:\n return true",
+            "case let value:\n return true",
+            "/*case 1: */return true",
+            "//case 1:\n return true",
+            "let x = [caseKey: value]",
+            "let x = [key: .default]"
+        ],
+        triggeringExamples: [
+            "case 1: return true",
+            "case let value: return true",
+            "default: return true",
+            "case \"a string\": return false"
+        ]
+    )
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        let pattern = "(case[^\n]*|default):[^\\S\n]*[^\n]+"
+        return file.rangesAndTokensMatching(pattern).filter { range, tokens in
+            guard let firstToken = tokens.first
+                where SyntaxKind(rawValue: firstToken.type) == .Keyword else {
+                    return false
+            }
+
+            let tokenString = contentForToken(firstToken, file: file)
+            return ["case", "default"].contains(tokenString)
+        }.map {
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: self.configuration.severity,
+                location: Location(file: file, byteOffset: $0.0.location))
+        }
+    }
+
+    private func contentForToken(token: SyntaxToken, file: File) -> String {
+        return file.contents.substringWithByteRange(start: token.offset,
+                                                    length: token.length) ?? ""
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
+		D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
@@ -256,6 +257,7 @@
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
+		D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
 				3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */,
 				692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */,
+				D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */,
 				E88DEA811B0990A700A66CB0 /* TodoRule.swift */,
 				E88DEA871B09924C00A66CB0 /* TrailingNewlineRule.swift */,
 				E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */,
@@ -947,6 +950,7 @@
 				85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */,
 				3BCC04D21C4F56D3006073C3 /* NameConfiguration.swift in Sources */,
 				B2902A0E1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift in Sources */,
+				D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */,
 				E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */,
 				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift in Sources */,
 				E88DEA771B098D0C00A66CB0 /* Rule.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -221,6 +221,10 @@ class RulesTests: XCTestCase {
         verifyRule(StatementPositionRule.uncuddledDescription, ruleConfiguration: configuration)
     }
 
+    func testSwitchCaseOnNewline() {
+        verifyRule(SwitchCaseOnNewlineRule.description)
+    }
+
     func testTodo() {
         verifyRule(TodoRule.description, commentDoesntViolate: false)
     }


### PR DESCRIPTION
This fixes https://github.com/realm/SwiftLint/issues/681

I actually haven't checked if the code is inside a `switch`, ~~so this is currently triggering a false positive: `if let case .someEnum(value) = aFunction([key: 2]) {`.~~

~~I thought about checking if `case` is the first keyword in the line instead of checking if it's inside a `switch`, as I think the later is trickier. Thoughts?~~

Update: I added a check to see if `case` is the first keyword in the line