### PR TITLE
Fix an incorrect link in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@
 * `type_name` rule now validates `typealias` and `associatedtype` too.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#49](https://github.com/realm/SwiftLint/issues/49)
-  [#956](https://github.com/realm/SwiftLint/issues/959)
+  [#956](https://github.com/realm/SwiftLint/issues/956)
 
 * Add `ProhibitedSuperRule` opt-in rule that warns about methods calling
   to super that should not, for example `UIViewController.loadView()`.  


### PR DESCRIPTION
The link was pointing to the wrong issue.
This same link is broken [in the GitHub release notes](https://github.com/realm/SwiftLint/releases/tag/0.14.0).