### PR TITLE
Allow specifying multiple rule identifiers in comment commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#319](https://github.com/realm/SwiftLint/issues/319)
 
+* Allow specifying multiple rule identifiers in comment commands. For example,
+  `// swiftlint:disable:next force_cast force_try`. Works with all command types
+  (`disable`/`enable`) and modifiers (`next`, `this`, `previous` or blank).  
+  [JP Simard](https://github.com/jpsim)
+  [#861](https://github.com/realm/SwiftLint/issues/861)
+
 ##### Bug Fixes
 
 

--- a/README.md
+++ b/README.md
@@ -116,17 +116,17 @@ Guidelines on when to implement a rule as opt-in:
 * A rule that is not general consensus or only useful in some cases
   (e.g. `force_unwrapping`, `missing_docs`)
 
-### Disable a rule in code
+### Disable rules in code
 
 Rules can be disabled with a comment inside a source file with the following
 format:
 
-`// swiftlint:disable <rule>`
+`// swiftlint:disable <rule1> [<rule2> <rule3>...]`
 
-The rule will be disabled until the end of the file or until the linter sees a
+The rules will be disabled until the end of the file or until the linter sees a
 matching enable comment:
 
-`// swiftlint:enable <rule>`
+`// swiftlint:enable <rule1> [<rule2> <rule3>...]`
 
 For example:
 

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -14,7 +14,7 @@ internal func regex(pattern: String) -> NSRegularExpression {
     // confirmed to work, so it's ok to force-try here.
 
     // swiftlint:disable:next force_try
-    return try! NSRegularExpression.cached(pattern: pattern)
+    return try! .cached(pattern: pattern)
 }
 
 extension File {

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -25,8 +25,8 @@ extension File {
         let commandPairs = zip(commands, Array(commands.dropFirst().map(Optional.init)) + [nil])
         for (command, nextCommand) in commandPairs {
             switch command.action {
-            case .Disable: disabledRules.insert(command.ruleIdentifier)
-            case .Enable: disabledRules.remove(command.ruleIdentifier)
+            case .Disable: disabledRules.unionInPlace(command.ruleIdentifiers)
+            case .Enable: disabledRules.subtractInPlace(command.ruleIdentifiers)
             }
             let start = Location(file: path, line: command.line, character: command.character)
             let end = endOfNextCommand(nextCommand)

--- a/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
@@ -21,6 +21,7 @@ extension NSRegularExpression {
         regexCache[pattern] = result
         return result
     }
+
     internal static func forcePattern(pattern: String) -> NSRegularExpression {
         // swiftlint:disable:next force_try
         return try! .cached(pattern: pattern)

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -28,15 +28,15 @@ public enum CommandModifier: String {
 
 public struct Command {
     let action: CommandAction
-    let ruleIdentifier: String
+    let ruleIdentifiers: [String]
     let line: Int
     let character: Int?
     let modifier: CommandModifier?
 
-    public init(action: CommandAction, ruleIdentifier: String, line: Int = 0, character: Int? = nil,
-                modifier: CommandModifier? = nil) {
+    public init(action: CommandAction, ruleIdentifiers: [String], line: Int = 0,
+                character: Int? = nil, modifier: CommandModifier? = nil) {
         self.action = action
-        self.ruleIdentifier = ruleIdentifier
+        self.ruleIdentifiers = ruleIdentifiers
         self.line = line
         self.character = character
         self.modifier = modifier
@@ -59,7 +59,9 @@ public struct Command {
                 return nil
         }
         self.action = action
-        ruleIdentifier = (scanner.string as NSString).substringFromIndex(scanner.scanLocation + 1)
+        ruleIdentifiers = (scanner.string as NSString)
+            .substringFromIndex(scanner.scanLocation + 1)
+            .componentsSeparatedByCharactersInSet(.whitespaceCharacterSet())
         line = lineAndCharacter.line
         character = lineAndCharacter.character
 
@@ -82,20 +84,20 @@ public struct Command {
         switch modifier {
         case .Previous:
             return [
-                Command(action: action, ruleIdentifier: ruleIdentifier, line: line - 1),
-                Command(action: action.inverse(), ruleIdentifier: ruleIdentifier, line: line - 1,
+                Command(action: action, ruleIdentifiers: ruleIdentifiers, line: line - 1),
+                Command(action: action.inverse(), ruleIdentifiers: ruleIdentifiers, line: line - 1,
                     character: Int.max)
             ]
         case .This:
             return [
-                Command(action: action, ruleIdentifier: ruleIdentifier, line: line),
-                Command(action: action.inverse(), ruleIdentifier: ruleIdentifier, line: line,
+                Command(action: action, ruleIdentifiers: ruleIdentifiers, line: line),
+                Command(action: action.inverse(), ruleIdentifiers: ruleIdentifiers, line: line,
                     character: Int.max)
             ]
         case .Next:
             return [
-                Command(action: action, ruleIdentifier: ruleIdentifier, line: line + 1),
-                Command(action: action.inverse(), ruleIdentifier: ruleIdentifier, line: line + 1,
+                Command(action: action, ruleIdentifiers: ruleIdentifiers, line: line + 1),
+                Command(action: action.inverse(), ruleIdentifiers: ruleIdentifiers, line: line + 1,
                     character: Int.max)
             ]
         }

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -154,8 +154,8 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             }
             return Set(syntaxKinds).intersect(commentAndStringKindsSet).isEmpty
         }.flatMap { range, syntaxTokens in
-            let identifierRange = nsstring // swiftlint:disable:next force_unwrapping
-                .byteRangeToNSRange(start: syntaxTokens.first!.offset, length: 0)
+            let identifierRange = nsstring
+                .byteRangeToNSRange(start: syntaxTokens[0].offset, length: 0)
             return identifierRange.map { NSUnionRange($0, range) }
         }
     }

--- a/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
@@ -105,7 +105,7 @@ public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         }
     }
 
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     public func correctFile(file: File) -> [Correction] {
         let varName = RegexHelpers.varNameGroup
         let twoVars = RegexHelpers.twoVars
@@ -158,5 +158,4 @@ public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         file.write(contents)
         return corrections
     }
-    // swiftlint:enable function_body_length
 }

--- a/Tests/SwiftLintFramework/ConfigurationTests.swift
+++ b/Tests/SwiftLintFramework/ConfigurationTests.swift
@@ -195,8 +195,7 @@ class ConfigurationTests: XCTestCase {
         let ruleConfiguration = [1, 2]
         let config = [RuleWithLevelsMock.description.identifier: ruleConfiguration]
         let rules = testRuleList.configuredRulesWithDictionary(config)
-        // swiftlint:disable:next force_try
-        XCTAssertTrue(rules == [try! RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
+        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
     }
 
     func testConfigureFallsBackCorrectly() {

--- a/Tests/SwiftLintFramework/CustomRulesTests.swift
+++ b/Tests/SwiftLintFramework/CustomRulesTests.swift
@@ -58,8 +58,7 @@ class CustomRulesTests: XCTestCase {
     func testLocalDisableCustomRule() {
         let (_, customRules) = getCustomRules()
         let file = File(contents: "//swiftlint:disable custom \n// file with a pattern")
-        XCTAssertEqual(customRules.validateFile(file),
-                       [])
+        XCTAssertEqual(customRules.validateFile(file), [])
     }
 
     func testCustomRulesIncludedDefault() {

--- a/Tests/SwiftLintFramework/IntegrationTests.swift
+++ b/Tests/SwiftLintFramework/IntegrationTests.swift
@@ -51,7 +51,6 @@ extension String {
             let rawPointer = $0._rawValue
             let byteSize = lengthOfBytesUsingEncoding(NSUTF8StringEncoding)._builtinWordValue
             let isASCII = true._getBuiltinLogicValue()
-            // swiftlint:disable:next variable_name
             let staticString = StaticString(_builtinStringLiteral: rawPointer, byteSize: byteSize,
                 isASCII: isASCII)
             closure(staticString)

--- a/Tests/SwiftLintFramework/RulesTests.swift
+++ b/Tests/SwiftLintFramework/RulesTests.swift
@@ -15,7 +15,7 @@ class RulesTests: XCTestCase {
         verifyRule(ClosingBraceRule.description)
     }
 
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     func testColon() {
         // Verify Colon rule with test values for when flexible_right_spacing
         // is false (default).
@@ -87,7 +87,6 @@ class RulesTests: XCTestCase {
 
         verifyRule(description, ruleConfiguration: ["flexible_right_spacing": true])
     }
-    // swiftlint:enable function_body_length
 
     func testComma() {
         verifyRule(CommaRule.description)

--- a/Tests/SwiftLintFramework/YamlParserTests.swift
+++ b/Tests/SwiftLintFramework/YamlParserTests.swift
@@ -11,14 +11,13 @@ import XCTest
 
 class YamlParserTests: XCTestCase {
 
-    // swiftlint:disable force_try
     func testParseEmptyString() {
-        XCTAssertEqual((try! YamlParser.parse("")).count, 0,
+        XCTAssertEqual((try YamlParser.parse("")).count, 0,
                        "Parsing empty YAML string should succeed")
     }
 
     func testParseValidString() {
-        XCTAssertEqual(try! YamlParser.parse("a: 1\nb: 2").count, 2,
+        XCTAssertEqual(try YamlParser.parse("a: 1\nb: 2").count, 2,
                        "Parsing valid YAML string should succeed")
     }
 
@@ -27,5 +26,4 @@ class YamlParserTests: XCTestCase {
             try YamlParser.parse("|\na")
         }
     }
-    // swiftlint:enable force_try
 }


### PR DESCRIPTION
Fixes #861. This was _super_ easy to do. Really should've done this a long time ago.