### PR TITLE
Separating level counting for types and functions in `nesting` rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,21 @@
   [JP Simard](https://github.com/jpsim)
   [#3412](https://github.com/realm/SwiftLint/issues/3412)
 
-* Renamed `statement_level` to `function_level` in `nesting` rule configuration.  
+* Renamed `statement_level` to `function_level` in `nesting` rule
+  configuration.  
   [Skoti](https://github.com/Skoti)
 
-* Separated `type_level` and `function_level` counting in `nesting` rule.  
+* Separated `type_level` and `function_level` counting in `nesting`
+  rule.  
   [Skoti](https://github.com/Skoti)
   [#1151](https://github.com/realm/SwiftLint/issues/1151)
 
 * `function_level` in `nesting` rule defaults to 2 levels.  
   [Skoti](https://github.com/Skoti)
 
-* Added `check_nesting_in_closures_and_statements` in `nesting` rule to search for nested types and functions within closures and statements. Defaults to `true`.  
+* Added `check_nesting_in_closures_and_statements` in `nesting` rule to
+  search for nested types and functions within closures and statements.
+  Defaults to `true`.  
   [Skoti](https://github.com/Skoti)
 
 #### Experimental
@@ -41,6 +45,9 @@
   [Artem Garmash](https://github.com/agarmash)
   [#3286](https://github.com/realm/SwiftLint/issues/3286)
 * Added `always_allow_one_type_in_functions` option in `nesting` rule configuration. Defaults to `false`. This allows to nest one type within a function even if breaking the maximum `type_level`.  
+* Added `always_allow_one_type_in_functions` option in `nesting` rule
+  configuration. Defaults to `false`. This allows to nest one type
+  within a function even if breaking the maximum `type_level`.  
   [Skoti](https://github.com/Skoti)
   [#1151](https://github.com/realm/SwiftLint/issues/1151)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@
   [JP Simard](https://github.com/jpsim)
   [#3412](https://github.com/realm/SwiftLint/issues/3412)
 
+* Renamed `statement_level` to `function_level` in `nesting` rule configuration.  
+  [Skoti](https://github.com/Skoti)
+
+* Separated `type_level` and `function_level` counting in `nesting` rule.  
+  [Skoti](https://github.com/Skoti)
+  [#1151](https://github.com/realm/SwiftLint/issues/1151)
+
+* `function_level` in `nesting` rule defaults to 2 levels.  
+  [Skoti](https://github.com/Skoti)
+
+* Added `check_nesting_in_closures_and_statements` in `nesting` rule to search for nested types and functions within closures and statements. Defaults to `true`.  
+  [Skoti](https://github.com/Skoti)
+
 #### Experimental
 
 * None.
@@ -27,6 +40,9 @@
   `Never`.  
   [Artem Garmash](https://github.com/agarmash)
   [#3286](https://github.com/realm/SwiftLint/issues/3286)
+* Added `always_allow_one_type_in_functions` option in `nesting` rule configuration. Defaults to `false`. This allows to nest one type within a function even if breaking the maximum `type_level`.  
+  [Skoti](https://github.com/Skoti)
+  [#1151](https://github.com/realm/SwiftLint/issues/1151)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
@@ -34,4 +34,12 @@ extension SwiftDeclarationKind {
         .associatedtype,
         .enum
     ]
+
+    internal static let extensionKinds: Set<SwiftDeclarationKind> = [
+        .extension,
+        .extensionClass,
+        .extensionEnum,
+        .extensionProtocol,
+        .extensionStruct
+    ]
 }

--- a/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
@@ -11,16 +11,16 @@ public struct NestingRule: ConfigurationProviderRule {
     public static let description = RuleDescription(
         identifier: "nesting",
         name: "Nesting",
-        description: "Types should be nested at most 1 level deep, " +
-        "and functions should be nested at most 2 levels deep.",
+        description:
+            "Types should be nested at most 1 level deep, and functions should be nested at most 2 levels deep.",
 		kind: .metrics,
 		nonTriggeringExamples: NestingRuleExamples.nonTriggeringExamples,
 		triggeringExamples: NestingRuleExamples.triggeringExamples
     )
 
-    private let omittedStructureKinds: [SwiftStructureKind] =
-        [.declaration(.enumcase), .declaration(.enumelement)]
-        + SwiftDeclarationKind.variableKinds.map { .declaration($0) }
+    private let omittedStructureKinds = SwiftDeclarationKind.variableKinds
+        .union([.enumcase, .enumelement])
+        .map(SwiftStructureKind.declaration)
 
     private struct ValidationArgs {
         var typeLevel: Int = -1
@@ -144,19 +144,6 @@ private enum SwiftStructureKind: Equatable {
             self = .statement(statementKind)
         } else {
             return nil
-        }
-    }
-
-    static func == (lhs: SwiftStructureKind, rhs: SwiftStructureKind) -> Bool {
-        switch (lhs, rhs) {
-        case let (.declaration(lhsKind), .declaration(rhsKind)):
-            return lhsKind == rhsKind
-        case let (.expression(lhsKind), .expression(rhsKind)):
-            return lhsKind == rhsKind
-        case let (.statement(lhsKind), .statement(rhsKind)):
-            return lhsKind == rhsKind
-        default:
-            return false
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
@@ -13,9 +13,9 @@ public struct NestingRule: ConfigurationProviderRule {
         name: "Nesting",
         description:
             "Types should be nested at most 1 level deep, and functions should be nested at most 2 levels deep.",
-		kind: .metrics,
-		nonTriggeringExamples: NestingRuleExamples.nonTriggeringExamples,
-		triggeringExamples: NestingRuleExamples.triggeringExamples
+        kind: .metrics,
+        nonTriggeringExamples: NestingRuleExamples.nonTriggeringExamples,
+        triggeringExamples: NestingRuleExamples.triggeringExamples
     )
 
     private let omittedStructureKinds = SwiftDeclarationKind.variableKinds

--- a/Source/SwiftLintFramework/Rules/Metrics/NestingRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NestingRuleExamples.swift
@@ -1,0 +1,415 @@
+// swiftlint:disable file_length type_body_length
+internal struct NestingRuleExamples {
+    static let nonTriggeringExamples = nonTriggeringTypeExamples
+        + nonTriggeringFunctionExamples
+        + nonTriggeringClosureAndStatementExamples
+        + nonTriggeringMixedExamples
+
+    private static let nonTriggeringTypeExamples =
+        ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                // default maximum type nesting level
+                .init("""
+                    \(type) Example_0 {
+                        \(type) Example_1 {}
+                    }
+                """),
+
+                /*
+                 all variableKinds of SwiftDeclarationKind (except .varParameter which is a function parameter)
+                 are flattend in a file structure so limits do not change
+                */
+                .init("""
+                    var example: Int {
+                        \(type) Example_0 {
+                            \(type) Example_1 {}
+                        }
+                        return 5
+                    }
+                """),
+
+                // didSet is not present in file structure although there is such a swift declaration kind
+                .init("""
+                    var example: Int = 5 {
+                        didSet {
+                            \(type) Example_0 {
+                                \(type) Example_1 {}
+                            }
+                        }
+                    }
+                """),
+
+                // extensions are counted as a type level
+                .init("""
+                    extension Example_0 {
+                        \(type) Example_1 {}
+                    }
+                """)
+            ]
+        }
+
+    private static let nonTriggeringFunctionExamples: [Example] = [
+        // default maximum function nesting level
+        .init("""
+            func f_0() {
+                func f_1() {
+                    func f_2() {}
+                }
+            }
+        """),
+
+        /*
+         all variableKinds of SwiftDeclarationKind (except .varParameter which is a function parameter)
+         are flattend in a file structure so level limits do not change
+        */
+        .init("""
+            var example: Int {
+                func f_0() {
+                    func f_1() {
+                        func f_2() {}
+                    }
+                }
+                return 5
+            }
+        """),
+
+        // didSet is not present in file structure although there is such a swift declaration kind
+        .init("""
+            var example: Int = 5 {
+                didSet {
+                    func f_0() {
+                        func f_1() {
+                            func f_2() {}
+                        }
+                    }
+                }
+            }
+        """),
+
+        // extensions are counted as a type level
+        .init("""
+            extension Example_0 {
+                func f_0() {
+                    func f_1() {
+                        func f_2() {}
+                    }
+                }
+            }
+        """)
+    ]
+
+    private static let nonTriggeringClosureAndStatementExamples =
+        ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                // swich statement example
+                .init("""
+                    switch example {
+                    case .exampleCase:
+                        \(type) Example_0 {
+                            \(type) Example_1 {}
+                        }
+                    default:
+                        func f_0() {
+                            func f_1() {
+                                func f_2() {}
+                            }
+                        }
+                    }
+                """),
+
+                // closure var example
+                .init("""
+                    var exampleClosure: () -> Void = {
+                        \(type) Example_0 {
+                            \(type) Example_1 {}
+                        }
+                        func f_0() {
+                            func f_1() {
+                                func f_2() {}
+                            }
+                        }
+                    }
+                """),
+
+                // function closure parameter example
+                .init("""
+                    exampleFunc(closure: {
+                        \(type) Example_0 {
+                            \(type) Example_1 {}
+                        }
+                        func f_0() {
+                            func f_1() {
+                                func f_2() {}
+                            }
+                        }
+                    })
+                """)
+            ]
+        }
+
+    private static let nonTriggeringMixedExamples =
+        ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                // default maximum nesting level for both type and function (nesting order is arbitrary)
+                .init("""
+                    \(type) Example_0 {
+                        func f_0() {
+                            \(type) Example_1 {
+                                func f_1() {
+                                    func f_2() {}
+                                }
+                            }
+                        }
+                    }
+                """),
+
+                // default maximum nesting level for both type and function within closures and statements
+                .init("""
+                    \(type) Example_0 {
+                        func f_0() {
+                            switch example {
+                            case .exampleCase:
+                                \(type) Example_1 {
+                                    func f_1() {
+                                        func f_2() {}
+                                    }
+                                }
+                            default:
+                                exampleFunc(closure: {
+                                    \(type) Example_1 {
+                                        func f_1() {
+                                            func f_2() {}
+                                        }
+                                    }
+                                })
+                            }
+                        }
+                    }
+                """)
+            ]
+        }
+
+    static let triggeringExamples = triggeringTypeExamples
+        + triggeringFunctionExamples
+        + triggeringClosureAndStatementExamples
+        + triggeringMixedExamples
+
+    private static let triggeringTypeExamples =
+        ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                // violation of default maximum type nesting level
+                .init("""
+                    \(type) Example_0 {
+                        \(type) Example_1 {
+                            ↓\(type) Example_2 {}
+                        }
+                    }
+                """),
+
+                /*
+                 all variableKinds of SwiftDeclarationKind (except .varParameter which is a function parameter)
+                 are flattend in a file structure so limits do not change
+                 */
+                .init("""
+                    var example: Int {
+                        \(type) Example_0 {
+                            \(type) Example_1 {
+                                ↓\(type) Example_2 {}
+                            }
+                        }
+                        return 5
+                    }
+                """),
+
+                // didSet is not present in file structure although there is such a swift declaration kind
+                .init("""
+                    var example: Int = 5 {
+                        didSet {
+                            \(type) Example_0 {
+                                \(type) Example_1 {
+                                    ↓\(type) Example_2 {}
+                                }
+                            }
+                        }
+                    }
+                """),
+
+                // extensions are counted as a type level, violation of default maximum type nesting level
+                .init("""
+                    extension Example_0 {
+                        \(type) Example_1 {
+                            ↓\(type) Example_2 {}
+                        }
+                    }
+                """)
+            ]
+        }
+
+    private static let triggeringFunctionExamples: [Example] = [
+        // violation of default maximum function nesting level
+        .init("""
+            func f_0() {
+                func f_1() {
+                    func f_2() {
+                        ↓func f_3() {}
+                    }
+                }
+            }
+        """),
+
+        /*
+         all variableKinds of SwiftDeclarationKind (except .varParameter which is a function parameter)
+         are flattend in a file structure so level limits do not change
+         */
+        .init("""
+            var example: Int {
+                func f_0() {
+                    func f_1() {
+                        func f_2() {
+                            ↓func f_3() {}
+                        }
+                    }
+                }
+                return 5
+            }
+        """),
+
+        // didSet is not present in file structure although there is such a swift declaration kind
+        .init("""
+            var example: Int = 5 {
+                didSet {
+                    func f_0() {
+                        func f_1() {
+                            func f_2() {
+                                ↓func f_3() {}
+                            }
+                        }
+                    }
+                }
+            }
+        """),
+
+        // extensions are counted as a type level, violation of default maximum function nesting level
+        .init("""
+            extension Example_0 {
+                func f_0() {
+                    func f_1() {
+                        func f_2() {
+                            ↓func f_3() {}
+                        }
+                    }
+                }
+            }
+        """)
+    ]
+
+    private static let triggeringClosureAndStatementExamples =
+        ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                // swich statement example
+                .init("""
+                    switch example {
+                    case .exampleCase:
+                        \(type) Example_0 {
+                            \(type) Example_1 {
+                                ↓\(type) Example_2 {}
+                            }
+                        }
+                    default:
+                        func f_0() {
+                            func f_1() {
+                                func f_2() {
+                                    ↓func f_3() {}
+                                }
+                            }
+                        }
+                    }
+                """),
+
+                // closure var example
+                .init("""
+                    var exampleClosure: () -> Void = {
+                        \(type) Example_0 {
+                            \(type) Example_1 {
+                                ↓\(type) Example_2 {}
+                            }
+                            }
+                        func f_0() {
+                            func f_1() {
+                                func f_2() {
+                                    ↓func f_3() {}
+                                }
+                            }
+                        }
+                    }
+                """),
+
+                // function closure parameter example
+                .init("""
+                    exampleFunc(closure: {
+                        \(type) Example_0 {
+                            \(type) Example_1 {}
+                        }
+                        func f_0() {
+                            func f_1() {
+                                func f_2() {
+                                    ↓func f_3() {}
+                                }
+                            }
+                        }
+                    })
+                """)
+            ]
+        }
+
+    private static let triggeringMixedExamples =
+        ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                // violation of default maximum nesting level for both type and function (nesting order is arbitrary)
+                .init("""
+                    \(type) Example_0 {
+                        func f_0() {
+                            \(type) Example_1 {
+                                func f_1() {
+                                    func f_2() {
+                                        ↓\(type) Example_2 {}
+                                        ↓func f_3() {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                """),
+
+                // violation of default maximum nesting level for both type and function within closures and statements
+                .init("""
+                    \(type) Example_0 {
+                        func f_0() {
+                            switch example {
+                            case .exampleCase:
+                                \(type) Example_1 {
+                                    func f_1() {
+                                        func f_2() {
+                                            ↓\(type) Example_2 {}
+                                            ↓func f_3() {}
+                                        }
+                                    }
+                                }
+                            default:
+                                exampleFunc(closure: {
+                                    \(type) Example_1 {
+                                        func f_1() {
+                                            func f_2() {
+                                                ↓\(type) Example_2 {}
+                                                ↓func f_3() {}
+                                            }
+                                        }
+                                    }
+                                })
+                            }
+                        }
+                    }
+                """)
+            ]
+        }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -1,18 +1,26 @@
 public struct NestingConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
-        return "(type_level) \(typeLevel.shortConsoleDescription), " +
-            "(statement_level) \(statementLevel.shortConsoleDescription)"
+        return "(type_level) \(typeLevel.shortConsoleDescription)"
+            + ", (function_level) \(functionLevel.shortConsoleDescription)"
+            + ", (check_nesting_in_closures_and_statements) \(checkNestingInClosuresAndStatements)"
+            + ", (always_allow_one_type_in_functions) \(alwaysAllowOneTypeInFunctions)"
     }
 
     var typeLevel: SeverityLevelsConfiguration
-    var statementLevel: SeverityLevelsConfiguration
+    var functionLevel: SeverityLevelsConfiguration
+    var checkNestingInClosuresAndStatements: Bool
+    var alwaysAllowOneTypeInFunctions: Bool
 
     public init(typeLevelWarning: Int,
                 typeLevelError: Int?,
-                statementLevelWarning: Int,
-                statementLevelError: Int?) {
-        typeLevel = SeverityLevelsConfiguration(warning: typeLevelWarning, error: typeLevelError)
-        statementLevel = SeverityLevelsConfiguration(warning: statementLevelWarning, error: statementLevelError)
+                functionLevelWarning: Int,
+                functionLevelError: Int?,
+                checkNestingInClosuresAndStatements: Bool = true,
+                alwaysAllowOneTypeInFunctions: Bool = false) {
+        self.typeLevel = SeverityLevelsConfiguration(warning: typeLevelWarning, error: typeLevelError)
+        self.functionLevel = SeverityLevelsConfiguration(warning: functionLevelWarning, error: functionLevelError)
+        self.checkNestingInClosuresAndStatements = checkNestingInClosuresAndStatements
+        self.alwaysAllowOneTypeInFunctions = alwaysAllowOneTypeInFunctions
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -23,9 +31,12 @@ public struct NestingConfiguration: RuleConfiguration, Equatable {
         if let typeLevelConfiguration = configurationDict["type_level"] {
             try typeLevel.apply(configuration: typeLevelConfiguration)
         }
-        if let statementLevelConfiguration = configurationDict["statement_level"] {
-            try statementLevel.apply(configuration: statementLevelConfiguration)
+        if let functionLevelConfiguration = configurationDict["function_level"] {
+            try functionLevel.apply(configuration: functionLevelConfiguration)
         }
+        // swiftlint:disable:next line_length
+        checkNestingInClosuresAndStatements = configurationDict["check_nesting_in_closures_and_statements"] as? Bool ?? true
+        alwaysAllowOneTypeInFunctions = configurationDict["always_allow_one_type_in_functions"] as? Bool ?? false
     }
 
     func severity(with config: SeverityLevelsConfiguration, for level: Int) -> ViolationSeverity? {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -33,6 +33,14 @@ public struct NestingConfiguration: RuleConfiguration, Equatable {
         }
         if let functionLevelConfiguration = configurationDict["function_level"] {
             try functionLevel.apply(configuration: functionLevelConfiguration)
+        } else if let statementLevelConfiguration = configurationDict["statement_level"] {
+            queuedPrintError(
+                """
+                'statement_level' has been renamed to 'function_level' and will be completely removed in a future \
+                release.
+                """
+            )
+            try functionLevel.apply(configuration: statementLevelConfiguration)
         }
         checkNestingInClosuresAndStatements =
             configurationDict["check_nesting_in_closures_and_statements"] as? Bool ?? true

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -34,9 +34,10 @@ public struct NestingConfiguration: RuleConfiguration, Equatable {
         if let functionLevelConfiguration = configurationDict["function_level"] {
             try functionLevel.apply(configuration: functionLevelConfiguration)
         }
-        // swiftlint:disable:next line_length
-        checkNestingInClosuresAndStatements = configurationDict["check_nesting_in_closures_and_statements"] as? Bool ?? true
-        alwaysAllowOneTypeInFunctions = configurationDict["always_allow_one_type_in_functions"] as? Bool ?? false
+        checkNestingInClosuresAndStatements =
+            configurationDict["check_nesting_in_closures_and_statements"] as? Bool ?? true
+        alwaysAllowOneTypeInFunctions =
+            configurationDict["always_allow_one_type_in_functions"] as? Bool ?? false
     }
 
     func severity(with config: SeverityLevelsConfiguration, for level: Int) -> ViolationSeverity? {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1011,7 +1011,9 @@ extension NSObjectPreferIsEqualRuleTests {
 
 extension NestingRuleTests {
     static var allTests: [(String, (NestingRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testNestingWithDefaultConfiguration", testNestingWithDefaultConfiguration),
+        ("testNestingWithAlwaysAllowOneTypeInFunctions", testNestingWithAlwaysAllowOneTypeInFunctions),
+        ("testNestingWithoutCheckNestingInClosuresAndStatements", testNestingWithoutCheckNestingInClosuresAndStatements)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -432,12 +432,6 @@ class NSObjectPreferIsEqualRuleTests: XCTestCase {
     }
 }
 
-class NestingRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(NestingRule.description)
-    }
-}
-
 class NimbleOperatorRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NimbleOperatorRule.description)

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -1,8 +1,6 @@
 @testable import SwiftLintFramework
 import XCTest
 
-// swiftlint:disable nesting
-
 class CollectingRuleTests: XCTestCase {
     func testCollectsIntoStorage() {
         struct Spec: MockCollectingRule {

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -1,0 +1,377 @@
+import SwiftLintFramework
+import XCTest
+
+// swiftlint:disable:next type_body_length
+class NestingRuleTests: XCTestCase {
+    func testNestingWithDefaultConfiguration() {
+        verifyRule(NestingRule.description)
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testNestingWithAlwaysAllowOneTypeInFunctions() {
+        var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples
+        nonTriggeringExamples.append(contentsOf: ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                .init("""
+                    \(type) Example_0 {
+                        \(type) Example_1 {
+                            func f_0() {
+                                \(type) Example_2 {}
+                            }
+                        }
+                    }
+                """),
+
+                .init("""
+                    \(type) Example_0 {
+                        \(type) Example_1 {
+                            func f_0() {
+                                \(type) Example_2 {
+                                    func f_1() {
+                                        \(type) Example_3 {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                """),
+
+                .init("""
+                    func f_0() {
+                        \(type) Example_0 {
+                            \(type) Example_1 {}
+                        }
+                    }
+                """)
+            ]
+        })
+        nonTriggeringExamples.append(contentsOf: ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                .init("""
+                    exampleFunc(closure: {
+                        \(type) Example_0 {
+                            \(type) Example_1 {
+                                func f_0() {
+                                   \(type) Example_2 {}
+                               }
+                           }
+                       }
+                       func f_0() {
+                           \(type) Example_0 {
+                               func f_1() {
+                                   \(type) Example_1 {
+                                       func f_2() {
+                                           \(type) Example_2 {}
+                                       }
+                                   }
+                               }
+                           }
+                       }
+                    })
+                """),
+
+                .init("""
+                    switch example {
+                    case .exampleCase:
+                       \(type) Example_0 {
+                           \(type) Example_1 {
+                               func f_0() {
+                                   \(type) Example_2 {}
+                               }
+                           }
+                       }
+                    default:
+                       func f_0() {
+                           \(type) Example_0 {
+                               func f_1() {
+                                   \(type) Example_1 {
+                                       func f_2() {
+                                           \(type) Example_2 {}
+                                       }
+                                   }
+                               }
+                           }
+                       }
+                    }
+                """)
+            ]
+        })
+
+        var triggeringExamples = ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                .init("""
+                    \(type) Example_0 {
+                       \(type) Example_1 {
+                           func f_0() {
+                               \(type) Example_2 {
+                                   ↓\(type) Example_3 {}
+                               }
+                           }
+                       }
+                    }
+                """),
+
+                .init("""
+                    \(type) Example_0 {
+                       \(type) Example_1 {
+                           func f_0() {
+                               \(type) Example_2 {
+                                   func f_1() {
+                                       \(type) Example_3 {
+                                           ↓\(type) Example_4 {}
+                                       }
+                                   }
+                               }
+                           }
+                       }
+                    }
+                """),
+
+                .init("""
+                    func f_0() {
+                       \(type) Example_0 {
+                           \(type) Example_1 {
+                               ↓\(type) Example_2 {}
+                           }
+                       }
+                    }
+                """)
+            ]
+        }
+
+        triggeringExamples.append(contentsOf: ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                .init("""
+                    exampleFunc(closure: {
+                       \(type) Example_0 {
+                           \(type) Example_1 {
+                               func f_0() {
+                                   \(type) Example_2 {
+                                       ↓\(type) Example_3 {}
+                                   }
+                               }
+                           }
+                       }
+                       func f_0() {
+                           \(type) Example_0 {
+                               func f_1() {
+                                   \(type) Example_1 {
+                                       func f_2() {
+                                           \(type) Example_2 {
+                                               ↓\(type) Example_3 {}
+                                           }
+                                       }
+                                   }
+                               }
+                           }
+                       }
+                    })
+                """),
+
+                .init("""
+                    switch example {
+                    case .exampleCase:
+                       \(type) Example_0 {
+                           \(type) Example_1 {
+                               func f_0() {
+                                   \(type) Example_2 {
+                                       ↓\(type) Example_3 {}
+                                   }
+                               }
+                           }
+                       }
+                    default:
+                       func f_0() {
+                           \(type) Example_0 {
+                               func f_1() {
+                                   \(type) Example_1 {
+                                       func f_2() {
+                                           \(type) Example_2 {
+                                               ↓\(type) Example_3 {}
+                                           }
+                                       }
+                                   }
+                               }
+                           }
+                       }
+                    }
+                """)
+            ]
+        })
+
+        let description = RuleDescription(
+            identifier: NestingRule.description.identifier,
+            name: NestingRule.description.name,
+            description: NestingRule.description.description,
+            kind: .metrics,
+            nonTriggeringExamples: nonTriggeringExamples,
+            triggeringExamples: triggeringExamples
+        )
+
+        verifyRule(description, ruleConfiguration: ["always_allow_one_type_in_functions": true])
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testNestingWithoutCheckNestingInClosuresAndStatements() {
+        var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples
+        nonTriggeringExamples.append(contentsOf: ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                .init("""
+                    exampleFunc(closure: {
+                       \(type) Example_0 {
+                           \(type) Example_1 {
+                               \(type) Example_2 {}
+                           }
+                       }
+                       func f_0() {
+                           func f_1() {
+                               func f_2() {
+                                   func f_3() {}
+                               }
+                           }
+                       }
+                    })
+                """),
+
+                .init("""
+                    switch example {
+                    case .exampleCase:
+                       \(type) Example_0 {
+                           \(type) Example_1 {
+                               \(type) Example 2 {}
+                           }
+                       }
+                    default:
+                       func f_0() {
+                           func f_1() {
+                               func f_2() {
+                                   func f_3() {}
+                               }
+                           }
+                       }
+                    }
+                """)
+            ]
+        })
+
+        var triggeringExamples = ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                .init("""
+                    \(type) Example_0 {
+                        \(type) Example_1 {
+                            ↓\(type) Example_2 {}
+                        }
+                    }
+                """),
+
+                .init("""
+                    var example: Int {
+                       \(type) Example_0 {
+                           \(type) Example_1 {
+                               ↓\(type) Example_2 {}
+                           }
+                       }
+                       return 5
+                    }
+                """),
+
+                .init("""
+                    var example: Int = 5 {
+                       didSet {
+                           \(type) Example_0 {
+                               \(type) Example_1 {
+                                   ↓\(type) Example_2 {}
+                               }
+                           }
+                       }
+                    }
+                """),
+
+                .init("""
+                    extension Example_0 {
+                       \(type) Example_1 {
+                           ↓\(type) Example_2 {}
+                       }
+                    }
+                """),
+
+                .init("""
+                    \(type) Example_0 {
+                       func f_0() {
+                           \(type) Example_1 {
+                               func f_1() {
+                                   func f_2() {
+                                       ↓\(type) Example_2 {}
+                                       ↓func f_3() {}
+                                   }
+                               }
+                           }
+                       }
+                    }
+                """)
+            ]
+        }
+
+        triggeringExamples.append(contentsOf: [
+            .init("""
+                func f_0() {
+                   func f_1() {
+                       func f_2() {
+                           ↓func f_3() {}
+                       }
+                   }
+                }
+            """),
+
+            .init("""
+                var example: Int {
+                   func f_0() {
+                       func f_1() {
+                           func f_2() {
+                               ↓func f_3() {}
+                           }
+                       }
+                   }
+                   return 5
+                }
+            """),
+
+            .init("""
+                var example: Int = 5 {
+                   didSet {
+                       func f_0() {
+                           func f_1() {
+                               func f_2() {
+                                   ↓func f_3() {}
+                               }
+                           }
+                       }
+                   }
+                }
+            """),
+
+            .init("""
+                extension Example_0 {
+                   func f_0() {
+                       func f_1() {
+                           func f_2() {
+                               ↓func f_3() {}
+                           }
+                       }
+                   }
+                }
+            """)
+        ])
+
+        let description = RuleDescription(
+            identifier: NestingRule.description.identifier,
+            name: NestingRule.description.name,
+            description: NestingRule.description.description,
+            kind: .metrics,
+            nonTriggeringExamples: nonTriggeringExamples,
+            triggeringExamples: triggeringExamples
+        )
+
+        verifyRule(description, ruleConfiguration: ["check_nesting_in_closures_and_statements": false])
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -70,20 +70,24 @@ class RuleConfigurationTests: XCTestCase {
             "type_level": [
                 "warning": 7, "error": 17
             ],
-            "statement_level": [
+            "function_level": [
                 "warning": 8, "error": 18
-            ]
+            ],
+            "check_nesting_in_closures_and_statements": false,
+            "always_allow_one_type_in_functions": true
         ] as [String: Any]
         var nestingConfig = NestingConfiguration(typeLevelWarning: 0,
                                                  typeLevelError: nil,
-                                                 statementLevelWarning: 0,
-                                                 statementLevelError: nil)
+                                                 functionLevelWarning: 0,
+                                                 functionLevelError: nil)
         do {
             try nestingConfig.apply(configuration: config)
             XCTAssertEqual(nestingConfig.typeLevel.warning, 7)
-            XCTAssertEqual(nestingConfig.statementLevel.warning, 8)
+            XCTAssertEqual(nestingConfig.functionLevel.warning, 8)
             XCTAssertEqual(nestingConfig.typeLevel.error, 17)
-            XCTAssertEqual(nestingConfig.statementLevel.error, 18)
+            XCTAssertEqual(nestingConfig.functionLevel.error, 18)
+            XCTAssert(nestingConfig.alwaysAllowOneTypeInFunctions)
+            XCTAssert(!nestingConfig.checkNestingInClosuresAndStatements)
         } catch {
             XCTFail("Failed to configure nested configurations")
         }
@@ -93,8 +97,8 @@ class RuleConfigurationTests: XCTestCase {
         let config = 17
         var nestingConfig = NestingConfiguration(typeLevelWarning: 0,
                                                  typeLevelError: nil,
-                                                 statementLevelWarning: 0,
-                                                 statementLevelError: nil)
+                                                 functionLevelWarning: 0,
+                                                 functionLevelError: nil)
         checkError(ConfigurationError.unknownConfiguration) {
             try nestingConfig.apply(configuration: config)
         }


### PR DESCRIPTION
1. Separated nesting level counting for types and functions in `nesting` rule (fixes #1151).
2. Enhanced `nesting` rule to search for nested types and functions within closures and statements.
3. Enhanced `nesting` rule to allow for one nested type within a function even if breaking a maximum type level nesting (fixes #1151).

**-> 1**
The previous implementation used one nesting level counter for both types and functions which was producing inconsistent and unexpected behaviours like:
- This was ok (1 nested type):
```
class Example_0 {
    class Example_1 {}
}
```
- This was an error (with default configuration - type is nested at level 2 instead of maximum 1), even though there is only one type (should be type level: 0):
```
func f_0() {
    func f_1() {
        class Example_0 {}
    }
}
```
So if `statement_level` was set to i.e. 0 (no function nesting) then only free global functions could have been written (due to any `type` being counted as a nesting level for functions), so these two level settings could be set to be mutually excluding.

The new implementation counts types and functions separately, so it only matters how many types is nested, no matter if there were some functions in between. The same goes for functions.
This also allows to lower the maximum function level from the default 5 to 2. The previous implementatin must have taken into account the possible first type/extension and the second type.

In the previous implementation `function_level` was called `statement_level` although in `SwiftDeclarationKind` there is no statement cases, so I renamed it to `function_level` to be more appropriate to what it does.

**-> 2**
The previous implementation did not cover searching for nested types and functions within closures and statements (like switch, for, etc.).
This is a new configuration option called `check_nesting_in_closures_and_statements` and it is turned on by default.

**-> 3**
I've also added another configuration option called `always_allow_one_type_in_functions` if one wants to keep the type nesting level constraint, but still be able to declare a type within a function even if breaking the maximum type nesting level. Such type is only accessible in that function so it makes sense to allow for it if needed.
Still the nesting tree is constrained by the maximum function nesting level.
This defaults to false.