### PR TITLE
Initial Danger integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ Packages
 
 # macOS
 .DS_Store
+
+# Bundler
+.bundle/
+bundle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env: JOB=SPM
       os: osx
       osx_image: xcode8.2
-      before_script: bundle exec danger
+      before_script: bundle install --jobs=3 --retry=3 --without documentation --path bundle && bundle exec danger
     - script: make docker_test
       env: JOB=Linux
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ matrix:
       env: JOB=SPM
       os: osx
       osx_image: xcode8.2
-      before_script: bundle install --jobs=3 --retry=3 --without documentation --path bundle && bundle exec danger
+      before_script:
+        - bundle install --jobs=3 --retry=3 --without documentation --path bundle
+        - bundle exec danger
     - script: make docker_test
       env: JOB=Linux
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
       env: JOB=SPM
       os: osx
       osx_image: xcode8.2
+      before_script: bundle exec danger
     - script: make docker_test
       env: JOB=Linux
       sudo: required

--- a/Dangerfile
+++ b/Dangerfile
@@ -12,9 +12,9 @@ if !git.modified_files.include?("CHANGELOG.md") && has_app_changes
     markdown <<-MARKDOWN
 Here's an example of your CHANGELOG entry:
 ```markdown
-* #{github.pr_title}#{' '}
-[#{github.pr_author}](https://github.com/#{github.pr_author})
-[#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
+* #{github.pr_title}#{'  '}
+  [#{github.pr_author}](https://github.com/#{github.pr_author})
+  [#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
 ```
 *note*: There are two invisible spaces after the entry's text.
 MARKDOWN

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,26 @@
+# Warn when there is a big PR
+warn("Big PR") if git.lines_of_code > 500
+
+# Sometimes its a README fix, or something like that - which isn't relevant for
+# including in a CHANGELOG for example
+has_app_changes = !git.modified_files.grep(/Source/).empty?
+has_test_changes = !git.modified_files.grep(/Tests/).empty?
+
+# Add a CHANGELOG entry for app changes
+if !git.modified_files.include?("CHANGELOG.md") && has_app_changes
+  fail("Please include a CHANGELOG entry to credit yourself! \nYou can find it at [CHANGELOG.md](https://github.com/realm/SwiftLint/blob/master/CHANGELOG.md).")
+    markdown <<-MARKDOWN
+Here's an example of your CHANGELOG entry:
+```markdown
+* #{github.pr_title}#{' '}
+[#{github.pr_author}](https://github.com/#{github.pr_author})
+[#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
+```
+*note*: There are two invisible spaces after the entry's text.
+MARKDOWN
+end
+
+# Non-trivial amounts of app changes without tests
+if git.lines_of_code > 50 && has_app_changes && !has_test_changes
+  warn "This PR may need tests."
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "danger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    claide (1.0.1)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    colored (1.2)
+    cork (0.2.0)
+      colored (~> 1.2)
+    danger (4.0.3)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored (~> 1.2)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1)
+      kramdown (~> 1.5)
+      octokit (~> 4.2)
+      terminal-table (~> 1)
+    faraday (0.10.0)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
+    git (1.3.0)
+    kramdown (1.13.1)
+    multipart-post (2.0.0)
+    nap (1.1.0)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    public_suffix (2.0.4)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    terminal-table (1.7.3)
+      unicode-display_width (~> 1.1.1)
+    unicode-display_width (1.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  danger
+
+BUNDLED WITH
+   1.13.6


### PR DESCRIPTION
Fixes #843

@jpsim We need to create a bot account and a token with it, then add it as an env var (`DANGER_GITHUB_API_TOKEN`)

From `danger init`:

```

Step 2: Creating a GitHub account

In order to get the most out of Danger, I'd recommend giving her the ability to post in
the code-review comment section.

IMO, it's best to do this by using the private mode of your browser. Create an account like
SwiftlintBot, and don't forget a cool robot avatar.

Here are great resources for creative commons images of robots:
 -> https://www.flickr.com/search/?text=robot&license=2%2C3%2C4%2C5%2C6%2C9
 -> https://www.google.com/search?q=robot&tbs=sur:fmc&tbm=isch&tbo=u&source=univ&sa=X&ved=0ahUKEwjgy8-f95jLAhWI7hoKHV_UD00QsAQIMQ&biw=1265&bih=1359
SwiftlintBot will need access to your repo. Simply because the code is not available for the public
to read and comment on.

Note: Holding cmd ( ⌘ ) and double clicking a link will open it in your browser.

Cool, please press return when you have your account ready (and you've verified the email...)


Step 3: Configuring a GitHub Personal Access Token

Here's the link, you should open this in the private session where you just created the new GitHub account
 -> https://github.com/settings/tokens/new

For token access rights, I need to know if this is for an Open Source or Closed Source project
? [ Open / Closed ]
> 
Using: open
For Open Source projects, I'd recommend giving the token the smallest scope possible.
This means only providing access to public_repo in the token.

This token limits Danger's abilities to just writing comments on OSS projects. I recommend
this because the token can quite easily be extracted from the environment via pull requests.

It is important that you do not store this token in your repository, as GitHub will automatically revoke it when pushed.

👍, please press return when you have your token set up...


Step 4: Add Danger for your CI

I'd recommend adding before_script: bundle exec danger to the script section of your .travis.yml file.
You shouldn't use after_success, after_failure, after_script as they cannot fail your builds.

OK, I'll give you a moment to do this...


Final step: exposing the GitHub token as an environment build variable.

As you have an Open Source repo, this token should be considered public, otherwise you cannot
run Danger on pull requests from forks, limiting its use.
In order to add an environment variable, go to:
 -> https://travis-ci.org/marcelofabri/SwiftLint/settings

The name is DANGER_GITHUB_API_TOKEN and the value is the GitHub Personal Access Token.
Make sure to have "Display value in build log" enabled.
This is the last step, I can give you a second...
```