### PR TITLE
remove unnecessary .lowercased() calls

### DIFF
--- a/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
@@ -28,7 +28,7 @@ public struct CheckstyleReporter: Reporter {
         let file: String = violation.location.file ?? "<nopath>"
         let line: Int = violation.location.line ?? 0
         let col: Int = violation.location.character ?? 0
-        let severity: String = violation.severity.rawValue.lowercased()
+        let severity: String = violation.severity.rawValue
         let reason: String = violation.reason
         return [
             "\n\t<file name=\"", file, "\">\n",

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -20,7 +20,7 @@ public struct JUnitReporter: Reporter {
         return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +
             violations.map({ violation in
                 let fileName = violation.location.file ?? "<nopath>"
-                let severity = violation.severity.rawValue.lowercased() + ":\n"
+                let severity = violation.severity.rawValue + ":\n"
                 let message = severity + "Line:" + String(violation.location.line ?? 0) + " "
                 return ["\n\t<testcase classname='Formatting Test' name='\(fileName)\'>\n",
                     "<failure message='\(violation.reason)\'>" + message + "</failure>",

--- a/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
@@ -22,7 +22,7 @@ public struct XcodeReporter: Reporter {
         // {full_path_to_file}{:line}{:character}: {error,warning}: {content}
         return [
             "\(violation.location): ",
-            "\(violation.severity.rawValue.lowercased()): ",
+            "\(violation.severity.rawValue): ",
             "\(violation.ruleDescription.name) Violation: ",
             violation.reason,
             " (\(violation.ruleDescription.identifier))"

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -103,7 +103,7 @@ public struct MissingDocsRule: OptInRule {
 
     public var configurationDescription: String {
         return parameters.map({
-            "\($0.severity.rawValue.lowercased()): \($0.value.rawValue)"
+            "\($0.severity.rawValue): \($0.value.rawValue)"
         }).joined(separator: ", ")
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -22,7 +22,7 @@ public struct PrivateUnitTestConfiguration: RuleConfiguration, Equatable {
     }
 
     public var consoleDescription: String {
-        return "\(severity.rawValue.lowercased()): \(regex.pattern)"
+        return "\(severity.rawValue): \(regex.pattern)"
     }
 
     public var description: RuleDescription {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -23,7 +23,7 @@ public struct RegexConfiguration: RuleConfiguration, Equatable {
     }
 
     public var consoleDescription: String {
-        return "\(severity.rawValue.lowercased()): \(regex.pattern)"
+        return "\(severity.rawValue): \(regex.pattern)"
     }
 
     public var description: RuleDescription {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct SeverityConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
-        return severity.rawValue.lowercased()
+        return severity.rawValue
     }
 
     var severity: ViolationSeverity

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -41,7 +41,7 @@ private func render(violations: [StyleViolation], in contents: String) -> String
             let character = violation.location.character else { continue }
 
         let message = String(repeating: " ", count: character - 1) + "^ " + [
-            "\(violation.severity.rawValue.lowercased()): ",
+            "\(violation.severity.rawValue): ",
             "\(violation.ruleDescription.name) Violation: ",
             violation.reason,
             " (\(violation.ruleDescription.identifier))"].joined()


### PR DESCRIPTION
now that ViolationSeverity is already lowercase.