### PR TITLE
Fix `ignores_case_statements` key in `cyclomatic_complexity` description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1334](https://github.com/realm/SwiftLint/issues/1334)
 
+* Fix `ignores_case_statements` key in `cyclomatic_complexity` description.  
+  [Jeff Blagdon](https://github.com/jefflovejapan)
+  [#1434](https://github.com/realm/SwiftLint/issues/1434)
+
 ## 0.18.1: Misaligned Drum
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -16,7 +16,8 @@ private enum ConfigurationKey: String {
 
 public struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
-        return length.consoleDescription + ", ignores switch statements: \(ignoresCaseStatements)"
+        return length.consoleDescription +
+            ", \(ConfigurationKey.ignoresCaseStatements.rawValue): \(ignoresCaseStatements)"
     }
 
     public static let defaultComplexityStatements: Set<StatementKind> = [


### PR DESCRIPTION
Fixes #1434.

Continued from #1496

// cc @jefflovejapan