### PR TITLE
Update README for Cocoapods script

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,17 @@ fi
 ![](assets/runscript.png)
 
 Alternatively, if you've installed SwiftLint via CocoaPods the script should look like this:
-
 ```bash
-${PODS_ROOT}/SwiftLint/swiftlint
+"${PODS_ROOT}/SwiftLint/swiftlint"
+```
+
+or if you don't want the build to fail if `pod install` hasn't been run:
+```bash
+if [ -x "${PODS_ROOT}/SwiftLint/swiftlint" ]; then
+    "${PODS_ROOT}/SwiftLint/swiftlint"
+else
+    echo "SwiftLint does not exist, download from https://github.com/realm/SwiftLint"
+fi
 ```
 
 #### Format on Save Xcode Plugin

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ or if you don't want the build to fail if `pod install` hasn't been run:
 if [ -x "${PODS_ROOT}/SwiftLint/swiftlint" ]; then
     "${PODS_ROOT}/SwiftLint/swiftlint"
 else
-    echo "SwiftLint does not exist, download from https://github.com/realm/SwiftLint"
+    echo "SwiftLint does not exist, run pod install to get swiftlint"
 fi
 ```
 


### PR DESCRIPTION
The script doesn't work out of the box if pods are not updated. In our project we don't want the build to fail because people haven't run pod update.

Another issue is also that the current script doesn't have `""` around the path, which causes it to fail when there are spaces in ${PODS_ROOT}.