### PR TITLE
Add minimum_fraction_length to number_separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   [#1169](https://github.com/realm/SwiftLint/issues/1169)
 
 * Update `number_separator` rule to allow for specifying
-  minimum length of fraction.
+  minimum length of fraction.  
   [Bjarke Søndergaard](https://github.com/bjarkehs)
   [#1200](https://github.com/realm/SwiftLint/issues/1200)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   [Aaron McTavish](https://github.com/aamctustwo)
   [#1169](https://github.com/realm/SwiftLint/issues/1169)
 
+* Update `number_separator` rule to allow for specifying
+  minimum length of fraction.
+  [Bjarke Søndergaard](https://github.com/bjarkehs)
+  [#1200](https://github.com/realm/SwiftLint/issues/1200)
+
 ##### Bug Fixes
 
 * Fix false positives on `shorthand_operator` rule.  

--- a/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
@@ -10,7 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProviderRule {
-    public var configuration = NumberSeparatorConfiguration(minimumLength: 0)
+    public var configuration = NumberSeparatorConfiguration(minimumLength: 0, minimumFractionLength: nil)
 
     public init() {}
 
@@ -51,13 +51,13 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
             var validFraction = true
             var expectedFraction: String?
             if components.count == 2, let fractionSubstring = components.last {
-                let result = isValid(number: fractionSubstring, reversed: false)
+                let result = isValid(number: fractionSubstring, reversed: false, isFraction: true)
                 validFraction = result.0
                 expectedFraction = result.1
             }
 
             guard let integerSubstring = components.first,
-                case let (valid, expected) = isValid(number: integerSubstring, reversed: true),
+                case let (valid, expected) = isValid(number: integerSubstring, reversed: true, isFraction: false),
                 !valid || !validFraction,
                 let range = file.contents.bridge().byteRangeToNSRange(start: token.offset,
                                                                       length: token.length) else {
@@ -113,10 +113,18 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
         return prefixes.filter { lowercased.hasPrefix($0) }.isEmpty
     }
 
-    private func isValid(number: String, reversed: Bool) -> (Bool, String) {
+    private func isValid(number: String, reversed: Bool, isFraction: Bool) -> (Bool, String) {
         var correctComponents = [String]()
         let clean = number.replacingOccurrences(of: "_", with: "")
-        let shouldAddSeparators = clean.characters.count >= configuration.minimumLength
+
+        let minimumLength: Int
+        if isFraction {
+            minimumLength = configuration.minimumFractionLength ?? configuration.minimumLength
+        } else {
+            minimumLength = configuration.minimumLength
+        }
+
+        let shouldAddSeparators = clean.characters.count >= minimumLength
 
         for (idx, char) in reversedIfNeeded(Array(clean.characters),
                                             reversed: reversed).enumerated() {

--- a/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
@@ -51,13 +51,13 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
             var validFraction = true
             var expectedFraction: String?
             if components.count == 2, let fractionSubstring = components.last {
-                let result = isValid(number: fractionSubstring, reversed: false, isFraction: true)
+                let result = isValid(number: fractionSubstring, isFraction: true)
                 validFraction = result.0
                 expectedFraction = result.1
             }
 
             guard let integerSubstring = components.first,
-                case let (valid, expected) = isValid(number: integerSubstring, reversed: true, isFraction: false),
+                case let (valid, expected) = isValid(number: integerSubstring, isFraction: false),
                 !valid || !validFraction,
                 let range = file.contents.bridge().byteRangeToNSRange(start: token.offset,
                                                                       length: token.length) else {
@@ -113,7 +113,7 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
         return prefixes.filter { lowercased.hasPrefix($0) }.isEmpty
     }
 
-    private func isValid(number: String, reversed: Bool, isFraction: Bool) -> (Bool, String) {
+    private func isValid(number: String, isFraction: Bool) -> (Bool, String) {
         var correctComponents = [String]()
         let clean = number.replacingOccurrences(of: "_", with: "")
 
@@ -127,7 +127,7 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
         let shouldAddSeparators = clean.characters.count >= minimumLength
 
         for (idx, char) in reversedIfNeeded(Array(clean.characters),
-                                            reversed: reversed).enumerated() {
+                                            reversed: !isFraction).enumerated() {
             if idx % 3 == 0 && idx > 0 && shouldAddSeparators {
                 correctComponents.append("_")
             }
@@ -135,7 +135,7 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
             correctComponents.append(String(char))
         }
 
-        let expected = reversedIfNeeded(correctComponents, reversed: reversed).joined()
+        let expected = reversedIfNeeded(correctComponents, reversed: !isFraction).joined()
         return (expected == number, expected)
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -9,13 +9,23 @@
 public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var minimumLength: Int
+    private(set) var minimumFractionLength: Int?
 
     public var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", minimum_length: \(minimumLength)"
+        let minimumFractionLengthDescription: String
+        if let minimumFractionLength = self.minimumFractionLength {
+            minimumFractionLengthDescription = ", minimum_fraction_length: \(minimumFractionLength)"
+        } else {
+            minimumFractionLengthDescription = ""
+        }
+        return severityConfiguration.consoleDescription
+            + ", minimum_length: \(minimumLength)"
+            + minimumFractionLengthDescription
     }
 
-    public init(minimumLength: Int) {
+    public init(minimumLength: Int, minimumFractionLength: Int?) {
         self.minimumLength = minimumLength
+        self.minimumFractionLength = minimumFractionLength
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -27,6 +37,10 @@ public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
             self.minimumLength = minimumLength
         }
 
+        if let minimumFractionLength = configuration["minimum_fraction_length"] as? Int {
+            self.minimumFractionLength = minimumFractionLength
+        }
+
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)
         }
@@ -35,6 +49,7 @@ public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
     public static func == (lhs: NumberSeparatorConfiguration,
                            rhs: NumberSeparatorConfiguration) -> Bool {
         return lhs.minimumLength == rhs.minimumLength &&
+            lhs.minimumFractionLength == rhs.minimumFractionLength &&
             lhs.severityConfiguration == rhs.severityConfiguration
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -13,7 +13,7 @@ public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
 
     public var consoleDescription: String {
         let minimumFractionLengthDescription: String
-        if let minimumFractionLength = self.minimumFractionLength {
+        if let minimumFractionLength = minimumFractionLength {
             minimumFractionLengthDescription = ", minimum_fraction_length: \(minimumFractionLength)"
         } else {
             minimumFractionLengthDescription = ""

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -132,9 +132,10 @@
 		D4C4A34C1DEA4FF000E0E04C /* AttributesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */; };
 		D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */; };
 		D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */; };
-		D4DA1DF81E175E8A0037413D /* LinterCache+CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DF71E175E8A0037413D /* LinterCache+CommandLine.swift */; };
+		D4CA758F1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */; };
 		D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5A5FE1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift */; };
 		D4DA1DF41E17511D0037413D /* CompilerProtocolInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DF31E17511D0037413D /* CompilerProtocolInitRule.swift */; };
+		D4DA1DF81E175E8A0037413D /* LinterCache+CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DF71E175E8A0037413D /* LinterCache+CommandLine.swift */; };
 		D4DA1DFA1E18D6200037413D /* LargeTupleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */; };
 		D4DA1DFE1E1A10DB0037413D /* NumberSeparatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */; };
 		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
@@ -398,9 +399,10 @@
 		D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesConfiguration.swift; sourceTree = "<group>"; };
 		D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRule.swift; sourceTree = "<group>"; };
 		D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
-		D4DA1DF71E175E8A0037413D /* LinterCache+CommandLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LinterCache+CommandLine.swift"; sourceTree = "<group>"; };
+		D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleTests.swift; sourceTree = "<group>"; };
 		D4D5A5FE1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShorthandOperatorRule.swift; sourceTree = "<group>"; };
 		D4DA1DF31E17511D0037413D /* CompilerProtocolInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompilerProtocolInitRule.swift; sourceTree = "<group>"; };
+		D4DA1DF71E175E8A0037413D /* LinterCache+CommandLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LinterCache+CommandLine.swift"; sourceTree = "<group>"; };
 		D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LargeTupleRule.swift; sourceTree = "<group>"; };
 		D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorConfiguration.swift; sourceTree = "<group>"; };
 		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
@@ -714,9 +716,9 @@
 				D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */,
 				3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */,
 				3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */,
-				C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */,
 				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
 				D4C27BFF1E12DFF500DF713E /* LinterCacheTests.swift */,
+				D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */,
 				E86396C61BADAFE6002C9E88 /* ReporterTests.swift */,
 				E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */,
 				E81224991B04F85B001783D2 /* TestHelpers.swift */,
@@ -1284,6 +1286,7 @@
 				D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */,
 				006204DE1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift in Sources */,
 				02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */,
+				D4CA758F1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift in Sources */,
 				D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */,
 				3B63D46D1E1F05160057BE35 /* LineLengthConfigurationTests.swift in Sources */,
 				6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */,

--- a/SwiftLint.xcodeproj/xcshareddata/xcschemes/swiftlint with Swift 2.3.xcscheme
+++ b/SwiftLint.xcodeproj/xcshareddata/xcschemes/swiftlint with Swift 2.3.xcscheme
@@ -46,7 +46,7 @@
                   Identifier = "IntegrationTests">
                </Test>
                <Test
-                  Identifier = "RulesTests/testNumberSeparator()">
+                  Identifier = "NumberSeparatorRuleTests/testNumberSeparatorWithDefaultConfiguration()">
                </Test>
                <Test
                   Identifier = "RulesTests/testTypeName()">

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -21,6 +21,7 @@ XCTMain([
     testCase(LineLengthConfigurationTests.allTests),
     testCase(LineLengthRuleTests.allTests),
     testCase(LinterCacheTests.allTests),
+    testCase(NumberSeparatorRuleTests.allTests),
     testCase(ReporterTests.allTests),
     testCase(RuleConfigurationsTests.allTests),
     testCase(RulesTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
@@ -1,0 +1,80 @@
+//
+//  NumberSeparatorRuleTests.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 01/17/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+import XCTest
+
+class NumberSeparatorRuleTests: XCTestCase {
+
+    func testNumberSeparatorWithDefaultConfiguration() {
+        verifyRule(NumberSeparatorRule.description)
+    }
+
+    func testNumberSeparatorWithMinimumLength() {
+        let description = RuleDescription(
+            identifier: NumberSeparatorRule.description.identifier,
+            name: NumberSeparatorRule.description.name,
+            description: NumberSeparatorRule.description.description,
+            nonTriggeringExamples: [
+                "let foo = 10_000",
+                "let foo = 1000",
+                "let foo = 1000.0001",
+                "let foo = 10_000.0001",
+                "let foo = 1000.000_01"
+            ],
+            triggeringExamples: [
+                "let foo = ↓1_000",
+                "let foo = ↓1.000_1",
+                "let foo = ↓1_000.000_1"
+            ],
+            corrections: [
+                "let foo = ↓1_000": "let foo = 1000",
+                "let foo = ↓1.000_1": "let foo = 1.0001",
+                "let foo = ↓1_000.000_1": "let foo = 1000.0001"
+            ]
+        )
+
+        verifyRule(description, ruleConfiguration: ["minimum_length": 5])
+    }
+
+    func testNumberSeparatorWithMinimumFractionLength() {
+        let description = RuleDescription(
+            identifier: NumberSeparatorRule.description.identifier,
+            name: NumberSeparatorRule.description.name,
+            description: NumberSeparatorRule.description.description,
+            nonTriggeringExamples: [
+                "let foo = 1_000.000_000_1",
+                "let foo = 1.000_001",
+                "let foo = 100.0001",
+                "let foo = 1_000.000_01"
+            ],
+            triggeringExamples: [
+                "let foo = ↓1000",
+                "let foo = ↓1.000_1",
+                "let foo = ↓1_000.000_1"
+            ],
+            corrections: [
+                "let foo = ↓1000": "let foo = 1_000",
+                "let foo = ↓1.000_1": "let foo = 1.0001",
+                "let foo = ↓1_000.000_1": "let foo = 1_000.0001"
+            ]
+        )
+
+        verifyRule(description, ruleConfiguration: ["minimum_fraction_length": 5])
+    }
+}
+
+extension NumberSeparatorRuleTests {
+    static var allTests: [(String, (NumberSeparatorRuleTests) -> () throws -> Void)] {
+        return [
+            ("testNumberSeparatorWithDefaultConfiguration", testNumberSeparatorWithDefaultConfiguration),
+            ("testNumberSeparatorWithMinimumLength", testNumberSeparatorWithMinimumLength),
+            ("testNumberSeparatorWithMinimumFractionLength", testNumberSeparatorWithMinimumFractionLength)
+        ]
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -151,49 +151,6 @@ class RulesTests: XCTestCase {
         verifyRule(NimbleOperatorRule.description)
     }
 
-    func testNumberSeparator() {
-        verifyRule(NumberSeparatorRule.description)
-
-        let baseDescription1 = NumberSeparatorRule.description
-        let nonTriggeringExamples1 = [
-            "let foo = 10_000",
-            "let foo = 1000",
-            "let foo = 1000.0001",
-            "let foo = 10_000.0001",
-            "let foo = 1000.000_01"
-        ]
-        let triggeringExamples1 = [
-            "let foo = 1_000",
-            "let foo = 1.000_1",
-            "let foo = 1_000.000_1"
-        ]
-        let description1 = RuleDescription(identifier: baseDescription1.identifier,
-                                          name: baseDescription1.name,
-                                          description: baseDescription1.description,
-                                          nonTriggeringExamples: nonTriggeringExamples1,
-                                          triggeringExamples: triggeringExamples1)
-        verifyRule(description1, ruleConfiguration: ["minimum_length": 5])
-
-        let baseDescription2 = NumberSeparatorRule.description
-        let nonTriggeringExamples2 = [
-            "let foo = 1_000.000_000_1",
-            "let foo = 1.000_001",
-            "let foo = 100.0001",
-            "let foo = 1_000.000_01"
-            ]
-        let triggeringExamples2 = [
-            "let foo = 1000",
-            "let foo = 1.000_1",
-            "let foo = 1_000.000_1"
-            ]
-        let description2 = RuleDescription(identifier: baseDescription2.identifier,
-                                           name: baseDescription2.name,
-                                           description: baseDescription2.description,
-                                           nonTriggeringExamples: nonTriggeringExamples2,
-                                           triggeringExamples: triggeringExamples2)
-        verifyRule(description2, ruleConfiguration: ["minimum_fraction_length": 5])
-    }
-
     func testObjectLiteral() {
         verifyRule(ObjectLiteralRule.description)
     }
@@ -415,7 +372,6 @@ extension RulesTests {
             ("testMark", testMark),
             ("testNesting", testNesting),
             ("testNimbleOperator", testNimbleOperator),
-            ("testNumberSeparator", testNumberSeparator),
             ("testObjectLiteral", testObjectLiteral),
             ("testOpeningBrace", testOpeningBrace),
             ("testOperatorFunctionWhitespace", testOperatorFunctionWhitespace),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -153,6 +153,45 @@ class RulesTests: XCTestCase {
 
     func testNumberSeparator() {
         verifyRule(NumberSeparatorRule.description)
+
+        let baseDescription1 = NumberSeparatorRule.description
+        let nonTriggeringExamples1 = [
+            "let foo = 10_000",
+            "let foo = 1000",
+            "let foo = 1000.0001",
+            "let foo = 10_000.0001",
+            "let foo = 1000.000_01"
+        ]
+        let triggeringExamples1 = [
+            "let foo = 1_000",
+            "let foo = 1.000_1",
+            "let foo = 1_000.000_1"
+        ]
+        let description1 = RuleDescription(identifier: baseDescription1.identifier,
+                                          name: baseDescription1.name,
+                                          description: baseDescription1.description,
+                                          nonTriggeringExamples: nonTriggeringExamples1,
+                                          triggeringExamples: triggeringExamples1)
+        verifyRule(description1, ruleConfiguration: ["minimum_length": 5])
+
+        let baseDescription2 = NumberSeparatorRule.description
+        let nonTriggeringExamples2 = [
+            "let foo = 1_000.000_000_1",
+            "let foo = 1.000_001",
+            "let foo = 100.0001",
+            "let foo = 1_000.000_01"
+            ]
+        let triggeringExamples2 = [
+            "let foo = 1000",
+            "let foo = 1.000_1",
+            "let foo = 1_000.000_1"
+            ]
+        let description2 = RuleDescription(identifier: baseDescription2.identifier,
+                                           name: baseDescription2.name,
+                                           description: baseDescription2.description,
+                                           nonTriggeringExamples: nonTriggeringExamples2,
+                                           triggeringExamples: triggeringExamples2)
+        verifyRule(description2, ruleConfiguration: ["minimum_fraction_length": 5])
     }
 
     func testObjectLiteral() {


### PR DESCRIPTION
This adds `minimum_fraction_length` as a configuration to `number_separator`. If specified it overrules `minimum_length`.

Closes #1200 