### PR TITLE
prevent invalid ranges from being formed in LetVarWhitespaceRule

### DIFF
--- a/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
@@ -159,13 +159,15 @@ public struct LetVarWhitespaceRule: OptInRule {
             let startLine = file.line(for: token.offset, startFrom: 0)
             let endLine = file.line(for: token.offset + token.length, startFrom: startLine)
 
-            result.formUnion(Set(startLine...endLine))
+            if startLine <= endLine {
+                result.formUnion(Set(startLine...endLine))
+            }
         }
 
         let conditionals = ["#if", "#elseif", "#else", "#endif", "@available"]
         let conditionalLines = file.lines.filter {
             let trimmed = $0.content.trimmingCharacters(in: .whitespaces)
-            return conditionals.contains(where: { trimmed.hasPrefix($0) })
+            return conditionals.contains(where: trimmed.hasPrefix)
         }
 
         result.formUnion(conditionalLines.map { $0.index - 1 })


### PR DESCRIPTION
fixes #1670