### PR TITLE
Improve user experience in reporting violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
   [Jason Moore](https://github.com/xinsight)
 
 * Improve violation reason wording in `function_body_length`,
-* Improve violation report UX in `function_body_length`,
   `large_type`, and `type_body_length` rules.  
   [ultimatedbz](https://github.com/ultimatedbz)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 * Add lowercase and missing colon checks to the `mark` rule.  
   [Jason Moore](https://github.com/xinsight)
 
+* Improve violation reason wording in `function_body_length`,
+  `large_type`, and `type_body_length` rules.  
+  [ultimatedbz](https://github.com/ultimatedbz)
+
 ##### Bug Fixes
 
 * `emoji` and `checkstyle` reporter output report sorted by file name.  
@@ -26,10 +30,6 @@
 
 * Fix typo in `DiscardedNotificationCenterObserverRule`.  
   [Spencer Kaiser](https://github.com/spencerkaiser)
-
-* Fix inaccurate violation report in `file_length` and
-  `function_parameter_count` rules.  
-  [ultimatedbz](https://github.com/ultimatedbz)
 
 ## 0.18.1: Misaligned Drum
 

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -31,7 +31,7 @@ public struct FileLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
             return [StyleViolation(ruleDescription: type(of: self).description,
                 severity: parameter.severity,
                 location: Location(file: file.path, line: lineCount),
-                reason: "File should contain \(parameter.value) lines or less: " +
+                reason: "File should contain \(configuration.warning) lines or less: " +
                         "currently contains \(lineCount)")]
         }
         return []

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -39,7 +39,7 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
             return [StyleViolation(ruleDescription: type(of: self).description,
                                    severity: parameter.severity,
                                    location: Location(file: file, byteOffset: offset),
-                                   reason: "Function body should span \(parameter.value) lines or less " +
+                                   reason: "Function body should span \(configuration.warning) lines or less " +
                                            "excluding comments and whitespace: currently spans \(lineCount) " +
                                            "lines")]
         }

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -69,7 +69,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
             return [StyleViolation(ruleDescription: type(of: self).description,
                 severity: parameter.severity,
                 location: Location(file: file, byteOffset: offset),
-                reason: "Function should have \(parameter.value) parameters or less: " +
+                reason: "Function should have \(configuration.warning) parameters or less: " +
                     "it currently has \(parameterCount)")]
         }
 

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -66,7 +66,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
 
         return offsets.flatMap { location, size in
             for parameter in configuration.params where size > parameter.value {
-                let reason = "Tuples should have at most \(parameter.value) members."
+                let reason = "Tuples should have at most \(configuration.warning) members."
                 return StyleViolation(ruleDescription: type(of: self).description,
                                       severity: parameter.severity,
                                       location: Location(file: file, byteOffset: location),

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -59,7 +59,7 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
                         return [StyleViolation(ruleDescription: type(of: self).description,
                             severity: parameter.severity,
                             location: Location(file: file, byteOffset: offset),
-                            reason: "Type body should span \(parameter.value) lines or less " +
+                            reason: "Type body should span \(configuration.warning) lines or less " +
                                 "excluding comments and whitespace: currently spans \(lineCount) " +
                                 "lines")]
                     }


### PR DESCRIPTION
This PR reverts #1463 and reports `configuration.warning` instead of `parameter.value` for three other rules.

For more context check out #1463  and #1465.