### PR TITLE
Run clean before starting the docker run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ test: clean bootstrap
 clean:
 	rm -f "$(OUTPUT_PACKAGE)"
 	rm -rf "$(TEMPORARY_FOLDER)"
+	rm -rf "./.build"
 	$(BUILD_TOOL) $(XCODEFLAGS) -configuration Debug clean
 	$(BUILD_TOOL) $(XCODEFLAGS) -configuration Release clean
 	$(BUILD_TOOL) $(XCODEFLAGS) -configuration Test clean
@@ -102,7 +103,7 @@ archive:
 
 release: package archive portable_zip
 
-docker_test:
+docker_test: clean
 	docker run -v `pwd`:/SwiftLint norionomura/sourcekit:302 bash -c "cd /SwiftLint && swift test"
 
 # http://irace.me/swift-profiling/


### PR DESCRIPTION
I stumbled across the error described [here](https://github.com/realm/SwiftLint/issues/1175#issuecomment-275108850) when I was trying to run `docker_test`. The [solution](https://github.com/realm/SwiftLint/issues/1175#issuecomment-275111430) is simple enough.

It's probably a good idea run clean before docker run anyway.