### PR TITLE
Refactor SourceKit member access

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -10,6 +10,68 @@ import Foundation
 import SourceKittenFramework
 
 extension Dictionary where Key: ExpressibleByStringLiteral {
+
+    /// Accessibility.
+    var accessibility: String? {
+        return self["key.accessibility"] as? String
+    }
+    /// Body length.
+    var bodyLength: Int? {
+        return (self["key.bodylength"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Body offset.
+    var bodyOffset: Int? {
+        return (self["key.bodyoffset"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Kind.
+    var kind: String? {
+        return self["key.kind"] as? String
+    }
+    /// Length.
+    var length: Int? {
+        return (self["key.length"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Name.
+    var name: String? {
+        return self["key.name"] as? String
+    }
+    /// Name length.
+    var nameLength: Int? {
+        return (self["key.namelength"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Name offset.
+    var nameOffset: Int? {
+        return (self["key.nameoffset"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Offset.
+    var offset: Int? {
+        return (self["key.offset"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Setter accessibility.
+    var setterAccessibility: String? {
+        return self["key.setter_accessibility"] as? String
+    }
+    /// Type name.
+    var typeName: String? {
+        return self["key.typename"] as? String
+    }
+    /// Column where the token's declaration begins.
+    var docColumn: Int? {
+        return (self["key.doc.column"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Line where the token's declaration begins.
+    var docLine: Int? {
+        return (self["key.doc.line"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Parsed scope start.
+    var docType: Int? {
+        return (self["key.doc.type"] as? Int64).flatMap({ Int($0) })
+    }
+    /// Parsed scope start end.
+    var usr: Int? {
+        return (self["key.usr"] as? Int64).flatMap({ Int($0) })
+    }
+
     var enclosedSwiftAttributes: [String] {
         let array = self["key.attributes"] as? [SourceKitRepresentable] ?? []
         return array.flatMap { ($0 as? [String: String])?["key.attribute"] }
@@ -20,9 +82,14 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
         return substructure.flatMap { $0 as? [String: SourceKitRepresentable] }
     }
 
+    var elements: [[String: SourceKitRepresentable]]? {
+        let elements = self["key.elements"] as? [SourceKitRepresentable]
+        return elements?.flatMap { $0 as? [String: SourceKitRepresentable] }
+    }
+
     var enclosedVarParameters: [[String: SourceKitRepresentable]] {
         return substructure.flatMap { subDict -> [[String: SourceKitRepresentable]] in
-            guard let kindString = subDict["key.kind"] as? String else {
+            guard let kindString = subDict.kind else {
                 return []
             }
 
@@ -32,7 +99,7 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
                     // with Swift 2.3, a closure parameter is inside another .varParameter and not inside an .argument
                     let parameters = subDict.enclosedVarParameters + [subDict]
                     return parameters.filter {
-                        $0["key.typename"] != nil
+                        $0.typeName != nil
                     }
                 case .three:
                     return [subDict]
@@ -47,7 +114,7 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
 
     var enclosedArguments: [[String: SourceKitRepresentable]] {
         return substructure.flatMap { subDict -> [[String: SourceKitRepresentable]] in
-            guard let kindString = subDict["key.kind"] as? String else {
+            guard let kindString = subDict.kind else {
                 return []
             }
 
@@ -68,14 +135,14 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
 
     var inheritedTypes: [String] {
         let array = self["key.inheritedtypes"] as? [SourceKitRepresentable] ?? []
-        return array.flatMap { ($0 as? [String: String])?["key.name"] }
+        return array.flatMap { ($0 as? [String: String])?.name }
     }
 
     internal func extractCallsToSuper(methodName: String) -> [String] {
         let superCall = "super.\(methodName)"
         return substructure.flatMap { elems in
-            guard let type = (elems["key.kind"] as? String).flatMap({ SwiftExpressionKind(rawValue: $0) }),
-                let name = elems["key.name"] as? String,
+            guard let type = elems.kind.flatMap({ SwiftExpressionKind(rawValue: $0) }),
+                let name = elems.name,
                 type == .call && superCall.contains(name)
                 else { return nil }
             return name

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -56,14 +56,14 @@ private struct RebuildQueue {
         guard !queue.isEmpty else { return }
         let allDeclarationsByType = queue.flatMap { structure -> (String, [String])? in
             guard let firstSubstructureDict = structure.dictionary.substructure.first,
-                let name = firstSubstructureDict["key.name"] as? String,
-                let kind = (firstSubstructureDict["key.kind"] as? String).flatMap(SwiftDeclarationKind.init),
+                let name = firstSubstructureDict.name,
+                let kind = (firstSubstructureDict.kind).flatMap(SwiftDeclarationKind.init),
                 kind == .protocol,
                 case let substructure = firstSubstructureDict.substructure,
                 !substructure.isEmpty else {
                     return nil
             }
-            return (name, substructure.flatMap({ $0["key.name"] as? String }))
+            return (name, substructure.flatMap({ $0.name }))
         }
         allDeclarationsByType.forEach { self.allDeclarationsByType[$0.0] = $0.1 }
         queue.removeAll(keepingCapacity: false)

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -171,8 +171,8 @@ extension File {
 
     internal func validateVariableName(_ dictionary: [String: SourceKitRepresentable],
                                        kind: SwiftDeclarationKind) -> (name: String, offset: Int)? {
-        guard let name = dictionary["key.name"] as? String,
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+        guard let name = dictionary.name,
+            let offset = dictionary.offset,
             SwiftDeclarationKind.variableKinds().contains(kind) && !name.hasPrefix("$") else {
                 return nil
         }

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -31,7 +31,7 @@ extension String {
     }
 
     internal func nameStrippingLeadingUnderscoreIfPrivate(_ dict: [String: SourceKitRepresentable]) -> String {
-        if let aclString = dict["key.accessibility"] as? String,
+        if let aclString = dict.accessibility,
            let acl = AccessControlLevel(identifier: aclString),
             acl.isPrivate && characters.first == "_" {
             return substring(from: index(after: startIndex))

--- a/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
@@ -21,14 +21,12 @@ extension Structure {
 
         func parse(_ dictionary: [String: SourceKitRepresentable]) {
             guard let
-                offset = (dictionary["key.offset"] as? Int64).map({ Int($0) }),
-                let byteRange = (dictionary["key.length"] as? Int64)
-                    .map({ Int($0) })
-                    .map({ NSRange(location: offset, length: $0) }),
+                offset = dictionary.offset,
+                let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }),
                 NSLocationInRange(byteOffset, byteRange) else {
                     return
             }
-            if let kind = dictionary["key.kind"] as? String {
+            if let kind = dictionary.kind {
                 results.append((kind: kind, byteRange: byteRange))
             }
             dictionary.substructure.forEach(parse)

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -20,7 +20,7 @@ extension ASTRule where KindType.RawValue == String {
 
     public func validate(file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 let kind = KindType(rawValue: kindString) else {
                     return []
             }

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -62,9 +62,8 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
     private func validateTestableImport(file: File) -> [StyleViolation] {
         let pattern = "@testable[\n]+\\s*import"
         return file.match(pattern: pattern).flatMap { range, kinds -> StyleViolation? in
-            guard kinds.count == 2 &&
-                kinds.first == .attributeBuiltin && kinds.last == .keyword else {
-                    return nil
+            guard kinds == [.attributeBuiltin, .keyword] else {
+                return nil
             }
 
             let contents = file.contents.bridge()

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -83,7 +83,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         let attributes = parseAttributes(dictionary: dictionary)
 
         guard !attributes.isEmpty,
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let offset = dictionary.offset,
             let (line, _) = file.contents.bridge().lineAndCharacter(forByteOffset: offset) else {
             return []
         }
@@ -173,7 +173,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
     private func violation(dictionary: [String: SourceKitRepresentable],
                            file: File) -> [StyleViolation] {
         let location: Location
-        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+        if let offset = dictionary.offset {
             location = Location(file: file, byteOffset: offset)
         } else {
             location = Location(file: file.path)

--- a/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
@@ -40,7 +40,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
         }
 
         // Check if name contains "Delegate"
-        guard let name = (dictionary["key.name"] as? String), isDelegateProtocol(name) else {
+        guard let name = dictionary.name, isDelegateProtocol(name) else {
             return []
         }
 
@@ -58,10 +58,10 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
         }
 
         // Check if : class
-        guard let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
-            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
+        guard let offset = dictionary.offset,
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let bodyOffset = dictionary.bodyOffset,
             case let contents = file.contents.bridge(),
             case let start = nameOffset + nameLength,
             let range = contents.byteRangeToNSRange(start: start, length: bodyOffset - start),

--- a/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
@@ -52,11 +52,11 @@ public struct ClosureEndIndentationRule: ASTRule, OptInRule, ConfigurationProvid
         }
 
         let contents = file.contents.bridge()
-        guard let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
-            let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
+        guard let offset = dictionary.offset,
+            let length = dictionary.length,
+            let bodyLength = dictionary.bodyLength,
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
             bodyLength > 0,
             case let endOffset = offset + length - 1,
             contents.substringWithByteRange(start: endOffset, length: 1) == "}",
@@ -89,8 +89,8 @@ public struct ClosureEndIndentationRule: ASTRule, OptInRule, ConfigurationProvid
     }
 
     private func startOffset(forDictionary dictionary: [String: SourceKitRepresentable], file: File) -> Int? {
-        guard let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }) else {
+        guard let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength else {
             return nil
         }
 

--- a/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
@@ -56,9 +56,9 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
             return []
         }
 
-        guard let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
+        guard let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let bodyLength = dictionary.bodyLength,
             bodyLength > 0 else {
                 return []
         }
@@ -70,8 +70,7 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
         // parameters from inner closures are reported on the top-level one, so we can't just
         // use the first and last parameters to check, we need to check all of them
         return parameters.flatMap { param -> StyleViolation? in
-            guard let paramOffset = (param["key.offset"] as? Int64).flatMap({ Int($0) }),
-                paramOffset > rangeStart else {
+            guard let paramOffset = param.offset, paramOffset > rangeStart else {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -232,7 +232,7 @@ extension ColonRule {
         }
 
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 let kind = KindType(rawValue: kindString) else {
                     return []
             }
@@ -252,7 +252,7 @@ extension ColonRule {
         return ranges.filter {
             guard let colon = contents.substringWithByteRange(start: $0.location,
                                                               length: $0.length) else {
-                                                                return false
+                return false
             }
 
             if configuration.flexibleRightSpacing {
@@ -265,17 +265,16 @@ extension ColonRule {
     }
 
     private func colonRanges(dictionary: [String: SourceKitRepresentable]) -> [NSRange]? {
-        guard let elements = dictionary["key.elements"] as? [SourceKitRepresentable],
+        guard let elements = dictionary.elements,
             elements.count % 2 == 0 else {
                 return nil
         }
 
         let expectedKind = "source.lang.swift.structure.elem.expr"
-        let ranges: [NSRange] = elements.flatMap {
-            guard let subDict = $0 as? [String: SourceKitRepresentable],
-                subDict["key.kind"] as? String == expectedKind,
-                let offset = (subDict["key.offset"] as? Int64).map({ Int($0) }),
-                let length = (subDict["key.length"] as? Int64).map({ Int($0) }) else {
+        let ranges: [NSRange] = elements.flatMap { subDict in
+            guard subDict.kind == expectedKind,
+                let offset = subDict.offset,
+                let length = subDict.length else {
                     return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/CompilerProtocolInitRule.swift
@@ -40,17 +40,16 @@ public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
 
     private func violationRanges(in file: File, kind: SwiftExpressionKind,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        guard kind == .call,
-            let name = dictionary["key.name"] as? String else {
-                return []
+        guard kind == .call, let name = dictionary.name else {
+            return []
         }
 
         for compilerProtocol in ExpressibleByCompiler.allProtocols {
             guard compilerProtocol.initCallNames.contains(name),
-                case let arguments = dictionary.enclosedArguments.flatMap({ $0["key.name"] as? String }),
+                case let arguments = dictionary.enclosedArguments.flatMap({ $0.name }),
                 compilerProtocol.match(arguments: arguments),
-                let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-                let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
+                let offset = dictionary.offset,
+                let length = dictionary.length,
                 let range = file.contents.bridge().byteRangeToNSRange(start: offset, length: length) else {
                     continue
             }

--- a/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
@@ -47,7 +47,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
         let complexity = measureComplexity(in: file, dictionary: dictionary)
 
         for parameter in configuration.params where complexity > parameter.value {
-            let offset = Int(dictionary["key.offset"] as? Int64 ?? 0)
+            let offset = dictionary.offset ?? 0
             return [StyleViolation(ruleDescription: type(of: self).description,
                 severity: parameter.severity,
                 location: Location(file: file, byteOffset: offset),
@@ -62,7 +62,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
         var hasSwitchStatements = false
 
         let complexity = dictionary.substructure.reduce(0) { complexity, subDict in
-            guard let kind = subDict["key.kind"] as? String else {
+            guard let kind = subDict.kind else {
                 return complexity
             }
 
@@ -95,8 +95,8 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
 
     private func reduceSwitchComplexity(initialComplexity complexity: Int, file: File,
                                         dictionary: [String: SourceKitRepresentable]) -> Int {
-        let bodyOffset = Int(dictionary["key.bodyoffset"] as? Int64 ?? 0)
-        let bodyLength = Int(dictionary["key.bodylength"] as? Int64 ?? 0)
+        let bodyOffset = dictionary.bodyOffset ?? 0
+        let bodyLength = dictionary.bodyLength ?? 0
 
         let c = file.contents.bridge()
             .substringWithByteRange(start: bodyOffset, length: bodyLength) ?? ""

--- a/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
@@ -42,7 +42,7 @@ public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule {
             case let attributes = dictionary.enclosedSwiftAttributes,
             attributes.contains("source.decl.attribute.dynamic"),
             attributes.contains("source.decl.attribute.inline"),
-            let funcByteOffset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let funcByteOffset = dictionary.offset,
             let funcOffset = file.contents.bridge()
                 .byteRangeToNSRange(start: funcByteOffset, length: 0)?.location,
             case let inlinePattern = regex("@inline"),

--- a/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
@@ -62,11 +62,11 @@ public struct EmptyParenthesesWithTrailingClosureRule: ASTRule, CorrectableRule,
             return []
         }
 
-        guard let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
-            let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
+        guard let offset = dictionary.offset,
+            let length = dictionary.length,
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let bodyLength = dictionary.bodyLength,
             bodyLength > 0 else {
                 return []
         }
@@ -86,7 +86,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: ASTRule, CorrectableRule,
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 let kind = SwiftExpressionKind(rawValue: kindString) else {
                     return []
             }

--- a/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
@@ -57,18 +57,18 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
         let length = ".init".utf8.count
 
         guard kind == .call,
-            let name = dictionary["key.name"] as? String, isExpected(name),
-            let nameOffset = dictionary["key.nameoffset"] as? Int64,
-            let nameLength = dictionary["key.namelength"] as? Int64,
+            let name = dictionary.name, isExpected(name),
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
             let range = file.contents.bridge()
-                .byteRangeToNSRange(start: Int(nameOffset + nameLength) - length, length: length)
+                .byteRangeToNSRange(start: nameOffset + nameLength - length, length: length)
             else { return [] }
         return [range]
     }
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 let kind = SwiftExpressionKind(rawValue: kindString) else {
                     return []
             }

--- a/Source/SwiftLintFramework/Rules/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/FirstWhereRule.swift
@@ -49,7 +49,7 @@ public struct FirstWhereRule: OptInRule, ConfigurationProviderRule {
 
             return methodCall(forByteOffset: bodyByteRange.location - 1, excludingOffset: firstByteRange.location,
                               dictionary: structure.dictionary, predicate: { dictionary in
-                guard let name = dictionary["key.name"] as? String else {
+                guard let name = dictionary.name else {
                     return false
                 }
 
@@ -68,11 +68,11 @@ public struct FirstWhereRule: OptInRule, ConfigurationProviderRule {
                             dictionary: [String: SourceKitRepresentable],
                             predicate: ([String: SourceKitRepresentable]) -> Bool) -> Int? {
 
-        if let kindString = (dictionary["key.kind"] as? String),
+        if let kindString = (dictionary.kind),
             SwiftExpressionKind(rawValue: kindString) == .call,
-            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+            let bodyOffset = dictionary.bodyOffset,
+            let bodyLength = dictionary.bodyLength,
+            let offset = dictionary.offset {
             let byteRange = NSRange(location: bodyOffset, length: bodyLength)
 
             if NSLocationInRange(byteOffset, byteRange) &&

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -22,9 +22,9 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds().contains(kind),
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
+            let offset = dictionary.offset,
+            let bodyOffset = dictionary.bodyOffset,
+            let bodyLength = dictionary.bodyLength,
             case let contentsNSString = file.contents.bridge(),
             let startLine = contentsNSString.lineAndCharacter(forByteOffset: bodyOffset)?.line,
             let endLine = contentsNSString.lineAndCharacter(forByteOffset: bodyOffset + bodyLength)?.line

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -46,8 +46,8 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
             return []
         }
 
-        let nameOffset = Int(dictionary["key.nameoffset"] as? Int64 ?? 0)
-        let length = Int(dictionary["key.namelength"] as? Int64 ?? 0)
+        let nameOffset = dictionary.nameOffset ?? 0
+        let length = dictionary.nameLength ?? 0
 
         if functionIsInitializer(file: file, byteOffset: nameOffset, byteLength: length) {
             return []
@@ -65,7 +65,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
             defaultFunctionParameterCount(file: file, byteOffset: nameOffset, byteLength: length)
 
         for parameter in configuration.params where parameterCount > parameter.value {
-            let offset = Int(dictionary["key.offset"] as? Int64 ?? 0)
+            let offset = dictionary.offset ?? 0
             return [StyleViolation(ruleDescription: type(of: self).description,
                 severity: parameter.severity,
                 location: Location(file: file, byteOffset: offset),
@@ -80,12 +80,12 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
                                                offset: Int, length: Int) -> Int {
         var parameterCount = 0
         for subDict in structure {
-            guard let key = subDict["key.kind"] as? String,
-                let parameterOffset = subDict["key.offset"] as? Int64 else {
+            guard let key = subDict.kind,
+                let parameterOffset = subDict.offset else {
                     continue
             }
 
-            guard offset..<(offset + length) ~= Int(parameterOffset) else {
+            guard offset..<(offset + length) ~= parameterOffset else {
                 return parameterCount
             }
 

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -93,9 +93,9 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
     private func genericTypesForType(in file: File, kind: SwiftDeclarationKind,
                                      dictionary: [String: SourceKitRepresentable]) -> [(String, Int)] {
         guard SwiftDeclarationKind.typeKinds().contains(kind),
-            let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
-            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let bodyOffset = dictionary.bodyOffset,
             case let contents = file.contents.bridge(),
             case let start = nameOffset + nameLength,
             case let length = bodyOffset - start,
@@ -111,8 +111,8 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
     private func genericTypesForFunction(in file: File, kind: SwiftDeclarationKind,
                                          dictionary: [String: SourceKitRepresentable]) -> [(String, Int)] {
         guard SwiftDeclarationKind.functionKinds().contains(kind),
-            let offset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let length = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
+            let offset = dictionary.nameOffset,
+            let length = dictionary.nameLength,
             case let contents = file.contents.bridge(),
             let range = contents.byteRangeToNSRange(start: offset, length: length),
             let match = genericTypeRegex.firstMatch(in: file.contents, options: [], range: range)?.rangeAt(1),
@@ -126,8 +126,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
 
     private func minParameterOffset(parameters: [[String: SourceKitRepresentable]], file: File) -> Int {
         let offsets = parameters.flatMap { param -> Int? in
-            let offset = (param["key.offset"] as? Int64).flatMap { Int($0) }
-            return offset.flatMap {
+            return param.offset.flatMap {
                 file.contents.bridge().byteRangeToNSRange(start: $0, length: 0)?.location
             }
         }

--- a/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
@@ -69,7 +69,7 @@ public struct ImplicitGetterRule: Rule, ConfigurationProviderRule {
             }
 
             // If there's a setter, `get` is allowed
-            return dict["key.setter_accessibility"] == nil
+            return dict.setterAccessibility == nil
         }
 
         return violatingTokens.map { token in
@@ -93,10 +93,10 @@ public struct ImplicitGetterRule: Rule, ConfigurationProviderRule {
 
             // Only accepts variable declarations which contains a body and contains the
             // searched byteOffset
-            if let kindString = (dictionary["key.kind"] as? String),
+            if let kindString = (dictionary.kind),
                 let kind = SwiftDeclarationKind(rawValue: kindString),
-                let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
-                let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
+                let bodyOffset = dictionary.bodyOffset,
+                let bodyLength = dictionary.bodyLength,
                 allowedKinds.contains(kind) {
                 let byteRange = NSRange(location: bodyOffset, length: bodyLength)
 
@@ -117,7 +117,7 @@ public struct ImplicitGetterRule: Rule, ConfigurationProviderRule {
             ] + allowedKinds
 
             for dictionary in dictionary.substructure {
-                if let kindString = (dictionary["key.kind"] as? String),
+                if let kindString = (dictionary.kind),
                     let kind = SwiftDeclarationKind(rawValue: kindString),
                     typeKinds.contains(kind) {
                     parse(dictionary: dictionary)

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -72,8 +72,8 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
                                           kind: SwiftDeclarationKind) -> [(offset: Int, size: Int)] {
         let kinds = SwiftDeclarationKind.variableKinds().filter { $0 != .varLocal }
         guard kinds.contains(kind),
-            let type = dictionary["key.typename"] as? String,
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let type = dictionary.typeName,
+            let offset = dictionary.offset,
             let ranges = try? parenthesesRanges(in: type) else {
                 return []
         }
@@ -122,15 +122,15 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func returnRangeForFunction(dictionary: [String: SourceKitRepresentable]) -> NSRange? {
-        guard let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
-            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) else {
+        guard let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let length = dictionary.length,
+            let offset = dictionary.offset else {
                 return nil
         }
 
         let start = nameOffset + nameLength
-        let end = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }) ?? length + offset
+        let end = dictionary.bodyOffset ?? length + offset
 
         guard end - start > 0 else {
             return nil

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -31,23 +31,23 @@ extension File {
         if declarationOverrides(in: dictionary) {
             return []
         }
-        if let name = dictionary["key.name"] as? String, skipping.contains(name) {
+        if let name = dictionary.name, skipping.contains(name) {
             return []
         }
         let inherited = inheritedMembers(for: dictionary)
         let substructureOffsets = dictionary.substructure.flatMap {
             missingDocOffsets(in: $0, acl: acl, skipping: inherited)
         }
-        guard (dictionary["key.kind"] as? String).flatMap(SwiftDeclarationKind.init) != nil,
-            let offset = dictionary["key.offset"] as? Int64,
-            let accessibility = dictionary["key.accessibility"] as? String,
+        guard (dictionary.kind).flatMap(SwiftDeclarationKind.init) != nil,
+            let offset = dictionary.offset,
+            let accessibility = dictionary.accessibility,
             acl.map({ $0.rawValue }).contains(accessibility) else {
                 return substructureOffsets
         }
         if parseDocumentationCommentBody(dictionary, syntaxMap: syntaxMap) != nil {
             return substructureOffsets
         }
-        return substructureOffsets + [Int(offset)]
+        return substructureOffsets + [offset]
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -41,7 +41,7 @@ public struct NestingRule: ASTRule, ConfigurationProviderRule {
                           level: Int) -> [StyleViolation] {
         var violations = [StyleViolation]()
         let typeKinds = SwiftDeclarationKind.typeKinds()
-        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+        if let offset = dictionary.offset {
             if level > 1 && typeKinds.contains(kind) {
                 violations.append(StyleViolation(ruleDescription: type(of: self).description,
                     severity: configuration.severity,
@@ -55,7 +55,7 @@ public struct NestingRule: ASTRule, ConfigurationProviderRule {
             }
         }
         violations.append(contentsOf: dictionary.substructure.flatMap { subDict in
-            if let kind = (subDict["key.kind"] as? String).flatMap(SwiftDeclarationKind.init) {
+            if let kind = (subDict.kind).flatMap(SwiftDeclarationKind.init) {
                 return (kind, subDict)
             }
             return nil

--- a/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
@@ -62,8 +62,8 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard let offset = dictionary["key.bodyoffset"] as? Int64,
-            let name = dictionary["key.name"] as? String,
+        guard let offset = dictionary.bodyOffset,
+            let name = dictionary.name,
             kind == .functionMethodInstance,
             configuration.resolvedMethodNames.contains(name),
             dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.override")
@@ -74,12 +74,12 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
         if callsToSuper.isEmpty {
             return [StyleViolation(ruleDescription: type(of: self).description,
                 severity: configuration.severity,
-                location: Location(file: file, byteOffset: Int(offset)),
+                location: Location(file: file, byteOffset: offset),
                 reason: "Method '\(name)' should call to super function")]
         } else if callsToSuper.count > 1 {
             return [StyleViolation(ruleDescription: type(of: self).description,
                 severity: configuration.severity,
-                location: Location(file: file, byteOffset: Int(offset)),
+                location: Location(file: file, byteOffset: offset),
                 reason: "Method '\(name)' should call to super only once")]
         }
         return []

--- a/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
@@ -42,11 +42,8 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
         guard isOutlet else { return [] }
 
         // Check if private
-        let accessibility = dictionary["key.accessibility"] as? String
-        let setterAccessiblity = dictionary["key.setter_accessibility"] as? String
-
-        let isPrivate = isPrivateLevel(identifier: accessibility)
-        let isPrivateSet = isPrivateLevel(identifier: setterAccessiblity)
+        let isPrivate = isPrivateLevel(identifier: dictionary.accessibility)
+        let isPrivateSet = isPrivateLevel(identifier: dictionary.setterAccessibility)
 
         if isPrivate || (configuration.allowPrivateSet && isPrivateSet) {
             return []
@@ -54,7 +51,7 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
         // Violation found!
         let location: Location
-        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+        if let offset = dictionary.offset {
             location = Location(file: file, byteOffset: offset)
         } else {
             location = Location(file: file.path)

--- a/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 
 private extension AccessControlLevel {
     init?(_ dictionary: [String: SourceKitRepresentable]) {
-        guard let accessibility = dictionary["key.accessibility"] as? String,
+        guard let accessibility = dictionary.accessibility,
             let acl = AccessControlLevel(rawValue: accessibility) else { return nil }
         self = acl
     }
@@ -19,7 +19,7 @@ private extension AccessControlLevel {
 
 private extension Dictionary where Key: ExpressibleByStringLiteral {
     var superclass: String? {
-        guard let kindString = self["key.kind"] as? String,
+        guard let kindString = self.kind,
             let kind = SwiftDeclarationKind(rawValue: kindString), kind == .class,
             let className = inheritedTypes.first else { return nil }
         return className
@@ -115,7 +115,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
         guard classViolations.isEmpty else { return classViolations }
 
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 let kind = KindType(rawValue: kindString), kind == .functionMethodInstance else {
                     return []
             }
@@ -134,7 +134,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
     private func validateFunction(file: File, kind: SwiftDeclarationKind,
                                   dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         assert(kind == .functionMethodInstance)
-        guard let name = dictionary["key.name"] as? String, name.hasPrefix("test") else {
+        guard let name = dictionary.name, name.hasPrefix("test") else {
             return []
         }
         return validateAccessControlLevel(file: file, dictionary: dictionary)
@@ -143,7 +143,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
     private func validateAccessControlLevel(file: File,
                                             dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         guard let acl = AccessControlLevel(dictionary), acl.isPrivate else { return [] }
-        let offset = Int(dictionary["key.offset"] as? Int64 ?? 0)
+        let offset = dictionary.offset ?? 0
         return [StyleViolation(ruleDescription: type(of: self).description,
                                severity: configuration.severityConfiguration.severity,
                                location: Location(file: file, byteOffset: offset),

--- a/Source/SwiftLintFramework/Rules/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/ProhibitedSuperRule.swift
@@ -53,8 +53,8 @@ public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard let offset = dictionary["key.bodyoffset"] as? Int64,
-            let name = dictionary["key.name"] as? String,
+        guard let offset = dictionary.bodyOffset,
+            let name = dictionary.name,
             kind == .functionMethodInstance,
             configuration.resolvedMethodNames.contains(name),
             dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.override"),
@@ -63,7 +63,7 @@ public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule
 
         return [StyleViolation(ruleDescription: type(of: self).description,
                                severity: configuration.severity,
-                               location: Location(file: file, byteOffset: Int(offset)),
+                               location: Location(file: file, byteOffset: offset),
                                reason: "Method '\(name)' should not call to super function")]
     }
 }

--- a/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
@@ -66,8 +66,8 @@ public struct RedundantOptionalInitializationRule: ASTRule, CorrectableRule, Con
     private func violationRanges(in file: File, kind: SwiftDeclarationKind,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         guard SwiftDeclarationKind.variableKinds().contains(kind),
-            dictionary["key.setter_accessibility"] != nil,
-            let type = dictionary["key.typename"] as? String,
+            dictionary.setterAccessibility != nil,
+            let type = dictionary.typeName,
             typeIsOptional(type),
             let range = range(for: dictionary, file: file),
             let match = file.match(pattern: pattern, with: [.keyword], range: range).first,
@@ -79,13 +79,13 @@ public struct RedundantOptionalInitializationRule: ASTRule, CorrectableRule, Con
     }
 
     private func range(for dictionary: [String: SourceKitRepresentable], file: File) -> NSRange? {
-        guard let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }) else {
+        guard let offset = dictionary.offset,
+            let length = dictionary.length else {
                 return nil
         }
 
         let contents = file.contents.bridge()
-        if let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }) {
+        if let bodyOffset = dictionary.bodyOffset {
             return contents.byteRangeToNSRange(start: offset, length: bodyOffset - offset)
         } else {
             return contents.byteRangeToNSRange(start: offset, length: length)
@@ -94,7 +94,7 @@ public struct RedundantOptionalInitializationRule: ASTRule, CorrectableRule, Con
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 let kind = SwiftDeclarationKind(rawValue: kindString) else {
                     return []
             }

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -55,12 +55,12 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
     private func violationRanges(in file: File, kind: SwiftDeclarationKind,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         guard SwiftDeclarationKind.functionKinds().contains(kind),
-            let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
-            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let length = dictionary.length,
+            let offset = dictionary.offset,
             case let start = nameOffset + nameLength,
-            case let end = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }) ?? offset + length,
+            case let end = dictionary.bodyOffset ?? offset + length,
             case let contents = file.contents.bridge(),
             let range = contents.byteRangeToNSRange(start: start, length: end - start),
             case let kinds = excludingKinds(),
@@ -78,7 +78,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 let kind = SwiftDeclarationKind(rawValue: kindString) else {
                     return []
             }

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -49,17 +49,16 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
 
         let allowedKinds: [SwiftExpressionKind] = [.array, .dictionary]
 
-        guard let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
-            let elements = dictionary["key.elements"] as? [SourceKitRepresentable],
+        guard let bodyOffset = dictionary.bodyOffset,
+            let bodyLength = dictionary.bodyLength,
+            let elements = dictionary.elements,
             allowedKinds.contains(kind) else {
                 return []
         }
 
-        let endPositions = elements.flatMap { element -> Int? in
-            guard let dictionary = element as? [String: SourceKitRepresentable],
-                let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-                let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }) else {
+        let endPositions = elements.flatMap { dictionary -> Int? in
+            guard let offset = dictionary.offset,
+                let length = dictionary.length else {
                     return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -43,9 +43,9 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
         guard SwiftDeclarationKind.typeKinds().contains(kind) else {
             return []
         }
-        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let bodyOffset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
+        if let offset = dictionary.offset,
+            let bodyOffset = dictionary.bodyOffset,
+            let bodyLength = dictionary.bodyLength {
             let startLine = file.contents.bridge().lineAndCharacter(forByteOffset: bodyOffset)
             let endLine = file.contents.bridge()
                 .lineAndCharacter(forByteOffset: bodyOffset + bodyLength)

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -46,8 +46,8 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
 
         guard typeKinds.contains(kind),
-            let name = dictionary["key.name"] as? String,
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) else {
+            let name = dictionary.name,
+            let offset = dictionary.offset else {
                 return []
         }
 

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -67,11 +67,11 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable],
                                  kind: SwiftExpressionKind) -> [(range: NSRange, name: String)] {
         guard kind == .call,
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
-            let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
-            let bodyLength = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }),
+            let offset = dictionary.offset,
+            let length = dictionary.length,
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let bodyLength = dictionary.bodyLength,
             bodyLength > 0 else {
                 return []
         }
@@ -82,8 +82,8 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
         let contents = file.contents.bridge()
 
         return parameters.flatMap { param -> (NSRange, String)? in
-            guard let paramOffset = (param["key.offset"] as? Int64).flatMap({ Int($0) }),
-                let paramLength = (param["key.length"] as? Int64).flatMap({ Int($0) }),
+            guard let paramOffset = param.offset,
+                let paramLength = param.length,
                 let name = param[nameKey(for: .current)] as? String,
                 name != "_",
                 let regex = try? NSRegularExpression(pattern: name,
@@ -128,7 +128,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
     private func violationRanges(in file: File,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 let kind = SwiftExpressionKind(rawValue: kindString) else {
                     return []
             }

--- a/Source/SwiftLintFramework/Rules/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedEnumeratedRule.swift
@@ -55,9 +55,9 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule {
 
     private func isEnumeratedCall(dictionary: [String: SourceKitRepresentable]) -> Bool {
         for subDict in dictionary.substructure {
-            guard let kindString = subDict["key.kind"] as? String,
+            guard let kindString = subDict.kind,
                 SwiftExpressionKind(rawValue: kindString) == .call,
-                let name = subDict["key.name"] as? String else {
+                let name = subDict.name else {
                     continue
             }
 
@@ -70,16 +70,15 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func byteRangeForVariables(dictionary: [String: SourceKitRepresentable]) -> NSRange? {
-        guard let elements = dictionary["key.elements"] as? [SourceKitRepresentable] else {
+        guard let elements = dictionary.elements else {
             return nil
         }
 
         let expectedKind = "source.lang.swift.structure.elem.id"
-        for element in elements {
-            guard let subDict = element as? [String: SourceKitRepresentable],
-                subDict["key.kind"] as? String == expectedKind,
-                let offset = (subDict["key.offset"] as? Int64).map({ Int($0) }),
-                let length = (subDict["key.length"] as? Int64).map({ Int($0) }) else {
+        for subDict in elements {
+            guard subDict.kind == expectedKind,
+                let offset = subDict.offset,
+                let length = subDict.length else {
                 continue
             }
 

--- a/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
@@ -48,8 +48,8 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
                          kind: StatementKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         guard kind == .if || kind == .guard,
-            let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
-            let length = (dictionary["key.length"] as? Int64).flatMap({ Int($0) }),
+            let offset = dictionary.offset,
+            let length = dictionary.length,
             let range = file.contents.bridge().byteRangeToNSRange(start: offset, length: length) else {
                 return []
         }

--- a/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
@@ -56,10 +56,10 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
         }
 
         let shouldMakeViolation: Bool
-        if dictionary["key.setter_accessibility"] == nil {
+        if dictionary.setterAccessibility == nil {
             // if key.setter_accessibility is nil, it's a `let` declaration
             shouldMakeViolation = true
-        } else if let type = dictionary["key.typename"] as? String,
+        } else if let type = dictionary.typeName,
             ValidIBInspectableRule.supportedTypes.contains(type) {
             shouldMakeViolation = false
         } else {
@@ -73,7 +73,7 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
         }
 
         let location: Location
-        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+        if let offset = dictionary.offset {
             location = Location(file: file, byteOffset: offset)
         } else {
             location = Location(file: file.path)

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
@@ -59,8 +59,8 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
         let contents = file.contents.bridge()
         let pattern = "\\(\\s*(\\S)"
 
-        guard let nameOffset = (dictionary["key.nameoffset"] as? Int64).flatMap({ Int($0) }),
-            let nameLength = (dictionary["key.namelength"] as? Int64).flatMap({ Int($0) }),
+        guard let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
             let nameRange = contents.byteRangeToNSRange(start: nameOffset, length: nameLength),
             let paramStart = regex(pattern).firstMatch(in: file.contents,
                                                        options: [], range: nameRange)?.rangeAt(1).location,

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -46,7 +46,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
         }
 
         // Check if name contains "delegate"
-        guard let name = (dictionary["key.name"] as? String),
+        guard let name = dictionary.name,
             name.lowercased().hasSuffix("delegate") else {
                 return []
         }
@@ -56,18 +56,18 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
         guard !isWeak else { return [] }
 
         // if the declaration is inside a protocol
-        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }),
+        if let offset = dictionary.offset,
             !protocolDeclarations(forByteOffset: offset, structure: file.structure).isEmpty {
             return []
         }
 
         // Check if non-computed
-        let isComputed = dictionary["key.bodylength"] as? Int64 ?? 0 > 0
+        let isComputed = dictionary.bodyLength ?? 0 > 0
         guard !isComputed else { return [] }
 
         // Violation found!
         let location: Location
-        if let offset = (dictionary["key.offset"] as? Int64).flatMap({ Int($0) }) {
+        if let offset = dictionary.offset {
             location = Location(file: file, byteOffset: offset)
         } else {
             location = Location(file: file.path)
@@ -90,10 +90,10 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
 
             // Only accepts protocols declarations which contains a body and contains the
             // searched byteOffset
-            if let kindString = (dictionary["key.kind"] as? String),
+            if let kindString = (dictionary.kind),
                 SwiftDeclarationKind(rawValue: kindString) == .protocol,
-                let offset = (dictionary["key.bodyoffset"] as? Int64).flatMap({ Int($0) }),
-                let length = (dictionary["key.bodylength"] as? Int64).flatMap({ Int($0) }) {
+                let offset = dictionary.bodyOffset,
+                let length = dictionary.bodyLength {
                 let byteRange = NSRange(location: offset, length: length)
 
                 if NSLocationInRange(byteOffset, byteRange) {


### PR DESCRIPTION
So much boilerplate duplication could've been avoided long ago.