### PR TITLE
Explicit Enum Raw Value Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@
 
 * Invalidate cache when Swift version changes.  
   [Marcelo Fabri](https://github.com/marcelofabri)
-* Add `explicit_associated_enum_value` opt-in rule to allow refactoring the
+
+* Add `explicit_enum_raw_value` opt-in rule to allow refactoring the
   Swift API without breaking the API contract.  
   [Mazyod](https://github.com/mazyod)
   [#1778](https://github.com/realm/SwiftLint/issues/1778)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 
 * Invalidate cache when Swift version changes.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+* Add `explicit_associated_enum_value` opt-in rule to allow refactoring the
+  Swift API without breaking the API contract.  
+  [Mazyod](https://github.com/mazyod)
+  [#1778](https://github.com/realm/SwiftLint/issues/1778)
 
 ##### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -22,6 +22,7 @@
 * [Empty Enum Arguments](#empty-enum-arguments)
 * [Empty Parameters](#empty-parameters)
 * [Empty Parentheses with Trailing Closure](#empty-parentheses-with-trailing-closure)
+* [Explicit Associated Enum Value](#explicit-associated-enum-value)
 * [Explicit Init](#explicit-init)
 * [Explicit Top Level ACL](#explicit-top-level-acl)
 * [Explicit Type Interface](#explicit-type-interface)
@@ -2082,6 +2083,111 @@ UIView.animateWithDuration(0.3, animations: {
 ```swift
 [1, 2].map↓(  ) { number in
  number + 1 
+}
+
+```
+
+</details>
+
+
+
+## Explicit Associated Enum Value
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`explicit_associated_enum_value` | Disabled | No | idiomatic
+
+Enums should be explicitly assigned their associated values.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+enum Numbers {
+ case int(Int)
+ case short(Int16)
+}
+
+```
+
+```swift
+enum Numbers: Int {
+ case one = 1
+ case two = 2
+}
+
+```
+
+```swift
+enum Numbers: Double {
+ case one = 1.1
+ case two = 2.2
+}
+
+```
+
+```swift
+enum Numbers: String {
+ case one = "one"
+ case two = "two"
+}
+
+```
+
+```swift
+enum Numbers: String {
+ case one = "one", two = "two"
+}
+
+```
+
+```swift
+enum Numbers: String {
+ case one = "ONE"
+ case two = "TWO"
+}
+
+```
+
+```swift
+enum Numbers: String {
+ case one = "ONE"
+ case two = "two"
+}
+
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+enum Numbers: Int {
+ case one = 10, ↓two, three = 30
+}
+
+```
+
+```swift
+enum Numbers: String {
+ case ↓one
+ case ↓two
+}
+
+```
+
+```swift
+enum Numbers: String {
+ case ↓one, two = "two"
+}
+
+```
+
+```swift
+enum Numbers: String {
+ case ↓one, ↓two
 }
 
 ```

--- a/Rules.md
+++ b/Rules.md
@@ -2095,7 +2095,7 @@ UIView.animateWithDuration(0.3, animations: {
 
 Identifier | Enabled by default | Supports autocorrection | Kind 
 --- | --- | --- | ---
-`explicit_associated_enum_value` | Disabled | No | idiomatic
+`explicit_enum_raw_value` | Disabled | No | idiomatic
 
 Enums should be explicitly assigned their raw values.
 
@@ -2137,9 +2137,9 @@ enum Numbers: String {
 ```
 
 ```swift
-enum Numbers: String {
- case one = "ONE"
- case two = "TWO"
+protocol Algebra {}
+enum Numbers: Algebra {
+ case one
 }
 
 ```
@@ -2151,6 +2151,13 @@ enum Numbers: String {
 ```swift
 enum Numbers: Int {
  case one = 10, ↓two, three = 30
+}
+
+```
+
+```swift
+enum Numbers: NSInteger {
+ case ↓one
 }
 
 ```
@@ -2171,7 +2178,7 @@ enum Numbers: String {
 ```
 
 ```swift
-enum Numbers: String {
+enum Numbers: Decimal {
  case ↓one, ↓two
 }
 

--- a/Rules.md
+++ b/Rules.md
@@ -2138,23 +2138,8 @@ enum Numbers: String {
 
 ```swift
 enum Numbers: String {
- case one = "one", two = "two"
-}
-
-```
-
-```swift
-enum Numbers: String {
  case one = "ONE"
  case two = "TWO"
-}
-
-```
-
-```swift
-enum Numbers: String {
- case one = "ONE"
- case two = "two"
 }
 
 ```

--- a/Rules.md
+++ b/Rules.md
@@ -22,7 +22,7 @@
 * [Empty Enum Arguments](#empty-enum-arguments)
 * [Empty Parameters](#empty-parameters)
 * [Empty Parentheses with Trailing Closure](#empty-parentheses-with-trailing-closure)
-* [Explicit Associated Enum Value](#explicit-associated-enum-value)
+* [Explicit Enum Raw Value](#explicit-enum-raw-value)
 * [Explicit Init](#explicit-init)
 * [Explicit Top Level ACL](#explicit-top-level-acl)
 * [Explicit Type Interface](#explicit-type-interface)
@@ -2091,13 +2091,13 @@ UIView.animateWithDuration(0.3, animations: {
 
 
 
-## Explicit Associated Enum Value
+## Explicit Enum Raw Value
 
 Identifier | Enabled by default | Supports autocorrection | Kind 
 --- | --- | --- | ---
 `explicit_associated_enum_value` | Disabled | No | idiomatic
 
-Enums should be explicitly assigned their associated values.
+Enums should be explicitly assigned their raw values.
 
 ### Examples
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -30,7 +30,7 @@ public let masterRuleList = RuleList(rules: [
     EmptyEnumArgumentsRule.self,
     EmptyParametersRule.self,
     EmptyParenthesesWithTrailingClosureRule.self,
-    ExplicitAssociatedEnumValueRule.self,
+    ExplicitEnumRawValueRule.self,
     ExplicitInitRule.self,
     ExplicitTopLevelACLRule.self,
     ExplicitTypeInterfaceRule.self,

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -30,6 +30,7 @@ public let masterRuleList = RuleList(rules: [
     EmptyEnumArgumentsRule.self,
     EmptyParametersRule.self,
     EmptyParenthesesWithTrailingClosureRule.self,
+    ExplicitAssociatedEnumValueRule.self,
     ExplicitInitRule.self,
     ExplicitTopLevelACLRule.self,
     ExplicitTypeInterfaceRule.self,

--- a/Source/SwiftLintFramework/Rules/ExplicitAssociatedEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitAssociatedEnumValueRule.swift
@@ -57,7 +57,7 @@ public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, Configuration
 
         let locs = substructureElements(of: dictionary, matching: .enumcase)
             .flatMap { substructureElements(of: $0, matching: .enumelement) }
-            .flatMap(enumElementsMissingInitExpr(_:))
+            .flatMap(enumElementsMissingInitExpr)
             .flatMap { $0.offset }
 
         return locs
@@ -66,7 +66,7 @@ public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, Configuration
     private func substructureElements(of dict: [String: SourceKitRepresentable],
                                       matching kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
         return dict.substructure
-            .filter { $0.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) == kind }
+            .filter { $0.kind.flatMap(SwiftDeclarationKind.init) == kind }
     }
 
     private func enumElementsMissingInitExpr(

--- a/Source/SwiftLintFramework/Rules/ExplicitAssociatedEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitAssociatedEnumValueRule.swift
@@ -24,9 +24,7 @@ public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, Configuration
             "enum Numbers: Int {\n case one = 1\n case two = 2\n}\n",
             "enum Numbers: Double {\n case one = 1.1\n case two = 2.2\n}\n",
             "enum Numbers: String {\n case one = \"one\"\n case two = \"two\"\n}\n",
-            "enum Numbers: String {\n case one = \"one\", two = \"two\"\n}\n",
-            "enum Numbers: String {\n case one = \"ONE\"\n case two = \"TWO\"\n}\n",
-            "enum Numbers: String {\n case one = \"ONE\"\n case two = \"two\"\n}\n"
+            "enum Numbers: String {\n case one = \"ONE\"\n case two = \"TWO\"\n}\n"
         ],
         triggeringExamples: [
             "enum Numbers: Int {\n case one = 10, ↓two, three = 30\n}\n",

--- a/Source/SwiftLintFramework/Rules/ExplicitAssociatedEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitAssociatedEnumValueRule.swift
@@ -1,0 +1,80 @@
+//
+//  ExplicitAssociatedEnumValueRule.swift
+//  SwiftLint
+//
+//  Created by Mazyad Alabduljaleel on 8/19/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+
+public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+    
+    public init() {}
+    
+    public static let description = RuleDescription(
+        identifier: "explicit_associated_enum_value",
+        name: "Explicit Associated Enum Value",
+        description: "Enums should be explicitly assigned their associated values.",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            "enum Numbers {\n case int(Int)\n case short(Int16)\n}\n",
+            "enum Numbers: Int {\n case one = 1\n case two = 2\n}\n",
+            "enum Numbers: Double {\n case one = 1.1\n case two = 2.2\n}\n",
+            "enum Numbers: String {\n case one = \"one\"\n case two = \"two\"\n}\n",
+            "enum Numbers: String {\n case one = \"one\", two = \"two\"\n}\n",
+            "enum Numbers: String {\n case one = \"ONE\"\n case two = \"TWO\"\n}\n",
+            "enum Numbers: String {\n case one = \"ONE\"\n case two = \"two\"\n}\n"
+        ],
+        triggeringExamples: [
+            "enum Numbers: Int {\n case one = 10, ↓two, three = 30\n}\n",
+            "enum Numbers: String {\n case ↓one\n case ↓two\n}\n",
+            "enum Numbers: String {\n case ↓one, two = \"two\"\n}\n",
+            "enum Numbers: String {\n case ↓one, ↓two\n}\n"
+        ]
+    )
+    
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .enum else {
+            return []
+        }
+        
+        // Check if it's an associated value enum
+        guard !dictionary.inheritedTypes.isEmpty else {
+            return []
+        }
+        
+        let violations = violatingOffsetsForEnum(dictionary: dictionary, file: file)
+        return violations.map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: $0))
+        }
+    }
+    
+    private func violatingOffsetsForEnum(dictionary: [String: SourceKitRepresentable], file: File) -> [Int] {
+        
+        let locs = substructureElements(of: dictionary, matching: .enumcase)
+            .flatMap { substructureElements(of: $0, matching: .enumelement) }
+            .flatMap(filterOutEnumElementsWithoutInitExpr(_:))
+            .flatMap { $0.offset }
+        
+        return locs
+    }
+    
+    private func substructureElements(of dict: [String: SourceKitRepresentable],
+                                      matching kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
+        return dict.substructure
+            .filter { $0.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) == kind }
+    }
+    
+    private func filterOutEnumElementsWithoutInitExpr(_ enumElements: [[String: SourceKitRepresentable]]) -> [[String: SourceKitRepresentable]] {
+        
+        return enumElements
+            .filter { !$0.elements.contains { $0.kind == "source.lang.swift.structure.elem.init_expr" } }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/ExplicitAssociatedEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitAssociatedEnumValueRule.swift
@@ -59,7 +59,7 @@ public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, Configuration
 
         let locs = substructureElements(of: dictionary, matching: .enumcase)
             .flatMap { substructureElements(of: $0, matching: .enumelement) }
-            .flatMap(filterOutEnumElementsWithoutInitExpr(_:))
+            .flatMap(enumElementsMissingInitExpr(_:))
             .flatMap { $0.offset }
 
         return locs
@@ -71,7 +71,8 @@ public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, Configuration
             .filter { $0.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) == kind }
     }
 
-    private func filterOutEnumElementsWithoutInitExpr(_ enumElements: [[String: SourceKitRepresentable]]) -> [[String: SourceKitRepresentable]] {
+    private func enumElementsMissingInitExpr(
+        _ enumElements: [[String: SourceKitRepresentable]]) -> [[String: SourceKitRepresentable]] {
 
         return enumElements
             .filter { !$0.elements.contains { $0.kind == "source.lang.swift.structure.elem.init_expr" } }

--- a/Source/SwiftLintFramework/Rules/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitEnumRawValueRule.swift
@@ -1,5 +1,5 @@
 //
-//  ExplicitAssociatedEnumValueRule.swift
+//  ExplicitEnumRawValueRule.swift
 //  SwiftLint
 //
 //  Created by Mazyad Alabduljaleel on 8/19/17.
@@ -9,15 +9,15 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
 
     public static let description = RuleDescription(
-        identifier: "explicit_associated_enum_value",
-        name: "Explicit Associated Enum Value",
-        description: "Enums should be explicitly assigned their associated values.",
+        identifier: "explicit_enum_raw_value",
+        name: "Explicit Enum Raw Value",
+        description: "Enums should be explicitly assigned their raw values.",
         kind: .idiomatic,
         nonTriggeringExamples: [
             "enum Numbers {\n case int(Int)\n case short(Int16)\n}\n",
@@ -45,7 +45,7 @@ public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, Configuration
             return []
         }
 
-        let violations = violatingOffsetsForEnum(dictionary: dictionary, file: file)
+        let violations = violatingOffsetsForEnum(dictionary: dictionary)
         return violations.map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -53,7 +53,7 @@ public struct ExplicitAssociatedEnumValueRule: ASTRule, OptInRule, Configuration
         }
     }
 
-    private func violatingOffsetsForEnum(dictionary: [String: SourceKitRepresentable], file: File) -> [Int] {
+    private func violatingOffsetsForEnum(dictionary: [String: SourceKitRepresentable]) -> [Int] {
 
         let locs = substructureElements(of: dictionary, matching: .enumcase)
             .flatMap { substructureElements(of: $0, matching: .enumelement) }

--- a/Source/SwiftLintFramework/Rules/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitEnumRawValueRule.swift
@@ -24,13 +24,14 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
             "enum Numbers: Int {\n case one = 1\n case two = 2\n}\n",
             "enum Numbers: Double {\n case one = 1.1\n case two = 2.2\n}\n",
             "enum Numbers: String {\n case one = \"one\"\n case two = \"two\"\n}\n",
-            "enum Numbers: String {\n case one = \"ONE\"\n case two = \"TWO\"\n}\n"
+            "protocol Algebra {}\nenum Numbers: Algebra {\n case one\n}\n"
         ],
         triggeringExamples: [
             "enum Numbers: Int {\n case one = 10, ↓two, three = 30\n}\n",
+            "enum Numbers: NSInteger {\n case ↓one\n}\n",
             "enum Numbers: String {\n case ↓one\n case ↓two\n}\n",
             "enum Numbers: String {\n case ↓one, two = \"two\"\n}\n",
-            "enum Numbers: String {\n case ↓one, ↓two\n}\n"
+            "enum Numbers: Decimal {\n case ↓one, ↓two\n}\n"
         ]
     )
 
@@ -40,8 +41,18 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
             return []
         }
 
-        // Check if it's an associated value enum
-        guard !dictionary.inheritedTypes.isEmpty else {
+        // Check if it's an enum which supports raw values
+        let implicitRawValueTypes: [Any] = [
+            Int.self, Int8.self, Int16.self, Int32.self, Int64.self,
+            UInt.self, UInt8.self, UInt16.self, UInt32.self, UInt64.self,
+            Double.self, Float.self, Float80.self, Decimal.self, NSNumber.self,
+            NSDecimalNumber.self, "NSInteger", String.self
+        ]
+
+        let implicitRawValueSet = Set(implicitRawValueTypes.map(String.init(describing:)))
+        let enumInheritedTypesSet = Set(dictionary.inheritedTypes)
+
+        guard !implicitRawValueSet.isDisjoint(with: enumInheritedTypesSet) else {
             return []
         }
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -94,7 +94,7 @@
 		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
 		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
 		825F19D11EEFF19700969EF1 /* ObjectLiteralRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */; };
-		827169B31F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827169B21F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift */; };
+		827169B31F488181003FB9AF /* ExplicitEnumRawValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827169B21F488181003FB9AF /* ExplicitEnumRawValueRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
 		85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856651A61D6B395F005E6B29 /* MarkRule.swift */; };
@@ -405,7 +405,7 @@
 		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
 		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
 		825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralRuleTests.swift; sourceTree = "<group>"; };
-		827169B21F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitAssociatedEnumValueRule.swift; sourceTree = "<group>"; };
+		827169B21F488181003FB9AF /* ExplicitEnumRawValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitEnumRawValueRule.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
 		856651A61D6B395F005E6B29 /* MarkRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
@@ -958,7 +958,7 @@
 				D4470D581EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift */,
 				D47079AC1DFE2FA700027086 /* EmptyParametersRule.swift */,
 				D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */,
-				827169B21F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift */,
+				827169B21F488181003FB9AF /* ExplicitEnumRawValueRule.swift */,
 				7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */,
 				1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */,
 				C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */,
@@ -1504,7 +1504,7 @@
 				D4D1B9BB1EAC2C910028BE6A /* AccessControlLevel.swift in Sources */,
 				4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */,
 				D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */,
-				827169B31F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift in Sources */,
+				827169B31F488181003FB9AF /* ExplicitEnumRawValueRule.swift in Sources */,
 				29FFC37A1F15764D007E4825 /* FileLengthRuleConfiguration.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
 				D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
 		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
 		825F19D11EEFF19700969EF1 /* ObjectLiteralRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */; };
+		827169B31F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827169B21F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift */; };
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
 		85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856651A61D6B395F005E6B29 /* MarkRule.swift */; };
@@ -404,6 +405,7 @@
 		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
 		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
 		825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralRuleTests.swift; sourceTree = "<group>"; };
+		827169B21F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitAssociatedEnumValueRule.swift; sourceTree = "<group>"; };
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
 		856651A61D6B395F005E6B29 /* MarkRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
@@ -956,6 +958,7 @@
 				D4470D581EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift */,
 				D47079AC1DFE2FA700027086 /* EmptyParametersRule.swift */,
 				D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */,
+				827169B21F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift */,
 				7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */,
 				1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */,
 				C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */,
@@ -1501,6 +1504,7 @@
 				D4D1B9BB1EAC2C910028BE6A /* AccessControlLevel.swift in Sources */,
 				4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */,
 				D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */,
+				827169B31F488181003FB9AF /* ExplicitAssociatedEnumValueRule.swift in Sources */,
 				29FFC37A1F15764D007E4825 /* FileLengthRuleConfiguration.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
 				D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -358,6 +358,7 @@ extension RulesTests {
         ("testEmptyEnumArguments", testEmptyEnumArguments),
         ("testEmptyParameters", testEmptyParameters),
         ("testEmptyParenthesesWithTrailingClosure", testEmptyParenthesesWithTrailingClosure),
+        ("testExplicitAssociatedEnumValue", testExplicitAssociatedEnumValue),
         ("testExplicitInit", testExplicitInit),
         ("testExplicitTopLevelACL", testExplicitTopLevelACL),
         ("testExplicitTypeInterface", testExplicitTypeInterface),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -358,7 +358,7 @@ extension RulesTests {
         ("testEmptyEnumArguments", testEmptyEnumArguments),
         ("testEmptyParameters", testEmptyParameters),
         ("testEmptyParenthesesWithTrailingClosure", testEmptyParenthesesWithTrailingClosure),
-        ("testExplicitAssociatedEnumValue", testExplicitAssociatedEnumValue),
+        ("testExplicitEnumRawValue", testExplicitEnumRawValue),
         ("testExplicitInit", testExplicitInit),
         ("testExplicitTopLevelACL", testExplicitTopLevelACL),
         ("testExplicitTypeInterface", testExplicitTypeInterface),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -80,7 +80,7 @@ class RulesTests: XCTestCase {
     func testEmptyParenthesesWithTrailingClosure() {
         verifyRule(EmptyParenthesesWithTrailingClosureRule.description)
     }
-    
+
     func testExplicitAssociatedEnumValue() {
         verifyRule(ExplicitAssociatedEnumValueRule.description)
     }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -81,8 +81,8 @@ class RulesTests: XCTestCase {
         verifyRule(EmptyParenthesesWithTrailingClosureRule.description)
     }
 
-    func testExplicitAssociatedEnumValue() {
-        verifyRule(ExplicitAssociatedEnumValueRule.description)
+    func testExplicitEnumRawValue() {
+        verifyRule(ExplicitEnumRawValueRule.description)
     }
 
     func testExplicitInit() {

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -80,6 +80,10 @@ class RulesTests: XCTestCase {
     func testEmptyParenthesesWithTrailingClosure() {
         verifyRule(EmptyParenthesesWithTrailingClosureRule.description)
     }
+    
+    func testExplicitAssociatedEnumValue() {
+        verifyRule(ExplicitAssociatedEnumValueRule.description)
+    }
 
     func testExplicitInit() {
         verifyRule(ExplicitInitRule.description)


### PR DESCRIPTION
Hey, as @marcelofabri suggested, this was a good rule for new contributors to get their hands dirty (assuming I did this with reasonable correctness!).

I feel the PR is self-explanatory, but just to reiterate:
1. Followed the contributing guideline points (except linux tests, will test on linux now)
2. The rule is opt-in, and enforces the existence of `init_expr`
3. Tested enums with associated types, `Int` enums, and `String` enums.

Fixes #1778 