### PR TITLE
Update changelog entry for xctfail_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ##### Enhancements
 
-* Add `xctfail_message` opt-in rule to enforce XCTFail
+* Add `xctfail_message` rule to enforce XCTFail
   calls to include a description of the assertion.  
   [Ornithologist Coder](https://github.com/ornithocoder)
   [#1370](https://github.com/realm/SwiftLint/issues/1370)


### PR DESCRIPTION
Not an opt-in rule. It's enabled by default https://github.com/realm/SwiftLint/blob/master/Source/SwiftLintFramework/Rules/XCTFailMessageRule.swift