### PR TITLE
Vertical whitespace msg fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,22 +38,9 @@
   [Otávio Lima](https://github.com/otaviolima)
   [#1710](https://github.com/realm/SwiftLint/issues/1710)
 
-## 0.22.0: Coffee Maker
-
-##### Breaking
-
-* None.
-
-##### Enhancements
-
-* None.
-
-##### Bug Fixes
-
-* Fix the warning message of `vertical-whitespace` rule to display the maximum empty lines allowed if `maxEmptyLines` is greater than 1.
-* Fix the autocorrection of `vertical-whitespace` rule to keep the `maxEmptyLines` in the cleaned section.
-  [Hossam Ghareeb](https://github.com/hossamghareeb)
-  [#1763](https://github.com/realm/SwiftLint/issues/1763)
+* Fix the warning message and autocorrection of `vertical-whitespace` rule to display the maximum empty lines allowed if `maxEmptyLines` is greater than 1.  
+[Hossam Ghareeb](https://github.com/hossamghareeb)
+[#1763](https://github.com/realm/SwiftLint/issues/1763)
 
 ## 0.21.0: Vintage Washboard
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,23 @@
   [Otávio Lima](https://github.com/otaviolima)
   [#1710](https://github.com/realm/SwiftLint/issues/1710)
 
+## 0.22.0: Coffee Maker
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* Fix the warning message of `vertical-whitespace` rule to display the maximum empty lines allowed if `maxEmptyLines` is greater than 1.
+* Fix the autocorrection of `vertical-whitespace` rule to keep the `maxEmptyLines` in the cleaned section.
+  [Hossam Ghareeb](https://github.com/hossamghareeb)
+  [#1763](https://github.com/realm/SwiftLint/issues/1763)
+
 ## 0.21.0: Vintage Washboard
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
@@ -39,7 +39,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
             "// bca \n\n\n": "// bca \n\n"
         ] // End of line autocorrections are handled by Trailing Newline Rule.
     )
-    
+
     private var configuredDescriptionReason: String {
         guard configuration.maxEmptyLines == 1 else {
             return "Limit vertical whitespace to maximum \(configuration.maxEmptyLines) empty lines."

--- a/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
@@ -146,7 +146,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
             // removes lines by skipping them from correctedLines
             if Set(indexOfLinesToDelete).contains(currentLine.index) {
                 let description = type(of: self).description
-                let location = Location(file: file.path, line: currentLine.index)
+                let location = Location(file: file, characterOffset: currentLine.range.location)
 
                 //reports every line that is being deleted
                 corrections.append(Correction(ruleDescription: description, location: location))

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -7,11 +7,10 @@
 //
 
 @testable import SwiftLintFramework
-@testable import SourceKittenFramework
 import XCTest
 
 class VerticalWhitespaceRuleTests: XCTestCase {
-    
+
     private let ruleID = "vertical_whitespace"
 
     func testVerticalWhitespaceWithDefaultConfiguration() {
@@ -29,22 +28,22 @@ class VerticalWhitespaceRuleTests: XCTestCase {
         verifyRule(maxEmptyLinesDescription,
                    ruleConfiguration: ["max_empty_lines": 2])
     }
-    
+
     func testViolationMessageWithMaxEmptyLines() {
         guard let config = makeConfig(["max_empty_lines": 2], ruleID) else {
             XCTFail("Failed to create configuration")
             return
         }
         let allViolations = violations("let aaaa = 0\n\n\n\nlet bbb = 2\n", config: config)
-        let verticalWhiteSpaceViolation = allViolations.filter { $0.ruleDescription.identifier == ruleID }.first
+        let verticalWhiteSpaceViolation = allViolations.first(where: { $0.ruleDescription.identifier == ruleID })
         if let violation = verticalWhiteSpaceViolation {
             XCTAssertEqual(violation.reason, "Limit vertical whitespace to maximum 2 empty lines. Currently 3.")
         }
     }
-    
+
     func testVilationMessageWithDefaultConfiguration() {
         let allViolations = violations("let aaaa = 0\n\n\n\nlet bbb = 2\n")
-        let verticalWhiteSpaceViolation = allViolations.filter { $0.ruleDescription.identifier == ruleID }.first
+        let verticalWhiteSpaceViolation = allViolations.first(where: { $0.ruleDescription.identifier == ruleID })
         if let violation = verticalWhiteSpaceViolation {
             XCTAssertEqual(violation.reason, "Limit vertical whitespace to a single empty line. Currently 3.")
         }

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -29,13 +29,27 @@ class VerticalWhitespaceRuleTests: XCTestCase {
                    ruleConfiguration: ["max_empty_lines": 2])
     }
 
+    func testAutoCorrection() {
+        let maxEmptyLinesDescription = VerticalWhitespaceRule.description
+            .with(nonTriggeringExamples: [])
+            .with(triggeringExamples: [])
+            .with(corrections: [
+                "let b = 0\n\n↓\n↓\n↓\n\nclass AAA {}\n": "let b = 0\n\n\nclass AAA {}\n",
+                "let b = 0\n\n\nclass AAA {}\n": "let b = 0\n\n\nclass AAA {}\n"
+                ])
+
+        verifyRule(maxEmptyLinesDescription,
+                   ruleConfiguration: ["max_empty_lines": 2])
+    }
+
     func testViolationMessageWithMaxEmptyLines() {
         guard let config = makeConfig(["max_empty_lines": 2], ruleID) else {
             XCTFail("Failed to create configuration")
             return
         }
         let allViolations = violations("let aaaa = 0\n\n\n\nlet bbb = 2\n", config: config)
-        let verticalWhiteSpaceViolation = allViolations.first(where: { $0.ruleDescription.identifier == ruleID })
+
+        let verticalWhiteSpaceViolation = allViolations.first { $0.ruleDescription.identifier == ruleID }
         if let violation = verticalWhiteSpaceViolation {
             XCTAssertEqual(violation.reason, "Limit vertical whitespace to maximum 2 empty lines. Currently 3.")
         } else {

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class VerticalWhitespaceRuleTests: XCTestCase {
 
-    private let ruleID = "vertical_whitespace"
+    private let ruleID = VerticalWhitespaceRule.description.identifier
 
     func testVerticalWhitespaceWithDefaultConfiguration() {
         // Test with default parameters
@@ -38,14 +38,18 @@ class VerticalWhitespaceRuleTests: XCTestCase {
         let verticalWhiteSpaceViolation = allViolations.first(where: { $0.ruleDescription.identifier == ruleID })
         if let violation = verticalWhiteSpaceViolation {
             XCTAssertEqual(violation.reason, "Limit vertical whitespace to maximum 2 empty lines. Currently 3.")
+        } else {
+            XCTFail("A vertical white space violation should have been triggered!")
         }
     }
 
-    func testVilationMessageWithDefaultConfiguration() {
+    func testViolationMessageWithDefaultConfiguration() {
         let allViolations = violations("let aaaa = 0\n\n\n\nlet bbb = 2\n")
         let verticalWhiteSpaceViolation = allViolations.first(where: { $0.ruleDescription.identifier == ruleID })
         if let violation = verticalWhiteSpaceViolation {
             XCTAssertEqual(violation.reason, "Limit vertical whitespace to a single empty line. Currently 3.")
+        } else {
+            XCTFail("A vertical white space violation should have been triggered!")
         }
     }
 }

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -7,9 +7,12 @@
 //
 
 @testable import SwiftLintFramework
+@testable import SourceKittenFramework
 import XCTest
 
 class VerticalWhitespaceRuleTests: XCTestCase {
+    
+    private let ruleID = "vertical_whitespace"
 
     func testVerticalWhitespaceWithDefaultConfiguration() {
         // Test with default parameters
@@ -25,5 +28,25 @@ class VerticalWhitespaceRuleTests: XCTestCase {
 
         verifyRule(maxEmptyLinesDescription,
                    ruleConfiguration: ["max_empty_lines": 2])
+    }
+    
+    func testViolationMessageWithMaxEmptyLines() {
+        guard let config = makeConfig(["max_empty_lines": 2], ruleID) else {
+            XCTFail("Failed to create configuration")
+            return
+        }
+        let allViolations = violations("let aaaa = 0\n\n\n\nlet bbb = 2\n", config: config)
+        let verticalWhiteSpaceViolation = allViolations.filter { $0.ruleDescription.identifier == ruleID }.first
+        if let violation = verticalWhiteSpaceViolation {
+            XCTAssertEqual(violation.reason, "Limit vertical whitespace to maximum 2 empty lines. Currently 3.")
+        }
+    }
+    
+    func testVilationMessageWithDefaultConfiguration() {
+        let allViolations = violations("let aaaa = 0\n\n\n\nlet bbb = 2\n")
+        let verticalWhiteSpaceViolation = allViolations.filter { $0.ruleDescription.identifier == ruleID }.first
+        if let violation = verticalWhiteSpaceViolation {
+            XCTAssertEqual(violation.reason, "Limit vertical whitespace to a single empty line. Currently 3.")
+        }
     }
 }


### PR DESCRIPTION
Fixing issue #1763 
Fixes:
1. Fix the warning message to display the maximum empty lines allowed based on `maxEmptyLines`. 
2. Fix autocorrect to delete empty lines till and keep the `maxEmptyLines` and not 1. 