### PR TITLE
Fixing a minor typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * Add lowercase and missing colon checks to the `mark` rule.  
   [Jason Moore](https://github.com/xinsight)
 
+* Fixed a minor typo within the `DiscardedNotificationCenterObserverRule` rule  
+  [Spencer Kaiser](https://github.com/spencerkaiser)
+
 ##### Bug Fixes
 
 * `emoji` and `checkstyle` reporter output report sorted by file name.  
@@ -113,7 +116,7 @@
   implicitly unwrapped optionals, except cases when this IUO is an IBOutlet.  
   [Siarhei Fedartsou](https://github.com/SiarheiFedartsou)
   [#56](https://github.com/realm/SwiftLint/issues/56)
- 
+
 * Performance improvements to `generic_type_name`,
   `redundant_nil_coalescing`, `mark`, `first_where` and
   `vertical_whitespace` rules.  

--- a/Source/SwiftLintFramework/Rules/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscardedNotificationCenterObserverRule.swift
@@ -17,7 +17,7 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
     public static let description = RuleDescription(
         identifier: "discarded_notification_center_observer",
         name: "Discarded Notification Center Observer",
-        description: "When registing for a notification using a block, the opaque observer that is " +
+        description: "When registering for a notification using a block, the opaque observer that is " +
                      "returned should be stored so it can be removed later.",
         nonTriggeringExamples: [
             "let foo = nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil) { }\n",


### PR DESCRIPTION
Fixed a minor typo: _"When ~~registing~~ registering for a notification using a block"_