### PR TITLE
Operator whitespace rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,6 +13,7 @@ opt_in_rules:
   - private_outlet
   - nimble_operator
   - attributes
+  - operator_usage_whitespace
 
 file_header:
   required_pattern: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#573](https://github.com/realm/SwiftLint/issues/573)
 
+* Add `operator_usage_whitespace` opt-in rule to validate that operators are
+  surrounded by a single whitespace when they are being used.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#626](https://github.com/realm/SwiftLint/issues/626)
+
 ##### Bug Fixes
 
 * Fix `weak_delegate` rule reporting a violation for variables containing

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -77,6 +77,7 @@ public let masterRuleList = RuleList(rules:
     NumberSeparatorRule.self,
     OpeningBraceRule.self,
     OperatorFunctionWhitespaceRule.self,
+    OperatorUsageWhitespaceRule.self,
     OverriddenSuperCallRule.self,
     PrivateOutletRule.self,
     PrivateUnitTestRule.self,

--- a/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
@@ -52,7 +52,7 @@ public struct ClosureSpacingRule: Rule, ConfigurationProviderRule, OptInRule {
         // find all lines and accurences of open { and closed } braces
         var linesWithBraces = [[NSRange]]()
         for eachLine in file.lines {
-            guard let nsrange  = lineContainsBracesIn(eachLine.range, content: nsstring) else {
+            guard let nsrange = lineContainsBracesIn(eachLine.range, content: nsstring) else {
                 continue
             }
 
@@ -84,7 +84,7 @@ public struct ClosureSpacingRule: Rule, ConfigurationProviderRule, OptInRule {
                 let length = validBraces[startIndex + 1 ].location + 1 - location
                 ranges.append(NSRange(location:location, length: length))
                 bracesAsString.replaceSubrange(foundRange, with: "")
-                validBraces.removeSubrange(startIndex...startIndex  + 1)
+                validBraces.removeSubrange(startIndex...startIndex + 1)
             }
             return ranges
         }

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -86,7 +86,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
                     continue
             }
 
-            guard offset..<offset+length ~= Int(parameterOffset) else {
+            guard offset..<(offset + length) ~= Int(parameterOffset) else {
                 return parameterCount
             }
 

--- a/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
@@ -47,13 +47,13 @@ public struct OperatorUsageWhitespaceRule: OptInRule, ConfigurationProviderRule 
     public func validateFile(_ file: File) -> [StyleViolation] {
         let escapedOperators = ["/", "=", "-", "+", "*", "|", "^", "~"]
             .map({ "\\\($0)" }).joined()
-        let rangePattern = "\\.\\.(\\.|<)" // ... or ..<
-        let operators = "([\(escapedOperators)%<>&]+|\(rangePattern))"
+        let rangePattern = "\\.\\.(?:\\.|<)" // ... or ..<
+        let operators = "(?:[\(escapedOperators)%<>&]+|\(rangePattern))"
 
         let oneSpace = "[^\\S\\r\\n]" // to allow lines ending with operators to be valid
         let zeroSpaces = oneSpace + "{0}"
         let manySpaces = oneSpace + "{2,}"
-        let variableOrNumber = "(\(RegexHelpers.varName)|\(RegexHelpers.number))"
+        let variableOrNumber = "(?:\(RegexHelpers.varName)|\(RegexHelpers.number))"
 
         let pattern1 = variableOrNumber + zeroSpaces + operators + zeroSpaces + variableOrNumber
         let pattern2 = variableOrNumber + oneSpace + operators + manySpaces + variableOrNumber
@@ -65,10 +65,10 @@ public struct OperatorUsageWhitespaceRule: OptInRule, ConfigurationProviderRule 
             zeroSpaces + variableOrNumber
 
         let pattern = [pattern1, pattern2, pattern3, pattern4].joined(separator: "|")
-        let excludingPattern = "(\(genericPattern)|\(validRangePattern))"
+        let excludingPattern = "(?:\(genericPattern)|\(validRangePattern))"
         let kinds = SyntaxKind.commentAndStringKinds()
 
-        return file.matchPattern("(\(pattern))", excludingSyntaxKinds: kinds,
+        return file.matchPattern("(?:\(pattern))", excludingSyntaxKinds: kinds,
                                  excludingPattern: excludingPattern).map {
             return StyleViolation(ruleDescription: type(of: self).description,
                                   severity: configuration.severity,

--- a/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
@@ -1,0 +1,78 @@
+//
+//  OperatorUsageWhitespaceRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 13/12/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct OperatorUsageWhitespaceRule: OptInRule, ConfigurationProviderRule {
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "operator_usage_whitespace",
+        name: "Operator Usage Whitespace",
+        description: "Operators should be surrounded by a single whitespace " +
+                     "when they are being used.",
+        nonTriggeringExamples: [
+            "let foo = 1 + 2\n",
+            "let foo = 1 > 2\n",
+            "let foo = !false\n",
+            "let foo: Int?\n",
+            "let foo: Array<String>\n",
+            "let foo: [String]\n",
+            "let foo = 1 + \n  2\n",
+            "let range = 1...3\n",
+            "let range = 1 ... 3\n",
+            "let range = 1..<3\n"
+        ],
+        triggeringExamples: [
+            "let foo = 1+2\n",
+            "let foo = 1   + 2\n",
+            "let foo = 1   +    2\n",
+            "let foo = 1 +    2\n",
+            "let foo=1+2\n",
+            "let foo=1 + 2\n",
+            "let foo=bar\n",
+            "let range = 1 ..<  3\n"
+        ]
+    )
+
+    public func validateFile(_ file: File) -> [StyleViolation] {
+        let escapedOperators = ["/", "=", "-", "+", "*", "|", "^", "~"]
+            .map({ "\\\($0)" }).joined()
+        let rangePattern = "\\.\\.(\\.|<)" // ... or ..<
+        let operators = "([\(escapedOperators)%<>&]+|\(rangePattern))"
+
+        let oneSpace = "[^\\S\\r\\n]" // to allow lines ending with operators to be valid
+        let zeroSpaces = oneSpace + "{0}"
+        let manySpaces = oneSpace + "{2,}"
+        let variableOrNumber = "(\(RegexHelpers.varName)|\(RegexHelpers.number))"
+
+        let pattern1 = variableOrNumber + zeroSpaces + operators + zeroSpaces + variableOrNumber
+        let pattern2 = variableOrNumber + oneSpace + operators + manySpaces + variableOrNumber
+        let pattern3 = variableOrNumber + manySpaces + operators + oneSpace + variableOrNumber
+        let pattern4 = variableOrNumber + manySpaces + operators + manySpaces + variableOrNumber
+
+        let genericPattern = "<.+?>"
+        let validRangePattern = variableOrNumber + zeroSpaces + rangePattern +
+            zeroSpaces + variableOrNumber
+
+        let pattern = [pattern1, pattern2, pattern3, pattern4].joined(separator: "|")
+        let excludingPattern = "(\(genericPattern)|\(validRangePattern))"
+        let kinds = SyntaxKind.commentAndStringKinds()
+
+        return file.matchPattern("(\(pattern))", excludingSyntaxKinds: kinds,
+                                 excludingPattern: excludingPattern).map {
+            return StyleViolation(ruleDescription: type(of: self).description,
+                                  severity: configuration.severity,
+                                  location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
@@ -2,7 +2,7 @@
 //  OperatorUsageWhitespaceRule.swift
 //  SwiftLint
 //
-//  Created by Marcelo Fabri on 13/12/16.
+//  Created by Marcelo Fabri on 12/13/16.
 //  Copyright © 2016 Realm. All rights reserved.
 //
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */; };
 		D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */; };
 		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
+		D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
 		E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
@@ -335,6 +336,7 @@
 		D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRule.swift; sourceTree = "<group>"; };
 		D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
 		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
+		D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorUsageWhitespaceRule.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
 		E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicInlineRule.swift; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
@@ -729,6 +731,7 @@
 				D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */,
 				692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */,
 				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
+				D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */,
 				78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */,
 				B2902A0B1D66815600BFCCF7 /* PrivateUnitTestRule.swift */,
 				094385021D5D4F78009168CF /* PrivateOutletRule.swift */,
@@ -1045,6 +1048,7 @@
 				E81CDE711C00FEAA00B430F6 /* ValidDocsRule.swift in Sources */,
 				DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */,
 				2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */,
+				D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */,
 				D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */,
 				D47079AD1DFE2FA700027086 /* EmptyParametersRule.swift in Sources */,
 				E87E4A091BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift in Sources */,
@@ -1094,7 +1098,6 @@
 				B2902A0E1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift in Sources */,
 				D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */,
 				D48AE2CC1DFB58C5001C6A4A /* AttributesRulesExamples.swift in Sources */,
-				1F8547141DFEA44C0052E729 /* String+XML.swift in Sources */,
 				E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */,
 				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift in Sources */,
 				D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -221,6 +221,10 @@ class RulesTests: XCTestCase {
         verifyRule(OperatorFunctionWhitespaceRule.description)
     }
 
+    func testOperatorUsageWhitespace() {
+        verifyRule(OperatorUsageWhitespaceRule.description)
+    }
+
     func testPrivateOutlet() {
         verifyRule(PrivateOutletRule.description)
 
@@ -431,6 +435,7 @@ extension RulesTests {
             ("testVerticalWhitespace", testVerticalWhitespace),
             ("testOpeningBrace", testOpeningBrace),
             ("testOperatorFunctionWhitespace", testOperatorFunctionWhitespace),
+            ("testOperatorUsageWhitespace", testOperatorUsageWhitespace),
             ("testPrivateOutlet", testPrivateOutlet),
             // ("testPrivateUnitTest", testPrivateUnitTest),
             ("testProhibitedSuper", testProhibitedSuper),


### PR DESCRIPTION
Fixes #626 

This is opt-in because it's super slow 🐌. Benchmarking on Realm:


```
... 
0,035: type_name
0,036: control_statement
0,071: empty_parentheses_with_trailing_closure
0,125: opening_brace
0,126: colon
0,229: comma
0,312: mark
0,320: implicit_getter
3,640: operator_usage_whitespace
```

Also, currently it triggers on attributes parameters (which can't have spaces):
```swift
@available(*, deprecated=1.0.2, renamed="Realm.performMigration(for:)")
public func migrateRealm(configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) -> NSError? 
```

However, this seems to have changed on Swift 3.0.1? It forces me to replace `=` with `:` on Xcode 8.2:
```
'=' has been replaced with ':' in attribute arguments
```

This is certainly the most magical regex I've ever used, so feel free to make suggestions (and make it fast, pleaseeeee)!