### PR TITLE
reset assertion handler in test

### DIFF
--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -77,6 +77,8 @@ class SourceKitCrashTests: XCTestCase {
         // swiftlint:disable:next force_unwrapping
         let configuration = Configuration(whitelistRules: allRuleIdentifiers)!
         _ = Linter(file: file, configuration: configuration).styleViolations
+        file.sourcekitdFailed = false
+        file.assertHandler = nil
     }
 }
 


### PR DESCRIPTION
specifically, after running `testRulesWithFileThatCrashedSourceKitService`.

Otherwise, other tests could fail if they're linting the same file, which can happen today if the integration tests happen to run afterwards.

/cc @marcelofabri @rakaramos 