### PR TITLE
Fall back to line 1 when no line is provided & reporting with `xcode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,11 +66,6 @@
   [Hesham Salman](https://github.com/heshamsalman)
   [#1507](https://github.com/realm/SwiftLint/issues/1507)
 
-* Update file_header rule to trigger on the first line when missing a header,
-  so the warning will be shown in Xcode editor.  
-  [rjhodge](https://github.com/rjhodge)
-  [#1520](https://github.com/realm/SwiftLint/issues/1520)
-
 ##### Bug Fixes
 
 * `emoji` and `checkstyle` reporter output report sorted by file name.  
@@ -92,6 +87,12 @@
 * Fix `ignores_case_statements` key in `cyclomatic_complexity` description.  
   [Jeff Blagdon](https://github.com/jefflovejapan)
   [#1434](https://github.com/realm/SwiftLint/issues/1434)
+
+* Fall back to reporting violations on line `1` if no line was provided for the
+  violation's location, ensuring Xcode always displays the warning or error.  
+  [rjhodge](https://github.com/rjhodge)
+  [JP Simard](https://github.com/jpsim)
+  [#1520](https://github.com/realm/SwiftLint/issues/1520)
 
 ## 0.18.1: Misaligned Drum
 

--- a/Source/SwiftLintFramework/Models/Location.swift
+++ b/Source/SwiftLintFramework/Models/Location.swift
@@ -17,7 +17,7 @@ public struct Location: CustomStringConvertible, Comparable {
         // Xcode likes warnings and errors in the following format:
         // {full_path_to_file}{:line}{:character}: {error,warning}: {content}
         let fileString: String = file ?? "<nopath>"
-        let lineString: String = line.map({ ":\($0)" }) ?? ""
+        let lineString: String = ":\(line ?? 1)"
         let charString: String = character.map({ ":\($0)" }) ?? ""
         return [fileString, lineString, charString].joined()
     }

--- a/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
@@ -83,7 +83,7 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
                 StyleViolation(
                     ruleDescription: type(of: self).description,
                     severity: configuration.severityConfiguration.severity,
-                    location: Location(file: file.path)
+                    location: Location(file: file.path, line: 1)
                 )
             ]
         }

--- a/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
@@ -83,7 +83,7 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
                 StyleViolation(
                     ruleDescription: type(of: self).description,
                     severity: configuration.severityConfiguration.severity,
-                    location: Location(file: file.path, line: 1) // Force to first line
+                    location: Location(file: file.path)
                 )
             ]
         }

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedXcodeReporterOutput.txt
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedXcodeReporterOutput.txt
@@ -1,4 +1,4 @@
 filename:1:2: warning: Line Length Violation: Violation Reason. (line_length)
 filename:1:2: error: Line Length Violation: Violation Reason. (line_length)
 filename:1:2: error: Syntactic Sugar Violation: Shorthand syntactic sugar should be used, i.e. [Int] instead of Array<Int>. (syntactic_sugar)
-<nopath>: error: Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)
+<nopath>:1: error: Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)


### PR DESCRIPTION
this is a generalization of the fix from #1521