### PR TITLE
add `make docker_htop` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,13 @@ archive:
 release: package archive portable_zip
 
 docker_test:
-	docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/sourcekit:311 swift test
+	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm norionomura/sourcekit:311 swift test
 
 docker_test_302:
-	docker run -v `pwd`:`pwd` -w `pwd` --rm norionomura/sourcekit:302 swift test
+	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm norionomura/sourcekit:302 swift test
+
+docker_htop:
+	docker run -it --rm --pid=container:swiftlint terencewestphal/htop
 
 # http://irace.me/swift-profiling/
 display_compilation_time:


### PR DESCRIPTION
docker provides very little insight into what's happening in its containers, so this command helps keep tabs on what processes are running.