### PR TITLE
Use severityConfiguration in rules == function

### DIFF
--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -35,5 +35,6 @@ public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
 
 public func == (lhs: PrivateOutletRuleConfiguration,
                 rhs: PrivateOutletRuleConfiguration) -> Bool {
-    return lhs.allowPrivateSet == rhs.allowPrivateSet
+    return lhs.allowPrivateSet == rhs.allowPrivateSet &&
+        lhs.severityConfiguration == rhs.severityConfiguration
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -35,5 +35,6 @@ public struct TrailingCommaConfiguration: RuleConfiguration, Equatable {
 
 public func == (lhs: TrailingCommaConfiguration,
                 rhs: TrailingCommaConfiguration) -> Bool {
-    return lhs.mandatoryComma == rhs.mandatoryComma
+    return lhs.mandatoryComma == rhs.mandatoryComma &&
+        lhs.severityConfiguration == rhs.severityConfiguration
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -41,5 +41,6 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
 public func == (lhs: TrailingWhitespaceConfiguration,
                 rhs: TrailingWhitespaceConfiguration) -> Bool {
     return lhs.ignoresEmptyLines == rhs.ignoresEmptyLines &&
-        lhs.ignoresComments == rhs.ignoresComments
+        lhs.ignoresComments == rhs.ignoresComments &&
+        lhs.severityConfiguration == rhs.severityConfiguration
 }


### PR DESCRIPTION
I'm not sure where the rules `==` function is used, but I thought we should be consistent.

This probably doesn't even deserve a CHANGELOG entry.