### PR TITLE
`type_name` rule now validates `typealias` and `associatedtype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#885](https://github.com/realm/SwiftLint/issues/885)
 
-* `type_name` rule now validates `typealias` too.  
+* `type_name` rule now validates `typealias` and `associatedtype` too.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#49](https://github.com/realm/SwiftLint/issues/49)
+  [#956](https://github.com/realm/SwiftLint/issues/959)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#885](https://github.com/realm/SwiftLint/issues/885)
 
+* `type_name` rule now validates `typealias` too.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#49](https://github.com/realm/SwiftLint/issues/49)
+
 ##### Bug Fixes
 
 * Fix `weak_delegate` rule reporting a violation for variables containing

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -18,29 +18,57 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
 
     public init() {}
 
-    public static let description = RuleDescription(
-        identifier: "type_name",
-        name: "Type Name",
-        description: "Type name should only contain alphanumeric characters, start with an " +
-                     "uppercase character and span between 3 and 40 characters in length.",
-        nonTriggeringExamples: ["class", "struct", "enum"].flatMap({ type in
+    private static func nonTriggeringExamples() -> [String] {
+        let typeExamples: [String] = ["class", "struct", "enum"].flatMap { type -> [String] in
             [
                 "\(type) MyType {}",
                 "private \(type) _MyType {}",
                 "enum MyType {\ncase value\n}",
-                "\(type) " + repeatElement("A", count: 40).joined() + " {}"
+                "\(type) \(repeatElement("A", count: 40).joined()) {}"
             ]
-        }),
-        triggeringExamples: ["class", "struct", "enum"].flatMap({ type in
+        }
+        let typeAliasExamples = [
+            "typealias Foo = Void",
+            "private typealias Foo = Void"
+        ]
+
+        return typeExamples + typeAliasExamples
+    }
+
+    private static func triggeringExamples() -> [String] {
+        let types = ["class", "struct", "enum"]
+        let typeExamples: [String] = types.flatMap { (type: String) -> [String] in
             [
                 "↓\(type) myType {}",
                 "↓\(type) _MyType {}",
                 "private ↓\(type) MyType_ {}",
                 "↓\(type) My {}",
-                "↓\(type) " + repeatElement("A", count: 41).joined() + " {}"
+                "↓\(type) \(repeatElement("A", count: 41).joined()) {}"
             ]
-        })
+        }
+        let typeAliasExamples: [String] = [
+            "typealias X = Void",
+            "private typealias Foo_Bar = Void",
+            "private typealias foo = Void",
+            "typealias \(repeatElement("A", count: 41).joined()) = Void"
+        ]
+
+        return typeExamples + typeAliasExamples
+    }
+
+    public static let description = RuleDescription(
+        identifier: "type_name",
+        name: "Type Name",
+        description: "Type name should only contain alphanumeric characters, start with an " +
+                     "uppercase character and span between 3 and 40 characters in length.",
+        nonTriggeringExamples: TypeNameRule.nonTriggeringExamples(),
+        triggeringExamples: TypeNameRule.triggeringExamples()
     )
+
+    public func validateFile(_ file: File) -> [StyleViolation] {
+        return validateTypeAliases(file) +
+            validateFile(file, dictionary: file.structure.dictionary)
+    }
 
     public func validateFile(_ file: File,
                              kind: SwiftDeclarationKind,
@@ -51,32 +79,64 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
             .typealias,
             .enum
         ]
-        if !typeKinds.contains(kind) {
+
+        guard typeKinds.contains(kind),
+            let name = dictionary["key.name"] as? String,
+            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) else {
+                return []
+        }
+
+        return validateName(name: name, dictionary: dictionary, file: file, offset: offset)
+    }
+
+    private func validateTypeAliases(_ file: File) -> [StyleViolation] {
+        let rangesAndTokens = file.rangesAndTokensMatching("typealias\\s+.+?\\b")
+        return rangesAndTokens.flatMap { range, tokens -> [StyleViolation] in
+            guard tokens.count == 2,
+                let keywordToken = tokens.first,
+                let nameToken = tokens.last,
+                SyntaxKind(rawValue: keywordToken.type) == .keyword,
+                SyntaxKind(rawValue: nameToken.type) == .identifier else {
+                    return []
+            }
+
+            guard let name = file.contents.substringWithByteRange(start: nameToken.offset,
+                                                                  length: nameToken.length) else {
+                return []
+            }
+
+            return validateName(name: name, file: file, offset: nameToken.offset)
+        }
+    }
+
+    private func validateName(name: String,
+                              dictionary: [String: SourceKitRepresentable] = [:],
+                              file: File,
+                              offset: Int) -> [StyleViolation] {
+        guard !configuration.excluded.contains(name) else {
             return []
         }
-        if let name = dictionary["key.name"] as? String ,
-            !configuration.excluded.contains(name),
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
-            let name = name.nameStrippingLeadingUnderscoreIfPrivate(dictionary)
-            let nameCharacterSet = CharacterSet(charactersIn: name)
-            if !CharacterSet.alphanumerics.isSuperset(of: nameCharacterSet) {
-                return [StyleViolation(ruleDescription: type(of: self).description,
-                    severity: .error,
-                    location: Location(file: file, byteOffset: offset),
-                    reason: "Type name should only contain alphanumeric characters: '\(name)'")]
-            } else if !name.substring(to: name.index(after: name.startIndex)).isUppercase() {
-                return [StyleViolation(ruleDescription: type(of: self).description,
-                    severity: .error,
-                    location: Location(file: file, byteOffset: offset),
-                    reason: "Type name should start with an uppercase character: '\(name)'")]
-            } else if let severity = severity(forLength: name.characters.count) {
-                return [StyleViolation(ruleDescription: type(of: self).description,
-                    severity: severity,
-                    location: Location(file: file, byteOffset: offset),
-                    reason: "Type name should be between \(configuration.minLengthThreshold) and " +
-                        "\(configuration.maxLengthThreshold) characters long: '\(name)'")]
-            }
+
+        let name = name.nameStrippingLeadingUnderscoreIfPrivate(dictionary)
+        let nameCharacterSet = CharacterSet(charactersIn: name)
+        if !CharacterSet.alphanumerics.isSuperset(of: nameCharacterSet) {
+            return [StyleViolation(ruleDescription: type(of: self).description,
+               severity: .error,
+               location: Location(file: file, byteOffset: offset),
+               reason: "Type name should only contain alphanumeric characters: '\(name)'")]
+        } else if !name.substring(to: name.index(after: name.startIndex)).isUppercase() {
+            return [StyleViolation(ruleDescription: type(of: self).description,
+               severity: .error,
+               location: Location(file: file, byteOffset: offset),
+               reason: "Type name should start with an uppercase character: '\(name)'")]
+        } else if let severity = severity(forLength: name.characters.count) {
+            return [StyleViolation(ruleDescription: type(of: self).description,
+               severity: severity,
+               location: Location(file: file, byteOffset: offset),
+               reason: "Type name should be between \(configuration.minLengthThreshold) and " +
+                    "\(configuration.maxLengthThreshold) characters long: '\(name)'")]
         }
+
         return []
     }
 }


### PR DESCRIPTION
Fixes #49 and #956 