### PR TITLE
Add rule to ban dynamic inline functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ##### Enhancements
 
 * Add `dynamic_inline` rule to discourage combination of `@inline(__always)`
-  and `dynamic` function properties.  
+  and `dynamic` function attributes.  
   [Daniel Duan](https://github.com/dduan)
 
 * Add `number_separator` opt-in rule that enforces that underscores are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ##### Enhancements
 
+* Add `dynamic_inline` rule to discourage combination of `@inline(__always)`
+  and `dynamic` function properties.  
+  [Daniel Duan](https://github.com/dduan)
+
 * Add `number_separator` opt-in rule that enforces that underscores are
   used as thousand separators in large numbers.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -1,0 +1,17 @@
+//
+//  DynamicInlineRule.swift
+//  SwiftLint
+//
+//  Created by Daniel Duan on 12/08/16.
+//  Copyright © 2015 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+extension Dictionary where Key: ExpressibleByStringLiteral {
+    var enclosedSwiftAttributes: [String] {
+        let array = self["key.attributes"] as? [SourceKitRepresentable] ?? []
+        return array.flatMap { ($0 as? [String: String])?["key.attribute"] }
+    }
+}

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -49,6 +49,7 @@ public let masterRuleList = RuleList(rules:
     ControlStatementRule.self,
     CustomRules.self,
     CyclomaticComplexityRule.self,
+    DynamicInlineRule.self,
     EmptyCountRule.self,
     EmptyParenthesesWithTrailingClosureRule.self,
     ExplicitInitRule.self,

--- a/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
@@ -1,0 +1,81 @@
+//
+//  DynamicInlineRule.swift
+//  SwiftLint
+//
+//  Created by Daniel Duan on 12/08/16.
+//  Copyright © 2015 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule {
+
+    public var configuration = SeverityConfiguration(.error)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "dynamic_inline",
+        name: "Dynamic Inline",
+        description: "avoid using 'dynamic' and '@inline(__always)' together.",
+        nonTriggeringExamples: [
+            "class C {\ndynamic func f() {}}",
+            "class C {\n@inline(__always) func f() {}}",
+            "class C {\n@inline(never) dynamic func f() {}}"
+        ],
+        triggeringExamples: [
+            "class C {\n@inline(__always) dynamic func f() {}\n}",
+            "class C {\n@inline(__always) public dynamic func f() {}\n}",
+            "class C {\n@inline(__always) dynamic internal func f() {}\n}",
+            "class C {\n@inline(__always)\ndynamic func f() {}\n}",
+            "class C {\n@inline(__always)\ndynamic\nfunc f() {}\n}"
+        ]
+    )
+
+    public func validateFile(_ file: File, kind: SwiftDeclarationKind,
+        dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        // Look for functions with both "inline" and "dynamic". For each of these, we can get offset
+        // of the "func" keyword. We can assume that the nearest "@inline" before this offset is
+        // the attribute we are interested in.
+        guard functionKinds.contains(kind),
+            case let attributes = dictionary.enclosedSwiftAttributes,
+            attributes.contains("source.decl.attribute.dynamic"),
+            attributes.contains("source.decl.attribute.inline"),
+            let funcByteOffset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let funcOffset = (file.contents as NSString)
+                .byteRangeToNSRange(start: funcByteOffset, length: 0)?
+                .location,
+            case let inlinePattern = regex("@inline"),
+            case let range = NSRange(location: 0, length: funcOffset),
+            let inlineMatch = inlinePattern.matches(in: file.contents, range: range).last,
+            inlineMatch.range.location != NSNotFound,
+            case let attributeRange = NSRange(location: inlineMatch.range.location,
+                length: funcOffset - inlineMatch.range.location),
+            case let alwaysInlinePattern = regex("@inline\\(\\s*__always\\s*\\)"),
+            alwaysInlinePattern.firstMatch(in: file.contents, range: attributeRange) != nil
+        else {
+            return []
+        }
+        return [StyleViolation(ruleDescription: type(of: self).description,
+                    severity: configuration.severity,
+                    location: Location(file: file, characterOffset: funcOffset))]
+    }
+
+    fileprivate let functionKinds: [SwiftDeclarationKind] = [
+        .functionAccessorAddress,
+        .functionAccessorDidset,
+        .functionAccessorGetter,
+        .functionAccessorMutableaddress,
+        .functionAccessorSetter,
+        .functionAccessorWillset,
+        .functionConstructor,
+        .functionDestructor,
+        .functionFree,
+        .functionMethodClass,
+        .functionMethodInstance,
+        .functionMethodStatic,
+        .functionOperator,
+        .functionSubscript
+    ]
+}

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -16,8 +16,7 @@ private func mappedDictValues(_ dictionary: [String: SourceKitRepresentable], ke
 }
 
 private func declarationOverrides(_ dictionary: [String: SourceKitRepresentable]) -> Bool {
-    return mappedDictValues(dictionary, key: "key.attributes", subKey: "key.attribute")
-        .contains("source.decl.attribute.override")
+    return dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.override")
 }
 
 private func inheritedMembersForDictionary(_ dictionary: [String: SourceKitRepresentable]) ->

--- a/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
@@ -70,7 +70,7 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
         let substructure = (dictionary["key.substructure"] as? [SourceKitRepresentable]) ?? []
         guard kind == .functionMethodInstance &&
               configuration.resolvedMethodNames.contains(name) &&
-              extractAttributes(dictionary).contains("source.decl.attribute.override")
+              dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.override")
         else { return [] }
 
         let callsToSuper = extractCallsToSuper(name, substructure: substructure)
@@ -87,14 +87,6 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
                 reason: "Method '\(name)' should call to super only once")]
         }
         return []
-    }
-
-    private func extractAttributes(_ dictionary: [String: SourceKitRepresentable]) -> [String] {
-        guard let attributesDict = dictionary["key.attributes"] as? [SourceKitRepresentable]
-            else { return [] }
-        return attributesDict.flatMap {
-            ($0 as? [String: SourceKitRepresentable])?["key.attribute"] as? String
-        }
     }
 
     private func extractCallsToSuper(_ name: String,

--- a/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
@@ -39,10 +39,8 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
         }
 
         // Check if IBOutlet
-        let attributes = (dictionary["key.attributes"] as? [SourceKitRepresentable])?
-            .flatMap({ ($0 as? [String: SourceKitRepresentable]) as? [String: String] })
-            .flatMap({ $0["key.attribute"] }) ?? []
-        let isOutlet = attributes.contains("source.decl.attribute.iboutlet")
+        let isOutlet = dictionary.enclosedSwiftAttributes.contains(
+           "source.decl.attribute.iboutlet")
         guard isOutlet else { return [] }
 
         // Check if private

--- a/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
@@ -49,10 +49,8 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
         }
 
         // Check if IBInspectable
-        let attributes = (dictionary["key.attributes"] as? [SourceKitRepresentable])?
-            .flatMap({ ($0 as? [String: SourceKitRepresentable]) as? [String: String] })
-            .flatMap({ $0["key.attribute"] }) ?? []
-        let isIBInspectable = attributes.contains("source.decl.attribute.ibinspectable")
+        let isIBInspectable = dictionary.enclosedSwiftAttributes.contains(
+           "source.decl.attribute.ibinspectable")
         guard isIBInspectable else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -52,10 +52,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
         }
 
         // Check if non-weak
-        let attributes = (dictionary["key.attributes"] as? [SourceKitRepresentable])?
-            .flatMap({ ($0 as? [String: SourceKitRepresentable]) as? [String: String] })
-            .flatMap({ $0["key.attribute"] }) ?? []
-        let isWeak = attributes.contains("source.decl.attribute.weak")
+        let isWeak = dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.weak")
         guard !isWeak else { return [] }
 
         // if the declaration is inside a protocol

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */; };
 		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
+		E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
 		E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA01B8A71DF00399043 /* Configuration.swift */; };
@@ -299,6 +300,7 @@
 		D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
 		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
+		E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicInlineRule.swift; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
 		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
@@ -652,6 +654,7 @@
 				65454F451B14D73800319A6C /* ControlStatementRule.swift */,
 				3B1DF0111C5148140011BCED /* CustomRules.swift */,
 				2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */,
+				E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */,
 				E847F0A81BFBBABD00EA9363 /* EmptyCountRule.swift */,
 				D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */,
 				7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */,
@@ -995,6 +998,7 @@
 				E88198531BEA944400333A11 /* LineLengthRule.swift in Sources */,
 				E847F0A91BFBBABD00EA9363 /* EmptyCountRule.swift in Sources */,
 				D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */,
+				E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */,
 				D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */,
 				E88198441BEA93D200333A11 /* ColonRule.swift in Sources */,
 				E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */; };
 		2E336D1B1DF08BFB00CCFE77 /* EmojiReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */; };
 		2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */; };
+		37B3FA8B1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */; };
 		3B0B14541C505D6300BE82F7 /* SeverityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */; };
 		3B1150CA1C31FC3F00D83B1E /* Yaml+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1150C91C31FC3F00D83B1E /* Yaml+SwiftLint.swift */; };
 		3B12C9C11C3209CB000B423F /* test.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3B12C9BF1C3209AC000B423F /* test.yml */; };
@@ -211,6 +212,7 @@
 		2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityRule.swift; sourceTree = "<group>"; };
 		2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiReporter.swift; sourceTree = "<group>"; };
 		2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRule.swift; sourceTree = "<group>"; };
+		37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+SwiftLint.swift"; sourceTree = "<group>"; };
 		3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeverityConfiguration.swift; sourceTree = "<group>"; };
 		3B1150C91C31FC3F00D83B1E /* Yaml+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Yaml+SwiftLint.swift"; sourceTree = "<group>"; };
 		3B12C9BF1C3209AC000B423F /* test.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = test.yml; sourceTree = "<group>"; };
@@ -734,6 +736,7 @@
 		E8A541811BF94604006BA322 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */,
 				24E17F701B1481FF008195BE /* File+Cache.swift */,
 				E88DEA741B09852000A66CB0 /* File+SwiftLint.swift */,
 				E832F10A1B17E2F5003F265F /* NSFileManager+SwiftLint.swift */,
@@ -986,6 +989,7 @@
 				E88198601BEA98F000333A11 /* VariableNameRule.swift in Sources */,
 				E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */,
 				E86396CB1BADB519002C9E88 /* CSVReporter.swift in Sources */,
+				37B3FA8B1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift in Sources */,
 				E88198561BEA94D800333A11 /* FileLengthRule.swift in Sources */,
 				E8B67C3E1C095E6300FDED8E /* Correction.swift in Sources */,
 				E88198531BEA944400333A11 /* LineLengthRule.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -109,6 +109,10 @@ class RulesTests: XCTestCase {
         verifyRule(CyclomaticComplexityRule.description)
     }
 
+    func testDynamicInline() {
+        verifyRule(DynamicInlineRule.description)
+    }
+
     func testEmptyCount() {
         verifyRule(EmptyCountRule.description)
     }


### PR DESCRIPTION
When a class method is marked as both `dynamic` and `@inline(__always)`, its
dispatch behavior is not well defined. Therefore this specific combination
should be discouraged.
