### PR TITLE
Adds opt-in multiline parameters rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,11 @@
 * Make `Region` & `Command` structs conform to `Equatable`.  
   [JP Simard](https://github.com/jpsim)
 
+* Add `multiline_parameters` opt-in rule that warns to either keep
+  all the parameters of a method or function on the same line,
+  or one per line.  
+  [Ornithologist Coder](https://github.com/ornithocoder)
+
 * Make `closure_spacing` a `CorrectableRule`.  
   [J. Cheyo Jimenez](https://github.com/masters3d)
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -119,6 +119,7 @@ public let masterRuleList = RuleList(rules:
     LegacyNSGeometryFunctionsRule.self,
     LineLengthRule.self,
     MarkRule.self,
+    MultilineParametersRule.self,
     NestingRule.self,
     NimbleOperatorRule.self,
     NoExtensionAccessModifierRule.self,

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRule.swift
@@ -1,0 +1,72 @@
+//
+//  MultilineParametersRule.swift
+//  SwiftLint
+//
+//  Created by Ornithologist Coder on 22/05/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "multiline_parameters",
+        name: "Multiline Parameters",
+        description: "Functions and methods parameters should be either on the same line, or one per line.",
+        nonTriggeringExamples: MultilineParametersRuleExamples.nonTriggeringExamples,
+        triggeringExamples: MultilineParametersRuleExamples.triggeringExamples
+    )
+
+    public func validate(file: File,
+                         kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard isValidFunction(kind),
+            let offset = dictionary.nameOffset,
+            let length = dictionary.nameLength
+            else {
+                return []
+        }
+
+        var numberOfParameters: Int = 0
+        var linesWithParameters: Set<Int> = []
+
+        for structure in dictionary.substructure {
+            guard
+                let structureOffset = structure.offset,
+                let structureKind = structure.kind, SwiftDeclarationKind(rawValue: structureKind) == .varParameter,
+                let (line, _) = file.contents.bridge().lineAndCharacter(forByteOffset: structureOffset)
+                else {
+                    continue
+            }
+
+            guard offset..<(offset + length) ~= structureOffset else { break }
+
+            linesWithParameters.insert(line)
+            numberOfParameters += 1
+        }
+
+        if linesWithParameters.count > 1 && numberOfParameters != linesWithParameters.count {
+            return [StyleViolation(ruleDescription: type(of: self).description,
+                                   severity: configuration.severity,
+                                   location: Location(file: file, byteOffset: offset))]
+        }
+
+        return []
+    }
+
+    // MARK: - Private
+
+    private func isValidFunction(_ kind: SwiftDeclarationKind) -> Bool {
+        return [
+            SwiftDeclarationKind.functionMethodStatic,
+            SwiftDeclarationKind.functionMethodClass,
+            SwiftDeclarationKind.functionMethodInstance,
+            SwiftDeclarationKind.functionFree
+        ].contains(kind)
+    }
+}

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
@@ -1,0 +1,176 @@
+//
+//  MultilineParametersRuleExamples.swift
+//  SwiftLint
+//
+//  Created by Ornithologist Coder on 22/05/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+
+internal struct MultilineParametersRuleExamples {
+    static let nonTriggeringExamples = [
+        "func foo() { }",
+        "func foo(param1: Int) { }",
+        "func foo(param1: Int, param2: Bool) { }",
+        "func foo(param1: Int, param2: Bool, param3: [String]) { }",
+        "func foo(param1: Int,\n" +
+        "         param2: Bool,\n" +
+        "         param3: [String]) { }",
+        "func foo(_ param1: Int, param2: Int, param3: Int) -> (Int) -> Int {\n" +
+        "   return { x in x + param1 + param2 + param3 }\n" +
+        "}",
+        "static func foo() { }",
+        "static func foo(param1: Int) { }",
+        "static func foo(param1: Int, param2: Bool) { }",
+        "static func foo(param1: Int, param2: Bool, param3: [String]) { }",
+        "static func foo(param1: Int,\n" +
+        "                param2: Bool,\n" +
+        "                param3: [String]) { }",
+        "protocol Foo {\n\tfunc foo() { }\n}",
+        "protocol Foo {\n\tfunc foo(param1: Int) { }\n}",
+        "protocol Foo {\n\tfunc foo(param1: Int, param2: Bool) { }\n}",
+        "protocol Foo {\n\tfunc foo(param1: Int, param2: Bool, param3: [String]) { }\n}",
+        "protocol Foo {\n" +
+        "   func foo(param1: Int,\n" +
+        "            param2: Bool,\n" +
+        "            param3: [String]) { }\n" +
+        "}",
+        "protocol Foo {\n\tstatic func foo(param1: Int, param2: Bool, param3: [String]) { }\n}",
+        "protocol Foo {\n" +
+        "   static func foo(param1: Int,\n" +
+        "                   param2: Bool,\n" +
+        "                   param3: [String]) { }\n" +
+        "}",
+        "protocol Foo {\n\tclass func foo(param1: Int, param2: Bool, param3: [String]) { }\n}",
+        "protocol Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: Bool,\n" +
+        "                  param3: [String]) { }\n" +
+        "}",
+        "enum Foo {\n\tfunc foo() { }\n}",
+        "enum Foo {\n\tfunc foo(param1: Int) { }\n}",
+        "enum Foo {\n\tfunc foo(param1: Int, param2: Bool) { }\n}",
+        "enum Foo {\n\tfunc foo(param1: Int, param2: Bool, param3: [String]) { }\n}",
+        "enum Foo {\n" +
+        "   func foo(param1: Int,\n" +
+        "            param2: Bool,\n" +
+        "            param3: [String]) { }\n" +
+        "}",
+        "enum Foo {\n\tstatic func foo(param1: Int, param2: Bool, param3: [String]) { }\n}",
+        "enum Foo {\n" +
+        "   static func foo(param1: Int,\n" +
+        "                   param2: Bool,\n" +
+        "                   param3: [String]) { }\n" +
+        "}",
+        "struct Foo {\n\tfunc foo() { }\n}",
+        "struct Foo {\n\tfunc foo(param1: Int) { }\n}",
+        "struct Foo {\n\tfunc foo(param1: Int, param2: Bool) { }\n}",
+        "struct Foo {\n\tfunc foo(param1: Int, param2: Bool, param3: [String]) { }\n}",
+        "struct Foo {\n" +
+        "   func foo(param1: Int,\n" +
+        "            param2: Bool,\n" +
+        "            param3: [String]) { }\n" +
+        "}",
+        "struct Foo {\n\tstatic func foo(param1: Int, param2: Bool, param3: [String]) { }\n}",
+        "struct Foo {\n" +
+        "   static func foo(param1: Int,\n" +
+        "                   param2: Bool,\n" +
+        "                   param3: [String]) { }\n" +
+        "}",
+        "class Foo {\n\tfunc foo() { }\n}",
+        "class Foo {\n\tfunc foo(param1: Int) { }\n}",
+        "class Foo {\n\tfunc foo(param1: Int, param2: Bool) { }\n}",
+        "class Foo {\n\tfunc foo(param1: Int, param2: Bool, param3: [String]) { }\n\t}",
+        "class Foo {\n" +
+        "   func foo(param1: Int,\n" +
+        "            param2: Bool,\n" +
+        "            param3: [String]) { }\n" +
+        "}",
+        "class Foo {\n\tclass func foo(param1: Int, param2: Bool, param3: [String]) { }\n}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: Bool,\n" +
+        "                  param3: [String]) { }\n" +
+        "}"
+    ]
+
+    static let triggeringExamples = [
+        "func ↓foo(_ param1: Int,\n" +
+        "          param2: Int, param3: Int) -> (Int) -> Int {\n" +
+        "   return { x in x + param1 + param2 + param3 }\n" +
+        "}",
+        "protocol Foo {\n" +
+        "   func ↓foo(param1: Int,\n" +
+        "             param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "protocol Foo {\n" +
+        "   func ↓foo(param1: Int, param2: Bool,\n" +
+        "             param3: [String]) { }\n" +
+        "}",
+        "protocol Foo {\n" +
+        "   static func ↓foo(param1: Int,\n" +
+        "                    param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "protocol Foo {\n" +
+        "   static func ↓foo(param1: Int, param2: Bool,\n" +
+        "                    param3: [String]) { }\n" +
+        "}",
+        "protocol Foo {\n" +
+        "   class func ↓foo(param1: Int,\n" +
+        "                   param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "protocol Foo {\n" +
+        "   class func ↓foo(param1: Int, param2: Bool,\n" +
+        "                   param3: [String]) { }\n" +
+        "}",
+        "enum Foo {\n" +
+        "   func ↓foo(param1: Int,\n" +
+        "             param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "enum Foo {\n" +
+        "   func ↓foo(param1: Int, param2: Bool,\n" +
+        "             param3: [String]) { }\n" +
+        "}",
+        "enum Foo {\n" +
+        "   static func ↓foo(param1: Int,\n" +
+        "                    param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "enum Foo {\n" +
+        "   static func ↓foo(param1: Int, param2: Bool,\n" +
+        "                    param3: [String]) { }\n" +
+        "}",
+        "struct Foo {\n" +
+        "   func ↓foo(param1: Int,\n" +
+        "             param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "struct Foo {\n" +
+        "   func ↓foo(param1: Int, param2: Bool,\n" +
+        "             param3: [String]) { }\n" +
+        "}",
+        "struct Foo {\n" +
+        "   static func ↓foo(param1: Int,\n" +
+        "                    param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "struct Foo {\n" +
+        "   static func ↓foo(param1: Int, param2: Bool,\n" +
+        "                    param3: [String]) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   func ↓foo(param1: Int,\n" +
+        "             param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   func ↓foo(param1: Int, param2: Bool,\n" +
+        "             param3: [String]) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func ↓foo(param1: Int,\n" +
+        "                   param2: Bool, param3: [String]) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func ↓foo(param1: Int, param2: Bool,\n" +
+        "                   param3: [String]) { }\n" +
+        "}"
+    ]
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
 		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
 		57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED82791CF65183002B3513 /* JUnitReporter.swift */; };
+		621061BF1ED57E640082D51E /* MultilineParametersRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */; };
+		6250D32A1ED4DFEB00735129 /* MultilineParametersRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6238AE411ED4D734006C3601 /* MultilineParametersRule.swift */; };
 		67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */; };
 		67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */; };
 		67EB4DFC1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */; };
@@ -339,6 +341,8 @@
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		57ED82791CF65183002B3513 /* JUnitReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JUnitReporter.swift; sourceTree = "<group>"; };
+		621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineParametersRuleExamples.swift; sourceTree = "<group>"; };
+		6238AE411ED4D734006C3601 /* MultilineParametersRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineParametersRule.swift; sourceTree = "<group>"; };
 		65454F451B14D73800319A6C /* ControlStatementRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlStatementRule.swift; sourceTree = "<group>"; };
 		67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityConfigurationTests.swift; sourceTree = "<group>"; };
 		67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityConfiguration.swift; sourceTree = "<group>"; };
@@ -897,6 +901,8 @@
 				F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */,
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
 				856651A61D6B395F005E6B29 /* MarkRule.swift */,
+				6238AE411ED4D734006C3601 /* MultilineParametersRule.swift */,
+				621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */,
 				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
 				D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */,
 				1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifier.swift */,
@@ -919,7 +925,6 @@
 				D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */,
 				D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */,
 				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
-				3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */,
 				D4D5A5FE1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift */,
 				D286EC001E02DA190003CF72 /* SortedImportsRule.swift */,
 				692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */,
@@ -941,6 +946,7 @@
 				1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */,
 				D47079AE1DFE520000027086 /* VoidReturnRule.swift */,
 				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
+				3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -1231,6 +1237,7 @@
 				D286EC021E02DF6F0003CF72 /* SortedImportsRule.swift in Sources */,
 				3BCC04CD1C4F5694006073C3 /* ConfigurationError.swift in Sources */,
 				D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */,
+				6250D32A1ED4DFEB00735129 /* MultilineParametersRule.swift in Sources */,
 				009E092A1DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift in Sources */,
 				47FF3BE11E7C75B600187E6D /* ImplicitlyUnwrappedOptionalRule.swift in Sources */,
 				BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */,
@@ -1316,6 +1323,7 @@
 				D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */,
 				D462021F1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift in Sources */,
 				D4DA1DF41E17511D0037413D /* CompilerProtocolInitRule.swift in Sources */,
+				621061BF1ED57E640082D51E /* MultilineParametersRuleExamples.swift in Sources */,
 				D48AE2CC1DFB58C5001C6A4A /* AttributesRulesExamples.swift in Sources */,
 				E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */,
 				D43B046B1E075905004016AF /* ClosureEndIndentationRule.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -165,6 +165,10 @@ class RulesTests: XCTestCase {
         verifyRule(MarkRule.description, commentDoesntViolate: false)
     }
 
+    func testMultilineParameters() {
+        verifyRule(MultilineParametersRule.description)
+    }
+
     func testNesting() {
         verifyRule(NestingRule.description)
     }
@@ -392,6 +396,7 @@ extension RulesTests {
             ("testLegacyConstant", testLegacyConstant),
             ("testLegacyConstructor", testLegacyConstructor),
             ("testMark", testMark),
+            ("testMultilineParameters", testMultilineParameters),
             ("testNesting", testNesting),
             ("testNimbleOperator", testNimbleOperator),
             ("testNoExtensionAccessModifierRule", testNoExtensionAccessModifierRule),


### PR DESCRIPTION
This commit introduces the opt-in rule that checks if methods and functions parameters are all on the same line or one per line. For instance, the dummy function below violates the rule.

```swift
func foo(param1: Int,
         param2: Int, param3: Int) -> (Int) -> Int {
    return { x in x + param1 + param2 + param3 }
}
```

It should be implemented either as:

```swift
func foo(param1: Int, param2: Int, param3: Int) -> (Int) -> Int {
    return { x in x + param1 + param2 + param3 }
}
```

or

```swift
func foo(param1: Int,
         param2: Int,
         param3: Int) -> (Int) -> Int {
    return { x in x + param1 + param2 + param3 }
}
```

Tasks:

- [x] Create rule
- [x] Add entry to CHANGELOG.md
- [x] Review violations:
    - [x] Aerial - 7 violations
    - [x] Alamofire - no violations found
    - [x] Firefox - 3 violations
    - [x] Kickstarter - 14 violations
    - [x] Moya - 1 violation
    - [x] Nimble - no violations found
    - [x] Quick - no violations found
    - [x] Realm - 14 violations
    - [x] SourceKitten - 4 violations
    - [x] Sourcery - no violations found
    - [x] Swift - 96 violations
    - [x] WordPress - 2 violations