### PR TITLE
Line length rule configuration console description

### DIFF
--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -47,7 +47,9 @@ private enum ConfigurationKey: String {
 
 public struct LineLengthConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
-        return length.consoleDescription + ", ignores urls: \(ignoresURLs)"
+        return length.consoleDescription + ", ignores urls: \(ignoresURLs), " +
+        "ignores function declarations: \(ignoresFunctionDeclarations), " +
+        "ignores comments: \(ignoresComments)"
     }
 
     var length: SeverityLevelsConfiguration


### PR DESCRIPTION
I forgot to change the console description for line line rule configuration when I added the ignores_function_declarations and ignores_comments in my last pull request. This fixes. 