### PR TITLE
Added HTML reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ benchmark_*
 # SPM
 .build
 Packages
+
+# macOS
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ##### Enhancements
 
+* Added HTML reporter, identifier is `html`.  
+  [Johnykutty Mathew](https://github.com/Johnykutty)
+  
 * Add `SuperCallRule` Opt-In rule that warns about methods not calling to super.  
   [Angel G. Olloqui](https://github.com/angelolloqui)
   [#803](https://github.com/realm/SwiftLint/issues/803)

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -24,6 +24,8 @@ public func reporterFromString(string: String) -> Reporter.Type {
         return CheckstyleReporter.self
     case JUnitReporter.identifier:
         return JUnitReporter.self
+    case HTMLReporter.identifier:
+        return HTMLReporter.self
     default:
         fatalError("no reporter with identifier '\(string)' available.")
     }

--- a/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
@@ -1,0 +1,77 @@
+//
+//  HTMLReporter.swift
+//  SwiftLint
+//
+//  Created by Johnykutty on 10/27/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+import Foundation
+
+public struct HTMLReporter: Reporter {
+    public static let identifier = "html"
+    public static let isRealtime = false
+
+    public var description: String {
+        return "Reports violations as Checkstyle XML."
+    }
+
+    public static func generateReport(violations: [StyleViolation]) -> String {
+        var rows = ""
+        for (index, violation) in violations.enumerate() {
+            rows += generateSingleRow(for: violation, at: index + 1)
+        }
+        var HTML = HTMLTemplate()
+        HTML = HTML.stringByReplacingOccurrencesOfString("__table_rows__", withString: rows)
+
+        let bundle = NSBundle(identifier: "io.realm.SwiftLintFramework")!
+        let version = bundle.objectForInfoDictionaryKey("CFBundleShortVersionString")
+        let v = (version as? String ?? "0.0.0")
+        HTML = HTML.stringByReplacingOccurrencesOfString("__version__", withString: v)
+
+        let files = violations.map { violation in
+            violation.location.file ?? ""
+        }
+        let uniqueFiles = Set(files)
+        var countKey = "__number_of_files__"
+        var count = "\(uniqueFiles.count)"
+        HTML = HTML.stringByReplacingOccurrencesOfString(countKey, withString: count)
+
+        let warnings = violations.filter { violation in
+            violation.severity == .Warning
+        }
+        countKey = "__number_of_warnings__"
+        count = "\(warnings.count)"
+        HTML = HTML.stringByReplacingOccurrencesOfString(countKey, withString: count)
+
+        let errors = violations.filter { violation in
+            violation.severity == .Error
+        }
+        countKey = "__number_of_errors__"
+        count = "\(errors.count)"
+        HTML = HTML.stringByReplacingOccurrencesOfString(countKey, withString: count)
+
+        let formatter = NSDateFormatter()
+        formatter.dateStyle = .ShortStyle
+        let dateString = formatter.stringFromDate(NSDate())
+        HTML = HTML.stringByReplacingOccurrencesOfString("__report_date__", withString: dateString)
+
+        return HTML
+    }
+
+    private static func generateSingleRow(for violation: StyleViolation, at index: Int) -> String {
+        let severity = violation.severity.rawValue
+        let location = violation.location
+        return "<tr>" +
+            "<td align=\"right\">\(index)</td>" +
+            "<td>\(location.file ?? "")</td>" +
+            "<td align=\"center\">\(location.line ?? 0):\(location.character ?? 0)</td>" +
+            "<td class=\'\(severity.lowercaseString)\'>\(severity) </td>" +
+            "<td>\(violation.reason)</td>" +
+            "</tr>"
+    }
+
+    private static func HTMLTemplate() -> String {
+
+        return "<!doctype html><html><head><title>Swiftlint Report</title><style type='text/css'>table { border: 1px solid gray; border-collapse: collapse; -moz-box-shadow: 3px 3px 4px #AAA; -webkit-box-shadow: 3px 3px 4px #AAA; box-shadow: 3px 3px 4px #AAA; } td, th { border: 1px solid #D3D3D3; padding: 5px 10px 5px 10px; } th { border-bottom: 1px solid gray; background-color: #29345C50; } .error, .warning {background-color: #f0f099;} .error{ color: #ff0000;} .warning { color: #b36b00;}</style></head><body><h1>Swiftlint Report</h1><hr /><h2>Violations</h2><table border=\"1\" style=\"vertical-align: top; height: 64px;\"><thead><tr><th style=\"width: 60pt;\"><b>Serial No.</b></th><th style=\"width: 500pt;\"><b>File</b></th><th style=\"width: 60pt;\"><b>Location</b></th><th style=\"width: 60pt;\"><b>Severity</b></th><th style=\"width: 500pt;\"><b>Message</b></th></tr></thead><tbody>__table_rows__</tbody></table><br/><h2>Summary</h2><table border=\"1\" style=\"vertical-align: top; height: 64px;\"><tbody><tr><td>Total files with violations</td><td>__number_of_files__</td></tr><tr><td>Total warnings</td><td>__number_of_warnings__</td></tr><tr><td>Total errors</td><td>__number_of_errors__</td></tr></tbody></table><hr /><p>Created with <a href=\"https://github.com/realm/SwiftLint\"><b>Swiftlint</b></a> __version__ on: __report_date__</p></body></html>"// swiftlint:disable:this line_length
+    }
+}

--- a/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
@@ -126,10 +126,12 @@ public struct HTMLReporter: Reporter {
     private static func generateSingleRow(for violation: StyleViolation, at index: Int) -> String {
         let severity = violation.severity.rawValue
         let location = violation.location
+        let line = location.line ?? 0
+        let character = location.character ?? 0
         return "\t\t\t\t<tr>\n" +
             "\t\t\t\t\t<td align=\"right\">\(index)</td>\n" +
             "\t\t\t\t\t<td>\(location.file ?? "")</td>\n" +
-            "\t\t\t\t\t<td align=\"center\">\(location.line ?? 0):\(location.character ?? 0)</td>\n" +
+            "\t\t\t\t\t<td align=\"center\">\(line):\(character)</td>\n" +
             "\t\t\t\t\t<td class=\'\(severity.lowercaseString)\'>\(severity) </td>\n" +
             "\t\t\t\t\t<td>\(violation.reason)</td>\n" +
         "\t\t\t\t</tr>\n"

--- a/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
@@ -12,66 +12,126 @@ public struct HTMLReporter: Reporter {
     public static let isRealtime = false
 
     public var description: String {
-        return "Reports violations as Checkstyle XML."
+        return "Reports violations as HTML"
     }
 
+    // swiftlint:disable function_body_length
     public static func generateReport(violations: [StyleViolation]) -> String {
+    // swiftlint:enable function_body_length
         var rows = ""
         for (index, violation) in violations.enumerate() {
             rows += generateSingleRow(for: violation, at: index + 1)
         }
-        var HTML = HTMLTemplate()
-        HTML = HTML.stringByReplacingOccurrencesOfString("__table_rows__", withString: rows)
 
         let bundle = NSBundle(identifier: "io.realm.SwiftLintFramework")!
         let version = bundle.objectForInfoDictionaryKey("CFBundleShortVersionString")
         let v = (version as? String ?? "0.0.0")
-        HTML = HTML.stringByReplacingOccurrencesOfString("__version__", withString: v)
 
         let files = violations.map { violation in
             violation.location.file ?? ""
         }
         let uniqueFiles = Set(files)
-        var countKey = "__number_of_files__"
-        var count = "\(uniqueFiles.count)"
-        HTML = HTML.stringByReplacingOccurrencesOfString(countKey, withString: count)
 
         let warnings = violations.filter { violation in
             violation.severity == .Warning
         }
-        countKey = "__number_of_warnings__"
-        count = "\(warnings.count)"
-        HTML = HTML.stringByReplacingOccurrencesOfString(countKey, withString: count)
 
         let errors = violations.filter { violation in
             violation.severity == .Error
         }
-        countKey = "__number_of_errors__"
-        count = "\(errors.count)"
-        HTML = HTML.stringByReplacingOccurrencesOfString(countKey, withString: count)
 
         let formatter = NSDateFormatter()
         formatter.dateStyle = .ShortStyle
         let dateString = formatter.stringFromDate(NSDate())
-        HTML = HTML.stringByReplacingOccurrencesOfString("__report_date__", withString: dateString)
 
-        return HTML
+        return "<!doctype html>\n" +
+            "<html>\n" +
+            "\t<head>\n" +
+            "\t\t<title>Swiftlint Report</title>\n" +
+            "\t\t<style type='text/css'>\n" +
+            "\t\t\ttable {\n" +
+            "\t\t\t\tborder: 1px solid gray;\n" +
+            "\t\t\t\tborder-collapse: collapse;\n" +
+            "\t\t\t\t-moz-box-shadow: 3px 3px 4px #AAA;\n" +
+            "\t\t\t\t-webkit-box-shadow: 3px 3px 4px #AAA;\n" +
+            "\t\t\t\tbox-shadow: 3px 3px 4px #AAA;\n" +
+            "\t\t\t}\n" +
+            "\t\ttd, th {\n" +
+            "\t\t\t\tborder: 1px solid #D3D3D3;\n" +
+            "\t\t\t\tpadding: 5px 10px 5px 10px;\n" +
+            "\t\t}\n" +
+            "\t\tth {\n" +
+            "\t\t\tborder-bottom: 1px solid gray;\n" +
+            "\t\t\tbackground-color: #29345C50;\n" +
+            "\t\t}\n" +
+            "\t\t.error, .warning {\n" +
+            "\t\t\tbackground-color: #f0f099;\n" +
+            "\t\t} .error{ color: #ff0000;}\n" +
+            "\t\t.warning { color: #b36b00;\n" +
+            "\t\t}\n" +
+            "\t\t</style>\n" +
+            "\t</head>\n" +
+            "\t<body>\n" +
+            "\t\t<h1>Swiftlint Report</h1>\n" +
+            "\t\t<hr />\n" +
+            "\t\t<h2>Violations</h2>\n" +
+            "\t\t<table border=\"1\" style=\"vertical-align: top; height: 64px;\">\n" +
+            "\t\t\t<thead>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<th style=\"width: 60pt;\">\n" +
+            "\t\t\t\t\t\t<b>Serial No.</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t\t<th style=\"width: 500pt;\">\n" +
+            "\t\t\t\t\t\t<b>File</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t\t<th style=\"width: 60pt;\">\n" +
+            "\t\t\t\t\t\t<b>Location</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t\t<th style=\"width: 60pt;\">\n" +
+            "\t\t\t\t\t\t<b>Severity</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t\t<th style=\"width: 500pt;\">\n" +
+            "\t\t\t\t\t\t<b>Message</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t</thead>\n" +
+            "\t\t\t<tbody>\n" + rows + "\t\t\t</tbody>\n" +
+            "\t\t</table>\n" +
+            "\t\t<br/>\n" +
+            "\t\t<h2>Summary</h2>\n" +
+            "\t\t<table border=\"1\" style=\"vertical-align: top; height: 64px;\">\n" +
+            "\t\t\t<tbody>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td>Total files with violations</td>\n" +
+            "\t\t\t\t\t<td>\(uniqueFiles.count)</td>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td>Total warnings</td>\n" +
+            "\t\t\t\t\t<td>\(warnings.count)</td>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td>Total errors</td>\n" +
+            "\t\t\t\t\t<td>\(errors.count)</td>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t</tbody>\n" +
+            "\t\t</table>\n" +
+            "\t\t<hr />\n" +
+            "\t\t<p>Created with <a href=\"https://github.com/realm/SwiftLint\">\n" +
+            "\t\t\t<b>Swiftlint</b>\n" +
+            "\t\t</a> " + v + " on: " + dateString + "</p>\n" +
+            "\t</body>\n" +
+        "</html>"
     }
 
     private static func generateSingleRow(for violation: StyleViolation, at index: Int) -> String {
         let severity = violation.severity.rawValue
         let location = violation.location
-        return "<tr>" +
-            "<td align=\"right\">\(index)</td>" +
-            "<td>\(location.file ?? "")</td>" +
-            "<td align=\"center\">\(location.line ?? 0):\(location.character ?? 0)</td>" +
-            "<td class=\'\(severity.lowercaseString)\'>\(severity) </td>" +
-            "<td>\(violation.reason)</td>" +
-            "</tr>"
-    }
-
-    private static func HTMLTemplate() -> String {
-
-        return "<!doctype html><html><head><title>Swiftlint Report</title><style type='text/css'>table { border: 1px solid gray; border-collapse: collapse; -moz-box-shadow: 3px 3px 4px #AAA; -webkit-box-shadow: 3px 3px 4px #AAA; box-shadow: 3px 3px 4px #AAA; } td, th { border: 1px solid #D3D3D3; padding: 5px 10px 5px 10px; } th { border-bottom: 1px solid gray; background-color: #29345C50; } .error, .warning {background-color: #f0f099;} .error{ color: #ff0000;} .warning { color: #b36b00;}</style></head><body><h1>Swiftlint Report</h1><hr /><h2>Violations</h2><table border=\"1\" style=\"vertical-align: top; height: 64px;\"><thead><tr><th style=\"width: 60pt;\"><b>Serial No.</b></th><th style=\"width: 500pt;\"><b>File</b></th><th style=\"width: 60pt;\"><b>Location</b></th><th style=\"width: 60pt;\"><b>Severity</b></th><th style=\"width: 500pt;\"><b>Message</b></th></tr></thead><tbody>__table_rows__</tbody></table><br/><h2>Summary</h2><table border=\"1\" style=\"vertical-align: top; height: 64px;\"><tbody><tr><td>Total files with violations</td><td>__number_of_files__</td></tr><tr><td>Total warnings</td><td>__number_of_warnings__</td></tr><tr><td>Total errors</td><td>__number_of_errors__</td></tr></tbody></table><hr /><p>Created with <a href=\"https://github.com/realm/SwiftLint\"><b>Swiftlint</b></a> __version__ on: __report_date__</p></body></html>"// swiftlint:disable:this line_length
+        return "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td align=\"right\">\(index)</td>\n" +
+            "\t\t\t\t\t<td>\(location.file ?? "")</td>\n" +
+            "\t\t\t\t\t<td align=\"center\">\(location.line ?? 0):\(location.character ?? 0)</td>\n" +
+            "\t\t\t\t\t<td class=\'\(severity.lowercaseString)\'>\(severity) </td>\n" +
+            "\t\t\t\t\t<td>\(violation.reason)</td>\n" +
+        "\t\t\t\t</tr>\n"
     }
 }

--- a/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
@@ -132,7 +132,7 @@ public struct HTMLReporter: Reporter {
             "\t\t\t\t\t<td align=\"right\">\(index)</td>\n" +
             "\t\t\t\t\t<td>\(location.file ?? "")</td>\n" +
             "\t\t\t\t\t<td align=\"center\">\(line):\(character)</td>\n" +
-            "\t\t\t\t\t<td class=\'\(severity.lowercaseString)\'>\(severity) </td>\n" +
+            "\t\t\t\t\t<td class=\'\(severity.lowercaseString)\'>\(severity)</td>\n" +
             "\t\t\t\t\t<td>\(violation.reason)</td>\n" +
         "\t\t\t\t</tr>\n"
     }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */; };
 		3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */; };
 		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
+		4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */; };
 		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
 		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
 		57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED82791CF65183002B3513 /* JUnitReporter.swift */; };
@@ -214,6 +215,7 @@
 		3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleConfigurationTests.swift; sourceTree = "<group>"; };
 		3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlParser.swift; sourceTree = "<group>"; };
 		3BDB224A1C345B4900473680 /* ProjectMock */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ProjectMock; sourceTree = "<group>"; };
+		4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLReporter.swift; sourceTree = "<group>"; };
 		4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
 		4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
@@ -598,6 +600,7 @@
 				E86396CA1BADB519002C9E88 /* CSVReporter.swift */,
 				E86396C81BADB2B9002C9E88 /* JSONReporter.swift */,
 				E86396C41BADAC15002C9E88 /* XcodeReporter.swift */,
+				4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */,
 			);
 			path = Reporters;
 			sourceTree = "<group>";
@@ -983,6 +986,7 @@
 				E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */,
 				3BB47D831C514E8100AE6A10 /* RegexConfiguration.swift in Sources */,
 				3B1150CA1C31FC3F00D83B1E /* Yaml+SwiftLint.swift in Sources */,
+				4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
 				E881985D1BEA97EB00333A11 /* TrailingWhitespaceRule.swift in Sources */,
 				E832F10B1B17E2F5003F265F /* NSFileManager+SwiftLint.swift in Sources */,

--- a/Tests/SwiftLintFramework/ReporterTests.swift
+++ b/Tests/SwiftLintFramework/ReporterTests.swift
@@ -161,14 +161,14 @@ class ReporterTests: XCTestCase {
             "\t\t\t\t\t<td align=\"right\">1</td>\n" +
             "\t\t\t\t\t<td>filename</td>\n" +
             "\t\t\t\t\t<td align=\"center\">1:2</td>\n" +
-            "\t\t\t\t\t<td class='warning'>Warning </td>\n" +
+            "\t\t\t\t\t<td class='warning'>Warning</td>\n" +
             "\t\t\t\t\t<td>Violation Reason.</td>\n" +
             "\t\t\t\t</tr>\n" +
             "\t\t\t\t<tr>\n" +
             "\t\t\t\t\t<td align=\"right\">2</td>\n" +
             "\t\t\t\t\t<td>filename</td>\n" +
             "\t\t\t\t\t<td align=\"center\">1:2</td>\n" +
-            "\t\t\t\t\t<td class='error'>Error </td>\n" +
+            "\t\t\t\t\t<td class='error'>Error</td>\n" +
             "\t\t\t\t\t<td>Violation Reason.</td>\n" +
             "\t\t\t\t</tr>\n" +
             "\t\t\t</tbody>\n" +

--- a/Tests/SwiftLintFramework/ReporterTests.swift
+++ b/Tests/SwiftLintFramework/ReporterTests.swift
@@ -99,7 +99,103 @@ class ReporterTests: XCTestCase {
         formatter.dateStyle = .ShortStyle
         let dateString = formatter.stringFromDate(NSDate())
 
-        let originalHTML = "<!doctype html><html><head><title>Swiftlint Report</title><style type='text/css'>table { border: 1px solid gray; border-collapse: collapse; -moz-box-shadow: 3px 3px 4px #AAA; -webkit-box-shadow: 3px 3px 4px #AAA; box-shadow: 3px 3px 4px #AAA; } td, th { border: 1px solid #D3D3D3; padding: 5px 10px 5px 10px; } th { border-bottom: 1px solid gray; background-color: #29345C50; } .error, .warning {background-color: #f0f099;} .error{ color: #ff0000;} .warning { color: #b36b00;}</style></head><body><h1>Swiftlint Report</h1><hr /><h2>Violations</h2><table border=\"1\" style=\"vertical-align: top; height: 64px;\"><thead><tr><th style=\"width: 60pt;\"><b>Serial No.</b></th><th style=\"width: 500pt;\"><b>File</b></th><th style=\"width: 60pt;\"><b>Location</b></th><th style=\"width: 60pt;\"><b>Severity</b></th><th style=\"width: 500pt;\"><b>Message</b></th></tr></thead><tbody><tr><td align=\"right\">1</td><td>filename</td><td align=\"center\">1:2</td><td class='warning'>Warning </td><td>Violation Reason.</td></tr><tr><td align=\"right\">2</td><td>filename</td><td align=\"center\">1:2</td><td class='error'>Error </td><td>Violation Reason.</td></tr></tbody></table><br/><h2>Summary</h2><table border=\"1\" style=\"vertical-align: top; height: 64px;\"><tbody><tr><td>Total files with violations</td><td>1</td></tr><tr><td>Total warnings</td><td>1</td></tr><tr><td>Total errors</td><td>1</td></tr></tbody></table><hr /><p>Created with <a href=\"https://github.com/realm/SwiftLint\"><b>Swiftlint</b></a> 0.12.0 on: \(dateString)</p></body></html>"// swiftlint:disable:this line_length
-         XCTAssertEqual(generatedHTML, originalHTML)
+        let bundle = NSBundle(identifier: "io.realm.SwiftLintFramework")!
+        let version = bundle.objectForInfoDictionaryKey("CFBundleShortVersionString")
+        let v = (version as? String ?? "0.0.0")
+
+        let expectedHTML = "<!doctype html>\n" +
+            "<html>\n" +
+            "\t<head>\n" +
+            "\t\t<title>Swiftlint Report</title>\n" +
+            "\t\t<style type='text/css'>\n" +
+            "\t\t\ttable {\n" +
+            "\t\t\t\tborder: 1px solid gray;\n" +
+            "\t\t\t\tborder-collapse: collapse;\n" +
+            "\t\t\t\t-moz-box-shadow: 3px 3px 4px #AAA;\n" +
+            "\t\t\t\t-webkit-box-shadow: 3px 3px 4px #AAA;\n" +
+            "\t\t\t\tbox-shadow: 3px 3px 4px #AAA;\n" +
+            "\t\t\t}\n" +
+            "\t\ttd, th {\n" +
+            "\t\t\t\tborder: 1px solid #D3D3D3;\n" +
+            "\t\t\t\tpadding: 5px 10px 5px 10px;\n" +
+            "\t\t}\n" +
+            "\t\tth {\n" +
+            "\t\t\tborder-bottom: 1px solid gray;\n" +
+            "\t\t\tbackground-color: #29345C50;\n" +
+            "\t\t}\n" +
+            "\t\t.error, .warning {\n" +
+            "\t\t\tbackground-color: #f0f099;\n" +
+            "\t\t} .error{ color: #ff0000;}\n" +
+            "\t\t.warning { color: #b36b00;\n" +
+            "\t\t}\n" +
+            "\t\t</style>\n" +
+            "\t</head>\n" +
+            "\t<body>\n" +
+            "\t\t<h1>Swiftlint Report</h1>\n" +
+            "\t\t<hr />\n" +
+            "\t\t<h2>Violations</h2>\n" +
+            "\t\t<table border=\"1\" style=\"vertical-align: top; height: 64px;\">\n" +
+            "\t\t\t<thead>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<th style=\"width: 60pt;\">\n" +
+            "\t\t\t\t\t\t<b>Serial No.</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t\t<th style=\"width: 500pt;\">\n" +
+            "\t\t\t\t\t\t<b>File</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t\t<th style=\"width: 60pt;\">\n" +
+            "\t\t\t\t\t\t<b>Location</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t\t<th style=\"width: 60pt;\">\n" +
+            "\t\t\t\t\t\t<b>Severity</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t\t<th style=\"width: 500pt;\">\n" +
+            "\t\t\t\t\t\t<b>Message</b>\n" +
+            "\t\t\t\t\t</th>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t</thead>\n" +
+            "\t\t\t<tbody>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td align=\"right\">1</td>\n" +
+            "\t\t\t\t\t<td>filename</td>\n" +
+            "\t\t\t\t\t<td align=\"center\">1:2</td>\n" +
+            "\t\t\t\t\t<td class='warning'>Warning </td>\n" +
+            "\t\t\t\t\t<td>Violation Reason.</td>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td align=\"right\">2</td>\n" +
+            "\t\t\t\t\t<td>filename</td>\n" +
+            "\t\t\t\t\t<td align=\"center\">1:2</td>\n" +
+            "\t\t\t\t\t<td class='error'>Error </td>\n" +
+            "\t\t\t\t\t<td>Violation Reason.</td>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t</tbody>\n" +
+            "\t\t</table>\n" +
+            "\t\t<br/>\n" +
+            "\t\t<h2>Summary</h2>\n" +
+            "\t\t<table border=\"1\" style=\"vertical-align: top; height: 64px;\">\n" +
+            "\t\t\t<tbody>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td>Total files with violations</td>\n" +
+            "\t\t\t\t\t<td>1</td>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td>Total warnings</td>\n" +
+            "\t\t\t\t\t<td>1</td>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t\t<tr>\n" +
+            "\t\t\t\t\t<td>Total errors</td>\n" +
+            "\t\t\t\t\t<td>1</td>\n" +
+            "\t\t\t\t</tr>\n" +
+            "\t\t\t</tbody>\n" +
+            "\t\t</table>\n" +
+            "\t\t<hr />\n" +
+            "\t\t<p>Created with <a href=\"https://github.com/realm/SwiftLint\">\n" +
+            "\t\t\t<b>Swiftlint</b>\n" +
+            "\t\t</a> " + v + " on: " + dateString + "</p>\n" +
+            "\t</body>\n" +
+        "</html>"
+
+        XCTAssertEqual(generatedHTML, expectedHTML)
     }
 }

--- a/Tests/SwiftLintFramework/ReporterTests.swift
+++ b/Tests/SwiftLintFramework/ReporterTests.swift
@@ -91,4 +91,15 @@ class ReporterTests: XCTestCase {
                 "\t</testcase>\n</testsuite></testsuites>"
         )
     }
+
+    func testHTMLReporter() {
+        let generatedHTML = HTMLReporter.generateReport(generateViolations())
+
+        let formatter = NSDateFormatter()
+        formatter.dateStyle = .ShortStyle
+        let dateString = formatter.stringFromDate(NSDate())
+
+        let originalHTML = "<!doctype html><html><head><title>Swiftlint Report</title><style type='text/css'>table { border: 1px solid gray; border-collapse: collapse; -moz-box-shadow: 3px 3px 4px #AAA; -webkit-box-shadow: 3px 3px 4px #AAA; box-shadow: 3px 3px 4px #AAA; } td, th { border: 1px solid #D3D3D3; padding: 5px 10px 5px 10px; } th { border-bottom: 1px solid gray; background-color: #29345C50; } .error, .warning {background-color: #f0f099;} .error{ color: #ff0000;} .warning { color: #b36b00;}</style></head><body><h1>Swiftlint Report</h1><hr /><h2>Violations</h2><table border=\"1\" style=\"vertical-align: top; height: 64px;\"><thead><tr><th style=\"width: 60pt;\"><b>Serial No.</b></th><th style=\"width: 500pt;\"><b>File</b></th><th style=\"width: 60pt;\"><b>Location</b></th><th style=\"width: 60pt;\"><b>Severity</b></th><th style=\"width: 500pt;\"><b>Message</b></th></tr></thead><tbody><tr><td align=\"right\">1</td><td>filename</td><td align=\"center\">1:2</td><td class='warning'>Warning </td><td>Violation Reason.</td></tr><tr><td align=\"right\">2</td><td>filename</td><td align=\"center\">1:2</td><td class='error'>Error </td><td>Violation Reason.</td></tr></tbody></table><br/><h2>Summary</h2><table border=\"1\" style=\"vertical-align: top; height: 64px;\"><tbody><tr><td>Total files with violations</td><td>1</td></tr><tr><td>Total warnings</td><td>1</td></tr><tr><td>Total errors</td><td>1</td></tr></tbody></table><hr /><p>Created with <a href=\"https://github.com/realm/SwiftLint\"><b>Swiftlint</b></a> 0.12.0 on: \(dateString)</p></body></html>"// swiftlint:disable:this line_length
+         XCTAssertEqual(generatedHTML, originalHTML)
+    }
 }

--- a/Tests/SwiftLintFramework/ReporterTests.swift
+++ b/Tests/SwiftLintFramework/ReporterTests.swift
@@ -92,7 +92,9 @@ class ReporterTests: XCTestCase {
         )
     }
 
+    // swiftlint:disable function_body_length
     func testHTMLReporter() {
+    // swiftlint:enable function_body_length
         let generatedHTML = HTMLReporter.generateReport(generateViolations())
 
         let formatter = NSDateFormatter()


### PR DESCRIPTION
Added new reporter which generates light-weight  HTML reports.
The identifier its `html`
Usage
`swiftlint lint --reporter html > Report.html`

This will generate HTML report Report.html in the same directory.

We can change look and feel for html if needed
