### PR TITLE
Comma rule does not get triggered in all situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,11 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#813](https://github.com/realm/SwiftLint/issues/813)  
 
+* Fixed regex bug in Comma Rule. Some violations were not being triggered 
+  when there were consecutive violations in the same expression.  
+  [Savio Figueiredo](https://github.com/sadefigu)
+  [#872](https://github.com/realm/SwiftLint/issues/872)
+
 ## 0.12.0: Vertical Laundry
 
 ##### Breaking


### PR DESCRIPTION
Improving comma rule to support expressions that begin with the comma. (fixes a gap when there are consecutive comma violations)

For example, if the expression is 'let a = [1,2,3]', the previous comma rule regexp would consume '1,2' and the remaining ',3' would not be consumed by the regexp because it does not support something that begins with a comma.