### PR TITLE
Update class_delegate_protocol to accept AnyObject and NSObjectProtocl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1061](https://github.com/realm/SwiftLint/issues/1061)
   
-* Accept `AnyObject` and `NSObjectProtocol` in `class_delegate_protocol`.
+* Accept `AnyObject` and `NSObjectProtocol` in `class_delegate_protocol`.  
   [Jon Shier](https://github.com/jshier)
   [#1261](https://github.com/realm/SwiftLint/issues/1261)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   removing itself from `NotificationCenter` in an unsafe location.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1061](https://github.com/realm/SwiftLint/issues/1061)
+  
+* Accept `AnyObject` and `NSObjectProtocol` in `class_delegate_protocol`.
+  [Jon Shier](https://github.com/jshier)
+  [#1261](https://github.com/realm/SwiftLint/issues/1261)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
@@ -67,7 +67,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
             case let contents = file.contents.bridge(),
             case let start = nameOffset + nameLength,
             let range = contents.byteRangeToNSRange(start: start, length: bodyOffset - start),
-            !(isClassProtocol(file: file, range: range) || isReferenceProtocol(file: file, range: range)) else {
+            !(isClassProtocol(file: file, range: range) || !Set(["AnyObject", "NSObjectProtocol"]).isDisjoint(with: dictionary.inheritedTypes)) else {
             return []
         }
 
@@ -80,10 +80,6 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
 
     private func isClassProtocol(file: File, range: NSRange) -> Bool {
         return !file.match(pattern: "\\bclass\\b", with: [.keyword], range: range).isEmpty
-    }
-    
-    private func isReferenceProtocol(file: File, range: NSRange) -> Bool {
-        return !file.match(pattern: "\\b(AnyObject|NSObjectProtocol)\\b", with: [.typeidentifier], range: range).isEmpty
     }
 
     private func isDelegateProtocol(_ name: String) -> Bool {

--- a/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
@@ -25,7 +25,9 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
             "class FooDelegate {}\n",
             "@objc protocol FooDelegate {}\n",
             "@objc(MyFooDelegate)\n protocol FooDelegate {}\n",
-            "protocol FooDelegate: BarDelegate {}\n"
+            "protocol FooDelegate: BarDelegate {}\n",
+            "protocol FooDelegate: AnyObject {}\n",
+            "protocol FooDelegate: NSObjectProtocol {}\n"
         ],
         triggeringExamples: [
             "↓protocol FooDelegate {}\n",
@@ -65,7 +67,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
             case let contents = file.contents.bridge(),
             case let start = nameOffset + nameLength,
             let range = contents.byteRangeToNSRange(start: start, length: bodyOffset - start),
-            !isClassProtocol(file: file, range: range) else {
+            !(isClassProtocol(file: file, range: range) || isReferenceProtocol(file: file, range: range)) else {
             return []
         }
 
@@ -78,6 +80,10 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
 
     private func isClassProtocol(file: File, range: NSRange) -> Bool {
         return !file.match(pattern: "\\bclass\\b", with: [.keyword], range: range).isEmpty
+    }
+    
+    private func isReferenceProtocol(file: File, range: NSRange) -> Bool {
+        return !file.match(pattern: "\\b(AnyObject|NSObjectProtocol)\\b", with: [.typeidentifier], range: range).isEmpty
     }
 
     private func isDelegateProtocol(_ name: String) -> Bool {


### PR DESCRIPTION
This PR updates `ClassDelegateProtocolRule` to accept the `AnyObject` and `NSObjectProtocol` types, as they also require a reference type. Fixes #1261.