### PR TITLE
Swift 3.1 on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ matrix:
       os: osx
       osx_image: xcode8.2
     - script: make docker_test
-      env: JOB=Linux
+      env: JOB=Linux3.1
+      sudo: required
+      services: docker
+    - script: make docker_test_302
+      env: JOB=Linux3.0.2
       sudo: required
       services: docker
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,10 @@ archive:
 release: package archive portable_zip
 
 docker_test:
-	docker run -v `pwd`:/SwiftLint norionomura/sourcekit:302 bash -c "cd /SwiftLint && swift test"
+	docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/sourcekit:31 swift test
+
+docker_test_302:
+	docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/sourcekit:302 swift test
 
 # http://irace.me/swift-profiling/
 display_compilation_time:

--- a/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
@@ -9,7 +9,9 @@
 import Foundation
 
 #if os(Linux)
+#if !swift(>=3.1)
 public typealias NSRegularExpression = RegularExpression
+#endif
 public typealias NSTextCheckingResult = TextCheckingResult
 #endif
 


### PR DESCRIPTION
Docker images norionomura/sourcekit:31 is updated to including apple/swift#8485 and apple/swift#8189.
This PR confirms that those PRs fix tests in SwiftLint on Linux.