### PR TITLE
Add number_separator opt-in rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Enhancements
 
-* None.
+* Add `number_separator` opt-in rule that enforces that underscores are
+  used as thousand separators in large numbers.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#924](https://github.com/realm/SwiftLint/issues/924)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -68,6 +68,7 @@ public let masterRuleList = RuleList(rules:
     MissingDocsRule.self,
     NestingRule.self,
     NimbleOperatorRule.self,
+    NumberSeparatorRule.self,
     OpeningBraceRule.self,
     OperatorFunctionWhitespaceRule.self,
     OverriddenSuperCallRule.self,

--- a/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
@@ -29,7 +29,8 @@ public struct NumberSeparatorRule: OptInRule, ConfigurationProviderRule {
             "let hex = 0xA",
             "let hex = 0xAA_BB",
             "let octal = 0o21",
-            "let octal = 0o21_1"
+            "let octal = 0o21_1",
+            "let exp = 1_000_000.000_000e2"
         ],
         triggeringExamples: [
             "let foo = ↓10_0",
@@ -49,7 +50,11 @@ public struct NumberSeparatorRule: OptInRule, ConfigurationProviderRule {
                     return false
             }
 
-            let components = content.components(separatedBy: ".")
+            guard let nonExponential = content.components(separatedBy: "e").first else {
+                return false
+            }
+
+            let components = nonExponential.components(separatedBy: ".")
             if let integerSubstring = components.first,
                 !isValid(number: integerSubstring, reversed: true) {
                 return true

--- a/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
@@ -1,0 +1,94 @@
+//
+//  NumberSeparatorRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 05/12/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct NumberSeparatorRule: OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "number_separator",
+        name: "Number Separator",
+        description: "Underscores should be used as thousand separator in large numbers.",
+        nonTriggeringExamples: [
+            "let foo = 100",
+            "let foo = 1_000",
+            "let foo = 1_000_000",
+            "let foo = 1.000_1",
+            "let foo = 1_000_000.000_000_1"
+        ],
+        triggeringExamples: [
+            "let foo = ↓10_0",
+            "let foo = ↓1000",
+            "let foo = ↓1__000",
+            "let foo = ↓1.0001",
+            "let foo = ↓1_000_000.000000_1",
+            "let foo = ↓1000000.000000_1"
+        ]
+    )
+
+    public func validateFile(_ file: File) -> [StyleViolation] {
+        let numberTokens = file.syntaxMap.tokens.filter { SyntaxKind(rawValue: $0.type) == .number }
+        let violations = numberTokens.filter { token in
+            guard let content = contentFrom(file: file, token: token) else {
+                return false
+            }
+
+            let components = content.components(separatedBy: ".")
+            if let integerSubstring = components.first,
+                !isValid(number: integerSubstring, reversed: true) {
+                return true
+            }
+
+            if components.count == 2, let fractionSubstring = components.last,
+                !isValid(number: fractionSubstring, reversed: false) {
+                return true
+            }
+
+            return false
+        }.map { token in
+            return StyleViolation(ruleDescription: type(of: self).description,
+                                  severity: configuration.severity,
+                                  location: Location(file: file, byteOffset: token.offset))
+        }
+
+        return violations
+    }
+
+    private func isValid(number: String, reversed: Bool) -> Bool {
+        var correctComponents = [String]()
+        let clean = number.replacingOccurrences(of: "_", with: "")
+
+        for (idx, char) in reversedIfNeeded(Array(clean.characters),
+                                            reversed: reversed).enumerated() {
+            if idx % 3 == 0 && idx > 0 {
+                correctComponents.append("_")
+            }
+
+            correctComponents.append(String(char))
+        }
+
+        let expected = reversedIfNeeded(correctComponents, reversed: reversed).joined()
+        return expected == number
+    }
+
+    private func reversedIfNeeded<T>(_ array: [T], reversed: Bool) -> [T] {
+        if reversed {
+            return array.reversed()
+        }
+
+        return array
+    }
+
+    private func contentFrom(file: File, token: SyntaxToken) -> String? {
+        return file.contents.substringWithByteRange(start: token.offset, length: token.length)
+    }
+}

--- a/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
@@ -30,7 +30,10 @@ public struct NumberSeparatorRule: OptInRule, ConfigurationProviderRule {
             "let hex = 0xAA_BB",
             "let octal = 0o21",
             "let octal = 0o21_1",
-            "let exp = 1_000_000.000_000e2"
+            "let octal = -0o21_1",
+            "let exp = 1_000_000.000_000e2",
+            "let negative = -1_000_000.000_000",
+            "let positive = +1_000_000.000_000"
         ],
         triggeringExamples: [
             "let foo = ↓10_0",
@@ -50,7 +53,9 @@ public struct NumberSeparatorRule: OptInRule, ConfigurationProviderRule {
                     return false
             }
 
-            guard let nonExponential = content.components(separatedBy: "e").first else {
+            let signals = CharacterSet(charactersIn: "+-")
+            guard let nonSignal = content.components(separatedBy: signals).first,
+                let nonExponential = nonSignal.components(separatedBy: "e").first else {
                 return false
             }
 
@@ -77,7 +82,7 @@ public struct NumberSeparatorRule: OptInRule, ConfigurationProviderRule {
 
     private func isDecimal(number: String) -> Bool {
         let lowercased = number.lowercased()
-        let prefixes = ["0x", "0o", "0b"]
+        let prefixes = ["0x", "0o", "0b"].flatMap { [$0, "-" + $0] }
 
         return prefixes.filter { lowercased.hasPrefix($0) }.isEmpty
     }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
 		D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
+		D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */; };
 		D46E041D1DE3712C00728374 /* TrailingCommaRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */; };
 		D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */; };
 		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
@@ -279,6 +280,7 @@
 		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
 		D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyntacticSugarRule.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
+		D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRule.swift; sourceTree = "<group>"; };
 		D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRule.swift; sourceTree = "<group>"; };
 		D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
 		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
@@ -652,6 +654,7 @@
 				E849FF271BF9481A009AE999 /* MissingDocsRule.swift */,
 				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
 				D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */,
+				D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */,
 				692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */,
 				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
 				78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */,
@@ -966,6 +969,7 @@
 				E8B67C3E1C095E6300FDED8E /* Correction.swift in Sources */,
 				E88198531BEA944400333A11 /* LineLengthRule.swift in Sources */,
 				E847F0A91BFBBABD00EA9363 /* EmptyCountRule.swift in Sources */,
+				D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */,
 				D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */,
 				E88198441BEA93D200333A11 /* ColonRule.swift in Sources */,
 				E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -187,6 +187,10 @@ class RulesTests: XCTestCase {
         verifyRule(NimbleOperatorRule.description)
     }
 
+    func testNumberSeparator() {
+        verifyRule(NumberSeparatorRule.description)
+    }
+
     func testVerticalWhitespace() {
         verifyRule(VerticalWhitespaceRule.description)
     }


### PR DESCRIPTION
Fixes #924 

Maybe we should add a `min_length` configuration that defaults to 4? (So `1000` would be valid, but `10000` wouldn't)