### PR TITLE
Addded TrailingCommaRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 * `closure_spacing` rule now accepts empty bodies with a space.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#875](https://github.com/realm/SwiftLint/issues/875)
+  
+* Add `TrailingCommaRule` to enforce/forbid trailing commas in arrays and
+  dictionaries. The default is to forbid them, but this can be changed with
+  the `mandatory_comma` configuration.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#883](https://github.com/realm/SwiftLint/issues/883)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -79,6 +79,7 @@ public let masterRuleList = RuleList(rules:
     SwitchCaseOnNewlineRule.self,
     SyntacticSugarRule.self,
     TodoRule.self,
+    TrailingCommaRule.self,
     TrailingNewlineRule.self,
     TrailingSemicolonRule.self,
     TrailingWhitespaceRule.self,

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -24,14 +24,14 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
             "abc(a: \"string\", b: \"string\"",
             "enum a { case a, b, c }",
             "func abc(\n  a: String,  // comment\n  bcd: String // comment\n) {\n}\n",
-            "func abc(\n  a: String,\n  bcd: String\n) {\n}\n",
+            "func abc(\n  a: String,\n  bcd: String\n) {\n}\n"
         ],
         triggeringExamples: [
             "func abc(a: String↓ ,b: String) { }",
             "func abc(a: String↓ ,b: String↓ ,c: String↓ ,d: String) { }",
             "abc(a: \"string\"↓,b: \"string\"",
             "enum a { case a↓ ,b }",
-            "let result = plus(\n    first: 3↓ , // #683\n    second: 4\n)\n",
+            "let result = plus(\n    first: 3↓ , // #683\n    second: 4\n)\n"
         ],
         corrections: [
             "func abc(a: String,b: String) {}\n": "func abc(a: String, b: String) {}\n",
@@ -39,7 +39,7 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
             "abc(a: \"string\"  ,  b: \"string\"\n": "abc(a: \"string\", b: \"string\"\n",
             "enum a { case a  ,b }\n": "enum a { case a, b }\n",
             "let a = [1,1]\nlet b = 1\nf(1, b)\n": "let a = [1, 1]\nlet b = 1\nf(1, b)\n",
-            "let a = [1↓,1↓,1↓,1]\n": "let a = [1, 1, 1, 1]\n",
+            "let a = [1↓,1↓,1↓,1]\n": "let a = [1, 1, 1, 1]\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
@@ -28,7 +28,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
             "if true {}; if true {}; if true {}; if true {}; if true {}; if true {}\n" +
                 "func f2() {\n" +
                     "if true {}; if true {}; if true {}; if true {}; if true {}\n" +
-                "}}",
+                "}}"
         ],
         triggeringExamples: [
             "func f1() {\n  if true {\n    if true {\n      if false {}\n    }\n" +

--- a/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
@@ -24,14 +24,14 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
             "struct S { let n: Int }; extension S { init() { self.init(n: 1) } }",      // self
             "[1].flatMap(String.init)",                   // pass init as closure
             "[String.self].map { $0.init(1) }",           // initialize from a metatype value
-            "[String.self].map { type in type.init(1) }", // initialize from a metatype value
+            "[String.self].map { type in type.init(1) }"  // initialize from a metatype value
         ],
         triggeringExamples: [
             "[1].flatMap{String↓.init($0)}",
-            "[String.self].map { Type in Type↓.init(1) }", // starting with capital assumes as type
+            "[String.self].map { Type in Type↓.init(1) }"  // starting with capital assumes as type
         ],
         corrections: [
-            "[1].flatMap{String.init($0)}" : "[1].flatMap{String($0)}",
+            "[1].flatMap{String.init($0)}" : "[1].flatMap{String($0)}"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -39,7 +39,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
             "let unwrapped = optional↓!",
             "return cell↓!",
             "let url = NSURL(string: \"http://www.google.com\")↓!",
-            "let dict = [\"Boooo\": \"👻\"]func bla() -> String { return dict[\"Boooo\"]↓! }",
+            "let dict = [\"Boooo\": \"👻\"]func bla() -> String { return dict[\"Boooo\"]↓! }"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -26,7 +26,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
         ],
         triggeringExamples: [
             "func f(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}",
-            "func f(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int = 2, g: Int) {}",
+            "func f(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int = 2, g: Int) {}"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -39,7 +39,7 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
             // "rect.divide(atDistance: 10.2, fromEdge: edge)", No correction available for divide
             "rect1.contains(rect2)",
             "rect.contains(point)",
-            "rect1.intersects(rect2)",
+            "rect1.intersects(rect2)"
         ],
         triggeringExamples: [
             "↓CGRectGetWidth(rect)",

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -39,7 +39,7 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
             "UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 10)",
             "UIEdgeInsets(top: aTop, left: aLeft, bottom: aBottom, right: aRight)",
             "NSEdgeInsets(top: 0, left: 0, bottom: 10, right: 10)",
-            "NSEdgeInsets(top: aTop, left: aLeft, bottom: aBottom, right: aRight)",
+            "NSEdgeInsets(top: aTop, left: aLeft, bottom: aBottom, right: aRight)"
         ],
         triggeringExamples: [
             "↓CGPointMake(10, 10)",
@@ -61,7 +61,7 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
             "↓UIEdgeInsetsMake(0, 0, 10, 10)",
             "↓UIEdgeInsetsMake(top, left, bottom, right)",
             "↓NSEdgeInsetsMake(0, 0, 10, 10)",
-            "↓NSEdgeInsetsMake(top, left, bottom, right)",
+            "↓NSEdgeInsetsMake(top, left, bottom, right)"
         ],
         corrections: [
             "↓CGPointMake(10,  10   )\n": "CGPoint(x: 10, y: 10)\n",
@@ -93,7 +93,7 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
             "↓NSEdgeInsetsMake(0, 0, 10, 10)\n":
             "NSEdgeInsets(top: 0, left: 0, bottom: 10, right: 10)\n",
             "↓NSEdgeInsetsMake(top, left, bottom, right)\n":
-            "NSEdgeInsets(top: top, left: left, bottom: bottom, right: right)\n",
+            "NSEdgeInsets(top: top, left: left, bottom: bottom, right: right)\n"
         ]
     )
 
@@ -128,7 +128,7 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
             "UIEdgeInsetsMake\\(\\s*\(twoVarsOrNum)\\s*,\\s*\(twoVarsOrNum)\\s*\\)":
             "UIEdgeInsets(top: $1, left: $2, bottom: $3, right: $4)",
             "NSEdgeInsetsMake\\(\\s*\(twoVarsOrNum)\\s*,\\s*\(twoVarsOrNum)\\s*\\)":
-            "NSEdgeInsets(top: $1, left: $2, bottom: $3, right: $4)",
+            "NSEdgeInsets(top: $1, left: $2, bottom: $3, right: $4)"
         ]
 
         let description = self.dynamicType.description

--- a/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
@@ -36,7 +36,7 @@ public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
             // "rect.divide(atDistance: 10.2, fromEdge: edge)", No correction available for divide
             "rect1.contains(rect2)",
             "rect.contains(point)",
-            "rect1.intersects(rect2)",
+            "rect1.intersects(rect2)"
         ],
         triggeringExamples: [
             "↓NSWidth(rect)",

--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -35,7 +35,7 @@ public struct MarkRule: ConfigurationProviderRule {
             "//MARK: - bad",
             "//MARK:- bad",
             "//MARK: -bad",
-            "//MARK:-bad",
+            "//MARK:-bad"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
@@ -38,7 +38,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule {
             "↓expect(10).to(beLessThan(11))\n",
             "↓expect(10).to(beLessThanOrEqualTo(10))\n",
             "↓expect(x).to(beIdenticalTo(x))\n",
-            "expect(10) > 2\n ↓expect(10).to(beGreaterThan(2))\n",
+            "expect(10) > 2\n ↓expect(10).to(beGreaterThan(2))\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
@@ -23,11 +23,11 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
             "class Foo {\n  @IBOutlet private var label: UILabel!\n}\n",
             "class Foo {\n  var notAnOutlet: UILabel\n}\n",
             "class Foo {\n  @IBOutlet weak private var label: UILabel?\n}\n",
-            "class Foo {\n  @IBOutlet private weak var label: UILabel?\n}\n",
+            "class Foo {\n  @IBOutlet private weak var label: UILabel?\n}\n"
         ],
         triggeringExamples: [
             "class Foo {\n  @IBOutlet var label: UILabel?\n}\n",
-            "class Foo {\n  @IBOutlet var label: UILabel!\n}\n",
+            "class Foo {\n  @IBOutlet var label: UILabel!\n}\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
@@ -103,7 +103,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
                 "internal func test2() {}\n " +
                 "public func test3() {}\n " +
                 "private ↓func test4() {}\n " +
-            "}",
+            "}"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -46,7 +46,7 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
             "func abc()\n  ->  Int {}\n": "func abc()\n  -> Int {}\n",
             "func abc()\n->  Int {}\n": "func abc()\n-> Int {}\n",
             "func abc()  ->\n  Int {}\n": "func abc() ->\n  Int {}\n",
-            "func abc()  ->\nInt {}\n": "func abc() ->\nInt {}\n",
+            "func abc()  ->\nInt {}\n": "func abc() ->\nInt {}\n"
         ]
     )
 
@@ -101,7 +101,7 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
             "(\(incorrectSpace)\\->\(space)*)",
             "(\(space)\\->\(incorrectSpace))",
             "\\n\(space)*\\->\(incorrectSpace)",
-            "\(incorrectSpace)\\->\\n\(space)*",
+            "\(incorrectSpace)\\->\\n\(space)*"
         ]
 
         // ex: `func abc()-> Int {` & `func abc() ->Int {`

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -1,0 +1,39 @@
+//
+//  TrailingCommaConfiguration.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 25/11/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+
+public struct TrailingCommaConfiguration: RuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.Warning)
+    private(set) var mandatoryComma: Bool
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription + ", mandatory_comma: \(mandatoryComma)"
+    }
+
+    public init(mandatoryComma: Bool = false) {
+        self.mandatoryComma = mandatoryComma
+    }
+
+    public mutating func applyConfiguration(configuration: AnyObject) throws {
+        guard let configuration = configuration as? [String: AnyObject] else {
+            throw ConfigurationError.UnknownConfiguration
+        }
+
+        mandatoryComma = (configuration["mandatory_comma"] as? Bool == true)
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.applyConfiguration(severityString)
+        }
+    }
+}
+
+public func == (lhs: TrailingCommaConfiguration,
+                rhs: TrailingCommaConfiguration) -> Bool {
+    return lhs.mandatoryComma == rhs.mandatoryComma
+}

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -55,7 +55,7 @@ public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule 
             "\n\n  }\n  catch {",
             "\"}\nelse{\"",
             "struct A { let catchphrase: Int }\nlet a = A(\n catchphrase: 0\n)",
-            "struct A { let `catch`: Int }\nlet a = A(\n `catch`: 0\n)",
+            "struct A { let `catch`: Int }\nlet a = A(\n `catch`: 0\n)"
         ],
         triggeringExamples: [
             "↓  }else if {",

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -35,7 +35,7 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
             "let x: ↓ImplicitlyUnwrappedOptional<Int>",
             "func x(a: ↓Array<Int>, b: Int) -> [Int: Any]",
             "func x(a: [Int], b: Int) -> ↓Dictionary<Int, String>",
-            "func x(a: ↓Array<Int>, b: Int) -> ↓Dictionary<Int, String>",
+            "func x(a: ↓Array<Int>, b: Int) -> ↓Dictionary<Int, String>"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -1,0 +1,97 @@
+//
+//  TrailingCommaRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 21/11/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct TrailingCommaRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.Warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "trailing_comma",
+        name: "Trailing Comma",
+        description: "Trailing commas in arrays and dictionaries should be avoided.",
+        nonTriggeringExamples: [
+            "let foo = [1, 2, 3]\n",
+            "let foo = []\n",
+            "let foo = [:]\n",
+            "let foo = [1: 2, 2: 3]\n"
+        ],
+        triggeringExamples: [
+            "let foo = [1, 2, 3↓,]\n",
+            "let foo = [1, 2, 3↓, ]\n",
+            "let foo = [1, 2, 3   ↓,]\n",
+            "let foo = [1: 2, 2: 3↓, ]\n",
+            "struct Bar {\n let foo = [1: 2, 2: 3↓, ]\n}\n"
+        ]
+    )
+
+    public func validateFile(file: File,
+                             kind: SwiftExpressionKind,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+
+        let allowedKinds: [SwiftExpressionKind] = [.Array, .Dictionary]
+
+        guard let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
+            bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
+            elements = dictionary["key.elements"]  as? [SourceKitRepresentable]
+            where allowedKinds.contains(kind) else {
+                return []
+        }
+
+        let endPositions = elements.flatMap { element -> Int? in
+            guard let dictionary = element as? [String: SourceKitRepresentable],
+                offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+                length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }) else {
+                    return nil
+            }
+
+            return offset + length
+        }
+
+        guard let lastPosition = endPositions.maxElement() else {
+            return []
+        }
+
+        let length = bodyLength + bodyOffset - lastPosition
+        let contentsAfterLastElement = file.contents
+            .substringWithByteRange(start: lastPosition, length: length) ?? ""
+
+        guard let commaIndex = contentsAfterLastElement.lastIndexOf(",") else {
+            return []
+        }
+
+        let violationOffset = lastPosition + commaIndex
+
+        return [
+            StyleViolation(ruleDescription: self.dynamicType.description,
+                severity: configuration.severity,
+                location: Location(file: file, byteOffset: violationOffset)
+            )
+        ]
+    }
+}
+
+public enum SwiftExpressionKind: String {
+    case Array = "source.lang.swift.expr.array"
+    case Dictionary = "source.lang.swift.expr.dictionary"
+    case Other
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        case Array.rawValue:
+            self = .Array
+        case Dictionary.rawValue:
+            self = .Dictionary
+        default:
+            self = .Other
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -193,7 +193,7 @@ public struct ValidDocsRule: ConfigurationProviderRule {
             "/// docs\n/// - throws: NSError\n/// - returns: false" +
                 "\nfunc a() throws -> Bool { return true }",
             "/// docs\n/// - parameter param: this is a closure\n/// - returns: Bool" +
-                "\nfunc a(param: (Void throws -> Bool)) -> Bool { return true }",
+                "\nfunc a(param: (Void throws -> Bool)) -> Bool { return true }"
         ],
         triggeringExamples: [
             "/// docs\npublic ↓func a(param: Void) {}\n",
@@ -223,7 +223,7 @@ public struct ValidDocsRule: ConfigurationProviderRule {
                 "\nfunc a(param: () -> Void) -> Foo<Void> {return Foo<Void>}",
             "/// docs\n/// - parameter param: this is a void closure" +
                 "\nfunc a(param: () -> Void) -> Foo<[Int]> {return Foo<[Int]>}",
-            "/// docs\nfunc a() throws -> Bool { return true }",
+            "/// docs\nfunc a() throws -> Bool { return true }"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
@@ -28,7 +28,7 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
             "class Foo {\n  @IBInspectable private var x: Optional<String>\n}\n",
             "class Foo {\n  @IBInspectable private var count: Int = 0\n}\n",
             "class Foo {\n  private var notInspectable = 0\n}\n",
-            "class Foo {\n  private let notInspectable: Int\n}\n",
+            "class Foo {\n  private let notInspectable: Int\n}\n"
         ],
         triggeringExamples: [
             "class Foo {\n  @IBInspectable private let count: Int\n}\n",
@@ -37,7 +37,7 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
             "class Foo {\n  @IBInspectable private var count: Int?\n}\n",
             "class Foo {\n  @IBInspectable private var count: Int!\n}\n",
             "class Foo {\n  @IBInspectable private var x: ImplicitlyUnwrappedOptional<Int>\n}\n",
-            "class Foo {\n  @IBInspectable private var count: Optional<Int>\n}\n",
+            "class Foo {\n  @IBInspectable private var count: Optional<Int>\n}\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
@@ -26,17 +26,17 @@ public struct VerticalWhitespaceRule: CorrectableRule,
             "let abc = 0\n",
             "let abc = 0\n\n",
             "/* bcs \n\n\n\n*/",
-            "// bca \n\n",
+            "// bca \n\n"
         ],
         triggeringExamples: [
             "let aaaa = 0\n\n\n",
             "struct AAAA {}\n\n\n\n",
-             "class BBBB {}\n\n\n",
+             "class BBBB {}\n\n\n"
         ],
         corrections: [
             "let b = 0\n\n\nclass AAA {}\n": "let b = 0\n\nclass AAA {}\n",
             "let c = 0\n\n\nlet num = 1\n": "let c = 0\n\nlet num = 1\n",
-            "// bca \n\n\n": "// bca \n\n",
+            "// bca \n\n\n": "// bca \n\n"
         ] // End of line autocorrections are handled by Trailing Newline Rule.
     )
 

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -30,7 +30,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
         triggeringExamples: [
             "class Foo {\n  var delegate: SomeProtocol?\n}\n",
             "class Foo {\n  var scrollDelegate: ScrollDelegate?\n}\n",
-            "class Foo {\n  var delegateScroll: ScrollDelegate?\n}\n",
+            "class Foo {\n  var delegateScroll: ScrollDelegate?\n}\n"
         ]
     )
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
+		D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */; };
 		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
@@ -272,6 +273,7 @@
 		D0D1217719E87B05005E4BAA /* SwiftLintFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftLintFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0D1217D19E87B05005E4BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaConfiguration.swift; sourceTree = "<group>"; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitGetterRule.swift; sourceTree = "<group>"; };
 		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */,
 				3BCC04CF1C4F56D3006073C3 /* SeverityLevelsConfiguration.swift */,
 				725094881D0855760039B353 /* StatementPositionConfiguration.swift */,
+				D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */,
 				BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */,
 			);
 			path = RuleConfigurations;
@@ -1014,6 +1017,7 @@
 				3BB47D831C514E8100AE6A10 /* RegexConfiguration.swift in Sources */,
 				3B1150CA1C31FC3F00D83B1E /* Yaml+SwiftLint.swift in Sources */,
 				4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */,
+				D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
 				E881985D1BEA97EB00333A11 /* TrailingWhitespaceRule.swift in Sources */,
 				E832F10B1B17E2F5003F265F /* NSFileManager+SwiftLint.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -9,9 +9,9 @@
 /* Begin PBXBuildFile section */
 		006ECFC41C44E99E00EF6364 /* LegacyConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */; };
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
+		094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094384FF1D5D2382009168CF /* WeakDelegateRule.swift */; };
 		094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094385021D5D4F78009168CF /* PrivateOutletRule.swift */; };
 		1E82D5591D7775C7009553D7 /* ClosureSpacingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */; };
-		094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094384FF1D5D2382009168CF /* WeakDelegateRule.swift */; };
 		1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */; };
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
 		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
@@ -57,7 +57,6 @@
 		6CCFCF301CFEF742003239EB /* Yaml.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = E89376AC1B8A701E0025708E /* Yaml.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7250948A1D0859260039B353 /* StatementPositionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725094881D0855760039B353 /* StatementPositionConfiguration.swift */; };
 		78F032461D7C877E00BE709A /* OverriddenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */; };
-		78F032461D7C877E00BE709A /* OverridenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverridenSuperCallRule.swift */; };
 		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
 		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
@@ -194,9 +193,9 @@
 /* Begin PBXFileReference section */
 		006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRule.swift; sourceTree = "<group>"; };
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
+		094384FF1D5D2382009168CF /* WeakDelegateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
 		094385021D5D4F78009168CF /* PrivateOutletRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
 		1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureSpacingRule.swift; sourceTree = "<group>"; };
-		094384FF1D5D2382009168CF /* WeakDelegateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
 		1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRule.swift; sourceTree = "<group>"; };
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
 		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
@@ -239,7 +238,6 @@
 		6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxMap+SwiftLint.swift"; sourceTree = "<group>"; };
 		725094881D0855760039B353 /* StatementPositionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionConfiguration.swift; sourceTree = "<group>"; };
 		78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverriddenSuperCallRule.swift; sourceTree = "<group>"; };
-		78F032441D7C877800BE709A /* OverridenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallRule.swift; sourceTree = "<group>"; };
 		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
 		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		6CCFCF301CFEF742003239EB /* Yaml.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = E89376AC1B8A701E0025708E /* Yaml.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7250948A1D0859260039B353 /* StatementPositionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725094881D0855760039B353 /* StatementPositionConfiguration.swift */; };
 		78F032461D7C877E00BE709A /* OverriddenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */; };
+		78F032461D7C877E00BE709A /* OverridenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverridenSuperCallRule.swift */; };
 		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
 		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
@@ -76,6 +77,7 @@
 		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
 		D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
+		D46E041D1DE3712C00728374 /* TrailingCommaRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */; };
 		D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */; };
 		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
@@ -237,6 +239,7 @@
 		6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxMap+SwiftLint.swift"; sourceTree = "<group>"; };
 		725094881D0855760039B353 /* StatementPositionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionConfiguration.swift; sourceTree = "<group>"; };
 		78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverriddenSuperCallRule.swift; sourceTree = "<group>"; };
+		78F032441D7C877800BE709A /* OverridenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallRule.swift; sourceTree = "<group>"; };
 		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
 		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
@@ -276,6 +279,7 @@
 		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
 		D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyntacticSugarRule.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
+		D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRule.swift; sourceTree = "<group>"; };
 		D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
 		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
@@ -659,6 +663,7 @@
 				D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */,
 				D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */,
 				E88DEA811B0990A700A66CB0 /* TodoRule.swift */,
+				D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */,
 				E88DEA871B09924C00A66CB0 /* TrailingNewlineRule.swift */,
 				E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */,
 				E88DEA851B0991BF00A66CB0 /* TrailingWhitespaceRule.swift */,
@@ -1019,6 +1024,7 @@
 				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
 				E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */,
 				E881985F1BEA987C00333A11 /* TypeNameRule.swift in Sources */,
+				D46E041D1DE3712C00728374 /* TrailingCommaRule.swift in Sources */,
 				E88198521BEA941300333A11 /* TodoRule.swift in Sources */,
 				3B828E531C546468000D180E /* RuleConfiguration.swift in Sources */,
 			);

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -9,6 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
+// swiftlint:disable:next type_body_length
 class RulesTests: XCTestCase {
 
     func testClosingBrace() {
@@ -249,7 +250,33 @@ class RulesTests: XCTestCase {
     }
 
     func testTrailingComma() {
+        // verify with mandatory_comma = false (default value)
         verifyRule(TrailingCommaRule.description)
+
+        // verify with mandatory_comma = true
+        let mandatoryCommaDescription = RuleDescription(
+            identifier: "trailing_comma",
+            name: "Trailing Comma",
+            description: "Trailing commas in arrays and dictionaries should be enforced.",
+            nonTriggeringExamples: [
+                "let foo = []\n",
+                "let foo = [:]\n",
+                "let foo = [1, 2, 3,]\n",
+                "let foo = [1, 2, 3, ]\n",
+                "let foo = [1, 2, 3   ,]\n",
+                "let foo = [1: 2, 2: 3, ]\n",
+                "struct Bar {\n let foo = [1: 2, 2: 3,]\n}\n"
+            ],
+            triggeringExamples: [
+                "let foo = [1, 2, 3↓]\n",
+                "let foo = [1: 2, 2: 3↓]\n",
+                "let foo = [1: 2, 2: 3↓   ]\n",
+                "struct Bar {\n let foo = [1: 2, 2: 3↓]\n}\n",
+                "let foo = [1, 2, 3↓] + [4, 5, 6↓]\n"
+            ]
+        )
+
+        verifyRule(mandatoryCommaDescription, ruleConfiguration: ["mandatory_comma": true])
     }
 
     func testTrailingNewline() {

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -248,6 +248,10 @@ class RulesTests: XCTestCase {
         verifyRule(TodoRule.description, commentDoesntViolate: false)
     }
 
+    func testTrailingComma() {
+        verifyRule(TrailingCommaRule.description)
+    }
+
     func testTrailingNewline() {
         verifyRule(TrailingNewlineRule.description, commentDoesntViolate: false,
                    stringDoesntViolate: false)


### PR DESCRIPTION
Fixes #883.

How would be the best way to handle both styles (mandatory comma and forbidden comma)? A configuration (if so, how should the rule description be)? Another rule?

I made this rule opt-in as even SwiftLint codebase isn't consistent. Thoughts?

PS: The changelog entry is missing on purpose as I thought it'd be better to think on how to handle both styles first.