### PR TITLE
Adding ValidIBInspectableRule rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
   `case pattern:` in a `switch`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#681](https://github.com/realm/SwiftLint/issues/681)
+  
+* Add `ValidIBInspectableRule` rule that checks if `@IBInspectable` declarations
+  are valid. An `@IBInspectable` is valid if:
+  * It's declared as a `var` (not `let`)
+  * Its type is explicit (not inferred)
+  * Its type is one of the 
+  [supported types](http://help.apple.com/xcode/mac/8.0/#/devf60c1c514)  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#756](https://github.com/realm/SwiftLint/issues/756)  
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   * Its type is explicit (not inferred)
   * Its type is one of the 
   [supported types](http://help.apple.com/xcode/mac/8.0/#/devf60c1c514)  
+
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#756](https://github.com/realm/SwiftLint/issues/756)  
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -79,6 +79,7 @@ public let masterRuleList = RuleList(rules:
     TypeBodyLengthRule.self,
     TypeNameRule.self,
     ValidDocsRule.self,
+    ValidIBInspectableRule.self,
     VariableNameRule.self,
     VerticalWhitespaceRule.self
 )

--- a/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
@@ -11,6 +11,7 @@ import SourceKittenFramework
 
 public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.Warning)
+    private static let supportedTypes = ValidIBInspectableRule.createSupportedTypes()
 
     public init() {}
 
@@ -58,21 +59,21 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
         }
 
         // if key.setter_accessibility is nil, it's a `let` declaration
-        if dictionary["key.setter_accessibility"] as? String == nil {
+        if dictionary["key.setter_accessibility"] == nil {
             return violation(dictionary, file: file)
         }
 
         // Variable should have explicit type or IB won't recognize it
         // Variable should be of one of the supported types
         guard let type = dictionary["key.typename"] as? String
-            where supportedTypes().contains(type) else {
+            where ValidIBInspectableRule.supportedTypes.contains(type) else {
                 return violation(dictionary, file: file)
         }
 
         return []
     }
 
-    private func supportedTypes() -> [String] {
+    private static func createSupportedTypes() -> [String] {
         // "You can add the IBInspectable attribute to any property in a class declaration,
         // class extension, or category of type: boolean, integer or floating point number, string,
         // localized string, rectangle, point, size, color, range, and nil."

--- a/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
@@ -1,0 +1,130 @@
+//
+//  ValidIBInspectableRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 10/20/2016.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.Warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "valid_ibinspectable",
+        name: "Valid IBInspectable",
+        description: "@IBInspectable should be applied to variables only, have its type explicit " +
+        "and be of a supported type",
+        nonTriggeringExamples: [
+            "class Foo {\n  @IBInspectable private var x: Int\n}\n",
+            "class Foo {\n  @IBInspectable private var x: String?\n}\n",
+            "class Foo {\n  @IBInspectable private var x: String!\n}\n",
+            "class Foo {\n  @IBInspectable private var x: ImplicitlyUnwrappedOptional<String>\n}\n",
+            "class Foo {\n  @IBInspectable private var x: Optional<String>\n}\n",
+            "class Foo {\n  @IBInspectable private var count: Int = 0\n}\n",
+            "class Foo {\n  private var notInspectable = 0\n}\n",
+            "class Foo {\n  private let notInspectable: Int\n}\n",
+        ],
+        triggeringExamples: [
+            "class Foo {\n  @IBInspectable private let count: Int\n}\n",
+            "class Foo {\n  @IBInspectable private var insets: UIEdgeInsets\n}\n",
+            "class Foo {\n  @IBInspectable private var count = 0\n}\n",
+            "class Foo {\n  @IBInspectable private var count: Int?\n}\n",
+            "class Foo {\n  @IBInspectable private var count: Int!\n}\n",
+            "class Foo {\n  @IBInspectable private var x: ImplicitlyUnwrappedOptional<Int>\n}\n",
+            "class Foo {\n  @IBInspectable private var count: Optional<Int>\n}\n",
+        ]
+    )
+
+    public func validateFile(file: File,
+                             kind: SwiftDeclarationKind,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+
+        guard kind == .VarInstance else {
+            return []
+        }
+
+        // Check if IBInspectable
+        let attributes = (dictionary["key.attributes"] as? [SourceKitRepresentable])?
+            .flatMap({ ($0 as? [String: SourceKitRepresentable]) as? [String: String] })
+            .flatMap({ $0["key.attribute"] }) ?? []
+        let isIBInspectable = attributes.contains("source.decl.attribute.ibinspectable")
+        guard isIBInspectable else {
+            return []
+        }
+
+        // if key.setter_accessibility is nil, it's a `let` declaration
+        if dictionary["key.setter_accessibility"] as? String == nil {
+            return violation(dictionary, file: file)
+        }
+
+        // Variable should have explicit type or IB won't recognize it
+        // Variable should be of one of the supported types
+        guard let type = dictionary["key.typename"] as? String
+            where supportedTypes().contains(type) else {
+                return violation(dictionary, file: file)
+        }
+
+        return []
+    }
+
+    private func supportedTypes() -> [String] {
+        // "You can add the IBInspectable attribute to any property in a class declaration,
+        // class extension, or category of type: boolean, integer or floating point number, string,
+        // localized string, rectangle, point, size, color, range, and nil."
+        //
+        // from http://help.apple.com/xcode/mac/8.0/#/devf60c1c514
+
+        let referenceTypes = [
+            "String",
+            "NSString",
+            "UIColor",
+            "NSColor",
+            "UIImage",
+            "NSImage",
+            "NSNumber"
+        ]
+
+        let types = [
+            "Int",
+            "CGFloat",
+            "Float",
+            "Double",
+            "Bool",
+            "CGPoint",
+            "NSPoint",
+            "CGSize",
+            "NSSize",
+            "CGRect",
+            "NSRect"
+        ]
+
+        // It seems that only reference types can be used as ImplicitlyUnwrappedOptional or Optional
+        return referenceTypes.flatMap {
+            [$0, $0 + "!", $0 + "?",
+            "ImplicitlyUnwrappedOptional<\($0)>", "Optional<\($0)>"] + types
+        }
+    }
+
+    private func violation(dictionary: [String: SourceKitRepresentable],
+                           file: File) -> [StyleViolation] {
+
+        let location: Location
+        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+            location = Location(file: file, byteOffset: offset)
+        } else {
+            location = Location(file: file.path)
+        }
+
+        return [
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: configuration.severity,
+                location: location
+            )
+        ]
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
+		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
 		D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
@@ -256,6 +257,7 @@
 		D0D1217D19E87B05005E4BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
+		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
 		D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
@@ -637,6 +639,7 @@
 				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
 				E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */,
+				D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */,
 				E88DEA931B099C0900A66CB0 /* VariableNameRule.swift */,
 				1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */,
 			);
@@ -947,6 +950,7 @@
 				2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */,
 				E86396C91BADB2B9002C9E88 /* JSONReporter.swift in Sources */,
 				E881985A1BEA96EA00333A11 /* OperatorFunctionWhitespaceRule.swift in Sources */,
+				D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */,
 				85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */,
 				3BCC04D21C4F56D3006073C3 /* NameConfiguration.swift in Sources */,
 				B2902A0E1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -267,6 +267,10 @@ class RulesTests: XCTestCase {
         verifyRule(ValidDocsRule.description)
     }
 
+    func testValidIBInspectable() {
+        verifyRule(ValidIBInspectableRule.description)
+    }
+
     func testVariableName() {
         verifyRule(VariableNameRule.description)
     }


### PR DESCRIPTION
Fixes #756 

Add `ValidIBInspectableRule` rule that checks if `@IBInspectable` declarations
  are valid. An `@IBInspectable` is valid if:
- It's declared as a `var` (not `let`)
- Its type is explicit (not inferred)
- Its type is one of the 
  [supported types](http://help.apple.com/xcode/mac/8.0/#/devf60c1c514)
