### PR TITLE
Fix ValidIBInspectable rule implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
 
 ##### Bug Fixes
 
+* Rule out a few invalid `@IBInspectable` cases in `valid_ibinspectable`.  
+  [Daniel Duan](https://github.com/dduan)
+
 * Fix a few edge cases where malformed `MARK:` comments wouldn't trigger a
   violation.  
   [JP Simard](https://github.com/jpsim)

--- a/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
@@ -24,8 +24,6 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
             "class Foo {\n  @IBInspectable private var x: Int\n}\n",
             "class Foo {\n  @IBInspectable private var x: String?\n}\n",
             "class Foo {\n  @IBInspectable private var x: String!\n}\n",
-            "class Foo {\n  @IBInspectable private var x: ImplicitlyUnwrappedOptional<String>\n}\n",
-            "class Foo {\n  @IBInspectable private var x: Optional<String>\n}\n",
             "class Foo {\n  @IBInspectable private var count: Int = 0\n}\n",
             "class Foo {\n  private var notInspectable = 0\n}\n",
             "class Foo {\n  private let notInspectable: Int\n}\n"
@@ -37,7 +35,9 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
             "class Foo {\n  @IBInspectable private var count: Int?\n}\n",
             "class Foo {\n  @IBInspectable private var count: Int!\n}\n",
             "class Foo {\n  @IBInspectable private var x: ImplicitlyUnwrappedOptional<Int>\n}\n",
-            "class Foo {\n  @IBInspectable private var count: Optional<Int>\n}\n"
+            "class Foo {\n  @IBInspectable private var count: Optional<Int>\n}\n",
+            "class Foo {\n  @IBInspectable private var x: Optional<String>\n}\n",
+            "class Foo {\n  @IBInspectable private var x: ImplicitlyUnwrappedOptional<String>\n}\n"
         ]
     )
 
@@ -85,8 +85,7 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
             "UIColor",
             "NSColor",
             "UIImage",
-            "NSImage",
-            "NSNumber"
+            "NSImage"
         ]
 
         let types = [
@@ -104,10 +103,7 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
         ]
 
         // It seems that only reference types can be used as ImplicitlyUnwrappedOptional or Optional
-        return referenceTypes.flatMap {
-            [$0, $0 + "!", $0 + "?",
-            "ImplicitlyUnwrappedOptional<\($0)>", "Optional<\($0)>"] + types
-        }
+        return referenceTypes.flatMap { [$0, $0 + "!", $0 + "?"] } + types
     }
 
     private func violation(dictionary: [String: SourceKitRepresentable],


### PR DESCRIPTION
There are several issue in the current implementation of this rule:

1. `NSNumber` is not IB-inspectable at all.
2. Explicitly typed `Optional`s and `ImplicitlyUnwrappedOptional`s aren't
   supported by `@IBInspectable`, reference type or not.
3. ~~Supported value types with `!`s and `?`s are indeed inspectable, contrary to
   what the current implementation deems.~~

For verification, try these out with this little class:

https://gist.github.com/dduan/da4050ca3a0bce5b4d54d21effb06b24