### PR TITLE
Fix bool negation false positive for force_unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1234](https://github.com/realm/SwiftLint/issues/1234)
 
+* Fix `force_unwrap` false positive for bool negation.  
+  [Aaron McTavish](https://github.com/aamctustwo)
+  [#918](https://github.com/realm/SwiftLint/issues/918)
+
 ## 0.16.1: Commutative Fabric Sheets
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -31,7 +31,8 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
                 "navigationBarHidden, animated: true)",
             "if addedToPlaylist && (!self.selectedFilters.isEmpty || " +
                 "self.searchBar?.text?.isEmpty == false) {}",
-            "print(\"\\(xVar)!\")"
+            "print(\"\\(xVar)!\")",
+            "var test = (!bar)"
         ],
         triggeringExamples: [
             "let url = NSURL(string: query)↓!",
@@ -53,7 +54,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
 
     // capture previous and next of "!"
     // http://userguide.icu-project.org/strings/regexp
-    private static let pattern = "(\\S)(!)(.?)"
+    private static let pattern = "([^\\s\\p{Ps}])(!)(.?)"
 
     private static let regularExpression = regex(pattern, options: [.dotMatchesLineSeparators])
     private static let excludingSyntaxKindsForFirstCapture = SyntaxKind


### PR DESCRIPTION
Resolves #918 `force_unwrapping: false positive when using ! as boolean
operator`.