### PR TITLE
Fixed UnusedClosureParameterRule crash

### DIFF
--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -50,7 +50,8 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
             "[1, 2].something { number, ↓idx in\n return number\n}\n",
             "genericsFunc { (↓number: TypeA, idx: TypeB) in return idx\n}\n",
             "hoge(arg: num) { ↓num in\n" +
-            "}\n"
+            "}\n",
+            "fooFunc { 아 in\n }"
         ],
         corrections: [
             "[1, 2].map { ↓number in\n return 3\n}\n":
@@ -118,7 +119,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
                 return nil
             }
 
-            let paramLength = name.bridge().length
+            let paramLength = name.lengthOfBytes(using: .utf8)
 
             let matches = regex.matches(in: file.contents, options: [], range: range).ranges()
             for range in matches {

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		47ACC89C1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */; };
 		47FF3BE11E7C75B600187E6D /* ImplicitlyUnwrappedOptionalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FF3BDF1E7C745100187E6D /* ImplicitlyUnwrappedOptionalRule.swift */; };
 		4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */; };
+		4AB21F451EE7A23400458D78 /* UnusedClosureParameterRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB21F441EE7A23400458D78 /* UnusedClosureParameterRuleTests.swift */; };
 		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
 		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
 		57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED82791CF65183002B3513 /* JUnitReporter.swift */; };
@@ -338,6 +339,7 @@
 		47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalRuleTests.swift; sourceTree = "<group>"; };
 		47FF3BDF1E7C745100187E6D /* ImplicitlyUnwrappedOptionalRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalRule.swift; sourceTree = "<group>"; };
 		4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLReporter.swift; sourceTree = "<group>"; };
+		4AB21F441EE7A23400458D78 /* UnusedClosureParameterRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedClosureParameterRuleTests.swift; sourceTree = "<group>"; };
 		4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
 		4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
@@ -803,6 +805,7 @@
 				D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */,
 				C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */,
 				3B20CD0B1EB699C20069EF2E /* TypeNameRuleTests.swift */,
+				4AB21F441EE7A23400458D78 /* UnusedClosureParameterRuleTests.swift */,
 				D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */,
 				006204DD1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift */,
 				3B12C9C21C320A53000B423F /* Yaml+SwiftLintTests.swift */,
@@ -1417,6 +1420,7 @@
 				3B12C9C31C320A53000B423F /* Yaml+SwiftLintTests.swift in Sources */,
 				E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */,
 				D4C27C001E12DFF500DF713E /* LinterCacheTests.swift in Sources */,
+				4AB21F451EE7A23400458D78 /* UnusedClosureParameterRuleTests.swift in Sources */,
 				E81ADD721ED5ED9D000CD451 /* RegionTests.swift in Sources */,
 				D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */,
 				47ACC89C1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/UnusedClosureParameterRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedClosureParameterRuleTests.swift
@@ -1,0 +1,26 @@
+//
+//  UnusedClosureParameterRuleTests.swift
+//  SwiftLint
+//
+//  Created by Woosik Byun on 07/06/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+@testable import SwiftLintFramework
+import XCTest
+
+class UnusedClosureParameterRuleTests: XCTestCase {
+
+    func testDefaultConfiguration() {
+        let baseDescription = UnusedClosureParameterRule.description
+        let description = RuleDescription(identifier: baseDescription.identifier,
+                                          name: baseDescription.name,
+                                          description: baseDescription.description,
+                                          nonTriggeringExamples: baseDescription.nonTriggeringExamples,
+                                          triggeringExamples: baseDescription.triggeringExamples,
+                                          corrections: baseDescription.corrections)
+
+        verifyRule(description)
+    }
+}


### PR DESCRIPTION
If closure parameter is unicode, it calculate length 1, but its real length is 3. 
So when running byteRangeToNSRange, it accured crash in String+SourceKitten.swift:131.

<img width="1383" alt="screenshot" src="https://user-images.githubusercontent.com/180553/26868524-3ce9c2d4-4ba4-11e7-985b-625a2f6933b2.png">
