### PR TITLE
Allowed Character Configuration for Name Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1061](https://github.com/realm/SwiftLint/issues/1061)
 
+* Update `variable_name`, `type_name`, and `generic_type_name` to allow configuration of
+  allowed characters. Use the new `additional_allowed_characters` configuration parameter
+  to pass in a string of the characters to allow in addition to alphanumerics.  
+  [Aaron McTavish](https://github.com/aamctustwo)
+  [#628](https://github.com/realm/SwiftLint/issues/628)
+
 ##### Bug Fixes
 
 * Fix a false positive on `large_tuple` rule when using closures.  
@@ -56,12 +62,6 @@
   minimum length of fraction.  
   [Bjarke Søndergaard](https://github.com/bjarkehs)
   [#1200](https://github.com/realm/SwiftLint/issues/1200)
-  
-* Updated `variable_name`, `type_name`, and `generic_type_name` to allow configuration of
-  allowed characters. Use the new `additional_allowed_characters` configuration parameter
-  to pass in a string of the characters to allow in addition to alphanumerics.  
-  [Aaron McTavish](https://github.com/aamctustwo)
-  [#628](https://github.com/realm/SwiftLint/issues/628)
 
 * Update `legacy_constant` rule to support `CGFloat.pi` and `Float.pi`.  
   [Aaron McTavish](https://github.com/aamctustwo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,9 @@
   [Bjarke Søndergaard](https://github.com/bjarkehs)
   [#1200](https://github.com/realm/SwiftLint/issues/1200)
   
-* Updated `variable_name` and `type_name` to allow configuration of allowed characters.
-  Use the new `additional_allowed_characters` configuration parameter to pass in a string
-  of the characters to allow in addition to alphanumerics.  
+* Updated `variable_name`, `type_name`, and `generic_type_name` to allow configuration of
+  allowed characters. Use the new `additional_allowed_characters` configuration parameter
+  to pass in a string of the characters to allow in addition to alphanumerics.  
   [Aaron McTavish](https://github.com/aamctustwo)
   [#628](https://github.com/realm/SwiftLint/issues/628)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@
   minimum length of fraction.  
   [Bjarke Søndergaard](https://github.com/bjarkehs)
   [#1200](https://github.com/realm/SwiftLint/issues/1200)
+  
+* Updated `variable_name` and `type_name` to allow configuration of allowed characters.
+  Use the new `additional_allowed_characters` configuration parameter to pass in a string
+  of the characters to allow in addition to alphanumerics.  
+  [Aaron McTavish](https://github.com/aamctustwo)
+  [#628](https://github.com/realm/SwiftLint/issues/628)
 
 * Update `legacy_constant` rule to support `CGFloat.pi` and `Float.pi`.  
   [Aaron McTavish](https://github.com/aamctustwo)

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
@@ -19,13 +19,8 @@ extension CharacterSet {
 
             return true
         #else
-            let otherSet = CharacterSet(charactersIn: string)
-
             // workaround for https://bugs.swift.org/browse/SR-3667
-            // swiftlint:disable force_cast
-            return CFCharacterSetIsSupersetOfSet(self as CFCharacterSet,
-                                                 (otherSet as NSCharacterSet).copy() as! CFCharacterSet)
-            // swiftlint:enable force_cast
+            return string.rangeOfCharacter(from: inverted) == nil
         #endif
     }
 }

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
@@ -21,6 +21,7 @@ extension CharacterSet {
         #else
             let otherSet = CharacterSet(charactersIn: string)
 
+            // workaround for https://bugs.swift.org/browse/SR-3667
             // swiftlint:disable force_cast
             return CFCharacterSetIsSupersetOfSet(self as CFCharacterSet,
                                                  (otherSet as NSCharacterSet).copy() as! CFCharacterSet)

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
@@ -20,7 +20,11 @@ extension CharacterSet {
             return true
         #else
             let otherSet = CharacterSet(charactersIn: string)
-            return isSuperset(of: otherSet)
+
+            // swiftlint:disable force_cast
+            return CFCharacterSetIsSupersetOfSet(self as CFCharacterSet,
+                                                 (otherSet as NSCharacterSet).copy() as! CFCharacterSet)
+            // swiftlint:enable force_cast
         #endif
     }
 }

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -166,7 +166,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
             return []
         }
 
-        if !CharacterSet.alphanumerics.isSuperset(ofCharactersIn: name) {
+        if !configuration.allowedCharacters.isSuperset(ofCharactersIn: name) {
             return [
                 StyleViolation(ruleDescription: type(of: self).description,
                                severity: .error,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -26,14 +26,26 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
         return min(maxLength.warning, maxLength.error ?? maxLength.warning)
     }
 
+    var allowedCharacters: CharacterSet {
+        guard !additionalAllowedCharacters.isEmpty else {
+            return CharacterSet.alphanumerics
+        }
+
+        return CharacterSet.alphanumerics.union(CharacterSet(charactersIn: self.additionalAllowedCharacters))
+    }
+
+    private var additionalAllowedCharacters: String = ""
+
     public init(minLengthWarning: Int,
                 minLengthError: Int,
                 maxLengthWarning: Int,
                 maxLengthError: Int,
-                excluded: [String] = []) {
+                excluded: [String] = [],
+                additionalAllowedCharacters: String = "") {
         minLength = SeverityLevelsConfiguration(warning: minLengthWarning, error: minLengthError)
         maxLength = SeverityLevelsConfiguration(warning: maxLengthWarning, error: maxLengthError)
         self.excluded = Set(excluded)
+        self.additionalAllowedCharacters = additionalAllowedCharacters
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -49,6 +61,9 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
         }
         if let excluded = [String].array(of: configurationDict["excluded"]) {
             self.excluded = Set(excluded)
+        }
+        if let additionalAllowedCharacters = configurationDict["additional_allowed_characters"] as? String {
+            self.additionalAllowedCharacters = additionalAllowedCharacters
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -31,10 +31,10 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
             return CharacterSet.alphanumerics
         }
 
-        return CharacterSet.alphanumerics.union(CharacterSet(charactersIn: self.additionalAllowedCharacters))
+        return CharacterSet.alphanumerics.union(CharacterSet(charactersIn: additionalAllowedCharacters))
     }
 
-    private var additionalAllowedCharacters: String = ""
+    private var additionalAllowedCharacters = ""
 
     public init(minLengthWarning: Int,
                 minLengthError: Int,

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -82,7 +82,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         let name = name.nameStrippingLeadingUnderscoreIfPrivate(dictionary)
-        if !CharacterSet.alphanumerics.isSuperset(ofCharactersIn: name) {
+        if !configuration.allowedCharacters.isSuperset(ofCharactersIn: name) {
             return [StyleViolation(ruleDescription: type(of: self).description,
                severity: .error,
                location: Location(file: file, byteOffset: offset),

--- a/Source/SwiftLintFramework/Rules/VariableNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/VariableNameRule.swift
@@ -74,7 +74,7 @@ public struct VariableNameRule: ASTRule, ConfigurationProviderRule {
             }
 
             let description = type(of: self).description
-            if !CharacterSet.alphanumerics.isSuperset(ofCharactersIn: name) {
+            if !configuration.allowedCharacters.isSuperset(ofCharactersIn: name) {
                 return [StyleViolation(ruleDescription: description,
                     severity: .error,
                     location: Location(file: file, byteOffset: offset),

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		009E09281DFEE4C200B588A7 /* ProhibitedSuperRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009E09271DFEE4C200B588A7 /* ProhibitedSuperRule.swift */; };
 		009E092A1DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009E09291DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift */; };
 		00B8D9791E2D1223004E0EEC /* LegacyConstantRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */; };
+		00ACCEA11E2F7294008574FE /* VariableNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00ACCEA01E2F7294008574FE /* VariableNameRuleTests.swift */; };
+		00FBB4821E2F8A530067464A /* TypeNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FBB4811E2F8A530067464A /* TypeNameRuleTests.swift */; };
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
 		094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094384FF1D5D2382009168CF /* WeakDelegateRule.swift */; };
 		094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094385021D5D4F78009168CF /* PrivateOutletRule.swift */; };
@@ -267,6 +269,8 @@
 		009E09271DFEE4C200B588A7 /* ProhibitedSuperRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProhibitedSuperRule.swift; sourceTree = "<group>"; };
 		009E09291DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProhibitedSuperConfiguration.swift; sourceTree = "<group>"; };
 		00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRuleExamples.swift; sourceTree = "<group>"; };
+		00ACCEA01E2F7294008574FE /* VariableNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableNameRuleTests.swift; sourceTree = "<group>"; };
+		00FBB4811E2F8A530067464A /* TypeNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRuleTests.swift; sourceTree = "<group>"; };
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
 		094384FF1D5D2382009168CF /* WeakDelegateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
 		094385021D5D4F78009168CF /* PrivateOutletRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
@@ -737,6 +741,8 @@
 				6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */,
 				D46202201E16002A0027AAD1 /* Swift2RulesTests.swift */,
 				C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */,
+				00FBB4811E2F8A530067464A /* TypeNameRuleTests.swift */,
+				00ACCEA01E2F7294008574FE /* VariableNameRuleTests.swift */,
 				006204DD1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift */,
 			);
 			name = SwiftLintFrameworkTests;
@@ -1300,6 +1306,7 @@
 				E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */,
 				D4C27C001E12DFF500DF713E /* LinterCacheTests.swift in Sources */,
 				D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */,
+				00FBB4821E2F8A530067464A /* TypeNameRuleTests.swift in Sources */,
 				006204DE1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift in Sources */,
 				02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */,
 				D4CA758F1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift in Sources */,
@@ -1312,6 +1319,7 @@
 				D43B04661E071ED3004016AF /* ColonRuleTests.swift in Sources */,
 				3B12C9C71C3361CB000B423F /* RuleTests.swift in Sources */,
 				3B30C4A11C3785B300E04027 /* YamlParserTests.swift in Sources */,
+				00ACCEA11E2F7294008574FE /* VariableNameRuleTests.swift in Sources */,
 				D4998DE71DF191380006E05D /* AttributesRuleTests.swift in Sources */,
 				E88198631BEA9A5400333A11 /* RulesTests.swift in Sources */,
 				D46202211E16002A0027AAD1 /* Swift2RulesTests.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -12,8 +12,9 @@
 		006ECFC41C44E99E00EF6364 /* LegacyConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */; };
 		009E09281DFEE4C200B588A7 /* ProhibitedSuperRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009E09271DFEE4C200B588A7 /* ProhibitedSuperRule.swift */; };
 		009E092A1DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009E09291DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift */; };
-		00B8D9791E2D1223004E0EEC /* LegacyConstantRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */; };
 		00ACCEA11E2F7294008574FE /* VariableNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00ACCEA01E2F7294008574FE /* VariableNameRuleTests.swift */; };
+		00B8D9791E2D1223004E0EEC /* LegacyConstantRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */; };
+		00C4086E1E3207990021ADED /* GenericTypeNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C4086D1E3207990021ADED /* GenericTypeNameRuleTests.swift */; };
 		00FBB4821E2F8A530067464A /* TypeNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FBB4811E2F8A530067464A /* TypeNameRuleTests.swift */; };
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
 		094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094384FF1D5D2382009168CF /* WeakDelegateRule.swift */; };
@@ -268,8 +269,9 @@
 		006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRule.swift; sourceTree = "<group>"; };
 		009E09271DFEE4C200B588A7 /* ProhibitedSuperRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProhibitedSuperRule.swift; sourceTree = "<group>"; };
 		009E09291DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProhibitedSuperConfiguration.swift; sourceTree = "<group>"; };
-		00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRuleExamples.swift; sourceTree = "<group>"; };
 		00ACCEA01E2F7294008574FE /* VariableNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableNameRuleTests.swift; sourceTree = "<group>"; };
+		00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRuleExamples.swift; sourceTree = "<group>"; };
+		00C4086D1E3207990021ADED /* GenericTypeNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericTypeNameRuleTests.swift; sourceTree = "<group>"; };
 		00FBB4811E2F8A530067464A /* TypeNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRuleTests.swift; sourceTree = "<group>"; };
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
 		094384FF1D5D2382009168CF /* WeakDelegateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
@@ -726,6 +728,7 @@
 				02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */,
 				D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */,
 				D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */,
+				00C4086D1E3207990021ADED /* GenericTypeNameRuleTests.swift */,
 				3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */,
 				3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */,
 				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
@@ -1314,6 +1317,7 @@
 				3B63D46D1E1F05160057BE35 /* LineLengthConfigurationTests.swift in Sources */,
 				6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */,
 				3BB47D871C51DE6E00AE6A10 /* CustomRulesTests.swift in Sources */,
+				00C4086E1E3207990021ADED /* GenericTypeNameRuleTests.swift in Sources */,
 				E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */,
 				E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */,
 				D43B04661E071ED3004016AF /* ColonRuleTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -17,6 +17,7 @@ XCTMain([
     testCase(ExtendedNSStringTests.allTests),
     testCase(FileHeaderRuleTests.allTests),
     testCase(FunctionBodyLengthRuleTests.allTests),
+    testCase(GenericTypeNameRuleTests.allTests),
     testCase(IntegrationTests.allTests),
     testCase(LineLengthConfigurationTests.allTests),
     testCase(LineLengthRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -28,6 +28,8 @@ XCTMain([
     testCase(RuleTests.allTests),
     testCase(SourceKitCrashTests.allTests),
     testCase(TrailingCommaRuleTests.allTests),
+    testCase(TypeNameRuleTests.allTests),
+    testCase(VariableNameRuleTests.allTests),
     testCase(VerticalWhitespaceRuleTests.allTests),
     testCase(YamlParserTests.allTests),
     testCase(YamlSwiftLintTests.allTests)

--- a/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
@@ -1,0 +1,47 @@
+//
+//  GenericTypeNameRuleTests.swift
+//  SwiftLint
+//
+//  Created by Aaron McTavish on 01/20/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+@testable import SwiftLintFramework
+import XCTest
+
+class GenericTypeNameRuleTests: XCTestCase {
+
+    func testGenericTypeNameWithDefaultConfiguration() {
+        // Test with default parameters
+        verifyRule(GenericTypeNameRule.description)
+    }
+
+    func testGenericTypeNameWithAdditionalAllowedCharacters() {
+        // Test with custom `additional_allowed_characters`
+        let genericTypeNameDescription = RuleDescription(
+            identifier: GenericTypeNameRule.description.identifier,
+            name: GenericTypeNameRule.description.name,
+            description: GenericTypeNameRule.description.description,
+            nonTriggeringExamples: [
+                "func foo<T_Foo>() {}\n"
+            ],
+            triggeringExamples: [
+                "func foo<↓T🤣Foo>() {}\n"
+            ]
+        )
+
+        verifyRule(genericTypeNameDescription,
+                   ruleConfiguration: ["min_length": ["warning": 3, "error": 2],
+                                       "max_length": ["warning": 40, "error": 60],
+                                       "additional_allowed_characters": "_"])
+    }
+}
+
+extension GenericTypeNameRuleTests {
+    static var allTests: [(String, (GenericTypeNameRuleTests) -> () throws -> Void)] {
+        return [
+            ("testGenericTypeNameWithDefaultConfiguration", testGenericTypeNameWithDefaultConfiguration),
+            ("testGenericTypeNameWithAdditionalAllowedCharacters", testGenericTypeNameWithAdditionalAllowedCharacters)
+        ]
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -105,10 +105,6 @@ class RulesTests: XCTestCase {
         verifyRule(FunctionParameterCountRule.description)
     }
 
-    func testGenericTypeName() {
-        verifyRule(GenericTypeNameRule.description)
-    }
-
     func testImplicitGetter() {
         verifyRule(ImplicitGetterRule.description)
     }
@@ -362,7 +358,6 @@ extension RulesTests {
             // ("testForceUnwrapping", testForceUnwrapping),
             ("testFunctionBodyLength", testFunctionBodyLength),
             ("testFunctionParameterCount", testFunctionParameterCount),
-            ("testGenericTypeName", testGenericTypeName),
             ("testImplicitGetter", testImplicitGetter),
             ("testLargeTuple", testLargeTuple),
             ("testLeadingWhitespace", testLeadingWhitespace),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -296,10 +296,6 @@ class RulesTests: XCTestCase {
         verifyRule(TypeBodyLengthRule.description)
     }
 
-    func testTypeName() {
-        verifyRule(TypeNameRule.description)
-    }
-
     func testUnusedClosureParameter() {
         verifyRule(UnusedClosureParameterRule.description)
     }
@@ -320,10 +316,6 @@ class RulesTests: XCTestCase {
 
     func testValidIBInspectable() {
         verifyRule(ValidIBInspectableRule.description)
-    }
-
-    func testVariableName() {
-        verifyRule(VariableNameRule.description)
     }
 
     func testVerticalParameterAlignment() {
@@ -405,12 +397,10 @@ extension RulesTests {
             ("testTrailingSemicolon", testTrailingSemicolon),
             ("testTrailingWhitespace", testTrailingWhitespace),
             ("testTypeBodyLength", testTypeBodyLength),
-            ("testTypeName", testTypeName),
             ("testUnusedClosureParameter", testUnusedClosureParameter),
             ("testUnusedEnumerated", testUnusedEnumerated),
             ("testUnusedOptionalBinding", testUnusedOptionalBinding),
             ("testValidIBInspectable", testValidIBInspectable),
-            ("testVariableName", testVariableName),
             ("VerticalParameterAlignment", testVerticalParameterAlignment),
             ("testVoidReturn", testVoidReturn),
             ("testSuperCall", testSuperCall),

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -1,0 +1,47 @@
+//
+//  TypeNameRuleTests.swift
+//  SwiftLint
+//
+//  Created by Aaron McTavish on 01/18/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+@testable import SwiftLintFramework
+import XCTest
+
+class TypeNameRuleTests: XCTestCase {
+
+    func testTypeNameWithDefaultConfiguration() {
+        // Test with default parameters
+        verifyRule(VariableNameRule.description)
+    }
+
+    func testTypeNameWithAdditionalAllowedCharacters() {
+        // Test with custom `additional_allowed_characters`
+        let typeNameDescription = RuleDescription(
+            identifier: TypeNameRule.description.identifier,
+            name: TypeNameRule.description.name,
+            description: TypeNameRule.description.description,
+            nonTriggeringExamples: [
+                "protocol m_Foo {\n associatedtype Bar\n }"
+            ],
+            triggeringExamples: [
+                "private typealias ↓Foo😎Bar = Void"
+            ]
+        )
+
+        verifyRule(typeNameDescription,
+                   ruleConfiguration: ["min_length": ["warning": 3, "error": 0],
+                                       "max_length": ["warning": 40, "error": 1_000],
+                                       "additional_allowed_characters": "_"])
+    }
+}
+
+extension TypeNameRuleTests {
+    static var allTests: [(String, (TypeNameRuleTests) -> () throws -> Void)] {
+        return [
+            ("testTypeNameWithDefaultConfiguration", testTypeNameWithDefaultConfiguration),
+            ("testTypeNameWithAdditionalAllowedCharacters", testTypeNameWithAdditionalAllowedCharacters)
+        ]
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -32,7 +32,7 @@ class TypeNameRuleTests: XCTestCase {
 
         verifyRule(typeNameDescription,
                    ruleConfiguration: ["min_length": ["warning": 3, "error": 0],
-                                       "max_length": ["warning": 40, "error": 1_000],
+                                       "max_length": ["warning": 40, "error": 1000],
                                        "additional_allowed_characters": "_"])
     }
 }

--- a/Tests/SwiftLintFrameworkTests/VariableNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VariableNameRuleTests.swift
@@ -1,0 +1,47 @@
+//
+//  VariableNameRuleTests.swift
+//  SwiftLint
+//
+//  Created by Aaron McTavish on 01/18/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+@testable import SwiftLintFramework
+import XCTest
+
+class VariableNameRuleTests: XCTestCase {
+
+    func testVariableNameWithDefaultConfiguration() {
+        // Test with default parameters
+        verifyRule(VariableNameRule.description)
+    }
+
+    func testVariableNameWithAdditionalAllowedCharacters() {
+        // Test with custom `additional_allowed_characters`
+        let variableNameDescription = RuleDescription(
+            identifier: VariableNameRule.description.identifier,
+            name: VariableNameRule.description.name,
+            description: VariableNameRule.description.description,
+            nonTriggeringExamples: [
+                "let m_myLet = 0"
+            ],
+            triggeringExamples: [
+                "↓let 😇😂😎 = 0"
+            ]
+        )
+
+        verifyRule(variableNameDescription,
+                   ruleConfiguration: ["min_length": ["warning": 3, "error": 2],
+                                       "max_length": ["warning": 40, "error": 60],
+                                       "additional_allowed_characters": "_"])
+    }
+}
+
+extension VariableNameRuleTests {
+    static var allTests: [(String, (VariableNameRuleTests) -> () throws -> Void)] {
+        return [
+            ("testVariableNameWithDefaultConfiguration", testVariableNameWithDefaultConfiguration),
+            ("testVariableNameWithAdditionalAllowedCharacters", testVariableNameWithAdditionalAllowedCharacters)
+        ]
+    }
+}


### PR DESCRIPTION
Resolves #628 `Allow '_' both in variable names and type names`.

### Summary
- Adds `additional_allowed_characters` for name rule configuration (used by both `variable_name` and `type_name` rules)
- Adjusted `CharacterSet.isSuperset(ofCharactersIn:)` to use CoreFoundation directly to work around crash. Still working on isolated this as an example to file a Swift bug report. May be a regression of https://bugs.swift.org/browse/SR-2307