### PR TITLE
Grammar checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Grammar checks.  
+  [Michael Helmbrecht](https://github.com/mrh-is)
 
 ## 0.14.0: Super Awesome Retractable Drying Rack
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#934](https://github.com/realm/SwiftLint/issues/934)
 
-* Fix `traling_comma` rule reporting a violation for commas in comments.  
+* Fix `trailing_comma` rule reporting a violation for commas in comments.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#940](https://github.com/realm/SwiftLint/issues/940)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ If your rule is configurable, but does not fit the pattern of
 * This initializer must throw if it does not understand the configuration, or
   it cannot be fully initialized with the configuration and default values.
 * By convention, a failing initializer throws
-  `ConfigurationError.UnknownConfiguration`
+  `ConfigurationError.UnknownConfiguration`.
 * If this initializer fails, your rule will be initialized with its default
   values by calling `init()`.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ fi
 To run `swiftlint autocorrect` on save in Xcode, install the
 [SwiftLintXcode](https://github.com/ypresto/SwiftLintXcode) plugin from Alcatraz.
 
+⚠ ️This plugin will not work with Xcode 8 without diabling SIP. This is not recommended.
+
 ### AppCode
 
 To integrate SwiftLint with AppCode, install

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ applying corrections.
 
 ## License
 
-[MIT licensed.](https://github.com/realm/SwiftLint/blob/master/LICENSE)
+[MIT licensed.](LICENSE)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ unacceptable behavior to [info@realm.io](mailto:info@realm.io).
 
 ## Installation
 
-Using [Homebrew](http://brew.sh/)
+Using [Homebrew](http://brew.sh/):
 
-```
+```bash
 brew install swiftlint
 ```
 
@@ -63,13 +63,13 @@ The `autocorrect` action is available via `⌥⏎`.
 
 ### Atom
 
-To integrate SwiftLint with [Atom](https://atom.io/) install the
+To integrate SwiftLint with [Atom](https://atom.io/), install the
 [`linter-swiftlint`](https://atom.io/packages/linter-swiftlint) package from
 APM.
 
 ### Command Line
 
-```
+```bash
 $ swiftlint help
 Available commands:
 
@@ -86,10 +86,10 @@ will be searched recursively.
 To specify a list of files when using `lint` or `autocorrect` (like the list of
 files modified by Xcode specified by the
 [`ExtraBuildPhase`](https://github.com/norio-nomura/ExtraBuildPhase) Xcode
-plugin, or modified files in the working tree based on `git ls-files -m`) you
+plugin, or modified files in the working tree based on `git ls-files -m`), you
 can do so by passing the option `--use-script-input-files` and setting the
 following instance variables: `SCRIPT_INPUT_FILE_COUNT` and
-`SCRIPT_INPUT_FILE_0`, `SCRIPT_INPUT_FILE_1`... `SCRIPT_INPUT_FILE_{SCRIPT_INPUT_FILE_COUNT}`.
+`SCRIPT_INPUT_FILE_0`, `SCRIPT_INPUT_FILE_1`...`SCRIPT_INPUT_FILE_{SCRIPT_INPUT_FILE_COUNT}`.
 
 These are same environment variables set for input files to
 [custom Xcode script phases](http://indiestack.com/2014/12/speeding-up-custom-script-phases/).
@@ -106,14 +106,14 @@ and are subject to change.
 See the [Source/SwiftLintFramework/Rules](Source/SwiftLintFramework/Rules)
 directory to see the currently implemented rules.
 
-`opt_in_rules` are disabled by default (you have to explicitly enable them in
+`opt_in_rules` are disabled by default (i.e., you have to explicitly enable them in
 your configuration file).
 
 Guidelines on when to implement a rule as opt-in:
 
 * A rule that can have many false positives (e.g. `empty_count`)
 * A rule that is too slow
-* A rule that is not general consensus or only useful in some cases
+* A rule that is not general consensus or is only useful in some cases
   (e.g. `force_unwrapping`, `missing_docs`)
 
 ### Disable rules in code
@@ -137,7 +137,7 @@ let noWarning :String = "" // No warning about colons immediately after variable
 let hasWarning :String = "" // Warning generated about colons immediately after variable names
 ```
 
-It's also possible to modify a disable or enable command by appending
+It's also possible to modify a `disable` or `enable` command by appending
 `:previous`, `:this` or `:next` for only applying the command to the previous,
 this (current) or next line respectively.
 
@@ -163,10 +163,10 @@ run SwiftLint from. The following parameters can be configured:
 Rule inclusion:
 
 * `disabled_rules`: Disable rules from the default enabled set.
-* `opt_in_rules`: Some rules are opt-in.
-* `whitelist_rules`: Can not be specified alongside `disabled_rules` or
-  `opt_in_rules`. Acts as a whitelist, only the rules specified in this list
-  will be enabled.
+* `opt_in_rules`: Enable rules not from the default set.
+* `whitelist_rules`: Acts as a whitelist, only the rules specified in this list
+  will be enabled. Can not be specified alongside `disabled_rules` or
+  `opt_in_rules`.
 
 ```yaml
 disabled_rules: # rule identifiers to exclude from running
@@ -296,7 +296,7 @@ applying corrections.
 
 ## License
 
-MIT licensed.
+[MIT licensed.](https://github.com/realm/SwiftLint/blob/master/LICENSE)
 
 ## About
 
@@ -307,5 +307,5 @@ Realm are trademarks of Realm Inc.
 
 We :heart: open source software!
 See [our other open source projects](https://github.com/realm),
-read [our blog](https://realm.io/news) or say hi on twitter
+read [our blog](https://realm.io/news), or say hi on twitter
 ([@realm](https://twitter.com/realm)).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ unacceptable behavior to [info@realm.io](mailto:info@realm.io).
 
 Using [Homebrew](http://brew.sh/):
 
-```bash
+```
 brew install swiftlint
 ```
 
@@ -71,7 +71,7 @@ APM.
 
 ### Command Line
 
-```bash
+```
 $ swiftlint help
 Available commands:
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -3,7 +3,7 @@
 For SwiftLint contributors, follow these steps to cut a release:
 
 1. Update version number: `make set_version 0.2.0`
-2. Come up with a witty washer/dryer themed release name. Past names include:
+2. Come up with a witty washer- or dryer-themed release name. Past names include:
     * Tumble Dry
     * FabricSoftenerRule
     * Top Loading
@@ -14,12 +14,13 @@ For SwiftLint contributors, follow these steps to cut a release:
 5. Tag: `git tag -a 0.2.0 -m "0.2.0: Tumble Dry"; git push origin 0.2.0`
 6. Make sure you have the latest stable Xcode version installed and
   `xcode-select`ed.
-7. Create the pkg installer, framework zip and portable zip: `make release`
+7. Create the pkg installer, framework zip, and portable zip: `make release`
 8. Create a GitHub release: https://github.com/realm/SwiftLint/releases/new
     * Specify the tag you just pushed from the dropdown.
     * Set the release title to the new version number & release name.
     * Add the changelog section to the release description text box.
-    * Upload the pkg installer, framework zip and portable zip you just built to
-      the GitHub release binaries.
+    * Upload the pkg installer, framework zip, and portable zip you just built
+      to the GitHub release binaries.
     * Click "Publish release".
 9. Publish to Homebrew and CocoaPods trunk: `make publish`
+10. Celebrate. :tada:


### PR DESCRIPTION
Nothing really major, mostly missing punctuation for clarity or consistency.

Added [one sentence](https://github.com/mrh-is/SwiftLint/commit/e9b990a43f4ba903d5a6be803bfa961bea9c6d93) to warn people that Xcode plugins won't work on Xcode 8 (the version required for this project). I would be in favor of removing the part about the plugin altogether, but that's something that should be discussed.

[🌵](https://jaltranslation.files.wordpress.com/2014/12/gary-the-grammar-cactus.jpg)