### PR TITLE
Fix false positive in `syntactic_sugar` rule when using nested types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1006](https://github.com/realm/SwiftLint/issues/1006)
 
+* Fix false positive in `syntactic_sugar` rule when using nested types named
+  `Optional`, `ImplicitlyUnwrappedOptional`, `Array` or `Dictionary`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1508](https://github.com/realm/SwiftLint/issues/1508)
+
 ## 0.18.1: Misaligned Drum
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -30,7 +30,8 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
             "var currentIndex: Array<OnboardingPage>.Index?",
             "func x(a: [Int], b: Int) -> Array<Int>.Index",
             "unsafeBitCast(nonOptionalT, to: Optional<T>.self)",
-            "type is Optional<String>.Type"
+            "type is Optional<String>.Type",
+            "let x: Foo.Optional<String>"
         ],
         triggeringExamples: [
             "let x: ↓Array<String>",
@@ -40,13 +41,15 @@ public struct SyntacticSugarRule: Rule, ConfigurationProviderRule {
             "func x(a: ↓Array<Int>, b: Int) -> [Int: Any]",
             "func x(a: [Int], b: Int) -> ↓Dictionary<Int, String>",
             "func x(a: ↓Array<Int>, b: Int) -> ↓Dictionary<Int, String>",
-            "let x = ↓Array<String>.array(of: object)"
+            "let x = ↓Array<String>.array(of: object)",
+            "let x: ↓Swift.Optional<String>"
         ]
     )
 
     public func validate(file: File) -> [StyleViolation] {
         let types = ["Optional", "ImplicitlyUnwrappedOptional", "Array", "Dictionary"]
-        let pattern = "\\b(" + types.joined(separator: "|") + ")\\s*<.*?>"
+        let negativeLookBehind = "(?:(?<!\\.)|Swift\\.)"
+        let pattern = negativeLookBehind + "\\b(?:" + types.joined(separator: "|") + ")\\s*<.*?>"
         let kinds = SyntaxKind.commentAndStringKinds()
         let contents = file.contents.bridge()
 


### PR DESCRIPTION
Fixes #1508