### PR TITLE
Add ImplicitGetterRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ##### Enhancements
 
-* None.
+* Add `ImplicitGetterRule` to warn against using `get` on computed read-only
+  properties.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#57](https://github.com/realm/SwiftLint/issues/57)
 
 ##### Bug Fixes
 
@@ -70,11 +73,6 @@
   directly.  
   [Matt Taube](https://github.com/mtaube)
   [#715](https://github.com/realm/SwiftLint/pull/715)
-  
-* Add `ImplicitGetterRule` to warn against using `get` on computed read-only
-  properties.  
-  [Marcelo Fabri](https://github.com/marcelofabri)
-  [#57](https://github.com/realm/SwiftLint/issues/57)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@
   directly.  
   [Matt Taube](https://github.com/mtaube)
   [#715](https://github.com/realm/SwiftLint/pull/715)
+  
+* Add `ImplicitGetterRule` to warn against using `get` on computed read-only
+  properties.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#57](https://github.com/realm/SwiftLint/issues/57)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -57,6 +57,7 @@ public let masterRuleList = RuleList(rules:
     ForceUnwrappingRule.self,
     FunctionBodyLengthRule.self,
     FunctionParameterCountRule.self,
+    ImplicitGetterRule.self,
     LeadingWhitespaceRule.self,
     LegacyCGGeometryFunctionsRule.self,
     LegacyConstantRule.self,

--- a/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
@@ -1,0 +1,119 @@
+//
+//  ImplicitGetterRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 29/10/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+private func classScoped(value: String) -> String {
+    return "class Foo {\n  \(value)\n}\n"
+}
+
+public struct ImplicitGetterRule: ASTRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.Warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "implicit_getter",
+        name: "Implicit Getter",
+        description: "Computed read-only properties should avoid using the get keyword.",
+        nonTriggeringExamples: [
+            classScoped("var foo: Int {\n get {\n return 3\n}\n set {\n _abc = newValue \n}\n}"),
+            classScoped("var foo: Int {\n return 20 \n} \n}"),
+            classScoped("static var foo: Int {\n return 20 \n} \n}"),
+            classScoped("static foo: Int {\n get {\n return 3\n}\n set {\n _abc = newValue \n}\n}"),
+            classScoped("var foo: Int"),
+            classScoped("var foo: Int {\n return getValueFromDisk() \n} \n}"),
+            classScoped("var foo: String {\n return \"get\" \n} \n}"),
+            "protocol Foo {\n var foo: Int { get }\n",
+            "protocol Foo {\n var foo: Int { get set }\n"
+        ],
+        triggeringExamples: [
+            classScoped("var foo: Int {\n ↓get {\n return 20 \n} \n} \n}"),
+            classScoped("static var foo: Int {\n ↓get {\n return 20 \n} \n} \n}")
+        ]
+    )
+
+    public func validateFile(file: File,
+                             kind: SwiftDeclarationKind,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        let typeKinds: [SwiftDeclarationKind] = [
+            .Class,
+            .Enum,
+            .Extension,
+            .ExtensionClass,
+            .ExtensionEnum,
+            .ExtensionProtocol,
+            .ExtensionStruct,
+            .Struct
+        ]
+
+        guard typeKinds.contains(kind) else {
+            return []
+        }
+
+        guard let substructures = (dictionary["key.substructure"] as? [SourceKitRepresentable])?
+            .flatMap({ $0 as? [String: SourceKitRepresentable] }) else {
+                return []
+        }
+
+        return substructures.flatMap { dictionary -> [StyleViolation] in
+            guard let kind = (dictionary["key.kind"] as? String).flatMap(KindType.init) else {
+                return []
+            }
+
+            return validateType(file, kind: kind, dictionary: dictionary)
+        }
+    }
+
+    private func validateType(file: File,
+                              kind: SwiftDeclarationKind,
+                              dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        let allowedKinds: [SwiftDeclarationKind] = [.VarClass, .VarInstance, .VarStatic]
+        guard allowedKinds.contains(kind) else {
+            return []
+        }
+
+        // If there's a setter, `get` is allowed
+        guard dictionary["key.setter_accessibility"] == nil else {
+            return []
+        }
+
+        // Only validates properties with body
+        guard let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
+            bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) else {
+                return []
+        }
+
+        let bodyRange = NSRange(location: bodyOffset, length: bodyLength)
+        let contents = (file.contents as NSString)
+
+        let tokens = file.syntaxMap.tokensIn(bodyRange).filter { token in
+            guard SyntaxKind(rawValue: token.type) == .Keyword else {
+                return false
+            }
+
+            guard let tokenValue = contents.substringWithByteRange(start: token.offset,
+                                                                   length: token.length) else {
+                return false
+            }
+
+            return tokenValue == "get"
+        }
+
+        return tokens.map { token in
+            // Violation found!
+            let location = Location(file: file, byteOffset: token.offset)
+
+            return StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: configuration.severity,
+                location: location
+            )
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -56,8 +56,8 @@
 		6CCFCF301CFEF742003239EB /* Yaml.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = E89376AC1B8A701E0025708E /* Yaml.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7250948A1D0859260039B353 /* StatementPositionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725094881D0855760039B353 /* StatementPositionConfiguration.swift */; };
 		78F032461D7C877E00BE709A /* OverridenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverridenSuperCallRule.swift */; };
-		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
 		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
+		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
 		85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856651A61D6B395F005E6B29 /* MarkRule.swift */; };
@@ -72,6 +72,7 @@
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
+		D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
 		D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
@@ -232,8 +233,8 @@
 		6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxMap+SwiftLint.swift"; sourceTree = "<group>"; };
 		725094881D0855760039B353 /* StatementPositionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionConfiguration.swift; sourceTree = "<group>"; };
 		78F032441D7C877800BE709A /* OverridenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallRule.swift; sourceTree = "<group>"; };
-		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
 		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
+		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
 		856651A61D6B395F005E6B29 /* MarkRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
@@ -268,6 +269,7 @@
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
+		D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitGetterRule.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
 		D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
@@ -628,6 +630,7 @@
 				B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */,
 				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
 				2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */,
+				D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */,
 				006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */,
@@ -974,6 +977,7 @@
 				D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */,
 				E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */,
 				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift in Sources */,
+				D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */,
 				7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */,
 				E88DEA771B098D0C00A66CB0 /* Rule.swift in Sources */,
 				24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -141,6 +141,10 @@ class RulesTests: XCTestCase {
         verifyRule(FunctionParameterCountRule.description)
     }
 
+    func testImplicitGetterRule() {
+        verifyRule(ImplicitGetterRule.description)
+    }
+
     func testLeadingWhitespace() {
         verifyRule(LeadingWhitespaceRule.description)
     }


### PR DESCRIPTION
Partially fixes https://github.com/realm/SwiftLint/issues/57

It seems that SourceKit doesn't provide information on `subscript`, which is weird because there is a `FunctionSubscript` case on `SyntaxKind`.

``` swift
struct Thing {

    subscript(index: Int) -> Int {
      return 2
    }
}
```

``` bash
sourcekitten structure --file file.swift
```

``` json
{
  "key.substructure" : [
    {
      "key.kind" : "source.lang.swift.decl.struct",
      "key.offset" : 0,
      "key.nameoffset" : 7,
      "key.namelength" : 5,
      "key.bodyoffset" : 14,
      "key.bodylength" : 58,
      "key.accessibility" : "source.lang.swift.accessibility.internal",
      "key.substructure" : [
        {
          "key.kind" : "source.lang.swift.decl.var.parameter",
          "key.offset" : 30,
          "key.nameoffset" : 0,
          "key.namelength" : 0,
          "key.length" : 10,
          "key.typename" : "Int",
          "key.name" : "index"
        }
      ],
      "key.name" : "Thing",
      "key.length" : 73
    }
  ],
  "key.offset" : 0,
  "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
  "key.length" : 74
}
```
