### PR TITLE
Fix false positives on closure rules on Swift 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#928](https://github.com/realm/SwiftLint/issues/928)
 
+* Fix false positives on `closure_parameter_position` and 
+  `unused_closure_parameter` rules on Swift 2.3.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1019](https://github.com/realm/SwiftLint/issues/1019)
+
 ## 0.15.0: Hand Washable Holiday Linens 🎄
 
 ##### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
   [#928](https://github.com/realm/SwiftLint/issues/928)
 
 * Fix false positives on `closure_parameter_position` and 
-  `unused_closure_parameter` rules on Swift 2.3.  
+  `unused_closure_parameter` rules with Swift 2.3.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1019](https://github.com/realm/SwiftLint/issues/1019)
 

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -27,7 +27,13 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
             }
 
             if SwiftDeclarationKind(rawValue: kindString) == .varParameter {
-                return [subDict]
+                let nestedParameters = subDict.enclosedVarParameters
+                // on Swift 2.3, a closure parameter is inside another .varParameter and not inside an .argument
+                if nestedParameters.isEmpty {
+                    return [subDict]
+                } else {
+                    return nestedParameters
+                }
             } else if SwiftExpressionKind(rawValue: kindString) == .argument {
                 return subDict.enclosedVarParameters
             }

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -31,7 +31,7 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
                 case .two:
                     // with Swift 2.3, a closure parameter is inside another .varParameter and not inside an .argument
                     return (subDict.enclosedVarParameters + [subDict]).filter {
-                        $0[SwiftVersion.two.nameKey] != nil
+                        $0["key.typename"] != nil
                     }
                 case .three:
                     return [subDict]

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -27,12 +27,14 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
             }
 
             if SwiftDeclarationKind(rawValue: kindString) == .varParameter {
-                let nestedParameters = subDict.enclosedVarParameters
-                // on Swift 2.3, a closure parameter is inside another .varParameter and not inside an .argument
-                if nestedParameters.isEmpty {
+                switch SwiftVersion.current {
+                case .two:
+                    // with Swift 2.3, a closure parameter is inside another .varParameter and not inside an .argument
+                    return (subDict.enclosedVarParameters + [subDict]).filter {
+                        $0[SwiftVersion.two.nameKey] != nil
+                    }
+                case .three:
                     return [subDict]
-                } else {
-                    return nestedParameters
                 }
             } else if SwiftExpressionKind(rawValue: kindString) == .argument {
                 return subDict.enclosedVarParameters

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -30,7 +30,8 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
                 switch SwiftVersion.current {
                 case .two:
                     // with Swift 2.3, a closure parameter is inside another .varParameter and not inside an .argument
-                    return (subDict.enclosedVarParameters + [subDict]).filter {
+                    let parameters = subDict.enclosedVarParameters + [subDict]
+                    return parameters.filter {
                         $0["key.typename"] != nil
                     }
                 case .three:

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -1,0 +1,26 @@
+//
+//  SwiftVersion.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 12/29/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+enum SwiftVersion {
+    case two
+    case three
+
+    static let current: SwiftVersion = {
+        let file = File(contents: "#sourceLocation()")
+        let kinds = file.syntaxMap.tokens.flatMap { SyntaxKind(rawValue: $0.type) }
+        if kinds == [.identifier] {
+            return .two
+        } else if kinds == [.keyword] {
+            return .three
+        }
+
+        fatalError("Unexpected Swift version")
+    }()
+}

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -23,11 +23,4 @@ enum SwiftVersion {
 
         fatalError("Unexpected Swift version")
     }()
-
-    var nameKey: String {
-        switch self {
-        case .two: return "key.typename"
-        case .three: return "key.name"
-        }
-    }
 }

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -23,4 +23,11 @@ enum SwiftVersion {
 
         fatalError("Unexpected Swift version")
     }()
+
+    var nameKey: String {
+        switch self {
+        case .two: return "key.typename"
+        case .three: return "key.name"
+        }
+    }
 }

--- a/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
@@ -68,11 +68,14 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
         let rangeStart = nameOffset + nameLength
         let regex = ClosureParameterPositionRule.openBraceRegex
 
+        let nameKey = SwiftVersion.current == .two ? "key.typename" : "key.name"
+
         // parameters from inner closures are reported on the top-level one, so we can't just
         // use the first and last parameters to check, we need to check all of them
         return parameters.flatMap { param -> StyleViolation? in
             guard let paramOffset = (param["key.offset"] as? Int64).flatMap({ Int($0) }),
-                paramOffset > rangeStart else {
+                paramOffset > rangeStart,
+                param[nameKey] != nil else {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
@@ -68,14 +68,11 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
         let rangeStart = nameOffset + nameLength
         let regex = ClosureParameterPositionRule.openBraceRegex
 
-        let nameKey = SwiftVersion.current == .two ? "key.typename" : "key.name"
-
         // parameters from inner closures are reported on the top-level one, so we can't just
         // use the first and last parameters to check, we need to check all of them
         return parameters.flatMap { param -> StyleViolation? in
             guard let paramOffset = (param["key.offset"] as? Int64).flatMap({ Int($0) }),
-                paramOffset > rangeStart,
-                param[nameKey] != nil else {
+                paramOffset > rangeStart else {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -86,7 +86,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
         let parameters = dictionary.enclosedVarParameters
         let contents = file.contents.bridge()
 
-        let nameKey = SwiftVersion.current == .two ? "key.typename" : "key.name"
+        let nameKey = SwiftVersion.current.nameKey
         return parameters.flatMap { param -> (NSRange, String)? in
             guard let paramOffset = (param["key.offset"] as? Int64).flatMap({ Int($0) }),
                 let paramLength = (param["key.length"] as? Int64).flatMap({ Int($0) }),

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -86,10 +86,12 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
         let parameters = dictionary.enclosedVarParameters
         let contents = file.contents.bridge()
 
+        let nameKey = SwiftVersion.current == .two ? "key.typename" : "key.name"
         return parameters.flatMap { param -> (NSRange, String)? in
             guard let paramOffset = (param["key.offset"] as? Int64).flatMap({ Int($0) }),
                 let paramLength = (param["key.length"] as? Int64).flatMap({ Int($0) }),
-                let name = param["key.name"] as? String,
+                let name = param[nameKey] as? String,
+                name != "_",
                 let regex = try? NSRegularExpression(pattern: name,
                                                      options: [.ignoreMetacharacters]),
                 let range = contents.byteRangeToNSRange(start: rangeStart, length: rangeLength)

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -110,11 +110,12 @@
 		D48AE2CC1DFB58C5001C6A4A /* AttributesRulesExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */; };
 		D4998DE71DF191380006E05D /* AttributesRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4998DE61DF191380006E05D /* AttributesRuleTests.swift */; };
 		D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */; };
+		D4A893351E15824100BF954D /* SwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A893341E15824100BF954D /* SwiftVersion.swift */; };
 		D4B0226F1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */; };
 		D4B0228E1E0CC608007E5297 /* ClassDelegateProtocolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */; };
 		D4B022961E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */; };
-		D4B022B21E10B613007E5297 /* RedundantVoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */; };
 		D4B022B01E109816007E5297 /* CharacterSet+LinuxHack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022AF1E109816007E5297 /* CharacterSet+LinuxHack.swift */; };
+		D4B022B21E10B613007E5297 /* RedundantVoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */; };
 		D4C4A34C1DEA4FF000E0E04C /* AttributesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */; };
 		D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */; };
 		D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */; };
@@ -355,11 +356,12 @@
 		D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRulesExamples.swift; sourceTree = "<group>"; };
 		D4998DE61DF191380006E05D /* AttributesRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRuleTests.swift; sourceTree = "<group>"; };
 		D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRuleTests.swift; sourceTree = "<group>"; };
+		D4A893341E15824100BF954D /* SwiftVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftVersion.swift; sourceTree = "<group>"; };
 		D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentRule.swift; sourceTree = "<group>"; };
 		D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClassDelegateProtocolRule.swift; sourceTree = "<group>"; };
 		D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantOptionalInitializationRule.swift; sourceTree = "<group>"; };
-		D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantVoidReturnRule.swift; sourceTree = "<group>"; };
 		D4B022AF1E109816007E5297 /* CharacterSet+LinuxHack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CharacterSet+LinuxHack.swift"; sourceTree = "<group>"; };
+		D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantVoidReturnRule.swift; sourceTree = "<group>"; };
 		D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesConfiguration.swift; sourceTree = "<group>"; };
 		D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRule.swift; sourceTree = "<group>"; };
 		D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
@@ -829,6 +831,7 @@
 				3B12C9C41C322032000B423F /* MasterRuleList.swift */,
 				3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */,
 				3BCC04CC1C4F5694006073C3 /* ConfigurationError.swift */,
+				D4A893341E15824100BF954D /* SwiftVersion.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1143,6 +1146,7 @@
 				E881985A1BEA96EA00333A11 /* OperatorFunctionWhitespaceRule.swift in Sources */,
 				D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */,
 				85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */,
+				D4A893351E15824100BF954D /* SwiftVersion.swift in Sources */,
 				D4B022B21E10B613007E5297 /* RedundantVoidReturnRule.swift in Sources */,
 				3BCC04D21C4F56D3006073C3 /* NameConfiguration.swift in Sources */,
 				B2902A0E1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift in Sources */,


### PR DESCRIPTION
This should fix #1019 

Maybe we should have a way of running the tests on all Swift versions 🤔