### PR TITLE
Add support for rule aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ##### Breaking
 
-* None.
+* Change the signature of `Configuration` initializers to support
+  rule aliases.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#973](https://github.com/realm/SwiftLint/issues/973)
 
 ##### Enhancements
 

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -44,7 +44,18 @@ extension Array {
         }
     }
 
+    func partitioned(by belongsInSecondPartition: (Element) throws -> Bool) rethrows ->
+        (first: ArraySlice<Element>, second: ArraySlice<Element>) {
+            var copy = self
+            let pivot = try copy.partition(by: belongsInSecondPartition)
+            return (copy[0..<pivot], copy[pivot..<count])
+    }
+
     func parallelFlatMap<T>(transform: @escaping ((Element) -> [T])) -> [T] {
+        return parallelMap(transform: transform).flatMap { $0 }
+    }
+
+    func parallelFlatMap<T>(transform: @escaping ((Element) -> T?)) -> [T] {
         return parallelMap(transform: transform).flatMap { $0 }
     }
 

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -114,7 +114,7 @@ public struct Configuration: Equatable {
         do {
             configuredRules = try ruleList.configuredRules(with: dict)
         } catch RuleListError.duplicatedConfigurations(let ruleType) {
-            let aliases = ruleType.description.allAliases.map { "'\($0)'" }.joined(separator: ", ")
+            let aliases = ruleType.description.deprecatedAliases.map { "'\($0)'" }.joined(separator: ", ")
             let identifier = ruleType.description.identifier
             queuedPrintError("Multiple configurations found for '\(identifier)'. Check for any aliases: \(aliases).")
             return nil

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -62,7 +62,7 @@ public struct Configuration: Equatable {
         // Validate that all rule identifiers map to a defined rule
         let validRuleIdentifiers = validateRuleIdentifiers(configuredRules: configuredRules,
                                                            disabledRules: disabledRules)
-        let validDisabledRules = disabledRules.filter { validRuleIdentifiers.contains($0) }
+        let validDisabledRules = disabledRules.filter(validRuleIdentifiers.contains)
 
         // Validate that rule identifiers aren't listed multiple times
         if containsDuplicatedRuleIdentifiers(validDisabledRules) {

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -41,9 +41,13 @@ public struct Configuration: Equatable {
                  warningThreshold: Int? = nil,
                  reporter: String = XcodeReporter.identifier,
                  configuredRules: [Rule] = masterRuleList.configuredRules(with: [:])) {
-        self.included = included
-        self.excluded = excluded
+        self.included = included.map(handleAlias)
+        self.excluded = excluded.map(handleAlias)
         self.reporter = reporter
+
+        let disabledRules = disabledRules.map(handleAlias)
+        let optInRules = optInRules.map(handleAlias)
+        let whitelistRules = whitelistRules.map(handleAlias)
 
         // Validate that all rule identifiers map to a defined rule
         let validRuleIdentifiers = configuredRules.map {
@@ -135,7 +139,7 @@ public struct Configuration: Equatable {
             .useNestedConfigs,
             .warningThreshold,
             .whitelistRules
-        ].map({ $0.rawValue }) + masterRuleList.list.keys
+        ].map({ $0.rawValue }) + masterRuleList.allValidIdentifiers()
 
         let invalidKeys = Set(dict.keys).subtracting(validKeys)
         if !invalidKeys.isEmpty {
@@ -211,6 +215,10 @@ public struct Configuration: Equatable {
         }
         return self
     }
+}
+
+private func handleAlias(_ alias: String) -> String {
+    return masterRuleList.identifier(for: alias) ?? alias
 }
 
 // MARK: - Nested Configurations Extension

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -51,7 +51,10 @@ public struct Configuration: Equatable {
             ?? (try? ruleList.configuredRules(with: [:]))
             ?? []
 
-        let handleAliasWithRuleList: (String) -> String = { handleAlias($0, ruleList: ruleList) }
+        let handleAliasWithRuleList = { (alias: String) -> String in
+            return ruleList.identifier(for: alias) ?? alias
+        }
+
         let disabledRules = disabledRules.map(handleAliasWithRuleList)
         let optInRules = optInRules.map(handleAliasWithRuleList)
         let whitelistRules = whitelistRules.map(handleAliasWithRuleList)
@@ -223,10 +226,6 @@ private func containsDuplicatedRuleIdentifiers(_ validDisabledRules: [String]) -
     }
 
     return false
-}
-
-private func handleAlias(_ alias: String, ruleList: RuleList) -> String {
-    return ruleList.identifier(for: alias) ?? alias
 }
 
 private func defaultStringArray(_ object: Any?) -> [String] {

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -46,17 +46,19 @@ public struct Linter {
             }
 
             return violations.filter { violation in
-                guard let violationRegion = regions
-                    .first(where: { $0.contains(violation.location) }) else {
-                        return true
+                guard let violationRegion = regions.first(where: { $0.contains(violation.location) }) else {
+                    return true
                 }
                 let enabled = violationRegion.isRuleEnabled(rule)
                 if !enabled {
                     let identifiers = violationRegion.deprecatedAliasesDisablingRule(rule)
-                    mutationQueue.sync {
-                        deprecatedIdentifiers.formUnion(identifiers)
-                        for deprecatedIdentifier in identifiers {
-                            deprecatedToValidIdentifier[deprecatedIdentifier] = type(of: rule).description.identifier
+                    if !identifiers.isEmpty {
+                        mutationQueue.sync {
+                            deprecatedIdentifiers.formUnion(identifiers)
+                            for deprecatedIdentifier in identifiers {
+                                let identifier = type(of: rule).description.identifier
+                                deprecatedToValidIdentifier[deprecatedIdentifier] = identifier
+                            }
                         }
                     }
                 }

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -34,7 +34,7 @@ extension Rule {
             ruleTime = nil
         }
 
-        let (enabledViolationsAndRegions, disabledViolationsAndRegions) = violations.map { violation in
+        let (disabledViolationsAndRegions, enabledViolationsAndRegions) = violations.map { violation in
             return (violation, regions.first(where: { $0.contains(violation.location) }))
         }.partitioned { _, region in
             return region?.isRuleEnabled(self) ?? true
@@ -53,7 +53,7 @@ extension Rule {
 
 public struct Linter {
     public let file: File
-    fileprivate let rules: [Rule]
+    private let rules: [Rule]
 
     public var styleViolations: [StyleViolation] {
         return getStyleViolations().0

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -22,7 +22,7 @@ public struct RuleList {
         for rule in rules {
             let identifier = rule.description.identifier
             tmpList[identifier] = rule
-            for alias in rule.description.allAliases {
+            for alias in rule.description.deprecatedAliases {
                 tmpAliases[alias] = identifier
             }
             tmpAliases[identifier] = identifier
@@ -65,8 +65,8 @@ public struct RuleList {
     }
 
     internal func allValidIdentifiers() -> [String] {
-        return list.flatMap { (identifier, rule) -> [String] in
-            Array(rule.description.allAliases) + [identifier]
+        return list.flatMap { (_, rule) -> [String] in
+            rule.description.allIdentifiers
         }
     }
 }

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -35,21 +35,18 @@ public struct RuleList {
         var rules = [String: Rule]()
 
         for (key, configuration) in dictionary {
-            if let identifier = identifier(for: key), let ruleType = list[identifier] {
-
-                guard rules[identifier] == nil else {
-                    throw RuleListError.duplicatedConfigurations(rule: ruleType)
-                }
-
-                do {
-                    let configuredRule = try ruleType.init(configuration: configuration)
-                    rules[identifier] = configuredRule
-                } catch {
-                    queuedPrintError(
-                        "Invalid configuration for '\(identifier)'. Falling back to default."
-                    )
-                    rules[identifier] = ruleType.init()
-                }
+            guard let identifier = identifier(for: key), let ruleType = list[identifier] else {
+                continue
+            }
+            guard rules[identifier] == nil else {
+                throw RuleListError.duplicatedConfigurations(rule: ruleType)
+            }
+            do {
+                let configuredRule = try ruleType.init(configuration: configuration)
+                rules[identifier] = configuredRule
+            } catch {
+                queuedPrintError("Invalid configuration for '\(identifier)'. Falling back to default.")
+                rules[identifier] = ruleType.init()
             }
         }
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+public enum RuleListError: Error {
+    case duplicatedConfigurations(rule: Rule.Type)
+}
+
 public struct RuleList {
     public let list: [String: Rule.Type]
     private let aliases: [String: String]
@@ -27,18 +31,14 @@ public struct RuleList {
         aliases = tmpAliases
     }
 
-    internal func configuredRules(with dictionary: [String: Any]) -> [Rule] {
+    internal func configuredRules(with dictionary: [String: Any]) throws -> [Rule] {
         var rules = [String: Rule]()
 
         for (key, configuration) in dictionary {
             if let identifier = identifier(for: key), let ruleType = list[identifier] {
 
                 guard rules[identifier] == nil else {
-                    let aliases = ruleType.description.allAliases.map { "'\($0)'" }.joined(separator: ", ")
-                    queuedPrintError(
-                        "Multiple configurations found for '\(identifier)'. Check for any aliases: \(aliases)."
-                    )
-                    continue
+                    throw RuleListError.duplicatedConfigurations(rule: ruleType)
                 }
 
                 do {

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -29,8 +29,7 @@ public struct Region {
     }
 
     public func isRuleDisabled(_ rule: Rule) -> Bool {
-        let description = type(of: rule).description
-        let identifiers = Array(description.allAliases) + [description.identifier]
+        let identifiers = type(of: rule).description.allIdentifiers
         return !disabledRuleIdentifiers.intersection(identifiers).isEmpty
     }
 }

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -32,4 +32,9 @@ public struct Region {
         let identifiers = type(of: rule).description.allIdentifiers
         return !disabledRuleIdentifiers.intersection(identifiers).isEmpty
     }
+
+    public func deprecatedAliasesDisablingRule(_ rule: Rule) -> Set<String> {
+        let identifiers = type(of: rule).description.deprecatedAliases
+        return disabledRuleIdentifiers.intersection(identifiers)
+    }
 }

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -29,6 +29,8 @@ public struct Region {
     }
 
     public func isRuleDisabled(_ rule: Rule) -> Bool {
-        return disabledRuleIdentifiers.contains(type(of: rule).description.identifier)
+        let description = type(of: rule).description
+        let identifiers = Array(description.allAliases) + [description.identifier]
+        return !disabledRuleIdentifiers.intersection(identifiers).isEmpty
     }
 }

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -13,23 +13,17 @@ public struct RuleDescription: Equatable {
     public let nonTriggeringExamples: [String]
     public let triggeringExamples: [String]
     public let corrections: [String: String]
-    public let aliases: Set<String>
     public let deprecatedAliases: Set<String>
 
     public var consoleDescription: String { return "\(name) (\(identifier)): \(description)" }
 
-    public var allAliases: Set<String> {
-        return aliases.union(deprecatedAliases)
-    }
-
     public var allIdentifiers: [String] {
-        return Array(allAliases) + [identifier]
+        return Array(deprecatedAliases) + [identifier]
     }
 
     public init(identifier: String, name: String, description: String,
                 nonTriggeringExamples: [String] = [], triggeringExamples: [String] = [],
                 corrections: [String: String] = [:],
-                aliases: Set<String> = [],
                 deprecatedAliases: Set<String> = []) {
         self.identifier = identifier
         self.name = name
@@ -37,7 +31,6 @@ public struct RuleDescription: Equatable {
         self.nonTriggeringExamples = nonTriggeringExamples
         self.triggeringExamples = triggeringExamples
         self.corrections = corrections
-        self.aliases = aliases
         self.deprecatedAliases = deprecatedAliases
     }
 }

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -13,18 +13,28 @@ public struct RuleDescription: Equatable {
     public let nonTriggeringExamples: [String]
     public let triggeringExamples: [String]
     public let corrections: [String: String]
+    public let aliases: Set<String>
+    public let deprecatedAliases: Set<String>
 
     public var consoleDescription: String { return "\(name) (\(identifier)): \(description)" }
 
+    public var allAliases: Set<String> {
+        return aliases.union(deprecatedAliases)
+    }
+
     public init(identifier: String, name: String, description: String,
                 nonTriggeringExamples: [String] = [], triggeringExamples: [String] = [],
-                corrections: [String: String] = [:]) {
+                corrections: [String: String] = [:],
+                aliases: [String] = [],
+                deprecatedAliases: [String] = []) {
         self.identifier = identifier
         self.name = name
         self.description = description
         self.nonTriggeringExamples = nonTriggeringExamples
         self.triggeringExamples = triggeringExamples
         self.corrections = corrections
+        self.aliases = Set(aliases)
+        self.deprecatedAliases = Set(deprecatedAliases)
     }
 }
 

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -22,6 +22,10 @@ public struct RuleDescription: Equatable {
         return aliases.union(deprecatedAliases)
     }
 
+    public var allIdentifiers: [String] {
+        return Array(allAliases) + [identifier]
+    }
+
     public init(identifier: String, name: String, description: String,
                 nonTriggeringExamples: [String] = [], triggeringExamples: [String] = [],
                 corrections: [String: String] = [:],

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -29,16 +29,16 @@ public struct RuleDescription: Equatable {
     public init(identifier: String, name: String, description: String,
                 nonTriggeringExamples: [String] = [], triggeringExamples: [String] = [],
                 corrections: [String: String] = [:],
-                aliases: [String] = [],
-                deprecatedAliases: [String] = []) {
+                aliases: Set<String> = [],
+                deprecatedAliases: Set<String> = []) {
         self.identifier = identifier
         self.name = name
         self.description = description
         self.nonTriggeringExamples = nonTriggeringExamples
         self.triggeringExamples = triggeringExamples
         self.corrections = corrections
-        self.aliases = Set(aliases)
-        self.deprecatedAliases = Set(deprecatedAliases)
+        self.aliases = aliases
+        self.deprecatedAliases = deprecatedAliases
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -219,6 +219,13 @@ class ConfigurationTests: XCTestCase {
         let rules = testRuleList.configuredRules(with: config)
         XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
     }
+
+    func testInitsWithDuplicatedConfiguration() {
+        let ruleConfiguration = [1, 2]
+        let config = ["severity_mock": ruleConfiguration, "severity_level_mock": [1, 3]]
+        let rules = testRuleList.configuredRules(with: config)
+        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
+    }
 }
 
 // MARK: - ProjectMock Paths

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -203,6 +203,22 @@ class ConfigurationTests: XCTestCase {
         let rules = testRuleList.configuredRules(with: config)
         XCTAssertTrue(rules == [RuleWithLevelsMock() as Rule])
     }
+
+    // MARK: - Aliases
+
+    func testInitsFromAlias() {
+        let ruleConfiguration = [1, 2]
+        let config = ["severity_mock": ruleConfiguration]
+        let rules = testRuleList.configuredRules(with: config)
+        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
+    }
+
+    func testInitsFromDeprecatedAlias() {
+        let ruleConfiguration = [1, 2]
+        let config = ["mock": ruleConfiguration]
+        let rules = testRuleList.configuredRules(with: config)
+        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
+    }
 }
 
 // MARK: - ProjectMock Paths
@@ -287,7 +303,9 @@ extension ConfigurationTests {
             ("testLevel2", testLevel2),
             ("testLevel3", testLevel3),
             ("testConfiguresCorrectlyFromDict", testConfiguresCorrectlyFromDict),
-            ("testConfigureFallsBackCorrectly", testConfigureFallsBackCorrectly)
+            ("testConfigureFallsBackCorrectly", testConfigureFallsBackCorrectly),
+            ("testInitsFromAlias", testInitsFromAlias),
+            ("testInitsFromDeprecatedAlias", testInitsFromDeprecatedAlias)
         ]
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -191,36 +191,32 @@ class ConfigurationTests: XCTestCase {
 
     let testRuleList = RuleList(rules: RuleWithLevelsMock.self)
 
-    func testConfiguresCorrectlyFromDict() {
+    func testConfiguresCorrectlyFromDict() throws {
         let ruleConfiguration = [1, 2]
         let config = [RuleWithLevelsMock.description.identifier: ruleConfiguration]
-        // swiftlint:disable:next force_try
-        let rules = try! testRuleList.configuredRules(with: config)
+        let rules = try testRuleList.configuredRules(with: config)
         XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
     }
 
-    func testConfigureFallsBackCorrectly() {
+    func testConfigureFallsBackCorrectly() throws {
         let config = [RuleWithLevelsMock.description.identifier: ["a", "b"]]
-        // swiftlint:disable:next force_try
-        let rules = try! testRuleList.configuredRules(with: config)
+        let rules = try testRuleList.configuredRules(with: config)
         XCTAssertTrue(rules == [RuleWithLevelsMock() as Rule])
     }
 
     // MARK: - Aliases
 
-    func testConfiguresCorrectlyFromAlias() {
+    func testConfiguresCorrectlyFromAlias() throws {
         let ruleConfiguration = [1, 2]
         let config = ["severity_mock": ruleConfiguration]
-        // swiftlint:disable:next force_try
-        let rules = try! testRuleList.configuredRules(with: config)
+        let rules = try testRuleList.configuredRules(with: config)
         XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
     }
 
-    func testConfiguresCorrectlyFromDeprecatedAlias() {
+    func testConfiguresCorrectlyFromDeprecatedAlias() throws {
         let ruleConfiguration = [1, 2]
         let config = ["mock": ruleConfiguration]
-        // swiftlint:disable:next force_try
-        let rules = try! testRuleList.configuredRules(with: config)
+        let rules = try testRuleList.configuredRules(with: config)
         XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -89,11 +89,11 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(disabledConfig.disabledRules,
                        ["nesting", "todo"],
                        "initializing Configuration with valid rules in Dictionary should succeed")
-        let expectedIdentifiers = Set(masterRuleList.list.keys
+        let expectedIdentifiers = Array(masterRuleList.list.keys
             .filter({ !(["nesting", "todo"] + optInRules).contains($0) }))
-        let configuredIdentifiers = Set(disabledConfig.rules.map {
+        let configuredIdentifiers = disabledConfig.rules.map {
             type(of: $0).description.identifier
-        })
+        }
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
 
         // Duplicate
@@ -110,11 +110,11 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.disabledRules,
                        [validRule],
                        "initializing Configuration with valid rules in YAML string should succeed")
-        let expectedIdentifiers = Set(masterRuleList.list.keys
-            .filter({ !([validRule] + optInRules).contains($0) }))
-        let configuredIdentifiers = Set(configuration.rules.map {
+        let expectedIdentifiers = Array(masterRuleList.list.keys)
+            .filter({ !([validRule] + optInRules).contains($0) })
+        let configuredIdentifiers = configuration.rules.map {
             type(of: $0).description.identifier
-        })
+        }
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
     }
 
@@ -195,13 +195,13 @@ class ConfigurationTests: XCTestCase {
         let ruleConfiguration = [1, 2]
         let config = [RuleWithLevelsMock.description.identifier: ruleConfiguration]
         let rules = try testRuleList.configuredRules(with: config)
-        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
+        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration)])
     }
 
     func testConfigureFallsBackCorrectly() throws {
         let config = [RuleWithLevelsMock.description.identifier: ["a", "b"]]
         let rules = try testRuleList.configuredRules(with: config)
-        XCTAssertTrue(rules == [RuleWithLevelsMock() as Rule])
+        XCTAssertTrue(rules == [RuleWithLevelsMock()])
     }
 
     // MARK: - Aliases
@@ -210,14 +210,14 @@ class ConfigurationTests: XCTestCase {
         let ruleConfiguration = [1, 2]
         let config = ["severity_mock": ruleConfiguration]
         let rules = try testRuleList.configuredRules(with: config)
-        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
+        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration)])
     }
 
     func testConfiguresCorrectlyFromDeprecatedAlias() throws {
         let ruleConfiguration = [1, 2]
         let config = ["mock": ruleConfiguration]
         let rules = try testRuleList.configuredRules(with: config)
-        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration) as Rule])
+        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration)])
     }
 
     func testReturnsNilWithDuplicatedConfiguration() {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -206,13 +206,6 @@ class ConfigurationTests: XCTestCase {
 
     // MARK: - Aliases
 
-    func testConfiguresCorrectlyFromAlias() throws {
-        let ruleConfiguration = [1, 2]
-        let config = ["severity_mock": ruleConfiguration]
-        let rules = try testRuleList.configuredRules(with: config)
-        XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration)])
-    }
-
     func testConfiguresCorrectlyFromDeprecatedAlias() throws {
         let ruleConfiguration = [1, 2]
         let config = ["mock": ruleConfiguration]
@@ -221,8 +214,7 @@ class ConfigurationTests: XCTestCase {
     }
 
     func testReturnsNilWithDuplicatedConfiguration() {
-        let ruleConfiguration = [1, 2]
-        let dict = ["severity_mock": ruleConfiguration, "severity_level_mock": [1, 3]]
+        let dict = ["mock": [1, 2], "severity_level_mock": [1, 3]]
         let configuration = Configuration(dict: dict, ruleList: testRuleList)
         XCTAssertNil(configuration)
     }
@@ -241,23 +233,11 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(configuredIdentifiers, ["severity_level_mock"])
     }
 
-    func testWhitelistRulesFromAlias() {
-        let configuration = Configuration(dict: ["whitelist_rules": ["severity_mock"]], ruleList: testRuleList)!
-        let configuredIdentifiers = configuration.rules.map {
-            type(of: $0).description.identifier
-        }
-        XCTAssertEqual(configuredIdentifiers, ["severity_level_mock"])
-    }
-
     func testDisabledRulesFromDeprecatedAlias() {
         let configuration = Configuration(dict: ["disabled_rules": ["mock"]], ruleList: testRuleList)!
         XCTAssert(configuration.rules.isEmpty)
     }
 
-    func testDisabledRulesFromAlias() {
-        let configuration = Configuration(dict: ["disabled_rules": ["severity_mock"]], ruleList: testRuleList)!
-        XCTAssert(configuration.rules.isEmpty)
-    }
 }
 
 // MARK: - ProjectMock Paths
@@ -343,14 +323,11 @@ extension ConfigurationTests {
             ("testLevel3", testLevel3),
             ("testConfiguresCorrectlyFromDict", testConfiguresCorrectlyFromDict),
             ("testConfigureFallsBackCorrectly", testConfigureFallsBackCorrectly),
-            ("testConfiguresCorrectlyFromAlias", testConfiguresCorrectlyFromAlias),
             ("testConfiguresCorrectlyFromDeprecatedAlias", testConfiguresCorrectlyFromDeprecatedAlias),
             ("testReturnsNilWithDuplicatedConfiguration", testReturnsNilWithDuplicatedConfiguration),
             ("testInitsFromDeprecatedAlias", testInitsFromDeprecatedAlias),
             ("testWhitelistRulesFromDeprecatedAlias", testWhitelistRulesFromDeprecatedAlias),
-            ("testWhitelistRulesFromAlias", testWhitelistRulesFromAlias),
-            ("testDisabledRulesFromDeprecatedAlias", testDisabledRulesFromDeprecatedAlias),
-            ("testDisabledRulesFromAlias", testDisabledRulesFromAlias)
+            ("testDisabledRulesFromDeprecatedAlias", testDisabledRulesFromDeprecatedAlias)
         ]
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -89,11 +89,11 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(disabledConfig.disabledRules,
                        ["nesting", "todo"],
                        "initializing Configuration with valid rules in Dictionary should succeed")
-        let expectedIdentifiers = Array(masterRuleList.list.keys
+        let expectedIdentifiers = Set(masterRuleList.list.keys
             .filter({ !(["nesting", "todo"] + optInRules).contains($0) }))
-        let configuredIdentifiers = disabledConfig.rules.map {
+        let configuredIdentifiers = Set(disabledConfig.rules.map {
             type(of: $0).description.identifier
-        }
+        })
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
 
         // Duplicate
@@ -110,11 +110,11 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.disabledRules,
                        [validRule],
                        "initializing Configuration with valid rules in YAML string should succeed")
-        let expectedIdentifiers = Array(masterRuleList.list.keys)
-            .filter({ !([validRule] + optInRules).contains($0) })
-        let configuredIdentifiers = configuration.rules.map {
+        let expectedIdentifiers = Set(masterRuleList.list.keys
+            .filter({ !([validRule] + optInRules).contains($0) }))
+        let configuredIdentifiers = Set(configuration.rules.map {
             type(of: $0).description.identifier
-        }
+        })
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -89,11 +89,11 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(disabledConfig.disabledRules,
                        ["nesting", "todo"],
                        "initializing Configuration with valid rules in Dictionary should succeed")
-        let expectedIdentifiers = Array(masterRuleList.list.keys)
-            .filter({ !(["nesting", "todo"] + optInRules).contains($0) })
-        let configuredIdentifiers = disabledConfig.rules.map {
+        let expectedIdentifiers = Set(masterRuleList.list.keys
+            .filter({ !(["nesting", "todo"] + optInRules).contains($0) }))
+        let configuredIdentifiers = Set(disabledConfig.rules.map {
             type(of: $0).description.identifier
-        }
+        })
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
 
         // Duplicate
@@ -110,11 +110,11 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.disabledRules,
                        [validRule],
                        "initializing Configuration with valid rules in YAML string should succeed")
-        let expectedIdentifiers = Array(masterRuleList.list.keys)
-            .filter({ !([validRule] + optInRules).contains($0) })
-        let configuredIdentifiers = configuration.rules.map {
+        let expectedIdentifiers = Set(masterRuleList.list.keys
+            .filter({ !([validRule] + optInRules).contains($0) }))
+        let configuredIdentifiers = Set(configuration.rules.map {
             type(of: $0).description.identifier
-        }
+        })
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
     }
 
@@ -346,7 +346,15 @@ extension ConfigurationTests {
             ("testLevel2", testLevel2),
             ("testLevel3", testLevel3),
             ("testConfiguresCorrectlyFromDict", testConfiguresCorrectlyFromDict),
-            ("testConfigureFallsBackCorrectly", testConfigureFallsBackCorrectly)
+            ("testConfigureFallsBackCorrectly", testConfigureFallsBackCorrectly),
+            ("testConfiguresCorrectlyFromAlias", testConfiguresCorrectlyFromAlias),
+            ("testConfiguresCorrectlyFromDeprecatedAlias", testConfiguresCorrectlyFromDeprecatedAlias),
+            ("testReturnsNilWithDuplicatedConfiguration", testReturnsNilWithDuplicatedConfiguration),
+            ("testInitsFromDeprecatedAlias", testInitsFromDeprecatedAlias),
+            ("testWhitelistRulesFromDeprecatedAlias", testWhitelistRulesFromDeprecatedAlias),
+            ("testWhitelistRulesFromAlias", testWhitelistRulesFromAlias),
+            ("testDisabledRulesFromDeprecatedAlias", testDisabledRulesFromDeprecatedAlias),
+            ("testDisabledRulesFromAlias", testDisabledRulesFromAlias)
         ]
     }
 }

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -15,7 +15,9 @@ struct RuleWithLevelsMock: ConfigurationProviderRule {
 
     static let description = RuleDescription(identifier: "severity_level_mock",
                                              name: "",
-                                             description: "")
+                                             description: "",
+                                             aliases: ["severity_mock"],
+                                             deprecatedAliases: ["mock"])
     func validateFile(_ file: File) -> [StyleViolation] { return [] }
 }
 

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -16,7 +16,6 @@ struct RuleWithLevelsMock: ConfigurationProviderRule {
     static let description = RuleDescription(identifier: "severity_level_mock",
                                              name: "",
                                              description: "",
-                                             aliases: ["severity_mock"],
                                              deprecatedAliases: ["mock"])
     func validateFile(_ file: File) -> [StyleViolation] { return [] }
 }

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -186,7 +186,7 @@ extension XCTestCase {
 
         let disableCommands = ruleDescription.allIdentifiers.map { "// swiftlint:disable \($0)\n" }
 
-        // "disable"s commands doesn't violate
+        // "disable" commands doesn't violate
         for command in disableCommands {
             XCTAssert(triggers.flatMap({ violations(command + $0, config: config) }).isEmpty)
         }

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -184,9 +184,13 @@ extension XCTestCase {
             )
         }
 
-        // "disable" command doesn't violate
-        let command = "// swiftlint:disable \(ruleDescription.identifier)\n"
-        XCTAssert(triggers.flatMap({ violations(command + $0, config: config) }).isEmpty)
+        var commands = [String]()
+        // "disable"s command doesn't violate
+        for identifier in ruleDescription.allIdentifiers {
+            let command = "// swiftlint:disable \(identifier)\n"
+            commands.append(command)
+            XCTAssert(triggers.flatMap({ violations(command + $0, config: config) }).isEmpty)
+        }
 
         // corrections
         ruleDescription.corrections.forEach {
@@ -199,9 +203,11 @@ extension XCTestCase {
 
         // "disable" command do not correct
         ruleDescription.corrections.forEach { before, _ in
-            let beforeDisabled = command + before
-            let expectedCleaned = cleanedContentsAndMarkerOffsets(from: beforeDisabled).0
-            config.assertCorrection(expectedCleaned, expected: expectedCleaned)
+            for command in commands {
+                let beforeDisabled = command + before
+                let expectedCleaned = cleanedContentsAndMarkerOffsets(from: beforeDisabled).0
+                config.assertCorrection(expectedCleaned, expected: expectedCleaned)
+            }
         }
 
     }

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -184,11 +184,10 @@ extension XCTestCase {
             )
         }
 
-        var commands = [String]()
-        // "disable"s command doesn't violate
-        for identifier in ruleDescription.allIdentifiers {
-            let command = "// swiftlint:disable \(identifier)\n"
-            commands.append(command)
+        let disableCommands = ruleDescription.allIdentifiers.map { "// swiftlint:disable \($0)\n" }
+
+        // "disable"s commands doesn't violate
+        for command in disableCommands {
             XCTAssert(triggers.flatMap({ violations(command + $0, config: config) }).isEmpty)
         }
 
@@ -201,9 +200,9 @@ extension XCTestCase {
             testCorrection($0, configuration: config, testMultiByteOffsets: testMultiByteOffsets)
         }
 
-        // "disable" command do not correct
+        // "disable" commands do not correct
         ruleDescription.corrections.forEach { before, _ in
-            for command in commands {
+            for command in disableCommands {
                 let beforeDisabled = command + before
                 let expectedCleaned = cleanedContentsAndMarkerOffsets(from: beforeDisabled).0
                 config.assertCorrection(expectedCleaned, expected: expectedCleaned)


### PR DESCRIPTION
Will fix #973 

To do:

- [x] Log a deprecation message when an identifier from `deprecatedAliases` is used (to declare a configuration or on any lists, such as `opt_in_rules`).
- [x] Add tests for using aliases on lists (`opt_in_rules`, `whitelist`, `disabled`, etc). This might be tricky as we don't inject `masterRuleList` and none of the current rules have aliases/deprecatedAliases.
- [x] Update rules tests to use aliases too when disabling the rule.
- [x] Test when 2 aliases are used for the same rule when configuring it.

Question: 

* Would keep using the official identifier in messages confusing? That's how it's done now.
* Is it worth having `aliases` and `deprecatedAliases`?

Trivia:

I was looking for some inspiration on how to do this and decided to check Rubocop. It turns out they apparently don't deprecate rules, just rename them: https://github.com/bbatsov/rubocop/pull/3226/files and https://github.com/bbatsov/rubocop/issues/2783.