### PR TITLE
Fix `==` operator in ColonConfiguration

### DIFF
--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -36,6 +36,6 @@ public struct ColonConfiguration: RuleConfiguration, Equatable {
                            rhs: ColonConfiguration) -> Bool {
         return lhs.severityConfiguration == rhs.severityConfiguration &&
             lhs.flexibleRightSpacing == rhs.flexibleRightSpacing &&
-            rhs.applyToDictionaries == rhs.applyToDictionaries
+            lhs.applyToDictionaries == rhs.applyToDictionaries
     }
 }


### PR DESCRIPTION
I think such issues can be easily detected by linter. We can add "identical operands in comparison operator" rule. I've tried to add it, but it is not so simple as it seemed to be. As I understand for now SourceKit give access to code structure only(like classes, functions, ifs, whiles etc), but not to expressions. So there is no easy way to parse for example "return A == B" or "if (A == B)" to know what is A and what is B. 
Maybe someone have some ideas how we can write this rule?