### PR TITLE
Add unused_closure_parameter rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#626](https://github.com/realm/SwiftLint/issues/626)
 
+* Add `unused_closure_parameter` rule that validates if all closure parameters
+  are being used. If any of them isn't, it should be replaced by `_`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#982](https://github.com/realm/SwiftLint/issues/982)
+
 ##### Bug Fixes
 
 * Fix `weak_delegate` rule reporting a violation for variables containing

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -14,4 +14,24 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
         let array = self["key.attributes"] as? [SourceKitRepresentable] ?? []
         return array.flatMap { ($0 as? [String: String])?["key.attribute"] }
     }
+
+    var enclosedVarParameters: [[String: SourceKitRepresentable]] {
+        let substructure = self["key.substructure"] as? [SourceKitRepresentable] ?? []
+        return substructure.flatMap { subItem -> [[String: SourceKitRepresentable]] in
+            guard let subDict = subItem as? [String: SourceKitRepresentable],
+                let kindString = subDict["key.kind"] as? String else {
+                    return []
+            }
+
+            if SwiftDeclarationKind(rawValue: kindString) == .varParameter {
+                return [subDict]
+            }
+
+            if SwiftExpressionKind(rawValue: kindString) == .argument {
+                return subDict.enclosedVarParameters
+            }
+
+            return []
+        }
+    }
 }

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -95,6 +95,7 @@ public let masterRuleList = RuleList(rules:
     TrailingWhitespaceRule.self,
     TypeBodyLengthRule.self,
     TypeNameRule.self,
+    UnusedClosureParameterRule.self,
     ValidDocsRule.self,
     ValidIBInspectableRule.self,
     VariableNameRule.self,

--- a/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
@@ -61,7 +61,7 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
                 return []
         }
 
-        let parameters = filterByKind(dictionary: dictionary, kind: .varParameter)
+        let parameters = dictionary.enclosedVarParameters
         let rangeStart = nameOffset + nameLength
         let regex = ClosureParameterPositionRule.openBraceRegex
 
@@ -90,28 +90,6 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
             return StyleViolation(ruleDescription: type(of: self).description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: paramOffset))
-        }
-    }
-
-    private func filterByKind(dictionary: [String: SourceKitRepresentable],
-                              kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
-
-        let substructure = dictionary["key.substructure"] as? [SourceKitRepresentable] ?? []
-        return substructure.flatMap { subItem -> [[String: SourceKitRepresentable]] in
-            guard let subDict = subItem as? [String: SourceKitRepresentable],
-                let kindString = subDict["key.kind"] as? String else {
-                    return []
-            }
-
-            if SwiftDeclarationKind(rawValue: kindString) == kind {
-                return [subDict]
-            }
-
-            if SwiftExpressionKind(rawValue: kindString) == .argument {
-                return filterByKind(dictionary: subDict, kind: kind)
-            }
-
-            return []
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -148,7 +148,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
     fileprivate func violationRangesInFile(_ file: File, withPattern pattern: String) -> [NSRange] {
         let nsstring = file.contents.bridge()
         let commentAndStringKindsSet = Set(SyntaxKind.commentAndStringKinds())
-        return file.rangesAndTokensMatching(pattern).filter { range, syntaxTokens in
+        return file.rangesAndTokensMatching(pattern).filter { _, syntaxTokens in
             let syntaxKinds = syntaxTokens.flatMap { SyntaxKind(rawValue: $0.type) }
             if !syntaxKinds.starts(with: [.identifier, .typeidentifier]) {
                 return false

--- a/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
@@ -39,7 +39,7 @@ public struct ConditionalReturnsOnNewline: ConfigurationProviderRule, Rule, OptI
 
     public func validateFile(_ file: File) -> [StyleViolation] {
         let pattern = "(guard|if)[^\n]*return"
-        return file.rangesAndTokensMatching(pattern).filter { range, tokens in
+        return file.rangesAndTokensMatching(pattern).filter { _, tokens in
             guard let firstToken = tokens.first, let lastToken = tokens.last,
                 SyntaxKind(rawValue: firstToken.type) == .keyword &&
                     SyntaxKind(rawValue: lastToken.type) == .keyword else {

--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -148,7 +148,7 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
 
     private func violationRangesInFile(_ file: File, withPattern pattern: String) -> [NSRange] {
         let nsstring = file.contents.bridge()
-        return file.rangesAndTokensMatching(pattern).filter { range, syntaxTokens in
+        return file.rangesAndTokensMatching(pattern).filter { _, syntaxTokens in
             return !syntaxTokens.isEmpty && SyntaxKind(rawValue: syntaxTokens[0].type) == .comment
         }.flatMap { range, syntaxTokens in
             let identifierRange = nsstring

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -2,7 +2,7 @@
 //  UnusedClosureParameterRule.swift
 //  SwiftLint
 //
-//  Created by Marcelo Fabri on 15/12/16.
+//  Created by Marcelo Fabri on 12/15/16.
 //  Copyright © 2016 Realm. All rights reserved.
 //
 
@@ -41,8 +41,6 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule {
         ]
     )
 
-    private static let emptyParenthesesRegex = regex("^\\s*\\(\\s*\\)")
-
     public func validateFile(_ file: File,
                              kind: SwiftExpressionKind,
                              dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
@@ -61,7 +59,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule {
 
         let rangeStart = nameOffset + nameLength
         let rangeLength = (offset + length) - (nameOffset + nameLength)
-        let parameters = filterByKind(dictionary: dictionary, kind: .varParameter)
+        let parameters = dictionary.enclosedVarParameters
         let contents = file.contents.bridge()
 
         return parameters.flatMap { param -> StyleViolation? in
@@ -107,28 +105,6 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule {
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: paramOffset),
                                   reason: reason)
-        }
-    }
-
-    private func filterByKind(dictionary: [String: SourceKitRepresentable],
-                              kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
-
-        let substructure = dictionary["key.substructure"] as? [SourceKitRepresentable] ?? []
-        return substructure.flatMap { subItem -> [[String: SourceKitRepresentable]] in
-            guard let subDict = subItem as? [String: SourceKitRepresentable],
-                let kindString = subDict["key.kind"] as? String else {
-                    return []
-            }
-
-            if SwiftDeclarationKind(rawValue: kindString) == kind {
-                return [subDict]
-            }
-
-            if SwiftExpressionKind(rawValue: kindString) == .argument {
-                return filterByKind(dictionary: subDict, kind: kind)
-            }
-
-            return []
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -1,0 +1,134 @@
+//
+//  UnusedClosureParameterRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 15/12/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "unused_closure_parameter",
+        name: "Unused Closure Parameter",
+        description: "Unused parameter in a closure should be replaced with _.",
+        nonTriggeringExamples: [
+            "[1, 2].map { $0 + 1 }\n",
+            "[1, 2].map({ $0 + 1 })\n",
+            "[1, 2].map { number in\n number + 1 \n}\n",
+            "[1, 2].map { _ in\n 3 \n}\n",
+            "[1, 2].something { number, idx in\n return number * idx\n}\n",
+            "let isEmpty = [1, 2].isEmpty()\n",
+            "violations.sorted(by: { lhs, rhs in \n return lhs.location > rhs.location\n})\n",
+            "rlmConfiguration.migrationBlock.map { rlmMigration in\n" +
+                "return { migration, schemaVersion in\n" +
+                "rlmMigration(migration.rlmMigration, schemaVersion)\n" +
+                "}\n" +
+            "}"
+        ],
+        triggeringExamples: [
+            "[1, 2].map { ↓number in\n return 3\n}\n",
+            "[1, 2].map { ↓number in\n return numberWithSuffix\n}\n",
+            "[1, 2].map { ↓number in\n return 3 // number\n}\n",
+            "[1, 2].map { ↓number in\n return 3 \"number\"\n}\n",
+            "[1, 2].something { number, ↓idx in\n return number\n}\n"
+        ]
+    )
+
+    private static let emptyParenthesesRegex = regex("^\\s*\\(\\s*\\)")
+
+    public func validateFile(_ file: File,
+                             kind: SwiftExpressionKind,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .call else {
+            return []
+        }
+
+        guard let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
+            let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
+            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
+            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
+            bodyLength > 0 else {
+                return []
+        }
+
+        let rangeStart = nameOffset + nameLength
+        let rangeLength = (offset + length) - (nameOffset + nameLength)
+        let parameters = filterByKind(dictionary: dictionary, kind: .varParameter)
+        let contents = file.contents.bridge()
+
+        return parameters.flatMap { param -> StyleViolation? in
+            guard let paramOffset = (param["key.offset"] as? Int64).flatMap({ Int($0) }),
+                let name = param["key.name"] as? String else {
+                return nil
+            }
+
+            // swiftlint:disable:next force_try
+            let regex = try! NSRegularExpression(pattern: name, options: [.ignoreMetacharacters])
+            guard let range = contents.byteRangeToNSRange(start: rangeStart,
+                                                          length: rangeLength) else {
+                return nil
+            }
+
+            let matches = regex.matches(in: file.contents, options: [], range: range).ranges()
+            for range in matches {
+                guard let byteRange = contents.NSRangeToByteRange(start: range.location,
+                                                                  length: range.length) else {
+                    continue
+                }
+
+                // if it's the parameter declaration itself, we should skip
+                if byteRange.location == paramOffset {
+                    continue
+                }
+
+                let tokens = file.syntaxMap.tokensIn(byteRange)
+                // a parameter usage should be only one token
+                if tokens.count != 1 {
+                    continue
+                }
+
+                // found an usage, there's no violation!
+                if let token = tokens.first, SyntaxKind(rawValue: token.type) == .identifier,
+                    token.offset == byteRange.location, token.length == byteRange.length {
+                    return nil
+                }
+            }
+
+            let reason = "Unused parameter \"\(name)\" in a closure should be replaced with _."
+            return StyleViolation(ruleDescription: type(of: self).description,
+                                  severity: configuration.severity,
+                                  location: Location(file: file, byteOffset: paramOffset),
+                                  reason: reason)
+        }
+    }
+
+    private func filterByKind(dictionary: [String: SourceKitRepresentable],
+                              kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
+
+        let substructure = dictionary["key.substructure"] as? [SourceKitRepresentable] ?? []
+        return substructure.flatMap { subItem -> [[String: SourceKitRepresentable]] in
+            guard let subDict = subItem as? [String: SourceKitRepresentable],
+                let kindString = subDict["key.kind"] as? String else {
+                    return []
+            }
+
+            if SwiftDeclarationKind(rawValue: kindString) == kind {
+                return [subDict]
+            }
+
+            if SwiftExpressionKind(rawValue: kindString) == .argument {
+                return filterByKind(dictionary: subDict, kind: kind)
+            }
+
+            return []
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
+		D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */; };
 		D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */; };
 		D41E7E0B1DF9DABB0065259A /* RedundantStringEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
@@ -95,8 +96,8 @@
 		D47079A71DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */; };
 		D47079A91DFDBED000027086 /* ClosureParameterPositionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */; };
 		D47079AB1DFDCF7A00027086 /* SwiftExpressionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079AA1DFDCF7A00027086 /* SwiftExpressionKind.swift */; };
-		D47079AF1DFE520000027086 /* VoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079AE1DFE520000027086 /* VoidReturnRule.swift */; };
 		D47079AD1DFE2FA700027086 /* EmptyParametersRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079AC1DFE2FA700027086 /* EmptyParametersRule.swift */; };
+		D47079AF1DFE520000027086 /* VoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079AE1DFE520000027086 /* VoidReturnRule.swift */; };
 		D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */; };
 		D47A51101DB2DD4800A4CC21 /* AttributesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */; };
 		D48AE2CC1DFB58C5001C6A4A /* AttributesRulesExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */; };
@@ -313,6 +314,7 @@
 		D0D1217719E87B05005E4BAA /* SwiftLintFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftLintFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0D1217D19E87B05005E4BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedClosureParameterRule.swift; sourceTree = "<group>"; };
 		D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaConfiguration.swift; sourceTree = "<group>"; };
 		D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStringEnumValueRule.swift; sourceTree = "<group>"; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
@@ -325,8 +327,8 @@
 		D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyParenthesesWithTrailingClosureRule.swift; sourceTree = "<group>"; };
 		D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureParameterPositionRule.swift; sourceTree = "<group>"; };
 		D47079AA1DFDCF7A00027086 /* SwiftExpressionKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExpressionKind.swift; sourceTree = "<group>"; };
-		D47079AE1DFE520000027086 /* VoidReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoidReturnRule.swift; sourceTree = "<group>"; };
 		D47079AC1DFE2FA700027086 /* EmptyParametersRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyParametersRule.swift; sourceTree = "<group>"; };
+		D47079AE1DFE520000027086 /* VoidReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoidReturnRule.swift; sourceTree = "<group>"; };
 		D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
 		D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRule.swift; sourceTree = "<group>"; };
 		D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRulesExamples.swift; sourceTree = "<group>"; };
@@ -750,6 +752,7 @@
 				E88DEA851B0991BF00A66CB0 /* TrailingWhitespaceRule.swift */,
 				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
+				D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */,
 				E81CDE701C00FEAA00B430F6 /* ValidDocsRule.swift */,
 				D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */,
 				E88DEA931B099C0900A66CB0 /* VariableNameRule.swift */,
@@ -1134,6 +1137,7 @@
 				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
 				E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */,
 				E881985F1BEA987C00333A11 /* TypeNameRule.swift in Sources */,
+				D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */,
 				D46E041D1DE3712C00728374 /* TrailingCommaRule.swift in Sources */,
 				E88198521BEA941300333A11 /* TodoRule.swift in Sources */,
 				3B828E531C546468000D180E /* RuleConfiguration.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -371,6 +371,10 @@ class RulesTests: XCTestCase {
         verifyRule(TypeNameRule.description)
     }
 
+    func testUnusedClosureParameter() {
+        verifyRule(UnusedClosureParameterRule.description)
+    }
+
 // swiftlint:disable:next todo
 // FIXME: https://github.com/jpsim/SourceKitten/issues/269
 //    func testValidDocs() {
@@ -453,6 +457,7 @@ extension RulesTests {
             ("testTrailingWhitespace", testTrailingWhitespace),
             ("testTypeBodyLength", testTypeBodyLength),
             // ("testTypeName", testTypeName),
+            ("testUnusedClosureParameter", testUnusedClosureParameter),
             ("testValidIBInspectable", testValidIBInspectable),
             // ("testVariableName", testVariableName),
             ("testVoidReturn", testVoidReturn),


### PR DESCRIPTION
Fixes #982


This currently doesn't catch some violations:

```swift
// 1. If there's a variable with the same name in another object
[1, 2].map { number in
  return otherThing.number
}

// 2. If there're nested closures and the inner one shadows a variable from the other one
[1, 2].map { number in
  return [1, 2].map { number in
    return number + 1
  }
}
```

1 seems to be possible to be fixed (I just don't have any good ideas). The other one though I'd say is much harder.

Maybe this should be opt-in since it's not a wide-spread convention AFAIK?