### PR TITLE
Fix invalid CSS in HTML reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@
   [JP Simard](https://github.com/jpsim)
   [#976](https://github.com/realm/SwiftLint/issues/976)
 
+* Fix invalid CSS in HTML reporter template.  
+  [Aaron McTavish](https://github.com/aamctustwo)
+  [#981](https://github.com/realm/SwiftLint/issues/981)
+
 ## 0.13.2: Light Cycle
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
@@ -60,7 +60,7 @@ public struct HTMLReporter: Reporter {
             "\t\t}\n",
             "\t\tth {\n",
             "\t\t\tborder-bottom: 1px solid gray;\n",
-            "\t\t\tbackground-color: #29345C50;\n",
+            "\t\t\tbackground-color: rgba(41,52,92,0.313);\n",
             "\t\t}\n",
             "\t\t.error, .warning {\n",
             "\t\t\tbackground-color: #f0f099;\n",

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedHTMLReporterOutput.html
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedHTMLReporterOutput.html
@@ -16,7 +16,7 @@
 		}
 		th {
 			border-bottom: 1px solid gray;
-			background-color: #29345C50;
+			background-color: rgba(41,52,92,0.313);
 		}
 		.error, .warning {
 			background-color: #f0f099;


### PR DESCRIPTION
Resolves #981 `HTML Reporter - Invalid CSS Styling`.

### Summary

Updates the HTML reporter template to use the `rgba` method for defining the semi-transparent table header color in the CSS Styling. The color itself has not been changed.