### PR TITLE
Enabling more rules in SwiftLint itself

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,12 @@ excluded:
 opt_in_rules:
   - empty_count
   - file_header
+  - explicit_init
+  - closure_spacing
+  - overridden_super_call
+  - redundant_nil_coalescing
+  - private_outlet
+  - nimble_operator
 
 file_header:
   required_pattern: |

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -31,7 +31,7 @@ private var syntaxKindsByLinesCache = Cache({ file in file.syntaxKindsByLine() }
 private var syntaxTokensByLinesCache = Cache({ file in file.syntaxTokensByLine() })
 
 private typealias AssertHandler = () -> ()
-private var assertHandlers = [String: AssertHandler?]()
+private var assertHandlers = [String: AssertHandler]()
 
 private var _allDeclarationsByType = [String: [String]]()
 private var queueForRebuild = [Structure]()
@@ -88,7 +88,7 @@ extension File {
 
     internal var assertHandler: (() -> ())? {
         get {
-            return assertHandlers[cacheKey] ?? nil
+            return assertHandlers[cacheKey]
         }
         set {
             assertHandlers[cacheKey] = newValue

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -138,7 +138,7 @@ extension File {
             return nil
         }
 
-        return tokens.map { $0.flatMap { SyntaxKind.init(rawValue: $0.type) } }
+        return tokens.map { $0.flatMap { SyntaxKind(rawValue: $0.type) } }
 
     }
 


### PR DESCRIPTION
This enables some recently added opt-in rules in SwiftLint source code.

I've enabled `nimble_operator` and `private_outlet` just as another check against false negatives, as they should never trigger in this project. They've only added `0,012`s combined on my rMBP.

I was thinking about enabling `switch_case_on_newline`  and `conditional_returns_on_newline` too, but there are several violations (23 and 31, respectively) in the current codebase and I'm not sure if we want to enforce them.

I don't this this is worth a changelog entry ¯\_(ツ)_/¯ 