### PR TITLE
make UnusedClosureParameterRule correctable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#626](https://github.com/realm/SwiftLint/issues/626)
 
-* Add `unused_closure_parameter` rule that validates if all closure parameters
-  are being used. If any of them isn't, it should be replaced by `_`.  
+* Add `unused_closure_parameter` correctable rule that validates if all closure
+  parameters are being used. If a parameter is unused, it should be replaced by
+  `_`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  [JP Simard](https://github.com/jpsim)
   [#982](https://github.com/realm/SwiftLint/issues/982)
 
 ##### Bug Fixes


### PR DESCRIPTION
I know @marcelofabri expressed an interest in improving how correctable rules are written in https://github.com/realm/SwiftLint/pull/992#issuecomment-267716268, but as I ran this rule on Realm and noticed that there were lots of violations, I realized it would take the same amount of time to manually fix the violations than it would take to make this rule correctable. So here we are...

How's this for now, @marcelofabri?