### PR TITLE
Add support for merging nested configuration with parent configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Xcode 8.3 or later and Swift 3.1 or later are required to build.  
   [Norio Nomura](https://github.com/norio-nomura)
+  
+* Nested configurations will now be merged with parent configurations, rather than replace them.  
+  [Stéphane Copin](https://github.com/stephanecopin/)
 
 ##### Enhancements
 
@@ -33,6 +36,10 @@
 * Improve performance when linting and correcting on Linux, matching behavior.  
   [JP Simard](https://github.com/jpsim)
   [#1577](https://github.com/realm/SwiftLint/issues/1577)
+  
+* Add support for merging nested configurations with parent configurations.  
+  [Stéphane Copin](https://github.com/stephanecopin/)
+  [#676](https://github.com/realm/SwiftLint/issues/676)
 
 ##### Bug Fixes
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -178,7 +178,16 @@ class ConfigurationTests: XCTestCase {
     // MARK: - Testing Nested Configurations
 
     func testMerge() {
-        XCTAssertEqual(projectMockConfig0.merge(with: projectMockConfig2), projectMockConfig2)
+        XCTAssertFalse(projectMockConfig0.rules.contains(where: { $0 is ForceCastRule }))
+        XCTAssertTrue(projectMockConfig2.rules.contains(where: { $0 is ForceCastRule }))
+        let config0Merge2 = projectMockConfig0.merge(with: projectMockConfig2)
+        XCTAssertFalse(config0Merge2.rules.contains(where: { $0 is ForceCastRule }))
+        XCTAssertTrue(projectMockConfig0.rules.contains(where: { $0 is TodoRule }))
+        XCTAssertTrue(projectMockConfig2.rules.contains(where: { $0 is TodoRule }))
+        XCTAssertTrue(config0Merge2.rules.contains(where: { $0 is TodoRule }))
+        XCTAssertFalse(projectMockConfig3.rules.contains(where: { $0 is TodoRule }))
+        XCTAssertFalse(config0Merge2.merge(with: projectMockConfig3)
+            .rules.contains(where: { $0 is TodoRule }))
     }
 
     func testLevel0() {
@@ -202,8 +211,8 @@ class ConfigurationTests: XCTestCase {
     }
 
     func testNestedConfigurationWithCustomRootPath() {
-        XCTAssertEqual(projectMockConfig3,
-                       projectMockConfig0.merge(with: projectMockConfig3))
+        XCTAssertNotEqual(projectMockConfig0.rootPath, projectMockConfig3.rootPath)
+        XCTAssertEqual(projectMockConfig0.merge(with: projectMockConfig3).rootPath, projectMockConfig3.rootPath)
     }
 
     // MARK: - Testing Custom Configuration File


### PR DESCRIPTION
This is an implementation of merging nested `Configuration`, based on the existing codebase (#676)

When creating a merged `Configuration`, the rule are:
For the parameters:
- Use the `included` and `excluded` folders of the nested configuration (with the `rootPath` of the nested configuration)
- Use the minimum warning threshold between the parent and the nested configuration. If just one or the other is present, use that one, otherwise just set it to `nil`
- Use the parent `reporter`
- Use the parent `cachePath`

For the rules:
- Nested configurations may specify rules they want to enable using `opt_in_rules`. Any rules specified under `opt_in_rules` in the nested .swiftlint.yml *will* be enabled.
- Nested configurations may specifically disable rules using `disable_rules`, in the same manner as described above.
- Nested configurations may also specify `whitelist_rules`, in which case only these rules will be enabled, and all others disabled.
- If a rule is both present in the parent and the nested configuration, the nested configuration wins.

There is room for improvements, as I just used the existing `internal func merge(with configuration: Configuration) -> Configuration` method to implement the changes.
There should also be a way to override just part of a rule's configuration (rather than the whole configuration), but that requires deeper changes for a very specific use case, so it's not done in this PR.

I'll be adding some unit tests while this is being reviewed.

Let me know what you think!