### PR TITLE
Make `mark` rule slightly faster

### DIFF
--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -54,27 +54,27 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
     private let mark = "MARK:"
 
     private var nonSpaceOrTwoOrMoreSpace: String {
-        return "(\(nonSpace)|\(twoOrMoreSpace))"
+        return "(?:\(nonSpace)|\(twoOrMoreSpace))"
     }
 
     private var spaceStartPattern: String {
-        return "(\(nonSpaceOrTwoOrMoreSpace)\(mark))"
+        return "(?:\(nonSpaceOrTwoOrMoreSpace)\(mark))"
     }
 
     private var endNonSpacePattern: String {
-        return "(\(mark)\(nonSpace))"
+        return "(?:\(mark)\(nonSpace))"
     }
 
     private var endTwoOrMoreSpacePattern: String {
-        return "(\(mark)\(twoOrMoreSpace))"
+        return "(?:\(mark)\(twoOrMoreSpace))"
     }
 
     private var twoOrMoreSpacesAfterHyphenPattern: String {
-        return "(\(mark) -\(twoOrMoreSpace))"
+        return "(?:\(mark) -\(twoOrMoreSpace))"
     }
 
     private var nonSpaceOrNewlineAfterHyphenPattern: String {
-        return "(\(mark) -[^ \n])"
+        return "(?:\(mark) -[^ \n])"
     }
 
     private var pattern: String {


### PR DESCRIPTION
The performance improvements weren't as great as in #1016, so I don't think this deserves a changelog entry.

Before:
```
0,277: mark
```

After:
```
0,190: mark
```