### PR TITLE
Update weak delegate rule to only match delegate suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ##### Bug Fixes
 
 * Fix `weak_delegate` rule reporting a violation for variables containing
-  but not ending in `delegate`.
+  but not ending in `delegate`. 
   [Phil Webster](https://github.com/philwebster)
 
 ## 0.13.2: Light Cycle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix `weak_delegate` rule reporting a violation for variables containing
+  but not ending in `delegate`.
+  [Phil Webster](https://github.com/philwebster)
 
 ## 0.13.2: Light Cycle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ##### Bug Fixes
 
 * Fix `weak_delegate` rule reporting a violation for variables containing
-  but not ending in `delegate`. 
+  but not ending in `delegate`.  
   [Phil Webster](https://github.com/philwebster)
 
 ## 0.13.2: Light Cycle

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -27,11 +27,11 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
             // Only trigger on instance variables, not local variables
             "func foo() {\n  var delegate: SomeDelegate\n}\n",
             // Only trigger when variable has the suffix "-delegate" to avoid false positives
-            "class Foo {\n  var delegateNotified: Bool?\n}\n",
+            "class Foo {\n  var delegateNotified: Bool?\n}\n"
         ],
         triggeringExamples: [
             "class Foo {\n  var delegate: SomeProtocol?\n}\n",
-            "class Foo {\n  var scrollDelegate: ScrollDelegate?\n}\n",
+            "class Foo {\n  var scrollDelegate: ScrollDelegate?\n}\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -25,7 +25,9 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
             // We only consider properties to be a delegate if it has "delegate" in its name
             "class Foo {\n  var scrollHandler: ScrollDelegate?\n}\n",
             // Only trigger on instance variables, not local variables
-            "func foo() {\n  var delegate: SomeDelegate\n}\n"
+            "func foo() {\n  var delegate: SomeDelegate\n}\n",
+            // Only trigger when variable has the suffix "-delegate" to avoid false positives
+            "class Foo {\n  var delegateNotified: Bool?\n}\n",
         ],
         triggeringExamples: [
             "class Foo {\n  var delegate: SomeProtocol?\n}\n",

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -30,7 +30,6 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
         triggeringExamples: [
             "class Foo {\n  var delegate: SomeProtocol?\n}\n",
             "class Foo {\n  var scrollDelegate: ScrollDelegate?\n}\n",
-            "class Foo {\n  var delegateScroll: ScrollDelegate?\n}\n"
         ]
     )
 
@@ -43,7 +42,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
 
         // Check if name contains "delegate"
         guard let name = (dictionary["key.name"] as? String),
-            name.lowercased().contains("delegate") else {
+            name.lowercased().hasSuffix("delegate") else {
                 return []
         }
 


### PR DESCRIPTION
The rule was warning on lines like the following line in our tests:

`var createActivityDelegateMethodCalled = false`

I'm not sure if anyone names their delegates with `delegate` prefixed or in the middle (which this change would miss), but this seems like a reasonable modification.