### PR TITLE
apply —lenient to reports emitted while running.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@
   [Kim de Vos](https://github.com/kimdv)
 
 * Add `--lenient` CLI option to `lint` command. Facilitates running a lint task
-  that doesn't fail a pipeline of other tasks.
+  that doesn't fail a pipeline of other tasks.  
   [aaroncrespo](https://github.com/aaroncrespo)
   [#1322](https://github.com/realm/SwiftLint/issues/1322)
 
@@ -108,6 +108,10 @@
   [#1348](https://github.com/realm/SwiftLint/issues/1348)
 
 ##### Bug Fixes
+
+* Fix `--lenient` reports errors before lint completion.  
+  [aaroncrespo](https://github.com/aaroncrespo)
+  [#1391](https://github.com/realm/SwiftLint/issues/1391)
 
 * Fix crashes when accessing cached regular expressions when linting in
   parallel.  

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -43,7 +43,6 @@ struct LintCommand: CommandProtocol {
                 }
             }
             linter.file.invalidateCache()
-            violations = LintCommand.applyLeniency(options: options, violations: violations)
             reporter.report(violations: currentViolations, realtimeCondition: true)
         }.flatMap { files in
             if LintCommand.isWarningThresholdBroken(configuration: configuration, violations: violations)

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -30,14 +30,14 @@ struct LintCommand: CommandProtocol {
             if options.benchmark {
                 let start = Date()
                 let (_currentViolations, currentRuleTimes) = linter.styleViolationsAndRuleTimes
-                currentViolations = _currentViolations
+                currentViolations = LintCommand.applyLeniency(options: options, violations: _currentViolations)
                 visitorMutationQueue.sync {
                     fileBenchmark.record(file: linter.file, from: start)
                     currentRuleTimes.forEach { ruleBenchmark.record(id: $0, time: $1) }
                     violations += currentViolations
                 }
             } else {
-                currentViolations = linter.styleViolations
+                currentViolations = LintCommand.applyLeniency(options: options, violations: linter.styleViolations)
                 visitorMutationQueue.sync {
                     violations += currentViolations
                 }


### PR DESCRIPTION
didn't know that some reporters run before all results are gathered. so we apply --lenient at the point of collection per file before `report()` of instead of after when they are aggregated. 