### PR TITLE
`implicit_getter` rule performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * `operator_usage_whitespace` rule is now correctable.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
-* `implicit_getter` rule performance improvements.  
+* `implicit_getter` and `mark` rule performance improvements.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 * `operator_usage_whitespace` rule is now correctable.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
+* `implicit_getter` rule performance improvements.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 ##### Bug Fixes
 
 * `FunctionParameterCountRule` also ignores generic initializers.  

--- a/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
@@ -46,22 +46,20 @@ public struct ImplicitGetterRule: Rule, ConfigurationProviderRule {
         ],
         triggeringExamples: [
             classScoped("var foo: Int {\n ↓get {\n return 20 \n} \n} \n}"),
+            classScoped("var foo: Int {\n ↓get{\n return 20 \n} \n} \n}"),
             classScoped("static var foo: Int {\n ↓get {\n return 20 \n} \n} \n}")
         ]
     )
 
     public func validateFile(_ file: File) -> [StyleViolation] {
-        let getTokens = file.syntaxMap.tokens.filter { token -> Bool in
-            guard SyntaxKind(rawValue: token.type) == .keyword else {
-                return false
+        let pattern = "\\bget\\b"
+        let getTokens: [SyntaxToken] = file.rangesAndTokensMatching(pattern).flatMap { _, tokens in
+            guard tokens.count == 1, let token = tokens.first,
+                SyntaxKind(rawValue: token.type) == .keyword else {
+                return nil
             }
 
-            guard let tokenValue = file.contents.bridge()
-                .substringWithByteRange(start: token.offset, length: token.length) else {
-                    return false
-            }
-
-            return tokenValue == "get"
+            return token
         }
 
         let violatingTokens = getTokens.filter { token -> Bool in


### PR DESCRIPTION
Before:

```
0,335: implicit_getter
```

After:

```
0,010: implicit_getter
```

Measured on Realm's codebase.