### PR TITLE
Fix test that crashed SourceKit with Swift 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
       env: JOB=Linux3.1
       sudo: required
       services: docker
+    - script: set -o pipefail && script/cibuild | xcpretty
+      env: JOB=Xcode9
+      os: osx
+      osx_image: xcode9
 notifications:
   email: false
   slack: realmio:vPdpsG9NLDo2DNlbqtcMAQuE

--- a/Rules.md
+++ b/Rules.md
@@ -6645,6 +6645,8 @@ let range = 1..<3
 
 ```swift
 #if swift(>=3.0)
+    foo()
+#endif
 
 ```
 

--- a/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
@@ -32,7 +32,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             "let range = 1...3\n",
             "let range = 1 ... 3\n",
             "let range = 1..<3\n",
-            "#if swift(>=3.0)\n",
+            "#if swift(>=3.0)\n    foo()\n#endif\n",
             "array.removeAtIndex(-200)\n",
             "let name = \"image-1\"\n",
             "button.setImage(#imageLiteral(resourceName: \"image-1\"), for: .normal)\n",

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -202,10 +202,7 @@ class RulesTests: XCTestCase {
     }
 
     func testOperatorUsageWhitespace() {
-#if !swift(>=3.2)
-        // Test crashes SourceKit with Swift 3.2 or later
         verifyRule(OperatorUsageWhitespaceRule.description)
-#endif
     }
 
     func testPrivateOverFilePrivate() {


### PR DESCRIPTION
And adds `xcode9` to the build matrix.