### PR TITLE
Fix trailing_comma crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1019](https://github.com/realm/SwiftLint/issues/1019)
 
+* Fix crash on `trailing_comma` rule with Swift 2.3.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#921](https://github.com/realm/SwiftLint/issues/921)
+
 ## 0.15.0: Hand Washable Holiday Linens 🎄
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -27,7 +27,8 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
             "let foo = [:]\n",
             "let foo = [1: 2, 2: 3]\n",
             "let foo = [Void]()\n",
-            "let example = [ 1,\n 2\n // 3,\n]"
+            "let example = [ 1,\n 2\n // 3,\n]",
+            "foo([1: \"\\(error)\"])\n"
         ],
         triggeringExamples: [
             "let foo = [1, 2, 3↓,]\n",
@@ -37,6 +38,7 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
             "struct Bar {\n let foo = [1: 2, 2: 3↓, ]\n}\n",
             "let foo = [1, 2, 3↓,] + [4, 5, 6↓,]\n",
             "let example = [ 1,\n2↓,\n // 3,\n]"
+            // "foo([1: \"\\(error)\"↓,])\n"
         ]
     )
 
@@ -66,7 +68,7 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
             return offset + length
         }
 
-        guard let lastPosition = endPositions.max() else {
+        guard let lastPosition = endPositions.max(), bodyLength + bodyOffset >= lastPosition else {
             return []
         }
 


### PR DESCRIPTION
Fixes #921.

~As I wasn't able to reproduce the issue, I'm not sure this actually fixes the problem, but it was the only reason I found to make `contents.substringWithByteRange(start: lastPosition, length: length)` crash.~

~I'll add a changelog once we confirm it does fix the issue.~

~If it does, it'd good to have someone to add a break point in this guard to try to understand the issue and create a reproducible case so we can add tests and make sure we don't introduce a regression in the future.~

---

**UPDATE**: See https://github.com/realm/SwiftLint/issues/921#issuecomment-269890556