### PR TITLE
Performance improvements to generic_type_name rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Performance improvements to `generic_type_name` rule.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -76,7 +76,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func validateGenericTypeAliases(in file: File) -> [StyleViolation] {
-        let pattern = "typealias\\s+.+?" + genericTypePattern + "\\s*="
+        let pattern = "typealias\\s+\\w+?\\s*" + genericTypePattern + "\\s*="
         return file.match(pattern: pattern).flatMap { (range, tokens) -> [(String, Int)] in
             guard tokens.first == .keyword,
                 Set(tokens.dropFirst()) == [.identifier],


### PR DESCRIPTION
This simple regex change boosted the rule time from ~`0,500`s to ~`0,070`s on realm-cocoa.