### PR TITLE
Fix false positive in `large_tuple` rule when using throwing closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1722](https://github.com/realm/SwiftLint/issues/1722)
 
+* Fix false positive in `large_tuple` rule when using throwing closure.  
+  [Liquidsoul](https://github.com/liquidsoul)
+
 ## 0.20.1: More Liquid Fabric Softener
 
 ##### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -4738,6 +4738,21 @@ let foo: (Int, Int, Int) -> Void
 ```
 
 ```swift
+let foo: (Int, Int, Int) throws -> Void
+
+```
+
+```swift
+func foo(bar: (Int, String, Float) -> Void)
+
+```
+
+```swift
+func foo(bar: (Int, String, Float) throws -> Void)
+
+```
+
+```swift
 var completionHandler: ((_ data: Data?, _ resp: URLResponse?, _ e: NSError?) -> Void)!
 
 ```

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -40,6 +40,9 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
             "func foo() throws -> (Int, Int)\n",
             "func foo() throws -> (Int, Int) {}\n",
             "let foo: (Int, Int, Int) -> Void\n",
+            "let foo: (Int, Int, Int) throws -> Void\n",
+            "func foo(bar: (Int, String, Float) -> Void)\n",
+            "func foo(bar: (Int, String, Float) throws -> Void)\n",
             "var completionHandler: ((_ data: Data?, _ resp: URLResponse?, _ e: NSError?) -> Void)!\n",
             "func getDictionaryAndInt() -> (Dictionary<Int, String>, Int)?\n",
             "func getGenericTypeAndInt() -> (Type<Int, String, Float>, Int)?\n"
@@ -203,7 +206,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func containsReturnArrow(in text: String, range: NSRange) -> Bool {
-        let arrowRegex = regex("\\A\\s*->")
+        let arrowRegex = regex("\\A(\\s*throws)?\\s*->")
         let start = NSMaxRange(range)
         let restOfStringRange = NSRange(location: start, length: text.bridge().length - start)
 


### PR DESCRIPTION
This is an issue that I have noticed in this [Swiftlint PR](https://github.com/SwiftGen/StencilSwiftKit/pull/54/files#diff-eb34ef67e2507f89acad77e19f598a4aR43).