### PR TITLE
Add human readable reporter that’s also funny because emoji.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Enhancements
 
-* None.
+* Add `EmojiReporter`: a human readble reporter.  
+  [Michał Kałużny](https://github.com/justMaku)
 
 ##### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ variable_name:
     - id
     - URL
     - GlobalAPIKey
-reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit, emoji)
 ```
 
 #### Defining Custom Rules

--- a/README_CN.md
+++ b/README_CN.md
@@ -162,7 +162,7 @@ variable_name:
     - id
     - URL
     - GlobalAPIKey
-reporter: "xcode" # 报告类型 (xcode, json, csv, checkstyle)
+reporter: "xcode" # 报告类型 (xcode, json, csv, checkstyle, junit, emoji)
 ```
 
 #### 定义自定义规则

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -24,3 +24,27 @@ extension Array where Element: NSTextCheckingResult {
         return map { $0.range }
     }
 }
+
+extension Array where Element: Equatable {
+    var unique: [Element] {
+        var uniqueValues: [Element] = []
+        forEach { item in
+            if !uniqueValues.contains(item) {
+                uniqueValues += [item]
+            }
+        }
+        return uniqueValues
+    }
+}
+
+extension Array {
+    // swiftlint:disable:next line_length
+    func group<U: Hashable>(by transform: (Element) -> U) -> [U: [Element]] {
+        var dictionary: [U: [Element]] = [:]
+        for element in self {
+            let key = transform(element)
+            if case nil = dictionary[key]?.append(element) { dictionary[key] = [element] }
+        }
+        return dictionary
+    }
+}

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -26,6 +26,8 @@ public func reporterFromString(_ string: String) -> Reporter.Type {
         return JUnitReporter.self
     case HTMLReporter.identifier:
         return HTMLReporter.self
+    case EmojiReporter.identifier:
+        return EmojiReporter.self
     default:
         fatalError("no reporter with identifier '\(string)' available.")
     }

--- a/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
@@ -1,0 +1,71 @@
+//
+//  EmojiReporter.swift
+//  SwiftLint
+//
+//  Created by Michał Kałużny on 01/12/2016.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+
+public struct EmojiReporter: Reporter {
+    public static let identifier = "emoji"
+    public static let isRealtime = false
+
+    public var description: String {
+        return "Reports violations in the format that's both fun and easy to read."
+    }
+
+    public static func generateReport(_ violations: [StyleViolation]) -> String {
+        return violations.group { (violation) in
+                violation.location.file ?? "Other"
+            }.map { (filename, violations) in
+                return reportFor(file: filename, with: violations)
+            }.joined(separator: "\n")
+    }
+
+    private static func reportFor(file: String, with violations: [StyleViolation]) -> String {
+        var lines: [String] = []
+
+        let sortedViolatons = violations.sorted { (lhs, rhs) -> Bool in
+            switch (lhs.severity, rhs.severity) {
+            case (.warning, .error): return false
+            case (.error, .warning): return true
+            case (_, _):
+                switch (lhs.location.line, rhs.location.line) {
+                case (.some(let lhs), .some(let rhs)): return lhs < rhs
+                case (.some, .none): return true
+                case (.none, .some): return false
+                case (.none, .none): return false
+                }
+            }
+        }
+
+        lines.append(file)
+
+        for violation in sortedViolatons {
+            var line = ""
+            line += emojiFor(violationSeverity: violation.severity)
+            line += " "
+
+            if let locationLine = violation.location.line {
+                line += "Line \(locationLine): "
+            }
+
+            line += violation.reason
+
+            lines.append(line)
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func emojiFor(violationSeverity: ViolationSeverity) -> String {
+        switch violationSeverity {
+        case .error:
+            return "⛔️"
+        case .warning:
+            return "⚠️"
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
 		2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */; };
+		2E336D1B1DF08BFB00CCFE77 /* EmojiReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */; };
 		2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */; };
 		3B0B14541C505D6300BE82F7 /* SeverityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */; };
 		3B1150CA1C31FC3F00D83B1E /* Yaml+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1150C91C31FC3F00D83B1E /* Yaml+SwiftLint.swift */; };
@@ -202,6 +203,7 @@
 		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
 		2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityRule.swift; sourceTree = "<group>"; };
+		2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiReporter.swift; sourceTree = "<group>"; };
 		2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRule.swift; sourceTree = "<group>"; };
 		3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeverityConfiguration.swift; sourceTree = "<group>"; };
 		3B1150C91C31FC3F00D83B1E /* Yaml+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Yaml+SwiftLint.swift"; sourceTree = "<group>"; };
@@ -618,6 +620,7 @@
 				E86396C81BADB2B9002C9E88 /* JSONReporter.swift */,
 				E86396C41BADAC15002C9E88 /* XcodeReporter.swift */,
 				4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */,
+				2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */,
 			);
 			path = Reporters;
 			sourceTree = "<group>";
@@ -969,6 +972,7 @@
 				D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */,
 				E88198441BEA93D200333A11 /* ColonRule.swift in Sources */,
 				E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */,
+				2E336D1B1DF08BFB00CCFE77 /* EmojiReporter.swift in Sources */,
 				E8EA41171C2D1DBE004F9930 /* CheckstyleReporter.swift in Sources */,
 				006ECFC41C44E99E00EF6364 /* LegacyConstantRule.swift in Sources */,
 				E88DEA731B0984C400A66CB0 /* String+SwiftLint.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -18,7 +18,8 @@ class ReporterTests: XCTestCase {
             CSVReporter.self,
             CheckstyleReporter.self,
             JUnitReporter.self,
-            HTMLReporter.self
+            HTMLReporter.self,
+            EmojiReporter.self
         ]
         for reporter in reporters {
             XCTAssertEqual(reporter.identifier, reporterFromString(reporter.identifier).identifier)
@@ -43,6 +44,15 @@ class ReporterTests: XCTestCase {
             XcodeReporter.generateReport(generateViolations()),
             "filename:1:2: warning: Line Length Violation: Violation Reason. (line_length)\n" +
             "filename:1:2: error: Line Length Violation: Violation Reason. (line_length)"
+        )
+    }
+
+    func testEmojiReporter() {
+        XCTAssertEqual(
+            EmojiReporter.generateReport(generateViolations()),
+            "filename\n" +
+            "⛔️ Line 1: Violation Reason.\n" +
+            "⚠️ Line 1: Violation Reason."
         )
     }
 


### PR DESCRIPTION
This pull request adds a new reporter type that's much easier to read for human eye. I believe it could be useful for people that use swiftlint for example in a pre-commit hook or on CI.

**Example:**
```
/Users/maku/Projects/Temp/Otter.swift
⛔️ Line 159: Function should have complexity 10 or less: currently complexity equals 21
⛔️ Line 185: Function should have complexity 10 or less: currently complexity equals 96
⚠️ Line 12: Lines should not have trailing whitespace.
⚠️ Line 18: Lines should not have trailing whitespace.
⚠️ Line 115: Lines should not have trailing whitespace.

/Users/maku/Projects/Temp/Other.swift
⚠️ Line 23: Lines should not have trailing whitespace.
⚠️ Line 69: Lines should not have trailing whitespace.
⚠️ Line 92: Lines should not have trailing whitespace.
```