### PR TITLE
Fix `mark` rule corrections generating invalid code in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1694](https://github.com/realm/SwiftLint/issues/1694)
 
+* Fix `mark` rule corrections generating invalid code in some cases.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1029](https://github.com/realm/SwiftLint/issues/1029)
+
 ## 0.20.1: More Liquid Fabric Softener
 
 ##### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -5342,6 +5342,15 @@ MARK comment should be in valid format. e.g. '// MARK: ...' or '// MARK: - ...'
 ↓// MARK - bad
 ```
 
+```swift
+↓//MARK:- Top-Level bad mark
+↓//MARK:- Another bad mark
+struct MarkTest {}
+↓// MARK:- Bad mark
+extension MarkTest {}
+
+```
+
 </details>
 
 

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -102,9 +102,7 @@ private struct Cache<T> {
     }
 
     fileprivate mutating func invalidate(_ file: File) {
-        if let key = file.path {
-            doLocked { values.removeValue(forKey: key) }
-        }
+        doLocked { values.removeValue(forKey: file.cacheKey) }
     }
 
     fileprivate mutating func clear() {

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -244,6 +244,7 @@ extension File {
             fatalError("can't write file to \(path)")
         }
         contents = string
+        invalidateCache()
         lines = contents.bridge().lines()
     }
 

--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -51,7 +51,8 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
             "↓// Mark: bad",
             "↓// MARK bad",
             "↓//MARK bad",
-            "↓// MARK - bad"
+            "↓// MARK - bad",
+            issue1029Example
         ],
         corrections: [
             "↓//MARK: comment": "// MARK: comment",
@@ -60,7 +61,8 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
             "↓//  MARK: comment": "// MARK: comment",
             "↓//MARK: - comment": "// MARK: - comment",
             "↓// MARK:- comment": "// MARK: - comment",
-            "↓// MARK: -comment": "// MARK: - comment"
+            "↓// MARK: -comment": "// MARK: - comment",
+            issue1029Example: issue1029Corretion
         ]
     )
 
@@ -123,7 +125,7 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
                                           replaceString: "// MARK: - ",
                                           keepLastChar: true))
 
-        return result
+        return result.unique
     }
 
     private func correct(file: File,
@@ -160,3 +162,15 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
         }
     }
 }
+
+private let issue1029Example = "↓//MARK:- Top-Level bad mark\n" +
+                               "↓//MARK:- Another bad mark\n" +
+                               "struct MarkTest {}\n" +
+                               "↓// MARK:- Bad mark\n" +
+                               "extension MarkTest {}\n"
+
+private let issue1029Corretion = "// MARK: - Top-Level bad mark\n" +
+                                 "// MARK: - Another bad mark\n" +
+                                 "struct MarkTest {}\n" +
+                                 "// MARK: - Bad mark\n" +
+                                 "extension MarkTest {}\n"

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -170,7 +170,7 @@ class RulesTests: XCTestCase {
     }
 
     func testMark() {
-        verifyRule(MarkRule.description, commentDoesntViolate: false)
+        verifyRule(MarkRule.description, skipCommentTests: true)
     }
 
     func testMultilineParameters() {


### PR DESCRIPTION
Apparently, we never invalidated the file cache when autocorrecting 😬

Fixes #1029 (finally!).