### PR TITLE
Merge master before running OSSCheck on branch

### DIFF
--- a/script/oss-check
+++ b/script/oss-check
@@ -145,7 +145,11 @@ def generate_reports(branch)
 end
 
 def build(branch)
-  `git fetch && git checkout origin/master` if branch == 'master'
+  if branch == 'master'
+    `git checkout master`
+  else
+    `git merge master || git reset --hard`
+  end
 
   build_command = 'swift build -c release'
 


### PR DESCRIPTION
To avoid the branch build being so out of date that OSSCheck reports unrelated differences, which is what happened https://github.com/realm/SwiftLint/pull/1489#issuecomment-298983845 for example.