### PR TITLE
Updated file_header rule to use line 1 character 1 for files that are missing a header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@
   [Hesham Salman](https://github.com/heshamsalman)
   [#1507](https://github.com/realm/SwiftLint/issues/1507)
 
-* Updated file_header rule to use line 1 character 1 for files that are missing a header
+* Update file_header rule to trigger on the first line when missing a header,
+  so the warning will be shown in Xcode editor.  
   [rjhodge](https://github.com/rjhodge)
   [#1520](https://github.com/realm/SwiftLint/issues/1520)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
   [Hesham Salman](https://github.com/heshamsalman)
   [#1507](https://github.com/realm/SwiftLint/issues/1507)
 
+* Updated file_header rule to use line 1 character 1 for files that are missing a header
+  [rjhodge](https://github.com/rjhodge)
+  [#1520](https://github.com/realm/SwiftLint/issues/1520)
+
 ##### Bug Fixes
 
 * `emoji` and `checkstyle` reporter output report sorted by file name.  

--- a/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
@@ -83,7 +83,7 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
                 StyleViolation(
                     ruleDescription: type(of: self).description,
                     severity: configuration.severityConfiguration.severity,
-                    location: Location(file: file.path, line: 1, character: 1) // Force to first line and character
+                    location: Location(file: file.path, line: 1) // Force to first line
                 )
             ]
         }

--- a/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
@@ -83,7 +83,7 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
                 StyleViolation(
                     ruleDescription: type(of: self).description,
                     severity: configuration.severityConfiguration.severity,
-                    location: Location(file: file.path)
+                    location: Location(file: file.path, line: 1, character: 1) // Force to first line and character
                 )
             ]
         }


### PR DESCRIPTION
Updated file_header rule to use line 1 character 1 for files that are missing a header. #1520 