### PR TITLE
Excluded file.zip from pod output

### DIFF
--- a/SwiftLint.podspec
+++ b/SwiftLint.podspec
@@ -7,4 +7,5 @@ Pod::Spec.new do |s|
   s.author         = { 'JP Simard' => 'jp@jpsim.com' }
   s.source         = { :http => "#{s.homepage}/releases/download/#{s.version}/portable_swiftlint.zip" }
   s.preserve_paths = '*'
+  s.exclude_files  = '**/file.zip'
 end


### PR DESCRIPTION
References: #1507

Hopefully this should remove `file.zip` in the pod output. 