### PR TITLE
Add fallback if swiftlint fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ in the IDE. Just add a new "Run Script Phase" with:
 
 ```bash
 if which swiftlint >/dev/null; then
-  swiftlint
+  swiftlint || echo "warning: SwiftLint failed with exit code $?. Is SwiftLint installed and up to date?"
 else
   echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
 fi


### PR DESCRIPTION
- Currently swiftlint fails if you are on a old version of it. There should be a fallback when it fails and some type of recommended next step.