### PR TITLE
Enable prohibited_super_call and overridden_super_call rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Breaking
 
-* None.
+* `prohibited_super_call` and `overridden_super_call` rules are 
+   now enabled by default.  
+   [Marcelo Fabri](https://github.com/marcelofabri)
 
 ##### Enhancements
 

--- a/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
@@ -8,7 +8,7 @@
 
 import SourceKittenFramework
 
-public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptInRule {
+public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule {
     public var configuration = OverridenSuperCallConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/ProhibitedSuperRule.swift
@@ -8,7 +8,7 @@
 
 import SourceKittenFramework
 
-public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule {
+public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule {
     public var configuration = ProhibitedSuperConfiguration()
 
     public init() {}


### PR DESCRIPTION
I don't see why these are not enabled by default - they seem too useful to be opt-in.