### PR TITLE
refactor LintCommand

### DIFF
--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -12,17 +12,6 @@ import Result
 import SourceKittenFramework
 import SwiftLintFramework
 
-extension Reporter {
-    static func reportViolations(_ violations: [StyleViolation], realtimeCondition: Bool) {
-        if isRealtime == realtimeCondition {
-            let report = generateReport(violations)
-            if !report.isEmpty {
-                queuedPrint(report)
-            }
-        }
-    }
-}
-
 struct LintCommand: CommandProtocol {
     let verb = "lint"
     let function = "Print lint warnings and errors (default command)"
@@ -31,14 +20,9 @@ struct LintCommand: CommandProtocol {
         var fileBenchmark = Benchmark(name: "files")
         var ruleBenchmark = Benchmark(name: "rules")
         var violations = [StyleViolation]()
-        let configuration = Configuration(commandLinePath: options.configurationFile,
-                                          rootPath: options.path, quiet: options.quiet)
-        let reporter = reporterFromString(
-            options.reporter.isEmpty ? configuration.reporter : options.reporter
-        )
-        return configuration.visitLintableFiles(options.path, action: "Linting",
-            useSTDIN: options.useSTDIN, quiet: options.quiet,
-            useScriptInputFiles: options.useScriptInputFiles) { linter in
+        let configuration = Configuration(options: options)
+        let reporter = reporterFrom(options: options, configuration: configuration)
+        return configuration.visitLintableFiles(options) { linter in
             let currentViolations: [StyleViolation]
             if options.benchmark {
                 let start = Date()
@@ -53,8 +37,8 @@ struct LintCommand: CommandProtocol {
             violations += currentViolations
             reporter.reportViolations(currentViolations, realtimeCondition: true)
         }.flatMap { files in
-            if isWarningThresholdBroken(configuration, violations: violations) {
-                violations.append(createThresholdViolation(configuration.warningThreshold!))
+            if LintCommand.isWarningThresholdBroken(configuration, violations: violations) {
+                violations.append(LintCommand.createThresholdViolation(configuration.warningThreshold!))
                 reporter.reportViolations([violations.last!], realtimeCondition: true)
             }
             reporter.reportViolations(violations, realtimeCondition: false)
@@ -67,22 +51,49 @@ struct LintCommand: CommandProtocol {
                 fileBenchmark.save()
                 ruleBenchmark.save()
             }
-            if numberOfSeriousViolations > 0 {
-                exit(2)
-            } else if options.strict && !violations.isEmpty {
-                exit(3)
-            }
-            return .success()
+            return LintCommand.successOrExit(numberOfSeriousViolations: numberOfSeriousViolations,
+                                             strictWithViolations: options.strict && !violations.isEmpty)
         }
     }
 
-    static func printStatus(violations: [StyleViolation], files: [File], serious: Int) {
-        let violationSuffix = (violations.count != 1 ? "s" : "")
-        let fileCount = files.count
-        let filesSuffix = (fileCount != 1 ? "s." : ".")
-        let message = "Done linting! Found \(violations.count) violation\(violationSuffix), " +
-            "\(serious) serious in \(fileCount) file\(filesSuffix)"
-        queuedPrintError(message)
+    static func successOrExit(numberOfSeriousViolations: Int,
+                              strictWithViolations: Bool) -> Result<(), CommandantError<()>> {
+        if numberOfSeriousViolations > 0 {
+            exit(2)
+        } else if strictWithViolations {
+            exit(3)
+        }
+        return .success()
+    }
+
+    private static func printStatus(violations: [StyleViolation], files: [File], serious: Int) {
+        let pluralSuffix = { (collection: [Any]) -> String in
+            return collection.count != 1 ? "s" : ""
+        }
+        queuedPrintError(
+            "Done linting! Found \(violations.count) violation\(pluralSuffix(violations)), " +
+            "\(serious) serious in \(files.count) file\(pluralSuffix(files))."
+        )
+    }
+
+    private static func isWarningThresholdBroken(_ configuration: Configuration,
+                                                 violations: [StyleViolation]) -> Bool {
+        guard let warningThreshold = configuration.warningThreshold else { return false }
+        let numberOfWarningViolations = violations.filter({ $0.severity == .warning }).count
+        return numberOfWarningViolations >= warningThreshold
+    }
+
+    private static func createThresholdViolation(_ threshold: Int) -> StyleViolation {
+        let description = RuleDescription(
+            identifier: "warning_threshold",
+            name: "Warning Threshold",
+            description: "Number of warnings thrown is above the threshold."
+        )
+        return StyleViolation(
+            ruleDescription: description,
+            severity: .error,
+            location: Location(file: "", line: 0, character: 0),
+            reason: "Number of warnings exceeded threshold of \(threshold).")
     }
 }
 
@@ -120,24 +131,4 @@ struct LintOptions: OptionsProtocol {
                                usage: "the reporter used to log errors and warnings")
             <*> mode <| quietOption(action: "linting")
     }
-}
-
-private func isWarningThresholdBroken(_ configuration: Configuration,
-                                      violations: [StyleViolation]) -> Bool {
-    guard let warningThreshold = configuration.warningThreshold else { return false }
-    let numberOfWarningViolations = violations.filter({ $0.severity == .warning }).count
-    return numberOfWarningViolations >= warningThreshold
-}
-
-private func createThresholdViolation(_ threshold: Int) -> StyleViolation {
-    let description = RuleDescription(
-        identifier: "warning_threshold",
-        name: "Warning Threshold",
-        description: "Number of warnings thrown is above the threshold."
-    )
-    return StyleViolation(
-        ruleDescription: description,
-        severity: .error,
-        location: Location(file: "", line: 0, character: 0),
-        reason: "Number of warnings exceeded threshold of \(threshold).")
 }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -56,8 +56,8 @@ struct LintCommand: CommandProtocol {
         }
     }
 
-    static func successOrExit(numberOfSeriousViolations: Int,
-                              strictWithViolations: Bool) -> Result<(), CommandantError<()>> {
+    private static func successOrExit(numberOfSeriousViolations: Int,
+                                      strictWithViolations: Bool) -> Result<(), CommandantError<()>> {
         if numberOfSeriousViolations > 0 {
             exit(2)
         } else if strictWithViolations {

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -110,4 +110,14 @@ extension Configuration {
         }
         return .success(lintableFilesForPath(path))
     }
+
+    init(options: LintOptions) {
+        self.init(commandLinePath: options.configurationFile, rootPath: options.path, quiet: options.quiet)
+    }
+
+    func visitLintableFiles(_ options: LintOptions, visitorBlock: @escaping (Linter) -> Void) ->
+                            Result<[File], CommandantError<()>> {
+        return visitLintableFiles(options.path, action: "Linting", useSTDIN: options.useSTDIN, quiet: options.quiet,
+                                  useScriptInputFiles: options.useScriptInputFiles, visitorBlock: visitorBlock)
+    }
 }

--- a/Source/swiftlint/Extensions/Reporter+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Reporter+CommandLine.swift
@@ -1,0 +1,25 @@
+//
+//  Reporter+CommandLine.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 12/30/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+
+extension Reporter {
+    static func reportViolations(_ violations: [StyleViolation], realtimeCondition: Bool) {
+        if isRealtime == realtimeCondition {
+            let report = generateReport(violations)
+            if !report.isEmpty {
+                queuedPrint(report)
+            }
+        }
+    }
+}
+
+func reporterFrom(options: LintOptions, configuration: Configuration) -> Reporter.Type {
+    let string = options.reporter.isEmpty ? configuration.reporter : options.reporter
+    return reporterFromString(string)
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86396C61BADAFE6002C9E88 /* ReporterTests.swift */; };
 		E86396C91BADB2B9002C9E88 /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86396C81BADB2B9002C9E88 /* JSONReporter.swift */; };
 		E86396CB1BADB519002C9E88 /* CSVReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86396CA1BADB519002C9E88 /* CSVReporter.swift */; };
+		E86E2B2E1E17443B001E823C /* Reporter+CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86E2B2D1E17443B001E823C /* Reporter+CommandLine.swift */; };
 		E876BFBE1B07828500114ED5 /* SourceKittenFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E876BFBD1B07828500114ED5 /* SourceKittenFramework.framework */; };
 		E87E4A051BFB927C00FCFE46 /* TrailingSemicolonRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */; };
 		E87E4A091BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87E4A081BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift */; };
@@ -404,6 +405,7 @@
 		E86396C81BADB2B9002C9E88 /* JSONReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONReporter.swift; sourceTree = "<group>"; };
 		E86396CA1BADB519002C9E88 /* CSVReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSVReporter.swift; sourceTree = "<group>"; };
 		E868473B1A587C6E0043DC65 /* sourcekitd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = sourcekitd.framework; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/sourcekitd.framework; sourceTree = DEVELOPER_DIR; };
+		E86E2B2D1E17443B001E823C /* Reporter+CommandLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Reporter+CommandLine.swift"; sourceTree = "<group>"; };
 		E876BFBD1B07828500114ED5 /* SourceKittenFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SourceKittenFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingSemicolonRule.swift; sourceTree = "<group>"; };
 		E87E4A081BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxKind+SwiftLint.swift"; sourceTree = "<group>"; };
@@ -876,6 +878,7 @@
 			isa = PBXGroup;
 			children = (
 				E8B067801C13E49600E9E13F /* Configuration+CommandLine.swift */,
+				E86E2B2D1E17443B001E823C /* Reporter+CommandLine.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1244,6 +1247,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E86E2B2E1E17443B001E823C /* Reporter+CommandLine.swift in Sources */,
 				E8B067811C13E49600E9E13F /* Configuration+CommandLine.swift in Sources */,
 				E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */,
 				E83A0B351A5D382B0041A60A /* VersionCommand.swift in Sources */,


### PR DESCRIPTION
mostly by moving things out of `run(_:)` and out of the file.

By the way, this and the last few PRs is the result of the unrelated work I ended up doing to implement parallel linting (#1077).