### PR TITLE
Fix checkstyle report format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,9 @@
 * Fix false negative on `unused_closure_parameter` rule.  
   [Hayashi Tatsuya](https://github.com/sora0077)
 
+* Fix `checkstyle` report format.  
+  [Yuki Oya](https://github.com/YukiOya)
+
 ## 0.16.1: Commutative Fabric Sheets
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
@@ -30,12 +30,15 @@ public struct CheckstyleReporter: Reporter {
         let col: Int = violation.location.character ?? 0
         let severity: String = violation.severity.rawValue
         let reason: String = violation.reason.escapedForXML()
+        let identifier: String = violation.ruleDescription.identifier
+        let source: String = identifier.isEmpty ? "" : "swiftlint.rules.\(identifier)".escapedForXML()
         return [
             "\n\t<file name=\"", file, "\">\n",
             "\t\t<error line=\"\(line)\" ",
             "column=\"\(col)\" ",
             "severity=\"", severity, "\" ",
-            "message=\"", reason, "\"/>\n",
+            "message=\"", reason, "\" ",
+            "source=\"\(source)\"/>\n",
             "\t</file>"
         ].joined()
     }

--- a/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
@@ -40,7 +40,7 @@ public struct CheckstyleReporter: Reporter {
         let severity: String = violation.severity.rawValue
         let reason: String = violation.reason.escapedForXML()
         let identifier: String = violation.ruleDescription.identifier
-        let source: String = identifier.isEmpty ? "" : "swiftlint.rules.\(identifier)".escapedForXML()
+        let source: String = "swiftlint.rules.\(identifier)".escapedForXML()
         return [
             "\t\t<error line=\"\(line)\" ",
             "column=\"\(col)\" ",

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedCheckstyleReporterOutput.xml
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedCheckstyleReporterOutput.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <checkstyle version="4.3">
 	<file name="filename">
-		<error line="1" column="2" severity="warning" message="Violation Reason."/>
-	</file>
-	<file name="filename">
-		<error line="1" column="2" severity="error" message="Violation Reason."/>
-	</file>
-	<file name="filename">
-		<error line="1" column="2" severity="error" message="Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;."/>
+		<error line="1" column="2" severity="warning" message="Violation Reason." source="swiftlint.rules.line_length"/>
+		<error line="1" column="2" severity="error" message="Violation Reason." source="swiftlint.rules.line_length"/>
+		<error line="1" column="2" severity="error" message="Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;." source="swiftlint.rules.syntactic_sugar"/>
 	</file>
 	<file name="&lt;nopath&gt;">
-		<error line="0" column="0" severity="error" message="Colons should be next to the identifier when specifying a type and next to the key in dictionary literals."/>
+		<error line="0" column="0" severity="error" message="Colons should be next to the identifier when specifying a type and next to the key in dictionary literals." source="swiftlint.rules.colon"/>
 	</file>
 </checkstyle>


### PR DESCRIPTION
Hi SwiftLint team,

we use swiftlint on Jenkins using the checkstyle plugin, but since the error element of the generated report does not have a `source` attribute, it is difficult to search for warnings or errors by the rule.

This PR fixes this problem, and fixed the file element to have some errors.

Thank you.
