### PR TITLE
Fix number separator violation swiftlint warnings

### DIFF
--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -9,7 +9,7 @@
 import SourceKittenFramework
 
 public struct FileLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 400, error: 1000)
+    public var configuration = SeverityLevelsConfiguration(warning: 400, error: 1_000)
 
     public init() {}
 

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -13,7 +13,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
     public var configuration = NameConfiguration(minLengthWarning: 1,
                                                  minLengthError: 0,
                                                  maxLengthWarning: 20,
-                                                 maxLengthError: 1000)
+                                                 maxLengthError: 1_000)
 
     public init() {}
 

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -14,7 +14,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
     public var configuration = NameConfiguration(minLengthWarning: 3,
                                                  minLengthError: 0,
                                                  maxLengthWarning: 40,
-                                                 maxLengthError: 1000)
+                                                 maxLengthError: 1_000)
 
     public init() {}
 


### PR DESCRIPTION
I have a WIP branch (PR coming soon) to add support for linting multiple files as CLI args, but I ran into these `swiftlint` warnings while working on it. I figured I fix these and get them out of the way first.