### PR TITLE
set 'swiftlint' scheme's arguments to 'lint --no-cache'

### DIFF
--- a/SwiftLint.xcodeproj/xcshareddata/xcschemes/swiftlint.xcscheme
+++ b/SwiftLint.xcodeproj/xcshareddata/xcschemes/swiftlint.xcscheme
@@ -79,6 +79,12 @@
             ReferencedContainer = "container:SwiftLint.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "lint --no-cache"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "DEVELOPER_DIR"


### PR DESCRIPTION
since the cache is per-version and the version number is only bumped for releases, meaning that during development the cache is likely to be incorrect.