### PR TITLE
Disable automatic caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1061](https://github.com/realm/SwiftLint/issues/1061)
 
+* Disable automatic caching  
+  [Ben Asher](https://github.com/benasher44)
+
 ##### Bug Fixes
 
 * Fix a false positive on `large_tuple` rule when using closures.  

--- a/Source/swiftlint/Extensions/LinterCache+CommandLine.swift
+++ b/Source/swiftlint/Extensions/LinterCache+CommandLine.swift
@@ -41,26 +41,5 @@ private func cacheURL(options: LintOptions, configuration: Configuration) -> URL
     }
 
     let path = options.cachePath.isEmpty ? configuration.cachePath : options.cachePath
-    return path.map(URL.init(fileURLWithPath:)) ?? defaultCacheURL(options: options)
-}
-
-private func defaultCacheURL(options: LintOptions) -> URL {
-    let rootPath = options.path.bridge().absolutePathRepresentation()
-
-    #if os(Linux)
-        let baseURL = URL(fileURLWithPath: "/var/tmp/")
-    #else
-        let baseURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-    #endif
-
-    let fileName = String(rootPath.hash) + ".json"
-    let folder = baseURL.appendingPathComponent("SwiftLint")
-
-    do {
-        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true, attributes: nil)
-    } catch {
-        queuedPrintError("Error while creating cache: " + error.localizedDescription)
-    }
-
-    return folder.appendingPathComponent(fileName)
+    return path.map(URL.init(fileURLWithPath:))
 }


### PR DESCRIPTION
As mentioned in #1184, disabling automatic caching would make `swiftlint`'s caching situation simpler as well as serve a few goals:

1. Running `swiftlint lint`from the CLI now behaves the same across multiple invocations (i.e. won't hit a cache the second time without a `.swiftlint.yml` specifying a `cache_path`).
2. This makes caching simpler in the case of passing multiple paths as arguments for #1191, since no cache key/url has to be determined based on the paths being linted in the case where there is no `cache_path` specified.
3. Caching is a feature that makes the most sense in the context of a project, in which case there should be a `.swiftlint.yml` (`cache_path` can be easily set), so automatic caching shouldn't be needed (again just reducing complexity).

I realize that this might be a bit premature, but I thought it might be useful to have the scope of the change out in the open. Thanks!