### PR TITLE
Add support for optional 'error' severity level in configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   should be separated from other statements by a single blank line.  
   [Uncommon](https://github.com/Uncommon)
 
+* Add support for optional `error` severity level configuration.  
+  [Jamie Edge](https://github.com/JamieEdge)
+  [#1647](https://github.com/realm/SwiftLint/issues/1647)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -41,10 +41,13 @@ public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {
         if let configurationArray = [Int].array(of: configuration), !configurationArray.isEmpty {
             warning = configurationArray[0]
             error = (configurationArray.count > 1) ? configurationArray[1] : nil
-        } else if let configDict = configuration as? [String: Int],
-            !configDict.isEmpty && Set(configDict.keys).isSubset(of: ["warning", "error"]) {
-            warning = configDict["warning"] ?? warning
-            error = configDict["error"]
+        } else if let configDict = configuration as? [String: Any?],
+            !configDict.isEmpty &&
+                Set(configDict.keys).isSubset(of: ["warning", "error"]) &&
+                (configDict["warning"] == nil || configDict["warning"] is Int) &&
+                (configDict["error"] == nil || configDict["error"] is Int || configDict["error"] is NSNull) {
+            warning = (configDict["warning"] as? Int) ?? warning
+            error = configDict["error"] as? Int
         } else {
             throw ConfigurationError.unknownConfiguration
         }


### PR DESCRIPTION
Addresses https://github.com/realm/SwiftLint/issues/1647 and adds validation, so if an invalid value type (e.g. string) is provided in the config, this will now error.