### PR TITLE
Unused optional binding rule ignore option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@
   [Sega-Zero](https://github.com/Sega-Zero)
   [#1432](https://github.com/realm/SwiftLint/issues/1432)
   
+  
+* Add lowercase and missing colon checks to the `mark` rule.  
+  [Jason Moore](https://github.com/xinsight)
+  
+* Add opt-in option to `unused_optional_binding` rule to ignore `try?` in `guard` statements  
+  [Sega-Zero](https://github.com/Sega-Zero)
+  [#1432](https://github.com/realm/SwiftLint/issues/1432)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,9 @@
   keyword when it can be omitted inside closures.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1194](https://github.com/realm/SwiftLint/issues/1194)
-* Add opt-in option to `unused_optional_binding` rule to ignore `try?` in `guard` statements  
-  [Sega-Zero](https://github.com/Sega-Zero)
-  [#1432](https://github.com/realm/SwiftLint/issues/1432)
   
-  
-* Add lowercase and missing colon checks to the `mark` rule.  
-  [Jason Moore](https://github.com/xinsight)
-  
-* Add opt-in option to `unused_optional_binding` rule to ignore `try?` in `guard` statements  
+* Add option to `unused_optional_binding` rule to ignore `try?`
+  in `guard` statements.  
   [Sega-Zero](https://github.com/Sega-Zero)
   [#1432](https://github.com/realm/SwiftLint/issues/1432)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
   keyword when it can be omitted inside closures.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1194](https://github.com/realm/SwiftLint/issues/1194)
+* Add opt-in option to `unused_optional_binding` rule to ignore `try?` in `guard` statements  
+  [Sega-Zero](https://github.com/Sega-Zero)
+  [#1432](https://github.com/realm/SwiftLint/issues/1432)
+  
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -1,0 +1,40 @@
+//
+//  UnusedOptionalBindingConfiguration.swift
+//  SwiftLint
+//
+//  Created by Sergey Galezdinov on 23/04/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+public struct UnusedOptionalBindingConfiguration: RuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var ignoreOptionalTry: Bool
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription + ", ignore_optional_try: \(ignoreOptionalTry)"
+    }
+
+    public init(ignoreOptionalTry: Bool) {
+        self.ignoreOptionalTry = ignoreOptionalTry
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let ignoreOptionalTry = configuration["ignore_optional_try"] as? Bool {
+            self.ignoreOptionalTry = ignoreOptionalTry
+        }
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+    }
+
+    public static func == (lhs: UnusedOptionalBindingConfiguration,
+                           rhs: UnusedOptionalBindingConfiguration) -> Bool {
+        return lhs.ignoreOptionalTry == rhs.ignoreOptionalTry &&
+            lhs.severityConfiguration == rhs.severityConfiguration
+    }
+}

--- a/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
@@ -10,7 +10,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+    public var configuration = UnusedOptionalBindingConfiguration(ignoreOptionalTry: true)
 
     public init() {}
 
@@ -66,24 +66,33 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
                     return []
             }
 
-            return violations(in: range, of: file).map {
-                StyleViolation(ruleDescription: type(of: self).description, severity: configuration.severity,
+            return violations(in: range, of: file, with: kind).map {
+                StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, characterOffset: $0.location))
             }
         }
     }
 
-    private func violations(in range: NSRange, of file: File) -> [NSRange] {
+    private func violations(in range: NSRange, of file: File, with kind: StatementKind) -> [NSRange] {
         let kinds = SyntaxKind.commentAndStringKinds()
 
-        let underscorePattern = "(_\\s*[=,)])"
-        let underscoreTuplePattern = "(\\((\\s*[_,]\\s*)+\\)\\s*=)"
+        let underscorePattern = "(_\\s*[=,)]\\s*(try\\?)?)"
+        let underscoreTuplePattern = "(\\((\\s*[_,]\\s*)+\\)\\s*=\\s*(try\\?)?)"
         let letUnderscore = "let\\s+(\(underscorePattern)|\(underscoreTuplePattern))"
 
         let matches = file.matchesAndSyntaxKinds(matching: letUnderscore, range: range)
 
         return matches
             .filter { $0.1.filter(kinds.contains).isEmpty }
+            .filter { kind != .guard || !self.containsOptionalTry(at: $0.0.range, of: file) }
             .map { $0.0.rangeAt(1) }
+    }
+
+    private func containsOptionalTry(at range: NSRange, of file: File) -> Bool {
+        guard self.configuration.ignoreOptionalTry else { return false }
+
+        let contents = file.contents.bridge().substring(with: range)
+        return contents.contains("try?")
     }
 }

--- a/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
@@ -68,8 +68,8 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
 
             return violations(in: range, of: file, with: kind).map {
                 StyleViolation(ruleDescription: type(of: self).description,
-                           severity: configuration.severityConfiguration.severity,
-                           location: Location(file: file, characterOffset: $0.location))
+                               severity: configuration.severityConfiguration.severity,
+                               location: Location(file: file, characterOffset: $0.location))
             }
         }
     }
@@ -85,14 +85,16 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
 
         return matches
             .filter { $0.1.filter(kinds.contains).isEmpty }
-            .filter { kind != .guard || !self.containsOptionalTry(at: $0.0.range, of: file) }
+            .filter { kind != .guard || !containsOptionalTry(at: $0.0.range, of: file) }
             .map { $0.0.rangeAt(1) }
     }
 
     private func containsOptionalTry(at range: NSRange, of file: File) -> Bool {
-        guard self.configuration.ignoreOptionalTry else { return false }
+        guard configuration.ignoreOptionalTry else {
+            return false
+        }
 
-        let contents = file.contents.bridge().substring(with: range)
-        return contents.contains("try?")
+        let matches = file.match(pattern: "try?", with: [.keyword], range: range)
+        return !matches.isEmpty
     }
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		C328A2F71E6759AE00A9E4D7 /* ExplicitTypeInterfaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */; };
 		C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */; };
 		C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */; };
+		CE8178ED1EAC039D0063186E /* UnusedOptionalBindingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
 		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
@@ -359,6 +360,7 @@
 		C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRule.swift; sourceTree = "<group>"; };
 		C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FatalErrorMessageRule.swift; sourceTree = "<group>"; };
 		C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
+		CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingConfiguration.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D0D1212619E878CC005E4BAA /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -582,6 +584,7 @@
 				D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */,
 				BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */,
 				006204DA1E1E48F900FFFBE1 /* VerticalWhitespaceConfiguration.swift */,
+				CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */,
 			);
 			path = RuleConfigurations;
 			sourceTree = "<group>";
@@ -1305,6 +1308,7 @@
 				E88DEA711B09847500A66CB0 /* ViolationSeverity.swift in Sources */,
 				B2902A0C1D66815600BFCCF7 /* PrivateUnitTestRule.swift in Sources */,
 				D47A51101DB2DD4800A4CC21 /* AttributesRule.swift in Sources */,
+				CE8178ED1EAC039D0063186E /* UnusedOptionalBindingConfiguration.swift in Sources */,
 				D4FD58B21E12A0200019503C /* LinterCache.swift in Sources */,
 				3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */,
 				F22314B01D4FA4D7009AD165 /* LegacyNSGeometryFunctionsRule.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
 		D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */; };
 		D4470D571EB69225008A1B2E /* ImplicitReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */; };
+		D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
 		D462021F1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */; };
 		D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */; };
@@ -401,6 +402,7 @@
 		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
 		D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyntacticSugarRule.swift; sourceTree = "<group>"; };
 		D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitReturnRule.swift; sourceTree = "<group>"; };
+		D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRuleTests.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
 		D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleExamples.swift; sourceTree = "<group>"; };
 		D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRule.swift; sourceTree = "<group>"; };
@@ -744,35 +746,36 @@
 			isa = PBXGroup;
 			children = (
 				D0D1212219E878CC005E4BAA /* Configuration */,
-				D0D1217C19E87B05005E4BAA /* Supporting Files */,
 				3B12C9BE1C3209AC000B423F /* Resources */,
+				D0D1217C19E87B05005E4BAA /* Supporting Files */,
 				D4998DE61DF191380006E05D /* AttributesRuleTests.swift */,
 				D43B04651E071ED3004016AF /* ColonRuleTests.swift */,
 				E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */,
 				3BB47D861C51DE6E00AE6A10 /* CustomRulesTests.swift */,
+				67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */,
+				67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */,
 				02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */,
-				D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */,
 				D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */,
+				D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */,
+				47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */,
+				47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */,
+				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
 				3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */,
 				3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */,
-				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
 				D4C27BFF1E12DFF500DF713E /* LinterCacheTests.swift */,
 				D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */,
 				E86396C61BADAFE6002C9E88 /* ReporterTests.swift */,
+				3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */,
 				E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */,
+				3B12C9C61C3361CB000B423F /* RuleTests.swift */,
+				6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */,
 				E81224991B04F85B001783D2 /* TestHelpers.swift */,
 				D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */,
-				3B12C9C21C320A53000B423F /* Yaml+SwiftLintTests.swift */,
-				3B12C9C61C3361CB000B423F /* RuleTests.swift */,
-				3B30C4A01C3785B300E04027 /* YamlParserTests.swift */,
-				3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */,
-				6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */,
 				C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */,
+				D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */,
 				006204DD1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift */,
-				67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */,
-				67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */,
-				47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */,
-				47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */,
+				3B12C9C21C320A53000B423F /* Yaml+SwiftLintTests.swift */,
+				3B30C4A01C3785B300E04027 /* YamlParserTests.swift */,
 			);
 			name = SwiftLintFrameworkTests;
 			path = Tests/SwiftLintFrameworkTests;
@@ -1371,6 +1374,7 @@
 				E88198631BEA9A5400333A11 /* RulesTests.swift in Sources */,
 				47ACC89A1E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift in Sources */,
 				67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */,
+				D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */,
 				C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */,
 				3B63D46F1E1F09DF0057BE35 /* LineLengthRuleTests.swift in Sources */,
 				3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -33,6 +33,7 @@ XCTMain([
     testCase(SourceKitCrashTests.allTests),
     testCase(TrailingCommaRuleTests.allTests),
     testCase(TodoRuleTests.allTests),
+    testCase(UnusedOptionalBindingRuleTests.allTests),
     testCase(VerticalWhitespaceRuleTests.allTests),
     testCase(YamlParserTests.allTests),
     testCase(YamlSwiftLintTests.allTests)

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -337,7 +337,28 @@ class RulesTests: XCTestCase {
     }
 
     func testUnusedOptionalBinding() {
-        verifyRule(UnusedOptionalBindingRule.description)
+        let testBinding = ["guard let _ = try? alwaysThows()"]
+        let baseDescription = UnusedOptionalBindingRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + testBinding
+        let description = RuleDescription(identifier: baseDescription.identifier,
+                                           name: baseDescription.name,
+                                           description: baseDescription.description,
+                                           nonTriggeringExamples: nonTriggeringExamples,
+                                           triggeringExamples: baseDescription.triggeringExamples,
+                                           corrections: baseDescription.corrections)
+
+        verifyRule(description)
+
+        // Perform additional tests with the ignore_optional_try settings disabled.
+        let triggeringExamples = baseDescription.triggeringExamples + testBinding
+        let description2 = RuleDescription(identifier: baseDescription.identifier,
+                                          name: baseDescription.name,
+                                          description: baseDescription.description,
+                                          nonTriggeringExamples: baseDescription.nonTriggeringExamples,
+                                          triggeringExamples: triggeringExamples,
+                                          corrections: baseDescription.corrections)
+
+        verifyRule(description2, ruleConfiguration: ["ignore_optional_try": false])
     }
 
 // swiftlint:disable:next todo

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -169,12 +169,6 @@ class RulesTests: XCTestCase {
         verifyRule(MarkRule.description, commentDoesntViolate: false)
     }
 
-// swiftlint:disable:next todo
-// FIXME: https://github.com/jpsim/SourceKitten/issues/269
-//    func testMissingDocs() {
-//        verifyRule(MissingDocsRule.description)
-//    }
-
     func testNesting() {
         verifyRule(NestingRule.description)
     }
@@ -336,37 +330,6 @@ class RulesTests: XCTestCase {
         verifyRule(UnusedEnumeratedRule.description)
     }
 
-    func testUnusedOptionalBinding() {
-        let testBinding = ["guard let _ = try? alwaysThrows() else { return }"]
-        let baseDescription = UnusedOptionalBindingRule.description
-        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + testBinding
-        let description = RuleDescription(identifier: baseDescription.identifier,
-                                           name: baseDescription.name,
-                                           description: baseDescription.description,
-                                           nonTriggeringExamples: nonTriggeringExamples,
-                                           triggeringExamples: baseDescription.triggeringExamples,
-                                           corrections: baseDescription.corrections)
-
-        verifyRule(description)
-
-        // Perform additional tests with the ignore_optional_try settings disabled.
-        let triggeringExamples = baseDescription.triggeringExamples + testBinding
-        let description2 = RuleDescription(identifier: baseDescription.identifier,
-                                          name: baseDescription.name,
-                                          description: baseDescription.description,
-                                          nonTriggeringExamples: baseDescription.nonTriggeringExamples,
-                                          triggeringExamples: triggeringExamples,
-                                          corrections: baseDescription.corrections)
-
-        verifyRule(description2, ruleConfiguration: ["ignore_optional_try": false])
-    }
-
-// swiftlint:disable:next todo
-// FIXME: https://github.com/jpsim/SourceKitten/issues/269
-//    func testValidDocs() {
-//        verifyRule(ValidDocsRule.description)
-//    }
-
     func testValidIBInspectable() {
         verifyRule(ValidIBInspectableRule.description)
     }
@@ -459,7 +422,6 @@ extension RulesTests {
             ("testTypeName", testTypeName),
             ("testUnusedClosureParameter", testUnusedClosureParameter),
             ("testUnusedEnumerated", testUnusedEnumerated),
-            ("testUnusedOptionalBinding", testUnusedOptionalBinding),
             ("testValidIBInspectable", testValidIBInspectable),
             ("testVerticalParameterAlignment", testVerticalParameterAlignment),
             ("testVoidReturn", testVoidReturn),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -337,7 +337,7 @@ class RulesTests: XCTestCase {
     }
 
     func testUnusedOptionalBinding() {
-        let testBinding = ["guard let _ = try? alwaysThows()"]
+        let testBinding = ["guard let _ = try? alwaysThrows() else { return }"]
         let baseDescription = UnusedOptionalBindingRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + testBinding
         let description = RuleDescription(identifier: baseDescription.identifier,

--- a/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleTests.swift
@@ -1,0 +1,54 @@
+//
+//  UnusedOptionalBindingRuleTests.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 05/01/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+@testable import SwiftLintFramework
+import XCTest
+
+class UnusedOptionalBindingRuleTests: XCTestCase {
+
+    func testDefaultConfiguration() {
+        let baseDescription = UnusedOptionalBindingRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
+            "guard let _ = try? alwaysThrows() else { return }"
+        ]
+        let description = RuleDescription(identifier: baseDescription.identifier,
+                                          name: baseDescription.name,
+                                          description: baseDescription.description,
+                                          nonTriggeringExamples: nonTriggeringExamples,
+                                          triggeringExamples: baseDescription.triggeringExamples,
+                                          corrections: baseDescription.corrections)
+
+        verifyRule(description)
+    }
+
+    func testIgnoreOptionalTryDisabled() {
+        // Perform additional tests with the ignore_optional_try settings disabled.
+        let baseDescription = UnusedOptionalBindingRule.description
+        let triggeringExamples = baseDescription.triggeringExamples + [
+            "guard let _ = try? alwaysThrows() else { return }"
+        ]
+        let description = RuleDescription(identifier: baseDescription.identifier,
+                                          name: baseDescription.name,
+                                          description: baseDescription.description,
+                                          nonTriggeringExamples: baseDescription.nonTriggeringExamples,
+                                          triggeringExamples: triggeringExamples,
+                                          corrections: baseDescription.corrections)
+
+        verifyRule(description, ruleConfiguration: ["ignore_optional_try": false])
+    }
+}
+
+extension UnusedOptionalBindingRuleTests {
+    static var allTests: [(String, (UnusedOptionalBindingRuleTests) -> () throws -> Void)] {
+        return [
+            ("testDefaultConfiguration", testDefaultConfiguration),
+            ("testIgnoreOptionalTryDisabled", testIgnoreOptionalTryDisabled)
+        ]
+    }
+}


### PR DESCRIPTION
Continued from #1454

I've rebased against master and fixed some issues with CHANGELOG and the length of `RulesTests`. Also improved the rule to be a bit safer, checking the type of `try?`.

// cc @Sega-Zero