### PR TITLE
Command Line Options for Interacting with the Configuration Merging Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   [JP Simard](https://github.com/jpsim)
   [#676](https://github.com/realm/SwiftLint/issues/676)
 
+  * Several command line options allow interaction with the merging process.
+    (See `swiftlint help lint`.)  
+    [Jeremy David Giesbrecht](https://github.com/SDGGiesbrecht)
+    [##1693](https://github.com/realm/SwiftLint/issues/1693)
+
 ##### Enhancements
 
 * Add `xctfail_message` rule to enforce XCTFail

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -213,7 +213,8 @@ public struct Configuration: Equatable {
             (lhs.reporter == rhs.reporter) &&
             (lhs.configurationPath == rhs.configurationPath) &&
             (lhs.rootPath == lhs.rootPath) &&
-            (lhs.rules == rhs.rules)
+            (lhs.rules.sorted(by: { String(describing: $0) < String(describing: $1) })
+                == rhs.rules.sorted(by: { String(describing: $0) < String(describing: $1) }))
     }
 }
 

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -45,6 +45,9 @@ struct AutoCorrectCommand: CommandProtocol {
 struct AutoCorrectOptions: OptionsProtocol {
     let path: String
     let configurationFile: String
+    let configurationDefaults: String?
+    let configurationOverrides: String?
+    let ignoreNestedConfigurations: Bool
     let useScriptInputFiles: Bool
     let quiet: Bool
     let format: Bool
@@ -53,10 +56,10 @@ struct AutoCorrectOptions: OptionsProtocol {
     let useTabs: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
-        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in
-            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
-        }}}}}}}
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ configurationDefaults: String?) -> (_ configurationOverrides: String?) -> (_ ignoreNestedConfigurations: Bool) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
+        return { configurationFile in { configurationDefaults in { configurationOverrides in { ignoreNestedConfigurations in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in
+            self.init(path: path, configurationFile: configurationFile, configurationDefaults: configurationDefaults, configurationOverrides: configurationOverrides, ignoreNestedConfigurations: ignoreNestedConfigurations, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
+        }}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
@@ -64,6 +67,9 @@ struct AutoCorrectOptions: OptionsProtocol {
         return create
             <*> mode <| pathOption(action: "correct")
             <*> mode <| configOption
+            <*> mode <| configDefaultsOption
+            <*> mode <| configOverridesOption
+            <*> mode <| ignoreNestedConfigsOption
             <*> mode <| useScriptInputFilesOption
             <*> mode <| quietOption(action: "correcting")
             <*> mode <| Option(key: "format",

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -128,6 +128,9 @@ struct LintOptions: OptionsProtocol {
     let path: String
     let useSTDIN: Bool
     let configurationFile: String
+    let configurationDefaults: String?
+    let configurationOverrides: String?
+    let ignoreNestedConfigurations: Bool
     let strict: Bool
     let lenient: Bool
     let useScriptInputFiles: Bool
@@ -139,10 +142,10 @@ struct LintOptions: OptionsProtocol {
     let enableAllRules: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> LintOptions {
-        return { useSTDIN in { configurationFile in { strict in { lenient in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in
-            self.init(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
-        }}}}}}}}}}}
+    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ configurationDefaults: String?) -> (_ configurationOverrides: String?) -> (_ ignoreNestedConfigurations: Bool) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> LintOptions {
+        return { useSTDIN in { configurationFile in { configurationDefaults in { configurationOverrides in { ignoreNestedConfigurations in { strict in { lenient in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in
+            self.init(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile, configurationDefaults: configurationDefaults, configurationOverrides: configurationOverrides, ignoreNestedConfigurations: ignoreNestedConfigurations, strict: strict, lenient: lenient, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
+        }}}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<LintOptions, CommandantError<CommandantError<()>>> {
@@ -152,6 +155,9 @@ struct LintOptions: OptionsProtocol {
             <*> mode <| Option(key: "use-stdin", defaultValue: false,
                                usage: "lint standard input")
             <*> mode <| configOption
+            <*> mode <| configDefaultsOption
+            <*> mode <| configOverridesOption
+            <*> mode <| ignoreNestedConfigsOption
             <*> mode <| Option(key: "strict", defaultValue: false,
                                usage: "fail on warnings")
             <*> mode <| Option(key: "lenient", defaultValue: false,

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -78,22 +78,28 @@ struct RulesCommand: CommandProtocol {
 struct RulesOptions: OptionsProtocol {
     fileprivate let ruleID: String?
     let configurationFile: String
+    let configurationDefaults: String?
+    let configurationOverrides: String?
     fileprivate let onlyEnabledRules: Bool
     fileprivate let onlyDisabledRules: Bool
 
     // swiftlint:disable line_length
-    static func create(_ configurationFile: String) -> (_ ruleID: String) -> (_ onlyEnabledRules: Bool) -> (_ onlyDisabledRules: Bool) -> RulesOptions {
-        return { ruleID in { onlyEnabledRules in { onlyDisabledRules in
+    static func create(_ configurationFile: String) -> (_ configurationDefaults: String?) -> (_ configurationOverrides: String?) -> (_ ruleID: String) -> (_ onlyEnabledRules: Bool) -> (_ onlyDisabledRules: Bool) -> RulesOptions {
+        return { configurationDefaults in { configurationOverrides in { ruleID in { onlyEnabledRules in { onlyDisabledRules in
             self.init(ruleID: (ruleID.isEmpty ? nil : ruleID),
                       configurationFile: configurationFile,
+                      configurationDefaults: configurationDefaults,
+                      configurationOverrides: configurationOverrides,
                       onlyEnabledRules: onlyEnabledRules,
                       onlyDisabledRules: onlyDisabledRules)
-        }}}
+        }}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<RulesOptions, CommandantError<CommandantError<()>>> {
         return create
             <*> mode <| configOption
+            <*> mode <| configDefaultsOption
+            <*> mode <| configOverridesOption
             <*> mode <| Argument(defaultValue: "",
                                  usage: "the rule identifier to display description for")
             <*> mode <| Switch(flag: "e",

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -124,7 +124,9 @@ extension Configuration {
         let cachePath = options.cachePath.isEmpty ? nil : options.cachePath
         let optional = !CommandLine.arguments.contains("--config")
         self.init(path: options.configurationFile, rootPath: options.path.absolutePathStandardized(),
-                  optional: optional, quiet: options.quiet,
+                  optional: optional,
+                  defaults: options.configurationDefaults, overrides: options.configurationOverrides,
+                  ignoreNested: options.ignoreNestedConfigurations, quiet: options.quiet,
                   enableAllRules: options.enableAllRules, cachePath: cachePath)
     }
 
@@ -141,13 +143,17 @@ extension Configuration {
         let cachePath = options.cachePath.isEmpty ? nil : options.cachePath
         let optional = !CommandLine.arguments.contains("--config")
         self.init(path: options.configurationFile, rootPath: options.path.absolutePathStandardized(),
-                  optional: optional, quiet: options.quiet, cachePath: cachePath)
+                  optional: optional,
+                  defaults: options.configurationDefaults, overrides: options.configurationOverrides,
+                  ignoreNested: options.ignoreNestedConfigurations,
+                  quiet: options.quiet, cachePath: cachePath)
     }
 
     // MARK: Rules command
 
     init(options: RulesOptions) {
         let optional = !CommandLine.arguments.contains("--config")
-        self.init(path: options.configurationFile, optional: optional)
+        self.init(path: options.configurationFile, optional: optional,
+                  defaults: options.configurationDefaults, overrides: options.configurationOverrides)
     }
 }

--- a/Source/swiftlint/Helpers/CommonOptions.swift
+++ b/Source/swiftlint/Helpers/CommonOptions.swift
@@ -19,6 +19,20 @@ let configOption = Option(key: "config",
                           defaultValue: Configuration.fileName,
                           usage: "the path to SwiftLint's configuration file")
 
+let configDefaultsOption = Option<String?>(key: "config-defaults",
+                                           defaultValue: nil,
+                                           usage: "the path of an external configuration file " +
+                                                  "to use as the root of the merge tree")
+
+let configOverridesOption = Option<String?>(key: "config-overrides",
+                                            defaultValue: nil,
+                                            usage: "the path of an external configuration file " +
+                                                   "to append to the end of each branch of the merge tree")
+
+let ignoreNestedConfigsOption = Option(key: "ignore-nested-configs",
+                                       defaultValue: false,
+                                       usage: "ignores nested configuration files")
+
 let useScriptInputFilesOption = Option(key: "use-script-input-files",
                                        defaultValue: false,
                                        usage: "read SCRIPT_INPUT_FILE* environment variables " +

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */; };
 		3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */; };
 		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
+		3FA6DA941F341F0500522BD1 /* defaults.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3FA6DA921F341ED800522BD1 /* defaults.yml */; };
+		3FA6DA951F341F0500522BD1 /* overrides.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3FA6DA931F341ED800522BD1 /* overrides.yml */; };
 		47ACC8981E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */; };
 		47ACC89A1E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */; };
 		47ACC89C1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */; };
@@ -362,6 +364,8 @@
 		3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleConfigurationTests.swift; sourceTree = "<group>"; };
 		3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlParser.swift; sourceTree = "<group>"; };
 		3BDB224A1C345B4900473680 /* ProjectMock */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ProjectMock; sourceTree = "<group>"; };
+		3FA6DA921F341ED800522BD1 /* defaults.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = defaults.yml; sourceTree = "<group>"; };
+		3FA6DA931F341ED800522BD1 /* overrides.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = overrides.yml; sourceTree = "<group>"; };
 		47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalConfiguration.swift; sourceTree = "<group>"; };
 		47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalConfigurationTests.swift; sourceTree = "<group>"; };
 		47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalRuleTests.swift; sourceTree = "<group>"; };
@@ -627,6 +631,8 @@
 			isa = PBXGroup;
 			children = (
 				3B12C9BF1C3209AC000B423F /* test.yml */,
+				3FA6DA921F341ED800522BD1 /* defaults.yml */,
+				3FA6DA931F341ED800522BD1 /* overrides.yml */,
 				3BDB224A1C345B4900473680 /* ProjectMock */,
 				F9D73F021D0CF15E00222FC4 /* test.txt */,
 				B3935250C8E0DBACFB27E021 /* CannedHTMLReporterOutput.html */,
@@ -1227,6 +1233,8 @@
 			files = (
 				3B12C9C11C3209CB000B423F /* test.yml in Resources */,
 				F9D73F031D0CF15E00222FC4 /* test.txt in Resources */,
+				3FA6DA941F341F0500522BD1 /* defaults.yml in Resources */,
+				3FA6DA951F341F0500522BD1 /* overrides.yml in Resources */,
 				3BDB224B1C345B4900473680 /* ProjectMock in Resources */,
 				B3935797FF80C7F97953D375 /* CannedHTMLReporterOutput.html in Resources */,
 				B3935371E92E0CF3F7668303 /* CannedJunitReporterOutput.xml in Resources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -80,7 +80,10 @@ extension ConfigurationTests {
         ("testLevel3", testLevel3),
         ("testNestedConfigurationWithCustomRootPath", testNestedConfigurationWithCustomRootPath),
         ("testMergedWarningThreshold", testMergedWarningThreshold),
-        ("testNestedWhitelistedRules", testNestedWhitelistedRules)
+        ("testNestedWhitelistedRules", testNestedWhitelistedRules),
+        ("testDefaults", testDefaults),
+        ("testOverrides", testOverrides),
+        ("testIgnoreNested", testIgnoreNested)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -94,4 +94,27 @@ extension ConfigurationTests {
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceCastRule.self))
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceTryRule.self))
     }
+
+    func testDefaults() {
+        let root = Configuration(path: Configuration.fileName, rootPath: projectMockPathLevel0,
+                                 defaults: projectMockDefaults)
+        let merged = root.configuration(for: File(path: projectMockSwift0)!)
+        XCTAssert(!merged.contains(rule: ColonRule.self)) // Default applied.
+        XCTAssert(merged.contains(rule: CommaRule.self)) // Default overridden.
+    }
+
+    func testOverrides() {
+        let root = Configuration(path: Configuration.fileName, rootPath: projectMockPathLevel0,
+                                 overrides: projectMockOverrides)
+        let merged = root.configuration(for: File(path: projectMockSwift3)!)
+        XCTAssert(merged.contains(rule: ForceTryRule.self)) // Override applied.
+        XCTAssert(!merged.contains(rule: TodoRule.self)) // Unaffected not stomped.
+    }
+
+    func testIgnoreNested() {
+        let root = Configuration(path: Configuration.fileName, rootPath: projectMockPathLevel0,
+                                 ignoreNested: true)
+        let merged = root.configuration(for: File(path: projectMockSwift3)!)
+        XCTAssert(merged.contains(rule: ForceTryRule.self)) // Nested ignored.
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+ProjectMock.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+ProjectMock.swift
@@ -74,4 +74,12 @@ extension ConfigurationTests {
         return Configuration(path: Configuration.fileName, rootPath: projectMockPathLevel3,
                              optional: false, quiet: true)
     }
+
+    var projectMockDefaults: String {
+        return bundlePath.stringByAppendingPathComponent("defaults.yml")
+    }
+
+    var projectMockOverrides: String {
+        return bundlePath.stringByAppendingPathComponent("overrides.yml")
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/.swiftlint.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/.swiftlint.yml
@@ -1,5 +1,7 @@
 disabled_rules:
   - force_cast
+opt_in_rules:
+  - comma
 included:
   - "everything"
 excluded:

--- a/Tests/SwiftLintFrameworkTests/Resources/defaults.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/defaults.yml
@@ -1,0 +1,3 @@
+disabled_rules:
+  - comma
+  - colon

--- a/Tests/SwiftLintFrameworkTests/Resources/overrides.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/overrides.yml
@@ -1,0 +1,2 @@
+opt_in_rules:
+  - force_try


### PR DESCRIPTION
(From #1693, expanded from @jpsim’s suggestions in #1323.)

#### Adds three command line options:

- `--config-defaults`: the path of an external configuration file to use as the root of the merge tree.
- `--config-overrides`: the path of an external configuration file to append to the end of each branch of the merge tree
- `--ignore-nested-configs`: ignores nested configuration files

(The combination of `--config-defaults` and `--ignore-nested-configs` can be used to make `--config-defaults` stomp anything present in the project, even the root directory.)

#### Commit breakdown:

The interaction with the merge logic is isolated in the second commit. (The first commit simply adds the options to the interface and gets them to `Configuration`.)

#### Other Notes:

I left `--config` alone for now, but I think this pull request would make it obsolete. (In the wake of #1687 it looks like it merges itself with anything it finds, all the way back to the system root, which I doubt anyone expects.)

The read‐me is out of date. It still says nested files trump their parents. I left it alone in case you want it in sync with the last stable release and not master.

In the process of writing this, I discovered that the existing merge process went backwards. A tree like this...
A
↳ B
&nbsp;&nbsp;↳ C
&nbsp;&nbsp;&nbsp;&nbsp;↳ D
...was being merged as A is overridden by D, which is overridden by C, which is overridden by B.
The refactors in this pull request eliminate the problem, but if this pull request is not accepted, that bug will have to be dealt with elsewhere.

Maintainers have been given direct write access.

(@Aranoledur, you were tracking the related issue, so you might want to look at this.)