### PR TITLE
Whitespace around let/var groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@
   in `guard` statements.  
   [Sega-Zero](https://github.com/Sega-Zero)
   [#1432](https://github.com/realm/SwiftLint/issues/1432)
+* Whitespace around let/var groups.  
+  [Uncommon](https://github.com/Uncommon)
+  [#1471](https://github.com/realm/SwiftLint/issues/1471)
 
 * Add `empty_enum_arguments` correctable rule that warns against using
   silent associated values inside a `case`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
   in `guard` statements.  
   [Sega-Zero](https://github.com/Sega-Zero)
   [#1432](https://github.com/realm/SwiftLint/issues/1432)
+
 * Whitespace around let/var groups.  
   [Uncommon](https://github.com/Uncommon)
   [#1471](https://github.com/realm/SwiftLint/issues/1471)

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -117,6 +117,7 @@ public let masterRuleList = RuleList(rules:
     LegacyConstantRule.self,
     LegacyConstructorRule.self,
     LegacyNSGeometryFunctionsRule.self,
+    LetVarWhitespaceRule.self,
     LineLengthRule.self,
     MarkRule.self,
     MultilineParametersRule.self,

--- a/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
@@ -45,7 +45,7 @@ public struct LetVarWhitespaceRule: OptInRule {
                   !commentLines.contains(index) else {
                 continue
             }
-            
+
             let trimmed = line.content.trimmingCharacters(in: .whitespaces)
             guard !trimmed.isEmpty else {
                 continue
@@ -54,14 +54,14 @@ public struct LetVarWhitespaceRule: OptInRule {
             // Precedes var/let and has text not ending with {
             if linePrecedesVar(index, varLines, commentLines) {
                 if !trimmed.hasSuffix("{") &&
-                   !file.lines[index+1].content.trimmingCharacters(in: .whitespaces).hasPrefix("}") {
-                    violated(&violations, file, index+1)
+                   !file.lines[index + 1].content.trimmingCharacters(in: .whitespaces).hasPrefix("}") {
+                    violated(&violations, file, index + 1)
                 }
             }
             // Follows var/let and has text not starting with }
             if lineFollowsVar(index, varLines, commentLines) {
                 if !trimmed.hasPrefix("}") &&
-                   !file.lines[index-1].content.trimmingCharacters(in: .whitespaces).hasSuffix("{") {
+                   !file.lines[index - 1].content.trimmingCharacters(in: .whitespaces).hasSuffix("{") {
                     violated(&violations, file, index)
                 }
             }
@@ -132,7 +132,7 @@ public struct LetVarWhitespaceRule: OptInRule {
                    let bodyLength = statement.bodyLength {
                     let bodyStart = file.line(for: bodyOffset, startFrom: startLine) + 1
                     let bodyEnd = file.line(for: bodyOffset + bodyLength, startFrom: bodyStart) - 1
-                    
+
                     if bodyStart <= bodyEnd {
                         lines.subtract(Set(bodyStart...bodyEnd))
                     }
@@ -141,9 +141,9 @@ public struct LetVarWhitespaceRule: OptInRule {
             default:
                 break
             }
-            
+
             let substructure = statement.substructure
-            
+
             if !substructure.isEmpty {
                 result.formUnion(varLetLineNumbers(file: file, structure: substructure))
             }

--- a/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
@@ -1,0 +1,118 @@
+//
+//  LetVarWhitespaceRule.swift
+//  SwiftLint
+//
+//  Created by David Catmull on 4/24/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct LetVarWhitespaceRule: OptInRule {
+
+    public var configurationDescription: String { return "" }
+
+    public init() {}
+    public init(configuration: Any) {}
+
+    public static let description = RuleDescription(
+        identifier: "let_var_whitespace",
+        name: "Variable Declaration Whitespace",
+        description: "Let and var should be separated from other statements by a blank line.",
+        nonTriggeringExamples: [
+            "let a = 0\nvar x = 1\n\nx = 2\n",
+            "a = 5\n\nvar x = 1\n",
+            "struct X {\n\tvar a = 0\n}\n"
+        ],
+        triggeringExamples: [
+            "var x = 1\n↓x = 2\n",
+            "↓a = 5\nvar x = 1\n",
+            "struct X {\n\tlet a\n\t↓func x() {}\n}\n"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        let varLines = varLetLineNumbers(file: file, structure: file.structure.dictionary.substructure)
+        var violations = [StyleViolation]()
+        let notWhitespace = CharacterSet.whitespaces.inverted
+        
+        for (index, line) in file.lines.enumerated() {
+            guard !varLines.contains(index) else { continue }
+            
+            let lastRange = line.content.rangeOfCharacter(from: notWhitespace, options: [.backwards])
+            let firstRange = line.content.rangeOfCharacter(from: notWhitespace)
+            
+            // Precedes var/let and has text not ending with {
+            if varLines.contains(index + 1) {
+                if let last = lastRange.map({ line.content.substring(with: $0) }), last != "{" {
+                    violated(&violations, file, index)
+                }
+            }
+            // Follows var/let and has text not starting with }
+            if varLines.contains(index - 1) {
+                if let first = firstRange.map({ line.content.substring(with: $0) }), first != "}" {
+                    violated(&violations, file, index)
+                }
+            }
+        }
+        return violations
+    }
+    
+    func violated(_ violations: inout [StyleViolation], _ file: File, _ line: Int) {
+        let content = file.lines[line].content
+        let startIndex = content.rangeOfCharacter(from: CharacterSet.whitespaces.inverted)?.lowerBound ?? content.startIndex
+        let offset = content.characters.distance(from: content.startIndex, to: startIndex)
+        
+        violations.append(StyleViolation(ruleDescription: LetVarWhitespaceRule.description, location: Location(file: file, characterOffset: offset + file.lines[line].range.location)))
+    }
+    
+    // Collects all the line numbers containing var or let declarations
+    func varLetLineNumbers(file: File, structure: [[String: SourceKitRepresentable]]) -> Set<Int> {
+        var result = Set<Int>()
+        
+        for statement in structure {
+            guard let kind = statement.kind else { continue }
+            
+            switch kind {
+            case SwiftDeclarationKind.varGlobal.rawValue,
+                 SwiftDeclarationKind.varClass.rawValue,
+                 SwiftDeclarationKind.varLocal.rawValue,
+                 SwiftDeclarationKind.varInstance.rawValue:
+                guard let offset = statement.offset else { break }
+                let lineNumber = file.line(for: offset, startFrom: 0)
+                
+                result.update(with: lineNumber)
+            default:
+                break
+            }
+            if statement["key.substructure"] != nil {
+                result.formUnion(varLetLineNumbers(file: file, structure: statement.substructure))
+            }
+            print(statement)
+        }
+        return result
+    }
+}
+
+extension File {
+    func line(for offset: Int, startFrom: Int) -> Int {
+        for index in startFrom..<lines.count {
+            let line = lines[index]
+            
+            if line.range.location + line.range.length > offset {
+                return index
+            }
+        }
+        return 0
+    }
+}
+
+extension CharacterSet {
+    var inverted: CharacterSet {
+        var other = self
+        
+        other.invert()
+        return other
+    }
+}

--- a/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
@@ -160,14 +160,14 @@ public struct LetVarWhitespaceRule: OptInRule {
 
             result.formUnion(Set(startLine...endLine))
         }
-        
+
         let conditionals = ["#if", "#elseif", "#else", "#endif", "@available"]
         let conditionalLines = file.lines.filter {
             let trimmed = $0.content.trimmingCharacters(in: .whitespaces)
             return conditionals.contains(where: { trimmed.hasPrefix($0) })
         }
-        
-        result.formUnion(conditionalLines.map { $0.index-1 })
+
+        result.formUnion(conditionalLines.map { $0.index - 1 })
         return result
     }
 }

--- a/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
@@ -27,7 +27,8 @@ public struct LetVarWhitespaceRule: OptInRule {
             "let a = 1 +\n\t2\nlet b = 5\n",
             "var x: Int {\n\treturn 0\n}\n",
             "var x: Int {\n\tlet a = 0\n\n\treturn a\n}\n",
-            "#if os(macOS)\nlet a = 0\n#endif\n"
+            "#if os(macOS)\nlet a = 0\n#endif\n",
+            "@available(swift 4)\nlet a = 0\n"
         ],
         triggeringExamples: [
             "var x = 1\n↓x = 2\n",
@@ -160,7 +161,7 @@ public struct LetVarWhitespaceRule: OptInRule {
             result.formUnion(Set(startLine...endLine))
         }
         
-        let conditionals = ["#if", "#elseif", "#else", "#endif"]
+        let conditionals = ["#if", "#elseif", "#else", "#endif", "@available"]
         let conditionalLines = file.lines.filter {
             let trimmed = $0.content.trimmingCharacters(in: .whitespaces)
             return conditionals.contains(where: { trimmed.hasPrefix($0) })

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
 		C328A2F71E6759AE00A9E4D7 /* ExplicitTypeInterfaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */; };
 		C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */; };
+		C946FECB1EAE67EE007DD778 /* LetVarWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */; };
 		C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */; };
 		CE8178ED1EAC039D0063186E /* UnusedOptionalBindingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -377,6 +378,7 @@
 		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
 		C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRule.swift; sourceTree = "<group>"; };
 		C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FatalErrorMessageRule.swift; sourceTree = "<group>"; };
+		C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LetVarWhitespaceRule.swift; sourceTree = "<group>"; };
 		C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
 		CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingConfiguration.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -899,6 +901,7 @@
 				00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */,
 				D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */,
 				F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */,
+				C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */,
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
 				856651A61D6B395F005E6B29 /* MarkRule.swift */,
 				6238AE411ED4D734006C3601 /* MultilineParametersRule.swift */,
@@ -1366,6 +1369,7 @@
 				D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
 				D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */,
+				C946FECB1EAE67EE007DD778 /* LetVarWhitespaceRule.swift in Sources */,
 				E881985D1BEA97EB00333A11 /* TrailingWhitespaceRule.swift in Sources */,
 				E832F10B1B17E2F5003F265F /* NSFileManager+SwiftLint.swift in Sources */,
 				E816194C1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -160,7 +160,7 @@ class RulesTests: XCTestCase {
     func testLegacyConstructor() {
         verifyRule(LegacyConstructorRule.description)
     }
-    
+
     func testLetVarWhitespace() {
         verifyRule(LetVarWhitespaceRule.description)
     }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -160,6 +160,10 @@ class RulesTests: XCTestCase {
     func testLegacyConstructor() {
         verifyRule(LegacyConstructorRule.description)
     }
+    
+    func testLetVarWhitespace() {
+        verifyRule(LetVarWhitespaceRule.description)
+    }
 
     func testMark() {
         verifyRule(MarkRule.description, commentDoesntViolate: false)


### PR DESCRIPTION
I have this mostly working pretty well, but I'm at a point where I could use a little help.

The goal is to require blank lines around groups of `let`/`var` statements, with comments allowed in those groups as well.

The thing I'm having trouble with is accessors - anything inside an accessor (get/set/didSet) is getting totally ignored. The file structure gives me info about the outer `var` declaration, but then there's no substructure so I'm not getting anything about what's in its accessors. For the `struct` case for example, I do get a substructure, and that works just fine. So how do I find info about statements inside accessors?

Next I need to figure out what to do with `guard` since `guard let` often goes with regular `let`. I figure the options are:
- Always allow `guard` next to let/var groups
- Never allow it
- Allow `guard` if it includes let/var (if that's not too much of a pain to figure out)
- Make it configurable

This also seems like a good candidate for auto-correct. The only thing is that comment lines can make it ambiguous.