### PR TITLE
Added ExplicitInternalTopLevelRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 * Add lowercase and missing colon checks to the `mark` rule.  
   [Jason Moore](https://github.com/xinsight)
 
+* Added ExplicitInternalTopLevelRule.  
+  [J. Cheyo Jimenez](https://github.com/masters3d)
+  [#58](https://github.com/realm/SwiftLint/issues/58)
+
 * Improve violation reason wording in `function_body_length`,
   `large_type`, and `type_body_length` rules.  
   [ultimatedbz](https://github.com/ultimatedbz)

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -94,6 +94,7 @@ public let masterRuleList = RuleList(rules:
     EmptyParenthesesWithTrailingClosureRule.self,
     ExplicitInitRule.self,
     ExplicitTypeInterfaceRule.self,
+    ExplicitInternalTopLevelRule.self,
     FatalErrorMessageRule.self,
     FileHeaderRule.self,
     FileLengthRule.self,

--- a/Source/SwiftLintFramework/Rules/ExplicitInternalTopLevelRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInternalTopLevelRule.swift
@@ -1,0 +1,97 @@
+//
+//  ExplicitInternalTopLevelRule.swift
+//  SwiftLint
+//
+//  Created by Jose Cheyo Jimenez on 4/28/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct ExplicitInternalTopLevelRule: OptInRule, ConfigurationProviderRule {
+    public init() {}
+    public var configuration = SeverityConfiguration(.warning)
+        public static let description = RuleDescription(
+        identifier: "explicit_internal_toplevel",
+        name: "Explicit Internal Top-level Rule",
+        description: "Top-level type declerations should specify Access Control Labels.",
+        nonTriggeringExamples: [
+            "internal enum A {}\n",
+            "public final class B {}\n",
+            "private struct C {}\n",
+            "internal enum A {\n enum A {}\n}"
+        ],
+        triggeringExamples: [
+            "enum A {}\n",
+            "final class B {}\n",
+            "struct C {}\n"
+        ]
+    )
+
+    private func isAccessControl(_ label: SyntaxToken, in file: File ) -> Bool {
+         let accessLabels = Set(["open", "public", "internal", "fileprivate", "private"])
+         let attibute = file.contents.bridge().substringWithByteRange(start: label.offset, length: label.length) ?? ""
+         return accessLabels.contains(attibute)
+     }
+
+    public func validate(file: File) -> [StyleViolation] {
+        var internalStructures = [[String: SourceKitRepresentable]]()
+        typealias ArrayDict = [[String: SourceKitRepresentable]]
+        guard let structure = file.structure.dictionary["key.substructure"] as? ArrayDict else { return [] }
+
+        // We collect all the implicit and explicit internal structures
+        for each in structure {
+            guard let access = each["key.accessibility"] as? String,
+                access == "source.lang.swift.accessibility.internal"
+                else { continue }
+            internalStructures.append(each)
+        }
+        // Bail out if there are not implicit or explicit internal declarations
+        guard !internalStructures.isEmpty else { return [] }
+
+        // Find all top-level declarations with different whitespace including \n
+        let pattern = "\\s*(?:class|(final\\s+class)|struct|enum)\\s+"
+        let filterOut = SyntaxKind.commentAndStringKinds()
+        let topLevelDeclByteRanges = file.match(pattern: pattern,
+                            excludingSyntaxKinds: filterOut ).flatMap({
+                            file.contents.bridge().NSRangeToByteRange(
+                            start: $0.location, length: $0.length)
+                            })
+        // Find all implicitly internal or structures lacking ACL
+        var implicitInternalByteRanges = [NSRange]()
+        // We are ignoring violations starting at 0 index in order to simplify
+        for each in topLevelDeclByteRanges where each.location > 0 {
+             let tokens = file.syntaxMap.tokens(inByteRange: NSRange(location: each.location - 1, length: each.length))
+
+            // Filter out explicit access control labels
+            // This should also handle the case when empty
+            let builtin = "source.lang.swift.syntaxtype.attribute.builtin"
+            guard let label = tokens.first( where: { $0.type == builtin })
+                else {
+                // if it doesn't find a builtin label then internal is implicit
+                        implicitInternalByteRanges.append(each)
+                        continue
+                     }
+
+            if !isAccessControl(label, in: file) {
+                // Assuming that the label found is not an ACL
+                implicitInternalByteRanges.append(each)
+                continue
+            }
+        } //end of topLevelDeclByteRanges loop
+
+        // Match the implicit internal to the top-level declarations
+        var violations = [StyleViolation]()
+        for each in internalStructures {
+            guard let start = each["key.offset"] as? NSNumber else { continue }
+            let range = NSRange(location: start.intValue, length: 1)
+            if range.intersects(implicitInternalByteRanges) {
+                violations.append(StyleViolation(ruleDescription: ExplicitInternalTopLevelRule.description,
+                severity: self.configuration.severity,
+                location: Location(file: file, byteOffset: start.intValue)))
+           }
+        }
+        return violations
+    }
+}

--- a/Source/SwiftLintFramework/Rules/ExplicitInternalTopLevelRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInternalTopLevelRule.swift
@@ -60,9 +60,10 @@ public struct ExplicitInternalTopLevelRule: OptInRule, ConfigurationProviderRule
                             })
         // Find all implicitly internal or structures lacking ACL
         var implicitInternalByteRanges = [NSRange]()
-        // We are ignoring violations starting at 0 index in order to simplify
-        for each in topLevelDeclByteRanges where each.location > 0 {
-             let tokens = file.syntaxMap.tokens(inByteRange: NSRange(location: each.location - 1, length: each.length))
+        for each in topLevelDeclByteRanges where each.location >= 0 {
+            let decrement = each.location == 0 ? 0 : 1
+            let tokens = file.syntaxMap.tokens(inByteRange: NSRange(
+                         location: each.location - decrement, length: each.length))
 
             // Filter out explicit access control labels
             // This should also handle the case when empty

--- a/Source/SwiftLintFramework/Rules/ExplicitInternalTopLevelRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInternalTopLevelRule.swift
@@ -84,13 +84,13 @@ public struct ExplicitInternalTopLevelRule: OptInRule, ConfigurationProviderRule
 
         // Match the implicit internal to the top-level declarations
         var violations = [StyleViolation]()
-        for each in internalStructures {
-            guard let start = each["key.offset"] as? NSNumber else { continue }
-            let range = NSRange(location: start.intValue, length: 1)
+        for each in internalStructures {   //Int would not cast only Int64
+            guard let start = each["key.offset"] as? Int64 else { continue }
+            let range = NSRange(location: Int(start), length: 1)
             if range.intersects(implicitInternalByteRanges) {
                 violations.append(StyleViolation(ruleDescription: ExplicitInternalTopLevelRule.description,
                 severity: self.configuration.severity,
-                location: Location(file: file, byteOffset: start.intValue)))
+                location: Location(file: file, byteOffset: Int(start))))
            }
         }
         return violations

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094385021D5D4F78009168CF /* PrivateOutletRule.swift */; };
 		1E82D5591D7775C7009553D7 /* ClosureSpacingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */; };
 		1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */; };
+		1EF115921EB2AD5900E30140 /* ExplicitInternalTopLevelRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF115911EB2AD5900E30140 /* ExplicitInternalTopLevelRule.swift */; };
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
 		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
@@ -281,6 +282,7 @@
 		094385021D5D4F78009168CF /* PrivateOutletRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
 		1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureSpacingRule.swift; sourceTree = "<group>"; };
 		1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRule.swift; sourceTree = "<group>"; };
+		1EF115911EB2AD5900E30140 /* ExplicitInternalTopLevelRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInternalTopLevelRule.swift; sourceTree = "<group>"; };
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
 		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
@@ -837,6 +839,7 @@
 				D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */,
 				7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */,
 				C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */,
+				1EF115911EB2AD5900E30140 /* ExplicitInternalTopLevelRule.swift */,
 				C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */,
 				D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */,
 				E88DEA891B0992B300A66CB0 /* FileLengthRule.swift */,
@@ -1293,6 +1296,7 @@
 				3BB47D851C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift in Sources */,
 				E881985B1BEA974E00333A11 /* StatementPositionRule.swift in Sources */,
 				B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */,
+				1EF115921EB2AD5900E30140 /* ExplicitInternalTopLevelRule.swift in Sources */,
 				D41E7E0B1DF9DABB0065259A /* RedundantStringEnumValueRule.swift in Sources */,
 				E88DEA711B09847500A66CB0 /* ViolationSeverity.swift in Sources */,
 				B2902A0C1D66815600BFCCF7 /* PrivateUnitTestRule.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -80,6 +80,10 @@ class RulesTests: XCTestCase {
         verifyRule(ExplicitTypeInterfaceRule.description)
     }
 
+    func testExplicitInternalTopLevelRule() {
+        verifyRule(ExplicitInternalTopLevelRule.description)
+    }
+
     func testFatalErrorMessageRule() {
         verifyRule(FatalErrorMessageRule.description)
     }
@@ -379,6 +383,7 @@ extension RulesTests {
             ("testEmptyParenthesesWithTrailingClosure", testEmptyParenthesesWithTrailingClosure),
             ("testExplicitInit", testExplicitInit),
             ("testExplicitTypeInterfaceRule", testExplicitTypeInterfaceRule),
+            ("testExplicitInternalTopLevelRule", testExplicitInternalTopLevelRule),
             ("testFatalErrorMessageRule", testFatalErrorMessageRule),
             ("testFileLength", testFileLength),
             ("testFirstWhere", testFirstWhere),


### PR DESCRIPTION
closes https://github.com/realm/SwiftLint/issues/58

Benchmark
```
0.001: file_length
0.001: custom_rules
0.001: leading_whitespace
0.003: trailing_newline
0.018: redundant_discardable_let
0.021: force_cast
0.022: shorthand_operator
0.023: force_try
0.023: closing_brace
0.023: empty_parameters
0.025: return_arrow_whitespace
0.028: trailing_semicolon
0.029: void_return
0.032: syntactic_sugar
0.032: todo
0.033: nimble_operator
0.035: operator_whitespace
0.036: statement_position
0.041: implicit_getter
0.041: legacy_cggeometry_functions
0.041: legacy_nsgeometry_functions
0.041: file_header
0.042: legacy_constructor
0.043: trailing_whitespace
0.044: legacy_constant
0.045: sorted_imports
0.056: first_where
0.059: redundant_nil_coalescing
0.093: empty_count
0.096: explicit_internal_toplevel          <------
0.114: vertical_whitespace
0.117: control_statement
0.170: opening_brace
0.200: number_separator
0.278: comma
0.287: mark
0.288: unused_enumerated
0.292: for_where
0.294: class_delegate_protocol
0.300: operator_usage_whitespace
0.302: weak_delegate
0.306: redundant_string_enum_value
0.313: valid_ibinspectable
0.318: private_outlet
0.319: private_unit_test
0.331: overridden_super_call
0.340: prohibited_super_call
0.348: redundant_optional_initialization
0.357: notification_center_detachment
0.361: dynamic_inline
0.366: fatal_error_message
0.374: discarded_notification_center_observer
0.382: type_body_length
0.386: type_name
0.412: attributes
0.412: explicit_init
0.422: unused_optional_binding
0.449: function_parameter_count
0.454: compiler_protocol_init
0.470: identifier_name
0.514: generic_type_name
0.518: cyclomatic_complexity
0.520: object_literal
0.523: nesting
0.542: vertical_parameter_alignment
0.569: closure_parameter_position
0.571: trailing_comma
0.585: large_tuple
0.598: closure_spacing
0.608: function_body_length
0.616: colon
0.693: redundant_void_return
0.719: line_length
0.725: unused_closure_parameter
0.821: empty_parentheses_with_trailing_closure
0.920: closure_end_indentation

```