### PR TITLE
Add large_tuple rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1096](https://github.com/realm/SwiftLint/issues/1096)
 
+* Add `large_tuple` configurable rule that validates that tuples shouldn't
+  have more than 2 members.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1065](https://github.com/realm/SwiftLint/issues/1065)
+
 ##### Bug Fixes
 
 * Ignore close parentheses on `vertical_parameter_alignment` rule.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
   [#1096](https://github.com/realm/SwiftLint/issues/1096)
 
 * Add `large_tuple` configurable rule that validates that tuples shouldn't
-  have more than 2 members.  
+  have too many members.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1065](https://github.com/realm/SwiftLint/issues/1065)
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -96,6 +96,7 @@ public let masterRuleList = RuleList(rules:
     FunctionBodyLengthRule.self,
     FunctionParameterCountRule.self,
     ImplicitGetterRule.self,
+    LargeTupleRule.self,
     LeadingWhitespaceRule.self,
     LegacyCGGeometryFunctionsRule.self,
     LegacyConstantRule.self,

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -22,7 +22,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
     public static let description = RuleDescription(
         identifier: "large_tuple",
         name: "Large Tuple",
-        description: "Tuples shouldn't have many members. Create a custom type instead.",
+        description: "Tuples shouldn't have too many members. Create a custom type instead.",
         nonTriggeringExamples: [
             "let foo: (Int, Int)\n",
             "let foo: (start: Int, end: Int)\n",
@@ -51,7 +51,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
     )
 
     public func validateFile(_ file: File, kind: SwiftDeclarationKind,
-                             dictionary: [String : SourceKitRepresentable]) -> [StyleViolation] {
+                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         let offsets = violationOffsetsForTypes(file, dictionary: dictionary, kind: kind) +
             violationOffsetsForFunctions(file, dictionary: dictionary, kind: kind)
 
@@ -84,7 +84,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
         for range in ranges {
             let substring = text.substring(with: range)
             let size = substring.components(separatedBy: ",").count
-            maxSize = max(size, maxSize ?? Int.min)
+            maxSize = max(size, maxSize ?? .min)
 
             let replacement = String(repeating: " ", count: substring.bridge().length)
             text = text.replacingCharacters(in: range, with: replacement).bridge()

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -32,7 +32,8 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
             "func foo(bar: String) -> (Int, Int)\n",
             "func foo(bar: String) -> (Int, Int) {}\n",
             "func foo() throws -> (Int, Int)\n",
-            "func foo() throws -> (Int, Int) {}\n"
+            "func foo() throws -> (Int, Int) {}\n",
+            "let foo: (Int, Int, Int) -> Void\n"
         ],
         triggeringExamples: [
             "↓let foo: (Int, Int, Int)\n",
@@ -173,7 +174,17 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
             throw LargeTupleRuleError.unbalencedParentheses
         }
 
-        return ranges
+        let arrowRegex = regex("\\s*->")
+        return ranges.filter { range in
+            let start = NSMaxRange(range)
+            let restOfStringRange = NSRange(location: start, length: length - start)
+            if let match = arrowRegex.firstMatch(in: text, options: [], range: restOfStringRange)?.range,
+                match.location == start {
+                return false
+            }
+
+            return true
+        }
     }
 
 }

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -146,12 +146,19 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
         var ranges = [NSRange]()
 
         let nsText = text.bridge()
-        let fullRange = NSRange(location: 0, length: nsText.length)
-        let options = NSString.EnumerationOptions.byComposedCharacterSequences
-        nsText.enumerateSubstrings(in: fullRange, options: options) { (substring, range, _, stop) in
-            guard let symbol = substring, ["(", ")"].contains(symbol) else {
-                return
+        let parentheses = CharacterSet(charactersIn: "()")
+        var index = 0
+        let length = nsText.length
+
+        while balanced {
+            let searchRange = NSRange(location: index, length: length - index)
+            let range = nsText.rangeOfCharacter(from: parentheses, options: [], range: searchRange)
+            if range.location == NSNotFound {
+                break
             }
+
+            index = NSMaxRange(range)
+            let symbol = nsText.substring(with: range)
 
             if symbol == "(" {
                 stack.append(range.location)
@@ -159,7 +166,6 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
                 ranges.append(NSRange(location: startIdx, length: range.location - startIdx + 1))
             } else {
                 balanced = false
-                stop.pointee = true
             }
         }
 

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -1,0 +1,173 @@
+//
+//  LargeTupleRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 01/01/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+private enum LargeTupleRuleError: Error {
+    case unbalencedParentheses
+}
+
+public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
+
+    public var configuration = SeverityLevelsConfiguration(warning: 2, error: 3)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "large_tuple",
+        name: "Large Tuple",
+        description: "Tuples shouldn't have many members. Create a custom type instead.",
+        nonTriggeringExamples: [
+            "let foo: (Int, Int)\n",
+            "let foo: (start: Int, end: Int)\n",
+            "let foo: (Int, (Int, String))\n",
+            "func foo() -> (Int, Int)\n",
+            "func foo() -> (Int, Int) {}\n",
+            "func foo(bar: String) -> (Int, Int)\n",
+            "func foo(bar: String) -> (Int, Int) {}\n",
+            "func foo() throws -> (Int, Int)\n",
+            "func foo() throws -> (Int, Int) {}\n"
+        ],
+        triggeringExamples: [
+            "↓let foo: (Int, Int, Int)\n",
+            "↓let foo: (start: Int, end: Int, value: String)\n",
+            "↓let foo: (Int, (Int, Int, Int))\n",
+            "func foo(↓bar: (Int, Int, Int))\n",
+            "func foo() -> ↓(Int, Int, Int)\n",
+            "func foo() -> ↓(Int, Int, Int) {}\n",
+            "func foo(bar: String) -> ↓(Int, Int, Int)\n",
+            "func foo(bar: String) -> ↓(Int, Int, Int) {}\n",
+            "func foo() throws -> ↓(Int, Int, Int)\n",
+            "func foo() throws -> ↓(Int, Int, Int) {}\n",
+            "func foo() throws -> ↓(Int, ↓(String, String, String), Int) {}\n"
+        ]
+    )
+
+    public func validateFile(_ file: File, kind: SwiftDeclarationKind,
+                             dictionary: [String : SourceKitRepresentable]) -> [StyleViolation] {
+        let offsets = violationOffsetsForTypes(file, dictionary: dictionary, kind: kind) +
+            violationOffsetsForFunctions(file, dictionary: dictionary, kind: kind)
+
+        return offsets.flatMap { location, size in
+            for parameter in configuration.params where size > parameter.value {
+                let reason = "Tuples should have at most \(parameter.value) members."
+                return StyleViolation(ruleDescription: type(of: self).description,
+                                      severity: parameter.severity,
+                                      location: Location(file: file, byteOffset: location),
+                                      reason: reason)
+            }
+
+            return nil
+        }
+    }
+
+    private func violationOffsetsForTypes(_ file: File,
+                                          dictionary: [String: SourceKitRepresentable],
+                                          kind: SwiftDeclarationKind) -> [(offset: Int, size: Int)] {
+        let kinds = SwiftDeclarationKind.variableKinds().filter { $0 != .varLocal }
+        guard kinds.contains(kind),
+            let type = dictionary["key.typename"] as? String,
+            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let ranges = try? parenthesesRanges(type) else {
+                return []
+        }
+
+        var text = type.bridge()
+        var maxSize: Int?
+        for range in ranges {
+            let substring = text.substring(with: range)
+            let size = substring.components(separatedBy: ",").count
+            maxSize = max(size, maxSize ?? Int.min)
+
+            let replacement = String(repeating: " ", count: substring.bridge().length)
+            text = text.replacingCharacters(in: range, with: replacement).bridge()
+        }
+
+        return maxSize.flatMap { [(offset: offset, size: $0)] } ?? []
+    }
+
+    private func violationOffsetsForFunctions(_ file: File,
+                                              dictionary: [String: SourceKitRepresentable],
+                                              kind: SwiftDeclarationKind) -> [(offset: Int, size: Int)] {
+        let contents = file.contents.bridge()
+        guard SwiftDeclarationKind.functionKinds().contains(kind),
+            let returnRange = returnRangeForFunction(dictionary),
+            let returnSubstring = contents.substringWithByteRange(start: returnRange.location,
+                                                                  length: returnRange.length),
+            let ranges = try? parenthesesRanges(returnSubstring) else {
+                return []
+        }
+
+        var text = returnSubstring.bridge()
+        var offsets = [(offset: Int, size: Int)]()
+
+        for range in ranges {
+            let substring = text.substring(with: range)
+            if let byteRange = text.NSRangeToByteRange(start: range.location, length: range.length) {
+                let size = substring.components(separatedBy: ",").count
+                let offset = byteRange.location + returnRange.location
+                offsets.append((offset: offset, size: size))
+            }
+
+            let replacement = String(repeating: " ", count: substring.bridge().length)
+            text = text.replacingCharacters(in: range, with: replacement).bridge()
+        }
+
+        return offsets.sorted(by: { $0.offset < $1.offset })
+    }
+
+    private func returnRangeForFunction(_ dictionary: [String: SourceKitRepresentable]) -> NSRange? {
+        guard let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
+            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
+            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
+            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) else {
+                return nil
+        }
+
+        let start = nameOffset + nameLength
+        let end = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }) ?? length + offset
+
+        guard end - start > 0 else {
+            return nil
+        }
+
+        return NSRange(location: start, length: end - start)
+    }
+
+    private func parenthesesRanges(_ text: String) throws -> [NSRange] {
+        var stack = [Int]()
+        var balanced = true
+        var ranges = [NSRange]()
+
+        let nsText = text.bridge()
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let options = NSString.EnumerationOptions.byComposedCharacterSequences
+        nsText.enumerateSubstrings(in: fullRange, options: options) { (substring, range, _, stop) in
+            guard let symbol = substring, ["(", ")"].contains(symbol) else {
+                return
+            }
+
+            if symbol == "(" {
+                stack.append(range.location)
+            } else if let startIdx = stack.popLast() {
+                ranges.append(NSRange(location: startIdx, length: range.location - startIdx + 1))
+            } else {
+                balanced = false
+                stop.pointee = true
+            }
+        }
+
+        guard balanced && stack.isEmpty else {
+            throw LargeTupleRuleError.unbalencedParentheses
+        }
+
+        return ranges
+    }
+
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */; };
 		D4DA1DFE1E1A10DB0037413D /* NumberSeparatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */; };
 		D4DA1DF41E17511D0037413D /* CompilerProtocolInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DF31E17511D0037413D /* CompilerProtocolInitRule.swift */; };
+		D4DA1DFA1E18D6200037413D /* LargeTupleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */; };
 		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
 		D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
@@ -378,6 +379,7 @@
 		D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
 		D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorConfiguration.swift; sourceTree = "<group>"; };
 		D4DA1DF31E17511D0037413D /* CompilerProtocolInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompilerProtocolInitRule.swift; sourceTree = "<group>"; };
+		D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LargeTupleRule.swift; sourceTree = "<group>"; };
 		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
 		D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorUsageWhitespaceRule.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
@@ -773,6 +775,7 @@
 				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
 				2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */,
 				D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */,
+				D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */,
 				006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */,
@@ -1129,6 +1132,7 @@
 				D4DA1DFE1E1A10DB0037413D /* NumberSeparatorConfiguration.swift in Sources */,
 				E88198601BEA98F000333A11 /* VariableNameRule.swift in Sources */,
 				E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */,
+				D4DA1DFA1E18D6200037413D /* LargeTupleRule.swift in Sources */,
 				E86396CB1BADB519002C9E88 /* CSVReporter.swift in Sources */,
 				37B3FA8B1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift in Sources */,
 				D4B022B01E109816007E5297 /* CharacterSet+LinuxHack.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -29,7 +29,7 @@ class RulesTests: XCTestCase {
         verifyRule(ClosureParameterPositionRule.description)
     }
 
-    func testClosureSpacingRule() {
+    func testClosureSpacing() {
         verifyRule(ClosureSpacingRule.description)
     }
 
@@ -98,12 +98,16 @@ class RulesTests: XCTestCase {
         verifyRule(FunctionBodyLengthRule.description)
     }
 
-    func testFunctionParameterCountRule() {
+    func testFunctionParameterCount() {
         verifyRule(FunctionParameterCountRule.description)
     }
 
-    func testImplicitGetterRule() {
+    func testImplicitGetter() {
         verifyRule(ImplicitGetterRule.description)
+    }
+
+    func testLargeTuple() {
+        verifyRule(LargeTupleRule.description)
     }
 
     func testLeadingWhitespace() {
@@ -343,7 +347,7 @@ extension RulesTests {
             ("testCompilerProtocolInit", testCompilerProtocolInit),
             ("testClosureEndIndentation", testClosureEndIndentation),
             ("testClosureParameterPosition", testClosureParameterPosition),
-            ("testClosureSpacingRule", testClosureSpacingRule),
+            ("testClosureSpacing", testClosureSpacing),
             ("testConditionalReturnsOnNewline", testConditionalReturnsOnNewline),
             ("testControlStatement", testControlStatement),
             ("testCyclomaticComplexity", testCyclomaticComplexity),
@@ -358,8 +362,9 @@ extension RulesTests {
             ("testForceTry", testForceTry),
             // ("testForceUnwrapping", testForceUnwrapping),
             ("testFunctionBodyLength", testFunctionBodyLength),
-            ("testFunctionParameterCountRule", testFunctionParameterCountRule),
-            ("testImplicitGetterRule", testImplicitGetterRule),
+            ("testFunctionParameterCount", testFunctionParameterCount),
+            ("testImplicitGetter", testImplicitGetter),
+            ("testLargeTuple", testLargeTuple),
             ("testLeadingWhitespace", testLeadingWhitespace),
             ("testLegacyCGGeometryFunctions", testLegacyCGGeometryFunctions),
             ("testLegacyNSGeometryFunctions", testLegacyNSGeometryFunctions),
@@ -398,7 +403,7 @@ extension RulesTests {
             ("testUnusedEnumerated", testUnusedEnumerated),
             ("testValidIBInspectable", testValidIBInspectable),
             ("testVariableName", testVariableName),
-            ("VerticalParameterAlignmentRule", testVerticalParameterAlignment),
+            ("VerticalParameterAlignment", testVerticalParameterAlignment),
             ("testVoidReturn", testVoidReturn),
             ("testSuperCall", testSuperCall),
             ("testWeakDelegate", testWeakDelegate)


### PR DESCRIPTION
Fixes #1065 

~This currently triggers when tuples are used to represent closure parameters, such as:~

```swift
func setAndTestAllTypes(_ setter: (SwiftObject, Any?, String) -> Void,
                          getter: (SwiftObject, String) -> (Any?), object: SwiftObject)
```

~I'm not sure if we should handle this case or not.~