### PR TITLE
Add support for optional 'error' severity level in configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 * Add support for optional `error` severity level configuration.  
   [Jamie Edge](https://github.com/JamieEdge)
+  [Marcelo Fabri](https://github.com/marcelofabri)
   [#1647](https://github.com/realm/SwiftLint/issues/1647)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@
 * Support building with Xcode 9 beta 3 in Swift 3.2 mode.  
   [JP Simard](https://github.com/jpsim)
 
+* Add support for optional `error` severity level configuration.  
+  [Jamie Edge](https://github.com/JamieEdge)
+  [#1647](https://github.com/realm/SwiftLint/issues/1647)
+
 ##### Bug Fixes
 
 * Fix false positive on `redundant_discardable_let` rule when using

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -41,10 +41,13 @@ public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {
         if let configurationArray = [Int].array(of: configuration), !configurationArray.isEmpty {
             warning = configurationArray[0]
             error = (configurationArray.count > 1) ? configurationArray[1] : nil
-        } else if let configDict = configuration as? [String: Int],
-            !configDict.isEmpty && Set(configDict.keys).isSubset(of: ["warning", "error"]) {
-            warning = configDict["warning"] ?? warning
-            error = configDict["error"]
+        } else if let configDict = configuration as? [String: Any?],
+            !configDict.isEmpty &&
+                Set(configDict.keys).isSubset(of: ["warning", "error"]) &&
+                (configDict["warning"] == nil || configDict["warning"] is Int) &&
+                (configDict["error"] == nil || configDict["error"] is Int || configDict["error"] is NSNull) {
+            warning = (configDict["warning"] as? Int) ?? warning
+            error = configDict["error"] as? Int
         } else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -41,11 +41,8 @@ public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {
         if let configurationArray = [Int].array(of: configuration), !configurationArray.isEmpty {
             warning = configurationArray[0]
             error = (configurationArray.count > 1) ? configurationArray[1] : nil
-        } else if let configDict = configuration as? [String: Any?],
-            !configDict.isEmpty &&
-                Set(configDict.keys).isSubset(of: ["warning", "error"]) &&
-                (configDict["warning"] == nil || configDict["warning"] is Int) &&
-                (configDict["error"] == nil || configDict["error"] is Int || configDict["error"] is NSNull) {
+        } else if let configDict = configuration as? [String: Int?],
+            !configDict.isEmpty, Set(configDict.keys).isSubset(of: ["warning", "error"]) {
             warning = (configDict["warning"] as? Int) ?? warning
             error = configDict["error"] as? Int
         } else {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -271,6 +271,8 @@ extension RuleConfigurationsTests {
         ("testSeverityConfigurationThrowsOnBadConfig", testSeverityConfigurationThrowsOnBadConfig),
         ("testSeverityLevelConfigParams", testSeverityLevelConfigParams),
         ("testSeverityLevelConfigPartialParams", testSeverityLevelConfigPartialParams),
+        ("testSeverityLevelConfigApplyNilErrorValue", testSeverityLevelConfigApplyNilErrorValue),
+        ("testSeverityLevelConfigApplyMissingErrorValue", testSeverityLevelConfigApplyMissingErrorValue),
         ("testRegexConfigurationThrows", testRegexConfigurationThrows),
         ("testRegexRuleDescription", testRegexRuleDescription),
         ("testTrailingWhitespaceConfigurationThrowsOnBadConfig", testTrailingWhitespaceConfigurationThrowsOnBadConfig),

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -151,6 +151,18 @@ class RuleConfigurationsTests: XCTestCase {
         XCTAssertEqual(severityConfig.params, [RuleParameter(severity: .warning, value: 17)])
     }
 
+    func testSeverityLevelConfigApplyNilErrorValue() throws {
+        var severityConfig = SeverityLevelsConfiguration(warning: 17, error: 20)
+        try severityConfig.apply(configuration: ["error": nil, "warning": 18])
+        XCTAssertEqual(severityConfig.params, [RuleParameter(severity: .warning, value: 18)])
+    }
+
+    func testSeverityLevelConfigApplyMissingErrorValue() throws {
+        var severityConfig = SeverityLevelsConfiguration(warning: 17, error: 20)
+        try severityConfig.apply(configuration: ["warning": 18])
+        XCTAssertEqual(severityConfig.params, [RuleParameter(severity: .warning, value: 18)])
+    }
+
     func testRegexConfigurationThrows() {
         let config = 17
         var regexConfig = RegexConfiguration(identifier: "")


### PR DESCRIPTION
Continued from #1664

Fixes #1647

@JamieEdge, I've added some tests and changed the behavior a little so we only set the `error` level to `nil` when it's explicitly set in the configuration.