### PR TITLE
Enable no_extension_access_modifier in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,6 +21,7 @@ opt_in_rules:
   - number_separator
   - prohibited_super_call
   - fatal_error_message
+  - no_extension_access_modifier
 
 file_header:
   required_pattern: |

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 #if !os(Linux)
-private extension Scanner {
-    func scanUpToString(_ string: String) -> String? {
+extension Scanner {
+    fileprivate func scanUpToString(_ string: String) -> String? {
         var result: NSString? = nil
         let success = scanUpTo(string, into: &result)
         if success {
@@ -19,7 +19,7 @@ private extension Scanner {
         return nil
     }
 
-    func scanString(string: String) -> String? {
+    fileprivate func scanString(string: String) -> String? {
         var result: NSString? = nil
         let success = scanString(string, into: &result)
         if success {

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -42,7 +42,7 @@ public protocol SourceKitFreeRule: Rule {}
 
 // MARK: - ConfigurationProviderRule conformance to Configurable
 
-public extension ConfigurationProviderRule {
+extension ConfigurationProviderRule {
     public init(configuration: Any) throws {
         self.init()
         try self.configuration.apply(configuration: configuration)

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -9,8 +9,8 @@
 import Foundation
 import SourceKittenFramework
 
-private extension Region {
-    func isRuleDisabled(customRuleIdentifier: String) -> Bool {
+extension Region {
+    fileprivate func isRuleDisabled(customRuleIdentifier: String) -> Bool {
         return disabledRuleIdentifiers.contains(customRuleIdentifier)
     }
 }

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -115,8 +115,8 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
     }
 }
 
-fileprivate extension String {
-    var isViolatingCase: Bool {
+extension String {
+    fileprivate var isViolatingCase: Bool {
         let secondIndex = characters.index(after: startIndex)
         let firstCharacter = substring(to: secondIndex)
         guard firstCharacter.isUppercase() else {
@@ -130,7 +130,7 @@ fileprivate extension String {
         return secondCharacter.isLowercase()
     }
 
-    var isOperator: Bool {
+    fileprivate var isOperator: Bool {
         let operators = ["/", "=", "-", "+", "!", "*", "|", "^", "~", "?", ".", "%", "<", ">", "&"]
         return !operators.filter(hasPrefix).isEmpty
     }

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -125,8 +125,8 @@ public struct LineLengthRule: ConfigurationProviderRule {
 
 }
 
-private extension String {
-    var strippingURLs: String {
+extension String {
+    fileprivate var strippingURLs: String {
         let range = NSRange(location: 0, length: bridge().length)
         // Workaround for Linux until NSDataDetector is available
         #if os(Linux)

--- a/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
@@ -9,16 +9,16 @@
 import Foundation
 import SourceKittenFramework
 
-private extension AccessControlLevel {
-    init?(_ dictionary: [String: SourceKitRepresentable]) {
+extension AccessControlLevel {
+    fileprivate init?(_ dictionary: [String: SourceKitRepresentable]) {
         guard let accessibility = dictionary.accessibility,
             let acl = AccessControlLevel(rawValue: accessibility) else { return nil }
         self = acl
     }
 }
 
-private extension Dictionary where Key: ExpressibleByStringLiteral {
-    var superclass: String? {
+extension Dictionary where Key: ExpressibleByStringLiteral {
+    fileprivate var superclass: String? {
         guard let kindString = self.kind,
             let kind = SwiftDeclarationKind(rawValue: kindString), kind == .class,
             let className = inheritedTypes.first else { return nil }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -78,7 +78,7 @@ public func == (lhs: NameConfiguration, rhs: NameConfiguration) -> Bool {
 
 // MARK: - ConfigurationProviderRule extensions
 
-public extension ConfigurationProviderRule where ConfigurationType == NameConfiguration {
+extension ConfigurationProviderRule where ConfigurationType == NameConfiguration {
     public func severity(forLength length: Int) -> ViolationSeverity? {
         if let minError = configuration.minLength.error, length < minError {
             return .error

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -91,14 +91,14 @@ public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule 
 }
 
 // Default Behaviors
-private extension StatementPositionRule {
+extension StatementPositionRule {
 
     // match literal '}'
     // followed by 1) nothing, 2) two+ whitespace/newlines or 3) newlines or tabs
     // followed by 'else' or 'catch' literals
-    static let defaultPattern = "\\}(?:[\\s\\n\\r]{2,}|[\\n\\t\\r]+)?\\b(else|catch)\\b"
+    fileprivate static let defaultPattern = "\\}(?:[\\s\\n\\r]{2,}|[\\n\\t\\r]+)?\\b(else|catch)\\b"
 
-    func defaultValidate(file: File) -> [StyleViolation] {
+    fileprivate func defaultValidate(file: File) -> [StyleViolation] {
         return defaultViolationRanges(in: file, matching: type(of: self).defaultPattern).flatMap { range in
             return StyleViolation(ruleDescription: type(of: self).description,
                 severity: configuration.severity.severity,
@@ -106,13 +106,13 @@ private extension StatementPositionRule {
         }
     }
 
-    func defaultViolationRanges(in file: File, matching pattern: String) -> [NSRange] {
+    fileprivate func defaultViolationRanges(in file: File, matching pattern: String) -> [NSRange] {
         return file.match(pattern: pattern).filter { _, syntaxKinds in
             return syntaxKinds.starts(with: [.keyword])
         }.flatMap { $0.0 }
     }
 
-    func defaultCorrect(file: File) -> [Correction] {
+    fileprivate func defaultCorrect(file: File) -> [Correction] {
         let violations = defaultViolationRanges(in: file, matching: type(of: self).defaultPattern)
         let matches = file.ruleEnabled(violatingRanges: violations, for: self)
         if matches.isEmpty { return [] }
@@ -132,8 +132,8 @@ private extension StatementPositionRule {
 }
 
 // Uncuddled Behaviors
-private extension StatementPositionRule {
-    func uncuddledValidate(file: File) -> [StyleViolation] {
+extension StatementPositionRule {
+    fileprivate func uncuddledValidate(file: File) -> [StyleViolation] {
         return uncuddledViolationRanges(in: file).flatMap { range in
             return StyleViolation(ruleDescription: type(of: self).uncuddledDescription,
                 severity: configuration.severity.severity,
@@ -145,11 +145,12 @@ private extension StatementPositionRule {
     // preceded by whitespace (or nothing)
     // followed by 1) nothing, 2) two+ whitespace/newlines or 3) newlines or tabs
     // followed by newline and the same amount of whitespace then 'else' or 'catch' literals
-    static let uncuddledPattern = "([ \t]*)\\}(\\n+)?([ \t]*)\\b(else|catch)\\b"
+    fileprivate static let uncuddledPattern = "([ \t]*)\\}(\\n+)?([ \t]*)\\b(else|catch)\\b"
 
-    static let uncuddledRegex = regex(uncuddledPattern, options: [])
+    fileprivate static let uncuddledRegex = regex(uncuddledPattern, options: [])
 
-    static func uncuddledMatchValidator(contents: String) -> ((NSTextCheckingResult) -> NSTextCheckingResult?) {
+    fileprivate static func uncuddledMatchValidator(contents: String) ->
+                            ((NSTextCheckingResult) -> NSTextCheckingResult?) {
         return { match in
             if match.numberOfRanges != 5 {
                 return match
@@ -168,7 +169,8 @@ private extension StatementPositionRule {
         }
     }
 
-    static func uncuddledMatchFilter(contents: String, syntaxMap: SyntaxMap) -> ((NSTextCheckingResult) -> Bool) {
+    fileprivate static func uncuddledMatchFilter(contents: String, syntaxMap: SyntaxMap) ->
+                            ((NSTextCheckingResult) -> Bool) {
         return { match in
             let range = match.range
             guard let matchRange = contents.bridge().NSRangeToByteRange(start: range.location,
@@ -180,7 +182,7 @@ private extension StatementPositionRule {
         }
     }
 
-    func uncuddledViolationRanges(in file: File) -> [NSRange] {
+    fileprivate func uncuddledViolationRanges(in file: File) -> [NSRange] {
         let contents = file.contents
         let range = NSRange(location: 0, length: contents.utf16.count)
         let syntaxMap = file.syntaxMap
@@ -193,7 +195,7 @@ private extension StatementPositionRule {
         return validMatches
     }
 
-    func uncuddledCorrect(file: File) -> [Correction] {
+    fileprivate func uncuddledCorrect(file: File) -> [Correction] {
         var contents = file.contents
         let range = NSRange(location: 0, length: contents.utf16.count)
         let syntaxMap = file.syntaxMap

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -246,8 +246,8 @@ class ConfigurationTests: XCTestCase {
 
 // MARK: - ProjectMock Paths
 
-fileprivate extension String {
-    func stringByAppendingPathComponent(_ pathComponent: String) -> String {
+extension String {
+    fileprivate func stringByAppendingPathComponent(_ pathComponent: String) -> String {
         return bridge().appendingPathComponent(pathComponent)
     }
 }
@@ -262,45 +262,45 @@ extension XCTestCase {
     }
 }
 
-fileprivate extension XCTestCase {
+extension XCTestCase {
 
-    var projectMockPathLevel0: String {
+    fileprivate var projectMockPathLevel0: String {
         return bundlePath.stringByAppendingPathComponent("ProjectMock")
     }
 
-    var projectMockPathLevel1: String {
+    fileprivate var projectMockPathLevel1: String {
         return projectMockPathLevel0.stringByAppendingPathComponent("Level1")
     }
 
-    var projectMockPathLevel2: String {
+    fileprivate var projectMockPathLevel2: String {
         return projectMockPathLevel1.stringByAppendingPathComponent("Level2")
     }
 
-    var projectMockPathLevel3: String {
+    fileprivate var projectMockPathLevel3: String {
         return projectMockPathLevel2.stringByAppendingPathComponent("Level3")
     }
 
-    var projectMockYAML0: String {
+    fileprivate var projectMockYAML0: String {
         return projectMockPathLevel0.stringByAppendingPathComponent(Configuration.fileName)
     }
 
-    var projectMockYAML2: String {
+    fileprivate var projectMockYAML2: String {
         return projectMockPathLevel2.stringByAppendingPathComponent(Configuration.fileName)
     }
 
-    var projectMockSwift0: String {
+    fileprivate var projectMockSwift0: String {
         return projectMockPathLevel0.stringByAppendingPathComponent("Level0.swift")
     }
 
-    var projectMockSwift1: String {
+    fileprivate var projectMockSwift1: String {
         return projectMockPathLevel1.stringByAppendingPathComponent("Level1.swift")
     }
 
-    var projectMockSwift2: String {
+    fileprivate var projectMockSwift2: String {
         return projectMockPathLevel2.stringByAppendingPathComponent("Level2.swift")
     }
 
-    var projectMockSwift3: String {
+    fileprivate var projectMockSwift3: String {
         return projectMockPathLevel3.stringByAppendingPathComponent("Level3.swift")
     }
 }


### PR DESCRIPTION
Rule added in #1538.

There are two cases where a function declaration overflowed to two lines, but I think the consistency win is worthwhile here.