### PR TITLE
Add class_delegate_protocol rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 * Add more helpful reason strings to TrailingCommaRule.  
   [Matt Rubin](https://github.com/mattrubin)
 
+* Add `class_delegate_protocol` rule that warns against protocol declarations
+  that aren't marked as `: class` or `@objc`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1039](https://github.com/realm/SwiftLint/issues/1039)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -34,4 +34,9 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
             return []
         }
     }
+
+    var inheritedTypes: [String] {
+        let array = self["key.inheritedtypes"] as? [SourceKitRepresentable] ?? []
+        return array.flatMap { ($0 as? [String: String])?["key.name"] }
+    }
 }

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -69,18 +69,20 @@ extension File {
     }
 
     internal func matchPattern(_ pattern: String,
-                               withSyntaxKinds syntaxKinds: [SyntaxKind]) -> [NSRange] {
-        return matchPattern(pattern).filter({ $0.1 == syntaxKinds }).map { $0.0 }
+                               withSyntaxKinds syntaxKinds: [SyntaxKind],
+                               range: NSRange? = nil) -> [NSRange] {
+        return matchPattern(pattern, range: range).filter({ $0.1 == syntaxKinds }).map { $0.0 }
     }
 
-    internal func rangesAndTokensMatching(_ pattern: String) -> [(NSRange, [SyntaxToken])] {
-        return rangesAndTokensMatching(regex(pattern))
+    internal func rangesAndTokensMatching(_ pattern: String,
+                                          range: NSRange? = nil) -> [(NSRange, [SyntaxToken])] {
+        return rangesAndTokensMatching(regex(pattern), range: range)
     }
 
-    internal func rangesAndTokensMatching(_ regex: NSRegularExpression) ->
-        [(NSRange, [SyntaxToken])] {
+    internal func rangesAndTokensMatching(_ regex: NSRegularExpression,
+                                          range: NSRange? = nil) -> [(NSRange, [SyntaxToken])] {
         let contents = self.contents.bridge()
-        let range = NSRange(location: 0, length: contents.length)
+        let range = range ?? NSRange(location: 0, length: contents.length)
         let syntax = syntaxMap
         return regex.matches(in: self.contents, options: [], range: range).map { match in
             let matchByteRange = contents.NSRangeToByteRange(start: match.range.location,
@@ -90,12 +92,12 @@ extension File {
         }
     }
 
-    internal func matchPattern(_ pattern: String) -> [(NSRange, [SyntaxKind])] {
-        return matchPattern(regex(pattern))
+    internal func matchPattern(_ pattern: String, range: NSRange? = nil) -> [(NSRange, [SyntaxKind])] {
+        return matchPattern(regex(pattern), range: range)
     }
 
-    internal func matchPattern(_ regex: NSRegularExpression) -> [(NSRange, [SyntaxKind])] {
-        return rangesAndTokensMatching(regex).map { range, tokens in
+    internal func matchPattern(_ regex: NSRegularExpression, range: NSRange? = nil) -> [(NSRange, [SyntaxKind])] {
+        return rangesAndTokensMatching(regex, range: range).map { range, tokens in
             (range, tokens.flatMap { SyntaxKind(rawValue: $0.type) })
         }
     }

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -42,6 +42,7 @@ public struct RuleList {
 
 public let masterRuleList = RuleList(rules:
     AttributesRule.self,
+    ClassDelegateProtocolRule.self,
     ClosingBraceRule.self,
     ClosureEndIndentationRule.self,
     ClosureParameterPositionRule.self,

--- a/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
@@ -24,7 +24,8 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
             "protocol Foo {}\n",
             "class FooDelegate {}\n",
             "@objc protocol FooDelegate {}\n",
-            "@objc(MyFooDelegate)\n protocol FooDelegate {}\n"
+            "@objc(MyFooDelegate)\n protocol FooDelegate {}\n",
+            "protocol FooDelegate: BarDelegate {}\n"
         ],
         triggeringExamples: [
             "↓protocol FooDelegate {}\n",
@@ -40,7 +41,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
         }
 
         // Check if name contains "Delegate"
-        guard let name = (dictionary["key.name"] as? String), name.hasSuffix("Delegate") else {
+        guard let name = (dictionary["key.name"] as? String), isDelegateProtocol(name) else {
             return []
         }
 
@@ -49,6 +50,11 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
                                  "source.decl.attribute.objc.name")
         let isObjc = !objcAttributes.intersection(dictionary.enclosedSwiftAttributes).isEmpty
         guard !isObjc else {
+            return []
+        }
+
+        // Check if inherits from another Delegate protocol
+        guard dictionary.inheritedTypes.filter(isDelegateProtocol).isEmpty else {
             return []
         }
 
@@ -73,6 +79,10 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
 
     private func isClassProtocol(file: File, range: NSRange) -> Bool {
         return !file.matchPattern("\\bclass\\b", withSyntaxKinds: [.keyword], range: range).isEmpty
+    }
+
+    private func isDelegateProtocol(_ name: String) -> Bool {
+        return name.hasSuffix("Delegate")
     }
 
 }

--- a/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
@@ -1,0 +1,78 @@
+//
+//  ClassDelegateProtocolRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 12/23/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "class_delegate_protocol",
+        name: "Class Delegate Protocol",
+        description: "Delegate protocols should be class-only so they can be weakly referenced.",
+        nonTriggeringExamples: [
+            "protocol FooDelegate: class {}\n",
+            "protocol FooDelegate: class, BarDelegate {}\n",
+            "protocol Foo {}\n",
+            "class FooDelegate {}\n",
+            "@objc protocol FooDelegate {}\n",
+            "@objc(MyFooDelegate)\n protocol FooDelegate {}\n"
+        ],
+        triggeringExamples: [
+            "↓protocol FooDelegate {}\n",
+            "↓protocol FooDelegate: Bar {}\n"
+        ]
+    )
+
+    public func validateFile(_ file: File,
+                             kind: SwiftDeclarationKind,
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .protocol else {
+            return []
+        }
+
+        // Check if name contains "Delegate"
+        guard let name = (dictionary["key.name"] as? String), name.hasSuffix("Delegate") else {
+            return []
+        }
+
+        // Check if @objc
+        let objcAttributes = Set(arrayLiteral: "source.decl.attribute.objc",
+                                 "source.decl.attribute.objc.name")
+        let isObjc = !objcAttributes.intersection(dictionary.enclosedSwiftAttributes).isEmpty
+        guard !isObjc else {
+            return []
+        }
+
+        // Check if : class
+        guard let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
+            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
+            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
+            case let contents = file.contents.bridge(),
+            case let start = nameOffset + nameLength,
+            let range = contents.byteRangeToNSRange(start: start, length: bodyOffset - start),
+            !isClassProtocol(file: file, range: range) else {
+            return []
+        }
+
+        return [
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: offset))
+        ]
+    }
+
+    private func isClassProtocol(file: File, range: NSRange) -> Bool {
+        return !file.matchPattern("\\bclass\\b", withSyntaxKinds: [.keyword], range: range).isEmpty
+    }
+
+}

--- a/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
@@ -20,9 +20,7 @@ private extension AccessControlLevel {
 private func superclass(_ dictionary: [String: SourceKitRepresentable]) -> String? {
     guard let kindString = dictionary["key.kind"] as? String,
         let kind = SwiftDeclarationKind(rawValue: kindString), kind == .class,
-        let inheritedTypes = dictionary["key.inheritedtypes"] as? [SourceKitRepresentable],
-        let firstInheritedTypeDict = inheritedTypes[0] as? [String: SourceKitRepresentable],
-        let className = firstInheritedTypeDict["key.name"] as? String else { return nil }
+        let className = dictionary.inheritedTypes.first else { return nil }
     return className
 }
 

--- a/Source/SwiftLintFramework/Rules/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantStringEnumValueRule.swift
@@ -52,10 +52,7 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule {
         }
 
         // Check if it's a String enum
-        let inheritedTypes = (dictionary["key.inheritedtypes"] as? [SourceKitRepresentable])?
-            .flatMap({ ($0 as? [String: SourceKitRepresentable]) as? [String: String] })
-            .flatMap({ $0["key.name"] }) ?? []
-        guard inheritedTypes.contains("String") else {
+        guard dictionary.inheritedTypes.contains("String") else {
             return []
         }
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		D4998DE71DF191380006E05D /* AttributesRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4998DE61DF191380006E05D /* AttributesRuleTests.swift */; };
 		D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */; };
 		D4B0226F1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */; };
+		D4B0228E1E0CC608007E5297 /* ClassDelegateProtocolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */; };
 		D4C4A34C1DEA4FF000E0E04C /* AttributesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */; };
 		D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */; };
 		D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */; };
@@ -350,6 +351,7 @@
 		D4998DE61DF191380006E05D /* AttributesRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRuleTests.swift; sourceTree = "<group>"; };
 		D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRuleTests.swift; sourceTree = "<group>"; };
 		D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentRule.swift; sourceTree = "<group>"; };
+		D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClassDelegateProtocolRule.swift; sourceTree = "<group>"; };
 		D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesConfiguration.swift; sourceTree = "<group>"; };
 		D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRule.swift; sourceTree = "<group>"; };
 		D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
@@ -719,6 +721,7 @@
 			children = (
 				D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */,
 				D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */,
+				D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */,
 				1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */,
 				D43B046A1E075905004016AF /* ClosureEndIndentationRule.swift */,
 				D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */,
@@ -1166,6 +1169,7 @@
 				3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */,
 				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
 				E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */,
+				D4B0228E1E0CC608007E5297 /* ClassDelegateProtocolRule.swift in Sources */,
 				E881985F1BEA987C00333A11 /* TypeNameRule.swift in Sources */,
 				D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */,
 				D46E041D1DE3712C00728374 /* TrailingCommaRule.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -13,6 +13,10 @@ import XCTest
 // swiftlint:disable:next type_body_length
 class RulesTests: XCTestCase {
 
+    func testClassDelegateProtocol() {
+        verifyRule(ClassDelegateProtocolRule.description)
+    }
+
     func testClosingBrace() {
         verifyRule(ClosingBraceRule.description)
     }
@@ -313,6 +317,7 @@ class RulesTests: XCTestCase {
 extension RulesTests {
     static var allTests: [(String, (RulesTests) -> () throws -> Void)] {
         return [
+            ("testClassDelegateProtocol", testClassDelegateProtocol),
             ("testClosingBrace", testClosingBrace),
             ("testComma", testComma),
             ("testClosureEndIndentation", testClosureEndIndentation),


### PR DESCRIPTION
Fixes #1039 

This could flag a valid declaration when the protocol inherits form another protocol that is `: class` or `@objc`. However, I feel like this should be default as it should be rare enough and you can always mark the child protocol as `: class` as well.