### PR TITLE
Adding SyntacticSugar rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@
   [Matt Taube](https://github.com/mtaube)
   [#715](https://github.com/realm/SwiftLint/pull/715)
 
+* Add `SyntacticSugar` rule that enforces that shorthanded syntax should be
+  used when possible, for example `[Int]` instead of `Array<Int>`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#319](https://github.com/realm/SwiftLint/issues/319)
+
+
 ##### Bug Fixes
 
 * Fixed whitespace being added to TODO messages.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ##### Enhancements
 
-* None.
+* Add `SyntacticSugar` rule that enforces that shorthanded syntax should be
+  used when possible, for example `[Int]` instead of `Array<Int>`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#319](https://github.com/realm/SwiftLint/issues/319)
 
 ##### Bug Fixes
 
@@ -70,12 +73,6 @@
   directly.  
   [Matt Taube](https://github.com/mtaube)
   [#715](https://github.com/realm/SwiftLint/pull/715)
-
-* Add `SyntacticSugar` rule that enforces that shorthanded syntax should be
-  used when possible, for example `[Int]` instead of `Array<Int>`.  
-  [Marcelo Fabri](https://github.com/marcelofabri)
-  [#319](https://github.com/realm/SwiftLint/issues/319)
-
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -78,7 +78,8 @@ extension File {
         }
         set {
             if newValue {
-                responseCache.values[cacheKey] = Optional<[String: SourceKitRepresentable]>.None
+                let value: [String: SourceKitRepresentable]? = nil
+                responseCache.values[cacheKey] = value
             } else {
                 responseCache.values.removeValueForKey(cacheKey)
             }

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -75,6 +75,7 @@ public let masterRuleList = RuleList(rules:
     StatementPositionRule.self,
     OverridenSuperCallRule.self,
     SwitchCaseOnNewlineRule.self,
+    SyntacticSugarRule.self,
     TodoRule.self,
     TrailingNewlineRule.self,
     TrailingSemicolonRule.self,

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -1,0 +1,55 @@
+//
+//  SyntacticSugarRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 21/10/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+import Foundation
+
+public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.Warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "syntactic_sugar",
+        name: "Syntactic Sugar",
+        description: "Shorthand syntactic sugar should be used, i.e. [Int] instead of Array<Int>",
+        nonTriggeringExamples: [
+            "let x: [Int]",
+            "let x: [Int: String]",
+            "let x: Int?",
+            "func x(a: [Int], b: Int) -> [Int: Any]",
+            "let x: Int!",
+            "extension Array { \n func x() { } \n }",
+            "extension Dictionary { \n func x() { } \n }",
+            "let x: CustomArray<String>"
+        ],
+        triggeringExamples: [
+            "let x: ↓Array<String>",
+            "let x: ↓Dictionary<Int, String>",
+            "let x: ↓Optional<Int>",
+            "let x: ↓ImplicitlyUnwrappedOptional<Int>",
+            "func x(a: ↓Array<Int>, b: Int) -> [Int: Any]",
+            "func x(a: [Int], b: Int) -> ↓Dictionary<Int, String>",
+            "func x(a: ↓Array<Int>, b: Int) -> ↓Dictionary<Int, String>",
+        ]
+    )
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        let types = ["Optional", "ImplicitlyUnwrappedOptional", "Array", "Dictionary"]
+
+        let pattern = "\\b(" + types.joinWithSeparator("|") + ")\\b\\s*<.*?>"
+
+        return file.matchPattern(pattern,
+            excludingSyntaxKinds: SyntaxKind.commentAndStringKinds()).map {
+                StyleViolation(ruleDescription: self.dynamicType.description,
+                    severity: configuration.severity,
+                    location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+
+}

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -42,7 +42,7 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
     public func validateFile(file: File) -> [StyleViolation] {
         let types = ["Optional", "ImplicitlyUnwrappedOptional", "Array", "Dictionary"]
 
-        let pattern = "\\b(" + types.joinWithSeparator("|") + ")\\b\\s*<.*?>"
+        let pattern = "\\b(" + types.joinWithSeparator("|") + ")\\s*<.*?>"
 
         return file.matchPattern(pattern,
             excludingSyntaxKinds: SyntaxKind.commentAndStringKinds()).map {

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
+		D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
 		D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
@@ -268,6 +269,7 @@
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
+		D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyntacticSugarRule.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
 		D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
@@ -647,6 +649,7 @@
 				3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */,
 				692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */,
 				D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */,
+				D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */,
 				E88DEA811B0990A700A66CB0 /* TodoRule.swift */,
 				E88DEA871B09924C00A66CB0 /* TrailingNewlineRule.swift */,
 				E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */,
@@ -948,6 +951,7 @@
 				E8B67C3E1C095E6300FDED8E /* Correction.swift in Sources */,
 				E88198531BEA944400333A11 /* LineLengthRule.swift in Sources */,
 				E847F0A91BFBBABD00EA9363 /* EmptyCountRule.swift in Sources */,
+				D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */,
 				E88198441BEA93D200333A11 /* ColonRule.swift in Sources */,
 				E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */,
 				E8EA41171C2D1DBE004F9930 /* CheckstyleReporter.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -233,6 +233,10 @@ class RulesTests: XCTestCase {
         verifyRule(SwitchCaseOnNewlineRule.description)
     }
 
+    func testSyntacticSugar() {
+        verifyRule(SyntacticSugarRule.description)
+    }
+
     func testTodo() {
         verifyRule(TodoRule.description, commentDoesntViolate: false)
     }


### PR DESCRIPTION
I've implemented the "Syntactic Sugar" from https://github.com/raywenderlich/swift-style-guide#syntactic-sugar (also mentioned in #319).

It should be easy to make this rule correctable, but I think it's better to do that on a later PR.

Also, should this be opt-in? (It's not currently) 
