### PR TITLE
Added IndentationRule

### DIFF
--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -57,6 +57,7 @@ public let masterRuleList = RuleList(rules:
     ForceUnwrappingRule.self,
     FunctionBodyLengthRule.self,
     FunctionParameterCountRule.self,
+    IndentationRule.self,
     LeadingWhitespaceRule.self,
     LegacyCGGeometryFunctionsRule.self,
     LegacyConstantRule.self,

--- a/Source/SwiftLintFramework/Rules/IndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/IndentationRule.swift
@@ -1,0 +1,81 @@
+//
+//  IndentationRule.swift
+//  SwiftLint
+//
+//  Created by Lois Di Qual on 11/9/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct IndentationRule: ConfigurationProviderRule, SourceKitFreeRule {
+    public var configuration = SeverityLevelsConfiguration(warning: 400, error: 1000)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "indentation",
+        name: "Indentation",
+        description: "Source code should have consistent indentation. " +
+            "Accepted indentations are tab characters or 4 spaces.",
+        nonTriggeringExamples: [
+            "\t",
+            "    ",
+            "\tfunc",
+            "\t\tfunc",
+            "\t\t\tfunc",
+            "    func",
+            "        func",
+            "            func"
+        ],
+        triggeringExamples: [
+            "\t    func",
+            "    \tfunc",
+            "    \t    func",
+            "  func",
+            "      func",
+            "  \t  func",
+            " func",
+            " \t func"
+        ]
+    )
+
+    private static let regex = try? NSRegularExpression(pattern: "(\\s*)\\S*", options: [])
+
+    public func validateFile(file: File) -> [StyleViolation] {
+        guard let regex = IndentationRule.regex else { return [] }
+
+        var violations: [StyleViolation] = []
+        for line in file.lines {
+            let range = NSRange(location: 0, length: line.content.characters.count)
+            let matches = regex.matchesInString(line.content, options: [], range: range)
+            guard !matches.isEmpty else {
+                continue
+            }
+            let linePrefix = (line.content as NSString)
+                .substringWithRange(matches[0].rangeAtIndex(1))
+            let spaceCount = linePrefix.componentsSeparatedByString(" ").count - 1
+            let tabCount = linePrefix.componentsSeparatedByString("\t").count - 1
+
+            if spaceCount > 0 && tabCount > 0 {
+                violations.append(StyleViolation(
+                    ruleDescription: IndentationRule.description,
+                    severity: .Warning,
+                    location: Location(file: file, characterOffset: line.range.location),
+                    reason: "Code should be indented with tabs or 4 spaces, but not both."
+                ))
+            } else if spaceCount % 4 != 0 {
+                violations.append(StyleViolation(
+                    ruleDescription: IndentationRule.description,
+                    severity: .Warning,
+                    location: Location(file: file, characterOffset: line.range.location),
+                    reason: "Code should be indented with tabs or 4 spaces, " +
+                        "got \(spaceCount) spaces."
+                ))
+            }
+        }
+
+        return violations
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -56,8 +56,8 @@
 		6CCFCF301CFEF742003239EB /* Yaml.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = E89376AC1B8A701E0025708E /* Yaml.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7250948A1D0859260039B353 /* StatementPositionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725094881D0855760039B353 /* StatementPositionConfiguration.swift */; };
 		78F032461D7C877E00BE709A /* OverridenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverridenSuperCallRule.swift */; };
-		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
 		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
+		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
 		85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856651A61D6B395F005E6B29 /* MarkRule.swift */; };
@@ -66,6 +66,7 @@
 		B2902A0E1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2902A0D1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift */; };
 		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
 		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
+		C045943E1DD3F62100AF5B28 /* IndentationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C045943D1DD3F62100AF5B28 /* IndentationRule.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
@@ -232,8 +233,8 @@
 		6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxMap+SwiftLint.swift"; sourceTree = "<group>"; };
 		725094881D0855760039B353 /* StatementPositionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionConfiguration.swift; sourceTree = "<group>"; };
 		78F032441D7C877800BE709A /* OverridenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallRule.swift; sourceTree = "<group>"; };
-		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
 		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
+		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
 		856651A61D6B395F005E6B29 /* MarkRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
@@ -242,6 +243,7 @@
 		B2902A0D1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateUnitTestConfiguration.swift; sourceTree = "<group>"; };
 		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
 		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
+		C045943D1DD3F62100AF5B28 /* IndentationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndentationRule.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D0D1212619E878CC005E4BAA /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -628,6 +630,7 @@
 				B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */,
 				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
 				2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */,
+				C045943D1DD3F62100AF5B28 /* IndentationRule.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */,
 				006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */,
@@ -926,6 +929,7 @@
 				E80E018D1B92C0F60078EB70 /* Command.swift in Sources */,
 				E88198571BEA953300333A11 /* ForceCastRule.swift in Sources */,
 				D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */,
+				C045943E1DD3F62100AF5B28 /* IndentationRule.swift in Sources */,
 				3BCC04CD1C4F5694006073C3 /* ConfigurationError.swift in Sources */,
 				BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */,
 				83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */,

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -141,6 +141,10 @@ class RulesTests: XCTestCase {
         verifyRule(FunctionParameterCountRule.description)
     }
 
+    func testIndentation() {
+        verifyRule(IndentationRule.description)
+    }
+
     func testLeadingWhitespace() {
         verifyRule(LeadingWhitespaceRule.description)
     }


### PR DESCRIPTION
Here's a proposal to fix https://github.com/realm/SwiftLint/issues/227

The rule enforces that code indentation uses 4 spaces or one tab, and not a mix of both. Let me know if you'd like to enforce 2/4 spaces or tabs from the configuration. Also let me know if you'd like this rule to be opt-in.

I don't believe there's a nice way to autocorrect this.

I'm also not 100% sure that triggering and non-triggering examples are properly validated because I get a bunch of errors that are unrelated to my rule.

Most notably:

![image](https://cloud.githubusercontent.com/assets/941453/20167745/59ad9f16-a6d2-11e6-8722-54a33b028e20.png)

The current SwiftLint codebase has about 230 validation issues because the indentation is inconsistent. The most common source of error is something like this:

```
private func getFiles(path: String, action: String, useSTDIN: Bool, quiet: Bool,
                          useScriptInputFiles: Bool) -> Result<[File], CommandantError<()>> {
```

I'm proposing to format it this way:

```
private func getFiles(
    path: String,
    action: String,
    useSTDIN: Bool, quiet: Bool,
    useScriptInputFiles: Bool
) -> Result<[File], CommandantError<()>> {
```

Or at the very least:

```
private func getFiles(path: String, action: String, useSTDIN: Bool, quiet: Bool,
    useScriptInputFiles: Bool) -> Result<[File], CommandantError<()>> {
```

Let me know how you want to deal with this kind of stuff.