### PR TITLE
Avoid pattern matching false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Avoid pattern matching false positives in `unused_optional_binding` rule.  
+  [Daniel Rodríguez Troitiño](https://github.com/drodriguez)
+  [#1376](https://github.com/realm/SwiftLint/issues/1376)
 
 ## 0.17.0: Extra Rinse Cycle
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   ],
   dependencies: [
     .Package(url: "https://github.com/jpsim/SourceKitten.git", majorVersion: 0, minor: 17),
-    .Package(url: "https://github.com/behrang/YamlSwift.git", majorVersion: 3),
+    .Package(url: "https://github.com/behrang/YamlSwift.git", majorVersion: 3, minor: 3),
     .Package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", majorVersion: 0, minor: 5),
   ]
 )

--- a/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
@@ -76,11 +76,9 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
     private func violations(in range: NSRange, of file: File) -> [NSRange] {
         let kinds = SyntaxKind.commentAndStringKinds()
 
-        let letUnderscore = "let\\s+(_\\s*[=,)])"
-        let letUnderscoreTuple = "let\\s+(\\((\\s*[_,]\\s*)+\\)\\s*=)"
+        let letUnderscore = "let\\s+((_\\s*[=,)])|(\\((\\s*[_,]\\s*)+\\)\\s*=))"
 
         let matches = file.matchesAndSyntaxKinds(matching: letUnderscore, range: range)
-            + file.matchesAndSyntaxKinds(matching: letUnderscoreTuple, range: range)
 
         return matches
             .filter { $0.1.filter(kinds.contains).isEmpty }

--- a/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
@@ -27,7 +27,8 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
             "}\n",
             "if foo() { let _ = bar() }\n",
             "if foo() { _ = bar() }\n",
-            "if case .some(_) = self {}"
+            "if case .some(_) = self {}",
+            "if let point = state.find({ _ in true }) {}"
         ],
         triggeringExamples: [
             "if let ↓_ = Foo.optionalValue {\n" +


### PR DESCRIPTION
The rule for unused optional binding was false triggering for pattern matching where the associated value was just an underscore. Additionally, pattern matching mixed with unused optional binding was not triggering in some cases.

New non triggering and triggering examples have been added for the failing cases, and new regular expressions are used to catch all the cases.

Modify the code in `File+SwiftLint` to expose full `NSTextCheckingResult` (and not just ranges) and rewire some pieces to use the new functions.

Fixes #1376