### PR TITLE
Add test and changelog entry for #1488

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@
 * Make `vertical_parameter_alignment` more robust, fixing false positives and
   detecting previously missed violations.  
   [JP Simard](https://github.com/jpsim)
+  [#1488](https://github.com/realm/SwiftLint/issues/1488)
 
 ## 0.20.1: More Liquid Fabric Softener
 

--- a/Rules.md
+++ b/Rules.md
@@ -13278,6 +13278,11 @@ func foo(a: Void,
 
 ```
 
+```swift
+func foo(data: (size: CGSize,
+                identifier: String)) {}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
@@ -39,7 +39,9 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
             "func regex(_ pattern: String,\n" +
             "           options: NSRegularExpression.Options = [.anchorsMatchLines,\n" +
             "                                                   .dotMatchesLineSeparators]) -> NSRegularExpression\n",
-            "func foo(a: Void,\n         b: [String: String] =\n           [:]) {\n}\n"
+            "func foo(a: Void,\n         b: [String: String] =\n           [:]) {\n}\n",
+            "func foo(data: (size: CGSize,\n" +
+            "                identifier: String)) {}"
         ],
         triggeringExamples: [
             "func validateFunction(_ file: File, kind: SwiftDeclarationKind,\n" +


### PR DESCRIPTION
#1488 was fixed in #1726.

This adds a test to make sure we don’t introduce regressions in the future and also adds a changelog entry.