### PR TITLE
Add configuration for trailing_whitespace to ignore comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ##### Enhancements
 
+* Add `ignores_comment` configuration for `trailing_whitespace` rule.  
+  [Javier Hernández](https://github.com/jaherhi)
+  [#576](https://github.com/realm/SwiftLint/issues/576)
+
 * Added HTML reporter, identifier is `html`.  
   [Johnykutty Mathew](https://github.com/Johnykutty)
   

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -30,20 +30,6 @@ extension String {
         return self == lowercaseString
     }
 
-    internal func isComment() -> Bool {
-        guard !isEmpty else {
-            return false
-        }
-
-        let trimmedString = stringByTrimmingCharactersInSet(.whitespaceAndNewlineCharacterSet())
-
-        guard trimmedString.characters.count > 1 else {
-            return false
-        }
-        let substring = trimmedString.substring(0, length: 2)
-        return substring == "//"
-    }
-
     internal func nameStrippingLeadingUnderscoreIfPrivate(dict: [String: SourceKitRepresentable]) ->
                                                           String {
         let privateACL = "source.lang.swift.accessibility.private"

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -30,6 +30,20 @@ extension String {
         return self == lowercaseString
     }
 
+    internal func isComment() -> Bool {
+        guard !isEmpty else {
+            return false
+        }
+
+        let trimmedString = stringByTrimmingCharactersInSet(.whitespaceAndNewlineCharacterSet())
+
+        guard trimmedString.characters.count > 1 else {
+            return false
+        }
+        let substring = trimmedString.substring(0, length: 2)
+        return substring == "//"
+    }
+
     internal func nameStrippingLeadingUnderscoreIfPrivate(dict: [String: SourceKitRepresentable]) ->
                                                           String {
         let privateACL = "source.lang.swift.accessibility.private"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -11,14 +11,17 @@ import Foundation
 public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.Warning)
     var ignoresEmptyLines = false
+    var ignoresComments = true
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription +
-            ", ignores_empty_lines: \(ignoresEmptyLines)"
+            ", ignores_empty_lines: \(ignoresEmptyLines)" +
+            ", ignores_comments: \(ignoresComments)"
     }
 
-    public init(ignoresEmptyLines: Bool) {
+    public init(ignoresEmptyLines: Bool, ignoresComments: Bool) {
         self.ignoresEmptyLines = ignoresEmptyLines
+        self.ignoresComments = ignoresComments
     }
 
     public mutating func applyConfiguration(configuration: AnyObject) throws {
@@ -27,6 +30,7 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
         }
 
         ignoresEmptyLines = (configuration["ignores_empty_lines"] as? Bool == true)
+        ignoresComments = (configuration["ignores_comments"] as? Bool == true)
 
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.applyConfiguration(severityString)
@@ -36,5 +40,6 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
 
 public func == (lhs: TrailingWhitespaceConfiguration,
                 rhs: TrailingWhitespaceConfiguration) -> Bool {
-    return lhs.ignoresEmptyLines == rhs.ignoresEmptyLines
+    return lhs.ignoresEmptyLines == rhs.ignoresEmptyLines &&
+        lhs.ignoresComments == rhs.ignoresComments
 }

--- a/Tests/SwiftLintFramework/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFramework/RuleConfigurationTests.swift
@@ -132,22 +132,36 @@ class RuleConfigurationsTests: XCTestCase {
 
     func testTrailingWhitespaceConfigurationThrowsOnBadConfig() {
         let config = "unknown"
-        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                            ignoresComments: true)
         checkError(ConfigurationError.UnknownConfiguration) {
             try configuration.applyConfiguration(config)
         }
     }
 
     func testTrailingWhitespaceConfigurationInitializerSetsIgnoresEmptyLines() {
-        let configuration1 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        let configuration1 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                             ignoresComments: true)
         XCTAssertFalse(configuration1.ignoresEmptyLines)
 
-        let configuration2 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true)
+        let configuration2 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true,
+                                                             ignoresComments: true)
         XCTAssertTrue(configuration2.ignoresEmptyLines)
     }
 
+    func testTrailingWhitespaceConfigurationInitializerSetsIgnoresComments() {
+        let configuration1 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                             ignoresComments: true)
+        XCTAssertTrue(configuration1.ignoresComments)
+
+        let configuration2 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                             ignoresComments: false)
+        XCTAssertFalse(configuration2.ignoresComments)
+    }
+
     func testTrailingWhitespaceConfigurationApplyConfigurationSetsIgnoresEmptyLines() {
-        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                            ignoresComments: true)
         do {
             let config1 = ["ignores_empty_lines": true]
             try configuration.applyConfiguration(config1)
@@ -161,17 +175,47 @@ class RuleConfigurationsTests: XCTestCase {
         }
     }
 
+    func testTrailingWhitespaceConfigurationApplyConfigurationSetsIgnoresComments() {
+        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                            ignoresComments: true)
+        do {
+            let config1 = ["ignores_comments": true]
+            try configuration.applyConfiguration(config1)
+            XCTAssertTrue(configuration.ignoresComments)
+
+            let config2 = ["ignores_comments": false]
+            try configuration.applyConfiguration(config2)
+            XCTAssertFalse(configuration.ignoresComments)
+        } catch {
+            XCTFail()
+        }
+    }
+
     func testTrailingWhitespaceConfigurationCompares() {
-        let configuration1 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
-        let configuration2 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true)
+        let configuration1 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                             ignoresComments: true)
+        let configuration2 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true,
+                                                             ignoresComments: true)
         XCTAssertFalse(configuration1 == configuration2)
 
-        let configuration3 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true)
+        let configuration3 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true,
+                                                             ignoresComments: true)
         XCTAssertTrue(configuration2 == configuration3)
+
+        let configuration4 = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                             ignoresComments: false)
+
+        XCTAssertFalse(configuration1 == configuration4)
+
+        let configuration5 = TrailingWhitespaceConfiguration(ignoresEmptyLines: true,
+                                                             ignoresComments: false)
+
+        XCTAssertFalse(configuration1 == configuration5)
     }
 
     func testTrailingWhitespaceConfigurationApplyConfigurationUpdatesSeverityConfiguration() {
-        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false)
+        var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                            ignoresComments: true)
         configuration.severityConfiguration.severity = .Warning
 
         do {

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -247,7 +247,7 @@ class RulesTests: XCTestCase {
     }
 
     func testTrailingWhitespace() {
-        verifyRule(TrailingWhitespaceRule.description, commentDoesntViolate: false)
+        verifyRule(TrailingWhitespaceRule.description)
 
         // Perform additional tests with the ignores_empty_lines setting enabled.
         // The set of non-triggering examples is extended by a whitespace-indented empty line
@@ -260,13 +260,14 @@ class RulesTests: XCTestCase {
                                   triggeringExamples: baseDescription.triggeringExamples,
                                          corrections: baseDescription.corrections)
         verifyRule(description,
-                   ruleConfiguration: ["ignores_empty_lines": true, "ignores_comments": true],
-                   commentDoesntViolate: false)
+                   ruleConfiguration: ["ignores_empty_lines": true, "ignores_comments": true])
 
         // Perform additional tests with the ignores_comments settings disabled.
+        let triggeringComments = ["// \n", "let name: String // \n"]
         let baseDescription2 = TrailingWhitespaceRule.description
-        let nonTriggeringExamples2 = baseDescription2.nonTriggeringExamples.filter { $0 != "// \n" }
-        let triggeringExamples2 = baseDescription2.triggeringExamples + ["// \n"]
+        let nonTriggeringExamples2 = baseDescription2.nonTriggeringExamples
+            .filter { !triggeringComments.contains($0) }
+        let triggeringExamples2 = baseDescription2.triggeringExamples + triggeringComments
         let description2 = RuleDescription(identifier: baseDescription2.identifier,
                                            name: baseDescription2.name,
                                            description: baseDescription2.description,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -259,7 +259,22 @@ class RulesTests: XCTestCase {
                                nonTriggeringExamples: nonTriggeringExamples,
                                   triggeringExamples: baseDescription.triggeringExamples,
                                          corrections: baseDescription.corrections)
-        verifyRule(description, ruleConfiguration: ["ignores_empty_lines": true],
+        verifyRule(description,
+                   ruleConfiguration: ["ignores_empty_lines": true, "ignores_comments": true],
+                   commentDoesntViolate: false)
+
+        // Perform additional tests with the ignores_comments settings disabled.
+        let baseDescription2 = TrailingWhitespaceRule.description
+        let nonTriggeringExamples2 = baseDescription2.nonTriggeringExamples.filter { $0 != "// \n" }
+        let triggeringExamples2 = baseDescription2.triggeringExamples + ["// \n"]
+        let description2 = RuleDescription(identifier: baseDescription2.identifier,
+                                           name: baseDescription2.name,
+                                           description: baseDescription2.description,
+                                           nonTriggeringExamples: nonTriggeringExamples2,
+                                           triggeringExamples: triggeringExamples2,
+                                           corrections: baseDescription2.corrections)
+        verifyRule(description2,
+                   ruleConfiguration: ["ignores_empty_lines": false, "ignores_comments": false],
                    commentDoesntViolate: false)
     }
 


### PR DESCRIPTION
Fixes #576 

Rule `trailing_whitespace` can now be configured to ignore comments using `ignores_comments`, its default value is `true`
