### PR TITLE
Add more helpful reason strings to TrailingCommaRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1005](https://github.com/realm/SwiftLint/issues/1005)
 
+* Add more helpful reason strings to TrailingCommaRule.  
+  [Matt Rubin](https://github.com/mattrubin)
+  [#1034](https://github.com/realm/SwiftLint/pull/1034)
+
 ##### Bug Fixes
 
 * `FunctionParameterCountRule` also ignores generic initializers.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
 
 * Add more helpful reason strings to TrailingCommaRule.  
   [Matt Rubin](https://github.com/mattrubin)
-  [#1034](https://github.com/realm/SwiftLint/pull/1034)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1033](https://github.com/realm/SwiftLint/issues/1033)
 
+* Add more helpful reason strings to TrailingCommaRule.  
+  [Matt Rubin](https://github.com/mattrubin)
+
 ##### Bug Fixes
 
 * None.
@@ -55,9 +58,6 @@
   `.first(where: { /* ... */ })` is often more efficient.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1005](https://github.com/realm/SwiftLint/issues/1005)
-
-* Add more helpful reason strings to TrailingCommaRule.  
-  [Matt Rubin](https://github.com/mattrubin)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -79,8 +79,7 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
         }
 
         let length = bodyLength + bodyOffset - lastPosition
-        let contentsAfterLastElement = contents.substringWithByteRange(start: lastPosition,
-                                                                       length: length) ?? ""
+        let contentsAfterLastElement = contents.substringWithByteRange(start: lastPosition, length: length) ?? ""
 
         // if a trailing comma is not present
         guard let commaIndex = trailingCommaIndex(contentsAfterLastElement, file: file, offset: lastPosition) else {

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -9,6 +9,9 @@
 import Foundation
 import SourceKittenFramework
 
+private let missingTrailingCommaReason = "Multi-line collection literals should have trailing commas."
+private let extraTrailingCommaReason = "Collection literals should not have trailing commas."
+
 public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
     public var configuration = TrailingCommaConfiguration()
 
@@ -38,8 +41,7 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
     )
 
     // swiftlint:disable:next force_try
-    private static let regex = try! NSRegularExpression(pattern: ",",
-                                                        options: [.ignoreMetacharacters])
+    private static let regex = try! NSRegularExpression(pattern: ",", options: [.ignoreMetacharacters])
 
     public func validateFile(_ file: File,
                              kind: SwiftExpressionKind,
@@ -81,13 +83,12 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
                                                                        length: length) ?? ""
 
         // if a trailing comma is not present
-        guard let commaIndex = trailingCommaIndex(contentsAfterLastElement, file: file,
-                                                  offset: lastPosition) else {
+        guard let commaIndex = trailingCommaIndex(contentsAfterLastElement, file: file, offset: lastPosition) else {
             guard configuration.mandatoryComma else {
                 return []
             }
 
-            return violations(file: file, byteOffset: lastPosition)
+            return violations(file: file, byteOffset: lastPosition, reason: missingTrailingCommaReason)
         }
 
         // trailing comma is present, which is a violation if mandatoryComma is false
@@ -96,14 +97,15 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
         }
 
         let violationOffset = lastPosition + commaIndex
-        return violations(file: file, byteOffset: violationOffset)
+        return violations(file: file, byteOffset: violationOffset, reason: extraTrailingCommaReason)
     }
 
-    private func violations(file: File, byteOffset: Int) -> [StyleViolation] {
+    private func violations(file: File, byteOffset: Int, reason: String) -> [StyleViolation] {
         return [
             StyleViolation(ruleDescription: type(of: self).description,
                 severity: configuration.severityConfiguration.severity,
-                location: Location(file: file, byteOffset: byteOffset)
+                location: Location(file: file, byteOffset: byteOffset),
+                reason: reason
             )
         ]
     }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		B3935EE74B1E8E14FBD65E7F /* String+XML.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39353F28BCCA39247B316BD /* String+XML.swift */; };
 		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
 		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
+		C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
@@ -297,6 +298,7 @@
 		B39359A325FE84B7EDD1C455 /* CannedJunitReporterOutput.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = CannedJunitReporterOutput.xml; sourceTree = "<group>"; };
 		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
 		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
+		C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D0D1212619E878CC005E4BAA /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -651,6 +653,7 @@
 				E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */,
 				D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */,
 				D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */,
+				C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */,
 				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
 				E86396C61BADAFE6002C9E88 /* ReporterTests.swift */,
 				E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */,
@@ -1187,6 +1190,7 @@
 				3B30C4A11C3785B300E04027 /* YamlParserTests.swift in Sources */,
 				D4998DE71DF191380006E05D /* AttributesRuleTests.swift in Sources */,
 				E88198631BEA9A5400333A11 /* RulesTests.swift in Sources */,
+				C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */,
 				3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */,
 				E809EDA31B8A73FB00399043 /* ConfigurationTests.swift in Sources */,
 			);

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -23,6 +23,7 @@ XCTMain([
     testCase(RuleTests.allTests),
     testCase(RulesTests.allTests),
     testCase(SourceKitCrashTests.allTests),
+    testCase(TrailingCommaRuleTests.allTests),
     testCase(YamlSwiftLintTests.allTests),
     testCase(YamlParserTests.allTests)
 ])

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -220,43 +220,6 @@ class RulesTests: XCTestCase {
         verifyRule(TodoRule.description, commentDoesntViolate: false)
     }
 
-    func testTrailingComma() {
-        // verify with mandatory_comma = false (default value)
-        verifyRule(TrailingCommaRule.description)
-
-        // verify with mandatory_comma = true
-        let mandatoryCommaDescription = RuleDescription(
-            identifier: "trailing_comma",
-            name: "Trailing Comma",
-            description: "Trailing commas in arrays and dictionaries should be enforced.",
-            nonTriggeringExamples: [
-                "let foo = []\n",
-                "let foo = [:]\n",
-                "let foo = [1, 2, 3,]\n",
-                "let foo = [1, 2, 3, ]\n",
-                "let foo = [1, 2, 3   ,]\n",
-                "let foo = [1: 2, 2: 3, ]\n",
-                "struct Bar {\n let foo = [1: 2, 2: 3,]\n}\n",
-                "let foo = [Void]()\n",
-                "let foo = [(Void, Void)]()\n",
-                "let foo = [1, 2, 3]\n",
-                "let foo = [1: 2, 2: 3]\n",
-                "let foo = [1: 2, 2: 3   ]\n",
-                "struct Bar {\n let foo = [1: 2, 2: 3]\n}\n",
-                "let foo = [1, 2, 3] + [4, 5, 6]\n"
-            ],
-            triggeringExamples: [
-                "let foo = [1, 2,\n 3↓]\n",
-                "let foo = [1: 2,\n 2: 3↓]\n",
-                "let foo = [1: 2,\n 2: 3↓   ]\n",
-                "struct Bar {\n let foo = [1: 2,\n 2: 3↓]\n}\n",
-                "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n"
-            ]
-        )
-
-        verifyRule(mandatoryCommaDescription, ruleConfiguration: ["mandatory_comma": true])
-    }
-
     func testTrailingNewline() {
         verifyRule(TrailingNewlineRule.description, commentDoesntViolate: false,
                    stringDoesntViolate: false)
@@ -392,7 +355,6 @@ extension RulesTests {
             ("testSwitchCaseOnNewline", testSwitchCaseOnNewline),
             ("testSyntacticSugar", testSyntacticSugar),
             ("testTodo", testTodo),
-            ("testTrailingComma", testTrailingComma),
             ("testTrailingNewline", testTrailingNewline),
             ("testTrailingSemicolon", testTrailingSemicolon),
             ("testTrailingWhitespace", testTrailingWhitespace),

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -14,6 +14,16 @@ class TrailingCommaRuleTests: XCTestCase {
     func testTrailingCommaRuleWithDefaultConfiguration() {
         // Verify TrailingCommaRule with test values for when mandatory_comma is false (default).
         verifyRule(TrailingCommaRule.description)
+
+        // Ensure the rule produces the correct reason string.
+        let failingCase = "let array = [\n\t1,\n\t2,\n]\n"
+        XCTAssertEqual(trailingCommaViolations(failingCase), [
+            StyleViolation(
+                ruleDescription: TrailingCommaRule.description,
+                location: Location(file: nil, line: 3, character: 3),
+                reason: "Collection literals should not have trailing commas."
+            )]
+        )
     }
 
     func testTrailingCommaRuleWithMandatoryComma() {
@@ -46,8 +56,24 @@ class TrailingCommaRuleTests: XCTestCase {
                 "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n"
             ]
         )
+        let ruleConfiguration = ["mandatory_comma": true]
 
-        verifyRule(ruleDescription, ruleConfiguration: ["mandatory_comma": true])
+        verifyRule(ruleDescription, ruleConfiguration: ruleConfiguration)
+
+        // Ensure the rule produces the correct reason string.
+        let failingCase = "let array = [\n\t1,\n\t2\n]\n"
+        XCTAssertEqual(trailingCommaViolations(failingCase, ruleConfiguration: ruleConfiguration), [
+            StyleViolation(
+                ruleDescription: TrailingCommaRule.description,
+                location: Location(file: nil, line: 3, character: 2),
+                reason: "Multi-line collection literals should have trailing commas."
+            )]
+        )
+    }
+
+    private func trailingCommaViolations(_ string: String, ruleConfiguration: Any? = nil) -> [StyleViolation] {
+        let config = makeConfig(ruleConfiguration, TrailingCommaRule.description.identifier)!
+        return SwiftLintFrameworkTests.violations(string, config: config)
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -1,0 +1,61 @@
+//
+//  TrailingCommaRuleTests.swift
+//  SwiftLint
+//
+//  Created by Matt Rubin on 12/22/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+import XCTest
+
+class TrailingCommaRuleTests: XCTestCase {
+
+    func testTrailingCommaRuleWithDefaultConfiguration() {
+        // Verify TrailingCommaRule with test values for when mandatory_comma is false (default).
+        verifyRule(TrailingCommaRule.description)
+    }
+
+    func testTrailingCommaRuleWithMandatoryComma() {
+        // Verify TrailingCommaRule with test values for when mandatory_comma is true.
+        let ruleDescription = RuleDescription(
+            identifier: TrailingCommaRule.description.identifier,
+            name: TrailingCommaRule.description.name,
+            description: TrailingCommaRule.description.description,
+            nonTriggeringExamples: [
+                "let foo = []\n",
+                "let foo = [:]\n",
+                "let foo = [1, 2, 3,]\n",
+                "let foo = [1, 2, 3, ]\n",
+                "let foo = [1, 2, 3   ,]\n",
+                "let foo = [1: 2, 2: 3, ]\n",
+                "struct Bar {\n let foo = [1: 2, 2: 3,]\n}\n",
+                "let foo = [Void]()\n",
+                "let foo = [(Void, Void)]()\n",
+                "let foo = [1, 2, 3]\n",
+                "let foo = [1: 2, 2: 3]\n",
+                "let foo = [1: 2, 2: 3   ]\n",
+                "struct Bar {\n let foo = [1: 2, 2: 3]\n}\n",
+                "let foo = [1, 2, 3] + [4, 5, 6]\n"
+            ],
+            triggeringExamples: [
+                "let foo = [1, 2,\n 3↓]\n",
+                "let foo = [1: 2,\n 2: 3↓]\n",
+                "let foo = [1: 2,\n 2: 3↓   ]\n",
+                "struct Bar {\n let foo = [1: 2,\n 2: 3↓]\n}\n",
+                "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n"
+            ]
+        )
+
+        verifyRule(ruleDescription, ruleConfiguration: ["mandatory_comma": true])
+    }
+}
+
+extension TrailingCommaRuleTests {
+    static var allTests: [(String, (TrailingCommaRuleTests) -> () throws -> Void)] {
+        return [
+            ("testTrailingCommaRuleWithDefaultConfiguration", testTrailingCommaRuleWithDefaultConfiguration),
+            ("testTrailingCommaRuleWithMandatoryComma", testTrailingCommaRuleWithMandatoryComma)
+        ]
+    }
+}


### PR DESCRIPTION
Also, unwraps some previously-wrapped lines that fit within the [new line length limit](https://github.com/realm/SwiftLint/pull/1010).