### PR TITLE
Fix inaccurate violation report in fileLengthRule and FunctionParameterCountRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 * Fix typo in `DiscardedNotificationCenterObserverRule`.  
   [Spencer Kaiser](https://github.com/spencerkaiser)
 
+* Fix inaccurate violation report in fileLengthRule and FunctionParameterCountRule.  
+  [ultimatedbz](https://github.com/ultimatedbz)
+
 ## 0.18.1: Misaligned Drum
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -31,7 +31,7 @@ public struct FileLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
             return [StyleViolation(ruleDescription: type(of: self).description,
                 severity: parameter.severity,
                 location: Location(file: file.path, line: lineCount),
-                reason: "File should contain \(configuration.warning) lines or less: " +
+                reason: "File should contain \(parameter.value) lines or less: " +
                         "currently contains \(lineCount)")]
         }
         return []

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -69,7 +69,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
             return [StyleViolation(ruleDescription: type(of: self).description,
                 severity: parameter.severity,
                 location: Location(file: file, byteOffset: offset),
-                reason: "Function should have \(configuration.warning) parameters or less: " +
+                reason: "Function should have \(parameter.value) parameters or less: " +
                     "it currently has \(parameterCount)")]
         }
 


### PR DESCRIPTION
We should be using parameter.value instead of configuration.warning in order to report accurate information about the violation.