### PR TITLE
Improve rules table rendering with multi-line or very long values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1271](https://github.com/realm/SwiftLint/issues/1271)
 
+* Truncate long configuration console descriptions to 80 characters when running
+  `swiftlint rules`.  
+  [JP Simard](https://github.com/jpsim)
+  [#1002](https://github.com/realm/SwiftLint/issues/1002)
+
 ##### Bug Fixes
 
 * Improve how `opening_brace` rule reports violations locations.  
@@ -54,6 +59,11 @@
 * Fix false positive in `class_delegate_protocol` rule when using Swift 4.0.1.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1856](https://github.com/realm/SwiftLint/issues/1856)
+
+* Print multi-line configuration values in a single line when running
+  `swiftlint rules` to avoid breaking the table format.  
+  [JP Simard](https://github.com/jpsim)
+  [#1002](https://github.com/realm/SwiftLint/issues/1002)
 
 ## 0.22.0: Wrinkle-free
 
@@ -109,7 +119,7 @@
 
 * Invalidate cache when Swift version changes.  
   [Marcelo Fabri](https://github.com/marcelofabri)
-  
+
 * Add `pattern_matching_keywords` opt-in rule to enforce moving `let` and `var`
   keywords outside tuples in a `switch`.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1271](https://github.com/realm/SwiftLint/issues/1271)
 
-* Truncate long configuration console descriptions to 80 characters when running
-  `swiftlint rules`.  
+* Truncate long configuration console descriptions to fit in the console window
+  when running `swiftlint rules`.  
   [JP Simard](https://github.com/jpsim)
   [#1002](https://github.com/realm/SwiftLint/issues/1002)
 

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -119,6 +119,15 @@ extension TextTable {
         ]
         self.init(columns: columns)
         let sortedRules = ruleList.list.sorted { $0.0 < $1.0 }
+        func truncate(_ string: String) -> String {
+            let stringWithNoNewlines = string.replacingOccurrences(of: "\n", with: "\\n")
+            let truncatedEndIndex = stringWithNoNewlines.index(stringWithNoNewlines.startIndex, offsetBy: 77,
+                                                               limitedBy: stringWithNoNewlines.endIndex)
+            if let truncatedEndIndex = truncatedEndIndex {
+                return stringWithNoNewlines.substring(to: truncatedEndIndex) + "..."
+            }
+            return stringWithNoNewlines
+        }
         for (ruleID, ruleType) in sortedRules {
             let rule = ruleType.init()
             let configuredRule = configuration.rules.first { rule in
@@ -131,7 +140,7 @@ extension TextTable {
                 configuredRule != nil ? "yes" : "no",
                 ruleType.description.kind.rawValue,
                 (configuredRule ?? rule).configurationDescription
-            ])
+            ].map(truncate))
         }
     }
 }

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
+// swiftlint:disable sorted_imports
 import Commandant
 #if os(Linux)
 import Glibc

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -126,7 +126,7 @@ extension TextTable {
         let sortedRules = ruleList.list.sorted { $0.0 < $1.0 }
         func truncate(_ string: String) -> String {
             let stringWithNoNewlines = string.replacingOccurrences(of: "\n", with: "\\n")
-            let minWidth = "configuration".count - "...".count
+            let minWidth = "configuration".characters.count - "...".characters.count
             let configurationStartColumn = 112
             let truncatedEndIndex = stringWithNoNewlines.index(
                 stringWithNoNewlines.startIndex,
@@ -134,7 +134,11 @@ extension TextTable {
                 limitedBy: stringWithNoNewlines.endIndex
             )
             if let truncatedEndIndex = truncatedEndIndex {
+#if swift(>=3.2)
                 return stringWithNoNewlines[..<truncatedEndIndex] + "..."
+#else
+                return stringWithNoNewlines.substring(to: truncatedEndIndex) + "..."
+#endif
             }
             return stringWithNoNewlines
         }


### PR DESCRIPTION
Fixes #1002. Sample output for SwiftLint itself:

```
+------------------------------------------+--------+-------------+------------------------+-------------+----------------------------------------------------------------------------------+
| identifier                               | opt-in | correctable | enabled in your config | kind        | configuration                                                                    |
+------------------------------------------+--------+-------------+------------------------+-------------+----------------------------------------------------------------------------------+
| attributes                               | yes    | no          | yes                    | style       | warning, always_on_same_line: ["@IBAction", "@NSManaged"], always_on_line_abo... |
| block_based_kvo                          | no     | no          | yes                    | idiomatic   | warning                                                                          |
| class_delegate_protocol                  | no     | no          | yes                    | lint        | warning                                                                          |
| closing_brace                            | no     | yes         | yes                    | style       | warning                                                                          |
| closure_end_indentation                  | yes    | no          | yes                    | style       | warning                                                                          |
| closure_parameter_position               | no     | no          | yes                    | style       | warning                                                                          |
| closure_spacing                          | yes    | yes         | yes                    | style       | warning                                                                          |
| colon                                    | no     | yes         | yes                    | style       | warning, flexible_right_spacing: false, apply_to_dictionaries: true              |
| comma                                    | no     | yes         | yes                    | style       | warning                                                                          |
| compiler_protocol_init                   | no     | no          | yes                    | lint        | warning                                                                          |
| conditional_returns_on_newline           | yes    | no          | no                     | style       | warning                                                                          |
| control_statement                        | no     | no          | yes                    | style       | warning                                                                          |
| custom_rules                             | no     | no          | yes                    | style       | user-defined                                                                     |
| cyclomatic_complexity                    | no     | no          | yes                    | metrics     | warning: 10, error: 20, ignores_case_statements: false                           |
| discarded_notification_center_observer   | no     | no          | yes                    | lint        | warning                                                                          |
| discouraged_direct_init                  | no     | no          | yes                    | lint        | warning, types: ["UIDevice.init", "Bundle", "UIDevice", "Bundle.init"]           |
| dynamic_inline                           | no     | no          | yes                    | lint        | error                                                                            |
| empty_count                              | yes    | no          | yes                    | performance | error                                                                            |
| empty_enum_arguments                     | no     | yes         | yes                    | style       | warning                                                                          |
| empty_parameters                         | no     | yes         | yes                    | style       | warning                                                                          |
| empty_parentheses_with_trailing_closure  | no     | yes         | yes                    | style       | warning                                                                          |
| explicit_init                            | yes    | yes         | yes                    | idiomatic   | warning                                                                          |
| explicit_top_level_acl                   | yes    | no          | no                     | idiomatic   | warning                                                                          |
| explicit_type_interface                  | yes    | no          | no                     | idiomatic   | warning                                                                          |
| extension_access_modifier                | yes    | no          | yes                    | idiomatic   | warning                                                                          |
| fatal_error_message                      | yes    | no          | yes                    | idiomatic   | warning                                                                          |
| file_header                              | yes    | no          | yes                    | style       | warning, required_string: None, required_pattern: \/\/\n\/\/  .*?\.swift\n\/\... |
| file_length                              | no     | no          | yes                    | metrics     | warning: 400, error: 1000ignore_comment_only_lines: false                        |
| first_where                              | yes    | no          | yes                    | performance | warning                                                                          |
| for_where                                | no     | no          | yes                    | idiomatic   | warning                                                                          |
| force_cast                               | no     | no          | yes                    | idiomatic   | error                                                                            |
| force_try                                | no     | no          | yes                    | idiomatic   | error                                                                            |
| force_unwrapping                         | yes    | no          | no                     | idiomatic   | warning                                                                          |
| function_body_length                     | no     | no          | yes                    | metrics     | warning: 40, error: 100                                                          |
| function_parameter_count                 | no     | no          | yes                    | metrics     | warning: 5, error: 8                                                             |
| generic_type_name                        | no     | no          | yes                    | idiomatic   | (min_length) w/e: 1/0, (max_length) w/e: 20/1000, excluded: [], allowed_symbo... |
| identifier_name                          | no     | no          | yes                    | style       | (min_length) w/e: 3/2, (max_length) w/e: 40/60, excluded: ["id"], allowed_sym... |
| implicit_getter                          | no     | no          | yes                    | style       | warning                                                                          |
| implicit_return                          | yes    | yes         | no                     | style       | warning                                                                          |
| implicitly_unwrapped_optional            | yes    | no          | no                     | idiomatic   | warning, mode: allExceptIBOutlets                                                |
| large_tuple                              | no     | no          | yes                    | metrics     | warning: 2, error: 3                                                             |
| leading_whitespace                       | no     | yes         | yes                    | style       | warning                                                                          |
| legacy_cggeometry_functions              | no     | yes         | yes                    | idiomatic   | warning                                                                          |
| legacy_constant                          | no     | yes         | yes                    | idiomatic   | warning                                                                          |
| legacy_constructor                       | no     | yes         | yes                    | idiomatic   | warning                                                                          |
| legacy_nsgeometry_functions              | no     | yes         | yes                    | idiomatic   | warning                                                                          |
| let_var_whitespace                       | yes    | no          | yes                    | style       | warning                                                                          |
| line_length                              | no     | no          | yes                    | metrics     | warning: 120, ignores urls: false, ignores function declarations: false, igno... |
| mark                                     | no     | yes         | yes                    | lint        | warning                                                                          |
| multiline_parameters                     | yes    | no          | no                     | style       | warning                                                                          |
| nesting                                  | no     | no          | yes                    | metrics     | (type_level) w: 1, (statement_level) w: 5                                        |
| nimble_operator                          | yes    | yes         | yes                    | idiomatic   | warning                                                                          |
| no_extension_access_modifier             | yes    | no          | no                     | idiomatic   | error                                                                            |
| notification_center_detachment           | no     | no          | yes                    | lint        | warning                                                                          |
| number_separator                         | yes    | yes         | yes                    | style       | warning, minimum_length: 5                                                       |
| object_literal                           | yes    | no          | yes                    | idiomatic   | warning, image_literal: true, color_literal: true                                |
| opening_brace                            | no     | yes         | yes                    | style       | warning                                                                          |
| operator_usage_whitespace                | yes    | yes         | yes                    | style       | warning                                                                          |
| operator_whitespace                      | no     | no          | yes                    | style       | warning                                                                          |
| overridden_super_call                    | yes    | no          | yes                    | lint        | warning, excluded: [[]], included: [["*"]]                                       |
| private_outlet                           | yes    | no          | yes                    | lint        | warning, allow_private_set: false                                                |
| private_over_fileprivate                 | no     | yes         | yes                    | idiomatic   | warning, validate_extensions: false                                              |
| private_unit_test                        | no     | no          | yes                    | lint        | warning: XCTestCase                                                              |
| prohibited_super_call                    | yes    | no          | yes                    | lint        | warning, excluded: [[]], included: [["*"]]                                       |
| protocol_property_accessors_order        | no     | yes         | yes                    | style       | warning                                                                          |
| redundant_discardable_let                | no     | yes         | yes                    | style       | warning                                                                          |
| redundant_nil_coalescing                 | yes    | yes         | yes                    | idiomatic   | warning                                                                          |
| redundant_optional_initialization        | no     | yes         | yes                    | idiomatic   | warning                                                                          |
| redundant_string_enum_value              | no     | no          | yes                    | idiomatic   | warning                                                                          |
| redundant_void_return                    | no     | yes         | yes                    | idiomatic   | warning                                                                          |
| return_arrow_whitespace                  | no     | yes         | yes                    | style       | warning                                                                          |
| shorthand_operator                       | no     | no          | yes                    | style       | error                                                                            |
| sorted_imports                           | yes    | no          | yes                    | style       | warning                                                                          |
| statement_position                       | no     | yes         | yes                    | style       | (statement_mode) default, (severity) warning                                     |
| strict_fileprivate                       | yes    | no          | no                     | idiomatic   | warning                                                                          |
| switch_case_on_newline                   | yes    | no          | no                     | style       | warning                                                                          |
| syntactic_sugar                          | no     | no          | yes                    | idiomatic   | warning                                                                          |
| todo                                     | no     | no          | yes                    | lint        | warning                                                                          |
| trailing_closure                         | yes    | no          | no                     | style       | warning                                                                          |
| trailing_comma                           | no     | yes         | yes                    | style       | warning, mandatory_comma: false                                                  |
| trailing_newline                         | no     | yes         | yes                    | style       | warning                                                                          |
| trailing_semicolon                       | no     | yes         | yes                    | idiomatic   | warning                                                                          |
| trailing_whitespace                      | no     | yes         | yes                    | style       | warning, ignores_empty_lines: false, ignores_comments: true                      |
| type_body_length                         | no     | no          | yes                    | metrics     | warning: 200, error: 350                                                         |
| type_name                                | no     | no          | yes                    | idiomatic   | (min_length) w/e: 3/0, (max_length) w/e: 40/1000, excluded: [], allowed_symbo... |
| unneeded_parentheses_in_closure_argument | yes    | yes         | yes                    | style       | warning                                                                          |
| unused_closure_parameter                 | no     | yes         | yes                    | lint        | warning                                                                          |
| unused_enumerated                        | no     | no          | yes                    | idiomatic   | warning                                                                          |
| unused_optional_binding                  | no     | no          | yes                    | style       | warning, ignore_optional_try: false                                              |
| valid_ibinspectable                      | no     | no          | yes                    | lint        | warning                                                                          |
| vertical_parameter_alignment             | no     | no          | yes                    | style       | warning                                                                          |
| vertical_parameter_alignment_on_call     | yes    | no          | yes                    | style       | warning                                                                          |
| vertical_whitespace                      | no     | yes         | yes                    | style       | warning, max_empty_lines: 1                                                      |
| void_return                              | no     | yes         | yes                    | style       | warning                                                                          |
| weak_delegate                            | no     | no          | yes                    | lint        | warning                                                                          |
| xctfail_message                          | no     | no          | yes                    | idiomatic   | warning                                                                          |
+------------------------------------------+--------+-------------+------------------------+-------------+----------------------------------------------------------------------------------+
```