### PR TITLE
Vertical parameter alignment on call rule

### DIFF
--- a/.sourcery/MasterRuleList.stencil
+++ b/.sourcery/MasterRuleList.stencil
@@ -6,6 +6,6 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
-public let masterRuleList = RuleList(rules:
+public let masterRuleList = RuleList(rules: [
 {% for rule in types.structs where rule.name|hasSuffix:"Rule" or rule.name|hasSuffix:"Rules" %}    {{ rule.name }}.self{% if not forloop.last %},{% endif %}
-{% endfor %})
+{% endfor %}])

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,6 +21,7 @@ opt_in_rules:
   - number_separator
   - prohibited_super_call
   - fatal_error_message
+  - vertical_parameter_alignment_on_call
 
 file_header:
   required_pattern: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1546](https://github.com/realm/SwiftLint/issues/1546)
 
+* Add `vertical_parameter_alignment_on_call` opt-in rule that validates that
+  parameters are vertically aligned on a method call.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1037](https://github.com/realm/SwiftLint/issues/1037)
+
 ##### Bug Fixes
 
 * Fix false positive in `empty_enum_arguments` rule when calling methods.  

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -105,19 +105,19 @@ public struct Command: Equatable {
             return [
                 Command(action: action, ruleIdentifiers: ruleIdentifiers, line: line - 1),
                 Command(action: action.inverse(), ruleIdentifiers: ruleIdentifiers, line: line - 1,
-                    character: Int.max)
+                        character: Int.max)
             ]
         case .this:
             return [
                 Command(action: action, ruleIdentifiers: ruleIdentifiers, line: line),
                 Command(action: action.inverse(), ruleIdentifiers: ruleIdentifiers, line: line,
-                    character: Int.max)
+                        character: Int.max)
             ]
         case .next:
             return [
                 Command(action: action, ruleIdentifiers: ruleIdentifiers, line: line + 1),
                 Command(action: action.inverse(), ruleIdentifiers: ruleIdentifiers, line: line + 1,
-                    character: Int.max)
+                        character: Int.max)
             ]
         }
     }

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -8,7 +8,7 @@
 // Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
-public let masterRuleList = RuleList(rules:
+public let masterRuleList = RuleList(rules: [
     AttributesRule.self,
     ClassDelegateProtocolRule.self,
     ClosingBraceRule.self,
@@ -92,8 +92,9 @@ public let masterRuleList = RuleList(rules:
     UnusedEnumeratedRule.self,
     UnusedOptionalBindingRule.self,
     ValidIBInspectableRule.self,
+    VerticalParameterAlignmentOnCallRule.self,
     VerticalParameterAlignmentRule.self,
     VerticalWhitespaceRule.self,
     VoidReturnRule.self,
     WeakDelegateRule.self
-)
+])

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -181,8 +181,8 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
         return [
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severityConfiguration.severity,
-                location: location)
+                           severity: configuration.severityConfiguration.severity,
+                           location: location)
         ]
     }
 

--- a/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewlineRule.swift
@@ -49,8 +49,8 @@ public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, Rule, 
                 content(for: lastToken, file: file) == "return"
         }.map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -67,8 +67,8 @@ public struct ControlStatementRule: ConfigurationProviderRule {
                     return nil
                 }
                 return StyleViolation(ruleDescription: type(of: self).description,
-                    severity: configuration.severity,
-                    location: Location(file: file, characterOffset: match.location))
+                                      severity: configuration.severity,
+                                      location: Location(file: file, characterOffset: match.location))
             }
         }
 

--- a/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
@@ -48,11 +48,12 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
 
         for parameter in configuration.params where complexity > parameter.value {
             let offset = dictionary.offset ?? 0
+            let reason = "Function should have complexity \(configuration.length.warning) or less: " +
+                         "currently complexity equals \(complexity)"
             return [StyleViolation(ruleDescription: type(of: self).description,
-                severity: parameter.severity,
-                location: Location(file: file, byteOffset: offset),
-                reason: "Function should have complexity \(configuration.length.warning) or less: " +
-                        "currently complexity equals \(complexity)")]
+                                   severity: parameter.severity,
+                                   location: Location(file: file, byteOffset: offset),
+                                   reason: reason)]
         }
 
         return []

--- a/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
@@ -51,15 +51,15 @@ public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule {
                 .last,
             inlineMatch.range.location != NSNotFound,
             case let attributeRange = NSRange(location: inlineMatch.range.location,
-                length: funcOffset - inlineMatch.range.location),
+                                              length: funcOffset - inlineMatch.range.location),
             case let alwaysInlinePattern = regex("@inline\\(\\s*__always\\s*\\)"),
             alwaysInlinePattern.firstMatch(in: file.contents, options: [], range: attributeRange) != nil
         else {
             return []
         }
         return [StyleViolation(ruleDescription: type(of: self).description,
-                    severity: configuration.severity,
-                    location: Location(file: file, characterOffset: funcOffset))]
+                               severity: configuration.severity,
+                               location: Location(file: file, characterOffset: funcOffset))]
     }
 
     fileprivate let functionKinds: [SwiftDeclarationKind] = [

--- a/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
@@ -35,8 +35,8 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
         let excludingKinds = SyntaxKind.commentAndStringKinds()
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
@@ -39,8 +39,8 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -28,11 +28,12 @@ public struct FileLengthRule: ConfigurationProviderRule, SourceKitFreeRule {
     public func validate(file: File) -> [StyleViolation] {
         let lineCount = file.lines.count
         for parameter in configuration.params where lineCount > parameter.value {
+            let reason = "File should contain \(configuration.warning) lines or less: " +
+                         "currently contains \(lineCount)"
             return [StyleViolation(ruleDescription: type(of: self).description,
-                severity: parameter.severity,
-                location: Location(file: file.path, line: lineCount),
-                reason: "File should contain \(configuration.warning) lines or less: " +
-                        "currently contains \(lineCount)")]
+                                   severity: parameter.severity,
+                                   location: Location(file: file.path, line: lineCount),
+                                   reason: reason)]
         }
         return []
     }

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -27,8 +27,8 @@ public struct ForceCastRule: ConfigurationProviderRule {
     public func validate(file: File) -> [StyleViolation] {
         return file.match(pattern: "as!", with: [.keyword]).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceTryRule.swift
@@ -29,8 +29,8 @@ public struct ForceTryRule: ConfigurationProviderRule {
     public func validate(file: File) -> [StyleViolation] {
         return file.match(pattern: "try!", with: [.keyword]).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -46,9 +46,9 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            return StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -71,11 +71,12 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
 
         for parameter in configuration.params where parameterCount > parameter.value {
             let offset = dictionary.offset ?? 0
+            let reason = "Function should have \(configuration.warning) parameters or less: " +
+                         "it currently has \(parameterCount)"
             return [StyleViolation(ruleDescription: type(of: self).description,
-                severity: parameter.severity,
-                location: Location(file: file, byteOffset: offset),
-                reason: "Function should have \(configuration.warning) parameters or less: " +
-                    "it currently has \(parameterCount)")]
+                                   severity: parameter.severity,
+                                   location: Location(file: file, byteOffset: offset),
+                                   reason: reason)]
         }
 
         return []

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -29,11 +29,14 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
         if countOfLeadingWhitespace == 0 {
             return []
         }
+
+        let reason = "File shouldn't start with whitespace: " +
+                     "currently starts with \(countOfLeadingWhitespace) whitespace characters"
+
         return [StyleViolation(ruleDescription: type(of: self).description,
-            severity: configuration.severity,
-            location: Location(file: file.path, line: 1),
-            reason: "File shouldn't start with whitespace: " +
-            "currently starts with \(countOfLeadingWhitespace) whitespace characters")]
+                               severity: configuration.severity,
+                               location: Location(file: file.path, line: 1),
+                               reason: reason)]
     }
 
     public func correct(file: File) -> [Correction] {

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -101,8 +101,8 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
 
         return file.match(pattern: pattern, with: [.identifier]).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -106,8 +106,8 @@ public struct LegacyConstructorRule: CorrectableRule, ConfigurationProviderRule 
 
         return file.match(pattern: pattern, with: [.identifier]).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
@@ -100,8 +100,8 @@ public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
 
         return file.match(pattern: pattern, with: [.identifier]).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -69,18 +69,19 @@ public struct LineLengthRule: ConfigurationProviderRule {
                 strippedString = strippedString.strippingURLs
             }
             strippedString = stripLiterals(fromSourceString: strippedString,
-                withDelimiter: "#colorLiteral")
+                                           withDelimiter: "#colorLiteral")
             strippedString = stripLiterals(fromSourceString: strippedString,
-                withDelimiter: "#imageLiteral")
+                                           withDelimiter: "#imageLiteral")
 
             let length = strippedString.characters.count
 
             for param in configuration.params where length > param.value {
+                let reason = "Line should be \(configuration.length.warning) characters or less: " +
+                             "currently \(length) characters"
                 return StyleViolation(ruleDescription: type(of: self).description,
-                    severity: param.severity,
-                    location: Location(file: file.path, line: line.index),
-                    reason: "Line should be \(configuration.length.warning) characters or less: " +
-                        "currently \(length) characters")
+                                      severity: param.severity,
+                                      location: Location(file: file.path, line: line.index),
+                                      reason: reason)
             }
             return nil
         }

--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -92,8 +92,8 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
     public func validate(file: File) -> [StyleViolation] {
         return violationRanges(in: file, matching: pattern).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 
@@ -101,26 +101,26 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
         var result = [Correction]()
 
         result.append(contentsOf: correct(file: file,
-            pattern: spaceStartPattern,
-            replaceString: "// MARK:"))
+                                          pattern: spaceStartPattern,
+                                          replaceString: "// MARK:"))
 
         result.append(contentsOf: correct(file: file,
-            pattern: endNonSpacePattern,
-            replaceString: "// MARK: ",
-            keepLastChar: true))
+                                          pattern: endNonSpacePattern,
+                                          replaceString: "// MARK: ",
+                                          keepLastChar: true))
 
         result.append(contentsOf: correct(file: file,
-            pattern: endTwoOrMoreSpacePattern,
-            replaceString: "// MARK: "))
+                                          pattern: endTwoOrMoreSpacePattern,
+                                          replaceString: "// MARK: "))
 
         result.append(contentsOf: correct(file: file,
-            pattern: twoOrMoreSpacesAfterHyphenPattern,
-            replaceString: "// MARK: - "))
+                                          pattern: twoOrMoreSpacesAfterHyphenPattern,
+                                          replaceString: "// MARK: - "))
 
         result.append(contentsOf: correct(file: file,
-            pattern: nonSpaceOrNewlineAfterHyphenPattern,
-            replaceString: "// MARK: - ",
-            keepLastChar: true))
+                                          pattern: nonSpaceOrNewlineAfterHyphenPattern,
+                                          replaceString: "// MARK: - ",
+                                          keepLastChar: true))
 
         return result
     }

--- a/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
@@ -73,8 +73,8 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
         let matches = violationMatchesRanges(in: file)
         return matches.map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -69,8 +69,8 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
     public func validate(file: File) -> [StyleViolation] {
         return file.violatingOpeningBraceRanges().map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -44,8 +44,8 @@ public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule {
             return syntaxKinds.first == .keyword
         }.map { range, _ in
             return StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: range.location))
+                                  severity: configuration.severity,
+                                  location: Location(file: file, characterOffset: range.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
@@ -80,14 +80,14 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
 
         if callsToSuper.isEmpty {
             return [StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, byteOffset: offset),
-                reason: "Method '\(name)' should call to super function")]
+                                   severity: configuration.severity,
+                                   location: Location(file: file, byteOffset: offset),
+                                   reason: "Method '\(name)' should call to super function")]
         } else if callsToSuper.count > 1 {
             return [StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, byteOffset: offset),
-                reason: "Method '\(name)' should call to super only once")]
+                                   severity: configuration.severity,
+                                   location: Location(file: file, byteOffset: offset),
+                                   reason: "Method '\(name)' should call to super only once")]
         }
         return []
     }

--- a/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
@@ -59,8 +59,8 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
         return [
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severityConfiguration.severity,
-                location: location)
+                           severity: configuration.severityConfiguration.severity,
+                           location: location)
         ]
     }
 

--- a/Source/SwiftLintFramework/Rules/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantNilCoalescingRule.swift
@@ -43,8 +43,8 @@ public struct RedundantNilCoalescingRule: OptInRule, CorrectableRule, Configurat
     public func validate(file: File) -> [StyleViolation] {
         return file.violatingRedundantNilCoalescingRanges().map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -53,8 +53,8 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
     public func validate(file: File) -> [StyleViolation] {
         return violationRanges(in: file, skipParentheses: true).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -100,9 +100,9 @@ private extension StatementPositionRule {
 
     func defaultValidate(file: File) -> [StyleViolation] {
         return defaultViolationRanges(in: file, matching: type(of: self).defaultPattern).flatMap { range in
-            return StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity.severity,
-                location: Location(file: file, characterOffset: range.location))
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity.severity,
+                           location: Location(file: file, characterOffset: range.location))
         }
     }
 
@@ -135,9 +135,9 @@ private extension StatementPositionRule {
 private extension StatementPositionRule {
     func uncuddledValidate(file: File) -> [StyleViolation] {
         return uncuddledViolationRanges(in: file).flatMap { range in
-            return StyleViolation(ruleDescription: type(of: self).uncuddledDescription,
-                severity: configuration.severity.severity,
-                location: Location(file: file, characterOffset: range.location))
+            StyleViolation(ruleDescription: type(of: self).uncuddledDescription,
+                           severity: configuration.severity.severity,
+                           location: Location(file: file, characterOffset: range.location))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -126,9 +126,9 @@ public struct TrailingCommaRule: ASTRule, CorrectableRule, ConfigurationProvider
     private func violations(file: File, byteOffset: Int, reason: String) -> [StyleViolation] {
         return [
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severityConfiguration.severity,
-                location: Location(file: file, byteOffset: byteOffset),
-                reason: reason
+                           severity: configuration.severityConfiguration.severity,
+                           location: Location(file: file, byteOffset: byteOffset),
+                           reason: reason
             )
         ]
     }

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -55,8 +55,8 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, S
             return []
         }
         return [StyleViolation(ruleDescription: type(of: self).description,
-            severity: configuration.severity,
-            location: Location(file: file.path, line: max(file.lines.count, 1)))]
+                               severity: configuration.severity,
+                               location: Location(file: file.path, line: max(file.lines.count, 1)))]
     }
 
     public func correct(file: File) -> [Correction] {

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -46,8 +46,8 @@ public struct TrailingSemicolonRule: CorrectableRule, ConfigurationProviderRule 
     public func validate(file: File) -> [StyleViolation] {
         return file.violatingTrailingSemicolonRanges().map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: $0.location))
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
         }
     }
 
@@ -71,7 +71,7 @@ public struct TrailingSemicolonRule: CorrectableRule, ConfigurationProviderRule 
         file.write(correctedContents)
         return adjustedRanges.map {
             Correction(ruleDescription: type(of: self).description,
-                location: Location(file: file, characterOffset: $0.location))
+                       location: Location(file: file, characterOffset: $0.location))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -45,8 +45,8 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
 
         return filteredLines.map {
             StyleViolation(ruleDescription: type(of: self).description,
-                severity: configuration.severityConfiguration.severity,
-                location: Location(file: file.path, line: $0.index))
+                           severity: configuration.severityConfiguration.severity,
+                           location: Location(file: file.path, line: $0.index))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -56,12 +56,12 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
                         startLine, endLine, parameter.value
                     )
                     if exceeds {
+                        let reason = "Type body should span \(configuration.warning) lines or less " +
+                            "excluding comments and whitespace: currently spans \(lineCount) lines"
                         return [StyleViolation(ruleDescription: type(of: self).description,
-                            severity: parameter.severity,
-                            location: Location(file: file, byteOffset: offset),
-                            reason: "Type body should span \(configuration.warning) lines or less " +
-                                "excluding comments and whitespace: currently spans \(lineCount) " +
-                                "lines")]
+                                               severity: parameter.severity,
+                                               location: Location(file: file, byteOffset: offset),
+                                               reason: reason)]
                     }
                 }
             }

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -22,7 +22,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         identifier: "type_name",
         name: "Type Name",
         description: "Type name should only contain alphanumeric characters, start with an " +
-                     "uppercase character and span between 3 and 40 characters in length.",
+        "uppercase character and span between 3 and 40 characters in length.",
         nonTriggeringExamples: TypeNameRuleExamples.nonTriggeringExamples,
         triggeringExamples: TypeNameRuleExamples.triggeringExamples
     )
@@ -60,7 +60,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
             let contents = file.contents.bridge()
             guard let name = contents.substringWithByteRange(start: nameToken.offset,
                                                              length: nameToken.length) else {
-                return []
+                                                                return []
             }
 
             return validate(name: name, file: file, offset: nameToken.offset)
@@ -77,21 +77,21 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         let containsAllowedSymbol = configuration.allowedSymbols.contains(where: name.contains)
         if !containsAllowedSymbol && !CharacterSet.alphanumerics.isSuperset(ofCharactersIn: name) {
             return [StyleViolation(ruleDescription: type(of: self).description,
-               severity: .error,
-               location: Location(file: file, byteOffset: offset),
-               reason: "Type name should only contain alphanumeric characters: '\(name)'")]
+                                   severity: .error,
+                                   location: Location(file: file, byteOffset: offset),
+                                   reason: "Type name should only contain alphanumeric characters: '\(name)'")]
         } else if configuration.validatesStartWithLowercase &&
             !name.substring(to: name.index(after: name.startIndex)).isUppercase() {
             return [StyleViolation(ruleDescription: type(of: self).description,
-               severity: .error,
-               location: Location(file: file, byteOffset: offset),
-               reason: "Type name should start with an uppercase character: '\(name)'")]
+                                   severity: .error,
+                                   location: Location(file: file, byteOffset: offset),
+                                   reason: "Type name should start with an uppercase character: '\(name)'")]
         } else if let severity = severity(forLength: name.characters.count) {
             return [StyleViolation(ruleDescription: type(of: self).description,
-               severity: severity,
-               location: Location(file: file, byteOffset: offset),
-               reason: "Type name should be between \(configuration.minLengthThreshold) and " +
-                    "\(configuration.maxLengthThreshold) characters long: '\(name)'")]
+                                   severity: severity,
+                                   location: Location(file: file, byteOffset: offset),
+                                   reason: "Type name should be between \(configuration.minLengthThreshold) and " +
+                "\(configuration.maxLengthThreshold) characters long: '\(name)'")]
         }
 
         return []

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
@@ -1,0 +1,73 @@
+//
+//  VerticalParameterAlignmentOnCallRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 02/05/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "vertical_parameter_alignment_on_call",
+        name: "Vertical Parameter Alignment On Call",
+        description: "Function parameters should be aligned vertically if they're in multiple lines in a method call.",
+        nonTriggeringExamples: [
+            "foo(param1: 1, param2: bar\n" +
+            "    param3: false, param4: true)",
+            "foo(param1: 1, param2: bar)",
+            "foo(param1: 1, param2: bar\n" +
+            "    param3: false,\n" +
+            "    param4: true)"
+        ],
+        triggeringExamples: [
+            "foo(param1: 1, param2: bar\n" +
+            "                ↓param3: false, param4: true)",
+            "foo(param1: 1, param2: bar\n" +
+            " ↓param3: false, param4: true)",
+            "foo(param1: 1, param2: bar\n" +
+            "       ↓param3: false,\n" +
+            "       ↓param4: true)"
+        ]
+    )
+
+    public func validate(file: File, kind: SwiftExpressionKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .call,
+            case let arguments = dictionary.enclosedArguments,
+            arguments.count > 1,
+            let firstArgumentOffset = arguments.first?.offset,
+            case let contents = file.contents.bridge(),
+            let firstArgumentPosition = contents.lineAndCharacter(forByteOffset: firstArgumentOffset) else {
+                return []
+        }
+
+        var visitedLines: Set<Int> = []
+        let violatingOffsets: [Int] = arguments.dropFirst().flatMap { argument in
+            guard let offset = argument.offset,
+                let (line, character) = contents.lineAndCharacter(forByteOffset: offset),
+                line > firstArgumentPosition.line else {
+                    return nil
+            }
+
+            let (firstVisit, _) = visitedLines.insert(line)
+            guard character != firstArgumentPosition.character && firstVisit else {
+                return nil
+            }
+
+            return offset
+        }
+
+        return violatingOffsets.map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: $0))
+        }
+    }
+}

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -28,8 +28,7 @@ struct AutoCorrectCommand: CommandProtocol {
             }
             if options.format {
                 let formattedContents = linter.file.format(trimmingTrailingWhitespace: true,
-                    useTabs: false,
-                    indentWidth: 4)
+                                                           useTabs: false, indentWidth: 4)
                 _ = try? formattedContents
                     .write(toFile: linter.file.path!, atomically: true, encoding: .utf8)
             }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		D4470D571EB69225008A1B2E /* ImplicitReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */; };
 		D4470D591EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D581EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift */; };
 		D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */; };
+		D4470D5D1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D5C1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
 		D462021F1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */; };
 		D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */; };
@@ -424,6 +425,7 @@
 		D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitReturnRule.swift; sourceTree = "<group>"; };
 		D4470D581EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyEnumArgumentsRule.swift; sourceTree = "<group>"; };
 		D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRuleTests.swift; sourceTree = "<group>"; };
+		D4470D5C1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentOnCallRule.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
 		D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleExamples.swift; sourceTree = "<group>"; };
 		D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRule.swift; sourceTree = "<group>"; };
@@ -947,6 +949,7 @@
 				D43B04631E0620AB004016AF /* UnusedEnumeratedRule.swift */,
 				92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */,
 				D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */,
+				D4470D5C1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift */,
 				D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */,
 				1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */,
 				D47079AE1DFE520000027086 /* VoidReturnRule.swift */,
@@ -1338,6 +1341,7 @@
 				D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */,
 				85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */,
 				D4A893351E15824100BF954D /* SwiftVersion.swift in Sources */,
+				D4470D5D1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift in Sources */,
 				D4DABFD31E29B4A5009617B6 /* DiscardedNotificationCenterObserverRule.swift in Sources */,
 				D4B022B21E10B613007E5297 /* RedundantVoidReturnRule.swift in Sources */,
 				3BCC04D21C4F56D3006073C3 /* NameConfiguration.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -360,6 +360,7 @@ extension RulesTests {
         ("testUnusedClosureParameter", testUnusedClosureParameter),
         ("testUnusedEnumerated", testUnusedEnumerated),
         ("testValidIBInspectable", testValidIBInspectable),
+        ("testVerticalParameterAlignmentOnCall", testVerticalParameterAlignmentOnCall),
         ("testVerticalParameterAlignment", testVerticalParameterAlignment),
         ("testVoidReturn", testVoidReturn),
         ("testSuperCall", testSuperCall),

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -50,9 +50,9 @@ class CustomRulesTests: XCTestCase {
         let file = File(contents: "// My file with\n// a pattern")
         XCTAssertEqual(customRules.validate(file: file),
                        [StyleViolation(ruleDescription: regexConfig.description,
-                        severity: .warning,
-                        location: Location(file: nil, line: 2, character: 6),
-                        reason: regexConfig.message)])
+                                       severity: .warning,
+                                       location: Location(file: nil, line: 2, character: 6),
+                                       reason: regexConfig.message)])
     }
 
     func testLocalDisableCustomRule() {

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
@@ -15,24 +15,20 @@ class CyclomaticComplexityConfigurationTests: XCTestCase {
         let warning = 10
         let error = 30
         let level = SeverityLevelsConfiguration(warning: warning, error: error)
-        let configuration1 = CyclomaticComplexityConfiguration(warning: warning,
-                                                               error: error)
+        let configuration1 = CyclomaticComplexityConfiguration(warning: warning, error: error)
         XCTAssertEqual(configuration1.length, level)
 
         let length2 = SeverityLevelsConfiguration(warning: warning, error: nil)
-        let configuration2 = CyclomaticComplexityConfiguration(warning: warning,
-                                                  error: nil)
+        let configuration2 = CyclomaticComplexityConfiguration(warning: warning, error: nil)
         XCTAssertEqual(configuration2.length, length2)
     }
 
     func testCyclomaticComplexityConfigurationInitializerSetsIgnoresCaseStatements() {
-        let configuration1 = CyclomaticComplexityConfiguration(warning: 10,
-                                                               error: 30,
+        let configuration1 = CyclomaticComplexityConfiguration(warning: 10, error: 30,
                                                                ignoresCaseStatements: true)
         XCTAssertTrue(configuration1.ignoresCaseStatements)
 
-        let configuration2 = CyclomaticComplexityConfiguration(warning:0,
-                                                               error: 30)
+        let configuration2 = CyclomaticComplexityConfiguration(warning:0, error: 30)
         XCTAssertFalse(configuration2.ignoresCaseStatements)
     }
 

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -221,7 +221,8 @@ class LinterCacheTests: XCTestCase {
             dict: [
                 "whitelist_rules": ["custom_rules", "rule1"],
                 "custom_rules": ["rule1": ["regex": "([n,N]inja)"]]
-            ], ruleList: RuleList(rules: CustomRules.self)
+            ],
+            ruleList: RuleList(rules: CustomRules.self)
         )!
         cacheAndValidateNoViolationsTwoFiles(configuration: initialConfig)
 
@@ -230,7 +231,8 @@ class LinterCacheTests: XCTestCase {
             dict: [
                 "whitelist_rules": ["custom_rules", "rule1"],
                 "custom_rules": ["rule1": ["regex": "([n,N]injas)"]]
-            ], initialConfig: initialConfig
+            ],
+            initialConfig: initialConfig
         )
 
         // Addition
@@ -238,7 +240,8 @@ class LinterCacheTests: XCTestCase {
             dict: [
                 "whitelist_rules": ["custom_rules", "rule1"],
                 "custom_rules": ["rule1": ["regex": "([n,N]injas)"], "rule2": ["regex": "([k,K]ittens)"]]
-            ], initialConfig: initialConfig
+            ],
+            initialConfig: initialConfig
         )
 
         // Removal

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -36,21 +36,21 @@ class ReporterTests: XCTestCase {
         let location = Location(file: "filename", line: 1, character: 2)
         return [
             StyleViolation(ruleDescription: LineLengthRule.description,
-                location: location,
-                reason: "Violation Reason."),
+                           location: location,
+                           reason: "Violation Reason."),
             StyleViolation(ruleDescription: LineLengthRule.description,
-                severity: .error,
-                location: location,
-                reason: "Violation Reason."),
+                           severity: .error,
+                           location: location,
+                           reason: "Violation Reason."),
             StyleViolation(ruleDescription: SyntacticSugarRule.description,
-                severity: .error,
-                location: location,
-                reason: "Shorthand syntactic sugar should be used" +
+                           severity: .error,
+                           location: location,
+                           reason: "Shorthand syntactic sugar should be used" +
                 ", i.e. [Int] instead of Array<Int>."),
             StyleViolation(ruleDescription: ColonRule.description,
-                severity: .error,
-                location: Location(file: nil),
-                reason: nil)
+                           severity: .error,
+                           location: Location(file: nil),
+                           reason: nil)
         ]
     }
 

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -342,6 +342,10 @@ class RulesTests: XCTestCase {
         verifyRule(ValidIBInspectableRule.description)
     }
 
+    func testVerticalParameterAlignmentOnCall() {
+        verifyRule(VerticalParameterAlignmentOnCallRule.description)
+    }
+
     func testVerticalParameterAlignment() {
         verifyRule(VerticalParameterAlignmentRule.description)
     }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -301,11 +301,11 @@ class RulesTests: XCTestCase {
         let baseDescription = TrailingWhitespaceRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [" \n"]
         let description = RuleDescription(identifier: baseDescription.identifier,
-                                                name: baseDescription.name,
-                                         description: baseDescription.description,
-                               nonTriggeringExamples: nonTriggeringExamples,
-                                  triggeringExamples: baseDescription.triggeringExamples,
-                                         corrections: baseDescription.corrections)
+                                          name: baseDescription.name,
+                                          description: baseDescription.description,
+                                          nonTriggeringExamples: nonTriggeringExamples,
+                                          triggeringExamples: baseDescription.triggeringExamples,
+                                          corrections: baseDescription.corrections)
         verifyRule(description,
                    ruleConfiguration: ["ignores_empty_lines": true, "ignores_comments": true])
 

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -37,7 +37,7 @@ class SourceKitCrashTests: XCTestCase {
         assertHandlerCalled = false
         _ = file.syntaxTokensByLines
         XCTAssertFalse(assertHandlerCalled,
-                      "Expects assert handler was not called on accessing File.syntaxTokensByLines")
+                       "Expects assert handler was not called on accessing File.syntaxTokensByLines")
     }
 
     func testAssertHandlerIsCalledOnFileThatCrashedSourceKitService() {
@@ -64,7 +64,7 @@ class SourceKitCrashTests: XCTestCase {
         assertHandlerCalled = false
         _ = file.syntaxTokensByLines
         XCTAssertTrue(assertHandlerCalled,
-                     "Expects assert handler was not called on accessing File.syntaxTokensByLines")
+                      "Expects assert handler was not called on accessing File.syntaxTokensByLines")
     }
 
     func testRulesWithFileThatCrashedSourceKitService() {


### PR DESCRIPTION
Fixes #1037

TODO:
- [x] Add proper examples/tests
- [x] Add CHANGELOG entry
- [x] Think what to do with `MasterRuleList.swift` ~(probably that shouldn't trigger)~
- [x] Check number of violations in oss-check to see if this should be opt-in or default rule (my bet is that it'll trigger LOTS of violations)