### PR TITLE
Add spaced_type_declaration rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@
   [Natan Rolnik](https://github.com/NatanRolnik)
   [#1270](https://github.com/realm/SwiftLint/issues/1270)
 
+* Add `spaced_type_declarations` rule that warns if either the start or end
+  of a type declaration is not enclosed by two empty lines.  
+  [Diego Ernst](https://github.com/dernster)
+  [#1345](https://github.com/realm/SwiftLint/pull/1345)
+
 ##### Bug Fixes
 
 * Fix a false positive on `large_tuple` rule when using closures.  

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -10,12 +10,15 @@ import Dispatch
 import Foundation
 
 extension Array where Element: NSTextCheckingResult {
+
     func ranges() -> [NSRange] {
         return map { $0.range }
     }
+
 }
 
 extension Array where Element: Equatable {
+
     var unique: [Element] {
         var uniqueValues = [Element]()
         for item in self where !uniqueValues.contains(item) {
@@ -23,9 +26,11 @@ extension Array where Element: Equatable {
         }
         return uniqueValues
     }
+
 }
 
 extension Array {
+
     static func array(of obj: Any?) -> [Element]? {
         if let array = obj as? [Element] {
             return array
@@ -73,4 +78,5 @@ extension Array {
         }
         return result.sorted { $0.0 < $1.0 }.map { $0.1 }
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 extension CharacterSet {
+
     func isSuperset(ofCharactersIn string: String) -> Bool {
         #if os(Linux)
             // workaround for https://bugs.swift.org/browse/SR-3485
@@ -23,13 +24,16 @@ extension CharacterSet {
             return isSuperset(of: otherSet)
         #endif
     }
+
 }
 
 extension Character {
+
     fileprivate var unicodeScalar: UnicodeScalar {
         let characterString = String(self)
         let scalars = characterString.unicodeScalars
 
         return scalars[scalars.startIndex]
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -148,4 +148,5 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
             return name
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -34,6 +34,7 @@ internal typealias AssertHandler = () -> Void
 private var assertHandlers = [String: AssertHandler]()
 
 private struct RebuildQueue {
+
     private let lock = NSLock()
     private var queue = [Structure]()
     private var allDeclarationsByType = [String: [String]]()
@@ -75,11 +76,13 @@ private struct RebuildQueue {
         rebuildIfNecessary()
         return allDeclarationsByType
     }
+
 }
 
 private var queueForRebuild = RebuildQueue()
 
 private struct Cache<T> {
+
     private var values = [String: T]()
     private let factory: (File) -> T
     private let lock = NSLock()
@@ -123,6 +126,7 @@ private struct Cache<T> {
         block()
         lock.unlock()
     }
+
 }
 
 extension File {
@@ -219,4 +223,5 @@ extension File {
     internal static var allDeclarationsByType: [String: [String]] {
         return queueForRebuild.getAllDeclarationsByType()
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -20,6 +20,7 @@ internal func regex(_ pattern: String,
 }
 
 extension File {
+
     internal func regions() -> [Region] {
         var regions = [Region]()
         var disabledRules = Set<String>()

--- a/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
@@ -9,10 +9,13 @@
 import Foundation
 
 public protocol LintableFileManager {
+
     func filesToLint(inPath: String, rootDirectory: String?) -> [String]
+
 }
 
 extension FileManager: LintableFileManager {
+
     public func filesToLint(inPath path: String, rootDirectory: String? = nil) -> [String] {
         let rootPath = rootDirectory ?? currentDirectoryPath
         let absolutePath = path.bridge()
@@ -31,4 +34,5 @@ extension FileManager: LintableFileManager {
             return nil
         } ?? []
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/NSRange+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRange+SwiftLint.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 extension NSRange {
+
     func intersects(_ range: NSRange) -> Bool {
         return NSIntersectionRange(self, range).length > 0
     }
@@ -19,4 +20,5 @@ extension NSRange {
         }
         return false
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
@@ -16,6 +16,7 @@ public typealias NSTextCheckingResult = TextCheckingResult
 private var regexCache = [RegexCacheKey: NSRegularExpression]()
 
 private struct RegexCacheKey: Hashable {
+
     let pattern: String
     let options: NSRegularExpression.Options
 
@@ -26,9 +27,11 @@ private struct RegexCacheKey: Hashable {
     static func == (lhs: RegexCacheKey, rhs: RegexCacheKey) -> Bool {
         return lhs.options == rhs.options && lhs.pattern == rhs.pattern
     }
+
 }
 
 extension NSRegularExpression {
+
     internal static func cached(pattern: String, options: Options? = nil) throws -> NSRegularExpression {
         let options = options ?? [.anchorsMatchLines, .dotMatchesLineSeparators]
         let key = RegexCacheKey(pattern: pattern, options: options)
@@ -40,4 +43,5 @@ extension NSRegularExpression {
         regexCache[key] = result
         return result
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 extension String {
+
     internal func hasTrailingWhitespace() -> Bool {
         if isEmpty {
             return false
@@ -92,4 +93,5 @@ extension String {
         }
         return false
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/String+XML.swift
+++ b/Source/SwiftLintFramework/Extensions/String+XML.swift
@@ -7,6 +7,7 @@
 //
 
 extension String {
+
     func escapedForXML() -> String {
         // & needs to go first, otherwise other replacements will be replaced again
         let htmlEscapes = [
@@ -22,4 +23,5 @@ extension String {
         }
         return newString
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
@@ -34,4 +34,5 @@ extension Structure {
         parse(dictionary)
         return results
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
@@ -9,6 +9,7 @@
 import SourceKittenFramework
 
 extension SwiftDeclarationKind {
+
     internal static func variableKinds() -> [SwiftDeclarationKind] {
         return [
             .varClass,

--- a/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public enum SwiftExpressionKind: String {
+
     case call = "source.lang.swift.expr.call"
     case argument = "source.lang.swift.expr.argument"
     case array = "source.lang.swift.expr.array"
@@ -32,4 +33,5 @@ public enum SwiftExpressionKind: String {
             self = .other
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
@@ -9,6 +9,7 @@
 import SourceKittenFramework
 
 extension SyntaxKind {
+
     init(shortName: Swift.String) throws {
         let prefix = "source.lang.swift.syntaxtype."
         guard let kind = SyntaxKind(rawValue: prefix + shortName.lowercased()) else {
@@ -35,4 +36,5 @@ extension SyntaxKind {
                 .keyword, .number, .objectLiteral, .parameter, .placeholder, .string,
                 .stringInterpolationAnchor, .typeidentifier]
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
@@ -33,4 +33,5 @@ extension SyntaxMap {
         }
         return Array(tokensBeginningIntersect)
     }
+
 }

--- a/Source/SwiftLintFramework/Extensions/Yaml+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Yaml+SwiftLint.swift
@@ -10,6 +10,7 @@ import Foundation
 import Yaml
 
 extension Yaml {
+
     var flatDictionary: [Swift.String: Any]? {
         if let dict = dictionary {
             var newDict: [Swift.String: Any] = [:]
@@ -63,4 +64,5 @@ extension Yaml {
             return "Null"
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
+++ b/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
@@ -24,4 +24,5 @@ struct RegexHelpers {
 
     // Two 'variable or number'
     static let twoVariableOrNumber = "\(variableOrNumber),\(variableOrNumber)"
+
 }

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -9,7 +9,9 @@
 import Foundation
 
 #if !os(Linux)
+
 private extension Scanner {
+
     func scanUpToString(_ string: String) -> String? {
         var result: NSString? = nil
         let success = scanUpTo(string, into: &result)
@@ -27,11 +29,15 @@ private extension Scanner {
         }
         return nil
     }
+
 }
+
 #endif
 
 public struct Command {
+
     public enum Action: String {
+
         case enable
         case disable
 
@@ -41,12 +47,15 @@ public struct Command {
             case .disable: return .enable
             }
         }
+
     }
 
     public enum Modifier: String {
+
         case previous
         case this
         case next
+
     }
 
     internal let action: Action
@@ -121,4 +130,5 @@ public struct Command {
             ]
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -12,6 +12,7 @@ import SourceKittenFramework
 private let fileManager = FileManager.default
 
 private enum ConfigurationKey: String {
+
     case cachePath = "cache_path"
     case disabledRules = "disabled_rules"
     case enabledRules = "enabled_rules" // deprecated in favor of optInRules
@@ -23,9 +24,11 @@ private enum ConfigurationKey: String {
     case useNestedConfigs = "use_nested_configs" // deprecated
     case warningThreshold = "warning_threshold"
     case whitelistRules = "whitelist_rules"
+
 }
 
 public struct Configuration: Equatable {
+
     public static let fileName = ".swiftlint.yml"
     public let included: [String]             // included
     public let excluded: [String]             // excluded
@@ -216,6 +219,7 @@ public struct Configuration: Equatable {
         }
         return self
     }
+
 }
 
 private func validateRuleIdentifiers(configuredRules: [Rule], disabledRules: [String]) -> [String] {
@@ -310,6 +314,7 @@ private func warnAboutDeprecations(configurationDictionary dict: [String: Any],
 // MARK: - Nested Configurations Extension
 
 extension Configuration {
+
     fileprivate func configuration(forPath path: String) -> Configuration {
         let pathNSString = path.bridge()
         let configurationSearchPath = pathNSString.appendingPathComponent(Configuration.fileName)
@@ -336,6 +341,7 @@ extension Configuration {
     internal func merge(with configuration: Configuration) -> Configuration {
         return configuration
     }
+
 }
 
 // Mark - == Implementation

--- a/Source/SwiftLintFramework/Models/ConfigurationError.swift
+++ b/Source/SwiftLintFramework/Models/ConfigurationError.swift
@@ -9,5 +9,7 @@
 import Foundation
 
 public enum ConfigurationError: Error {
+
     case unknownConfiguration
+
 }

--- a/Source/SwiftLintFramework/Models/Correction.swift
+++ b/Source/SwiftLintFramework/Models/Correction.swift
@@ -7,12 +7,14 @@
 //
 
 public struct Correction: Equatable {
+
     public let ruleDescription: RuleDescription
     public let location: Location
 
     public var consoleDescription: String {
         return "\(location) Corrected \(ruleDescription.name)"
     }
+
 }
 
 // MARK: Equatable

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -11,12 +11,15 @@ import Foundation
 import SourceKittenFramework
 
 private struct LintResult {
+
     let violations: [StyleViolation]
     let ruleTime: (id: String, time: Double)?
     let deprecatedToValidIDPairs: [(String, String)]
+
 }
 
 extension Rule {
+
     fileprivate func lint(file: File, regions: [Region], benchmark: Bool) -> LintResult? {
         if !(self is SourceKitFreeRule) && file.sourcekitdFailed {
             return nil
@@ -49,9 +52,11 @@ extension Rule {
         return LintResult(violations: enabledViolations, ruleTime: ruleTime,
                           deprecatedToValidIDPairs: deprecatedToValidIDPairs)
     }
+
 }
 
 public struct Linter {
+
     public let file: File
     private let rules: [Rule]
     private let cache: LinterCache?
@@ -137,4 +142,5 @@ public struct Linter {
         }
         return corrections
     }
+
 }

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -10,12 +10,15 @@ import Foundation
 import SourceKittenFramework
 
 public enum LinterCacheError: Error {
+
     case invalidFormat
     case differentVersion
     case differentConfiguration
+
 }
 
 public final class LinterCache {
+
     private var cache: [String: Any]
     private let lock = NSLock()
 
@@ -95,9 +98,11 @@ public final class LinterCache {
             "reason": violation.reason
         ]
     }
+
 }
 
 extension StyleViolation {
+
     fileprivate static func from(cache: [String: Any], file: String) -> StyleViolation? {
         guard let severity = (cache["severity"] as? String).flatMap({ ViolationSeverity(rawValue: $0) }),
             let name = cache["type"] as? String,
@@ -116,4 +121,5 @@ extension StyleViolation {
 
         return violation
     }
+
 }

--- a/Source/SwiftLintFramework/Models/Location.swift
+++ b/Source/SwiftLintFramework/Models/Location.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct Location: CustomStringConvertible, Comparable {
+
     public let file: String?
     public let line: Int?
     public let character: Int?
@@ -52,6 +53,7 @@ public struct Location: CustomStringConvertible, Comparable {
             character = nil
         }
     }
+
 }
 
 // MARK: Comparable

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -134,6 +134,7 @@ public let masterRuleList = RuleList(rules:
     ReturnArrowWhitespaceRule.self,
     ShorthandOperatorRule.self,
     SortedImportsRule.self,
+    SpacedTypeDeclarationsRule.self,
     StatementPositionRule.self,
     SwitchCaseOnNewlineRule.self,
     SyntacticSugarRule.self,

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -9,10 +9,13 @@
 import Foundation
 
 public enum RuleListError: Error {
+
     case duplicatedConfigurations(rule: Rule.Type)
+
 }
 
 public struct RuleList {
+
     public let list: [String: Rule.Type]
     private let aliases: [String: String]
 
@@ -71,6 +74,7 @@ public struct RuleList {
             rule.description.allIdentifiers
         }
     }
+
 }
 
 public let masterRuleList = RuleList(rules:

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct Region {
+
     let start: Location
     let end: Location
     let disabledRuleIdentifiers: Set<String>
@@ -37,4 +38,5 @@ public struct Region {
         let identifiers = type(of: rule).description.deprecatedAliases
         return disabledRuleIdentifiers.intersection(identifiers)
     }
+
 }

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -7,6 +7,7 @@
 //
 
 public struct RuleDescription: Equatable {
+
     public let identifier: String
     public let name: String
     public let description: String
@@ -33,6 +34,7 @@ public struct RuleDescription: Equatable {
         self.corrections = corrections
         self.deprecatedAliases = deprecatedAliases
     }
+
 }
 
 // MARK: Equatable

--- a/Source/SwiftLintFramework/Models/RuleParameter.swift
+++ b/Source/SwiftLintFramework/Models/RuleParameter.swift
@@ -7,6 +7,7 @@
 //
 
 public struct RuleParameter<T: Equatable>: Equatable {
+
     public let severity: ViolationSeverity
     public let value: T
 
@@ -14,6 +15,7 @@ public struct RuleParameter<T: Equatable>: Equatable {
         self.severity = severity
         self.value = value
     }
+
 }
 
 // MARK: - Equatable

--- a/Source/SwiftLintFramework/Models/StyleViolation.swift
+++ b/Source/SwiftLintFramework/Models/StyleViolation.swift
@@ -7,6 +7,7 @@
 //
 
 public struct StyleViolation: CustomStringConvertible, Equatable {
+
     public let ruleDescription: RuleDescription
     public let severity: ViolationSeverity
     public let location: Location
@@ -22,6 +23,7 @@ public struct StyleViolation: CustomStringConvertible, Equatable {
         self.location = location
         self.reason = reason ?? ruleDescription.description
     }
+
 }
 
 // MARK: Equatable

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 enum SwiftVersion {
+
     case two
     case twoPointThree
     case three

--- a/Source/SwiftLintFramework/Models/Version.swift
+++ b/Source/SwiftLintFramework/Models/Version.swift
@@ -7,7 +7,9 @@
 //
 
 public struct Version {
+
     public let value: String
 
     public static let current = Version(value: "0.16.1")
+
 }

--- a/Source/SwiftLintFramework/Models/ViolationSeverity.swift
+++ b/Source/SwiftLintFramework/Models/ViolationSeverity.swift
@@ -7,8 +7,10 @@
 //
 
 public enum ViolationSeverity: String, Comparable {
+
     case warning
     case error
+
 }
 
 // MARK: Comparable

--- a/Source/SwiftLintFramework/Models/YamlParser.swift
+++ b/Source/SwiftLintFramework/Models/YamlParser.swift
@@ -11,8 +11,10 @@ import Yaml
 // MARK: - YamlParsingError
 
 internal enum YamlParserError: Error, Equatable {
+
     case yamlParsing(String)
     case yamlFlattening
+
 }
 
 internal func == (lhs: YamlParserError, rhs: YamlParserError) -> Bool {
@@ -29,6 +31,7 @@ internal func == (lhs: YamlParserError, rhs: YamlParserError) -> Bool {
 // MARK: - YamlParser
 
 public struct YamlParser {
+
     public static func parse(_ yaml: String) throws -> [String: Any] {
         do {
             if let dict = try Yaml.load(yaml).flatDictionary {
@@ -41,4 +44,5 @@ public struct YamlParser {
             throw error
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -9,11 +9,14 @@
 import SourceKittenFramework
 
 public protocol ASTRule: Rule {
+
     associatedtype KindType: RawRepresentable
     func validate(file: File, kind: KindType, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]
+
 }
 
 extension ASTRule where KindType.RawValue == String {
+
     public func validate(file: File) -> [StyleViolation] {
         return validate(file: file, dictionary: file.structure.dictionary)
     }
@@ -30,4 +33,5 @@ extension ASTRule where KindType.RawValue == String {
             return violations
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -7,9 +7,11 @@
 //
 
 public protocol Reporter: CustomStringConvertible {
+
     static var identifier: String { get }
     static func generateReport(_ violations: [StyleViolation]) -> String
     static var isRealtime: Bool { get }
+
 }
 
 public func reporterFrom(identifier: String) -> Reporter.Type {

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -9,29 +9,37 @@
 import SourceKittenFramework
 
 public protocol Rule {
+
     init() // Rules need to be able to be initialized with default values
     init(configuration: Any) throws
     static var description: RuleDescription { get }
     func validate(file: File) -> [StyleViolation]
     func isEqualTo(_ rule: Rule) -> Bool
     var configurationDescription: String { get }
+
 }
 
 extension Rule {
+
     public func isEqualTo(_ rule: Rule) -> Bool {
         return type(of: self).description == type(of: rule).description
     }
+
 }
 
 public protocol OptInRule: Rule {}
 
 public protocol ConfigurationProviderRule: Rule {
+
     associatedtype ConfigurationType: RuleConfiguration
     var configuration: ConfigurationType { get set }
+
 }
 
 public protocol CorrectableRule: Rule {
+
     func correct(file: File) -> [Correction]
+
 }
 
 public protocol SourceKitFreeRule: Rule {}
@@ -39,6 +47,7 @@ public protocol SourceKitFreeRule: Rule {}
 // MARK: - ConfigurationProviderRule conformance to Configurable
 
 public extension ConfigurationProviderRule {
+
     public init(configuration: Any) throws {
         self.init()
         try self.configuration.apply(configuration: configuration)
@@ -54,6 +63,7 @@ public extension ConfigurationProviderRule {
     public var configurationDescription: String {
         return configuration.consoleDescription
     }
+
 }
 
 // MARK: - == Implementations

--- a/Source/SwiftLintFramework/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Protocols/RuleConfiguration.swift
@@ -9,13 +9,17 @@
 import Foundation
 
 public protocol RuleConfiguration {
+
     mutating func apply(configuration: Any) throws
     func isEqualTo(_ ruleConfiguration: RuleConfiguration) -> Bool
     var consoleDescription: String { get }
+
 }
 
 extension RuleConfiguration where Self: Equatable {
+
     public func isEqualTo(_ ruleConfiguration: RuleConfiguration) -> Bool {
         return self == ruleConfiguration as? Self
     }
+
 }

--- a/Source/SwiftLintFramework/Reporters/CSVReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CSVReporter.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 extension String {
+
     fileprivate func escapedForCSV() -> String {
         let escapedString = replacingOccurrences(of: "\"", with: "\"\"")
         if escapedString.contains(",") || escapedString.contains("\n") {
@@ -16,9 +17,11 @@ extension String {
         }
         return escapedString
     }
+
 }
 
 public struct CSVReporter: Reporter {
+
     public static let identifier = "csv"
     public static let isRealtime = false
 
@@ -50,4 +53,5 @@ public struct CSVReporter: Reporter {
             violation.ruleDescription.identifier
         ]
     }
+
 }

--- a/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct CheckstyleReporter: Reporter {
+
     public static let identifier = "checkstyle"
     public static let isRealtime = false
 
@@ -39,4 +40,5 @@ public struct CheckstyleReporter: Reporter {
             "\t</file>"
         ].joined()
     }
+
 }

--- a/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct EmojiReporter: Reporter {
+
     public static let identifier = "emoji"
     public static let isRealtime = false
 
@@ -40,4 +41,5 @@ public struct EmojiReporter: Reporter {
         }
         return lines.joined(separator: "\n")
     }
+
 }

--- a/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
@@ -15,6 +15,7 @@ private let formatter: DateFormatter = {
 }()
 
 public struct HTMLReporter: Reporter {
+
     public static let identifier = "html"
     public static let isRealtime = false
 
@@ -167,4 +168,5 @@ public struct HTMLReporter: Reporter {
             "\t\t\t\t</tr>\n"
         ].joined()
     }
+
 }

--- a/Source/SwiftLintFramework/Reporters/JSONReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JSONReporter.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct JSONReporter: Reporter {
+
     public static let identifier = "json"
     public static let isRealtime = false
 
@@ -32,4 +33,5 @@ public struct JSONReporter: Reporter {
             "reason": violation.reason
         ]
     }
+
 }

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct JUnitReporter: Reporter {
+
     public static let identifier = "junit"
     public static let isRealtime = false
 
@@ -28,4 +29,5 @@ public struct JUnitReporter: Reporter {
                     "\t</testcase>"].joined()
             }).joined() + "\n</testsuite></testsuites>"
     }
+
 }

--- a/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
@@ -7,6 +7,7 @@
 //
 
 public struct XcodeReporter: Reporter {
+
     public static let identifier = "xcode"
     public static let isRealtime = true
 
@@ -28,4 +29,5 @@ public struct XcodeReporter: Reporter {
             " (\(violation.ruleDescription.identifier))"
         ].joined()
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -10,11 +10,14 @@ import Foundation
 import SourceKittenFramework
 
 private enum AttributesRuleError: Error {
+
     case unexpectedBlankLine
     case moreThanOneAttributeInSameLine
+
 }
 
 public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
+
     public var configuration = AttributesConfiguration()
 
     private static let parametersPattern = "^\\s*\\(.+\\)"
@@ -314,4 +317,5 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         ]
         return attributes.filter { !blacklist.contains($0) }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/AttributesRulesExamples.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRulesExamples.swift
@@ -104,4 +104,5 @@ internal struct AttributesRuleExamples {
         "@objc\n\n @warn_unused_result\n ↓func a() -> Int",
         "@noreturn ↓func exit(_: Int)"
     ]
+
 }

--- a/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
@@ -12,9 +12,11 @@ import SourceKittenFramework
 private let whitespaceAndNewlineCharacterSet = CharacterSet.whitespacesAndNewlines
 
 extension File {
+
     fileprivate func violatingClosingBraceRanges() -> [NSRange] {
         return match(pattern: "(\\}[ \\t]+\\))", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
     }
+
 }
 
 public struct ClosingBraceRule: CorrectableRule, ConfigurationProviderRule {
@@ -68,4 +70,5 @@ public struct ClosingBraceRule: CorrectableRule, ConfigurationProviderRule {
                        location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct ClosureEndIndentationRule: ASTRule, OptInRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -156,4 +157,5 @@ public struct ClosureEndIndentationRule: ASTRule, OptInRule, ConfigurationProvid
             return true
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -92,4 +93,5 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
                                   location: Location(file: file, byteOffset: paramOffset))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
@@ -112,4 +112,5 @@ public struct ClosureSpacingRule: Rule, ConfigurationProviderRule, OptInRule {
                            location: Location(file: file, characterOffset: $0.location))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -10,8 +10,10 @@ import Foundation
 import SourceKittenFramework
 
 private enum ColonKind {
+
     case type
     case dictionary
+
 }
 
 public struct ColonRule: ASTRule, CorrectableRule, ConfigurationProviderRule {
@@ -167,6 +169,7 @@ public struct ColonRule: ASTRule, CorrectableRule, ConfigurationProviderRule {
 
         return (violations + dictViolations).sorted { $0.range.location < $1.range.location }
     }
+
 }
 
 // MARK: Type Colon Rule
@@ -207,6 +210,7 @@ extension ColonRule {
             return identifierRange.map { NSUnionRange($0, range) }
         }
     }
+
 }
 
 // MARK: Dictionary Colon Rule
@@ -291,4 +295,5 @@ extension ColonRule {
             return NSRange(location: location, length: length)
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -148,4 +148,5 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
                 return firstRange
             }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/CompilerProtocolInitRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -59,9 +60,11 @@ public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
 
         return []
     }
+
 }
 
 private struct ExpressibleByCompiler {
+
     private let protocolName: String
     let initCallNames: Set<String>
     private let arguments: [[String]]
@@ -145,4 +148,5 @@ private struct ExpressibleByCompiler {
                                                                    types: ["Dictionary", "DictionaryLiteral",
                                                                            "NSDictionary", "NSMutableDictionary"],
                                                                    arguments: [["dictionaryLiteral"]])
+
 }

--- a/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewline.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct ConditionalReturnsOnNewline: ConfigurationProviderRule, Rule, OptInRule {
+
     public let configurationDescription = "N/A"
     public var configuration = SeverityConfiguration(.warning)
 
@@ -58,4 +59,5 @@ public struct ConditionalReturnsOnNewline: ConfigurationProviderRule, Rule, OptI
     private func content(for token: SyntaxToken, file: File) -> String {
         return file.contents.bridge().substringWithByteRange(start: token.offset, length: token.length) ?? ""
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -98,4 +98,5 @@ public struct ControlStatementRule: ConfigurationProviderRule {
         }
         return false
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -10,14 +10,17 @@ import Foundation
 import SourceKittenFramework
 
 private extension Region {
+
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {
         return disabledRuleIdentifiers.contains(customRuleIdentifier)
     }
+
 }
 
 // MARK: - CustomRulesConfiguration
 
 public struct CustomRulesConfiguration: RuleConfiguration, Equatable {
+
     public var consoleDescription: String { return "user-defined" }
     public var customRuleConfigurations = [RegexConfiguration]()
 
@@ -34,6 +37,7 @@ public struct CustomRulesConfiguration: RuleConfiguration, Equatable {
             customRuleConfigurations.append(ruleConfiguration)
         }
     }
+
 }
 
 public func == (lhs: CustomRulesConfiguration, rhs: CustomRulesConfiguration) -> Bool {
@@ -92,4 +96,5 @@ public struct CustomRules: Rule, ConfigurationProviderRule {
             }
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityLevelsConfiguration(warning: 10, error: 20)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscardedNotificationCenterObserverRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -59,4 +60,5 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
 
         return [offset]
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
@@ -78,4 +78,5 @@ public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule {
         .functionOperator,
         .functionSubscript
     ]
+
 }

--- a/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
@@ -9,6 +9,7 @@
 import SourceKittenFramework
 
 public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
+
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}
@@ -39,4 +40,5 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
                 location: Location(file: file, characterOffset: $0.location))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParametersRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct EmptyParametersRule: ConfigurationProviderRule, CorrectableRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -82,4 +83,5 @@ public struct EmptyParametersRule: ConfigurationProviderRule, CorrectableRule {
                        location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct EmptyParenthesesWithTrailingClosureRule: ASTRule, CorrectableRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -120,4 +121,5 @@ public struct EmptyParenthesesWithTrailingClosureRule: ASTRule, CorrectableRule,
                        location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
@@ -100,4 +100,5 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
         file.write(contents)
         return corrections
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
+
     public var configuration = FileHeaderConfiguration()
 
     public init() {}
@@ -109,4 +110,5 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
             )
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -9,6 +9,7 @@
 import SourceKittenFramework
 
 public struct FileLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
+
     public var configuration = SeverityLevelsConfiguration(warning: 400, error: 1000)
 
     public init() {}
@@ -36,4 +37,5 @@ public struct FileLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
         }
         return []
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/FirstWhereRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct FirstWhereRule: OptInRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -91,4 +92,5 @@ public struct FirstWhereRule: OptInRule, ConfigurationProviderRule {
 
         return nil
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForWhereRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct ForWhereRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -31,4 +31,5 @@ public struct ForceCastRule: ConfigurationProviderRule {
                 location: Location(file: file, characterOffset: $0.location))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceTryRule.swift
@@ -33,4 +33,5 @@ public struct ForceTryRule: ConfigurationProviderRule {
                 location: Location(file: file, characterOffset: $0.location))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -171,4 +171,5 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
         }
         return false
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -9,6 +9,7 @@
 import SourceKittenFramework
 
 public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityLevelsConfiguration(warning: 40, error: 100)
 
     public init() {}
@@ -45,4 +46,5 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
         }
         return []
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityLevelsConfiguration(warning: 5, error: 8)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = NameConfiguration(minLengthWarning: 1,
                                                  minLengthError: 0,
                                                  maxLengthWarning: 20,
@@ -192,9 +193,11 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
 
         return []
     }
+
 }
 
 extension String {
+
     fileprivate func split(separator: String) -> [(String, NSRange)] {
         let separatorLength = separator.bridge().length
         var previousEndOffset = 0
@@ -221,4 +224,5 @@ extension String {
         let trimmedRange = match.rangeAt(1)
         return (bridged.substring(with: trimmedRange), trimmedRange)
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -115,9 +115,11 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             return "Variable"
         }
     }
+
 }
 
 fileprivate extension String {
+
     var isViolatingCase: Bool {
         let secondIndex = characters.index(after: startIndex)
         let firstCharacter = substring(to: secondIndex)
@@ -136,4 +138,5 @@ fileprivate extension String {
         let operators = ["/", "=", "-", "+", "!", "*", "|", "^", "~", "?", ".", "%", "<", ">", "&"]
         return !operators.filter(hasPrefix).isEmpty
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRuleExamples.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 internal struct IdentifierNameRuleExamples {
+
     private static let commonNonTriggeringExamples = [
         "let myLet = 0",
         "var myVar = 0",
@@ -48,4 +49,5 @@ internal struct IdentifierNameRuleExamples {
     static let swift3TriggeringExamples = commonTriggeringExamples + [
         "enum Foo { case ↓MyEnum }"
     ]
+
 }

--- a/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
@@ -14,6 +14,7 @@ private func classScoped(_ value: String) -> String {
 }
 
 public struct ImplicitGetterRule: ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -116,4 +117,5 @@ public struct ImplicitGetterRule: ConfigurationProviderRule {
 
         return results
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -10,12 +10,16 @@ import Foundation
 import SourceKittenFramework
 
 private enum LargeTupleRuleError: Error {
+
     case unbalencedParentheses
+
 }
 
 private enum RangeKind {
+
     case tuple
     case generic
+
 }
 
 public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -53,4 +53,5 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
         let location = Location(file: file.path, line: max(file.lines.count, 1))
         return [Correction(ruleDescription: type(of: self).description, location: location)]
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -134,4 +135,5 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         ]
         return file.correct(legacyRule: self, patterns: patterns)
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
@@ -74,4 +74,5 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule {
 
         return file.correct(legacyRule: self, patterns: wordBoundPatterns)
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -131,4 +131,5 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
         ]
         return file.correct(legacyRule: self, patterns: patterns)
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -134,4 +135,5 @@ public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         ]
         return file.correct(legacyRule: self, patterns: patterns)
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct LineLengthRule: ConfigurationProviderRule {
+
     public var configuration = LineLengthConfiguration(warning: 120, error: 200)
 
     public init() {}
@@ -126,6 +127,7 @@ public struct LineLengthRule: ConfigurationProviderRule {
 }
 
 private extension String {
+
     var strippingURLs: String {
         let range = NSRange(location: 0, length: bridge().length)
         // Workaround for Linux until NSDataDetector is available
@@ -144,4 +146,5 @@ private extension String {
             return urlDetector.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "")
         #endif
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -144,4 +144,5 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
             return identifierRange.map { NSUnionRange($0, range) }
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -26,6 +26,7 @@ private func inheritedMembers(for dictionary: [String: SourceKitRepresentable]) 
 }
 
 extension File {
+
     fileprivate func missingDocOffsets(in dictionary: [String: SourceKitRepresentable],
                                        acl: [AccessControlLevel], skipping: [String] = []) -> [Int] {
         if declarationOverrides(in: dictionary) {
@@ -49,9 +50,11 @@ extension File {
         }
         return substructureOffsets + [offset]
     }
+
 }
 
 public enum AccessControlLevel: String, CustomStringConvertible {
+
     case `private` = "source.lang.swift.accessibility.private"
     case `fileprivate` = "source.lang.swift.accessibility.fileprivate"
     case `internal` = "source.lang.swift.accessibility.internal"
@@ -91,6 +94,7 @@ public enum AccessControlLevel: String, CustomStringConvertible {
 }
 
 public struct MissingDocsRule: OptInRule {
+
     public init(configuration: Any) throws {
         guard let array = [String].array(of: configuration) else {
             throw ConfigurationError.unknownConfiguration
@@ -172,6 +176,7 @@ public struct MissingDocsRule: OptInRule {
         }
         return false
     }
+
 }
 
 private let warnMissingDocsRuleDisabledOnce: Void = {

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -64,4 +64,5 @@ public struct NestingRule: ASTRule, ConfigurationProviderRule {
         })
         return violations
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, CorrectableRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -122,6 +123,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
         file.write(contents)
         return corrections
     }
+
 }
 
 extension String {
@@ -154,4 +156,5 @@ extension String {
 
         return correctedString
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/NotificationCenterDetachmentRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -85,4 +86,5 @@ public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRu
         let body = file.contents.bridge().substringWithByteRange(start: token.offset, length: token.length)
         return body == "self"
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProviderRule {
+
     public var configuration = NumberSeparatorConfiguration(minimumLength: 0, minimumFractionLength: nil)
 
     public init() {}
@@ -153,4 +154,5 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
         return file.contents.bridge().substringWithByteRange(start: token.offset,
                                                              length: token.length)
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/ObjectLiteralRule.swift
@@ -109,4 +109,5 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         let range = NSRange(location: offset, length: length)
         return Set(file.syntaxMap.tokens(inByteRange: range).flatMap({ SyntaxKind(rawValue: $0.type) }))
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -12,11 +12,13 @@ import SourceKittenFramework
 private let whitespaceAndNewlineCharacterSet = CharacterSet.whitespacesAndNewlines
 
 extension File {
+
     fileprivate func violatingOpeningBraceRanges() -> [NSRange] {
         return match(pattern: "((?:[^( ]|[\\s(][\\s]+)\\{)",
                      excludingSyntaxKinds: SyntaxKind.commentAndStringKinds(),
                      excludingPattern: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{")
     }
+
 }
 
 public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
@@ -132,4 +134,5 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
             return (contents, nil)
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -48,4 +48,5 @@ public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule {
                 location: Location(file: file, characterOffset: range.location))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
@@ -178,4 +178,5 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
                        location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
@@ -9,6 +9,7 @@
 import SourceKittenFramework
 
 public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptInRule {
+
     public var configuration = OverridenSuperCallConfiguration()
 
     public init() {}
@@ -84,4 +85,5 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
         }
         return []
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
+
     public var configuration = PrivateOutletRuleConfiguration(allowPrivateSet: false)
 
     public init() {}
@@ -67,4 +68,5 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
     private func isPrivateLevel(identifier: String?) -> Bool {
         return identifier.flatMap(AccessControlLevel.init(identifier:))?.isPrivate ?? false
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
@@ -10,20 +10,24 @@ import Foundation
 import SourceKittenFramework
 
 private extension AccessControlLevel {
+
     init?(_ dictionary: [String: SourceKitRepresentable]) {
         guard let accessibility = dictionary.accessibility,
             let acl = AccessControlLevel(rawValue: accessibility) else { return nil }
         self = acl
     }
+
 }
 
 private extension Dictionary where Key: ExpressibleByStringLiteral {
+
     var superclass: String? {
         guard let kindString = self.kind,
             let kind = SwiftDeclarationKind(rawValue: kindString), kind == .class,
             let className = inheritedTypes.first else { return nil }
         return className
     }
+
 }
 
 public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
@@ -149,4 +153,5 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule {
                                location: Location(file: file, byteOffset: offset),
                                reason: configuration.message)]
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/ProhibitedSuperRule.swift
@@ -9,6 +9,7 @@
 import SourceKittenFramework
 
 public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule {
+
     public var configuration = ProhibitedSuperConfiguration()
 
     public init() {}
@@ -66,4 +67,5 @@ public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule
                                location: Location(file: file, byteOffset: offset),
                                reason: "Method '\(name)' should not call to super function")]
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantNilCoalescingRule.swift
@@ -10,10 +10,12 @@ import Foundation
 import SourceKittenFramework
 
 extension File {
+
     fileprivate func violatingRedundantNilCoalescingRanges() -> [NSRange] {
         // {whitespace} ?? {whitespace} nil {word boundary}
         return match(pattern: "\\s?\\?{2}\\s*nil\\b", with: [.keyword])
     }
+
 }
 
 public struct RedundantNilCoalescingRule: OptInRule, CorrectableRule, ConfigurationProviderRule {
@@ -68,4 +70,5 @@ public struct RedundantNilCoalescingRule: OptInRule, CorrectableRule, Configurat
                        location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantStringEnumValueRule.swift
@@ -21,6 +21,7 @@ private func children(of dict: [String: SourceKitRepresentable],
 }
 
 public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -119,4 +120,5 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule {
             $0.kind == "source.lang.swift.structure.elem.init_expr"
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -124,4 +124,5 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
             NSRange(location: $0.location + 1, length: $0.length - 1)
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct AttributesConfiguration: RuleConfiguration, Equatable {
+
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var alwaysOnSameLine = Set<String>()
     private(set) var alwaysOnNewLine = Set<String>()
@@ -42,6 +43,7 @@ public struct AttributesConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
+
 }
 
 public func == (lhs: AttributesConfiguration,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct ColonConfiguration: RuleConfiguration, Equatable {
+
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var flexibleRightSpacing = false
     private(set) var applyToDictionaries = true
@@ -38,4 +39,5 @@ public struct ColonConfiguration: RuleConfiguration, Equatable {
             lhs.flexibleRightSpacing == rhs.flexibleRightSpacing &&
             rhs.applyToDictionaries == rhs.applyToDictionaries
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
+
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private var requiredString: String?
     private var requiredPattern: String?
@@ -72,6 +73,7 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
+
 }
 
 public func == (lhs: FileHeaderConfiguration,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct LineLengthRuleOptions: OptionSet {
+
     public let rawValue: Int
 
     public init(rawValue: Int = 0) {
@@ -20,17 +21,21 @@ public struct LineLengthRuleOptions: OptionSet {
     public static let ignoreComments = LineLengthRuleOptions(rawValue: 1 << 2)
 
     public static let all: LineLengthRuleOptions = [.ignoreURLs, .ignoreFunctionDeclarations, .ignoreComments]
+
 }
 
 private enum ConfigurationKey: String {
+
     case warning = "warning"
     case error = "error"
     case ignoresURLs = "ignores_urls"
     case ignoresFunctionDeclarations = "ignores_function_declarations"
     case ignoresComments = "ignores_comments"
+
 }
 
 public struct LineLengthConfiguration: RuleConfiguration, Equatable {
+
     public var consoleDescription: String {
         return length.consoleDescription +
                ", ignores urls: \(ignoresURLs)" +

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct NameConfiguration: RuleConfiguration, Equatable {
+
     public var consoleDescription: String {
         return "(min_length) \(minLength.shortConsoleDescription), " +
             "(max_length) \(maxLength.shortConsoleDescription)"
@@ -51,6 +52,7 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
             self.excluded = Set(excluded)
         }
     }
+
 }
 
 public func == (lhs: NameConfiguration, rhs: NameConfiguration) -> Bool {
@@ -62,6 +64,7 @@ public func == (lhs: NameConfiguration, rhs: NameConfiguration) -> Bool {
 // MARK: - ConfigurationProviderRule extensions
 
 public extension ConfigurationProviderRule where ConfigurationType == NameConfiguration {
+
     public func severity(forLength length: Int) -> ViolationSeverity? {
         if let minError = configuration.minLength.error, length < minError {
             return .error
@@ -73,4 +76,5 @@ public extension ConfigurationProviderRule where ConfigurationType == NameConfig
         }
         return nil
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -7,6 +7,7 @@
 //
 
 public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
+
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var minimumLength: Int
     private(set) var minimumFractionLength: Int?
@@ -52,4 +53,5 @@ public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
             lhs.minimumFractionLength == rhs.minimumFractionLength &&
             lhs.severityConfiguration == rhs.severityConfiguration
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct OverridenSuperCallConfiguration: RuleConfiguration, Equatable {
+
     var defaultIncluded = [
         //NSObject
         "awakeFromNib()",
@@ -91,6 +92,7 @@ public struct OverridenSuperCallConfiguration: RuleConfiguration, Equatable {
         names = names.filter { !excluded.contains($0) }
         return names
     }
+
 }
 
 public func == (lhs: OverridenSuperCallConfiguration,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
+
     var severityConfiguration = SeverityConfiguration(.warning)
     var allowPrivateSet = false
 
@@ -31,6 +32,7 @@ public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
+
 }
 
 public func == (lhs: PrivateOutletRuleConfiguration,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct PrivateUnitTestConfiguration: RuleConfiguration, Equatable {
+
     public let identifier: String
     public var name: String?
     public var message = "Regex matched."
@@ -53,6 +54,7 @@ public struct PrivateUnitTestConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
+
 }
 
 public func == (lhs: PrivateUnitTestConfiguration, rhs: PrivateUnitTestConfiguration) -> Bool {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct ProhibitedSuperConfiguration: RuleConfiguration, Equatable {
+
     var severityConfiguration = SeverityConfiguration(.warning)
     var excluded = [String]()
     var included = ["*"]
@@ -65,6 +66,7 @@ public struct ProhibitedSuperConfiguration: RuleConfiguration, Equatable {
         names = names.filter { !excluded.contains($0) }
         return names
     }
+
 }
 
 public func == (lhs: ProhibitedSuperConfiguration,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct RegexConfiguration: RuleConfiguration, Equatable {
+
     public let identifier: String
     public var name: String?
     public var message = "Regex matched."
@@ -59,6 +60,7 @@ public struct RegexConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
+
 }
 
 public func == (lhs: RegexConfiguration, rhs: RegexConfiguration) -> Bool {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct SeverityConfiguration: RuleConfiguration, Equatable {
+
     public var consoleDescription: String {
         return severity.rawValue
     }
@@ -32,6 +33,7 @@ public struct SeverityConfiguration: RuleConfiguration, Equatable {
     fileprivate func severity(fromString string: String) -> ViolationSeverity? {
         return ViolationSeverity(rawValue: string.lowercased())
     }
+
 }
 
 public func == (lhs: SeverityConfiguration, rhs: SeverityConfiguration) -> Bool {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {
+
     public var consoleDescription: String {
         let errorString: String
         if let errorValue = error {
@@ -49,6 +50,7 @@ public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {
             throw ConfigurationError.unknownConfiguration
         }
     }
+
 }
 
 public func == (lhs: SeverityLevelsConfiguration, rhs: SeverityLevelsConfiguration) -> Bool {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementPositionConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementPositionConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public enum StatementModeConfiguration: String {
+
     case `default` = "default"
     case uncuddledElse = "uncuddled_else"
 
@@ -24,6 +25,7 @@ public enum StatementModeConfiguration: String {
 }
 
 public struct StatementConfiguration: RuleConfiguration, Equatable {
+
     public var consoleDescription: String {
         return "(statement_mode) \(statementMode.rawValue), " +
             "(severity) \(severity.consoleDescription)"
@@ -49,6 +51,7 @@ public struct StatementConfiguration: RuleConfiguration, Equatable {
             try severity.apply(configuration: severityConfiguration)
         }
     }
+
 }
 
 public func == (lhs: StatementConfiguration, rhs: StatementConfiguration) -> Bool {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct TrailingCommaConfiguration: RuleConfiguration, Equatable {
+
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var mandatoryComma: Bool
 
@@ -31,6 +32,7 @@ public struct TrailingCommaConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
+
 }
 
 public func == (lhs: TrailingCommaConfiguration,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
+
     var severityConfiguration = SeverityConfiguration(.warning)
     var ignoresEmptyLines = false
     var ignoresComments = true
@@ -36,6 +37,7 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
+
 }
 
 public func == (lhs: TrailingWhitespaceConfiguration,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -7,6 +7,7 @@
 //
 
 public struct VerticalWhitespaceConfiguration: RuleConfiguration, Equatable {
+
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var maxEmptyLines: Int
 
@@ -37,4 +38,5 @@ public struct VerticalWhitespaceConfiguration: RuleConfiguration, Equatable {
         return lhs.maxEmptyLines == rhs.maxEmptyLines &&
             lhs.severityConfiguration == rhs.severityConfiguration
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/ShorthandOperatorRule.swift
@@ -105,4 +105,5 @@ public struct ShorthandOperatorRule: ConfigurationProviderRule {
     private func kindsAreValid(_ kinds: [SyntaxKind]) -> Bool {
         return Set(kinds).isSubset(of: [.identifier, .keyword])
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -51,4 +52,5 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
                            location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/SpacedTypeDeclarationsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SpacedTypeDeclarationsRule.swift
@@ -1,0 +1,162 @@
+//
+//  LineAfterDeclarationRule.swift
+//  SwiftLint
+//
+//  Created by Diego Ernst on 1/31/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct SpacedTypeDeclarationsRule: ASTRule, ConfigurationProviderRule, CorrectableRule {
+
+    public var configuration = SeverityConfiguration(.warning)
+    private var declarationTypes: [SwiftDeclarationKind] = [.class, .enum, .struct, .protocol, .extension]
+
+    public static let description = RuleDescription(
+        identifier: "spaced_type_declarations",
+        name: "Spaced Type Declarations",
+        description: "The start and end of a type declaration must be enclosed by two empty lines.",
+        nonTriggeringExamples: [
+            "class Example { }\n",
+            "class Example {\n" +
+            "\n" +
+            "}\n" +
+            "",
+            " /* multiline\n" +
+            "    comment */\n" +
+            "enum Enum { // testing comments\n" +
+            "\n" +
+            "   case first\n" +
+            "   case second\n" +
+            "\n" +
+            "}\n" +
+            ""
+        ],
+        triggeringExamples: [
+            "↓extension Example {\n" +
+            "↓   func doSomething() { }\n" +
+            "↓}\n" +
+            "protocol SomeProtocol { }\n",
+            "struct Struct {\n" +
+            "\n" +
+            "↓  let someConstante: Int?\n" +
+            "}\n",
+            "struct Struct {\n" +
+            "\n" +
+            "↓  let someConstante: Int?\n" +
+            "↓}\n" +
+            "extension Another { }\n"
+        ],
+        corrections: [
+            "↓extension Example {\n" +
+            "↓   func doSomething() { }\n" +
+            "↓}\n" +
+            "protocol SomeProtocol { }\n":
+            "extension Example {\n\n" +
+            "   func doSomething() { }\n\n" +
+            "}\n\n" +
+            "protocol SomeProtocol { }\n",
+            "struct Struct {\n" +
+            "\n" +
+            "↓  let someConstante: Int?\n" +
+            "}\n":
+            "struct Struct {\n" +
+            "\n" +
+            "  let someConstante: Int?\n\n" +
+            "}\n",
+            "struct Struct {\n" +
+            "\n" +
+            "↓  let someConstante: Int?\n" +
+            "↓}\n" +
+            "extension Another { }\n":
+            "struct Struct {\n" +
+            "\n" +
+            "  let someConstante: Int?\n\n" +
+            "}\n\n" +
+            "extension Another { }\n",
+            "↓class Class {\n" +
+            "   let array = [\n" +
+            "       1,\n" +
+            "       2\n" +
+            "↓   ]\n" +
+            "}\n":
+            "class Class {\n\n" +
+            "   let array = [\n" +
+            "       1,\n" +
+            "       2\n" +
+            "   ]\n\n" +
+            "}\n"
+        ]
+    )
+
+    public init() {}
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard
+            declarationTypes.contains(kind),
+            let bodyOffset = dictionary.bodyOffset,
+            let bodyLength = dictionary.bodyLength,
+            let (startLine, _) = file.contents.bridge().lineAndCharacter(forByteOffset: bodyOffset),
+            let (endLine, _) = file.contents.bridge().lineAndCharacter(forByteOffset: bodyOffset + bodyLength),
+            startLine != endLine
+        else {
+            return []
+        }
+        return findErrors(startLine: startLine, endLine: endLine, file: file)
+    }
+
+    private func findErrors(startLine: Int, endLine: Int, file: File) -> [StyleViolation] {
+        var errorLines = [Int]()
+        errorLines.append(contentsOf: checkBeforeAndAfterLines(line: startLine, file: file))
+        errorLines.append(contentsOf: checkBeforeAndAfterLines(line: endLine, file: file))
+        return errorLines.unique.map { StyleViolation(
+                ruleDescription: type(of: self).description,
+                severity: self.configuration.severity,
+                location: Location(file: file.path, line: $0, character: 1)
+            )
+        }
+    }
+
+    private func checkBeforeAndAfterLines(line: Int, file: File) -> [Int] {
+        var nonEmptyLines = [Int]()
+        if line - 2 >= 0 && !isLineEmpty(line - 2, file: file) {
+            nonEmptyLines.append(line - 1)
+        }
+        if line < file.lines.count && !isLineEmpty(line, file: file) {
+            nonEmptyLines.append(line)
+        }
+        return nonEmptyLines
+    }
+
+    private func isLineEmpty(_ lineIndex: Int, file: File) -> Bool {
+        let line = file.lines[lineIndex].content.trimmingCharacters(in: .whitespaces)
+        guard line != "}" && line != "]" else { return false }
+        let lineKinds: [SyntaxKind] = file.syntaxTokensByLines[lineIndex + 1].flatMap { SyntaxKind(rawValue: $0.type) }
+        let commentKinds = SyntaxKind.commentKinds()
+        return lineKinds.reduce(true) { $0.0 && commentKinds.contains($0.1) }
+    }
+
+    public func correct(file: File) -> [Correction] {
+        let ranges: [StyleViolation] = validate(file: file)
+        guard !ranges.isEmpty else { return [] }
+        var lines: [String] = file.lines.map { $0.content }
+        var corrections = [Correction]()
+
+        ranges.sorted { $0.location > $1.location }.forEach {
+            if let line = $0.location.line {
+                let lineRange = file.lines[line].range
+                if !file.ruleEnabled(violatingRanges: [lineRange], for: self).isEmpty {
+                    lines.insert("", at: line)
+                    corrections.append(Correction(ruleDescription: type(of: self).description, location: $0.location))
+                }
+            }
+        }
+
+        file.write(lines.joined(separator: "\n") + "\n")
+        return corrections
+    }
+
+}

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -88,6 +88,7 @@ public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule 
             return uncuddledCorrect(file: file)
         }
     }
+
 }
 
 // Default Behaviors
@@ -129,10 +130,12 @@ private extension StatementPositionRule {
         file.write(contents)
         return corrections
     }
+
 }
 
 // Uncuddled Behaviors
 private extension StatementPositionRule {
+
     func uncuddledValidate(file: File) -> [StyleViolation] {
         return uncuddledViolationRanges(in: file).flatMap { range in
             return StyleViolation(ruleDescription: type(of: self).uncuddledDescription,
@@ -229,4 +232,5 @@ private extension StatementPositionRule {
         file.write(contents)
         return corrections
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseOnNewlineRule.swift
@@ -14,6 +14,7 @@ private func wrapInSwitch(_ str: String) -> String {
 }
 
 public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptInRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -90,4 +91,5 @@ public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptIn
             return !SyntaxKind.commentKinds().contains(kind)
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -19,6 +19,7 @@ extension SyntaxKind {
             .docCommentField
         ].contains(self)
     }
+
 }
 
 public struct TodoRule: ConfigurationProviderRule {
@@ -96,4 +97,5 @@ public struct TodoRule: ConfigurationProviderRule {
                 reason: reason )
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -13,6 +13,7 @@ private let missingTrailingCommaReason = "Multi-line collection literals should 
 private let extraTrailingCommaReason = "Collection literals should not have trailing commas."
 
 public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = TrailingCommaConfiguration()
 
     public init() {}
@@ -121,4 +122,5 @@ public struct TrailingCommaRule: ASTRule, ConfigurationProviderRule {
             contents.bridge().NSRangeToByteRange(start: $0.location, length: $0.length)
         }?.location
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 extension String {
+
     private func countOfTrailingCharacters(in characterSet: CharacterSet) -> Int {
         var count = 0
         for char in unicodeScalars.lazy.reversed() {
@@ -24,6 +25,7 @@ extension String {
     fileprivate func trailingNewlineCount() -> Int? {
         return countOfTrailingCharacters(in: .newlines)
     }
+
 }
 
 public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
@@ -79,4 +81,5 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, S
         let location = Location(file: file.path, line: max(file.lines.count, 1))
         return [Correction(ruleDescription: type(of: self).description, location: location)]
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -10,10 +10,12 @@ import Foundation
 import SourceKittenFramework
 
 extension File {
+
     fileprivate func violatingTrailingSemicolonRanges() -> [NSRange] {
         return match(pattern: "(;+([^\\S\\n]?)*)+;?$",
                      excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
     }
+
 }
 
 public struct TrailingSemicolonRule: CorrectableRule, ConfigurationProviderRule {
@@ -74,4 +76,5 @@ public struct TrailingSemicolonRule: CorrectableRule, ConfigurationProviderRule 
                 location: Location(file: file, characterOffset: $0.location))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -95,4 +95,5 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         }
         return []
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -17,6 +17,7 @@ private func example(_ type: String,
 }
 
 public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityLevelsConfiguration(warning: 200, error: 350)
 
     public init() {}
@@ -68,4 +69,5 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
         }
         return []
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -102,4 +102,5 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
 
         return []
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, CorrectableRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -184,4 +185,5 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
                        location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedEnumeratedRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -109,4 +110,5 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule {
         let contents = file.contents.bridge()
         return contents.substringWithByteRange(start: token.offset, length: token.length) == "_"
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -80,4 +81,5 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
                           excludingSyntaxKinds: kinds,
                           range: range)
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidDocsRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 extension File {
+
     fileprivate func invalidDocOffsets(in dictionary: [String: SourceKitRepresentable]) -> [Int] {
         let substructure = dictionary.substructure
         let substructureOffsets = substructure.flatMap(invalidDocOffsets)
@@ -32,6 +33,7 @@ extension File {
 
         return substructureOffsets + (hasViolation ? [offset] : [])
     }
+
 }
 
 func superfluousOrMissingThrowsDocumentation(_ declaration: String, comment: String) -> Bool {
@@ -237,6 +239,7 @@ public struct ValidDocsRule: ConfigurationProviderRule, OptInRule {
                 location: Location(file: file, byteOffset: $0))
         }
     }
+
 }
 
 private let warnValidDocsRuleDisabledOnce: Void = {

--- a/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
     private static let supportedTypes = ValidIBInspectableRule.createSupportedTypes()
 
@@ -126,4 +127,5 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
         // It seems that only reference types can be used as ImplicitlyUnwrappedOptional or Optional
         return referenceTypes.flatMap(expandToIncludeOptionals) + types + intTypes
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -91,4 +92,5 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
                            location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
@@ -155,4 +155,5 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         }
         return []
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct VoidReturnRule: ConfigurationProviderRule, CorrectableRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -82,4 +83,5 @@ public struct VoidReturnRule: ConfigurationProviderRule, CorrectableRule {
                        location: Location(file: file, characterOffset: $0))
         }
     }
+
 }

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -10,6 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
+
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -105,4 +106,5 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule {
         parse(dictionary: structure.dictionary)
         return results
     }
+
 }

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -11,6 +11,7 @@ import Result
 import SwiftLintFramework
 
 struct AutoCorrectCommand: CommandProtocol {
+
     let verb = "autocorrect"
     let function = "Automatically correct warnings and errors"
 
@@ -36,9 +37,11 @@ struct AutoCorrectCommand: CommandProtocol {
             return .success()
         }
     }
+
 }
 
 struct AutoCorrectOptions: OptionsProtocol {
+
     let path: String
     let configurationFile: String
     let useScriptInputFiles: Bool
@@ -63,4 +66,5 @@ struct AutoCorrectOptions: OptionsProtocol {
                                defaultValue: false,
                                usage: "should reformat the Swift files")
     }
+
 }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -14,6 +14,7 @@ import SourceKittenFramework
 import SwiftLintFramework
 
 struct LintCommand: CommandProtocol {
+
     let verb = "lint"
     let function = "Print lint warnings and errors (default command)"
 
@@ -106,9 +107,11 @@ struct LintCommand: CommandProtocol {
             location: Location(file: "", line: 0, character: 0),
             reason: "Number of warnings exceeded threshold of \(threshold).")
     }
+
 }
 
 struct LintOptions: OptionsProtocol {
+
     let path: String
     let useSTDIN: Bool
     let configurationFile: String
@@ -151,4 +154,5 @@ struct LintOptions: OptionsProtocol {
             <*> mode <| Option(key: "enable-all-rules", defaultValue: false,
                                usage: "run all rules, even opt-in and disabled ones, ignoring `whitelist_rules`")
     }
+
 }

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -28,6 +28,7 @@ private func print(ruleDescription desc: RuleDescription) {
 }
 
 struct RulesCommand: CommandProtocol {
+
     let verb = "rules"
     let function = "Display the list of rules and their identifiers"
 
@@ -67,9 +68,11 @@ struct RulesCommand: CommandProtocol {
 
         return RuleList(rules: filtered)
     }
+
 }
 
 struct RulesOptions: OptionsProtocol {
+
     fileprivate let ruleID: String?
     fileprivate let configurationFile: String
     fileprivate let filterEnabled: Bool
@@ -90,11 +93,13 @@ struct RulesOptions: OptionsProtocol {
                                key: "enabled",
                                usage: "only display enabled rules")
     }
+
 }
 
 // MARK: - SwiftyTextTable
 
 extension TextTable {
+
     init(ruleList: RuleList, configuration: Configuration) {
         let columns = [
             TextTableColumn(header: "identifier"),
@@ -119,4 +124,5 @@ extension TextTable {
             ])
         }
     }
+
 }

--- a/Source/swiftlint/Commands/VersionCommand.swift
+++ b/Source/swiftlint/Commands/VersionCommand.swift
@@ -11,6 +11,7 @@ import Result
 import SwiftLintFramework
 
 struct VersionCommand: CommandProtocol {
+
     let verb = "version"
     let function = "Display the current version of SwiftLint"
 
@@ -18,4 +19,5 @@ struct VersionCommand: CommandProtocol {
         print(Version.current.value)
         return .success()
     }
+
 }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -137,4 +137,5 @@ extension Configuration {
     init(options: AutoCorrectOptions) {
         self.init(commandLinePath: options.configurationFile, rootPath: options.path, quiet: options.quiet)
     }
+
 }

--- a/Source/swiftlint/Extensions/Reporter+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Reporter+CommandLine.swift
@@ -9,6 +9,7 @@
 import SwiftLintFramework
 
 extension Reporter {
+
     static func report(violations: [StyleViolation], realtimeCondition: Bool) {
         if isRealtime == realtimeCondition {
             let report = generateReport(violations)
@@ -17,6 +18,7 @@ extension Reporter {
             }
         }
     }
+
 }
 
 func reporterFrom(options: LintOptions, configuration: Configuration) -> Reporter.Type {

--- a/Source/swiftlint/Helpers/Benchmark.swift
+++ b/Source/swiftlint/Helpers/Benchmark.swift
@@ -10,11 +10,14 @@ import Foundation
 import SourceKittenFramework
 
 struct BenchmarkEntry {
+
     let id: String // swiftlint:disable:this identifier_name
     let time: Double
+
 }
 
 struct Benchmark {
+
     private let name: String
     private var entries = [BenchmarkEntry]()
 
@@ -45,6 +48,7 @@ struct Benchmark {
         let url = URL(fileURLWithPath: "benchmark_\(name)_\(timestamp).txt")
         try? data?.write(to: url, options: [.atomic])
     }
+
 }
 
 private let numberFormatter: NumberFormatter = {

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
 		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
 		C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */; };
+		CF151E871E417B4E004D6880 /* SpacedTypeDeclarationsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF151E861E417B4E004D6880 /* SpacedTypeDeclarationsRule.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
@@ -341,6 +342,7 @@
 		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
 		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
 		C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
+		CF151E861E417B4E004D6880 /* SpacedTypeDeclarationsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpacedTypeDeclarationsRule.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D0D1212619E878CC005E4BAA /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -880,6 +882,7 @@
 				1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */,
 				D47079AE1DFE520000027086 /* VoidReturnRule.swift */,
 				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
+				CF151E861E417B4E004D6880 /* SpacedTypeDeclarationsRule.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -1289,6 +1292,7 @@
 				E816194C1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift in Sources */,
 				D4DABFD71E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift in Sources */,
 				3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */,
+				CF151E871E417B4E004D6880 /* SpacedTypeDeclarationsRule.swift in Sources */,
 				D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */,
 				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
 				E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
@@ -64,9 +64,11 @@ class AttributesRuleTests: XCTestCase {
         verifyRule(alwaysOnNewLineDescription,
                    ruleConfiguration: ["always_on_line_above": ["@objc"]])
     }
+
 }
 
 extension AttributesRuleTests {
+
     static var allTests: [(String, (AttributesRuleTests) -> () throws -> Void)] {
         return [
             ("testAttributesWithDefaultConfiguration", testAttributesWithDefaultConfiguration),
@@ -74,4 +76,5 @@ extension AttributesRuleTests {
             ("testAttributesWithAlwaysOnLineAbove", testAttributesWithAlwaysOnLineAbove)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
@@ -152,9 +152,11 @@ class ColonRuleTests: XCTestCase {
 
         verifyRule(description, ruleConfiguration: ["apply_to_dictionaries": false])
     }
+
 }
 
 extension ColonRuleTests {
+
     static var allTests: [(String, (ColonRuleTests) -> () throws -> Void)] {
         return [
             ("testColonWithDefaultConfiguration", testColonWithDefaultConfiguration),
@@ -162,4 +164,5 @@ extension ColonRuleTests {
             ("testColonWithoutApplyToDictionaries", testColonWithoutApplyToDictionaries)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -14,6 +14,7 @@ import XCTest
 private let optInRules = masterRuleList.list.filter({ $0.1.init() is OptInRule }).map({ $0.0 })
 
 extension Configuration {
+
     fileprivate var disabledRules: [String] {
         let configuredRuleIDs = rules.map({ type(of: $0).description.identifier })
         let defaultRuleIDs = Set(masterRuleList.list.values.filter({
@@ -21,6 +22,7 @@ extension Configuration {
         }).map({ $0.description.identifier }))
         return defaultRuleIDs.subtracting(configuredRuleIDs).sorted(by: <)
     }
+
 }
 
 class ConfigurationTests: XCTestCase {
@@ -119,6 +121,7 @@ class ConfigurationTests: XCTestCase {
     }
 
     private class TestFileManager: LintableFileManager {
+
         func filesToLint(inPath path: String, rootDirectory: String? = nil) -> [String] {
             switch path {
             case "directory": return ["directory/File1.swift", "directory/File2.swift",
@@ -131,6 +134,7 @@ class ConfigurationTests: XCTestCase {
             XCTFail("Should not be called with path \(path)")
             return []
         }
+
     }
 
     func testExcludedPaths() {
@@ -243,12 +247,15 @@ class ConfigurationTests: XCTestCase {
 // MARK: - ProjectMock Paths
 
 fileprivate extension String {
+
     func stringByAppendingPathComponent(_ pathComponent: String) -> String {
         return bridge().appendingPathComponent(pathComponent)
     }
+
 }
 
 extension XCTestCase {
+
     var bundlePath: String {
         #if SWIFT_PACKAGE
             return "Tests/SwiftLintFrameworkTests/Resources".bridge().absolutePathRepresentation()
@@ -256,6 +263,7 @@ extension XCTestCase {
             return Bundle(for: type(of: self)).resourcePath!
         #endif
     }
+
 }
 
 fileprivate extension XCTestCase {
@@ -299,9 +307,11 @@ fileprivate extension XCTestCase {
     var projectMockSwift3: String {
         return projectMockPathLevel3.stringByAppendingPathComponent("Level3.swift")
     }
+
 }
 
 extension ConfigurationTests {
+
     static var allTests: [(String, (ConfigurationTests) -> () throws -> Void)] {
         return [
             ("testInit", testInit),
@@ -330,4 +340,5 @@ extension ConfigurationTests {
             ("testDisabledRulesFromDeprecatedAlias", testDisabledRulesFromDeprecatedAlias)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -102,9 +102,11 @@ class CustomRulesTests: XCTestCase {
     func getTestTextFile() -> File {
         return File(path: "\(bundlePath)/test.txt")!
     }
+
 }
 
 extension CustomRulesTests {
+
     static var allTests: [(String, (CustomRulesTests) -> () throws -> Void)] {
         return [
             ("testCustomRuleConfigurationSetsCorrectly",
@@ -121,4 +123,5 @@ extension CustomRulesTests {
                 testCustomRulesIncludedExcludesFile)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
@@ -29,13 +29,16 @@ class ExtendedNSStringTests: XCTestCase {
             XCTFail("NSString.lineAndCharacterForByteOffset should return non-nil tuple.")
         }
     }
+
 }
 
 extension ExtendedNSStringTests {
+
     static var allTests: [(String, (ExtendedNSStringTests) -> () throws -> Void)] {
         return [
             ("testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters",
                 testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -100,9 +100,11 @@ class FileHeaderRuleTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["forbidden_pattern": "\\s\\w+\\.swift"],
                    skipCommentTests: true)
     }
+
 }
 
 extension FileHeaderRuleTests {
+
     static var allTests: [(String, (FileHeaderRuleTests) -> () throws -> Void)] {
         return [
             ("testFileHeaderWithDefaultConfiguration", testFileHeaderWithDefaultConfiguration),
@@ -112,4 +114,5 @@ extension FileHeaderRuleTests {
             ("testFileHeaderWithForbiddenPattern", testFileHeaderWithForbiddenPattern)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -77,9 +77,11 @@ class FunctionBodyLengthRuleTests: XCTestCase {
         let config = makeConfig(nil, FunctionBodyLengthRule.description.identifier)!
         return SwiftLintFrameworkTests.violations(string, config: config)
     }
+
 }
 
 extension FunctionBodyLengthRuleTests {
+
     static var allTests: [(String, (FunctionBodyLengthRuleTests) -> () throws -> Void)] {
         return [
             ("testFunctionBodyLengths",
@@ -90,4 +92,5 @@ extension FunctionBodyLengthRuleTests {
                 testFunctionBodyLengthsWithMultilineComments)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -47,9 +47,11 @@ class IntegrationTests: XCTestCase {
             }
         }
     }
+
 }
 
 extension String {
+
     func withStaticString(_ closure: (StaticString) -> Void) {
         withCString {
             let rawPointer = $0._rawValue
@@ -61,13 +63,16 @@ extension String {
             closure(staticString)
         }
     }
+
 }
 
 extension IntegrationTests {
+
     static var allTests: [(String, (IntegrationTests) -> () throws -> Void)] {
         return [
             ("testSwiftLintLints", testSwiftLintLints),
             ("testSwiftLintAutoCorrects", testSwiftLintAutoCorrects)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -11,6 +11,7 @@ import SourceKittenFramework
 import XCTest
 
 class LineLengthConfigurationTests: XCTestCase {
+
     func testLineLengthConfigurationInitializerSetsLength() {
         let warning = 100
         let error = 150
@@ -191,9 +192,11 @@ class LineLengthConfigurationTests: XCTestCase {
                                                                .ignoreComments])
         XCTAssertTrue(configuration2 == configuration6)
     }
+
 }
 
 extension LineLengthConfigurationTests {
+
     static var allTests: [(String, (LineLengthConfigurationTests) -> () throws -> Void)] {
         return [
             ("testLineLengthConfigurationInitializerSetsLength",
@@ -214,4 +217,5 @@ extension LineLengthConfigurationTests {
              testLineLengthConfigurationCompares)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -72,13 +72,16 @@ class LineLengthRuleTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["ignores_urls": true],
                    commentDoesntViolate: false, stringDoesntViolate: false)
     }
+
 }
 
 extension LineLengthRuleTests {
+
     static var allTests: [(String, (LineLengthRuleTests) -> () throws -> Void)] {
         return [
             ("testLineLength", testLineLength),
             ("testLineLengthWithIgnoreURLsEnabled", testLineLengthWithIgnoreURLsEnabled)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -86,9 +86,11 @@ class LinterCacheTests: XCTestCase {
 
         XCTAssertNil(cachedViolations)
     }
+
 }
 
 extension LinterCacheTests {
+
     static var allTests: [(String, (LinterCacheTests) -> () throws -> Void)] {
         return [
             ("testInitThrowsWhenUsingDifferentVersion", testInitThrowsWhenUsingDifferentVersion),
@@ -101,4 +103,5 @@ extension LinterCacheTests {
             ("testParsesViolationsWithEmptyViolations", testParsesViolationsWithEmptyViolations)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
@@ -67,9 +67,11 @@ class NumberSeparatorRuleTests: XCTestCase {
 
         verifyRule(description, ruleConfiguration: ["minimum_fraction_length": 5])
     }
+
 }
 
 extension NumberSeparatorRuleTests {
+
     static var allTests: [(String, (NumberSeparatorRuleTests) -> () throws -> Void)] {
         return [
             ("testNumberSeparatorWithDefaultConfiguration", testNumberSeparatorWithDefaultConfiguration),
@@ -77,4 +79,5 @@ extension NumberSeparatorRuleTests {
             ("testNumberSeparatorWithMinimumFractionLength", testNumberSeparatorWithMinimumFractionLength)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -110,9 +110,11 @@ class ReporterTests: XCTestCase {
         )
         XCTAssertEqual(result, expectedOutput)
     }
+
 }
 
 extension ReporterTests {
+
     static var allTests: [(String, (ReporterTests) -> () throws -> Void)] {
         return [
             ("testReporterFromString", testReporterFromString),
@@ -125,4 +127,5 @@ extension ReporterTests {
             ("testHTMLReporter", testHTMLReporter)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -274,9 +274,11 @@ class RuleConfigurationsTests: XCTestCase {
             XCTFail()
         }
     }
+
 }
 
 extension RuleConfigurationsTests {
+
     static var allTests: [(String, (RuleConfigurationsTests) -> () throws -> Void)] {
         return [
             ("testNameConfigurationSetsCorrectly",
@@ -319,4 +321,5 @@ extension RuleConfigurationsTests {
                 testOverridenSuperCallConfigurationFromDictionary)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -11,6 +11,7 @@ import SourceKittenFramework
 import XCTest
 
 struct RuleWithLevelsMock: ConfigurationProviderRule {
+
     var configuration = SeverityLevelsConfiguration(warning: 2, error: 3)
 
     static let description = RuleDescription(identifier: "severity_level_mock",
@@ -18,11 +19,13 @@ struct RuleWithLevelsMock: ConfigurationProviderRule {
                                              description: "",
                                              deprecatedAliases: ["mock"])
     func validate(file: File) -> [StyleViolation] { return [] }
+
 }
 
 class RuleTests: XCTestCase {
 
     fileprivate struct RuleMock1: Rule {
+
         init() {}
         init(configuration: Any) throws { self.init() }
         var configurationDescription: String { return "N/A" }
@@ -30,9 +33,11 @@ class RuleTests: XCTestCase {
         func validate(file: File) -> [StyleViolation] {
             return []
         }
+
     }
 
     fileprivate struct RuleMock2: Rule {
+
         init() {}
         init(configuration: Any) throws { self.init() }
         var configurationDescription: String { return "N/A" }
@@ -40,15 +45,18 @@ class RuleTests: XCTestCase {
         func validate(file: File) -> [StyleViolation] {
             return []
         }
+
     }
 
     fileprivate struct RuleWithLevelsMock2: ConfigurationProviderRule {
+
         var configuration = SeverityLevelsConfiguration(warning: 2, error: 3)
 
         static let description = RuleDescription(identifier: "violation_level_mock2",
                                                  name: "",
                                                  description: "")
         func validate(file: File) -> [StyleViolation] { return [] }
+
     }
 
     func testRuleIsEqualTo() {
@@ -125,9 +133,11 @@ class RuleTests: XCTestCase {
     func testDifferentSeverityLevelRulesNotEqual() {
         XCTAssertFalse(RuleWithLevelsMock().isEqualTo(RuleWithLevelsMock2()))
     }
+
 }
 
 extension RuleTests {
+
     static var allTests: [(String, (RuleTests) -> () throws -> Void)] {
         return [
             ("testRuleIsEqualTo",
@@ -154,4 +164,5 @@ extension RuleTests {
                 testDifferentSeverityLevelRulesNotEqual)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -357,6 +357,7 @@ class RulesTests: XCTestCase {
 }
 
 extension RulesTests {
+
     static var allTests: [(String, (RulesTests) -> () throws -> Void)] {
         return [
             ("testClassDelegateProtocol", testClassDelegateProtocol),
@@ -432,4 +433,5 @@ extension RulesTests {
             ("testWeakDelegate", testWeakDelegate)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -241,6 +241,10 @@ class RulesTests: XCTestCase {
         verifyRule(SortedImportsRule.description)
     }
 
+    func testSpacedTypeDeclarationsRule() {
+        verifyRule(SpacedTypeDeclarationsRule.description)
+    }
+
     func testStatementPosition() {
         verifyRule(StatementPositionRule.description)
     }
@@ -407,6 +411,7 @@ extension RulesTests {
             ("testReturnArrowWhitespace", testReturnArrowWhitespace),
             ("testShorthandOperator", testShorthandOperator),
             ("testSortedImports", testSortedImports),
+            ("testSpacedTypeDeclarationsRule", testSpacedTypeDeclarationsRule),
             ("testStatementPosition", testStatementPosition),
             ("testStatementPositionUncuddled", testStatementPositionUncuddled),
             ("testSwitchCaseOnNewline", testSwitchCaseOnNewline),

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -80,9 +80,11 @@ class SourceKitCrashTests: XCTestCase {
         file.sourcekitdFailed = false
         file.assertHandler = nil
     }
+
 }
 
 extension SourceKitCrashTests {
+
     static var allTests: [(String, (SourceKitCrashTests) -> () throws -> Void)] {
         return [
             ("testAssertHandlerIsNotCalledOnNormalFile",
@@ -93,4 +95,5 @@ extension SourceKitCrashTests {
                 testRulesWithFileThatCrashedSourceKitService)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/Swift2RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/Swift2RulesTests.swift
@@ -10,6 +10,7 @@
 import XCTest
 
 #if !SWIFT_PACKAGE
+
 class Swift2RulesTests: XCTestCase {
 
     func testAttributes() {
@@ -72,5 +73,7 @@ class Swift2RulesTests: XCTestCase {
 
         verifyRule(description)
     }
+
 }
+
 #endif

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -67,6 +67,7 @@ private func render(locations: [Location], in contents: String) -> String {
 }
 
 extension Configuration {
+
     fileprivate func assertCorrection(_ before: String, expected: String) {
         guard let path = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(NSUUID().uuidString + ".swift")?.path else {
@@ -105,12 +106,15 @@ extension Configuration {
             XCTFail("couldn't read file at path '\(path)': \(error)")
         }
     }
+
 }
 
 extension String {
+
     fileprivate func toStringLiteral() -> String {
         return "\"" + replacingOccurrences(of: "\n", with: "\\n") + "\""
     }
+
 }
 
 internal func makeConfig(_ ruleConfiguration: Any?, _ identifier: String) -> Configuration? {
@@ -273,4 +277,5 @@ extension XCTestCase {
             XCTFail("Wrong error caught")
         }
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -75,13 +75,16 @@ class TrailingCommaRuleTests: XCTestCase {
         let config = makeConfig(ruleConfiguration, TrailingCommaRule.description.identifier)!
         return SwiftLintFrameworkTests.violations(string, config: config)
     }
+
 }
 
 extension TrailingCommaRuleTests {
+
     static var allTests: [(String, (TrailingCommaRuleTests) -> () throws -> Void)] {
         return [
             ("testTrailingCommaRuleWithDefaultConfiguration", testTrailingCommaRuleWithDefaultConfiguration),
             ("testTrailingCommaRuleWithMandatoryComma", testTrailingCommaRuleWithMandatoryComma)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -33,13 +33,16 @@ class VerticalWhitespaceRuleTests: XCTestCase {
         verifyRule(maxEmptyLinesDescription,
                    ruleConfiguration: ["max_empty_lines": 2])
     }
+
 }
 
 extension VerticalWhitespaceRuleTests {
+
     static var allTests: [(String, (VerticalWhitespaceRuleTests) -> () throws -> Void)] {
         return [
             ("testVerticalWhitespaceWithDefaultConfiguration", testVerticalWhitespaceWithDefaultConfiguration),
             ("testAttributesWithMaxEmptyLines", testAttributesWithMaxEmptyLines)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
+++ b/Tests/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
@@ -50,12 +50,15 @@ class YamlSwiftLintTests: XCTestCase {
         // swiftlint:disable:next force_try
         return try! String(contentsOfFile: "\(bundlePath)/test.yml", encoding: .utf8)
     }
+
 }
 
 extension YamlSwiftLintTests {
+
     static var allTests: [(String, (YamlSwiftLintTests) -> () throws -> Void)] {
         return [
             ("testFlattenYaml", testFlattenYaml)
         ]
     }
+
 }

--- a/Tests/SwiftLintFrameworkTests/YamlParserTests.swift
+++ b/Tests/SwiftLintFrameworkTests/YamlParserTests.swift
@@ -26,9 +26,11 @@ class YamlParserTests: XCTestCase {
             _ = try YamlParser.parse("|\na")
         }
     }
+
 }
 
 extension YamlParserTests {
+
     static var allTests: [(String, (YamlParserTests) -> () throws -> Void)] {
         return [
             ("testParseEmptyString", testParseEmptyString),
@@ -36,4 +38,5 @@ extension YamlParserTests {
             ("testParseInvalidStringThrows", testParseInvalidStringThrows)
         ]
     }
+
 }


### PR DESCRIPTION
Added `spaced_type_declaration` rule that warns if either the start or end of a type declaration is not enclosed by two empty lines. 

For example:
```swift
protocol Protocol {
    func somethingAmazing()
}
class Example {
    let value = ""
}
```
should be written as follows:
```swift
protocol Protocol {

    func somethingAmazing()

}

class Example {

    let value = ""

}
```

I have done two commits: the first one is the actual implementation of this rule and the second one is the result of autocorrecting the entire project so that all tests run successfully. Please let me know if there is something I missed.