### PR TITLE
update README with cocoapod config file example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
   in `guard` statements.  
   [Sega-Zero](https://github.com/Sega-Zero)
   [#1432](https://github.com/realm/SwiftLint/issues/1432)
+  
+* Improve documentation for using a specific `.swiftlint.yml` config file 
+  with cocoapods.  
+  [Andrew Erickson](https://github.com/aerickson14)
 
 ##### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ in your Script Build Phases.
 This is the recommended way to install a specific version of SwiftLint since it supports
 installing a pinned version rather than simply the latest (which is the case with Homebrew).
 
+The default set of rules will be used to start with, and overwritten by any nested configuration files. 
+To start with a base configuration you must tell swiftlint where to find your base `.swiftlint.yml` 
+file using the `--config` option. (ie `"${PODS_ROOT}"/SwiftLint/swiftlint lint --config "${SOURCE_ROOT}"/.swiftlint.yml`)
+
 Note that this will add the SwiftLint binaries, its dependencies' binaries and the Swift binary
 library distribution to the `Pods/` directory, so checking in this directory to SCM such as
 git is discouraged.


### PR DESCRIPTION
Added further explanation in the `README` outlining how to setup a base `.swiftlint.yml` file by passing its location in using the `--config` option as part of the build script command.