### PR TITLE
Lowercase imports before sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#663](https://github.com/realm/SwiftLint/issues/663)
 
+* Fix `sorted_imports` rule to sort ignoring case.  
+  [Keith Smiley](https://github.com/keith)
+  [#1185](https://github.com/realm/SwiftLint/issues/1185)
+
 ##### Enhancements
 
 * Performance improvements to `generic_type_name`,

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -19,7 +19,9 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
         name: "Sorted Imports",
         description: "Imports should be sorted.",
         nonTriggeringExamples: [
-            "import AAA\nimport BBB\nimport CCC\nimport DDD"
+            "import AAA\nimport BBB\nimport CCC\nimport DDD",
+            "import Alamofire\nimport API",
+            "import labc\nimport Ldef"
         ],
         triggeringExamples: [
             "import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC"
@@ -35,7 +37,7 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
             let moduleRange = NSRange(location: range.location + importLength,
                                       length: range.length - importLength)
             let moduleName = contents.substring(with: moduleRange)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             let offset = NSMaxRange(range) - moduleName.bridge().length
             return (moduleName, offset)
         }


### PR DESCRIPTION
Currently if you have imports that differ in case, they are not sorted
as you would expect.

Fixes https://github.com/realm/SwiftLint/issues/1185