### PR TITLE
Updated AutoCorrectOptions to enable --use-tabs options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@
   [#1309](https://github.com/realm/SwiftLint/issues/1309)
   [#1589](https://github.com/realm/SwiftLint/issues/1589)
 
+* Add `--use-tabs` option to `AutoCorrectOptions`, enabling formatting using
+  tabs over spaces.  
+  [Cody Winton](https://github.com/codytwinton)
+  [#1327](https://github.com/realm/SwiftLint/issues/1327)
+
 ##### Bug Fixes
 
 * Fix false positive on `redundant_discardable_let` rule when using

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -28,7 +28,7 @@ struct AutoCorrectCommand: CommandProtocol {
             }
             if options.format {
                 let formattedContents = linter.file.format(trimmingTrailingWhitespace: true,
-                                                           useTabs: false, indentWidth: 4)
+                                                           useTabs: options.useTabs, indentWidth: 4)
                 _ = try? formattedContents
                     .write(toFile: linter.file.path!, atomically: true, encoding: .utf8)
             }
@@ -49,12 +49,13 @@ struct AutoCorrectOptions: OptionsProtocol {
     let format: Bool
     let cachePath: String
     let ignoreCache: Bool
+    let useTabs: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> AutoCorrectOptions {
-        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in
-            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache)
-        }}}}}}
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
+        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in
+            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
+        }}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
@@ -71,5 +72,8 @@ struct AutoCorrectOptions: OptionsProtocol {
                                usage: "the directory of the cache used when correcting")
             <*> mode <| Option(key: "no-cache", defaultValue: false,
                                usage: "ignore cache when correcting")
+            <*> mode <| Option(key: "use-tabs",
+                               defaultValue: false,
+                               usage: "should use tabs over spaces when reformatting")
     }
 }


### PR DESCRIPTION
This allows for better formatting, using:
```shell
$ swiftlint autocorrect --format --use-tabs
```

This resolves issue: #1327