### PR TITLE
retain closure parameter types when they are specified during autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1242](https://github.com/realm/SwiftLint/issues/1242)
 
+* Retain closure parameter types when they are specified during autocorrect.  
+  [Allen Zeng](https://github.com/allen-zeng)
+  [#1175](https://github.com/realm/SwiftLint/issues/1175)
+
 ## 0.16.1: Commutative Fabric Sheets
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -97,7 +97,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
 
         return parameters.flatMap { param -> (NSRange, String)? in
             guard let paramOffset = param.offset,
-                let name = param["key.name"] as? String,
+                let name = param.name,
                 name != "_",
                 let regex = try? NSRegularExpression(pattern: name,
                                                      options: [.ignoreMetacharacters]),

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -106,7 +106,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
                 return nil
             }
 
-            let paramLength = name.characters.count
+            let paramLength = name.bridge().length
 
             let matches = regex.matches(in: file.contents, options: [], range: range).ranges()
             for range in matches {


### PR DESCRIPTION
This fixes the autocorrect behaviour of unused closure parameters. See #1175 

The function `nameKey(for:)` is removed. It appears that for both Swift 2 and 3, `key.name` is populated correctly.