### PR TITLE
Make getting style violations thread-safe and parallelize linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1060](https://github.com/realm/SwiftLint/issues/1060)
 
+* Make many operations in SwiftLintFramework safe to call in multithreaded
+  scenarios, including accessing `Linter.styleViolations`.  
+  [JP Simard](https://github.com/jpsim)
+  [#1077](https://github.com/realm/SwiftLint/issues/1077)
+
+* Speed up linting by processing multiple files and rules concurrently.  
+  [JP Simard](https://github.com/jpsim)
+  [#1077](https://github.com/realm/SwiftLint/issues/1077)
+
 ##### Bug Fixes
 
 * Ignore close parentheses on `vertical_parameter_alignment` rule.  

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -60,6 +60,6 @@ extension Array {
                 result.append(jobIndexAndResults)
             }
         }
-        return result.sorted { $0.0 < $1.0 }.flatMap { $0.1 }
+        return result.sorted { $0.0 < $1.0 }.map { $0.1 }
     }
 }

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Realm. All rights reserved.
 //
 
+import Dispatch
 import Foundation
 
 extension Array where Element: NSTextCheckingResult {
@@ -41,5 +42,45 @@ extension Array {
             dictionary[key] = (dictionary[key] ?? []) + [element]
             return dictionary
         }
+    }
+
+    public func parallelForEach(block: @escaping ((Element) -> Void)) {
+        _ = parallelMap(transform: block)
+    }
+
+    func parallelFlatMap<T>(transform: @escaping ((Element) -> [T])) -> [T] {
+        return parallelMap(transform: transform).flatMap { $0 }
+    }
+
+    func parallelMap<T>(transform: @escaping ((Element) -> T)) -> [T] {
+        let count = self.count
+        let maxConcurrentJobs = ProcessInfo.processInfo.activeProcessorCount
+
+        guard count > 1 && maxConcurrentJobs > 1 else {
+            // skip GCD overhead if we'd only run one at a time anyway
+            return map(transform)
+        }
+
+        var result = [(Int, [T])]()
+        result.reserveCapacity(count)
+        let group = DispatchGroup()
+        let uuid = NSUUID().uuidString
+        let jobCount = Int(ceil(Double(count) / Double(maxConcurrentJobs)))
+
+        let queueLabelPrefix = "io.realm.SwiftLintFramework.map.\(uuid)"
+        let resultAccumulatorQueue = DispatchQueue(label: "\(queueLabelPrefix).resultAccumulator")
+
+        for jobIndex in stride(from: 0, to: count, by: jobCount) {
+            let queue = DispatchQueue(label: "\(queueLabelPrefix).\(jobIndex / jobCount)")
+            queue.async(group: group) {
+                let jobElements = self[jobIndex..<Swift.min(count, jobIndex + jobCount)]
+                let jobIndexAndResults = (jobIndex, jobElements.map(transform))
+                resultAccumulatorQueue.sync {
+                    result.append(jobIndexAndResults)
+                }
+            }
+        }
+        group.wait()
+        return result.sorted { $0.0 < $1.0 }.flatMap { $0.1 }
     }
 }

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -44,43 +44,22 @@ extension Array {
         }
     }
 
-    public func parallelForEach(block: @escaping ((Element) -> Void)) {
-        _ = parallelMap(transform: block)
-    }
-
     func parallelFlatMap<T>(transform: @escaping ((Element) -> [T])) -> [T] {
         return parallelMap(transform: transform).flatMap { $0 }
     }
 
     func parallelMap<T>(transform: @escaping ((Element) -> T)) -> [T] {
-        let count = self.count
-        let maxConcurrentJobs = ProcessInfo.processInfo.activeProcessorCount
-
-        guard count > 1 && maxConcurrentJobs > 1 else {
-            // skip GCD overhead if we'd only run one at a time anyway
-            return map(transform)
-        }
-
-        var result = [(Int, [T])]()
+        var result = [(Int, T)]()
         result.reserveCapacity(count)
-        let group = DispatchGroup()
-        let uuid = NSUUID().uuidString
-        let jobCount = Int(ceil(Double(count) / Double(maxConcurrentJobs)))
 
-        let queueLabelPrefix = "io.realm.SwiftLintFramework.map.\(uuid)"
+        let queueLabelPrefix = "io.realm.SwiftLintFramework.map.\(NSUUID().uuidString)"
         let resultAccumulatorQueue = DispatchQueue(label: "\(queueLabelPrefix).resultAccumulator")
-
-        for jobIndex in stride(from: 0, to: count, by: jobCount) {
-            let queue = DispatchQueue(label: "\(queueLabelPrefix).\(jobIndex / jobCount)")
-            queue.async(group: group) {
-                let jobElements = self[jobIndex..<Swift.min(count, jobIndex + jobCount)]
-                let jobIndexAndResults = (jobIndex, jobElements.map(transform))
-                resultAccumulatorQueue.sync {
-                    result.append(jobIndexAndResults)
-                }
+        DispatchQueue.concurrentPerform(iterations: count) { index in
+            let jobIndexAndResults = (index, transform(self[index]))
+            resultAccumulatorQueue.sync {
+                result.append(jobIndexAndResults)
             }
         }
-        group.wait()
         return result.sorted { $0.0 < $1.0 }.flatMap { $0.1 }
     }
 }

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -91,13 +91,12 @@ private struct Cache<T> {
     fileprivate mutating func get(_ file: File) -> T {
         let key = file.cacheKey
         lock.lock()
+        defer { lock.unlock() }
         if let cachedValue = values[key] {
-            lock.unlock()
             return cachedValue
         }
-        lock.unlock()
         let value = factory(file)
-        set(key: key, value: value)
+        values[key] = value
         return value
     }
 

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -27,12 +27,12 @@ public struct Linter {
         }
         let regions = file.regions()
         var ruleTimes = [(id: String, time: Double)]()
-        let violations = rules.flatMap { rule -> [StyleViolation] in
-            if !(rule is SourceKitFreeRule) && file.sourcekitdFailed {
+        let violations = rules.parallelFlatMap { rule -> [StyleViolation] in
+            if !(rule is SourceKitFreeRule) && self.file.sourcekitdFailed {
                 return []
             }
             let start: Date! = benchmark ? Date() : nil
-            let violations = rule.validateFile(file)
+            let violations = rule.validateFile(self.file)
             if benchmark {
                 let id = type(of: rule).description.identifier
                 ruleTimes.append((id, -start.timeIntervalSinceNow))

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -97,7 +97,9 @@ extension Configuration {
                 visitorBlock(Linter(file: file, configuration: self.configurationForFile(file)))
             }
             if parallel {
-                files.parallelForEach(block: visit)
+                DispatchQueue.concurrentPerform(iterations: files.count) { index in
+                    visit(files[index])
+                }
             } else {
                 files.forEach(visit)
             }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -94,7 +94,9 @@ extension Configuration {
                         increment()
                     }
                 }
-                visitorBlock(Linter(file: file, configuration: self.configurationForFile(file)))
+                autoreleasepool {
+                    visitorBlock(Linter(file: file, configuration: self.configurationForFile(file)))
+                }
             }
             if parallel {
                 DispatchQueue.concurrentPerform(iterations: files.count) { index in

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -7,6 +7,7 @@
 //
 
 import Commandant
+import Dispatch
 import Foundation
 import Result
 import SourceKittenFramework
@@ -66,8 +67,8 @@ extension Configuration {
     }
 
     func visitLintableFiles(_ path: String, action: String, useSTDIN: Bool = false,
-                            quiet: Bool = false, useScriptInputFiles: Bool,
-                            visitorBlock: (Linter) -> Void) -> Result<[File], CommandantError<()>> {
+                            quiet: Bool = false, useScriptInputFiles: Bool, parallel: Bool = false,
+                            visitorBlock: @escaping (Linter) -> Void) -> Result<[File], CommandantError<()>> {
         return getFiles(path, action: action, useSTDIN: useSTDIN, quiet: quiet,
                         useScriptInputFiles: useScriptInputFiles)
         .flatMap { files -> Result<[File], CommandantError<()>> in
@@ -77,15 +78,28 @@ extension Configuration {
             }
             return .success(files)
         }.flatMap { files in
+            let queue = DispatchQueue(label: "io.realm.swiftlint.indexIncrementer")
+            var index = 0
             let fileCount = files.count
-            for (index, file) in files.enumerated() {
+            let visit = { (file: File) -> Void in
                 if !quiet, let path = file.path {
-                    let filename = path.bridge().lastPathComponent
-                    queuedPrintError("\(action) '\(filename)' (\(index + 1)/\(fileCount))")
+                    let increment = {
+                        index += 1
+                        let filename = path.bridge().lastPathComponent
+                        queuedPrintError("\(action) '\(filename)' (\(index)/\(fileCount))")
+                    }
+                    if parallel {
+                        queue.sync(execute: increment)
+                    } else {
+                        increment()
+                    }
                 }
-                autoreleasepool {
-                    visitorBlock(Linter(file: file, configuration: configurationForFile(file)))
-                }
+                visitorBlock(Linter(file: file, configuration: self.configurationForFile(file)))
+            }
+            if parallel {
+                files.parallelForEach(block: visit)
+            } else {
+                files.forEach(visit)
             }
             return .success(files)
         }
@@ -118,6 +132,7 @@ extension Configuration {
     func visitLintableFiles(_ options: LintOptions, visitorBlock: @escaping (Linter) -> Void) ->
                             Result<[File], CommandantError<()>> {
         return visitLintableFiles(options.path, action: "Linting", useSTDIN: options.useSTDIN, quiet: options.quiet,
-                                  useScriptInputFiles: options.useScriptInputFiles, visitorBlock: visitorBlock)
+                                  useScriptInputFiles: options.useScriptInputFiles, parallel: true,
+                                  visitorBlock: visitorBlock)
     }
 }


### PR DESCRIPTION
Addresses #1077. Thread sanitizer seems happy with this when running unit tests and linting a few projects I could find, including the Swift standard library.

Generally speeds up linting by ~30% to ~140% on my 2013 MacBook Pro, though the gains should be higher on more recent CPUs.

* **apple/swift:** 218s to 166s (31% faster)
* **realm/realm-cocoa:** 9.6s to 5.6s (71% faster)
* **Carthage/Carthage:** 96s to 53s (80% faster)
* **jpsim/SourceKitten:** 4.2s to 2.1s (100% faster)
* **realm/SwiftLint:** 6.8s to 3.3s (136% faster)

I had initially added a `--parallel` flag to the lint command, but have since removed that option since I haven't run into any issues with it so far, and couldn't come up with a compelling reason to hide it behind an opt-in flag.