### PR TITLE
Ignore overriddes in FunctionParameterCountRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   or one per line.  
   [Ornithologist Coder](https://github.com/ornithocoder)
 
+* Update `function_parameter_count` rule to ignore overridden methods.  
+  [Markus Gasser](https://github.com/frenetisch-applaudierend)
+  [#1562](https://github.com/realm/SwiftLint/issues/1562)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -28,7 +28,8 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
             "func f2(p1: Int, p2: Int) { }",
             "func f(a: Int, b: Int, c: Int, d: Int, x: Int = 42) {}",
             "func f(a: [Int], b: Int, c: Int, d: Int, f: Int) -> [Int] {\n" +
-                "let s = a.flatMap { $0 as? [String: Int] } ?? []}}"
+                "let s = a.flatMap { $0 as? [String: Int] } ?? []}}",
+            "override func f(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}"
         ],
         triggeringExamples: [
             "↓func f(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}",
@@ -50,6 +51,10 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
         let length = dictionary.nameLength ?? 0
 
         if functionIsInitializer(file: file, byteOffset: nameOffset, byteLength: length) {
+            return []
+        }
+
+        if functionIsOverride(attributes: dictionary.enclosedSwiftAttributes) {
             return []
         }
 
@@ -116,4 +121,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
         return alphaNumericName == "init"
     }
 
+    fileprivate func functionIsOverride(attributes: [String]) -> Bool {
+        return attributes.contains("source.decl.attribute.override")
+    }
 }


### PR DESCRIPTION
Fixes #1562.

Note, `make docker_test` failed with the following error, but I doubt this is due to the change:

    /usr/bin/ld.gold: fatal error: /Users/username/Development/SwiftLint/.build/debug/SwiftLintPackageTests.xctest: open: Is a directory
