### PR TITLE
Fix example in empty_enum_arguments rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1744,7 +1744,7 @@ switch foo {
 
 ```swift
 switch foo {
-    .bar(let x): break
+    case .bar(let x): break
 }
 ```
 

--- a/Source/SwiftLintFramework/Rules/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyEnumArgumentsRule.swift
@@ -27,7 +27,7 @@ public struct EmptyEnumArgumentsRule: ASTRule, ConfigurationProviderRule, Correc
         kind: .style,
         nonTriggeringExamples: [
             wrapInSwitch("case .bar"),
-            wrapInSwitch(".bar(let x)"),
+            wrapInSwitch("case .bar(let x)"),
             wrapInSwitch("case let .bar(x)"),
             wrapInSwitch(variable: "(foo, bar)", "case (_, _)"),
             wrapInSwitch("case \"bar\".uppercased()"),


### PR DESCRIPTION
This was mistakenly introduced in 189e055.