### PR TITLE
`syntactic_sugar` rule now doesn't flag declarations that can't be fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 * Ignore close parentheses on `vertical_parameter_alignment` rule.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1042](https://github.com/realm/SwiftLint/issues/1042)
+  
+* `syntactic_sugar` rule now doesn't flag declarations that can't be fixed.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#928](https://github.com/realm/SwiftLint/issues/928)
 
 ## 0.15.0: Hand Washable Holiday Linens 🎄
 

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -26,7 +26,9 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
             "let x: Int!",
             "extension Array { \n func x() { } \n }",
             "extension Dictionary { \n func x() { } \n }",
-            "let x: CustomArray<String>"
+            "let x: CustomArray<String>",
+            "var currentIndex: Array<OnboardingPage>.Index?",
+            "func x(a: [Int], b: Int) -> Array<Int>.Index"
         ],
         triggeringExamples: [
             "let x: ↓Array<String>",
@@ -35,20 +37,38 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
             "let x: ↓ImplicitlyUnwrappedOptional<Int>",
             "func x(a: ↓Array<Int>, b: Int) -> [Int: Any]",
             "func x(a: [Int], b: Int) -> ↓Dictionary<Int, String>",
-            "func x(a: ↓Array<Int>, b: Int) -> ↓Dictionary<Int, String>"
+            "func x(a: ↓Array<Int>, b: Int) -> ↓Dictionary<Int, String>",
+            "let x = ↓Array<String>.array(of: object)"
         ]
     )
 
     public func validateFile(_ file: File) -> [StyleViolation] {
         let types = ["Optional", "ImplicitlyUnwrappedOptional", "Array", "Dictionary"]
-
         let pattern = "\\b(" + types.joined(separator: "|") + ")\\s*<.*?>"
+        let kinds = SyntaxKind.commentAndStringKinds()
+        let contents = file.contents.bridge()
 
-        return file.matchPattern(pattern,
-                                 excludingSyntaxKinds: SyntaxKind.commentAndStringKinds()).map {
-                StyleViolation(ruleDescription: type(of: self).description,
-                    severity: configuration.severity,
-                    location: Location(file: file, characterOffset: $0.location))
+        return file.matchPattern(pattern, excludingSyntaxKinds: kinds).flatMap { range in
+
+            // avoids trigering when referring to an associatedtype
+            let start = range.location + range.length
+            let restOfFileRange = NSRange(location: start, length: contents.length - start)
+            if regex("\\s*\\.").firstMatch(in: file.contents, options: [],
+                                           range: restOfFileRange)?.range.location == start {
+                guard let byteOffset = contents.NSRangeToByteRange(start: range.location,
+                                                                   length: range.length)?.location else {
+                    return nil
+                }
+
+                let kinds = file.structure.kindsFor(byteOffset).flatMap { SwiftExpressionKind(rawValue: $0.kind) }
+                guard kinds.contains(.call) else {
+                    return nil
+                }
+            }
+
+            return StyleViolation(ruleDescription: type(of: self).description,
+                                  severity: configuration.severity,
+                                  location: Location(file: file, characterOffset: range.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -29,7 +29,8 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
             "let x: CustomArray<String>",
             "var currentIndex: Array<OnboardingPage>.Index?",
             "func x(a: [Int], b: Int) -> Array<Int>.Index",
-            "unsafeBitCast(nonOptionalT, to: Optional<T>.self)"
+            "unsafeBitCast(nonOptionalT, to: Optional<T>.self)",
+            "type is Optional<String>.Type"
         ],
         triggeringExamples: [
             "let x: ↓Array<String>",
@@ -66,8 +67,8 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
                     return nil
                 }
 
-                if file.matchPattern("\\s*\\.self", withSyntaxKinds: [.keyword],
-                                     range: restOfFileRange).first?.location == start {
+                if let (range, kinds) = file.matchPattern("\\s*\\.(?:self|Type)", range: restOfFileRange).first,
+                    range.location == start, kinds == [.keyword] || kinds == [.identifier] {
                     return nil
                 }
             }


### PR DESCRIPTION
Fixes #928