### PR TITLE
Closure end indentation rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,6 +14,7 @@ opt_in_rules:
   - nimble_operator
   - attributes
   - operator_usage_whitespace
+  - closure_end_indentation
 
 file_header:
   required_pattern: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@
 
 ##### Enhancements
 
-* None.
+* Add `closure_end_indentation` opt-in rule that validates closure closing 
+  braces according to this logic:
+  * If the method call is chained breaking lines on each method 
+  (`.` is on a new line), the closing brace should be in the same 
+  indentation as the `.`.
+  * Else, the closing brace should be in the same indentation as 
+  the beginning of the statement (in the first line).  
+
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#326](https://github.com/realm/SwiftLint/issues/326)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 ##### Enhancements
 
-* Add `closure_end_indentation` opt-in rule that validates closure closing 
-  braces according to this logic:
-  * If the method call is chained breaking lines on each method 
-  (`.` is on a new line), the closing brace should be in the same 
-  indentation as the `.`.
-  * Else, the closing brace should be in the same indentation as 
-  the beginning of the statement (in the first line).  
+* Add `closure_end_indentation` opt-in rule that validates closure closing
+  braces according to these rules:
+  * If the method call has chained breaking lines on each method
+    (`.` is on a new line), the closing brace should be vertically aligned
+    with the `.`.
+  * Otherwise, the closing brace should be vertically aligned with
+    the beginning of the statement in the first line.  
 
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#326](https://github.com/realm/SwiftLint/issues/326)

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -45,7 +45,7 @@ extension File {
                 return Command(string: contents, range: range)
             }.flatMap { command in
                 return command.expand()
-        }
+            }
     }
 
     fileprivate func endOfNextCommand(_ nextCommand: Command?) -> Location {

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -40,12 +40,12 @@ extension File {
             return []
         }
         let contents = self.contents.bridge()
-        return matchPattern("swiftlint:(enable|disable)(:previous|:this|:next)?\\ [^\\n]+",
-            withSyntaxKinds: [.comment]).flatMap { range in
-                return Command(string: contents, range: range)
-            }.flatMap { command in
-                return command.expand()
-            }
+        let pattern = "swiftlint:(enable|disable)(:previous|:this|:next)?\\ [^\\n]+"
+        return matchPattern(pattern, withSyntaxKinds: [.comment]).flatMap { range in
+            return Command(string: contents, range: range)
+        }.flatMap { command in
+            return command.expand()
+        }
     }
 
     fileprivate func endOfNextCommand(_ nextCommand: Command?) -> Location {

--- a/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
@@ -28,7 +28,7 @@ extension FileManager {
                 return try subpathsOfDirectory(atPath: absolutePath)
                     .map(absolutePath.bridge().appendingPathComponent).filter {
                         $0.bridge().isSwiftFile()
-                }
+                    }
             } catch {
                 fatalError("Couldn't find files in \(absolutePath): \(error)")
             }

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -43,6 +43,7 @@ public struct RuleList {
 public let masterRuleList = RuleList(rules:
     AttributesRule.self,
     ClosingBraceRule.self,
+    ClosureEndIndentationRule.self,
     ClosureParameterPositionRule.self,
     ClosureSpacingRule.self,
     ColonRule.self,

--- a/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
@@ -52,7 +52,7 @@ public struct ClosureEndIndentationRule: ASTRule, OptInRule, ConfigurationProvid
             return []
         }
 
-        let contents = file.contents
+        let contents = file.contents.bridge()
         guard let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
             let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
             let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
@@ -60,7 +60,7 @@ public struct ClosureEndIndentationRule: ASTRule, OptInRule, ConfigurationProvid
             let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
             bodyLength > 0,
             case let endOffset = offset + length - 1,
-            contents.bridge().substringWithByteRange(start: endOffset, length: 1) == "}",
+            contents.substringWithByteRange(start: endOffset, length: 1) == "}",
             let startOffset = startOffsetFor(dictionary: dictionary, file: file),
             let (startLine, _) = contents.lineAndCharacter(forByteOffset: startOffset),
             let (endLine, endPosition) = contents.lineAndCharacter(forByteOffset: endOffset),
@@ -73,7 +73,7 @@ public struct ClosureEndIndentationRule: ASTRule, OptInRule, ConfigurationProvid
         let range = file.lines[startLine - 1].range
         let regex = ClosureEndIndentationRule.notWhitespace
         let actual = endPosition - 1
-        guard let match = regex.firstMatch(in: contents, options: [], range: range)?.range,
+        guard let match = regex.firstMatch(in: file.contents, options: [], range: range)?.range,
             case let expected = match.location - range.location,
             expected != actual  else {
                 return []

--- a/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
@@ -1,0 +1,71 @@
+//
+//  ClosureEndIndentationRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 12/18/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct ClosureEndIndentationRule: ASTRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "closure_end_indentation",
+        name: "Closure End Indentation",
+        description: "Closure end should have the same indentation as the line that started it.",
+        nonTriggeringExamples: [
+            "SignalProducer(values: [1, 2, 3])\n" +
+            "   .startWithNext { number in\n" +
+            "       print(number)\n" +
+            "   }"
+        ],
+        triggeringExamples: [
+            "SignalProducer(values: [1, 2, 3])\n" +
+            "   .startWithNext { number in\n" +
+            "       print(number)\n" +
+            "}"
+        ]
+    )
+
+    private static let notWhitespace = regex("[^\\s]")
+
+    public func validateFile(_ file: File,
+                             kind: SwiftExpressionKind,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .call else {
+            return []
+        }
+
+        let contents = file.contents
+        guard let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
+            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
+            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
+            bodyLength > 0,
+            case let endOffset = offset + length - 1,
+            contents.bridge().substringWithByteRange(start: endOffset, length: 1) == "}",
+            let (startLine, _) = contents.lineAndCharacter(forByteOffset: bodyOffset),
+            let (endLine, endPosition) = contents.lineAndCharacter(forByteOffset: endOffset),
+            startLine != endLine else {
+                return []
+        }
+
+        let range = file.lines[startLine - 1].range
+        let regex = ClosureEndIndentationRule.notWhitespace
+        guard let match = regex.firstMatch(in: contents, options: [], range: range)?.range,
+            match.location - range.location != endPosition - 1 else {
+                return []
+        }
+
+        return [
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: endOffset))
+        ]
+    }
+}

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -148,6 +148,6 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
 
                 // return first captured range
                 return firstRange
-        }
+            }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -134,7 +134,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
                 } else {
                     return nil
                 }
-        }
+            }
     }
 
     // Returns if range should generate violation

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -26,7 +26,7 @@ public struct NestingRule: ASTRule, ConfigurationProviderRule {
         } + ["enum Enum0 { enum Enum1 { case Case } }"],
         triggeringExamples: ["class", "struct", "enum"].map { kind in
             "\(kind) A { \(kind) B { ↓\(kind) C {} } }\n"
-            } + [
+        } + [
                 "func func0() {\nfunc func1() {\nfunc func2() {\nfunc func3() {\nfunc func4() { " +
                 "func func5() {\n↓func func6() {\n}\n}\n}\n}\n}\n}\n}\n"
         ]

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -45,7 +45,7 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
         let pattern = "\\b(" + types.joined(separator: "|") + ")\\s*<.*?>"
 
         return file.matchPattern(pattern,
-            excludingSyntaxKinds: SyntaxKind.commentAndStringKinds()).map {
+                                 excludingSyntaxKinds: SyntaxKind.commentAndStringKinds()).map {
                 StyleViolation(ruleDescription: type(of: self).description,
                     severity: configuration.severity,
                     location: Location(file: file, characterOffset: $0.location))

--- a/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
@@ -56,7 +56,8 @@ public struct VoidReturnRule: ConfigurationProviderRule, CorrectableRule {
         let excludingPattern = "(\(pattern))\\s*(throws\\s+)?->"
 
         return file.matchPattern(pattern, excludingSyntaxKinds: kinds,
-                                 excludingPattern: excludingPattern) { $0.rangeAt(1) }.flatMap {
+                                 excludingPattern: excludingPattern,
+                                 exclusionMapping: { $0.rangeAt(1) }).flatMap {
             let parensRegex = NSRegularExpression.forcePattern(parensPattern)
             return parensRegex.firstMatch(in: file.contents, options: [], range: $0)?.range
         }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		D41E7E0B1DF9DABB0065259A /* RedundantStringEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
 		D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B04631E0620AB004016AF /* UnusedEnumeratedRule.swift */; };
+		D43B046B1E075905004016AF /* ClosureEndIndentationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B046A1E075905004016AF /* ClosureEndIndentationRule.swift */; };
 		D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */; };
 		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
 		D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */; };
@@ -322,6 +323,7 @@
 		D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStringEnumValueRule.swift; sourceTree = "<group>"; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		D43B04631E0620AB004016AF /* UnusedEnumeratedRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedEnumeratedRule.swift; sourceTree = "<group>"; };
+		D43B046A1E075905004016AF /* ClosureEndIndentationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureEndIndentationRule.swift; sourceTree = "<group>"; };
 		D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitGetterRule.swift; sourceTree = "<group>"; };
 		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
 		D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyntacticSugarRule.swift; sourceTree = "<group>"; };
@@ -705,6 +707,7 @@
 				D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */,
 				D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */,
 				1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */,
+				D43B046A1E075905004016AF /* ClosureEndIndentationRule.swift */,
 				D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */,
 				1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */,
 				E88DEA831B0990F500A66CB0 /* ColonRule.swift */,
@@ -1109,6 +1112,7 @@
 				D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */,
 				D48AE2CC1DFB58C5001C6A4A /* AttributesRulesExamples.swift in Sources */,
 				E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */,
+				D43B046B1E075905004016AF /* ClosureEndIndentationRule.swift in Sources */,
 				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift in Sources */,
 				D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */,
 				7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -94,6 +94,10 @@ class RulesTests: XCTestCase {
         verifyRule(CommaRule.description)
     }
 
+    func testClosureEndIndentation() {
+        verifyRule(ClosureEndIndentationRule.description)
+    }
+
     func testClosureParameterPosition() {
         verifyRule(ClosureParameterPositionRule.description)
     }
@@ -414,6 +418,7 @@ extension RulesTests {
             ("testClosingBrace", testClosingBrace),
             ("testColon", testColon),
             ("testComma", testComma),
+            ("testClosureEndIndentation", testClosureEndIndentation),
             ("testClosureParameterPosition", testClosureParameterPosition),
             ("testClosureSpacingRule", testClosureSpacingRule),
             ("testConditionalReturnsOnNewline", testConditionalReturnsOnNewline),


### PR DESCRIPTION
Fixes #326

This still have some issues:
- [x] It should be opt-in. It's not currently to make it easier to test.
- [x] Some false positives are being trigged, mainly related to opening brace on different line than the method call. For example:
```swift
return file.matchPattern(pattern, excludingSyntaxKinds: kinds,
                                          excludingPattern: excludingPattern).map {
    return StyleViolation(ruleDescription: type(of: self).description,
                          severity: configuration.severity,
                          location: Location(file: file, characterOffset: $0.location))
}
```
- [x] It should check (and skip) if the closure begins and ends on the same line, not the body offset. This should prevent this false violation:
```swift
 return file.matchPattern(pattern, excludingSyntaxKinds: kinds,
                                 excludingPattern: excludingPattern) { ↓$0.rangeAt(1) }.flatMap {
            let parensRegex = NSRegularExpression.forcePattern(parensPattern)
            return parensRegex.firstMatch(in: file.contents, options: [], range: $0)?.range
}
```

The main issue here is that I'd need the starting point of the method related to the closure, not the full chained one (which is what SourceKits gives me). Any ideas on how to get it?