### PR TITLE
Fixed Readme custom rule included/excluded regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ following syntax:
 ```yaml
 custom_rules:
   pirates_beat_ninjas: # rule identifier
-    included: ".*.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test.swift" # regex that defines paths to exclude during linting. optional
+    included: ".*\\.swift" # regex that defines paths to include during linting. optional.
+    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Pirates Beat Ninjas" # rule name. optional.
     regex: "([n,N]inja)" # matching pattern
     match_kinds: # SyntaxKinds to match. optional.


### PR DESCRIPTION
Currently, it does not check for dot presence, but for any symbol, so for example, if a filename is `MySuperFileswift` it would also work for this regexp. Same for excluded.