### PR TITLE
Changes for issue #598 to make line length rule configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1061](https://github.com/realm/SwiftLint/issues/1061)
 
+* Add 'ignores_function_declarations' and 'ignores_comments' as options
+  to LineLengthRule.
+  [Michael Welles](https://github.com/mlwelles)
+  [#598](https://github.com/realm/SwiftLint/issues/598)
+  [#975](https://github.com/realm/SwiftLint/issues/975)
+
 ##### Bug Fixes
 
 * Fix a false positive on `large_tuple` rule when using closures.  
@@ -1705,7 +1711,7 @@ This release has seen a phenomenal uptake in community contributions!
 * The following rules now conform to `ASTRule`:
   FunctionBodyLength, Nesting, TypeBodyLength, TypeName, VariableName.  
   [JP Simard](https://github.com/jpsim)
-
+  
 ##### Bug Fixes
 
 * Trailing newline and file length violations are now displayed in Xcode.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1061](https://github.com/realm/SwiftLint/issues/1061)
 
-* Add 'ignores_function_declarations' and 'ignores_comments' as options
-  to LineLengthRule.
+* Add `ignores_function_declarations` and `ignores_comments` as options
+  to LineLengthRule.  
   [Michael L. Welles](https://github.com/mlwelles)
   [#598](https://github.com/realm/SwiftLint/issues/598)
   [#975](https://github.com/realm/SwiftLint/issues/975)
@@ -1710,8 +1710,7 @@ This release has seen a phenomenal uptake in community contributions!
 
 * The following rules now conform to `ASTRule`:
   FunctionBodyLength, Nesting, TypeBodyLength, TypeName, VariableName.  
-  [JP Simard](https://github.com/jpsim)
-  
+  [JP Simard](https://github.com/jpsim)  
 ##### Bug Fixes
 
 * Trailing newline and file length violations are now displayed in Xcode.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 * Add 'ignores_function_declarations' and 'ignores_comments' as options
   to LineLengthRule.
-  [Michael Welles](https://github.com/mlwelles)
+  [Michael L. Welles](https://github.com/mlwelles)
   [#598](https://github.com/realm/SwiftLint/issues/598)
   [#975](https://github.com/realm/SwiftLint/issues/975)
 

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -95,6 +95,34 @@ extension File {
         }
     }
 
+    internal func swiftDeclarationKindsByLine() -> [[SwiftDeclarationKind]]? {
+        if sourcekitdFailed {
+            return nil
+        }
+        var results = [[SwiftDeclarationKind]](repeating: [], count: lines.count + 1)
+        let structureKinds = structure.kinds()
+        var lineIterator = lines.makeIterator()
+        var structureIterator = structureKinds.makeIterator()
+        var maybeLine = lineIterator.next()
+        var maybeStructure = structureIterator.next()
+        while let line = maybeLine, let structure = maybeStructure {
+            if NSLocationInRange(structure.byteRange.location, line.byteRange) ||
+                NSLocationInRange(line.byteRange.location, structure.byteRange) {
+                if let swiftDeclarationKind = SwiftDeclarationKind(rawValue:structure.kind) {
+                    results[line.index].append(swiftDeclarationKind)
+                }
+            }
+            let lineEnd = NSMaxRange(line.byteRange)
+            if structure.byteRange.location > lineEnd {
+                maybeLine = lineIterator.next()
+            } else {
+                maybeStructure = structureIterator.next()
+            }
+
+        }
+        return results
+    }
+
     internal func syntaxTokensByLine() -> [[SyntaxToken]]? {
         if sourcekitdFailed {
             return nil

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -106,8 +106,7 @@ extension File {
         var maybeLine = lineIterator.next()
         var maybeStructure = structureIterator.next()
         while let line = maybeLine, let structure = maybeStructure {
-            if NSLocationInRange(structure.byteRange.location, line.byteRange) ||
-                NSLocationInRange(line.byteRange.location, structure.byteRange) {
+            if NSLocationInRange(structure.byteRange.location, line.byteRange) {
                 if let swiftDeclarationKind = SwiftDeclarationKind(rawValue:structure.kind) {
                     results[line.index].append(swiftDeclarationKind)
                 }

--- a/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
@@ -17,17 +17,21 @@ extension Structure {
     /// - Parameter byteOffset: Int
     // swiftlint:disable:next valid_docs
     internal func kinds(forByteOffset byteOffset: Int) -> [(kind: String, byteRange: NSRange)] {
-        var results = [(kind: String, byteRange: NSRange)]()
+        return kinds().filter {
+            NSLocationInRange(byteOffset, $0.byteRange)
+        }
+    }
 
+    /// Returns complete array of tuples containing "key.kind" and "byteRange" from Structure
+    internal func kinds() -> [(kind: String, byteRange: NSRange)] {
+        var results = [(kind: String, byteRange: NSRange)]()
         func parse(_ dictionary: [String: SourceKitRepresentable]) {
-            guard let
-                offset = dictionary.offset,
-                let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }),
-                NSLocationInRange(byteOffset, byteRange) else {
+            guard let offset = dictionary.offset,
+                let length = dictionary.length else {
                     return
             }
             if let kind = dictionary.kind {
-                results.append((kind: kind, byteRange: byteRange))
+                results.append((kind: kind, byteRange: NSRange(location: offset, length: length)))
             }
             dictionary.substructure.forEach(parse)
         }

--- a/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
@@ -12,26 +12,26 @@ import SourceKittenFramework
 extension Structure {
 
     /// Returns array of tuples containing "key.kind" and "byteRange" from Structure
-    /// that contains the byte offset.
+    /// that contains the byte offset. Will return all kinds if no parameter specified.
     ///
-    /// - Parameter byteOffset: Int
+    /// - Parameter byteOffset: Int?
     // swiftlint:disable:next valid_docs
-    internal func kinds(forByteOffset byteOffset: Int) -> [(kind: String, byteRange: NSRange)] {
-        return kinds().filter {
-            NSLocationInRange(byteOffset, $0.byteRange)
-        }
-    }
-
-    /// Returns complete array of tuples containing "key.kind" and "byteRange" from Structure
-    internal func kinds() -> [(kind: String, byteRange: NSRange)] {
+    internal func kinds(forByteOffset byteOffset: Int? = nil) -> [(kind: String, byteRange: NSRange)] {
         var results = [(kind: String, byteRange: NSRange)]()
+
         func parse(_ dictionary: [String: SourceKitRepresentable]) {
-            guard let offset = dictionary.offset,
-                let length = dictionary.length else {
+            guard let
+                offset = dictionary.offset,
+                let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }) else {
                     return
             }
+            if let byteOffset = byteOffset {
+                if !NSLocationInRange(byteOffset, byteRange) {
+                    return
+                }
+            }
             if let kind = dictionary.kind {
-                results.append((kind: kind, byteRange: NSRange(location: offset, length: length)))
+                results.append((kind: kind, byteRange: byteRange))
             }
             dictionary.substructure.forEach(parse)
         }

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -124,7 +124,6 @@ public struct LineLengthRule: ConfigurationProviderRule {
 
 }
 
-
 fileprivate extension String {
     var strippingURLs: String {
         let range = NSRange(location: 0, length: bridge().length)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -33,7 +33,7 @@ fileprivate enum ConfigurationKey: String {
             .ignoresComments]
     }
     static func allValues() -> [String] {
-        return all().map{ $0.rawValue }
+        return all().map { $0.rawValue }
     }
 
 }
@@ -47,7 +47,7 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
     var ignoresURLs: Bool
     var ignoresFunctionDeclarations: Bool
     var ignoresComments: Bool
-    
+
     var params: [RuleParameter<Int>] {
         return length.params
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -12,12 +12,30 @@ public struct LineLengthRuleOptions: OptionSet {
     public let rawValue: Int
     public init(rawValue: Int) { self.rawValue = rawValue }
     public init() { self.rawValue = 0 }
+    public static let ignoreUrls = LineLengthRuleOptions(rawValue: 1 << 0)
+    public static let ignoreFunctionDeclarations = LineLengthRuleOptions(rawValue: 1 << 1)
+    public static let ignoreComments = LineLengthRuleOptions(rawValue: 1 << 2)
 
-    static let ignoreUrls = LineLengthRuleOptions(rawValue: 1 << 0)
-    static let ignoreFunctionDeclarations = LineLengthRuleOptions(rawValue: 1 << 1)
-    static let ignoreComments = LineLengthRuleOptions(rawValue: 1 << 2)
+    public static let all: LineLengthRuleOptions = [.ignoreUrls, .ignoreFunctionDeclarations, .ignoreComments]
+}
 
-    static let all: LineLengthRuleOptions = [.ignoreUrls, .ignoreFunctionDeclarations, .ignoreComments]
+fileprivate enum ConfigurationKey: String {
+    case warning = "warning"
+    case error = "error"
+    case ignoresURLs = "ignores_urls"
+    case ignoresFunctionDeclarations = "ignores_function_declarations"
+    case ignoresComments = "ignores_comments"
+    static func all() -> [ConfigurationKey] {
+        return [.warning,
+            .error,
+            .ignoresURLs,
+            .ignoresFunctionDeclarations,
+            .ignoresComments]
+    }
+    static func allValues() -> [String] {
+        return all().map{ $0.rawValue }
+    }
+
 }
 
 public struct LineLengthConfiguration: RuleConfiguration, Equatable {
@@ -29,22 +47,16 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
     var ignoresURLs: Bool
     var ignoresFunctionDeclarations: Bool
     var ignoresComments: Bool
-
+    
     var params: [RuleParameter<Int>] {
         return length.params
     }
 
-    public init(warning: Int, error: Int?, options: LineLengthRuleOptions? = []) {
-        length = SeverityLevelsConfiguration(warning: warning, error: error)
-        if let options = options {
-            self.ignoresURLs = options.contains(.ignoreUrls)
-            self.ignoresFunctionDeclarations = options.contains(.ignoreFunctionDeclarations)
-            self.ignoresComments = options.contains(.ignoreComments)
-        } else {
-            self.ignoresURLs = false
-            self.ignoresFunctionDeclarations = false
-            self.ignoresComments = false
-        }
+    public init(warning: Int, error: Int?, options: LineLengthRuleOptions = []) {
+        self.length = SeverityLevelsConfiguration(warning: warning, error: error)
+        self.ignoresURLs = options.contains(.ignoreUrls)
+        self.ignoresFunctionDeclarations = options.contains(.ignoreFunctionDeclarations)
+        self.ignoresComments = options.contains(.ignoreComments)
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -53,20 +65,26 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
             let warning = configurationArray[0]
             let error = (configurationArray.count > 1) ? configurationArray[1] : nil
             length = SeverityLevelsConfiguration(warning: warning, error: error)
-        } else if let configDict = configuration as? [String: Any], !configDict.isEmpty
-            && Set(configDict.keys).isSubset(of: ["warning",
-                                                  "error",
-                                                  "ignores_urls",
-                                                  "ignores_function_declarations",
-                                                  "ignores_comments"]) {
-            let warning = configDict["warning"] as? Int ?? length.warning
-            let error = configDict["error"] as? Int
-            length = SeverityLevelsConfiguration(warning: warning, error: error)
-            ignoresURLs = configDict["ignores_urls"] as? Bool ?? ignoresURLs
-            if let funcDec =
-                configDict["ignores_function_declarations"] as? Bool {            ignoresFunctionDeclarations = funcDec
+        } else if let configDict = configuration as? [String: Any], !configDict.isEmpty {
+            for (string, value) in configDict {
+                guard let key = ConfigurationKey(rawValue:string) else {
+                    throw ConfigurationError.unknownConfiguration
+                }
+                switch (key, value) {
+                case (.error, let intValue as Int):
+                    length.error = intValue
+                case (.warning, let intValue as Int):
+                    length.warning = intValue
+                case (.ignoresFunctionDeclarations, let boolValue as Bool):
+                    ignoresFunctionDeclarations = boolValue
+                case (.ignoresComments, let boolValue as Bool):
+                    ignoresComments = boolValue
+                case (.ignoresURLs, let boolValue as Bool):
+                    ignoresURLs = boolValue
+                default:
+                    throw ConfigurationError.unknownConfiguration
+                }
             }
-            ignoresComments = configDict["ignores_comments"] as? Bool ?? ignoresComments
         } else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -8,6 +8,15 @@
 
 import Foundation
 
+public enum LineLengthConfigurationFlag {
+    case ignoreUrls
+    case ignoreFunctionDeclarations
+    case ignoreComments
+    static func allFlags() -> [LineLengthConfigurationFlag] {
+        return [.ignoreUrls, .ignoreFunctionDeclarations, .ignoreComments]
+    }
+}
+
 public struct LineLengthConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
         return length.consoleDescription + ", ignores urls: \(ignoresURLs)"
@@ -15,27 +24,46 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
 
     var length: SeverityLevelsConfiguration
     var ignoresURLs: Bool
+    var ignoresFunctionDeclarations: Bool
+    var ignoresComments: Bool
 
     var params: [RuleParameter<Int>] {
         return length.params
     }
 
-    public init(warning: Int, error: Int?, ignoresURLs: Bool) {
+    public init(warning: Int, error: Int?, flags: [LineLengthConfigurationFlag]? = []) {
         length = SeverityLevelsConfiguration(warning: warning, error: error)
-        self.ignoresURLs = ignoresURLs
+        if let flags = flags {
+            self.ignoresURLs = flags.contains(.ignoreUrls)
+            self.ignoresFunctionDeclarations = flags.contains(.ignoreFunctionDeclarations)
+            self.ignoresComments = flags.contains(.ignoreComments)
+        } else {
+            self.ignoresURLs = false
+            self.ignoresFunctionDeclarations = false
+            self.ignoresComments = false
+        }
     }
 
     public mutating func apply(configuration: Any) throws {
-        if let configurationArray = [Int].array(of: configuration), !configurationArray.isEmpty {
+        if let configurationArray = [Int].array(of: configuration),
+            !configurationArray.isEmpty {
             let warning = configurationArray[0]
             let error = (configurationArray.count > 1) ? configurationArray[1] : nil
             length = SeverityLevelsConfiguration(warning: warning, error: error)
         } else if let configDict = configuration as? [String: Any], !configDict.isEmpty
-            && Set(configDict.keys).isSubset(of: ["warning", "error", "ignores_urls"]) {
+            && Set(configDict.keys).isSubset(of: ["warning",
+                                                  "error",
+                                                  "ignores_urls",
+                                                  "ignores_function_declarations",
+                                                  "ignores_comments"]) {
             let warning = configDict["warning"] as? Int ?? length.warning
             let error = configDict["error"] as? Int
             length = SeverityLevelsConfiguration(warning: warning, error: error)
             ignoresURLs = configDict["ignores_urls"] as? Bool ?? ignoresURLs
+            if let funcDec =
+                configDict["ignores_function_declarations"] as? Bool {            ignoresFunctionDeclarations = funcDec
+            }
+            ignoresComments = configDict["ignores_comments"] as? Bool ?? ignoresComments
         } else {
             throw ConfigurationError.unknownConfiguration
         }
@@ -44,5 +72,8 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
 }
 
 public func == (lhs: LineLengthConfiguration, rhs: LineLengthConfiguration) -> Bool {
-    return lhs.length == rhs.length && lhs.ignoresURLs == rhs.ignoresURLs
+    return lhs.length == rhs.length &&
+        lhs.ignoresURLs == rhs.ignoresURLs &&
+        lhs.ignoresComments == rhs.ignoresComments &&
+        lhs.ignoresFunctionDeclarations == rhs.ignoresFunctionDeclarations
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -8,13 +8,16 @@
 
 import Foundation
 
-public enum LineLengthConfigurationFlag {
-    case ignoreUrls
-    case ignoreFunctionDeclarations
-    case ignoreComments
-    static func allFlags() -> [LineLengthConfigurationFlag] {
-        return [.ignoreUrls, .ignoreFunctionDeclarations, .ignoreComments]
-    }
+public struct LineLengthRuleOptions: OptionSet {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    public init() { self.rawValue = 0 }
+
+    static let ignoreUrls = LineLengthRuleOptions(rawValue: 1 << 0)
+    static let ignoreFunctionDeclarations = LineLengthRuleOptions(rawValue: 1 << 1)
+    static let ignoreComments = LineLengthRuleOptions(rawValue: 1 << 2)
+
+    static let all: LineLengthRuleOptions = [.ignoreUrls, .ignoreFunctionDeclarations, .ignoreComments]
 }
 
 public struct LineLengthConfiguration: RuleConfiguration, Equatable {
@@ -31,12 +34,12 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
         return length.params
     }
 
-    public init(warning: Int, error: Int?, flags: [LineLengthConfigurationFlag]? = []) {
+    public init(warning: Int, error: Int?, options: LineLengthRuleOptions? = []) {
         length = SeverityLevelsConfiguration(warning: warning, error: error)
-        if let flags = flags {
-            self.ignoresURLs = flags.contains(.ignoreUrls)
-            self.ignoresFunctionDeclarations = flags.contains(.ignoreFunctionDeclarations)
-            self.ignoresComments = flags.contains(.ignoreComments)
+        if let options = options {
+            self.ignoresURLs = options.contains(.ignoreUrls)
+            self.ignoresFunctionDeclarations = options.contains(.ignoreFunctionDeclarations)
+            self.ignoresComments = options.contains(.ignoreComments)
         } else {
             self.ignoresURLs = false
             self.ignoresFunctionDeclarations = false

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -36,32 +36,30 @@ class LineLengthConfigurationTests: XCTestCase {
                                                      error: 150)
         XCTAssertFalse(configuration2.ignoresURLs)
     }
-    
+
     func testLineLengthConfigurationInitialiserSetsIgnoresFunctionDeclarations() {
         let configuration1 = LineLengthConfiguration(warning: 100,
                                                      error: 150,
                                                      options: [.ignoreFunctionDeclarations])
-        
+
         XCTAssertTrue(configuration1.ignoresFunctionDeclarations)
-        
+
         let configuration2 = LineLengthConfiguration(warning: 100,
                                                      error: 150)
         XCTAssertFalse(configuration2.ignoresFunctionDeclarations)
     }
-    
+
     func testLineLengthConfigurationInitialiserSetsIgnoresComments() {
         let configuration1 = LineLengthConfiguration(warning: 100,
                                                      error: 150,
                                                      options: [.ignoreComments])
-        
+
         XCTAssertTrue(configuration1.ignoresComments)
-        
+
         let configuration2 = LineLengthConfiguration(warning: 100,
                                                      error: 150)
         XCTAssertFalse(configuration2.ignoresComments)
     }
-
-
 
     func testLineLengthConfigurationParams() {
         let warning = 13
@@ -86,14 +84,14 @@ class LineLengthConfigurationTests: XCTestCase {
             try configuration.apply(configuration: config)
         }
     }
-    
+
     func testLineLengthConfigurationThrowsOnBadConfigValues() {
         let badConfigs: [[String: Any]] = [
             ["warning": true],
             ["ignores_function_declarations": 300],
             ["unsupported_key": "unsupported key is unsupported"]
         ]
-        
+
         for badConfig in badConfigs {
             var configuration = LineLengthConfiguration(warning: 100, error: 150)
             checkError(ConfigurationError.unknownConfiguration) {
@@ -101,7 +99,6 @@ class LineLengthConfigurationTests: XCTestCase {
             }
         }
     }
-
 
     func testLineLengthConfigurationApplyConfigurationWithArray() {
         var configuration = LineLengthConfiguration(warning: 0, error: 0)

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -11,20 +11,17 @@ import SourceKittenFramework
 import XCTest
 
 class LineLengthConfigurationTests: XCTestCase {
-    let allFlags = LineLengthRuleOptions.all
     func testLineLengthConfigurationInitializerSetsLength() {
         let warning = 100
         let error = 150
         let length1 = SeverityLevelsConfiguration(warning: warning, error: error)
         let configuration1 = LineLengthConfiguration(warning: warning,
-                                                     error: error,
-                                                     options: allFlags)
+                                                     error: error)
         XCTAssertEqual(configuration1.length, length1)
 
         let length2 = SeverityLevelsConfiguration(warning: warning, error: nil)
         let configuration2 = LineLengthConfiguration(warning: warning,
-                                                     error: nil,
-                                                     options: allFlags)
+                                                     error: nil)
         XCTAssertEqual(configuration2.length, length2)
     }
 
@@ -36,17 +33,41 @@ class LineLengthConfigurationTests: XCTestCase {
         XCTAssertTrue(configuration1.ignoresURLs)
 
         let configuration2 = LineLengthConfiguration(warning: 100,
-                                                     error: 150,
-                                                     options: nil)
+                                                     error: 150)
         XCTAssertFalse(configuration2.ignoresURLs)
     }
+    
+    func testLineLengthConfigurationInitialiserSetsIgnoresFunctionDeclarations() {
+        let configuration1 = LineLengthConfiguration(warning: 100,
+                                                     error: 150,
+                                                     options: [.ignoreFunctionDeclarations])
+        
+        XCTAssertTrue(configuration1.ignoresFunctionDeclarations)
+        
+        let configuration2 = LineLengthConfiguration(warning: 100,
+                                                     error: 150)
+        XCTAssertFalse(configuration2.ignoresFunctionDeclarations)
+    }
+    
+    func testLineLengthConfigurationInitialiserSetsIgnoresComments() {
+        let configuration1 = LineLengthConfiguration(warning: 100,
+                                                     error: 150,
+                                                     options: [.ignoreComments])
+        
+        XCTAssertTrue(configuration1.ignoresComments)
+        
+        let configuration2 = LineLengthConfiguration(warning: 100,
+                                                     error: 150)
+        XCTAssertFalse(configuration2.ignoresComments)
+    }
+
+
 
     func testLineLengthConfigurationParams() {
         let warning = 13
         let error = 10
         let configuration = LineLengthConfiguration(warning: warning,
-                                                    error: error,
-                                                    options: [.ignoreFunctionDeclarations])
+                                                    error: error)
         let params = [RuleParameter(severity: .error, value: error), RuleParameter(severity: .warning, value: warning)]
         XCTAssertEqual(configuration.params, params)
     }
@@ -54,21 +75,36 @@ class LineLengthConfigurationTests: XCTestCase {
     func testLineLengthConfigurationPartialParams() {
         let warning = 13
         let configuration = LineLengthConfiguration(warning: warning,
-                                                    error: nil,
-                                                    options: [.ignoreFunctionDeclarations])
+                                                    error: nil)
         XCTAssertEqual(configuration.params, [RuleParameter(severity: .warning, value: 13)])
     }
 
     func testLineLengthConfigurationThrowsOnBadConfig() {
         let config = "unknown"
-        var configuration = LineLengthConfiguration(warning: 100, error: 150, options: allFlags)
+        var configuration = LineLengthConfiguration(warning: 100, error: 150)
         checkError(ConfigurationError.unknownConfiguration) {
             try configuration.apply(configuration: config)
         }
     }
+    
+    func testLineLengthConfigurationThrowsOnBadConfigValues() {
+        let badConfigs: [[String: Any]] = [
+            ["warning": true],
+            ["ignores_function_declarations": 300],
+            ["unsupported_key": "unsupported key is unsupported"]
+        ]
+        
+        for badConfig in badConfigs {
+            var configuration = LineLengthConfiguration(warning: 100, error: 150)
+            checkError(ConfigurationError.unknownConfiguration) {
+                try configuration.apply(configuration: badConfig)
+            }
+        }
+    }
+
 
     func testLineLengthConfigurationApplyConfigurationWithArray() {
-        var configuration = LineLengthConfiguration(warning: 0, error: 0, options: nil)
+        var configuration = LineLengthConfiguration(warning: 0, error: 0)
 
         let warning1 = 100
         let error1 = 100
@@ -107,7 +143,7 @@ class LineLengthConfigurationTests: XCTestCase {
         let length2 = SeverityLevelsConfiguration(warning: warning2, error: error2)
         let config2: [String: Int] = ["warning": warning2, "error": error2]
 
-        let length3 = SeverityLevelsConfiguration(warning: warning2, error: nil)
+        let length3 = SeverityLevelsConfiguration(warning: warning2, error: error2)
         let config3: [String: Bool] = ["ignores_urls": false,
                                        "ignores_function_declarations": false,
                                        "ignores_comments": false]
@@ -136,20 +172,20 @@ class LineLengthConfigurationTests: XCTestCase {
     }
 
     func testLineLengthConfigurationCompares() {
-        let configuration1 = LineLengthConfiguration(warning: 100, error: 100, options: allFlags)
+        let configuration1 = LineLengthConfiguration(warning: 100, error: 100)
         let configuration2 = LineLengthConfiguration(warning: 100,
                                                      error: 100,
                                                      options: [.ignoreFunctionDeclarations,
                                                                .ignoreComments])
         XCTAssertFalse(configuration1 == configuration2)
 
-        let configuration3 = LineLengthConfiguration(warning: 100, error: 200, options: allFlags)
+        let configuration3 = LineLengthConfiguration(warning: 100, error: 200)
         XCTAssertFalse(configuration1 == configuration3)
 
-        let configuration4 = LineLengthConfiguration(warning: 200, error: 100, options: allFlags)
+        let configuration4 = LineLengthConfiguration(warning: 200, error: 100)
         XCTAssertFalse(configuration1 == configuration4)
 
-        let configuration5 = LineLengthConfiguration(warning: 100, error: 100, options: allFlags)
+        let configuration5 = LineLengthConfiguration(warning: 100, error: 100)
         XCTAssertTrue(configuration1 == configuration5)
 
         let configuration6 = LineLengthConfiguration(warning: 100,

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -11,33 +11,33 @@ import SourceKittenFramework
 import XCTest
 
 class LineLengthConfigurationTests: XCTestCase {
-    let allFlags = LineLengthConfigurationFlag.allFlags()
+    let allFlags = LineLengthRuleOptions.all
     func testLineLengthConfigurationInitializerSetsLength() {
         let warning = 100
         let error = 150
         let length1 = SeverityLevelsConfiguration(warning: warning, error: error)
         let configuration1 = LineLengthConfiguration(warning: warning,
                                                      error: error,
-                                                     flags: allFlags)
+                                                     options: allFlags)
         XCTAssertEqual(configuration1.length, length1)
 
         let length2 = SeverityLevelsConfiguration(warning: warning, error: nil)
         let configuration2 = LineLengthConfiguration(warning: warning,
                                                      error: nil,
-                                                     flags: allFlags)
+                                                     options: allFlags)
         XCTAssertEqual(configuration2.length, length2)
     }
 
     func testLineLengthConfigurationInitialiserSetsIgnoresUrls() {
         let configuration1 = LineLengthConfiguration(warning: 100,
                                                      error: 150,
-                                                     flags: [.ignoreUrls])
+                                                     options: [.ignoreUrls])
 
         XCTAssertTrue(configuration1.ignoresURLs)
 
         let configuration2 = LineLengthConfiguration(warning: 100,
                                                      error: 150,
-                                                     flags: nil)
+                                                     options: nil)
         XCTAssertFalse(configuration2.ignoresURLs)
     }
 
@@ -46,7 +46,7 @@ class LineLengthConfigurationTests: XCTestCase {
         let error = 10
         let configuration = LineLengthConfiguration(warning: warning,
                                                     error: error,
-                                                    flags: [.ignoreFunctionDeclarations])
+                                                    options: [.ignoreFunctionDeclarations])
         let params = [RuleParameter(severity: .error, value: error), RuleParameter(severity: .warning, value: warning)]
         XCTAssertEqual(configuration.params, params)
     }
@@ -55,20 +55,20 @@ class LineLengthConfigurationTests: XCTestCase {
         let warning = 13
         let configuration = LineLengthConfiguration(warning: warning,
                                                     error: nil,
-                                                    flags: [.ignoreFunctionDeclarations])
+                                                    options: [.ignoreFunctionDeclarations])
         XCTAssertEqual(configuration.params, [RuleParameter(severity: .warning, value: 13)])
     }
 
     func testLineLengthConfigurationThrowsOnBadConfig() {
         let config = "unknown"
-        var configuration = LineLengthConfiguration(warning: 100, error: 150, flags: allFlags)
+        var configuration = LineLengthConfiguration(warning: 100, error: 150, options: allFlags)
         checkError(ConfigurationError.unknownConfiguration) {
             try configuration.apply(configuration: config)
         }
     }
 
     func testLineLengthConfigurationApplyConfigurationWithArray() {
-        var configuration = LineLengthConfiguration(warning: 0, error: 0, flags: nil)
+        var configuration = LineLengthConfiguration(warning: 0, error: 0, options: nil)
 
         let warning1 = 100
         let error1 = 100
@@ -136,25 +136,25 @@ class LineLengthConfigurationTests: XCTestCase {
     }
 
     func testLineLengthConfigurationCompares() {
-        let configuration1 = LineLengthConfiguration(warning: 100, error: 100, flags: allFlags)
+        let configuration1 = LineLengthConfiguration(warning: 100, error: 100, options: allFlags)
         let configuration2 = LineLengthConfiguration(warning: 100,
                                                      error: 100,
-                                                     flags: [.ignoreFunctionDeclarations,
+                                                     options: [.ignoreFunctionDeclarations,
                                                                .ignoreComments])
         XCTAssertFalse(configuration1 == configuration2)
 
-        let configuration3 = LineLengthConfiguration(warning: 100, error: 200, flags: allFlags)
+        let configuration3 = LineLengthConfiguration(warning: 100, error: 200, options: allFlags)
         XCTAssertFalse(configuration1 == configuration3)
 
-        let configuration4 = LineLengthConfiguration(warning: 200, error: 100, flags: allFlags)
+        let configuration4 = LineLengthConfiguration(warning: 200, error: 100, options: allFlags)
         XCTAssertFalse(configuration1 == configuration4)
 
-        let configuration5 = LineLengthConfiguration(warning: 100, error: 100, flags: allFlags)
+        let configuration5 = LineLengthConfiguration(warning: 100, error: 100, options: allFlags)
         XCTAssertTrue(configuration1 == configuration5)
 
         let configuration6 = LineLengthConfiguration(warning: 100,
                                                      error: 100,
-                                                     flags: [.ignoreFunctionDeclarations,
+                                                     options: [.ignoreFunctionDeclarations,
                                                                .ignoreComments])
         XCTAssertTrue(configuration2 == configuration6)
     }

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -11,52 +11,64 @@ import SourceKittenFramework
 import XCTest
 
 class LineLengthConfigurationTests: XCTestCase {
-
+    let allFlags = LineLengthConfigurationFlag.allFlags()
     func testLineLengthConfigurationInitializerSetsLength() {
         let warning = 100
         let error = 150
         let length1 = SeverityLevelsConfiguration(warning: warning, error: error)
-        let configuration1 = LineLengthConfiguration(warning: warning, error: error, ignoresURLs: true)
+        let configuration1 = LineLengthConfiguration(warning: warning,
+                                                     error: error,
+                                                     flags: allFlags)
         XCTAssertEqual(configuration1.length, length1)
 
         let length2 = SeverityLevelsConfiguration(warning: warning, error: nil)
-        let configuration2 = LineLengthConfiguration(warning: warning, error: nil, ignoresURLs: true)
+        let configuration2 = LineLengthConfiguration(warning: warning,
+                                                     error: nil,
+                                                     flags: allFlags)
         XCTAssertEqual(configuration2.length, length2)
     }
 
     func testLineLengthConfigurationInitialiserSetsIgnoresUrls() {
-        let configuration1 = LineLengthConfiguration(warning: 100, error: 150, ignoresURLs: true)
+        let configuration1 = LineLengthConfiguration(warning: 100,
+                                                     error: 150,
+                                                     flags: [.ignoreUrls])
+
         XCTAssertTrue(configuration1.ignoresURLs)
 
-        let configuration2 = LineLengthConfiguration(warning: 100, error: 150, ignoresURLs: false)
+        let configuration2 = LineLengthConfiguration(warning: 100,
+                                                     error: 150,
+                                                     flags: nil)
         XCTAssertFalse(configuration2.ignoresURLs)
     }
 
     func testLineLengthConfigurationParams() {
         let warning = 13
         let error = 10
-        let configuration = LineLengthConfiguration(warning: warning, error: error, ignoresURLs: true)
+        let configuration = LineLengthConfiguration(warning: warning,
+                                                    error: error,
+                                                    flags: [.ignoreFunctionDeclarations])
         let params = [RuleParameter(severity: .error, value: error), RuleParameter(severity: .warning, value: warning)]
         XCTAssertEqual(configuration.params, params)
     }
 
     func testLineLengthConfigurationPartialParams() {
         let warning = 13
-        let configuration = LineLengthConfiguration(warning: warning, error: nil, ignoresURLs: true)
+        let configuration = LineLengthConfiguration(warning: warning,
+                                                    error: nil,
+                                                    flags: [.ignoreFunctionDeclarations])
         XCTAssertEqual(configuration.params, [RuleParameter(severity: .warning, value: 13)])
     }
 
     func testLineLengthConfigurationThrowsOnBadConfig() {
         let config = "unknown"
-        var configuration = LineLengthConfiguration(warning: 100, error: 150, ignoresURLs: true)
-
+        var configuration = LineLengthConfiguration(warning: 100, error: 150, flags: allFlags)
         checkError(ConfigurationError.unknownConfiguration) {
             try configuration.apply(configuration: config)
         }
     }
 
     func testLineLengthConfigurationApplyConfigurationWithArray() {
-        var configuration = LineLengthConfiguration(warning: 0, error: 0, ignoresURLs: false)
+        var configuration = LineLengthConfiguration(warning: 0, error: 0, flags: nil)
 
         let warning1 = 100
         let error1 = 100
@@ -79,12 +91,16 @@ class LineLengthConfigurationTests: XCTestCase {
     }
 
     func testLineLengthConfigurationApplyConfigurationWithDictionary() {
-        var configuration = LineLengthConfiguration(warning: 0, error: 0, ignoresURLs: false)
+        var configuration = LineLengthConfiguration(warning: 0, error: 0)
 
         let warning1 = 100
         let error1 = 100
         let length1 = SeverityLevelsConfiguration(warning: warning1, error: error1)
-        let config1: [String: Any] = ["warning": warning1, "error": error1, "ignores_urls": true]
+        let config1: [String: Any] = ["warning": warning1,
+                                      "error": error1,
+                                      "ignores_urls": true,
+                                      "ignores_function_declarations": true,
+                                      "ignores_comments": true]
 
         let warning2 = 200
         let error2 = 200
@@ -92,40 +108,54 @@ class LineLengthConfigurationTests: XCTestCase {
         let config2: [String: Int] = ["warning": warning2, "error": error2]
 
         let length3 = SeverityLevelsConfiguration(warning: warning2, error: nil)
-        let config3: [String: Bool] = ["ignores_urls": false]
+        let config3: [String: Bool] = ["ignores_urls": false,
+                                       "ignores_function_declarations": false,
+                                       "ignores_comments": false]
 
         do {
             try configuration.apply(configuration: config1)
             XCTAssertEqual(configuration.length, length1)
             XCTAssertTrue(configuration.ignoresURLs)
+            XCTAssertTrue(configuration.ignoresFunctionDeclarations)
+            XCTAssertTrue(configuration.ignoresComments)
 
             try configuration.apply(configuration: config2)
             XCTAssertEqual(configuration.length, length2)
             XCTAssertTrue(configuration.ignoresURLs)
+            XCTAssertTrue(configuration.ignoresFunctionDeclarations)
+            XCTAssertTrue(configuration.ignoresComments)
 
             try configuration.apply(configuration: config3)
             XCTAssertEqual(configuration.length, length3)
             XCTAssertFalse(configuration.ignoresURLs)
+            XCTAssertFalse(configuration.ignoresFunctionDeclarations)
+            XCTAssertFalse(configuration.ignoresComments)
         } catch {
             XCTFail()
         }
     }
 
     func testLineLengthConfigurationCompares() {
-        let configuration1 = LineLengthConfiguration(warning: 100, error: 100, ignoresURLs: true)
-        let configuration2 = LineLengthConfiguration(warning: 100, error: 100, ignoresURLs: false)
+        let configuration1 = LineLengthConfiguration(warning: 100, error: 100, flags: allFlags)
+        let configuration2 = LineLengthConfiguration(warning: 100,
+                                                     error: 100,
+                                                     flags: [.ignoreFunctionDeclarations,
+                                                               .ignoreComments])
         XCTAssertFalse(configuration1 == configuration2)
 
-        let configuration3 = LineLengthConfiguration(warning: 100, error: 200, ignoresURLs: true)
+        let configuration3 = LineLengthConfiguration(warning: 100, error: 200, flags: allFlags)
         XCTAssertFalse(configuration1 == configuration3)
 
-        let configuration4 = LineLengthConfiguration(warning: 200, error: 100, ignoresURLs: true)
+        let configuration4 = LineLengthConfiguration(warning: 200, error: 100, flags: allFlags)
         XCTAssertFalse(configuration1 == configuration4)
 
-        let configuration5 = LineLengthConfiguration(warning: 100, error: 100, ignoresURLs: true)
+        let configuration5 = LineLengthConfiguration(warning: 100, error: 100, flags: allFlags)
         XCTAssertTrue(configuration1 == configuration5)
 
-        let configuration6 = LineLengthConfiguration(warning: 100, error: 100, ignoresURLs: false)
+        let configuration6 = LineLengthConfiguration(warning: 100,
+                                                     error: 100,
+                                                     flags: [.ignoreFunctionDeclarations,
+                                                               .ignoreComments])
         XCTAssertTrue(configuration2 == configuration6)
     }
 }

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -38,7 +38,7 @@ class LineLengthRuleTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["ignores_function_declarations": true],
                    commentDoesntViolate: false, stringDoesntViolate: false)
     }
-    
+
     func testLineLengthWithIgnoreCommentsEnabled() {
         let baseDescription = LineLengthRule.description
         let triggeringExamples = [longFunctionDeclaration]
@@ -51,8 +51,6 @@ class LineLengthRuleTests: XCTestCase {
                                           corrections: baseDescription.corrections)
         verifyRule(description, ruleConfiguration: ["ignores_comments": true],
                    commentDoesntViolate: false, stringDoesntViolate: false, skipCommentTests: true)
-        
-        
     }
 
     func testLineLengthWithIgnoreURLsEnabled() {

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -12,20 +12,20 @@ import XCTest
 
 class LineLengthRuleTests: XCTestCase {
 
-    let longFunctionDeclaration = "public func superDuperLongFunctionDeclaration(a: String, b: String, " +
+    private let longFunctionDeclaration = "public func superDuperLongFunctionDeclaration(a: String, b: String, " +
         "c: String, d: String, e: String, f: String, g: String, h: String, i: String, " +
         "j: String, k: String, l: String, m: String, n: String, o: String, p: String, " +
         "q: String, r: String, s: String, t: String, u: String, v: String, w: String, " +
     "x: String, y: String, z: String) {\n"
 
-    let longComment = String(repeating: "/", count: 121) + "\n"
-    let longBlockComment = "/*" + String(repeating: " ", count: 121) + "*/\n"
-
+    private let longComment = String(repeating: "/", count: 121) + "\n"
+    private let longBlockComment = "/*" + String(repeating: " ", count: 121) + "*/\n"
+    private let declarationWithTrailingLongComment = "let foo = 1 " + String(repeating: "/", count: 121) + "\n"
     func testLineLength() {
         verifyRule(LineLengthRule.description, commentDoesntViolate: false, stringDoesntViolate: false)
     }
 
-    func testLineLengthWithIgnoreFunctionDeclaraionsEnabled() {
+    func testLineLengthWithIgnoreFunctionDeclarationsEnabled() {
         let baseDescription = LineLengthRule.description
         let triggeringExamples = baseDescription.triggeringExamples
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [longFunctionDeclaration]
@@ -41,7 +41,7 @@ class LineLengthRuleTests: XCTestCase {
 
     func testLineLengthWithIgnoreCommentsEnabled() {
         let baseDescription = LineLengthRule.description
-        let triggeringExamples = [longFunctionDeclaration]
+        let triggeringExamples = [longFunctionDeclaration, declarationWithTrailingLongComment]
         let nonTriggeringExamples = [longComment, longBlockComment]
         let description = RuleDescription(identifier: baseDescription.identifier,
                                           name: baseDescription.name,

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -12,8 +12,47 @@ import XCTest
 
 class LineLengthRuleTests: XCTestCase {
 
+    let longFunctionDeclaration = "public func superDuperLongFunctionDeclaration(a: String, b: String, " +
+        "c: String, d: String, e: String, f: String, g: String, h: String, i: String, " +
+        "j: String, k: String, l: String, m: String, n: String, o: String, p: String, " +
+        "q: String, r: String, s: String, t: String, u: String, v: String, w: String, " +
+    "x: String, y: String, z: String) {\n"
+
+    let longComment = String(repeating: "/", count: 121) + "\n"
+    let longBlockComment = "/*" + String(repeating: " ", count: 121) + "*/\n"
+
     func testLineLength() {
         verifyRule(LineLengthRule.description, commentDoesntViolate: false, stringDoesntViolate: false)
+    }
+
+    func testLineLengthWithIgnoreFunctionDeclaraionsEnabled() {
+        let baseDescription = LineLengthRule.description
+        let triggeringExamples = baseDescription.triggeringExamples
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [longFunctionDeclaration]
+        let description = RuleDescription(identifier: baseDescription.identifier,
+                                          name: baseDescription.name,
+                                          description: baseDescription.description,
+                                          nonTriggeringExamples: nonTriggeringExamples,
+                                          triggeringExamples: triggeringExamples,
+                                          corrections: baseDescription.corrections)
+        verifyRule(description, ruleConfiguration: ["ignores_function_declarations": true],
+                   commentDoesntViolate: false, stringDoesntViolate: false)
+    }
+    
+    func testLineLengthWithIgnoreCommentsEnabled() {
+        let baseDescription = LineLengthRule.description
+        let triggeringExamples = [longFunctionDeclaration]
+        let nonTriggeringExamples = [longComment, longBlockComment]
+        let description = RuleDescription(identifier: baseDescription.identifier,
+                                          name: baseDescription.name,
+                                          description: baseDescription.description,
+                                          nonTriggeringExamples: nonTriggeringExamples,
+                                          triggeringExamples: triggeringExamples,
+                                          corrections: baseDescription.corrections)
+        verifyRule(description, ruleConfiguration: ["ignores_comments": true],
+                   commentDoesntViolate: false, stringDoesntViolate: false, skipCommentTests: true)
+        
+        
     }
 
     func testLineLengthWithIgnoreURLsEnabled() {

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -170,9 +170,8 @@ extension XCTestCase {
 
         // Comment doesn't violate
         if !skipCommentTests {
-            let commentTriggers =  triggers.flatMap({ violations("/*\n  " + $0 + "\n */", config: config) })
             XCTAssertEqual(
-                commentTriggers.count,
+                triggers.flatMap({ violations("/*\n  " + $0 + "\n */", config: config) }).count,
                 commentDoesntViolate ? 0 : triggers.count
             )
         }

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -170,8 +170,9 @@ extension XCTestCase {
 
         // Comment doesn't violate
         if !skipCommentTests {
+            let commentTriggers =  triggers.flatMap({ violations("/*\n  " + $0 + "\n */", config: config) })
             XCTAssertEqual(
-                triggers.flatMap({ violations("/*\n  " + $0 + "\n */", config: config) }).count,
+                commentTriggers.count,
                 commentDoesntViolate ? 0 : triggers.count
             )
         }


### PR DESCRIPTION
Hi, I took a pass at adding support for new new options on LineLengthRule to allow support for it to not trigger on long function declarations or long comments (or both): 'ignores_function_declarations' and 'ignores_comments', respectively. 



