### PR TITLE
Support Optional<()> returns that use syntactic sugar, ()?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1721](https://github.com/realm/SwiftLint/issues/1721)
 
+* Sugared `Optional<()>` return types,  `()?`, Void?, `()!`, and Void!
+  no longer triggr the `redundant_void_return` rule.  
+  [Ryan Booker](https://github.com/ryanbooker)
+  [#1761](https://github.com/realm/SwiftLint/issues/1761)
+ 
 ##### Bug Fixes
 
 * Fix false positive on `force_unwrapping` rule when declaring

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -27,7 +27,11 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
             "func foo() -> VoidResponse\n",
             "let foo: Int -> Void\n",
             "func foo() -> Int -> () {}\n",
-            "let foo: Int -> ()\n"
+            "let foo: Int -> ()\n",
+            "func foo() -> ()?\n",
+            "func foo() -> ()!\n",
+            "func foo() -> Void?\n",
+            "func foo() -> Void!\n"
         ],
         triggeringExamples: [
             "func foo()↓ -> Void {}\n",
@@ -43,7 +47,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
         ]
     )
 
-    private let pattern = "\\s*->\\s*(?:Void\\b|\\(\\s*\\))"
+    private let pattern = "\\s*->\\s*(?:Void\\b|\\(\\s*\\))(?![?!])"
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {


### PR DESCRIPTION
https://github.com/realm/SwiftLint/issues/1761