### PR TITLE
Fix `empty_parameters` rule with Swift 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 * Fix typo in `DiscardedNotificationCenterObserverRule`.  
   [Spencer Kaiser](https://github.com/spencerkaiser)
 
+* Fix `empty_parameters` rule with Swift 3.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1460](https://github.com/realm/SwiftLint/issues/1460)
+
 ## 0.18.1: Misaligned Drum
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParametersRule.swift
@@ -27,17 +27,17 @@ public struct EmptyParametersRule: ConfigurationProviderRule, CorrectableRule {
             "let foo: (ConfigurationTests) ->Void throws -> Void)\n"
         ],
         triggeringExamples: [
-            "let abc: ↓Void -> Void = {}\n",
-            "func foo(completion: ↓Void -> Void)\n",
-            "func foo(completion: ↓Void throws -> Void)\n",
-            "let foo: ↓Void -> () throws -> Void)\n"
+            "let abc: ↓(Void) -> Void = {}\n",
+            "func foo(completion: ↓(Void) -> Void)\n",
+            "func foo(completion: ↓(Void) throws -> Void)\n",
+            "let foo: ↓(Void) -> () throws -> Void)\n"
         ],
         corrections: [
-            "let abc: ↓Void -> Void = {}\n": "let abc: () -> Void = {}\n",
-            "func foo(completion: ↓Void -> Void)\n": "func foo(completion: () -> Void)\n",
-            "func foo(completion: ↓Void throws -> Void)\n":
+            "let abc: ↓(Void) -> Void = {}\n": "let abc: () -> Void = {}\n",
+            "func foo(completion: ↓(Void) -> Void)\n": "func foo(completion: () -> Void)\n",
+            "func foo(completion: ↓(Void) throws -> Void)\n":
                 "func foo(completion: () throws -> Void)\n",
-            "let foo: ↓Void -> () throws -> Void)\n": "let foo: () -> () throws -> Void)\n"
+            "let foo: ↓(Void) -> () throws -> Void)\n": "let foo: () -> () throws -> Void)\n"
         ]
     )
 
@@ -50,7 +50,7 @@ public struct EmptyParametersRule: ConfigurationProviderRule, CorrectableRule {
     }
 
     private func violationRanges(file: File) -> [NSRange] {
-        let voidPattern = "Void"
+        let voidPattern = "\\(Void\\)"
         let pattern = voidPattern + "\\s*(throws\\s+)?->"
         let excludingPattern = "->\\s*" + pattern // excludes curried functions
 


### PR DESCRIPTION
Fixes #1460