### PR TITLE
Ignore overrides for `variable_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Improve `unused_optional_binding` rule on tuples check.  
   [Rafael Machado](https://github.com/rakaramos/)
 
+* Updated `variable_name` to ignore overrides.  
+  [Aaron McTavish](https://github.com/aamctustwo)
+  [#1169](https://github.com/realm/SwiftLint/issues/1169)
+
 ##### Bug Fixes
 
 * Fix false positives on `shorthand_operator` rule.  

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -32,7 +32,8 @@ public struct VariableNameRule: ASTRule, ConfigurationProviderRule {
             "private let _myLet = 0",
             "class Abc { static let MyLet = 0 }",
             "let URL: NSURL? = nil",
-            "let XMLString: String? = nil"
+            "let XMLString: String? = nil",
+            "override var i = 0"
         ],
         triggeringExamples: [
             "↓let MyLet = 0",
@@ -63,6 +64,10 @@ public struct VariableNameRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard !dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.override") else {
+            return []
+        }
+
         return file.validateVariableName(dictionary, kind: kind).map { name, offset in
             if configuration.excluded.contains(name) {
                 return []


### PR DESCRIPTION
Resolves #1169 `variable_name should not apply to overriding properties`.

### Summary

Updated `variable_name` to ignore overrides.