### PR TITLE
Fix `make docker_test` failure after running SwiftPM on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ XCODEFLAGS=-workspace 'SwiftLint.xcworkspace' \
 BUILT_BUNDLE=$(TEMPORARY_FOLDER)/Applications/swiftlint.app
 SWIFTLINTFRAMEWORK_BUNDLE=$(BUILT_BUNDLE)/Contents/Frameworks/SwiftLintFramework.framework
 SWIFTLINT_EXECUTABLE=$(BUILT_BUNDLE)/Contents/MacOS/swiftlint
+XCTEST_LOCATION=.build/debug/SwiftLintPackageTests.xctest
 
 FRAMEWORKS_FOLDER=/Library/Frameworks
 BINARIES_FOLDER=/usr/local/bin
@@ -89,6 +90,7 @@ archive:
 release: package archive portable_zip
 
 docker_test:
+	if [ -d $(XCTEST_LOCATION) ]; then rm -rf $(XCTEST_LOCATION); fi
 	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm norionomura/sourcekit:311 swift test
 
 docker_htop:


### PR DESCRIPTION
SwiftPM on Darwin produces a `.xctest` _bundle_ (i.e. folder).
SwiftPM on Linux produces a `.xctest` _binary_ (i.e. file).

SwitPM on Linux exits unsuccessfully if it finds a folder at the `.xctest` location.

```
$ make docker_test
...
Linking ./.build/debug/SwiftLintPackageTests.xctest
/usr/bin/ld.gold: fatal error: ./.build/debug/SwiftLintPackageTests.xctest: open: Is a directory
clang: error: linker command failed with exit code 1 (use -v to see invocation)
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
<unknown>:0: error: build had 1 command failures
swift-test: error: exit(1): /usr/bin/swift-build-tool -f .build/debug.yaml test
make: *** [docker_test] Error 1
```

This change detects this scenario and pre-emptively deletes the `.xctest` folder if it exists.