### PR TITLE
Fix function_parameter_count rule for generic initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@
 
 * `operator_usage_whitespace` rule is now correctable.  
   [Marcelo Fabri](https://github.com/marcelofabri)
-  
+
 ##### Bug Fixes
+
+* `FunctionParameterCountRule` also ignores generic initializers.  
+  [Mauricio Hanika](https://github.com/mAu888)
 
 * Grammar checks.  
   [Michael Helmbrecht](https://github.com/mrh-is)

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -23,6 +23,8 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
             "init (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}",
             "`init`(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}",
             "init?(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}",
+            "init?<T>(a: T, b: Int, c: Int, d: Int, e: Int, f: Int) {}",
+            "init?<T: String>(a: T, b: Int, c: Int, d: Int, e: Int, f: Int) {}",
             "func f2(p1: Int, p2: Int) { }",
             "func f(a: Int, b: Int, c: Int, d: Int, x: Int = 42) {}",
             "func f(a: [Int], b: Int, c: Int, d: Int, f: Int) -> [Int] {\n" +
@@ -106,7 +108,8 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
         guard let name = file.contents.bridge()
             .substringWithByteRange(start: offset, length: length),
             name.hasPrefix("init"),
-            let funcName = name.components(separatedBy: "(").first else {
+            let funcName = name
+                .components(separatedBy: CharacterSet(charactersIn: "<(")).first else {
             return false
         }
         if funcName == "init" { // fast path


### PR DESCRIPTION
The current implementation of the `function_parameter_count` rule did not account for generic initializers. The rule was triggering a false positive, as the `funcName` was not extracted correctly.

This PR should fix the issue for generic initializers.