### PR TITLE
Match `(Void)` as return type in the `void_return` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ##### Enhancements
 
+* Match `(Void)` as return type in the `void_return` rule.  
+  [Anders Hasselqvist](https://github.com/nevil)
+
 * Add `multiline_parameters` opt-in rule that warns to either keep
   all the parameters of a method or function on the same line,
   or one per line.  

--- a/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
@@ -20,6 +20,7 @@ public struct VoidReturnRule: ConfigurationProviderRule, CorrectableRule {
         description: "Prefer `-> Void` over `-> ()`.",
         nonTriggeringExamples: [
             "let abc: () -> Void = {}\n",
+            "let abc: () -> (VoidVoid) = {}\n",
             "func foo(completion: () -> Void)\n",
             "let foo: (ConfigurationTests) -> () throws -> Void)\n",
             "let foo: (ConfigurationTests) ->   () throws -> Void)\n",
@@ -28,14 +29,20 @@ public struct VoidReturnRule: ConfigurationProviderRule, CorrectableRule {
         ],
         triggeringExamples: [
             "let abc: () -> ↓() = {}\n",
+            "let abc: () -> ↓(Void) = {}\n",
+            "let abc: () -> ↓(   Void ) = {}\n",
             "func foo(completion: () -> ↓())\n",
             "func foo(completion: () -> ↓(   ))\n",
+            "func foo(completion: () -> ↓(Void))\n",
             "let foo: (ConfigurationTests) -> () throws -> ↓())\n"
         ],
         corrections: [
             "let abc: () -> ↓() = {}\n": "let abc: () -> Void = {}\n",
+            "let abc: () -> ↓(Void) = {}\n": "let abc: () -> Void = {}\n",
+            "let abc: () -> ↓(   Void ) = {}\n": "let abc: () -> Void = {}\n",
             "func foo(completion: () -> ↓())\n": "func foo(completion: () -> Void)\n",
             "func foo(completion: () -> ↓(   ))\n": "func foo(completion: () -> Void)\n",
+            "func foo(completion: () -> ↓(Void))\n": "func foo(completion: () -> Void)\n",
             "let foo: (ConfigurationTests) -> () throws -> ↓())\n":
                 "let foo: (ConfigurationTests) -> () throws -> Void)\n"
         ]
@@ -51,7 +58,7 @@ public struct VoidReturnRule: ConfigurationProviderRule, CorrectableRule {
 
     private func violationRanges(file: File) -> [NSRange] {
         let kinds = SyntaxKind.commentAndStringKinds()
-        let parensPattern = "\\(\\s*\\)"
+        let parensPattern = "\\(\\s*(?:Void)?\\s*\\)"
         let pattern = "->\\s*\(parensPattern)\\s*(?!->)"
         let excludingPattern = "(\(pattern))\\s*(throws\\s+)?->"
 


### PR DESCRIPTION
Update the regexp to match on 0 or 1 occurence of `Void` within
the parentheses.