### PR TITLE
Fix `todo` rule messages when the comment is not on a new line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1216](https://github.com/realm/SwiftLint/issues/1216)
 
+* Fix `todo` rule messages when the comment is not on a new line.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1304](https://github.com/realm/SwiftLint/issues/1304)
+
 ## 0.16.1: Commutative Fabric Sheets
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -47,24 +47,22 @@ public struct TodoRule: ConfigurationProviderRule {
         ]
     )
 
-    private func customMessage(lines: [Line], location: Location) -> String {
+    private func customMessage(file: File, range: NSRange) -> String {
         var reason = type(of: self).description.description
+        let offset = NSMaxRange(range)
 
-        guard let lineIndex = location.line,
-            let currentLine = lines.first(where: { $0.index == lineIndex }) else {
-                return reason
+        guard let (lineNumber, _) = file.contents.bridge().lineAndCharacter(forCharacterOffset: offset) else {
+            return reason
         }
 
+        let line = file.lines[lineNumber - 1]
         // customizing the reason message to be specific to fixme or todo
-        var message = currentLine.content
-        if currentLine.content.contains("FIXME") {
-            reason = "FIXMEs should be avoided"
-            message = message.replacingOccurrences(of: "FIXME", with: "")
-        } else {
-            reason = "TODOs should be avoided"
-            message = message.replacingOccurrences(of: "TODO", with: "")
-        }
-        message = message.replacingOccurrences(of: "//", with: "")
+        let violationSubstring = file.contents.bridge().substring(with: range)
+
+        let range = NSRange(location: offset, length: NSMaxRange(line.range) - offset)
+        var message = file.contents.bridge().substring(with: range)
+        let kind = violationSubstring.hasPrefix("FIXME") ? "FIXMEs" : "TODOs"
+
         // trim whitespace
         message = message.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -74,26 +72,29 @@ public struct TodoRule: ConfigurationProviderRule {
             let index = message.index(message.startIndex,
                                       offsetBy: maxLengthOfMessage,
                                       limitedBy: message.endIndex) ?? message.endIndex
-            reason += message.substring(to: index) + "..."
+            message = message.substring(to: index) + "..."
+        }
+
+        if message.isEmpty {
+            reason = "\(kind) should be avoided."
         } else {
-            reason += message
+            reason = "\(kind) should be avoided (\(message))."
         }
 
         return reason
     }
 
     public func validate(file: File) -> [StyleViolation] {
-        return file.match(pattern: "\\b(TODO|FIXME)\\b").flatMap { range, syntaxKinds in
+        return file.match(pattern: "\\b(?:TODO|FIXME)(?::|\\b)").flatMap { range, syntaxKinds in
             if !syntaxKinds.filter({ !$0.isCommentLike }).isEmpty {
                 return nil
             }
-            let location = Location(file: file, characterOffset: range.location)
-            let reason = customMessage(lines: file.lines, location: location)
+            let reason = customMessage(file: file, range: range)
 
             return StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: location,
-                reason: reason )
+                                  severity: configuration.severity,
+                                  location: Location(file: file, characterOffset: range.location),
+                                  reason: reason)
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 
 extension SyntaxKind {

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -94,8 +94,8 @@
 		D286EC021E02DF6F0003CF72 /* SortedImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286EC001E02DA190003CF72 /* SortedImportsRule.swift */; };
 		D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */; };
 		D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */; };
-		D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */; };
 		D4130D971E16183F00242361 /* IdentifierNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4130D961E16183F00242361 /* IdentifierNameRuleExamples.swift */; };
+		D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */; };
 		D41E7E0B1DF9DABB0065259A /* RedundantStringEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */; };
 		D42D2B381E09CC0D00CD7A2E /* FirstWhereRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42D2B371E09CC0D00CD7A2E /* FirstWhereRule.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
@@ -146,6 +146,7 @@
 		D4DABFD71E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */; };
 		D4DABFD91E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */; };
 		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
+		D4DB92251E628898005DE9C1 /* TodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */; };
 		D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */; };
 		D4FD58B21E12A0200019503C /* LinterCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD58B11E12A0200019503C /* LinterCache.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
@@ -368,8 +369,8 @@
 		D286EC001E02DA190003CF72 /* SortedImportsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedImportsRule.swift; sourceTree = "<group>"; };
 		D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedClosureParameterRule.swift; sourceTree = "<group>"; };
 		D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaConfiguration.swift; sourceTree = "<group>"; };
-		D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRuleExamples.swift; sourceTree = "<group>"; };
 		D4130D961E16183F00242361 /* IdentifierNameRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierNameRuleExamples.swift; sourceTree = "<group>"; };
+		D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRuleExamples.swift; sourceTree = "<group>"; };
 		D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStringEnumValueRule.swift; sourceTree = "<group>"; };
 		D42D2B371E09CC0D00CD7A2E /* FirstWhereRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirstWhereRule.swift; sourceTree = "<group>"; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
@@ -420,6 +421,7 @@
 		D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenterDetachmentRule.swift; sourceTree = "<group>"; };
 		D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenterDetachmentRuleExamples.swift; sourceTree = "<group>"; };
 		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
+		D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoRuleTests.swift; sourceTree = "<group>"; };
 		D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorUsageWhitespaceRule.swift; sourceTree = "<group>"; };
 		D4FD58B11E12A0200019503C /* LinterCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinterCache.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
@@ -736,6 +738,7 @@
 				E86396C61BADAFE6002C9E88 /* ReporterTests.swift */,
 				E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */,
 				E81224991B04F85B001783D2 /* TestHelpers.swift */,
+				D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */,
 				3B12C9C21C320A53000B423F /* Yaml+SwiftLintTests.swift */,
 				3B12C9C61C3361CB000B423F /* RuleTests.swift */,
 				3B30C4A01C3785B300E04027 /* YamlParserTests.swift */,
@@ -1315,6 +1318,7 @@
 				006204DE1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift in Sources */,
 				02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */,
 				D4CA758F1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift in Sources */,
+				D4DB92251E628898005DE9C1 /* TodoRuleTests.swift in Sources */,
 				D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */,
 				3B63D46D1E1F05160057BE35 /* LineLengthConfigurationTests.swift in Sources */,
 				6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -28,6 +28,7 @@ XCTMain([
     testCase(RuleTests.allTests),
     testCase(SourceKitCrashTests.allTests),
     testCase(TrailingCommaRuleTests.allTests),
+    testCase(TodoRuleTests.allTests),
     testCase(VerticalWhitespaceRuleTests.allTests),
     testCase(YamlParserTests.allTests),
     testCase(YamlSwiftLintTests.allTests)

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -258,10 +258,6 @@ class RulesTests: XCTestCase {
         verifyRule(SyntacticSugarRule.description)
     }
 
-    func testTodo() {
-        verifyRule(TodoRule.description, commentDoesntViolate: false)
-    }
-
     func testTrailingNewline() {
         verifyRule(TrailingNewlineRule.description, commentDoesntViolate: false,
                    stringDoesntViolate: false)
@@ -411,7 +407,6 @@ extension RulesTests {
             ("testStatementPositionUncuddled", testStatementPositionUncuddled),
             ("testSwitchCaseOnNewline", testSwitchCaseOnNewline),
             ("testSyntacticSugar", testSyntacticSugar),
-            ("testTodo", testTodo),
             ("testTrailingNewline", testTrailingNewline),
             ("testTrailingSemicolon", testTrailingSemicolon),
             ("testTrailingWhitespace", testTrailingWhitespace),

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -1,0 +1,46 @@
+//
+//  TodoRuleTests.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 02/26/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+import XCTest
+
+class TodoRuleTests: XCTestCase {
+
+    func testTodo() {
+        verifyRule(TodoRule.description, commentDoesntViolate: false)
+    }
+
+    func testTodoMessage() {
+        let string = "fatalError() // TODO: Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "TODOs should be avoided (Implement).")
+    }
+
+    func testFixMeMessage() {
+        let string = "fatalError() // FIXME: Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "FIXMEs should be avoided (Implement).")
+    }
+
+    private func violations(_ string: String) -> [StyleViolation] {
+        let config = makeConfig(nil, TodoRule.description.identifier)!
+        return SwiftLintFrameworkTests.violations(string, config: config)
+    }
+}
+
+extension TodoRuleTests {
+    static var allTests: [(String, (TodoRuleTests) -> () throws -> Void)] {
+        return [
+            ("testTodo", testTodo),
+            ("testTodoMessage", testTodoMessage)
+            ("testFixMeMessage", testFixMeMessage)
+        ]
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -39,7 +39,7 @@ extension TodoRuleTests {
     static var allTests: [(String, (TodoRuleTests) -> () throws -> Void)] {
         return [
             ("testTodo", testTodo),
-            ("testTodoMessage", testTodoMessage)
+            ("testTodoMessage", testTodoMessage),
             ("testFixMeMessage", testFixMeMessage)
         ]
     }


### PR DESCRIPTION
Fixes #1304

// cc @reitzig