### PR TITLE
Add rule requiring imports be sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1005](https://github.com/realm/SwiftLint/issues/1005)
 
+* Add a rule that enforces alphabetical sorting of imports.  
+  [Scott Berrevoets](https://github.com/sberrevoets)
+  [#900](https://github.com/realm/SwiftLint/issues/900)
+
 ##### Bug Fixes
 
 * `FunctionParameterCountRule` also ignores generic initializers.  
@@ -79,10 +83,6 @@
   [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Enhancements
-
-* Add a rule that enforces alphabetical sorting of imports.  
-  [Scott Berrevoets](https://github.com/sberrevoets)
-  [#900](https://github.com/realm/SwiftLint/issues/900)
 
 * Now builds and passes most tests on Linux using the Swift Package Manager with
   Swift 3. This requires `libsourcekitdInProc.so` to be built and located in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
 
 ##### Enhancements
 
+* Add a rule that enforces alphabetical sorting of imports.  
+  [Scott Berrevoets](https://github.com/sberrevoets)
+  [#991](https://github.com/realm/SwiftLint/pull/991)
+
 * Now builds and passes most tests on Linux using the Swift Package Manager with
   Swift 3. This requires `libsourcekitdInProc.so` to be built and located in
   `/usr/lib`, or in another location specified by the `LINUX_SOURCEKIT_LIB_PATH`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * Add a rule that enforces alphabetical sorting of imports.  
   [Scott Berrevoets](https://github.com/sberrevoets)
   [#991](https://github.com/realm/SwiftLint/pull/991)
+  [#900](https://github.com/realm/SwiftLint/issues/900)
 
 * Now builds and passes most tests on Linux using the Swift Package Manager with
   Swift 3. This requires `libsourcekitdInProc.so` to be built and located in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,6 @@
 
 * Add a rule that enforces alphabetical sorting of imports.  
   [Scott Berrevoets](https://github.com/sberrevoets)
-  [#991](https://github.com/realm/SwiftLint/pull/991)
   [#900](https://github.com/realm/SwiftLint/issues/900)
 
 * Now builds and passes most tests on Linux using the Swift Package Manager with

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -87,6 +87,7 @@ public let masterRuleList = RuleList(rules:
     RedundantNilCoalescingRule.self,
     RedundantStringEnumValueRule.self,
     ReturnArrowWhitespaceRule.self,
+    SortedImportsRule.self,
     StatementPositionRule.self,
     SwitchCaseOnNewlineRule.self,
     SyntacticSugarRule.self,

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2016 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
-
-    private let moduleCharacterOffset = "import ".characters.count
 
     public init() {}
 
@@ -48,7 +47,7 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
                 return nil
             }
 
-            let characterOffset = range.location + moduleCharacterOffset
+            let characterOffset = range.location + moduleStartIndex
             let location = Location(file: file, characterOffset: characterOffset)
             return StyleViolation(ruleDescription: type(of: self).description,
                                   severity: configuration.severity, location: location)

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -36,10 +36,15 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
                 return nil
             }
 
-            let match = file.contents.bridge().substring(with: range)
-            defer { previousMatch = match }
+            let fullMatch = file.contents.bridge().substring(with: range)
+            let moduleStartIndex = (fullMatch.lastIndexOf(" ") ?? -1) + 1
+            let moduleLength = range.length - moduleStartIndex
+            let moduleRange = NSRange(location: moduleStartIndex, length: moduleLength)
+            let moduleNameMatch = fullMatch.bridge().substring(with: moduleRange)
 
-            if match > previousMatch {
+            defer { previousMatch = moduleNameMatch }
+
+            if moduleNameMatch > previousMatch {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -28,7 +28,7 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
     )
 
     public func validateFile(_ file: File) -> [StyleViolation] {
-        let pattern = "import (\\w+)"
+        let pattern = "import\\s+\\w+"
 
         var previousMatch = ""
         return file.matchPattern(pattern).flatMap { range, kinds in

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -1,0 +1,51 @@
+//
+//  SortedImportsRule.swift
+//  SwiftLint
+//
+//  Created by Scott Berrevoets on 12/15/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "sorted_imports",
+        name: "Sorted Imports",
+        description: "Imports should be sorted.",
+        nonTriggeringExamples: [
+            "import AAA\nimport BBB\nimport CCC\nimport DDD"
+        ],
+        triggeringExamples: [
+            "import AAA\nimport ZZZ\nimport BBB\nimport CCC",
+            "import AAA\nimport ZZZ\nimport BBB\nimport CCC\nimport AAA"
+        ]
+    )
+
+    public func validateFile(_ file: File) -> [StyleViolation] {
+        let pattern = "import\\s+(\\w+)"
+        let excludingKinds = SyntaxKind.commentAndStringKinds()
+
+        let importRanges = file.matchPattern(pattern, excludingSyntaxKinds: excludingKinds)
+        let imports = importRanges.map { file.contents.substring($0.location, length: $0.length) }
+
+        var violations = [StyleViolation]()
+        for index in 0 ..< imports.count {
+            if index == 0 || imports[index] > imports[index - 1] {
+                continue
+            }
+
+            let location = Location(file: file, characterOffset: importRanges[index].location)
+            violations.append(
+                              StyleViolation(ruleDescription: type(of: self).description,
+                                             severity: configuration.severity, location: location)
+                             )
+        }
+
+        return violations
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
+		D286EC021E02DF6F0003CF72 /* SortedImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286EC001E02DA190003CF72 /* SortedImportsRule.swift */; };
 		D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */; };
 		D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */; };
 		D41E7E0B1DF9DABB0065259A /* RedundantStringEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */; };
@@ -321,6 +322,7 @@
 		D0D1217719E87B05005E4BAA /* SwiftLintFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftLintFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0D1217D19E87B05005E4BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D286EC001E02DA190003CF72 /* SortedImportsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedImportsRule.swift; sourceTree = "<group>"; };
 		D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedClosureParameterRule.swift; sourceTree = "<group>"; };
 		D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaConfiguration.swift; sourceTree = "<group>"; };
 		D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStringEnumValueRule.swift; sourceTree = "<group>"; };
@@ -760,6 +762,7 @@
 				D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */,
 				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
 				3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */,
+				D286EC001E02DA190003CF72 /* SortedImportsRule.swift */,
 				692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */,
 				D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */,
 				D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */,
@@ -1058,6 +1061,7 @@
 				E80E018D1B92C0F60078EB70 /* Command.swift in Sources */,
 				E88198571BEA953300333A11 /* ForceCastRule.swift in Sources */,
 				D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */,
+				D286EC021E02DF6F0003CF72 /* SortedImportsRule.swift in Sources */,
 				3BCC04CD1C4F5694006073C3 /* ConfigurationError.swift in Sources */,
 				D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */,
 				009E092A1DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -391,6 +391,7 @@ extension RulesTests {
             ("testRedundantNilCoalescing", testRedundantNilCoalescing),
             ("testRedundantStringEnumValue", testRedundantStringEnumValue),
             ("testReturnArrowWhitespace", testReturnArrowWhitespace),
+            ("testSortedImports", testSortedImports),
             ("testStatementPosition", testStatementPosition),
             ("testStatementPositionUncuddled", testStatementPositionUncuddled),
             ("testSwitchCaseOnNewline", testSwitchCaseOnNewline),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -199,6 +199,10 @@ class RulesTests: XCTestCase {
         verifyRule(ReturnArrowWhitespaceRule.description)
     }
 
+    func testSortedImports() {
+        verifyRule(SortedImportsRule.description)
+    }
+
     func testStatementPosition() {
         verifyRule(StatementPositionRule.description)
     }


### PR DESCRIPTION
Adds an opt-in rule to requiring imports to be sorted, as requested in #900.