### PR TITLE
TypeNameRuleExamples: added test to verify that enum cases are lowercase in Swift 3

### DIFF
--- a/Source/SwiftLintFramework/Rules/TypeNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRuleExamples.swift
@@ -16,7 +16,7 @@ internal struct TypeNameRuleExamples {
 
     static let swift2TriggeringExamples = commonTriggeringExamples + ["enum MyType {\ncase ↓value\n}"]
 
-    static let swift3TriggeringExamples = commonTriggeringExamples
+    static let swift3TriggeringExamples = commonTriggeringExamples + ["enum MyType {\ncase Value\n}"]
 
     private static let types = ["class", "struct", "enum"]
 


### PR DESCRIPTION
To my surprise, the `type_name` rule is not currently validating this. I've found some issues referring to this (#655, #654, #663, and the change in #660), but it's not clear to me whether not validating this was on purpose.

So I figured I'd ask this question by sending the failing test. I'd love to have this rule validate this, but I wonder if there's a reason why this was not enabled.

Thanks.