### PR TITLE
Reorganize OSSCheck script

### DIFF
--- a/script/oss-check
+++ b/script/oss-check
@@ -88,50 +88,55 @@ def non_empty_lines(path)
   File.read(path).split(/\n+/).reject(&:empty?)
 end
 
-def generate_reports(clone, branch)
-  Dir.chdir(@working_dir) do
-    @repos.each do |repo|
-      if clone
-        puts "Cloning #{repo.name}"
-        `git clone "https://github.com/#{repo}" --depth 1 2> /dev/null`
-        if repo.name == 'swift'
-          File.open('swift/.swiftlint.yml', 'w') do |file|
-            file << 'included: stdlib'
-          end
+def setup_repos
+  @repos.each do |repo|
+    dir = "#{@working_dir}/#{repo.name}"
+    puts "Cloning #{repo}"
+    `git clone #{repo.git_url} --depth 1 #{dir} 2> /dev/null`
+    if repo.name == 'Swift'
+      File.open("#{dir}/.swiftlint.yml", 'w') do |file|
+        file << 'included: stdlib'
+      end
+    end
+    Dir.chdir(dir) do
+      repo.commit_hash = `git rev-parse HEAD`.strip
+    end
+  end
+end
+
+def generate_reports(branch)
+  @repos.each do |repo|
+    Dir.chdir("#{@working_dir}/#{repo.name}") do
+      iterations = 2
+      print "Linting #{iterations} iterations of #{repo} with #{branch}: 1"
+      durations = []
+      start = Time.now
+      command = '../../.build/release/swiftlint lint --no-cache --enable-all-rules --reporter xcode'
+      File.open("../#{branch}_reports/#{repo}.txt", 'w') do |file|
+        Open3.popen3(command) do |_, stdout, _, _|
+          file << stdout.read.chomp
         end
       end
-      Dir.chdir(repo.name) do
-        iterations = 5
-        print "Linting #{iterations} iterations of #{repo.name} with #{branch}: 1"
-        repo.commit_hash = `git rev-parse HEAD`.strip
-        durations = []
+      durations << Time.now - start
+      for i in 2..iterations
+        print "..#{i}"
         start = Time.now
-        command = '../../.build/release/swiftlint lint --no-cache --enable-all-rules --reporter xcode'
-        File.open("../#{branch}_reports/#{repo.name}.txt", 'w') do |file|
-          Open3.popen3(command) do |_, stdout, _, _|
-            file << stdout.read.chomp
-          end
-        end
+        Open3.popen3(command) { |_, stdout, _, _| stdout.read }
         durations << Time.now - start
-        for i in 2..iterations
-          print "..#{i}"
-          start = Time.now
-          Open3.popen3(command) { |_, stdout, _, _| stdout.read }
-          durations << Time.now - start
-        end
-        puts ''
-        average_duration = (durations.reduce(:+) / iterations).round(2)
-        if branch == 'branch'
-          repo.branch_duration = average_duration
-        else
-          repo.master_duration = average_duration
-        end
+      end
+      puts ''
+      average_duration = (durations.reduce(:+) / iterations).round(2)
+      if branch == 'branch'
+        repo.branch_duration = average_duration
+      else
+        repo.master_duration = average_duration
       end
     end
   end
 end
 
 # Prep
+setup_repos
 ["#{@working_dir}/branch_reports", "#{@working_dir}/master_reports"].each do |dir|
   FileUtils.mkdir_p(dir)
 end
@@ -141,7 +146,7 @@ puts 'Building branch'
 `swift build -c release`
 
 # Generate branch reports
-generate_reports(true, 'branch')
+generate_reports('branch')
 # Build master
 `git fetch`
 `git checkout origin/master`
@@ -163,7 +168,7 @@ unless $?.success?
 end
 
 # Generate master reports
-generate_reports(false, 'master')
+generate_reports('master')
 # Diff and report changes to Danger
 @repos.each do |repo|
   branch = non_empty_lines("#{@working_dir}/branch_reports/#{repo.name}.txt")

--- a/script/oss-check
+++ b/script/oss-check
@@ -21,6 +21,7 @@ repo_clean = `git status --porcelain`.empty?
 
 fail 'git repo needs to be clean to run oss-check. Aborting.' unless repo_clean
 
+@working_dir = 'osscheck'
 @branch_name = `git symbolic-ref HEAD --short`.strip
 
 if @branch_name == 'master'
@@ -48,7 +49,7 @@ end
 @master_durations = {}
 
 def convert_to_link(string)
-  string.sub!("#{Dir.pwd}/osscheck/#{@repo_name}", '')
+  string.sub!("#{Dir.pwd}/#{@working_dir}/#{@repo_name}", '')
   string.sub!('.swift:', '.swift#L')
   string = string.partition(': warning:').first.partition(': error:').first
   "https://github.com/#{@repo}/blob/#{@commits[@repo]}#{string}"
@@ -59,7 +60,7 @@ def non_empty_lines(path)
 end
 
 def generate_reports(clone, branch)
-  Dir.chdir('osscheck') do
+  Dir.chdir(@working_dir) do
     @repos.each do |repo|
       repo_name = repo.partition('/').last
       if clone
@@ -103,7 +104,7 @@ def generate_reports(clone, branch)
 end
 
 # Prep
-['osscheck/branch_reports', 'osscheck/master_reports'].each do |dir|
+["#{@working_dir}/branch_reports", "#{@working_dir}/master_reports"].each do |dir|
   FileUtils.mkdir_p(dir)
 end
 
@@ -139,8 +140,8 @@ generate_reports(false, 'master')
 @repos.each do |repo|
   @repo_name = repo.partition('/').last
 
-  branch = non_empty_lines("osscheck/branch_reports/#{@repo_name}.txt")
-  master = non_empty_lines("osscheck/master_reports/#{@repo_name}.txt")
+  branch = non_empty_lines("#{@working_dir}/branch_reports/#{@repo_name}.txt")
+  master = non_empty_lines("#{@working_dir}/master_reports/#{@repo_name}.txt")
   @repo = repo
 
   (master - branch).each do |fixed|
@@ -169,5 +170,5 @@ end
 
 # Clean up
 `git reset --hard HEAD`
-FileUtils.rm_rf('osscheck')
+FileUtils.rm_rf(@working_dir)
 `git checkout #{@branch_name}`

--- a/script/oss-check
+++ b/script/oss-check
@@ -19,9 +19,7 @@ end
 $stdout.sync = true
 repo_clean = `git status --porcelain`.empty?
 
-unless repo_clean
-  fail 'git repo needs to be clean to run oss-check. Aborting.'
-end
+fail 'git repo needs to be clean to run oss-check. Aborting.' unless repo_clean
 
 @branch_name = `git symbolic-ref HEAD --short`.strip
 
@@ -68,7 +66,7 @@ def generate_reports(clone, branch)
         puts "Cloning #{repo_name}"
         `git clone "https://github.com/#{repo}" --depth 1 2> /dev/null`
         if repo_name == 'swift'
-          File.open("swift/.swiftlint.yml", 'w') do |file|
+          File.open('swift/.swiftlint.yml', 'w') do |file|
             file << 'included: stdlib'
           end
         end
@@ -85,12 +83,12 @@ def generate_reports(clone, branch)
             file << stdout.read.chomp
           end
         end
-        durations += [Time.now - start]
+        durations << Time.now - start
         for i in 2..iterations
           print "..#{i}"
           start = Time.now
           Open3.popen3(command) { |_, stdout, _, _| stdout.read }
-          durations += [Time.now - start]
+          durations << Time.now - start
         end
         puts ''
         average_duration = (durations.reduce(:+) / iterations).round(2)
@@ -122,7 +120,7 @@ puts 'Building master'
 `swift build -c release`
 unless $?.success?
   # Couldn't build, start fresh
-  FileUtils.rm_rf %w(Packages .build)
+  FileUtils.rm_rf %w[Packages .build]
   return_value = nil
   Open3.popen3('swift build -c release') do |_, stdout, _, wait_thr|
     puts stdout.read.chomp
@@ -146,10 +144,10 @@ generate_reports(false, 'master')
   @repo = repo
 
   (master - branch).each do |fixed|
-      message "This PR fixed a violation in #{@repo_name}: [#{fixed}](#{convert_to_link(fixed)})"
+    message "This PR fixed a violation in #{@repo_name}: [#{fixed}](#{convert_to_link(fixed)})"
   end
   (branch - master).each do |violation|
-      warn "This PR introduced a violation in #{@repo_name}: [#{violation}](#{convert_to_link(violation)})"
+    warn "This PR introduced a violation in #{@repo_name}: [#{violation}](#{convert_to_link(violation)})"
   end
 end
 
@@ -159,10 +157,10 @@ end
   percent_change = 100 * (master_duration - branch_duration) / master_duration
   faster_slower = nil
   if branch_duration < master_duration
-      faster_slower = 'faster'
+    faster_slower = 'faster'
   else
-      faster_slower = 'slower'
-      percent_change *= -1
+    faster_slower = 'slower'
+    percent_change *= -1
   end
   repo_name = repo.partition('/').last
   message "Linting #{repo_name} with this PR took #{branch_duration}s " \

--- a/script/oss-check
+++ b/script/oss-check
@@ -28,30 +28,60 @@ if `git symbolic-ref HEAD --short`.strip == 'master'
        "the performance of this branch against 'master'"
 end
 
+class Repo
+  attr_accessor :name
+  attr_accessor :github_location
+  attr_accessor :commit_hash
+  attr_accessor :branch_duration
+  attr_accessor :master_duration
+
+  def initialize(name, github_location)
+    @name = name
+    @github_location = github_location
+  end
+
+  def git_url
+    "https://github.com/#{github_location}"
+  end
+
+  def to_s
+    @name
+  end
+
+  def duration_report
+    percent_change = 100 * (@master_duration - @branch_duration) / @master_duration
+    faster_slower = nil
+    if @branch_duration < @master_duration
+      faster_slower = 'faster'
+    else
+      faster_slower = 'slower'
+      percent_change *= -1
+    end
+    "Linting #{self} with this PR took #{@branch_duration}s " \
+    "vs #{@master_duration}s on master (#{percent_change.to_i}\% #{faster_slower})"
+  end
+end
+
 @repos = [
-  'Alamofire/Alamofire',
-  'apple/swift',
-  'JohnCoates/Aerial',
-  'jpsim/SourceKitten',
-  'krzysztofzablocki/Sourcery',
-  'kickstarter/ios-oss',
-  'Moya/Moya',
-  'mozilla-mobile/firefox-ios',
-  'Quick/Nimble',
-  'Quick/Quick',
-  'realm/realm-cocoa',
-  'wordpress-mobile/WordPress-iOS'
+  Repo.new('Alamofire', 'Alamofire/Alamofire'),
+  Repo.new('Swift', 'apple/swift'),
+  Repo.new('Aerial', 'JohnCoates/Aerial'),
+  Repo.new('SourceKitten', 'jpsim/SourceKitten'),
+  Repo.new('Sourcery', 'krzysztofzablocki/Sourcery'),
+  Repo.new('Kickstarter', 'kickstarter/ios-oss'),
+  Repo.new('Moya', 'Moya/Moya'),
+  Repo.new('Firefox', 'mozilla-mobile/firefox-ios'),
+  Repo.new('Nimble', 'Quick/Nimble'),
+  Repo.new('Quick', 'Quick/Quick'),
+  Repo.new('Realm', 'realm/realm-cocoa'),
+  Repo.new('WordPress', 'wordpress-mobile/WordPress-iOS')
 ]
 
-@commits = {}
-@branch_durations = {}
-@master_durations = {}
-
-def convert_to_link(string)
-  string.sub!("#{Dir.pwd}/#{@working_dir}/#{@repo_name}", '')
+def convert_to_link(repo, string)
+  string.sub!("#{Dir.pwd}/#{@working_dir}/#{repo.name}", '')
   string.sub!('.swift:', '.swift#L')
   string = string.partition(': warning:').first.partition(': error:').first
-  "https://github.com/#{@repo}/blob/#{@commits[@repo]}#{string}"
+  "#{repo.git_url}/blob/#{repo.commit_hash}#{string}"
 end
 
 def non_empty_lines(path)
@@ -61,24 +91,23 @@ end
 def generate_reports(clone, branch)
   Dir.chdir(@working_dir) do
     @repos.each do |repo|
-      repo_name = repo.partition('/').last
       if clone
-        puts "Cloning #{repo_name}"
+        puts "Cloning #{repo.name}"
         `git clone "https://github.com/#{repo}" --depth 1 2> /dev/null`
-        if repo_name == 'swift'
+        if repo.name == 'swift'
           File.open('swift/.swiftlint.yml', 'w') do |file|
             file << 'included: stdlib'
           end
         end
       end
-      Dir.chdir(repo_name) do
+      Dir.chdir(repo.name) do
         iterations = 5
-        print "Linting #{iterations} iterations of #{repo_name} with #{branch}: 1"
-        @commits[repo] = `git rev-parse HEAD`.strip
+        print "Linting #{iterations} iterations of #{repo.name} with #{branch}: 1"
+        repo.commit_hash = `git rev-parse HEAD`.strip
         durations = []
         start = Time.now
         command = '../../.build/release/swiftlint lint --no-cache --enable-all-rules --reporter xcode'
-        File.open("../#{branch}_reports/#{repo_name}.txt", 'w') do |file|
+        File.open("../#{branch}_reports/#{repo.name}.txt", 'w') do |file|
           Open3.popen3(command) do |_, stdout, _, _|
             file << stdout.read.chomp
           end
@@ -93,9 +122,9 @@ def generate_reports(clone, branch)
         puts ''
         average_duration = (durations.reduce(:+) / iterations).round(2)
         if branch == 'branch'
-          @branch_durations[repo] = average_duration
+          repo.branch_duration = average_duration
         else
-          @master_durations[repo] = average_duration
+          repo.master_duration = average_duration
         end
       end
     end
@@ -137,34 +166,19 @@ end
 generate_reports(false, 'master')
 # Diff and report changes to Danger
 @repos.each do |repo|
-  @repo_name = repo.partition('/').last
-
-  branch = non_empty_lines("#{@working_dir}/branch_reports/#{@repo_name}.txt")
-  master = non_empty_lines("#{@working_dir}/master_reports/#{@repo_name}.txt")
-  @repo = repo
+  branch = non_empty_lines("#{@working_dir}/branch_reports/#{repo.name}.txt")
+  master = non_empty_lines("#{@working_dir}/master_reports/#{repo.name}.txt")
 
   (master - branch).each do |fixed|
-    message "This PR fixed a violation in #{@repo_name}: [#{fixed}](#{convert_to_link(fixed)})"
+    message "This PR fixed a violation in #{repo.name}: [#{fixed}](#{convert_to_link(repo, fixed)})"
   end
   (branch - master).each do |violation|
-    warn "This PR introduced a violation in #{@repo_name}: [#{violation}](#{convert_to_link(violation)})"
+    warn "This PR introduced a violation in #{repo.name}: [#{violation}](#{convert_to_link(repo, violation)})"
   end
 end
 
 @repos.each do |repo|
-  branch_duration = @branch_durations[repo]
-  master_duration = @master_durations[repo]
-  percent_change = 100 * (master_duration - branch_duration) / master_duration
-  faster_slower = nil
-  if branch_duration < master_duration
-    faster_slower = 'faster'
-  else
-    faster_slower = 'slower'
-    percent_change *= -1
-  end
-  repo_name = repo.partition('/').last
-  message "Linting #{repo_name} with this PR took #{branch_duration}s " \
-          "vs #{master_duration}s on master (#{percent_change.to_i}\% #{faster_slower})"
+  message repo.duration_report
 end
 
 # Clean up

--- a/script/oss-check
+++ b/script/oss-check
@@ -111,7 +111,7 @@ end
 def generate_reports(branch)
   @repos.each do |repo|
     Dir.chdir("#{@working_dir}/#{repo.name}") do
-      iterations = 2
+      iterations = 5
       print "Linting #{iterations} iterations of #{repo} with #{branch}: 1"
       durations = []
       start = Time.now

--- a/script/oss-check
+++ b/script/oss-check
@@ -1,32 +1,15 @@
 #!/usr/bin/env ruby
 
+################################
+# Requires
+################################
+
 require 'fileutils'
 require 'open3'
 
-def message(str)
-  $stderr.puts('Message: ' + str)
-end
-
-def warn(str)
-  $stderr.puts('Warning: ' + str)
-end
-
-def fail(str)
-  $stderr.puts('Error: ' + str)
-  exit
-end
-
-$stdout.sync = true
-repo_clean = `git status --porcelain`.empty?
-
-fail 'git repo needs to be clean to run oss-check. Aborting.' unless repo_clean
-
-@working_dir = 'osscheck'
-
-if `git symbolic-ref HEAD --short`.strip == 'master'
-  fail "can't run osscheck from 'master' as the script compares "\
-       "the performance of this branch against 'master'"
-end
+################################
+# Classes
+################################
 
 class Repo
   attr_accessor :name
@@ -64,20 +47,39 @@ class Repo
   end
 end
 
-@repos = [
-  Repo.new('Alamofire', 'Alamofire/Alamofire'),
-  Repo.new('Swift', 'apple/swift'),
-  Repo.new('Aerial', 'JohnCoates/Aerial'),
-  Repo.new('SourceKitten', 'jpsim/SourceKitten'),
-  Repo.new('Sourcery', 'krzysztofzablocki/Sourcery'),
-  Repo.new('Kickstarter', 'kickstarter/ios-oss'),
-  Repo.new('Moya', 'Moya/Moya'),
-  Repo.new('Firefox', 'mozilla-mobile/firefox-ios'),
-  Repo.new('Nimble', 'Quick/Nimble'),
-  Repo.new('Quick', 'Quick/Quick'),
-  Repo.new('Realm', 'realm/realm-cocoa'),
-  Repo.new('WordPress', 'wordpress-mobile/WordPress-iOS')
-]
+################################
+# Methods
+################################
+
+def message(str)
+  $stderr.puts('Message: ' + str)
+end
+
+def warn(str)
+  $stderr.puts('Warning: ' + str)
+end
+
+def fail(str)
+  $stderr.puts('Error: ' + str)
+  exit
+end
+
+def validate_state_to_run
+  repo_clean = `git status --porcelain`.empty?
+
+  fail 'git repo needs to be clean to run oss-check. Aborting.' unless repo_clean
+
+  if `git symbolic-ref HEAD --short`.strip == 'master'
+    fail "can't run osscheck from 'master' as the script compares " \
+         "the performance of this branch against 'master'"
+  end
+end
+
+def make_directory_structure
+  ["#{@working_dir}/branch_reports", "#{@working_dir}/master_reports"].each do |dir|
+    FileUtils.mkdir_p(dir)
+  end
+end
 
 def convert_to_link(repo, string)
   string.sub!("#{Dir.pwd}/#{@working_dir}/#{repo.name}", '')
@@ -142,66 +144,90 @@ def generate_reports(branch)
   end
 end
 
-# Prep
-setup_repos
-["#{@working_dir}/branch_reports", "#{@working_dir}/master_reports"].each do |dir|
-  FileUtils.mkdir_p(dir)
-end
+def build(branch)
+  `git fetch && git checkout origin/master` if branch == 'master'
 
-# Build branch
-puts 'Building branch'
-`swift build -c release`
+  build_command = 'swift build -c release'
 
-# Generate branch reports
-generate_reports('branch')
-# Build master
-`git fetch`
-`git checkout origin/master`
-puts 'Building master'
-`swift build -c release`
-unless $?.success?
+  puts "Building #{branch}"
+  `#{build_command}`
+  return if $?.success?
+
   # Couldn't build, start fresh
   FileUtils.rm_rf %w[Packages .build]
   return_value = nil
-  Open3.popen3('swift build -c release') do |_, stdout, _, wait_thr|
+  Open3.popen3(build_command) do |_, stdout, _, wait_thr|
     puts stdout.read.chomp
     return_value = wait_thr.value
   end
 
-  unless return_value.success?
-    fail 'Could not build master'
-    return
+  fail "Could not build #{branch}" unless return_value.success?
+end
+
+def diff_and_report_changes_to_danger
+  @repos.each do |repo|
+    if repo.master_exit_value != repo.branch_exit_value
+      warn "This PR changed the exit value when running on #{repo.name}: " \
+           "(#{repo.master_exit_value} to #{repo.branch_exit_value})"
+      # If the exit value changed, don't show the fixes or regressions for this
+      # repo because it's likely due to a crash, and all violations would be noisy
+      next
+    end
+
+    branch = non_empty_lines("#{@working_dir}/branch_reports/#{repo.name}.txt")
+    master = non_empty_lines("#{@working_dir}/master_reports/#{repo.name}.txt")
+
+    (master - branch).each do |fixed|
+      message "This PR fixed a violation in #{repo.name}: [#{fixed}](#{convert_to_link(repo, fixed)})"
+    end
+    (branch - master).each do |violation|
+      warn "This PR introduced a violation in #{repo.name}: [#{violation}](#{convert_to_link(repo, violation)})"
+    end
+    message repo.duration_report
   end
 end
 
-# Generate master reports
-generate_reports('master')
+def clean_up
+  `git reset --hard HEAD`
+  FileUtils.rm_rf(@working_dir)
+  `git checkout -`
+end
+
+################################
+# Script
+################################
+
+# Constants
+@working_dir = 'osscheck'
+@repos = [
+  Repo.new('Aerial', 'JohnCoates/Aerial'),
+  Repo.new('Alamofire', 'Alamofire/Alamofire'),
+  Repo.new('Firefox', 'mozilla-mobile/firefox-ios'),
+  Repo.new('Kickstarter', 'kickstarter/ios-oss'),
+  Repo.new('Moya', 'Moya/Moya'),
+  Repo.new('Nimble', 'Quick/Nimble'),
+  Repo.new('Quick', 'Quick/Quick'),
+  Repo.new('Realm', 'realm/realm-cocoa'),
+  Repo.new('SourceKitten', 'jpsim/SourceKitten'),
+  Repo.new('Sourcery', 'krzysztofzablocki/Sourcery'),
+  Repo.new('Swift', 'apple/swift'),
+  Repo.new('WordPress', 'wordpress-mobile/WordPress-iOS')
+]
+
+# Prep
+$stdout.sync = true
+validate_state_to_run
+setup_repos
+make_directory_structure
+
+# Build & generate reports for branch & master
+['branch', 'master'].each do |branch|
+  build(branch)
+  generate_reports(branch)
+end
+
 # Diff and report changes to Danger
-@repos.each do |repo|
-  if repo.master_exit_value != repo.branch_exit_value
-    warn "This PR changed the exit value when running on #{repo.name}: " \
-         "(#{repo.master_exit_value} to #{repo.branch_exit_value})"
-    # If the exit value changed, don't show the fixes or regressions for this
-    # repo because it's likely due to a crash, and all violations would be noisy
-    next
-  end
-
-  branch = non_empty_lines("#{@working_dir}/branch_reports/#{repo.name}.txt")
-  master = non_empty_lines("#{@working_dir}/master_reports/#{repo.name}.txt")
-
-  (master - branch).each do |fixed|
-    message "This PR fixed a violation in #{repo.name}: [#{fixed}](#{convert_to_link(repo, fixed)})"
-  end
-  (branch - master).each do |violation|
-    warn "This PR introduced a violation in #{repo.name}: [#{violation}](#{convert_to_link(repo, violation)})"
-  end
-end
-
-@repos.each do |repo|
-  message repo.duration_report
-end
+diff_and_report_changes_to_danger
 
 # Clean up
-`git reset --hard HEAD`
-FileUtils.rm_rf(@working_dir)
-`git checkout -`
+clean_up

--- a/script/oss-check
+++ b/script/oss-check
@@ -22,9 +22,8 @@ repo_clean = `git status --porcelain`.empty?
 fail 'git repo needs to be clean to run oss-check. Aborting.' unless repo_clean
 
 @working_dir = 'osscheck'
-@branch_name = `git symbolic-ref HEAD --short`.strip
 
-if @branch_name == 'master'
+if `git symbolic-ref HEAD --short`.strip == 'master'
   fail "can't run osscheck from 'master' as the script compares "\
        "the performance of this branch against 'master'"
 end
@@ -171,4 +170,4 @@ end
 # Clean up
 `git reset --hard HEAD`
 FileUtils.rm_rf(@working_dir)
-`git checkout #{@branch_name}`
+`git checkout -`

--- a/script/oss-check
+++ b/script/oss-check
@@ -32,7 +32,9 @@ class Repo
   attr_accessor :name
   attr_accessor :github_location
   attr_accessor :commit_hash
+  attr_accessor :branch_exit_value
   attr_accessor :branch_duration
+  attr_accessor :master_exit_value
   attr_accessor :master_duration
 
   def initialize(name, github_location)
@@ -113,8 +115,13 @@ def generate_reports(branch)
       start = Time.now
       command = '../../.build/release/swiftlint lint --no-cache --enable-all-rules --reporter xcode'
       File.open("../#{branch}_reports/#{repo}.txt", 'w') do |file|
-        Open3.popen3(command) do |_, stdout, _, _|
+        Open3.popen3(command) do |_, stdout, _, wait_thr|
           file << stdout.read.chomp
+          if branch == 'branch'
+            repo.branch_exit_value = wait_thr.value
+          else
+            repo.master_exit_value = wait_thr.value
+          end
         end
       end
       durations << Time.now - start
@@ -171,6 +178,14 @@ end
 generate_reports('master')
 # Diff and report changes to Danger
 @repos.each do |repo|
+  if repo.master_exit_value != repo.branch_exit_value
+    warn "This PR changed the exit value when running on #{repo.name}: " \
+         "(#{repo.master_exit_value} to #{repo.branch_exit_value})"
+    # If the exit value changed, don't show the fixes or regressions for this
+    # repo because it's likely due to a crash, and all violations would be noisy
+    next
+  end
+
   branch = non_empty_lines("#{@working_dir}/branch_reports/#{repo.name}.txt")
   master = non_empty_lines("#{@working_dir}/master_reports/#{repo.name}.txt")
 


### PR DESCRIPTION
Also compare exit status between runs so we can be notified when the exit code changes, or a PR makes a run crash (such as what happened in #1411).

If the exit status changed, skip reporting fixes/regressions which will avoid the wall of output that we also saw in #1411, which was quite confusing.