### PR TITLE
Enable testCustomRuleConfigurationIgnoreInvalidRules on Linux

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -83,6 +83,7 @@ extension CustomRulesTests {
     static var allTests: [(String, (CustomRulesTests) -> () throws -> Void)] = [
         ("testCustomRuleConfigurationSetsCorrectly", testCustomRuleConfigurationSetsCorrectly),
         ("testCustomRuleConfigurationThrows", testCustomRuleConfigurationThrows),
+        ("testCustomRuleConfigurationIgnoreInvalidRules", testCustomRuleConfigurationIgnoreInvalidRules),
         ("testCustomRules", testCustomRules),
         ("testLocalDisableCustomRule", testLocalDisableCustomRule),
         ("testLocalDisableCustomRuleWithMultipleRules", testLocalDisableCustomRuleWithMultipleRules),

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -44,19 +44,15 @@ class CustomRulesTests: XCTestCase {
         }
     }
 
-    // sourcery: skipTestOnLinux
-    // (check https://bugs.swift.org/browse/SR-5477)
     func testCustomRuleConfigurationIgnoreInvalidRules() throws {
-        let configDict = ["my_custom_rule": ["name": "MyCustomRule",
-                                             "message": "Message",
-                                             "regex": "regex",
-                                             "match_kinds": "comment",
-                                             "severity": "error"],
-                          "invalid_rule": ["name": "InvalidRule",
-                                           "message": "Message",
-                                           "regex": "{", // not a valid regex
-                                           "match_kinds": "comment",
-                                           "severity": "error"]]
+        let configDict = [
+            "my_custom_rule": ["name": "MyCustomRule",
+                               "message": "Message",
+                               "regex": "regex",
+                               "match_kinds": "comment",
+                               "severity": "error"],
+            "invalid_rule": ["name": "InvalidRule"] // missing `regex`
+        ]
         var customRulesConfig = CustomRulesConfiguration()
         try customRulesConfig.apply(configuration: configDict)
 


### PR DESCRIPTION
By failing in a way that doesn’t trigger https://bugs.swift.org/browse/SR-5477