### PR TITLE
Minor Improvements

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -8,17 +8,6 @@
 
 import Foundation
 
-extension Array {
-    static func array(of obj: Any?) -> [Element]? {
-        if let array = obj as? [Element] {
-            return array
-        } else if let obj = obj as? Element {
-            return [obj]
-        }
-        return nil
-    }
-}
-
 extension Array where Element: NSTextCheckingResult {
     func ranges() -> [NSRange] {
         return map { $0.range }
@@ -36,6 +25,15 @@ extension Array where Element: Equatable {
 }
 
 extension Array {
+    static func array(of obj: Any?) -> [Element]? {
+        if let array = obj as? [Element] {
+            return array
+        } else if let obj = obj as? Element {
+            return [obj]
+        }
+        return nil
+    }
+
     func group<U: Hashable>(by transform: (Element) -> U) -> [U: [Element]] {
         return reduce([:]) { dictionary, element in
             var dictionary = dictionary

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SourceKittenFramework
 
-private var responseCache = Cache({file -> [String: SourceKitRepresentable]? in
+private var responseCache = Cache({ file -> [String: SourceKitRepresentable]? in
     do {
         return try Request.editorOpen(file: file).failableSend()
     } catch let error as Request.Error {
@@ -37,7 +37,6 @@ private var _allDeclarationsByType = [String: [String]]()
 private var queueForRebuild = [Structure]()
 
 private struct Cache<T> {
-
     fileprivate var values = [String: T]()
     fileprivate var factory: (File) -> T
 

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -132,16 +132,11 @@ extension File {
     }
 
     internal func syntaxKindsByLine() -> [[SyntaxKind]]? {
-
-        if sourcekitdFailed {
-            return nil
-        }
-        guard let tokens = syntaxTokensByLine() else {
+        guard !sourcekitdFailed, let tokens = syntaxTokensByLine() else {
             return nil
         }
 
         return tokens.map { $0.flatMap { SyntaxKind(rawValue: $0.type) } }
-
     }
 
     //Added by S2dent

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -67,7 +67,7 @@ struct LintCommand: CommandProtocol {
             let numberOfSeriousViolations = violations.filter({ $0.severity == .error }).count
             if !options.quiet {
                 LintCommand.printStatus(violations: violations, files: files,
-                    serious: numberOfSeriousViolations)
+                                        serious: numberOfSeriousViolations)
             }
             if options.benchmark {
                 fileBenchmark.save()

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -55,6 +55,10 @@ extension File {
     }
 }
 
+#if os(Linux)
+private func autoreleasepool(block: () -> Void) { block() }
+#endif
+
 extension Configuration {
     init(commandLinePath: String, rootPath: String? = nil, quiet: Bool = false) {
         self.init(path: commandLinePath, rootPath: rootPath?.absolutePathStandardized(),
@@ -79,7 +83,9 @@ extension Configuration {
                     let filename = path.bridge().lastPathComponent
                     queuedPrintError("\(action) '\(filename)' (\(index + 1)/\(fileCount))")
                 }
-                visitorBlock(Linter(file: file, configuration: configurationForFile(file)))
+                autoreleasepool {
+                    visitorBlock(Linter(file: file, configuration: configurationForFile(file)))
+                }
             }
             return .success(files)
         }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -117,9 +117,9 @@
 		D4B0226F1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */; };
 		D4B0228E1E0CC608007E5297 /* ClassDelegateProtocolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */; };
 		D4B022961E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */; };
+		D4B022981E102EE8007E5297 /* ObjectLiteralRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022971E102EE8007E5297 /* ObjectLiteralRule.swift */; };
 		D4B022B01E109816007E5297 /* CharacterSet+LinuxHack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022AF1E109816007E5297 /* CharacterSet+LinuxHack.swift */; };
 		D4B022B21E10B613007E5297 /* RedundantVoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */; };
-		D4B022981E102EE8007E5297 /* ObjectLiteralRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022971E102EE8007E5297 /* ObjectLiteralRule.swift */; };
 		D4C4A34C1DEA4FF000E0E04C /* AttributesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */; };
 		D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */; };
 		D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */; };
@@ -367,9 +367,9 @@
 		D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentRule.swift; sourceTree = "<group>"; };
 		D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClassDelegateProtocolRule.swift; sourceTree = "<group>"; };
 		D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantOptionalInitializationRule.swift; sourceTree = "<group>"; };
+		D4B022971E102EE8007E5297 /* ObjectLiteralRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralRule.swift; sourceTree = "<group>"; };
 		D4B022AF1E109816007E5297 /* CharacterSet+LinuxHack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CharacterSet+LinuxHack.swift"; sourceTree = "<group>"; };
 		D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantVoidReturnRule.swift; sourceTree = "<group>"; };
-		D4B022971E102EE8007E5297 /* ObjectLiteralRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralRule.swift; sourceTree = "<group>"; };
 		D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesConfiguration.swift; sourceTree = "<group>"; };
 		D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRule.swift; sourceTree = "<group>"; };
 		D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
@@ -851,23 +851,23 @@
 		E8A541811BF94604006BA322 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				3B5B9FE01C444DA20009AD27 /* Array+SwiftLint.swift */,
 				D4B022AF1E109816007E5297 /* CharacterSet+LinuxHack.swift */,
 				37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */,
 				24E17F701B1481FF008195BE /* File+Cache.swift */,
 				E88DEA741B09852000A66CB0 /* File+SwiftLint.swift */,
 				E832F10A1B17E2F5003F265F /* NSFileManager+SwiftLint.swift */,
+				3BA79C9A1C4767910057E705 /* NSRange+SwiftLint.swift */,
+				3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */,
 				E81619521BFC162C00946723 /* QueuedPrint.swift */,
 				E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */,
+				B39353F28BCCA39247B316BD /* String+XML.swift */,
 				6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */,
 				E816194B1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift */,
 				D47079AA1DFDCF7A00027086 /* SwiftExpressionKind.swift */,
 				E87E4A081BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift */,
 				6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */,
 				3B1150C91C31FC3F00D83B1E /* Yaml+SwiftLint.swift */,
-				3B5B9FE01C444DA20009AD27 /* Array+SwiftLint.swift */,
-				3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */,
-				3BA79C9A1C4767910057E705 /* NSRange+SwiftLint.swift */,
-				B39353F28BCCA39247B316BD /* String+XML.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";


### PR DESCRIPTION
* move `array(of:)` into other unconstrained Array extension
* minor spacing fixes
* move `autoreleasepool` invocation into `visitLintableFiles` which cleans up the call site a bit and brings the memory footprint improvements to `AutoCorrectCommand` too.
* sort extensions in Xcode project and apparently fix `ObjectLiteralRule.swift`'s placement in `pbxproj` file, which Xcode did automatically
