### PR TITLE
Support for passing multiple paths to swiftlint lint and autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1871](https://github.com/realm/SwiftLint/issues/1871)  
 
+* Support for passing multiple path arguments.  
+  [Ben Asher](https://github.com/benasher44)
+  [#810](https://github.com/realm/SwiftLint/issues/810)
+
 #### Bug Fixes
 
 * Update `LowerACLThanParent` rule to not lint extensions.  

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -66,7 +66,12 @@ struct AutoCorrectOptions: OptionsProtocol {
     // swiftlint:disable line_length
     static func create(_ path: String) -> (_ paths: [String]) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ forceExclude: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
         return { paths in { configurationFile in { useScriptInputFiles in { quiet in { forceExclude in { format in { cachePath in { ignoreCache in { useTabs in
-            let allPaths = Set([path] + paths)
+            let allPaths: [String]
+            if !path.isEmpty {
+                allPaths = [path]
+            } else {
+                allPaths = paths
+            }
             return self.init(paths: Array(allPaths), configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, forceExclude: forceExclude, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
         }}}}}}}}}
     }

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -72,7 +72,7 @@ struct AutoCorrectOptions: OptionsProtocol {
             } else {
                 allPaths = paths
             }
-            return self.init(paths: Array(allPaths), configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, forceExclude: forceExclude, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
+            return self.init(paths: allPaths, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, forceExclude: forceExclude, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
         }}}}}}}}}
     }
 

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -27,7 +27,7 @@ struct AutoCorrectCommand: CommandProtocol {
             useTabs = options.useTabs
         }
 
-        return configuration.visitLintableFiles(path: options.path, action: "Correcting",
+        return configuration.visitLintableFiles(paths: options.paths, action: "Correcting",
                                                 quiet: options.quiet,
                                                 useScriptInputFiles: options.useScriptInputFiles,
                                                 forceExclude: options.forceExclude,
@@ -53,7 +53,7 @@ struct AutoCorrectCommand: CommandProtocol {
 }
 
 struct AutoCorrectOptions: OptionsProtocol {
-    let path: String
+    let paths: [String]
     let configurationFile: String
     let useScriptInputFiles: Bool
     let quiet: Bool
@@ -64,16 +64,18 @@ struct AutoCorrectOptions: OptionsProtocol {
     let useTabs: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ forceExclude: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
-        return { configurationFile in { useScriptInputFiles in { quiet in { forceExclude in { format in { cachePath in { ignoreCache in { useTabs in
-            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, forceExclude: forceExclude, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
-        }}}}}}}}
+    static func create(_ path: String) -> (_ paths: [String]) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ forceExclude: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
+        return { paths in { configurationFile in { useScriptInputFiles in { quiet in { forceExclude in { format in { cachePath in { ignoreCache in { useTabs in
+            let allPaths = Set([path] + paths)
+            return self.init(paths: Array(allPaths), configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, forceExclude: forceExclude, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
+        }}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
         // swiftlint:enable line_length
         return create
             <*> mode <| pathOption(action: "correct")
+            <*> mode <| pathsArgument(action: "correct")
             <*> mode <| configOption
             <*> mode <| useScriptInputFilesOption
             <*> mode <| quietOption(action: "correcting")

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -64,8 +64,8 @@ struct AutoCorrectOptions: OptionsProtocol {
     let useTabs: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ paths: [String]) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ forceExclude: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
-        return { paths in { configurationFile in { useScriptInputFiles in { quiet in { forceExclude in { format in { cachePath in { ignoreCache in { useTabs in
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ forceExclude: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> (_ paths: [String]) -> AutoCorrectOptions {
+        return { configurationFile in { useScriptInputFiles in { quiet in { forceExclude in { format in { cachePath in { ignoreCache in { useTabs in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
@@ -80,7 +80,6 @@ struct AutoCorrectOptions: OptionsProtocol {
         // swiftlint:enable line_length
         return create
             <*> mode <| pathOption(action: "correct")
-            <*> mode <| pathsArgument(action: "correct")
             <*> mode <| configOption
             <*> mode <| useScriptInputFilesOption
             <*> mode <| quietOption(action: "correcting")
@@ -97,5 +96,7 @@ struct AutoCorrectOptions: OptionsProtocol {
             <*> mode <| Option(key: "use-tabs",
                                defaultValue: false,
                                usage: "should use tabs over spaces when reformatting. Deprecated.")
+            // This should go last to avoid eating other args
+            <*> mode <| pathsArgument(action: "correct")
     }
 }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -117,7 +117,7 @@ struct LintCommand: CommandProtocol {
 }
 
 struct LintOptions: OptionsProtocol {
-    let path: String
+    let paths: [String]
     let useSTDIN: Bool
     let configurationFile: String
     let strict: Bool
@@ -132,16 +132,18 @@ struct LintOptions: OptionsProtocol {
     let enableAllRules: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> LintOptions {
-        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in
-            self.init(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
-        }}}}}}}}}}}}
+    static func create(_ path: String) -> (_ paths: [String]) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> LintOptions {
+        return { paths in { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in
+            let allPaths = Set([path] + paths)
+            return self.init(paths: Array(allPaths), useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
+        }}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<LintOptions, CommandantError<CommandantError<()>>> {
         // swiftlint:enable line_length
         return create
             <*> mode <| pathOption(action: "lint")
+            <*> mode <| pathsArgument(action: "lint")
             <*> mode <| Option(key: "use-stdin", defaultValue: false,
                                usage: "lint standard input")
             <*> mode <| configOption

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -134,7 +134,12 @@ struct LintOptions: OptionsProtocol {
     // swiftlint:disable line_length
     static func create(_ path: String) -> (_ paths: [String]) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> LintOptions {
         return { paths in { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in
-            let allPaths = Set([path] + paths)
+            let allPaths: [String]
+            if !path.isEmpty {
+                allPaths = [path]
+            } else {
+                allPaths = paths
+            }
             return self.init(paths: Array(allPaths), useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
         }}}}}}}}}}}}}
     }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -140,7 +140,7 @@ struct LintOptions: OptionsProtocol {
             } else {
                 allPaths = paths
             }
-            return self.init(paths: Array(allPaths), useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
+            return self.init(paths: allPaths, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
         }}}}}}}}}}}}}
     }
 

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -132,8 +132,8 @@ struct LintOptions: OptionsProtocol {
     let enableAllRules: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ paths: [String]) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> LintOptions {
-        return { paths in { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in
+    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> (_ paths: [String]) -> LintOptions {
+        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
@@ -148,7 +148,6 @@ struct LintOptions: OptionsProtocol {
         // swiftlint:enable line_length
         return create
             <*> mode <| pathOption(action: "lint")
-            <*> mode <| pathsArgument(action: "lint")
             <*> mode <| Option(key: "use-stdin", defaultValue: false,
                                usage: "lint standard input")
             <*> mode <| configOption
@@ -171,5 +170,7 @@ struct LintOptions: OptionsProtocol {
                                usage: "ignore cache when linting")
             <*> mode <| Option(key: "enable-all-rules", defaultValue: false,
                                usage: "run all rules, even opt-in and disabled ones, ignoring `whitelist_rules`")
+            // This should go last to avoid eating other args
+            <*> mode <| pathsArgument(action: "lint")
     }
 }

--- a/Source/swiftlint/Helpers/CommonOptions.swift
+++ b/Source/swiftlint/Helpers/CommonOptions.swift
@@ -7,6 +7,11 @@ func pathOption(action: String) -> Option<String> {
                   usage: "the path to the file or directory to \(action)")
 }
 
+func pathsArgument(action: String) -> Argument<[String]> {
+    return Argument(defaultValue: [""],
+                    usage: "list of paths to the files or directories to \(action)")
+}
+
 let configOption = Option(key: "config",
                           defaultValue: Configuration.fileName,
                           usage: "the path to SwiftLint's configuration file")


### PR DESCRIPTION
This implements #810:

TODO:

- [x] What does `rootPath` mean now (especially in terms of caching) when multiple files are passed? (disabled with a warning)
- [x] Okay to get drop the `--path` option? (decided to keep)
- [x] Add tests. (filed CLI arg testing follow up ticket  #1213)
- [x] Add CHANGELOG entry.

This + pre-commit/pre-commit#467 (personal motivation for this PR) + hooks.yaml (maybe in a follow up PR) makes this work with pre-commit using SwiftPM. I've tested this branch locally with pre-commit, and it works great!

I'd appreciate thoughts and feedback on the above TODOs and existing changes :)