### PR TITLE
[WIP] Add opt-in IBOutlet Setter Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1504](https://github.com/realm/SwiftLint/issues/1504)
 
+* Add `outlet_setter` opt-in rule that warns when IBOutlet properties are reset
+  in code, rather than set automaticaly by IB.  
+  [Jeffrey Bergier](https://github.com/jeffreybergier)
+
 ##### Bug Fixes
 
 * `emoji` and `checkstyle` reporter output report sorted by file name.  

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -128,6 +128,7 @@ public let masterRuleList = RuleList(rules:
     OpeningBraceRule.self,
     OperatorFunctionWhitespaceRule.self,
     OperatorUsageWhitespaceRule.self,
+    OutletSetterRule.self,
     OverriddenSuperCallRule.self,
     PrivateOutletRule.self,
     PrivateUnitTestRule.self,

--- a/Source/SwiftLintFramework/Rules/OutletSetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/OutletSetterRule.swift
@@ -1,0 +1,116 @@
+//
+//  OutletSetterRule.swift
+//  SwiftLint
+//
+//  Created by Jeffrey Bergier on 3/9/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct OutletSetterRule: ASTRule, OptInRule, ConfigurationProviderRule {
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "outlet_setter",
+        name: "Outlet Setter",
+        description: "@IBOutlet properties should only be set by Interface Builder, not in code.",
+        nonTriggeringExamples: [
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t let \t bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t let \t bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t var \t bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t var \t bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t if case \t .bar \t = bar {} \n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t if case \t .bar=bar {} \n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t 123bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t 123bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t XYZbar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t XYZbar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t XYZ123bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t XYZ123bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self.bar?.backgroundColor = .blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self.bar?.backgroundColor=.blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self!.bar?.backgroundColor = .blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self!.bar?.backgroundColor=.blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self?.bar?.backgroundColor = .blue\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self?.bar?.backgroundColor=.blue\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self.bar \t = UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self.bar=UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self!.bar \t = UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self!.bar=UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self?.bar \t = UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t self?.bar=UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t bar \t = UILabel()\n }\n }",
+            "class Foo {\n var bar: UIView?\n func fubar() {\n \t bar=UILabel()\n }\n }"
+            // swiftlint:disable line_length
+            // MARK: ToDo: This string literal causes warning
+            // "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n print(\"my bar = \\(bar?.description)\")\n }\n }",
+            // MARK: ToDo: This valid multiline local variable will cause warning
+            // "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t var \t bar: UIView?\n bar \t = UILabel()\n }\n }",
+            // swiftlint:enable line_length
+        ],
+        triggeringExamples: [
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self.bar \t  = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self.bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self!.bar \t = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self!.bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self?.bar \t = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t self?.bar=UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t bar \t = UILabel()\n }\n }",
+            "class Foo {\n @IBOutlet var bar: UIView?\n func fubar() {\n \t bar=UILabel()\n }\n }"
+            // MARK: ToDo: Fix Bug. This is very uncommon, but it should be warned against. Currently is not matched.
+            // "class Foo {\n @IBOutlet var invalidLabel = UILabel()\n }",
+        ]
+    )
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+
+        // Find IBOutlets in the File
+        let substructure = dictionary.substructure
+        let outlets = substructure.filter({ $0.enclosedSwiftAttributes.contains("source.decl.attribute.iboutlet") })
+        let outletNames = outlets.flatMap({ $0.name })
+
+        // If there are no IBOutlets, we can bail
+        guard outletNames.isEmpty == false else { return [] }
+
+        // Find any line that contains a string that matches the discovered outlet names
+        // This will have many false positives
+        let possibleViolations: [(String, Line)] = outletNames.flatMap { outletName -> [(String, Line)] in
+            return file.lines.filter({ $0.content.contains(outletName) }).map({ (outletName, $0) })
+        }
+
+        // Go through possible violations, use regex to see if they violate rules
+        let confirmedViolations = possibleViolations.filter { outletName, line -> Bool in
+
+            // build the regex pattern
+            let noSelfPattern = "^\\s*\(outletName)\\s*="
+            let selfPattern = "self[\\?\\!]?\\.\(outletName)\\s*="
+            let noDotPattern = "[\\W*][\\D*][^\\.]\\s+\(outletName)\\s*="
+            let pattern = "(\(noSelfPattern)|\(selfPattern)|\(noDotPattern))"
+
+            // get the text that is being scanned
+            let content = line.content
+            let range = content.bridge().range(of: content)
+
+            // init new regex object and start operation
+            let regex = try? NSRegularExpression(pattern: pattern, options: [])
+            let match = regex?.firstMatch(in: content, options: [], range: range)
+
+            // if we have a match, then there is a violation
+            return match != nil
+        }
+
+        // Convert the Lines into errors
+        return confirmedViolations.map { _, line -> StyleViolation in
+            let location = Location(file: file, byteOffset: line.range.location)
+            return StyleViolation(ruleDescription: type(of: self).description,
+                                  severity: configuration.severity,
+                                  location: location)
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */; };
 		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
 		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
+		509B10A81E7262E500E2EE70 /* OutletSetterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509B10A61E72627000E2EE70 /* OutletSetterRule.swift */; };
 		57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED82791CF65183002B3513 /* JUnitReporter.swift */; };
 		67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */; };
 		67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */; };
@@ -333,6 +334,7 @@
 		4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLReporter.swift; sourceTree = "<group>"; };
 		4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
 		4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
+		509B10A61E72627000E2EE70 /* OutletSetterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutletSetterRule.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		57ED82791CF65183002B3513 /* JUnitReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JUnitReporter.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 				692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */,
 				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
 				D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */,
+				509B10A61E72627000E2EE70 /* OutletSetterRule.swift */,
 				78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */,
 				094385021D5D4F78009168CF /* PrivateOutletRule.swift */,
 				B2902A0B1D66815600BFCCF7 /* PrivateUnitTestRule.swift */,
@@ -1289,6 +1292,7 @@
 				D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */,
 				6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */,
 				D4C0E46F1E3D973600C560F2 /* ForWhereRule.swift in Sources */,
+				509B10A81E7262E500E2EE70 /* OutletSetterRule.swift in Sources */,
 				E86396C51BADAC15002C9E88 /* XcodeReporter.swift in Sources */,
 				094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */,
 				3B1DF0121C5148140011BCED /* CustomRules.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -197,6 +197,10 @@ class RulesTests: XCTestCase {
         verifyRule(OperatorUsageWhitespaceRule.description)
     }
 
+    func testOutletSetter() {
+        verifyRule(OutletSetterRule.description)
+    }
+
     func testPrivateOutlet() {
         verifyRule(PrivateOutletRule.description)
 
@@ -400,6 +404,7 @@ extension RulesTests {
             ("testOpeningBrace", testOpeningBrace),
             ("testOperatorFunctionWhitespace", testOperatorFunctionWhitespace),
             ("testOperatorUsageWhitespace", testOperatorUsageWhitespace),
+            ("testOutletSetter", testOutletSetter),
             ("testPrivateOutlet", testPrivateOutlet),
             ("testPrivateUnitTest", testPrivateUnitTest),
             ("testProhibitedSuper", testProhibitedSuper),


### PR DESCRIPTION
Continued from #1355.

This rule checks if the file contains IBOutlets, if it does it looks for any lines of code that attempt to call the setter on that outlet. e.g. self.myLabel = UILabel() would trigger this rule.

While the rule is not perfect, it will help avoid an Interface Builder anti- pattern. In general, if your code is resetting IBOutlets, there is probably a better way to accomplish what you want.

There are a lot of triggering and non-triggering test cases. Along with a 3 TODOs where the rule can be triggered when it shouldn't. Because this is opt-in and the cases where the rule is triggered are fairly rare and can often be fixed by renaming a local variable, I left them as TODOs for now.