### PR TITLE
Temporarily disable cache when linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   [Keith Smiley](https://github.com/keith)
   [#1185](https://github.com/realm/SwiftLint/issues/1185)
 
+* Temporarily disable cache when linting. This will be reverted on a
+  later version, after we fix the issues related to caching.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 ##### Enhancements
 
 * Add `implicitly_unwrapped_optional` opt-in rule

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -141,7 +141,7 @@ struct LintOptions: OptionsProtocol {
     // swiftlint:disable line_length
     static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> LintOptions {
         return { useSTDIN in { configurationFile in { strict in { lenient in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in
-            self.init(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
+            self.init(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: true, enableAllRules: enableAllRules)
         }}}}}}}}}}}
     }
 


### PR DESCRIPTION
Since we're having many issues with the cache, let's just disable by now until we have time to fix it.