### PR TITLE
Fix redundant_void_return execution if return type starts with Void~

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
   [Allen Zeng](https://github.com/allen-zeng)
   [#1175](https://github.com/realm/SwiftLint/issues/1175)
 
+* Fix `redundant_void_return` matches if return type starts with Void~.
+  [Hayashi Tatsuya](https://github.com/sora0077)
+
 ## 0.16.1: Commutative Fabric Sheets
 
 ##### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
   [Allen Zeng](https://github.com/allen-zeng)
   [#1175](https://github.com/realm/SwiftLint/issues/1175)
 
-* Fix `redundant_void_return` matches if return type starts with Void~.
+* Fix `redundant_void_return` matches if return type starts with Void~.  
   [Hayashi Tatsuya](https://github.com/sora0077)
 
 ## 0.16.1: Commutative Fabric Sheets

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -42,7 +42,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
         ]
     )
 
-    private let pattern = "\\s*->\\s*(?:Void(?=\\b)|\\(\\s*\\))"
+    private let pattern = "\\s*->\\s*(?:Void\\b|\\(\\s*\\))"
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -23,6 +23,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
             "func foo() {}\n",
             "func foo() -> Int {}\n",
             "func foo() -> Int -> Void {}\n",
+            "func foo() -> VoidResponse\n",
             "let foo: Int -> Void\n",
             "func foo() -> Int -> () {}\n",
             "let foo: Int -> ()\n"
@@ -41,7 +42,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
         ]
     )
 
-    private let pattern = "\\s*->\\s*(?:Void|\\(\\s*\\))"
+    private let pattern = "\\s*->\\s*(?:Void(?=(\\W|$))|\\(\\s*\\))"
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -42,7 +42,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
         ]
     )
 
-    private let pattern = "\\s*->\\s*(?:Void(?=(\\W|$))|\\(\\s*\\))"
+    private let pattern = "\\s*->\\s*(?:Void(?=\\b)|\\(\\s*\\))"
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {


### PR DESCRIPTION
`redundant_void_return` matches wrong pattern like an example below.

```swift
struct Response<T> {}
typealias VoidResponse = Response<Void>

func foo() -> VoidResponse {}
// -> after autocorrect
func foo()Response {}
```

