### PR TITLE
[Abandoned] Fix number of lines reported by function_body_length and type_body_length

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,6 +44,10 @@ identifier_name:
 line_length: 120
 number_separator:
   minimum_length: 5
+type_body_length:
+    - 250
+function_body_length:
+    - 50
 
 custom_rules:
   rule_id:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix number of lines reported by `function_body_length` and
+  `type_body_length`.  
+  [Ornithologist Coder](https://github.com/ornithocoder)
+  [#1750](https://github.com/realm/SwiftLint/issues/1750)
 
 ## 0.24.0: Timed Dry
 

--- a/Rules.md
+++ b/Rules.md
@@ -11920,7 +11920,6 @@ let abc = 0
 let abc = 0
 let abc = 0
 }
-
 ```
 
 ```swift
@@ -12127,7 +12126,6 @@ class Abc {
 
 
 }
-
 ```
 
 ```swift
@@ -12334,7 +12332,6 @@ class Abc {
 // this is a comment
 // this is a comment
 }
-
 ```
 
 ```swift
@@ -12543,7 +12540,6 @@ let abc = 0
 a multiline comment
 */
 }
-
 ```
 
 ```swift
@@ -12748,7 +12744,6 @@ let abc = 0
 let abc = 0
 let abc = 0
 }
-
 ```
 
 ```swift
@@ -12955,7 +12950,6 @@ struct Abc {
 
 
 }
-
 ```
 
 ```swift
@@ -13162,7 +13156,6 @@ struct Abc {
 // this is a comment
 // this is a comment
 }
-
 ```
 
 ```swift
@@ -13371,7 +13364,6 @@ let abc = 0
 a multiline comment
 */
 }
-
 ```
 
 ```swift
@@ -13576,7 +13568,6 @@ let abc = 0
 let abc = 0
 let abc = 0
 }
-
 ```
 
 ```swift
@@ -13783,7 +13774,6 @@ enum Abc {
 
 
 }
-
 ```
 
 ```swift
@@ -13990,7 +13980,6 @@ enum Abc {
 // this is a comment
 // this is a comment
 }
-
 ```
 
 ```swift
@@ -14199,7 +14188,6 @@ let abc = 0
 a multiline comment
 */
 }
-
 ```
 
 </details>
@@ -14410,7 +14398,6 @@ let abc = 0
 let abc = 0
 let abc = 0
 }
-
 ```
 
 ```swift
@@ -14617,7 +14604,6 @@ let abc = 0
 let abc = 0
 let abc = 0
 }
-
 ```
 
 ```swift
@@ -14824,7 +14810,6 @@ let abc = 0
 let abc = 0
 let abc = 0
 }
-
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -269,19 +269,24 @@ extension File {
     }
 
     fileprivate func numberOfCommentAndWhitespaceOnlyLines(startLine: Int, endLine: Int) -> Int {
-        let commentKinds = SyntaxKind.commentKinds
-        return syntaxKindsByLines[startLine...endLine].filter { kinds in
-            kinds.filter { !commentKinds.contains($0) }.isEmpty
+        return (startLine...endLine).filter { lineNumber in
+            let line = lines[lineNumber - 1]
+            let isLineEmpty = line.content.rangeOfCharacter(from: CharacterSet.whitespaces.inverted) == nil
+            if isLineEmpty { return true }
+
+            return syntaxKindsByLines[lineNumber].contains(where: SyntaxKind.commentKinds.contains)
         }.count
     }
 
     internal func exceedsLineCountExcludingCommentsAndWhitespace(_ start: Int, _ end: Int,
-                                                                 _ limit: Int) -> (Bool, Int) {
-        guard end - start > limit else {
-            return (false, end - start)
+                                                                 _ limit: Int, inclusive: Bool = true) -> (Bool, Int) {
+        let totalNumberOfLines = (start...end).count - (inclusive ? 0 : 2)
+
+        guard totalNumberOfLines > limit else {
+            return (false, totalNumberOfLines)
         }
 
-        let count = end - start - numberOfCommentAndWhitespaceOnlyLines(startLine: start, endLine: end)
+        let count = totalNumberOfLines - numberOfCommentAndWhitespaceOnlyLines(startLine: start, endLine: end)
         return (count > limit, count)
     }
 

--- a/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
@@ -84,20 +84,16 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
                 Location(file: file, byteOffset: $0.offset)
             } ?? Location(file: file.path, line: 1)
             return [
-                StyleViolation(
-                    ruleDescription: type(of: self).description,
-                    severity: configuration.severityConfiguration.severity,
-                    location: location
-                )
+                StyleViolation(ruleDescription: type(of: self).description,
+                               severity: configuration.severityConfiguration.severity,
+                               location: location)
             ]
         }
 
         return violationsOffsets.map {
-            StyleViolation(
-                ruleDescription: type(of: self).description,
-                severity: configuration.severityConfiguration.severity,
-                location: Location(file: file, characterOffset: $0)
-            )
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severityConfiguration.severity,
+                           location: Location(file: file, characterOffset: $0))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -34,7 +34,7 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
         }
         for parameter in configuration.params {
             let (exceeds, lineCount) = file.exceedsLineCountExcludingCommentsAndWhitespace(
-                startLine, endLine, parameter.value
+                startLine, endLine, parameter.value, inclusive: false
             )
             guard exceeds else { continue }
             return [StyleViolation(ruleDescription: type(of: self).description,

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-// swiftlint:disable type_body_length
-
 internal struct MultilineParametersRuleExamples {
     static let nonTriggeringExamples = [
         "func foo() { }",

--- a/Source/SwiftLintFramework/Rules/QuickDiscouragedCallRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/QuickDiscouragedCallRuleExamples.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-// swiftlint:disable type_body_length
-
 internal struct QuickDiscouragedCallRuleExamples {
     static let nonTriggeringExamples: [String] = [
         "class TotoTests: QuickSpec {\n" +

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -13,7 +13,8 @@ private func example(_ type: String,
                      _ count: Int,
                      _ add: String = "") -> String {
     return "\(type) Abc {\n" +
-        repeatElement(template, count: count).joined() + "\(add)}\n"
+        repeatElement(template, count: count).joined() + "\(add)" +
+    "}"
 }
 
 public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
@@ -54,7 +55,7 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
             if let startLine = startLine?.line, let endLine = endLine?.line {
                 for parameter in configuration.params {
                     let (exceeds, lineCount) = file.exceedsLineCountExcludingCommentsAndWhitespace(
-                        startLine, endLine, parameter.value
+                        startLine, endLine, parameter.value, inclusive: false
                     )
                     if exceeds {
                         let reason = "Type body should span \(configuration.warning) lines or less " +

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -92,12 +92,7 @@ extension Configuration {
             var filesAndConfigurations = [(File, Configuration)]()
             filesAndConfigurations.reserveCapacity(fileCount)
             for (config, files) in filesPerConfiguration {
-                let newConfig: Configuration
-                if cache != nil {
-                    newConfig = config.withPrecomputedCacheDescription()
-                } else {
-                    newConfig = config
-                }
+                let newConfig = cache != nil ? config.withPrecomputedCacheDescription() : config
                 filesAndConfigurations += files.map { ($0, newConfig) }
             }
             if parallel {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -164,7 +164,8 @@ extension FunctionBodyLengthRuleTests {
     static var allTests: [(String, (FunctionBodyLengthRuleTests) -> () throws -> Void)] = [
         ("testFunctionBodyLengths", testFunctionBodyLengths),
         ("testFunctionBodyLengthsWithComments", testFunctionBodyLengthsWithComments),
-        ("testFunctionBodyLengthsWithMultilineComments", testFunctionBodyLengthsWithMultilineComments)
+        ("testFunctionBodyLengthsWithMultilineComments", testFunctionBodyLengthsWithMultilineComments),
+        ("testFunctionBodyLengthsWithIfs", testFunctionBodyLengthsWithIfs)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -73,6 +73,24 @@ class FunctionBodyLengthRuleTests: XCTestCase {
             "whitespace: currently spans 41 lines")])
     }
 
+    func testFunctionBodyLengthsWithIfs() {
+        let longFunctionBodyWithIfs = funcWithBody(
+            repeatElement("if true {\n\tx = 0\n}\n\n", count: 13).joined() +
+            "// comment only line should be ignored.\n"
+        )
+        XCTAssertEqual(violations(longFunctionBodyWithIfs), [])
+
+        let longerFunctionBodyWithIfs = violatingFuncWithBody(
+            repeatElement("if true {\n\tx = 0\n}\n\n", count: 14).joined() +
+            "// comment only line should be ignored.\n"
+        )
+        XCTAssertEqual(violations(longerFunctionBodyWithIfs), [StyleViolation(
+            ruleDescription: FunctionBodyLengthRule.description,
+            location: Location(file: nil, line: 1, character: 1),
+            reason: "Function body should span 40 lines or less excluding comments and " +
+            "whitespace: currently spans 43 lines")])
+    }
+
     private func violations(_ string: String) -> [StyleViolation] {
         let config = makeConfig(nil, FunctionBodyLengthRule.description.identifier)!
         return SwiftLintFrameworkTests.violations(string, config: config)

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -183,18 +183,14 @@ extension XCTestCase {
 
         // Comment doesn't violate
         if !skipCommentTests {
-            XCTAssertEqual(
-                triggers.flatMap({ violations("/*\n  " + $0 + "\n */", config: config) }).count,
-                commentDoesntViolate ? 0 : triggers.count
-            )
+            XCTAssertEqual(triggers.flatMap({ violations("/*\n  " + $0 + "\n */", config: config) }).count,
+                           commentDoesntViolate ? 0 : triggers.count)
         }
 
         // String doesn't violate
         if !skipStringTests {
-            XCTAssertEqual(
-                triggers.flatMap({ violations($0.toStringLiteral(), config: config) }).count,
-                stringDoesntViolate ? 0 : triggers.count
-            )
+            XCTAssertEqual(triggers.flatMap({ violations($0.toStringLiteral(), config: config) }).count,
+                           stringDoesntViolate ? 0 : triggers.count)
         }
 
         let disableCommands: [String]
@@ -226,7 +222,6 @@ extension XCTestCase {
                 config.assertCorrection(expectedCleaned, expected: expectedCleaned)
             }
         }
-
     }
 
     private func verifyExamples(triggers: [String], nonTriggers: [String],


### PR DESCRIPTION
This commit implements a fix for the issue described in #1750. The following rules are returning the incorrect number of lines:

* `function_body_length`
* `type_body_length`

This PR contains several commits to make the code review easier.