### PR TITLE
Changing the default line length limit to 120

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,3 +25,4 @@ file_header:
                     \/\/  Created by .*? on \d{1,2}\/\d{1,2}\/\d{2}\.
                     \/\/  Copyright © \d{4} Realm\. All rights reserved\.
                     \/\/
+line_length: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Breaking
 
-* None.
+* `file_length` rule now has a default value of `120` for warnings.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1008](https://github.com/realm/SwiftLint/issues/1008)
 
 ##### Enhancements
 

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -167,8 +167,7 @@ extension File {
     }
 }
 
-private func substructureForDict(_ dict: [String: SourceKitRepresentable]) ->
-                                 [[String: SourceKitRepresentable]]? {
+private func substructureForDict(_ dict: [String: SourceKitRepresentable]) -> [[String: SourceKitRepresentable]]? {
     return (dict["key.substructure"] as? [SourceKitRepresentable])?.flatMap {
         $0 as? [String: SourceKitRepresentable]
     }

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -30,8 +30,7 @@ extension String {
         return self == lowercased()
     }
 
-    internal func nameStrippingLeadingUnderscoreIfPrivate(
-        _ dict: [String: SourceKitRepresentable]) -> String {
+    internal func nameStrippingLeadingUnderscoreIfPrivate(_ dict: [String: SourceKitRepresentable]) -> String {
         if let aclString = dict["key.accessibility"] as? String,
            let acl = AccessControlLevel(identifier: aclString),
             acl.isPrivate && characters.first == "_" {

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -21,8 +21,7 @@ public struct Linter {
         return getStyleViolations(true)
     }
 
-    fileprivate func getStyleViolations(_ benchmark: Bool = false) ->
-        ([StyleViolation], [(id: String, time: Double)]) {
+    private func getStyleViolations(_ benchmark: Bool = false) -> ([StyleViolation], [(id: String, time: Double)]) {
         if file.sourcekitdFailed {
             queuedPrintError("Most of rules are skipped because sourcekitd fails.")
         }

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -19,8 +19,7 @@ extension ASTRule where KindType.RawValue == String {
         return validateFile(file, dictionary: file.structure.dictionary)
     }
 
-    public func validateFile(_ file: File, dictionary: [String: SourceKitRepresentable]) ->
-                             [StyleViolation] {
+    public func validateFile(_ file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         let substructure = dictionary["key.substructure"] as? [SourceKitRepresentable] ?? []
         return substructure.flatMap { subItem -> [StyleViolation] in
             guard let subDict = subItem as? [String: SourceKitRepresentable],

--- a/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
@@ -59,14 +59,14 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func measureComplexity(_ file: File,
-                                       dictionary: [String: SourceKitRepresentable]) -> Int {
+                                   dictionary: [String: SourceKitRepresentable]) -> Int {
         var hasSwitchStatements = false
 
         let substructure = dictionary["key.substructure"] as? [SourceKitRepresentable] ?? []
 
         let complexity = substructure.reduce(0) { complexity, subItem in
             guard let subDict = subItem as? [String: SourceKitRepresentable],
-                      let kind = subDict["key.kind"] as? String else {
+                let kind = subDict["key.kind"] as? String else {
                 return complexity
             }
 

--- a/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
@@ -34,7 +34,7 @@ public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule {
     )
 
     public func validateFile(_ file: File, kind: SwiftDeclarationKind,
-        dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         // Look for functions with both "inline" and "dynamic". For each of these, we can get offset
         // of the "func" keyword. We can assume that the nearest "@inline" before this offset is
         // the attribute we are interested in.

--- a/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
@@ -86,8 +86,8 @@ public struct ImplicitGetterRule: Rule, ConfigurationProviderRule {
         }
     }
 
-    private func variableDeclarationsFor(_ byteOffset: Int, structure: Structure) ->
-                                                          [[String: SourceKitRepresentable]] {
+    private func variableDeclarationsFor(_ byteOffset: Int,
+                                         structure: Structure) -> [[String: SourceKitRepresentable]] {
         var results = [[String: SourceKitRepresentable]]()
 
         func parse(dictionary: [String: SourceKitRepresentable]) {

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -9,7 +9,7 @@
 import SourceKittenFramework
 
 public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 100, error: 200)
+    public var configuration = SeverityLevelsConfiguration(warning: 120, error: 200)
 
     public init() {}
 
@@ -18,14 +18,14 @@ public struct LineLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
         name: "Line Length",
         description: "Lines should not span too many characters.",
         nonTriggeringExamples: [
-            String(repeating: "/", count: 100) + "\n",
-            String(repeating: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)", count: 100) + "\n",
-            String(repeating: "#imageLiteral(resourceName: \"image.jpg\")", count: 100) + "\n"
+            String(repeating: "/", count: 120) + "\n",
+            String(repeating: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)", count: 120) + "\n",
+            String(repeating: "#imageLiteral(resourceName: \"image.jpg\")", count: 120) + "\n"
         ],
         triggeringExamples: [
-            String(repeating: "/", count: 101) + "\n",
-            String(repeating: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)", count: 101) + "\n",
-            String(repeating: "#imageLiteral(resourceName: \"image.jpg\")", count: 101) + "\n"
+            String(repeating: "/", count: 121) + "\n",
+            String(repeating: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)", count: 121) + "\n",
+            String(repeating: "#imageLiteral(resourceName: \"image.jpg\")", count: 121) + "\n"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -19,8 +19,7 @@ private func declarationOverrides(_ dictionary: [String: SourceKitRepresentable]
     return dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.override")
 }
 
-private func inheritedMembersForDictionary(_ dictionary: [String: SourceKitRepresentable]) ->
-                                           [String] {
+private func inheritedMembersForDictionary(_ dictionary: [String: SourceKitRepresentable]) -> [String] {
     return mappedDictValues(dictionary, key: "key.inheritedtypes", subKey: "key.name").flatMap {
         File.allDeclarationsByType[$0] ?? []
     }
@@ -28,7 +27,7 @@ private func inheritedMembersForDictionary(_ dictionary: [String: SourceKitRepre
 
 extension File {
     fileprivate func missingDocOffsets(_ dictionary: [String: SourceKitRepresentable],
-                                   acl: [AccessControlLevel], skipping: [String] = []) -> [Int] {
+                                       acl: [AccessControlLevel], skipping: [String] = []) -> [Int] {
         if declarationOverrides(dictionary) {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -84,7 +84,7 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
         return writeToFile(file, violatingRanges: violatingRanges)
     }
 
-    fileprivate func writeToFile(_ file: File, violatingRanges: [NSRange]) -> [Correction] {
+    private func writeToFile(_ file: File, violatingRanges: [NSRange]) -> [Correction] {
         var correctedContents = file.contents
         var adjustedLocations = [Int]()
 
@@ -106,8 +106,8 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
         }
     }
 
-    fileprivate func correctContents(_ contents: String, violatingRange: NSRange)
-        -> (correctedContents: String, adjustedRange: NSRange?) {
+    private func correctContents(_ contents: String,
+                                 violatingRange: NSRange) -> (correctedContents: String, adjustedRange: NSRange?) {
         guard let indexRange = contents.nsrangeToIndexRange(violatingRange) else {
             return (contents, nil)
         }

--- a/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
@@ -127,7 +127,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
         }
     }
 
-    fileprivate func isTestClass(_ dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isTestClass(_ dictionary: [String: SourceKitRepresentable]) -> Bool {
         guard let regex = configuration.regex, let superclass = superclass(dictionary) else {
             return false
         }
@@ -135,9 +135,8 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
         return !regex.matches(in: superclass, options: [], range: range).isEmpty
     }
 
-    fileprivate func validateFunction(_ file: File, kind: SwiftDeclarationKind,
-                                      dictionary: [String: SourceKitRepresentable])
-                                      -> [StyleViolation] {
+    private func validateFunction(_ file: File, kind: SwiftDeclarationKind,
+                                  dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         assert(kind == .functionMethodInstance)
         guard let name = dictionary["key.name"] as? String, name.hasPrefix("test") else {
             return []
@@ -145,9 +144,8 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
         return validateAccessControlLevel(file, dictionary: dictionary)
     }
 
-    fileprivate func validateAccessControlLevel(_ file: File,
-                                                dictionary: [String: SourceKitRepresentable])
-                                                -> [StyleViolation] {
+    private func validateAccessControlLevel(_ file: File,
+                                            dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         guard let acl = AccessControlLevel(dictionary), acl.isPrivate else { return [] }
         let offset = Int(dictionary["key.offset"] as? Int64 ?? 0)
         return [StyleViolation(ruleDescription: type(of: self).description,

--- a/Source/SwiftLintFramework/Rules/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantStringEnumValueRule.swift
@@ -122,8 +122,7 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule {
         }
     }
 
-    private func filterEnumInits(dictionary: [String: SourceKitRepresentable]) ->
-                                                                [[String: SourceKitRepresentable]] {
+    private func filterEnumInits(dictionary: [String: SourceKitRepresentable]) -> [[String: SourceKitRepresentable]] {
         guard let elements = dictionary["key.elements"] as? [SourceKitRepresentable] else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -156,8 +156,7 @@ private extension StatementPositionRule {
     // swiftlint:disable:next force_try
     static let uncuddledRegex = try! NSRegularExpression(pattern: uncuddledPattern, options: [])
 
-    static func uncuddledMatchValidator(_ contents: String) ->
-        ((NSTextCheckingResult) -> NSTextCheckingResult?) {
+    static func uncuddledMatchValidator(_ contents: String) -> ((NSTextCheckingResult) -> NSTextCheckingResult?) {
         return { match in
             if match.numberOfRanges != 5 {
                 return match
@@ -176,8 +175,8 @@ private extension StatementPositionRule {
         }
     }
 
-    static func uncuddledMatchFilter(contents: String, syntaxMap: SyntaxMap) ->
-        ((NSTextCheckingResult) -> Bool) {
+    static func uncuddledMatchFilter(contents: String,
+                                     syntaxMap: SyntaxMap) -> ((NSTextCheckingResult) -> Bool) {
         return { match in
             let range = match.range
             guard let matchRange = contents.bridge().NSRangeToByteRange(start: range.location,

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -56,7 +56,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
     public func validateFile(_ file: File,
                              kind: SwiftExpressionKind,
                              dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        return violationRangesInFile(file, kind: kind, dictionary: dictionary).map { range, name in
+        return violationRangesInFile(file, dictionary: dictionary, kind: kind).map { range, name in
             let reason = "Unused parameter \"\(name)\" in a closure should be replaced with _."
             return StyleViolation(ruleDescription: type(of: self).description,
                                   severity: configuration.severity,
@@ -65,9 +65,9 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
         }
     }
 
-    private func violationRangesInFile(_ file: File, kind: SwiftExpressionKind,
-                                       dictionary: [String: SourceKitRepresentable])
-                                       -> [(range: NSRange, name: String)] {
+    private func violationRangesInFile(_ file: File,
+                                       dictionary: [String: SourceKitRepresentable],
+                                       kind: SwiftExpressionKind) -> [(range: NSRange, name: String)] {
         guard kind == .call else {
             return []
         }
@@ -132,7 +132,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
                     return []
             }
             return violationRangesInFile(file, dictionary: subDict) +
-                violationRangesInFile(file, kind: kind, dictionary: subDict).map({ $0.0 })
+                violationRangesInFile(file, dictionary: subDict, kind: kind).map({ $0.0 })
         }
     }
 


### PR DESCRIPTION
Fixes #1008.

I particularly don't like breaking lines on `(` or `->` in function declarations, so I've changed the ones I've found now that we have a larger line length limit.  