### PR TITLE
Fix false positive in `empty_enum_arguments` rule when using wildcards and  `where` clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1029](https://github.com/realm/SwiftLint/issues/1029)
 
+* Fix false positive in `empty_enum_arguments` rule when using wildcards and
+  `where` clauses.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1722](https://github.com/realm/SwiftLint/issues/1722)
+
 ## 0.20.1: More Liquid Fabric Softener
 
 ##### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -1738,31 +1738,37 @@ Arguments can be omitted when matching enums with associated types if they are n
 
 ```swift
 switch foo {
- case .bar: break
+    case .bar: break
 }
 ```
 
 ```swift
 switch foo {
- case .bar(let x): break
+    .bar(let x): break
 }
 ```
 
 ```swift
 switch foo {
- case let .bar(x): break
+    case let .bar(x): break
 }
 ```
 
 ```swift
 switch (foo, bar) {
- case (_, _): break
+    case (_, _): break
 }
 ```
 
 ```swift
 switch foo {
- case "bar".uppercased(): break
+    case "bar".uppercased(): break
+}
+```
+
+```swift
+switch (foo, bar) {
+    case (_, _) where !something: break
 }
 ```
 
@@ -1772,25 +1778,25 @@ switch foo {
 
 ```swift
 switch foo {
- case .bar↓(_): break
+    case .bar↓(_): break
 }
 ```
 
 ```swift
 switch foo {
- case .bar↓(): break
+    case .bar↓(): break
 }
 ```
 
 ```swift
 switch foo {
- case .bar↓(_), .bar2↓(_): break
+    case .bar↓(_), .bar2↓(_): break
 }
 ```
 
 ```swift
 switch foo {
- case .bar↓() where method() > 2: break
+    case .bar↓() where method() > 2: break
 }
 ```
 
@@ -9011,7 +9017,7 @@ Identifier | Enabled by default | Supports autocorrection | Kind
 --- | --- | --- | ---
 `trailing_closure` | Disabled | No | style
 
-Trailing closure syntax should be used whenever possible
+Trailing closure syntax should be used whenever possible.
 
 ### Examples
 


### PR DESCRIPTION
Fixes #1722