### PR TITLE
enable explicit_top_level_acl  and extension_access_modifier

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,8 @@ opt_in_rules:
   - object_literal
   - number_separator
   - prohibited_super_call
+  - explicit_top_level_acl
+  - extension_access_modifier
   - fatal_error_message
   - vertical_parameter_alignment_on_call
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@
   when using subscript.  
   [Otávio Lima](https://github.com/otaviolima)
 
+* Enable explicit_top_level_acl and extension_access_modifier rules.  
+  [masters3d](https://github.com/masters3d)
+
 * Match `(Void)` as return type in the `void_return` rule.  
   [Anders Hasselqvist](https://github.com/nevil)
 

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
@@ -25,8 +25,8 @@ extension CharacterSet {
     }
 }
 
-extension Character {
-    fileprivate var unicodeScalar: UnicodeScalar {
+private extension Character {
+    var unicodeScalar: UnicodeScalar {
         let characterString = String(self)
         let scalars = characterString.unicodeScalars
 

--- a/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
+++ b/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Realm. All rights reserved.
 //
 
-struct RegexHelpers {
+internal struct RegexHelpers {
     // A single variable
     static let varName = "[a-zA-Z_][a-zA-Z0-9_]+"
 

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -16,8 +16,8 @@ private struct LintResult {
     let deprecatedToValidIDPairs: [(String, String)]
 }
 
-extension Rule {
-    fileprivate func lint(file: File, regions: [Region], benchmark: Bool) -> LintResult? {
+private extension Rule {
+    func lint(file: File, regions: [Region], benchmark: Bool) -> LintResult? {
         if !(self is SourceKitFreeRule) && file.sourcekitdFailed {
             return nil
         }

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -159,8 +159,8 @@ private extension Dictionary where Key == String {
     }
 }
 
-extension StyleViolation {
-    fileprivate static func from(cache: [String: Any], file: String) -> StyleViolation? {
+private extension StyleViolation {
+    static func from(cache: [String: Any], file: String) -> StyleViolation? {
         guard let severityString = cache[.severity] as? String,
             let severity = ViolationSeverity(rawValue: severityString),
             let name = cache[.type] as? String,

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -138,8 +138,8 @@ public final class LinterCache {
     }
 }
 
-extension LinterCache {
-    fileprivate enum Key: String {
+private extension LinterCache {
+    enum Key: String {
         case character
         case configuration
         case lastModification = "last_modification"

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum SwiftVersion {
+internal enum SwiftVersion {
     case three
 
     static let current: SwiftVersion = {

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -13,12 +13,12 @@ public protocol ASTRule: Rule {
     func validate(file: File, kind: KindType, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]
 }
 
-extension ASTRule where KindType.RawValue == String {
-    public func validate(file: File) -> [StyleViolation] {
+public extension ASTRule where KindType.RawValue == String {
+    func validate(file: File) -> [StyleViolation] {
         return validate(file: file, dictionary: file.structure.dictionary)
     }
 
-    public func validate(file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+    func validate(file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict)
 

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -43,19 +43,19 @@ public protocol SourceKitFreeRule: Rule {}
 // MARK: - ConfigurationProviderRule conformance to Configurable
 
 public extension ConfigurationProviderRule {
-    public init(configuration: Any) throws {
+    init(configuration: Any) throws {
         self.init()
         try self.configuration.apply(configuration: configuration)
     }
 
-    public func isEqualTo(_ rule: Rule) -> Bool {
+    func isEqualTo(_ rule: Rule) -> Bool {
         if let rule = rule as? Self {
             return configuration.isEqualTo(rule.configuration)
         }
         return false
     }
 
-    public var configurationDescription: String {
+    var configurationDescription: String {
         return configuration.consoleDescription
     }
 }

--- a/Source/SwiftLintFramework/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Protocols/RuleConfiguration.swift
@@ -18,8 +18,8 @@ extension RuleConfiguration {
     }
 }
 
-extension RuleConfiguration where Self: Equatable {
-    public func isEqualTo(_ ruleConfiguration: RuleConfiguration) -> Bool {
+public extension RuleConfiguration where Self: Equatable {
+    func isEqualTo(_ ruleConfiguration: RuleConfiguration) -> Bool {
         return self == ruleConfiguration as? Self
     }
 }

--- a/Source/SwiftLintFramework/Reporters/CSVReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CSVReporter.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-extension String {
-    fileprivate func escapedForCSV() -> String {
+private extension String {
+    func escapedForCSV() -> String {
         let escapedString = replacingOccurrences(of: "\"", with: "\"\"")
         if escapedString.contains(",") || escapedString.contains("\n") {
             return "\"\(escapedString)\""

--- a/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
@@ -11,8 +11,8 @@ import SourceKittenFramework
 
 private let whitespaceAndNewlineCharacterSet = CharacterSet.whitespacesAndNewlines
 
-extension File {
-    fileprivate func violatingClosingBraceRanges() -> [NSRange] {
+private extension File {
+    func violatingClosingBraceRanges() -> [NSRange] {
         return match(pattern: "(\\}[ \\t]+\\))", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
     }
 }

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -172,9 +172,9 @@ public struct ColonRule: ASTRule, CorrectableRule, ConfigurationProviderRule {
 
 // MARK: Type Colon Rule
 
-extension ColonRule {
+private extension ColonRule {
 
-    fileprivate var pattern: String {
+    var pattern: String {
         // If flexible_right_spacing is true, match only 0 whitespaces.
         // If flexible_right_spacing is false or omitted, match 0 or 2+ whitespaces.
         let spacingRegex = configuration.flexibleRightSpacing ? "(?:\\s{0})" : "(?:\\s{0}|\\s{2,})"
@@ -193,7 +193,7 @@ extension ColonRule {
                "\\S)"          // lazily to the first non-whitespace character.
     }
 
-    fileprivate func typeColonViolationRanges(in file: File, matching pattern: String) -> [NSRange] {
+    func typeColonViolationRanges(in file: File, matching pattern: String) -> [NSRange] {
         let nsstring = file.contents.bridge()
         let commentAndStringKindsSet = Set(SyntaxKind.commentAndStringKinds())
         return file.rangesAndTokens(matching: pattern).filter { _, syntaxTokens in

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -195,8 +195,8 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
     }
 }
 
-extension String {
-    fileprivate func split(separator: String) -> [(String, NSRange)] {
+private extension String {
+    func split(separator: String) -> [(String, NSRange)] {
         let separatorLength = separator.bridge().length
         var previousEndOffset = 0
         var result = [(String, NSRange)]()
@@ -211,7 +211,7 @@ extension String {
         return result
     }
 
-    fileprivate func trimmingWhitespaces() -> (String, NSRange) {
+    func trimmingWhitespaces() -> (String, NSRange) {
         let bridged = bridge()
         let range = NSRange(location: 0, length: bridged.length)
         guard let match = regex("^\\s*(\\S*)\\s*$").firstMatch(in: self, options: [], range: range),

--- a/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
@@ -125,11 +125,11 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
     }
 }
 
-extension String {
+private extension String {
     /// Returns corrected string if the correction is possible, otherwise returns nil.
-    fileprivate func replace(function name: NimbleOperatorRule.MatcherFunction,
-                             with operators: NimbleOperatorRule.Operators,
-                             in range: NSRange) -> String? {
+    func replace(function name: NimbleOperatorRule.MatcherFunction,
+                 with operators: NimbleOperatorRule.Operators,
+                 in range: NSRange) -> String? {
 
         let anything = "\\s*(.*?)\\s*"
 

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -11,8 +11,8 @@ import SourceKittenFramework
 
 private let whitespaceAndNewlineCharacterSet = CharacterSet.whitespacesAndNewlines
 
-extension File {
-    fileprivate func violatingOpeningBraceRanges() -> [NSRange] {
+private extension File {
+    func violatingOpeningBraceRanges() -> [NSRange] {
         return match(pattern: "((?:[^( ]|[\\s(][\\s]+)\\{)",
                      excludingSyntaxKinds: SyntaxKind.commentAndStringKinds(),
                      excludingPattern: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{")

--- a/Source/SwiftLintFramework/Rules/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantNilCoalescingRule.swift
@@ -9,8 +9,8 @@
 import Foundation
 import SourceKittenFramework
 
-extension File {
-    fileprivate func violatingRedundantNilCoalescingRanges() -> [NSRange] {
+private extension File {
+    func violatingRedundantNilCoalescingRanges() -> [NSRange] {
         // {whitespace} ?? {whitespace} nil {word boundary}
         return match(pattern: "\\s?\\?{2}\\s*nil\\b", with: [.keyword])
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -84,7 +84,7 @@ public func == (lhs: NameConfiguration, rhs: NameConfiguration) -> Bool {
 // MARK: - ConfigurationProviderRule extensions
 
 public extension ConfigurationProviderRule where ConfigurationType == NameConfiguration {
-    public func severity(forLength length: Int) -> ViolationSeverity? {
+    func severity(forLength length: Int) -> ViolationSeverity? {
         if let minError = configuration.minLength.error, length < minError {
             return .error
         } else if let maxError = configuration.maxLength.error, length > maxError {

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -9,9 +9,9 @@
 import Foundation
 import SourceKittenFramework
 
-extension SyntaxKind {
+public extension SyntaxKind {
     /// Returns if the syntax kind is comment-like.
-    public var isCommentLike: Bool {
+    var isCommentLike: Bool {
         return [
             SyntaxKind.comment,
             .commentMark,

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -9,8 +9,8 @@
 import Foundation
 import SourceKittenFramework
 
-extension File {
-    fileprivate func violatingTrailingSemicolonRanges() -> [NSRange] {
+private extension File {
+    func violatingTrailingSemicolonRanges() -> [NSRange] {
         return match(pattern: "(;+([^\\S\\n]?)*)+;?$",
                      excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
     }

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -10,7 +10,7 @@ import Commandant
 import Result
 import SwiftLintFramework
 
-struct AutoCorrectCommand: CommandProtocol {
+internal struct AutoCorrectCommand: CommandProtocol {
     let verb = "autocorrect"
     let function = "Automatically correct warnings and errors"
 
@@ -41,7 +41,7 @@ struct AutoCorrectCommand: CommandProtocol {
     }
 }
 
-struct AutoCorrectOptions: OptionsProtocol {
+internal struct AutoCorrectOptions: OptionsProtocol {
     let path: String
     let configurationFile: String
     let useScriptInputFiles: Bool

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -13,7 +13,7 @@ import Result
 import SourceKittenFramework
 import SwiftLintFramework
 
-struct LintCommand: CommandProtocol {
+internal struct LintCommand: CommandProtocol {
     let verb = "lint"
     let function = "Print lint warnings and errors (default command)"
 
@@ -124,7 +124,7 @@ struct LintCommand: CommandProtocol {
     }
 }
 
-struct LintOptions: OptionsProtocol {
+internal struct LintOptions: OptionsProtocol {
     let path: String
     let useSTDIN: Bool
     let configurationFile: String

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -27,7 +27,7 @@ private func print(ruleDescription desc: RuleDescription) {
     }
 }
 
-struct RulesCommand: CommandProtocol {
+internal struct RulesCommand: CommandProtocol {
     let verb = "rules"
     let function = "Display the list of rules and their identifiers"
 
@@ -69,7 +69,7 @@ struct RulesCommand: CommandProtocol {
     }
 }
 
-struct RulesOptions: OptionsProtocol {
+internal struct RulesOptions: OptionsProtocol {
     fileprivate let ruleID: String?
     let configurationFile: String
     fileprivate let filterEnabled: Bool

--- a/Source/swiftlint/Commands/RulesDocsCommand.swift
+++ b/Source/swiftlint/Commands/RulesDocsCommand.swift
@@ -10,7 +10,7 @@ import Commandant
 import Result
 import SwiftLintFramework
 
-struct RulesDocsCommand: CommandProtocol {
+internal struct RulesDocsCommand: CommandProtocol {
     let verb = "rules_docs"
     let function = "Generates a markdown with all rules documentation"
 
@@ -111,7 +111,7 @@ struct RulesDocsCommand: CommandProtocol {
     }
 }
 
-struct RulesDocsOptions: OptionsProtocol {
+internal struct RulesDocsOptions: OptionsProtocol {
     let path: String?
 
     static func create(_ path: String?) -> RulesDocsOptions {

--- a/Source/swiftlint/Commands/VersionCommand.swift
+++ b/Source/swiftlint/Commands/VersionCommand.swift
@@ -10,7 +10,7 @@ import Commandant
 import Result
 import SwiftLintFramework
 
-struct VersionCommand: CommandProtocol {
+internal struct VersionCommand: CommandProtocol {
     let verb = "version"
     let function = "Display the current version of SwiftLint"
 

--- a/Source/swiftlint/Extensions/Reporter+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Reporter+CommandLine.swift
@@ -19,7 +19,7 @@ extension Reporter {
     }
 }
 
-func reporterFrom(options: LintOptions, configuration: Configuration) -> Reporter.Type {
+internal func reporterFrom(options: LintOptions, configuration: Configuration) -> Reporter.Type {
     let string = options.reporter.isEmpty ? configuration.reporter : options.reporter
     return reporterFrom(identifier: string)
 }

--- a/Source/swiftlint/Helpers/Benchmark.swift
+++ b/Source/swiftlint/Helpers/Benchmark.swift
@@ -9,12 +9,12 @@
 import Foundation
 import SourceKittenFramework
 
-struct BenchmarkEntry {
+internal struct BenchmarkEntry {
     let id: String
     let time: Double
 }
 
-struct Benchmark {
+internal struct Benchmark {
     private let name: String
     private var entries = [BenchmarkEntry]()
 

--- a/Source/swiftlint/Helpers/CommonOptions.swift
+++ b/Source/swiftlint/Helpers/CommonOptions.swift
@@ -9,22 +9,22 @@
 import Commandant
 import SwiftLintFramework
 
-func pathOption(action: String) -> Option<String> {
+internal func pathOption(action: String) -> Option<String> {
     return Option(key: "path",
                   defaultValue: "",
                   usage: "the path to the file or directory to \(action)")
 }
 
-let configOption = Option(key: "config",
+internal let configOption = Option(key: "config",
                           defaultValue: Configuration.fileName,
                           usage: "the path to SwiftLint's configuration file")
 
-let useScriptInputFilesOption = Option(key: "use-script-input-files",
+internal let useScriptInputFilesOption = Option(key: "use-script-input-files",
                                        defaultValue: false,
                                        usage: "read SCRIPT_INPUT_FILE* environment variables " +
                                             "as files")
 
-func quietOption(action: String) -> Option<Bool> {
+internal func quietOption(action: String) -> Option<Bool> {
     return Option(key: "quiet",
                   defaultValue: false,
                   usage: "don't print status logs like '\(action.capitalized) <file>' & " +

--- a/Source/swiftlint/Helpers/CommonOptions.swift
+++ b/Source/swiftlint/Helpers/CommonOptions.swift
@@ -16,12 +16,12 @@ internal func pathOption(action: String) -> Option<String> {
 }
 
 internal let configOption = Option(key: "config",
-                          defaultValue: Configuration.fileName,
-                          usage: "the path to SwiftLint's configuration file")
+                                   defaultValue: Configuration.fileName,
+                                   usage: "the path to SwiftLint's configuration file")
 
 internal let useScriptInputFilesOption = Option(key: "use-script-input-files",
-                                       defaultValue: false,
-                                       usage: "read SCRIPT_INPUT_FILE* environment variables " +
+                                                defaultValue: false,
+                                                usage: "read SCRIPT_INPUT_FILE* environment variables " +
                                             "as files")
 
 internal func quietOption(action: String) -> Option<Bool> {

--- a/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
@@ -9,7 +9,7 @@
 @testable import SwiftLintFramework
 import XCTest
 
-class AttributesRuleTests: XCTestCase {
+internal class AttributesRuleTests: XCTestCase {
 
     func testAttributesWithDefaultConfiguration() {
         // Test with default parameters

--- a/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class ColonRuleTests: XCTestCase {
+internal class ColonRuleTests: XCTestCase {
 
     func testColonWithDefaultConfiguration() {
         // Verify Colon rule with test values for when flexible_right_spacing

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -11,14 +11,14 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-extension Command {
-    fileprivate init?(string: String) {
+private extension Command {
+    init?(string: String) {
         let nsString = string.bridge()
         self.init(string: nsString, range: NSRange(location: 3, length: nsString.length - 4))
     }
 }
 
-class CommandTests: XCTestCase {
+internal class CommandTests: XCTestCase {
 
     // MARK: Command Creation
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -13,8 +13,8 @@ import XCTest
 
 private let optInRules = masterRuleList.list.filter({ $0.1.init() is OptInRule }).map({ $0.0 })
 
-extension Configuration {
-    fileprivate var disabledRules: [String] {
+private extension Configuration {
+    var disabledRules: [String] {
         let configuredRuleIDs = rules.map({ type(of: $0).description.identifier })
         let defaultRuleIDs = Set(masterRuleList.list.values.filter({
             !($0.init() is OptInRule)
@@ -23,7 +23,7 @@ extension Configuration {
     }
 }
 
-class ConfigurationTests: XCTestCase {
+internal class ConfigurationTests: XCTestCase {
 
     func testInit() {
         XCTAssert(Configuration(dict: [:]) != nil,

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-class CustomRulesTests: XCTestCase {
+internal class CustomRulesTests: XCTestCase {
 
     func testCustomRuleConfigurationSetsCorrectly() {
         let configDict = ["my_custom_rule": ["name": "MyCustomRule",

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
@@ -10,7 +10,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-class CyclomaticComplexityConfigurationTests: XCTestCase {
+internal class CyclomaticComplexityConfigurationTests: XCTestCase {
     func testCyclomaticComplexityConfigurationInitializerSetsLevels() {
         let warning = 10
         let error = 30

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftLintFramework
 import XCTest
 
-class CyclomaticComplexityRuleTests: XCTestCase {
+internal class CyclomaticComplexityRuleTests: XCTestCase {
     private lazy var complexSwitchExample: String = {
         var example = "func switcheroo() {\n"
         example += "    switch foo {\n"

--- a/Tests/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import XCTest
 
-class ExtendedNSStringTests: XCTestCase {
+internal class ExtendedNSStringTests: XCTestCase {
 
     func testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters() {
         let contents = "" +

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class FileHeaderRuleTests: XCTestCase {
+internal class FileHeaderRuleTests: XCTestCase {
 
     func testFileHeaderWithDefaultConfiguration() {
         verifyRule(FileHeaderRule.description, skipCommentTests: true)

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -18,7 +18,7 @@ private func violatingFuncWithBody(_ body: String) -> String {
     return funcWithBody(body, violates: true)
 }
 
-class FunctionBodyLengthRuleTests: XCTestCase {
+internal class FunctionBodyLengthRuleTests: XCTestCase {
 
     func testFunctionBodyLengths() {
         let longFunctionBody = funcWithBody(repeatElement("x = 0\n", count: 39).joined())

--- a/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class GenericTypeNameRuleTests: XCTestCase {
+internal class GenericTypeNameRuleTests: XCTestCase {
 
     func testGenericTypeName() {
         verifyRule(GenericTypeNameRule.description)

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class IdentifierNameRuleTests: XCTestCase {
+internal class IdentifierNameRuleTests: XCTestCase {
 
     func testIdentifierName() {
         verifyRule(IdentifierNameRule.description)

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 import XCTest
 
 // swiftlint:disable:next type_name
-class ImplicitlyUnwrappedOptionalConfigurationTests: XCTestCase {
+internal class ImplicitlyUnwrappedOptionalConfigurationTests: XCTestCase {
 
     func testImplicitlyUnwrappedOptionalConfigurationProperlyAppliesConfigurationFromDictionary() throws {
         var configuration = ImplicitlyUnwrappedOptionalConfiguration(mode: .allExceptIBOutlets,

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import SwiftLintFramework
 import XCTest
 
-class ImplicitlyUnwrappedOptionalRuleTests: XCTestCase {
+internal class ImplicitlyUnwrappedOptionalRuleTests: XCTestCase {
 
     func testImplicitlyUnwrappedOptionalRuleDefaultConfiguration() {
         let rule = ImplicitlyUnwrappedOptionalRule()

--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 import SwiftLintFramework
 import XCTest
 
-let config: Configuration = {
+internal let config: Configuration = {
     let directory = #file.bridge()
         .deletingLastPathComponent.bridge()
         .deletingLastPathComponent.bridge()
@@ -20,7 +20,7 @@ let config: Configuration = {
     return Configuration(path: Configuration.fileName)
 }()
 
-class IntegrationTests: XCTestCase {
+internal class IntegrationTests: XCTestCase {
 
     func testSwiftLintLints() {
         // This is as close as we're ever going to get to a self-hosting linter.

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -10,7 +10,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-class LineLengthConfigurationTests: XCTestCase {
+internal class LineLengthConfigurationTests: XCTestCase {
     func testLineLengthConfigurationInitializerSetsLength() {
         let warning = 100
         let error = 150

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -10,7 +10,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-class LineLengthRuleTests: XCTestCase {
+internal class LineLengthRuleTests: XCTestCase {
 
     private let longFunctionDeclaration = "public func superDuperLongFunctionDeclaration(a: String, b: String, " +
         "c: String, d: String, e: String, f: String, g: String, h: String, i: String, " +

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -72,7 +72,7 @@ private class TestFileManager: LintableFileManager {
     }
 }
 
-class LinterCacheTests: XCTestCase {
+internal class LinterCacheTests: XCTestCase {
 
     // MARK: Test Helpers
 

--- a/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class NumberSeparatorRuleTests: XCTestCase {
+internal class NumberSeparatorRuleTests: XCTestCase {
 
     func testNumberSeparatorWithDefaultConfiguration() {
         verifyRule(NumberSeparatorRule.description)

--- a/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class ObjectLiteralRuleTests: XCTestCase {
+internal class ObjectLiteralRuleTests: XCTestCase {
     // MARK: - Instance Properties
     private let imageLiteralTriggeringExamples = ["", ".init"].flatMap { (method: String) -> [String] in
         ["UI", "NS"].flatMap { (prefix: String) -> [String] in

--- a/Tests/SwiftLintFrameworkTests/RegionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RegionTests.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-class RegionTests: XCTestCase {
+internal class RegionTests: XCTestCase {
 
     // MARK: Regions From Files
 

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-class ReporterTests: XCTestCase {
+internal class ReporterTests: XCTestCase {
 
     func testReporterFromString() {
         let reporters: [Reporter.Type] = [

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 // swiftlint:disable type_body_length
 
-class RuleConfigurationsTests: XCTestCase {
+internal class RuleConfigurationsTests: XCTestCase {
     func testNameConfigurationSetsCorrectly() {
         let config = [ "min_length": ["warning": 17, "error": 7],
                        "max_length": ["warning": 170, "error": 700],

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -10,7 +10,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-struct RuleWithLevelsMock: ConfigurationProviderRule {
+internal struct RuleWithLevelsMock: ConfigurationProviderRule {
     var configuration = SeverityLevelsConfiguration(warning: 2, error: 3)
 
     static let description = RuleDescription(identifier: "severity_level_mock",
@@ -21,7 +21,7 @@ struct RuleWithLevelsMock: ConfigurationProviderRule {
     func validate(file: File) -> [StyleViolation] { return [] }
 }
 
-class RuleTests: XCTestCase {
+internal class RuleTests: XCTestCase {
 
     fileprivate struct RuleMock1: Rule {
         init() {}

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -10,7 +10,7 @@ import SwiftLintFramework
 import XCTest
 
 // swiftlint:disable file_length
-class RulesTests: XCTestCase {
+internal class RulesTests: XCTestCase {
 
     func testClassDelegateProtocol() {
         verifyRule(ClassDelegateProtocolRule.description)

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-class SourceKitCrashTests: XCTestCase {
+internal class SourceKitCrashTests: XCTestCase {
 
     func testAssertHandlerIsNotCalledOnNormalFile() {
         let file = File(contents: "A file didn't crash SourceKitService")

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -13,9 +13,9 @@ import XCTest
 
 private let violationMarker = "↓"
 
-let allRuleIdentifiers = Array(masterRuleList.list.keys)
+internal let allRuleIdentifiers = Array(masterRuleList.list.keys)
 
-func violations(_ string: String, config: Configuration = Configuration()) -> [StyleViolation] {
+internal func violations(_ string: String, config: Configuration = Configuration()) -> [StyleViolation] {
     File.clearCaches()
     let stringStrippingMarkers = string.replacingOccurrences(of: violationMarker, with: "")
     let file = File(contents: stringStrippingMarkers)
@@ -65,8 +65,8 @@ private func render(locations: [Location], in contents: String) -> String {
     return (["```"] + contents + ["```"]).joined(separator: "\n")
 }
 
-extension Configuration {
-    fileprivate func assertCorrection(_ before: String, expected: String) {
+private extension Configuration {
+    func assertCorrection(_ before: String, expected: String) {
         guard let path = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(NSUUID().uuidString + ".swift")?.path else {
                 XCTFail("couldn't generate temporary path for assertCorrection()")
@@ -106,8 +106,8 @@ extension Configuration {
     }
 }
 
-extension String {
-    fileprivate func toStringLiteral() -> String {
+private extension String {
+    func toStringLiteral() -> String {
         return "\"" + replacingOccurrences(of: "\n", with: "\\n") + "\""
     }
 }

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class TodoRuleTests: XCTestCase {
+internal class TodoRuleTests: XCTestCase {
 
     func testTodo() {
         verifyRule(TodoRule.description, commentDoesntViolate: false)

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class TrailingCommaRuleTests: XCTestCase {
+internal class TrailingCommaRuleTests: XCTestCase {
 
     func testTrailingCommaRuleWithDefaultConfiguration() {
         // Verify TrailingCommaRule with test values for when mandatory_comma is false (default).

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -9,7 +9,7 @@
 import SwiftLintFramework
 import XCTest
 
-class TypeNameRuleTests: XCTestCase {
+internal class TypeNameRuleTests: XCTestCase {
 
     func testTypeName() {
         verifyRule(TypeNameRule.description)

--- a/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleTests.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import SwiftLintFramework
 import XCTest
 
-class UnusedOptionalBindingRuleTests: XCTestCase {
+internal class UnusedOptionalBindingRuleTests: XCTestCase {
 
     func testDefaultConfiguration() {
         let baseDescription = UnusedOptionalBindingRule.description

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -9,7 +9,7 @@
 @testable import SwiftLintFramework
 import XCTest
 
-class VerticalWhitespaceRuleTests: XCTestCase {
+internal class VerticalWhitespaceRuleTests: XCTestCase {
 
     func testVerticalWhitespaceWithDefaultConfiguration() {
         // Test with default parameters

--- a/Tests/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
+++ b/Tests/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
@@ -11,7 +11,7 @@ import Foundation
 import XCTest
 import Yams
 
-class YamlSwiftLintTests: XCTestCase {
+internal class YamlSwiftLintTests: XCTestCase {
 
     func testFlattenYaml() throws {
         do {

--- a/Tests/SwiftLintFrameworkTests/YamlParserTests.swift
+++ b/Tests/SwiftLintFrameworkTests/YamlParserTests.swift
@@ -9,7 +9,7 @@
 @testable import SwiftLintFramework
 import XCTest
 
-class YamlParserTests: XCTestCase {
+internal class YamlParserTests: XCTestCase {
 
     func testParseEmptyString() {
         XCTAssertEqual((try YamlParser.parse("")).count, 0,


### PR DESCRIPTION
In order to reach the consistency goals of https://github.com/realm/SwiftLint/pull/1543 ;

This PR seeks to Enable :
* `explicit_top_level_acl` 
* `extension_access_modifier`

Complementary PR to the above goals https://github.com/realm/SwiftLint/pull/1489 
* `fileprivate` 
