### PR TITLE
BodyLengthConfiguration for length rules allowing exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,11 @@
   have an explicit type interface.  
   [Kim de Vos](https://github.com/kimdv)
 
+* `file_length`, `type_body_length` and `function_body_length` can be configured
+  to exclude certain file names, type names and function names, respectively.
+  [Daniel Rodríguez Troitiño](https://github.com/drodriguez)
+  [#1363](https://github.com/realm/SwiftLint/issues/1363)
+
 * Add `fatal_error_message` opt-in rule that validates that `fatalError()` calls
   have a message.  
   [Kim de Vos](https://github.com/kimdv)

--- a/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
@@ -16,7 +16,7 @@ public typealias NSTextCheckingResult = TextCheckingResult
 private var regexCache = [RegexCacheKey: NSRegularExpression]()
 private let regexCacheLock = NSLock()
 
-private struct RegexCacheKey: Hashable {
+struct RegexCacheKey: Hashable {
     let pattern: String
     let options: NSRegularExpression.Options
 

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -9,7 +9,7 @@
 import SourceKittenFramework
 
 public struct FileLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 400, error: 1000)
+    public var configuration = BodyLengthConfiguration(warning: 400, error: 1000)
 
     public init() {}
 
@@ -26,6 +26,8 @@ public struct FileLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
     )
 
     public func validate(file: File) -> [StyleViolation] {
+        guard !configuration.isExcluded(file.path?.absolutePathStandardized()) else { return [] }
+
         let lineCount = file.lines.count
         for parameter in configuration.params where lineCount > parameter.value {
             return [StyleViolation(ruleDescription: type(of: self).description,

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -9,7 +9,7 @@
 import SourceKittenFramework
 
 public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 40, error: 100)
+    public var configuration = BodyLengthConfiguration(warning: 40, error: 100)
 
     public init() {}
 
@@ -22,6 +22,7 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds().contains(kind),
+            !configuration.isExcluded(dictionary.name),
             let offset = dictionary.offset,
             let bodyOffset = dictionary.bodyOffset,
             let bodyLength = dictionary.bodyLength,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/BodyLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/BodyLengthConfiguration.swift
@@ -1,0 +1,93 @@
+//
+//  BodyLengthConfiguration.swift
+//  SwiftLint
+//
+//  Created by Daniel Rodriguez Troitino on 3/16/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+
+public struct BodyLengthConfiguration: RuleConfiguration, Equatable {
+    public var consoleDescription: String {
+        return severityLevels.consoleDescription
+    }
+
+    private var severityLevels: SeverityLevelsConfiguration
+    private(set) var excluded: Set<NSRegularExpression>
+
+    var warning: Int {
+        return severityLevels.warning
+    }
+
+    var error: Int? {
+        return severityLevels.error
+    }
+
+    var params: [RuleParameter<Int>] {
+        return severityLevels.params
+    }
+
+    func isExcluded(_ name: String?) -> Bool {
+        guard let name = name else { return false }
+
+        let range = NSRange(location: 0, length: name.characters.count)
+        for regex in excluded {
+            if regex.firstMatch(in: name, options: [], range: range) != nil {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    public init(warning: Int, error: Int, excluded: Set<NSRegularExpression> = []) {
+        severityLevels = SeverityLevelsConfiguration(warning: warning, error: error)
+        self.excluded = excluded
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        // The composition with SeverityLevelsConfiguration is tricky.
+        // We know that the formats accepted right now cannot be compatible with our format,
+        // but we cannot be sure about the future.
+        do {
+            try severityLevels.apply(configuration: configuration)
+            return
+        } catch {
+            // Nothing to be done here.
+        }
+
+        guard let configurationDict = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let excluded = [String].array(of: configurationDict["excluded"]) {
+            self.excluded = Set(try excluded.map { try .cached(pattern: $0) })
+        }
+
+        // At this point we know configurationDict is a dictionary, and at least one value
+        // wasn’t an Int (knowledge from SeverityLevelsConfiguration). If we remove a
+        // possible excluded, we either end up with a dictionary good for SeverityLevels
+        // or we might have some extra invalid key, in any case, the code there will take
+        // care of it.
+        var cleanConfiguration = configurationDict
+        _ = cleanConfiguration.removeValue(forKey: "excluded")
+
+        if !cleanConfiguration.isEmpty {
+            try severityLevels.apply(configuration: cleanConfiguration)
+        }
+    }
+}
+
+public func == (lhs: BodyLengthConfiguration, rhs: BodyLengthConfiguration) -> Bool {
+    return lhs.warning == rhs.warning &&
+        lhs.error == rhs.error &&
+        zip(lhs.excluded, rhs.excluded).reduce(true) { $0 && (RegexCacheKey($1.0) == RegexCacheKey($1.1)) }
+}
+
+extension RegexCacheKey {
+    init(_ regex: NSRegularExpression) {
+        pattern = regex.pattern
+        options = regex.options
+    }
+}

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -17,7 +17,7 @@ private func example(_ type: String,
 }
 
 public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 200, error: 350)
+    public var configuration = BodyLengthConfiguration(warning: 200, error: 350)
 
     public init() {}
 
@@ -43,7 +43,8 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
         guard SwiftDeclarationKind.typeKinds().contains(kind) else {
             return []
         }
-        if let offset = dictionary.offset,
+        if !configuration.isExcluded(dictionary.name),
+            let offset = dictionary.offset,
             let bodyOffset = dictionary.bodyOffset,
             let bodyLength = dictionary.bodyLength {
             let startLine = file.contents.bridge().lineAndCharacter(forByteOffset: bodyOffset)

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -156,6 +156,10 @@
 		D4FD58B21E12A0200019503C /* LinterCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD58B11E12A0200019503C /* LinterCache.swift */; };
 		D93DA3D11E699E6300809827 /* NestingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
+		E0A300CC1E7BB22200730BE4 /* BodyLengthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A300CA1E7BAB4D00730BE4 /* BodyLengthConfiguration.swift */; };
+		E0A300CF1E7C528A00730BE4 /* BodyLengthConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A300CD1E7C51DC00730BE4 /* BodyLengthConfigurationTests.swift */; };
+		E0A300D21E7C8BDB00730BE4 /* FileLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A300D11E7C8BDB00730BE4 /* FileLengthRuleTests.swift */; };
+		E0A300D41E7C978100730BE4 /* TypeBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A300D31E7C978100730BE4 /* TypeBodyLengthRuleTests.swift */; };
 		E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
@@ -437,6 +441,10 @@
 		D4FD58B11E12A0200019503C /* LinterCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinterCache.swift; sourceTree = "<group>"; };
 		D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestingConfiguration.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
+		E0A300CA1E7BAB4D00730BE4 /* BodyLengthConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyLengthConfiguration.swift; sourceTree = "<group>"; };
+		E0A300CD1E7C51DC00730BE4 /* BodyLengthConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyLengthConfigurationTests.swift; sourceTree = "<group>"; };
+		E0A300D11E7C8BDB00730BE4 /* FileLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLengthRuleTests.swift; sourceTree = "<group>"; };
+		E0A300D31E7C978100730BE4 /* TypeBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeBodyLengthRuleTests.swift; sourceTree = "<group>"; };
 		E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicInlineRule.swift; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
@@ -558,6 +566,7 @@
 			isa = PBXGroup;
 			children = (
 				D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */,
+				E0A300CA1E7BAB4D00730BE4 /* BodyLengthConfiguration.swift */,
 				D43B04671E07228D004016AF /* ColonConfiguration.swift */,
 				67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */,
 				D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */,
@@ -738,12 +747,14 @@
 				D0D1217C19E87B05005E4BAA /* Supporting Files */,
 				3B12C9BE1C3209AC000B423F /* Resources */,
 				D4998DE61DF191380006E05D /* AttributesRuleTests.swift */,
+				E0A300CD1E7C51DC00730BE4 /* BodyLengthConfigurationTests.swift */,
 				D43B04651E071ED3004016AF /* ColonRuleTests.swift */,
 				E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */,
 				3BB47D861C51DE6E00AE6A10 /* CustomRulesTests.swift */,
 				02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */,
 				D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */,
 				D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */,
+				E0A300D11E7C8BDB00730BE4 /* FileLengthRuleTests.swift */,
 				3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */,
 				3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */,
 				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
@@ -753,6 +764,7 @@
 				E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */,
 				E81224991B04F85B001783D2 /* TestHelpers.swift */,
 				D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */,
+				E0A300D31E7C978100730BE4 /* TypeBodyLengthRuleTests.swift */,
 				3B12C9C21C320A53000B423F /* Yaml+SwiftLintTests.swift */,
 				3B12C9C61C3361CB000B423F /* RuleTests.swift */,
 				3B30C4A01C3785B300E04027 /* YamlParserTests.swift */,
@@ -1278,6 +1290,7 @@
 				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewline.swift in Sources */,
 				D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */,
 				7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */,
+				E0A300CC1E7BB22200730BE4 /* BodyLengthConfiguration.swift in Sources */,
 				E88DEA771B098D0C00A66CB0 /* Rule.swift in Sources */,
 				D47079AB1DFDCF7A00027086 /* SwiftExpressionKind.swift in Sources */,
 				00B8D9791E2D1223004E0EEC /* LegacyConstantRuleExamples.swift in Sources */,
@@ -1342,6 +1355,7 @@
 				D4CA758F1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift in Sources */,
 				D4DB92251E628898005DE9C1 /* TodoRuleTests.swift in Sources */,
 				D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */,
+				E0A300D41E7C978100730BE4 /* TypeBodyLengthRuleTests.swift in Sources */,
 				3B63D46D1E1F05160057BE35 /* LineLengthConfigurationTests.swift in Sources */,
 				6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */,
 				3BB47D871C51DE6E00AE6A10 /* CustomRulesTests.swift in Sources */,
@@ -1350,7 +1364,9 @@
 				D43B04661E071ED3004016AF /* ColonRuleTests.swift in Sources */,
 				3B12C9C71C3361CB000B423F /* RuleTests.swift in Sources */,
 				67EB4DFC1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift in Sources */,
+				E0A300D21E7C8BDB00730BE4 /* FileLengthRuleTests.swift in Sources */,
 				3B30C4A11C3785B300E04027 /* YamlParserTests.swift in Sources */,
+				E0A300CF1E7C528A00730BE4 /* BodyLengthConfigurationTests.swift in Sources */,
 				D4998DE71DF191380006E05D /* AttributesRuleTests.swift in Sources */,
 				E88198631BEA9A5400333A11 /* RulesTests.swift in Sources */,
 				D46202211E16002A0027AAD1 /* Swift2RulesTests.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/BodyLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/BodyLengthConfigurationTests.swift
@@ -1,0 +1,109 @@
+//
+//  BodyLengthConfigurationTests.swift
+//  SwiftLint
+//
+//  Created by Daniel Rodriguez Troitino on 3/17/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+@testable import SwiftLintFramework
+import XCTest
+
+class BodyLengthConfigurationTests: XCTestCase {
+    func testBodyLengthConfigurationFromSeverityLevelsArray() {
+        var configuration = BodyLengthConfiguration(warning: 0, error: 0)
+
+        let configurationArray = [123, 456]
+
+        do {
+            try configuration.apply(configuration: configurationArray)
+            XCTAssertEqual(configuration.warning, 123)
+            XCTAssertEqual(configuration.error, 456)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testBodyLengthConfigurationFromSeverityLevelsDictionary() {
+        var configuration = BodyLengthConfiguration(warning: 0, error: 0)
+
+        let configurationDict = ["warning": 123, "error": 456]
+
+        do {
+            try configuration.apply(configuration: configurationDict)
+            XCTAssertEqual(configuration.warning, 123)
+            XCTAssertEqual(configuration.error, 456)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testBodyLengthConfigurationWithExcludedTypes() {
+        var configuration = BodyLengthConfiguration(warning: 0, error: 0)
+
+        let configurationDict: [String: Any] = [
+            "warning": 123,
+            "error": 456,
+            "excluded": ["regex1", "regex2"]
+        ]
+
+        do {
+            try configuration.apply(configuration: configurationDict)
+            XCTAssertEqual(configuration.warning, 123)
+            XCTAssertEqual(configuration.error, 456)
+            XCTAssertEqual(configuration.excluded.count, 2)
+            XCTAssert(Array(configuration.excluded).map { $0.pattern }.contains("regex1"))
+            XCTAssert(Array(configuration.excluded).map { $0.pattern }.contains("regex2"))
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testBodyLengthConfigurationWithOnlyExcluded() {
+        var configuration = BodyLengthConfiguration(warning: 123, error: 456)
+
+        let configurationDict: [String: Any] = [
+            "excluded": ["regex1", "regex2"]
+        ]
+
+        do {
+            try configuration.apply(configuration: configurationDict)
+            XCTAssertEqual(configuration.warning, 123)
+            XCTAssertEqual(configuration.error, 456)
+            XCTAssertEqual(configuration.excluded.count, 2)
+            XCTAssert(Array(configuration.excluded).map { $0.pattern }.contains("regex1"))
+            XCTAssert(Array(configuration.excluded).map { $0.pattern }.contains("regex2"))
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testBodyLengthConfigurationWithInvalidConfiguration() {
+        var configuration = BodyLengthConfiguration(warning: 0, error: 0)
+
+        let configurationDict: [String: Any] = [
+            "warning": 123,
+            "error": 456,
+            "foobar": ["regex1", "regex2"]
+        ]
+
+        checkError(ConfigurationError.unknownConfiguration) {
+            try configuration.apply(configuration: configurationDict)
+        }
+    }
+}
+
+extension BodyLengthConfigurationTests {
+    static var allTests: [(String, (BodyLengthConfigurationTests) -> () throws -> Void)] {
+        return [
+            ("testBodyLengthConfigurationFromSeverityLevelsArray",
+             testBodyLengthConfigurationFromSeverityLevelsArray),
+            ("testBodyLengthConfigurationFromSeverityLevelsDictionary",
+             testBodyLengthConfigurationFromSeverityLevelsDictionary),
+            ("testBodyLengthConfigurationWithExcludedTypes",
+             testBodyLengthConfigurationWithExcludedTypes),
+            ("testBodyLengthConfigurationWithInvalidConfiguration",
+             testBodyLengthConfigurationWithInvalidConfiguration)
+        ]
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
@@ -1,0 +1,67 @@
+//
+//  FileLengthRuleTests.swift
+//  SwiftLint
+//
+//  Created by Daniel Rodriguez Troitino on 3/17/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+@testable import SwiftLintFramework
+import XCTest
+
+class FileLengthRuleTests: XCTestCase {
+    func testFileLength() {
+        verifyRule(FileLengthRule.description, commentDoesntViolate: false,
+                   testMultiByteOffsets: false)
+    }
+
+    func testFileLengthWithExcluded() {
+        guard let config = makeConfig(["warning": 10, "error": 15, "excluded": ["code"]],
+                                      FileLengthRule.description.identifier) else {
+            XCTFail()
+            return
+        }
+
+        let file = File.makeTemporalFile(contents: repeatElement("//\n", count: 16).joined())!
+        let violations = Linter(file: file, configuration: config).styleViolations
+
+        XCTAssertEqual(violations, [])
+    }
+}
+
+extension FileLengthRuleTests {
+    static var allTests: [(String, (FileLengthRuleTests) -> () throws -> Void)] {
+        return [
+            ("testFileLength", testFileLength),
+            ("testFileLengthWithExcluded", testFileLengthWithExcluded)
+        ]
+    }
+}
+
+extension File {
+    static func makeTemporalFile(contents: String) -> File? {
+        let temporaryDirectoryURL = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let fileNameTemplate = "code.XXXXXX.swift"
+        let template = temporaryDirectoryURL.appendingPathComponent(fileNameTemplate)!
+        let nsTemplate = NSURL(fileURLWithPath: template.path, isDirectory: false)
+
+        let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: Int(PATH_MAX))
+        buffer.initialize(to: 0, count: Int(PATH_MAX))
+
+        _ = nsTemplate.getFileSystemRepresentation(buffer, maxLength: Int(PATH_MAX))
+
+        let fd = mkstemps(buffer, 6) // .swift is 6 bytes
+        guard fd != -1 else {
+            fatalError("Could not create temporal file.")
+        }
+
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+        handle.write(contents.data(using: .utf8)!)
+        handle.synchronizeFile()
+
+        let temporaryURL = URL(fileURLWithFileSystemRepresentation: buffer, isDirectory: false, relativeTo: nil)
+        return File(path: temporaryURL.path)
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -73,6 +73,22 @@ class FunctionBodyLengthRuleTests: XCTestCase {
             "whitespace: currently spans 41 lines")])
     }
 
+    func testFunctionBodyLengthsWithExcludedPatterns() {
+        let longerFunctionBody = funcWithBody(repeatElement("x = 0\n", count: 40).joined())
+
+        let config1 = makeConfig(["warning": 40, "error": 100, "excluded": ["abc"]],
+                                FunctionBodyLengthRule.description.identifier)!
+        XCTAssertEqual(SwiftLintFrameworkTests.violations(longerFunctionBody, config: config1), [])
+
+        let config2 = makeConfig(["warning": 40, "error": 100, "excluded": ["abcd"]],
+                                FunctionBodyLengthRule.description.identifier)!
+        XCTAssertEqual(SwiftLintFrameworkTests.violations(longerFunctionBody, config: config2), [StyleViolation(
+            ruleDescription: FunctionBodyLengthRule.description,
+            location: Location(file: nil, line: 1, character: 1),
+            reason: "Function body should span 40 lines or less excluding comments and " +
+            "whitespace: currently spans 41 lines")])
+    }
+
     private func violations(_ string: String) -> [StyleViolation] {
         let config = makeConfig(nil, FunctionBodyLengthRule.description.identifier)!
         return SwiftLintFrameworkTests.violations(string, config: config)
@@ -87,7 +103,9 @@ extension FunctionBodyLengthRuleTests {
             ("testFunctionBodyLengthsWithComments",
                 testFunctionBodyLengthsWithComments),
             ("testFunctionBodyLengthsWithMultilineComments",
-                testFunctionBodyLengthsWithMultilineComments)
+                testFunctionBodyLengthsWithMultilineComments),
+            ("testFunctionBodyLengthsWithExcludedPatterns",
+                testFunctionBodyLengthsWithExcludedPatterns)
         ]
     }
 }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -84,11 +84,6 @@ class RulesTests: XCTestCase {
         verifyRule(FatalErrorMessageRule.description)
     }
 
-    func testFileLength() {
-        verifyRule(FileLengthRule.description, commentDoesntViolate: false,
-                   testMultiByteOffsets: false)
-    }
-
     func testFirstWhere() {
         verifyRule(FirstWhereRule.description)
     }
@@ -308,10 +303,6 @@ class RulesTests: XCTestCase {
                    commentDoesntViolate: false)
     }
 
-    func testTypeBodyLength() {
-        verifyRule(TypeBodyLengthRule.description)
-    }
-
     func testTypeName() {
         verifyRule(TypeNameRule.description)
     }
@@ -376,7 +367,6 @@ extension RulesTests {
             ("testExplicitInit", testExplicitInit),
             ("testExplicitTypeInterfaceRule", testExplicitTypeInterfaceRule),
             ("testFatalErrorMessageRule", testFatalErrorMessageRule),
-            ("testFileLength", testFileLength),
             ("testFirstWhere", testFirstWhere),
             ("testForceCast", testForceCast),
             ("testForceTry", testForceTry),
@@ -419,7 +409,6 @@ extension RulesTests {
             ("testTrailingNewline", testTrailingNewline),
             ("testTrailingSemicolon", testTrailingSemicolon),
             ("testTrailingWhitespace", testTrailingWhitespace),
-            ("testTypeBodyLength", testTypeBodyLength),
             ("testTypeName", testTypeName),
             ("testUnusedClosureParameter", testUnusedClosureParameter),
             ("testUnusedEnumerated", testUnusedEnumerated),

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -67,7 +67,10 @@ private func render(locations: [Location], in contents: String) -> String {
 }
 
 extension Configuration {
-	fileprivate func assertCorrection(_ before: String, expected: String, file: StaticString = #file, line: UInt = #line) {
+    fileprivate func assertCorrection(_ before: String,
+                                      expected: String,
+                                      file: StaticString = #file,
+                                      line: UInt = #line) {
         guard let path = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(NSUUID().uuidString + ".swift")?.path else {
                 XCTFail("couldn't generate temporary path for assertCorrection()", file: file, line: line)
@@ -275,14 +278,14 @@ extension XCTestCase {
         }
     }
 
-	func checkError<T: Error & Equatable>(
-		_ error: T,
-		file: StaticString = #file,
-		line: UInt = #line,
-		closure: () throws -> Void) {
+    func checkError<T: Error & Equatable>(
+        _ error: T,
+        file: StaticString = #file,
+        line: UInt = #line,
+        closure: () throws -> Void) {
         do {
             try closure()
-			XCTFail("No error caught", file: file, line: line)
+            XCTFail("No error caught", file: file, line: line)
         } catch let rError as T {
             if error != rError {
                 XCTFail("Wrong error caught", file: file, line: line)

--- a/Tests/SwiftLintFrameworkTests/TypeBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeBodyLengthRuleTests.swift
@@ -1,0 +1,37 @@
+//
+//  TypeBodyLengthRuleTests.swift
+//  SwiftLint
+//
+//  Created by Daniel Rodriguez Troitino on 3/17/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+@testable import SwiftLintFramework
+import XCTest
+
+class TypeBodyLengthRuleTests: XCTestCase {
+    func testTypeBodyLength() {
+        verifyRule(TypeBodyLengthRule.description)
+    }
+
+    func testTypeBodyLengthWithExcluded() {
+        guard let config = makeConfig(["warning": 200, "error": 400, "excluded": ["Abc"]],
+                                      TypeBodyLengthRule.description.identifier) else {
+            XCTFail()
+            return
+        }
+
+        for example in TypeBodyLengthRule.description.triggeringExamples {
+            XCTAssertEqual(violations(example, config: config), [])
+        }
+    }
+}
+
+extension TypeBodyLengthRuleTests {
+    static var allTests: [(String, (TypeBodyLengthRuleTests) -> () throws -> Void)] {
+        return [
+            ("testTypeBodyLength", testTypeBodyLength),
+            ("testTypeBodyLengthWithExcluded", testTypeBodyLengthWithExcluded)
+        ]
+    }
+}


### PR DESCRIPTION
BodyLengthConfiguration is a new configuration for the length rules (file length, type body length and function body length).

Besides the already existing warning and error configuration options, it allows a third one which applies exclusions to the specific rule. That way, one can keep the rule enabled and with sane defaults, but avoid the rule triggering in a common set of file, types or functions. The main example will be XCTestCase subtypes which might go for more than 400 lines and need disabling comments in each of the files.