### PR TITLE
Added opt-in IBOutlet Setter Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 ##### Enhancements
 
+* Add `outlet_setter` opt-in rule
+  that warns when IBOutlet properties are reset in code,
+  rather than set automaticaly by IB.
+  [Jeffrey Bergier](https://github.com/jeffreybergier)
+
 * Performance improvements to `generic_type_name`,
   `redundant_nil_coalescing`, `mark`, `first_where` and
   `vertical_whitespace` rules.  

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -122,6 +122,7 @@ public let masterRuleList = RuleList(rules:
     OpeningBraceRule.self,
     OperatorFunctionWhitespaceRule.self,
     OperatorUsageWhitespaceRule.self,
+    OutletSetterRule.self,
     OverriddenSuperCallRule.self,
     PrivateOutletRule.self,
     PrivateUnitTestRule.self,

--- a/Source/SwiftLintFramework/Rules/OutletSetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/OutletSetterRule.swift
@@ -1,0 +1,118 @@
+//
+//  OutletSetterRule.swift
+//  SwiftLint
+//
+//  Created by Jeffrey Bergier on 3/9/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct OutletSetterRule: ASTRule, OptInRule, ConfigurationProviderRule {
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    // swiftlint:disable line_length
+    public static let description = RuleDescription(
+        identifier: "outlet_setter",
+        name: "Outlet Setter",
+        description: "@IBOutlet properties should only be set by Interface Builder, not in code.",
+        nonTriggeringExamples: [
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t let \t bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t let \t bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t var \t bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t var \t bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t if case \t .bar \t = bar {} \n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t if case \t .bar=bar {} \n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t 123bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t 123bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t XYZbar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t XYZbar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t XYZ123bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t XYZ123bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self.bar?.backgroundColor = .blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self.bar?.backgroundColor=.blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self!.bar?.backgroundColor = .blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self!.bar?.backgroundColor=.blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self?.bar?.backgroundColor = .blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self?.bar?.backgroundColor=.blue\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self.bar \t = UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self.bar=UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self!.bar \t = UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self!.bar=UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self?.bar \t = UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self?.bar=UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t bar \t = UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t bar=UILabel()\n }\n }"
+            // MARK: ToDo: This string literal causes warning
+            // "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n print(\"my bar = \\(bar?.description)\")\n }\n }",
+            // MARK: ToDo: This valid multiline local variable will cause warning
+            // "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t var \t bar: UIView?\n bar \t = UILabel()\n }\n }",
+        ],
+        triggeringExamples: [
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self.bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self.bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self!.bar \t = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self!.bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self?.bar \t = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self?.bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t bar \t = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t bar=UILabel()\n }\n }"
+            // MARK: ToDo: Fix Bug. This is very uncommon, but it should be warned against. Currently is not matched.
+            // "class Foo {\n @IBOutlet var invalidLabel = UILabel()\n }",
+        ]
+    )
+    // swiftlint:enable line_length
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+
+        // Find IBOutlets in the File
+        let substructure = dictionary.substructure
+        let outlets = substructure.filter({ $0.enclosedSwiftAttributes.contains("source.decl.attribute.iboutlet") })
+        let outletNames = outlets.flatMap({ $0.name })
+
+        // If there are no IBOutlets, we can bail
+        guard outletNames.isEmpty == false else { return [] }
+
+        // Find any line that contains a string that matches the discovered outlet names
+        // This will have many false positives
+        let possibleViolations: [(String, Line)] = outletNames.flatMap { outletName -> [(String, Line)] in
+            return file.lines.filter({ $0.content.contains(outletName) }).map({ (outletName, $0) })
+        }
+
+        // Go through possible violations, use regex to see if they violate rules
+        let confirmedViolations = possibleViolations.filter { outletName, line -> Bool in
+
+            // build the regex pattern
+            let noSelfPattern = "^\\s*\(outletName)\\s*="
+            let selfPattern = "self[\\?\\!]?\\.\(outletName)\\s*="
+            let noDotPattern = "[\\W*][\\D*][^\\.]\\s+\(outletName)\\s*="
+            let pattern = "(\(noSelfPattern)|\(selfPattern)|\(noDotPattern))"
+
+            // get the text that is being scanned
+            let content = line.content
+            let range = content.bridge().range(of: content)
+
+            // init new regex object and start operation
+            let regex = try? NSRegularExpression(pattern: pattern, options: [])
+            let match = regex?.firstMatch(in: content, options: [], range: range)
+
+            // if we have a match, then there is a violation
+            return match != nil
+        }
+
+        // Convert the Lines into errors
+        let errors = confirmedViolations.map { _, line -> StyleViolation in
+            let location = Location(file: file, byteOffset: line.range.location)
+            return StyleViolation(ruleDescription: type(of: self).description,
+                                  severity: self.configuration.severity,
+                                  location: location)
+        }
+
+        return errors
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */; };
 		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
 		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
+		509B10A81E7262E500E2EE70 /* OutletSetterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509B10A61E72627000E2EE70 /* OutletSetterRule.swift */; };
 		57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED82791CF65183002B3513 /* JUnitReporter.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */; };
@@ -94,8 +95,8 @@
 		D286EC021E02DF6F0003CF72 /* SortedImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286EC001E02DA190003CF72 /* SortedImportsRule.swift */; };
 		D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */; };
 		D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */; };
-		D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */; };
 		D4130D971E16183F00242361 /* IdentifierNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4130D961E16183F00242361 /* IdentifierNameRuleExamples.swift */; };
+		D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */; };
 		D41E7E0B1DF9DABB0065259A /* RedundantStringEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */; };
 		D42D2B381E09CC0D00CD7A2E /* FirstWhereRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42D2B371E09CC0D00CD7A2E /* FirstWhereRule.swift */; };
 		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
@@ -309,6 +310,7 @@
 		4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLReporter.swift; sourceTree = "<group>"; };
 		4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
 		4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
+		509B10A61E72627000E2EE70 /* OutletSetterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutletSetterRule.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		57ED82791CF65183002B3513 /* JUnitReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JUnitReporter.swift; sourceTree = "<group>"; };
@@ -368,8 +370,8 @@
 		D286EC001E02DA190003CF72 /* SortedImportsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedImportsRule.swift; sourceTree = "<group>"; };
 		D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedClosureParameterRule.swift; sourceTree = "<group>"; };
 		D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaConfiguration.swift; sourceTree = "<group>"; };
-		D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRuleExamples.swift; sourceTree = "<group>"; };
 		D4130D961E16183F00242361 /* IdentifierNameRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierNameRuleExamples.swift; sourceTree = "<group>"; };
+		D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRuleExamples.swift; sourceTree = "<group>"; };
 		D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStringEnumValueRule.swift; sourceTree = "<group>"; };
 		D42D2B371E09CC0D00CD7A2E /* FirstWhereRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirstWhereRule.swift; sourceTree = "<group>"; };
 		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
@@ -847,6 +849,7 @@
 				692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */,
 				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
 				D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */,
+				509B10A61E72627000E2EE70 /* OutletSetterRule.swift */,
 				78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */,
 				B2902A0B1D66815600BFCCF7 /* PrivateUnitTestRule.swift */,
 				094385021D5D4F78009168CF /* PrivateOutletRule.swift */,
@@ -1231,6 +1234,7 @@
 				D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */,
 				6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */,
 				D4C0E46F1E3D973600C560F2 /* ForWhereRule.swift in Sources */,
+				509B10A81E7262E500E2EE70 /* OutletSetterRule.swift in Sources */,
 				E86396C51BADAC15002C9E88 /* XcodeReporter.swift in Sources */,
 				094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */,
 				3B1DF0121C5148140011BCED /* CustomRules.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -201,6 +201,10 @@ class RulesTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["allow_private_set": true])
     }
 
+    func testOutletSetter() {
+        verifyRule(OutletSetterRule.description)
+    }
+
     func testPrivateUnitTest() {
         verifyRule(PrivateUnitTestRule.description)
     }
@@ -396,6 +400,7 @@ extension RulesTests {
             ("testOpeningBrace", testOpeningBrace),
             ("testOperatorFunctionWhitespace", testOperatorFunctionWhitespace),
             ("testOperatorUsageWhitespace", testOperatorUsageWhitespace),
+            ("testOutletSetter", testOutletSetter),
             ("testPrivateOutlet", testPrivateOutlet),
             ("testPrivateUnitTest", testPrivateUnitTest),
             ("testProhibitedSuper", testProhibitedSuper),


### PR DESCRIPTION
Hi Swiftlint team,

## Problem
I recently came across issues in an iOS project, where IBOutlets were being reset without going through the whole proper process of removing the old object from the view hierarchy and adding the new one into the view hierarchy. Swift doesn't have a native way to prevent outlets from being reset.

I thought this would be a good idea for an Opt-In rule for SwiftLint. Let me know what you think and if you think this rule is a good idea for SwiftLint.

## Solution
This rule checks if the file contains IBOutlets, if it does it looks for any lines of code that attempt to call the setter on that outlet. e.g. self.myLabel = UILabel() would trigger this rule.

While the rule is not perfect, it will help avoid an Interface Builder anti-pattern. In general, if your code is resetting IBOutlets, there is probably a better way to accomplish what you want. 

I added many triggering and non-triggering test cases. They all have a variety of spacing, tabbing and other issues inserted into them to make sure the regular expressions work correctly.

## Pull Request Info
I'm a first time contributor to the Swiftlint project. I apologize in advance if I am doing something incorrect. I would love to be corrected :). I checked the contributing guidelines. This project passes all Xcode tests and `swift test`. Also, script/cibuild appeared to work fine. 

However, when I ran `make docker_test` I received the following error. I've never used docker before, so I'm not quite sure how to resolve the issue. I'm also not sure if thats a deal-breaker for the PR. If it is, let me know.:

```
bash-3.2$ make docker_test
docker run -v `pwd`:/SwiftLint norionomura/sourcekit:302 bash -c "cd /SwiftLint && swift test"
docker: Error parsing reference: "Github/SwiftLint:/SwiftLint" is not a valid repository/tag: invalid reference format.
See 'docker run --help'.
make: *** [docker_test] Error 125
```

## Known Issues
- This rule can only protect against setting IBOutlets within the same file. This rule should be combined with the 'private_outlet' rule in order to make it effective for the whole project.
- 3 TODOs that are commented out in the triggering/non-triggering test cases array. Because this is opt-in and the cases where the rule is triggered are fairly rare and can often be fixed by renaming a local variable, I left them as TODOs for now.