### PR TITLE
Update README for Cocoapods script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ fi
 Alternatively, if you've installed SwiftLint via CocoaPods the script should look like this:
 
 ```bash
-${PODS_ROOT}/SwiftLint/swiftlint
+"${PODS_ROOT}/SwiftLint/swiftlint"
 ```
 
 #### Format on Save Xcode Plugin


### PR DESCRIPTION
The path should be surrounded by `""` to fix issues with spaces in `PODS_ROOT` path.

E.g. right now the script would fail if swiftlint is located in path: `/Users/me/Awesome Project/Pods/Swiftlint/swiftlint`