### PR TITLE
Updates docker image to use Swift 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   Swift 3. This requires `libsourcekitdInProc.so` to be built and located in
   `/usr/lib`, or in another location specified by the `LINUX_SOURCEKIT_LIB_PATH`
   environment variable. A preconfigured Docker image is available on Docker Hub
-  by the ID of `norionomura/sourcekit:301`.  
+  by the ID of `norionomura/sourcekit:302`.  
   [JP Simard](https://github.com/jpsim)
   [Norio Nomura](https://github.com/norio-nomura)
   [#732](https://github.com/realm/SwiftLint/issues/732)

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ archive:
 release: package archive portable_zip
 
 docker_test:
-	docker run -v `pwd`:/SwiftLint norionomura/sourcekit:301 bash -c "cd /SwiftLint && swift test"
+	docker run -v `pwd`:/SwiftLint norionomura/sourcekit:302 bash -c "cd /SwiftLint && swift test"
 
 # http://irace.me/swift-profiling/
 display_compilation_time:


### PR DESCRIPTION
I don't think this will fix any of the issues we've been facing with Foundation on Linux, but it can't hurt.

Thanks to @norio-nomura for keeping these images updated 🙇 