### PR TITLE
Add unneeded_parentheses_in_closure_argument rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,6 +23,7 @@ opt_in_rules:
   - fatal_error_message
   - vertical_parameter_alignment_on_call
   - let_var_whitespace
+  - unneeded_parentheses_in_closure_argument
 
 file_header:
   required_pattern: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,8 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1647](https://github.com/realm/SwiftLint/issues/1647)
 
-* Add `unneeded_parentheses_in_closure_argument` correctable rule that warns
-  against using parentheses around argument declarations in closures.  
+* Add `unneeded_parentheses_in_closure_argument` opt-in correctable rule that
+  warns against using parentheses around argument declarations in closures.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1483](https://github.com/realm/SwiftLint/issues/1483)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
   [Jamie Edge](https://github.com/JamieEdge)
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1647](https://github.com/realm/SwiftLint/issues/1647)
+
 * Add `unneeded_parentheses_in_closure_argument` correctable rule that warns
   against using parentheses around argument declarations in closures.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@
   [Jamie Edge](https://github.com/JamieEdge)
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1647](https://github.com/realm/SwiftLint/issues/1647)
+* Add `unneeded_parentheses_in_closure_argument` correctable rule that warns
+  against using parentheses around argument declarations in closures.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1483](https://github.com/realm/SwiftLint/issues/1483)
 
 ##### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -83,6 +83,7 @@
 * [Trailing Whitespace](#trailing-whitespace)
 * [Type Body Length](#type-body-length)
 * [Type Name](#type-name)
+* [Unneeded Parentheses in Closure Argument](#unneeded-parentheses-in-closure-argument)
 * [Unused Closure Parameter](#unused-closure-parameter)
 * [Unused Enumerated](#unused-enumerated)
 * [Unused Optional Binding](#unused-optional-binding)
@@ -12130,6 +12131,52 @@ protocol Foo {
 protocol Foo {
  associatedtype ↓AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  }
+```
+
+</details>
+
+
+
+## Unneeded Parentheses in Closure Argument
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`unneeded_parentheses_in_closure_argument` | Enabled | Yes | style
+
+Parentheses are not needed when declaring closure arguments.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+let foo = { (bar: Int) in }
+
+```
+
+```swift
+let foo = { bar in }
+
+```
+
+```swift
+let foo = { bar -> Bool in return true }
+
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+call(arg: { ↓(bar) in })
+
+```
+
+```swift
+let foo = { ↓(bar) -> Bool in return true }
+
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -12141,7 +12141,7 @@ protocol Foo {
 
 Identifier | Enabled by default | Supports autocorrection | Kind 
 --- | --- | --- | ---
-`unneeded_parentheses_in_closure_argument` | Enabled | Yes | style
+`unneeded_parentheses_in_closure_argument` | Disabled | Yes | style
 
 Parentheses are not needed when declaring closure arguments.
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -91,6 +91,7 @@ public let masterRuleList = RuleList(rules: [
     TrailingWhitespaceRule.self,
     TypeBodyLengthRule.self,
     TypeNameRule.self,
+    UnneededParenthesesInClosureArgumentRule.self,
     UnusedClosureParameterRule.self,
     UnusedEnumeratedRule.self,
     UnusedOptionalBindingRule.self,

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -156,7 +156,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         }
         let allAttributes = previousAttributes + attributesTokensWithParameters
 
-        return Set(allAttributes.flatMap { (token, hasParameter) -> String? in
+        return Set(allAttributes.flatMap { token, hasParameter -> String? in
             // an attribute should be on a new line if one of these is true:
             // 1. it's a parameterized attribute
             //      a. the parameter is on the token (i.e. warn_unused_result)

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -78,7 +78,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
 
     private func validateGenericTypeAliases(in file: File) -> [StyleViolation] {
         let pattern = "typealias\\s+\\w+?\\s*" + genericTypePattern + "\\s*="
-        return file.match(pattern: pattern).flatMap { (range, tokens) -> [(String, Int)] in
+        return file.match(pattern: pattern).flatMap { range, tokens -> [(String, Int)] in
             guard tokens.first == .keyword,
                 Set(tokens.dropFirst()) == [.identifier],
                 let match = genericTypeRegex.firstMatch(in: file.contents, options: [],
@@ -149,7 +149,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         let contents = file.contents.bridge()
-        return namesAndRanges.flatMap { (name, range) -> (String, Int)? in
+        return namesAndRanges.flatMap { name, range -> (String, Int)? in
             guard let byteRange = contents.NSRangeToByteRange(start: range.location + offset,
                                                               length: range.length),
                 file.syntaxMap.kinds(inByteRange: byteRange) == [.identifier] else {

--- a/Source/SwiftLintFramework/Rules/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnneededParenthesesInClosureArgumentRule.swift
@@ -1,0 +1,96 @@
+//
+//  UnneededParenthesesInClosureArgumentRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 07/17/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import Foundation
+import SourceKittenFramework
+
+public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, CorrectableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "unneeded_parentheses_in_closure_argument",
+        name: "Unneeded Parentheses in Closure Argument",
+        description: "Parentheses are not needed when declaring closure arguments.",
+        kind: .style,
+        nonTriggeringExamples: [
+            "let foo = { (bar: Int) in }\n",
+            "let foo = { bar in }\n",
+            "let foo = { bar -> Bool in return true }\n"
+        ],
+        triggeringExamples: [
+            "call(arg: { ↓(bar) in })\n",
+            "let foo = { ↓(bar) -> Bool in return true }\n"
+        ],
+        corrections: [
+            "call(arg: { ↓(bar) in })\n": "call(arg: { bar in })\n",
+            "let foo = { ↓(bar) -> Bool in return true }\n": "let foo = { bar -> Bool in return true }\n",
+            "method { ↓(foo, bar) in }\n": "method { foo, bar in }\n"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        return violationRanges(file: file).map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+
+    private func violationRanges(file: File) -> [NSRange] {
+        let pattern = "\\{\\s*(\\([^:]+\\))\\s*(in|->)"
+        let contents = file.contents.bridge()
+        let range = NSRange(location: 0, length: contents.length)
+        return regex(pattern).matches(in: file.contents, options: [], range: range).flatMap { match -> NSRange? in
+            let parametersRange = match.range(at: 1)
+            let inRange = match.range(at: 2)
+            guard let parametersByteRange = contents.NSRangeToByteRange(start: parametersRange.location,
+                                                                        length: parametersRange.length),
+                let inByteRange = contents.NSRangeToByteRange(start: inRange.location,
+                                                              length: inRange.length) else {
+                    return nil
+            }
+
+            let parametersKinds = Set(file.syntaxMap.kinds(inByteRange: parametersByteRange))
+            let inKinds = Set(file.syntaxMap.kinds(inByteRange: inByteRange))
+            guard parametersKinds == [.identifier],
+                inKinds.isEmpty || inKinds == [.keyword] else {
+                    return nil
+            }
+
+            return parametersRange
+        }
+    }
+
+    public func correct(file: File) -> [Correction] {
+        let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(file: file), for: self)
+        var correctedContents = file.contents
+        var adjustedLocations = [Int]()
+
+        for violatingRange in violatingRanges.reversed() {
+            let correctingRange = NSRange(location: violatingRange.location + 1,
+                                          length: violatingRange.length - 2)
+            if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange),
+                let updatedRange = correctedContents.nsrangeToIndexRange(correctingRange) {
+                let updatedArguments = correctedContents.substring(with: updatedRange)
+                correctedContents = correctedContents.replacingCharacters(in: indexRange, with: updatedArguments)
+                adjustedLocations.insert(violatingRange.location, at: 0)
+            }
+        }
+
+        file.write(correctedContents)
+
+        return adjustedLocations.map {
+            Correction(ruleDescription: type(of: self).description,
+                       location: Location(file: file, characterOffset: $0))
+        }
+    }
+
+}

--- a/Source/SwiftLintFramework/Rules/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnneededParenthesesInClosureArgumentRule.swift
@@ -10,7 +10,7 @@ import Foundation
 import Foundation
 import SourceKittenFramework
 
-public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, CorrectableRule {
+public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, CorrectableRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		D45255C81F0932F8003C9B56 /* RuleDescription+Examples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45255C71F0932F8003C9B56 /* RuleDescription+Examples.swift */; };
 		D462021F1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */; };
 		D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */; };
+		D46A317F1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46A317E1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift */; };
 		D46E041D1DE3712C00728374 /* TrailingCommaRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */; };
 		D47079A71DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */; };
 		D47079A91DFDBED000027086 /* ClosureParameterPositionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */; };
@@ -447,6 +448,7 @@
 		D45255C71F0932F8003C9B56 /* RuleDescription+Examples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RuleDescription+Examples.swift"; sourceTree = "<group>"; };
 		D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleExamples.swift; sourceTree = "<group>"; };
 		D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRule.swift; sourceTree = "<group>"; };
+		D46A317E1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnneededParenthesesInClosureArgumentRule.swift; sourceTree = "<group>"; };
 		D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRule.swift; sourceTree = "<group>"; };
 		D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyParenthesesWithTrailingClosureRule.swift; sourceTree = "<group>"; };
 		D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureParameterPositionRule.swift; sourceTree = "<group>"; };
@@ -974,6 +976,7 @@
 				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
 				D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */,
+				D46A317E1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift */,
 				D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */,
 				D43B04631E0620AB004016AF /* UnusedEnumeratedRule.swift */,
 				92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */,
@@ -1405,6 +1408,7 @@
 				E81619531BFC162C00946723 /* QueuedPrint.swift in Sources */,
 				E87E4A051BFB927C00FCFE46 /* TrailingSemicolonRule.swift in Sources */,
 				E88198421BEA929F00333A11 /* NestingRule.swift in Sources */,
+				D46A317F1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift in Sources */,
 				D4470D591EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift in Sources */,
 				3BB47D851C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift in Sources */,
 				E881985B1BEA974E00333A11 /* StatementPositionRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -374,6 +374,7 @@ extension RulesTests {
         ("testTrailingSemicolon", testTrailingSemicolon),
         ("testTrailingWhitespace", testTrailingWhitespace),
         ("testTypeBodyLength", testTypeBodyLength),
+        ("testUnneededParenthesesInClosureArgument", testUnneededParenthesesInClosureArgument),
         ("testUnusedClosureParameter", testUnusedClosureParameter),
         ("testUnusedEnumerated", testUnusedEnumerated),
         ("testValidIBInspectable", testValidIBInspectable),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -329,6 +329,10 @@ class RulesTests: XCTestCase {
         verifyRule(TypeBodyLengthRule.description)
     }
 
+    func testUnneededParenthesesInClosureArgument() {
+        verifyRule(UnneededParenthesesInClosureArgumentRule.description)
+    }
+
     func testUnusedClosureParameter() {
         verifyRule(UnusedClosureParameterRule.description)
     }


### PR DESCRIPTION
Fixes #1483

* Should this be a default rule?
* Should it be configurable (see https://github.com/realm/SwiftLint/issues/1483#issuecomment-298456009)?