### PR TITLE
Make NimbleOperatorRule correctable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ##### Enhancements
 
+* Make `nimble_operator` rule correctable.  
+  [Vojta Stavik](https://github.com/VojtaStavik)
+
 * Add `vertical_parameter_alignment` rule that checks if parameters are
   vertically aligned for multi-line function declarations.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, CorrectableRule {

--- a/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
@@ -69,7 +69,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
     ]
 
     public func validateFile(_ file: File) -> [StyleViolation] {
-        let matches = violationMatchesRanges(inFile: file)
+        let matches = violationMatchesRanges(in: file)
         return matches.map {
             StyleViolation(ruleDescription: type(of: self).description,
                 severity: configuration.severity,
@@ -77,7 +77,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
         }
     }
 
-    private func violationMatchesRanges(inFile file: File) -> [NSRange] {
+    private func violationMatchesRanges(in file: File) -> [NSRange] {
         let operatorNames = operatorsMapping.keys
         let operatorsPattern = "(" + operatorNames.joined(separator: "|") + ")"
 
@@ -93,7 +93,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
     }
 
     public func correctFile(_ file: File) -> [Correction] {
-        let matches = violationMatchesRanges(inFile: file)
+        let matches = violationMatchesRanges(in: file)
             .filter { file.ruleEnabledViolatingRanges([$0], forRule: self).isEmpty == false }
         guard matches.isEmpty == false else { return [] }
 


### PR DESCRIPTION
Hey guys! I had over 500 warnings in my project from the new nimble_operator rule and I didn't want to correct it manually. I made the rule correctable for the most common use cases.