### PR TITLE
Invalidate cache when Swift version changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
   [Ornithologist Coder](https://github.com/ornithocoder)
   [#1781](https://github.com/realm/SwiftLint/issues/1781)
 
+* Invalidate cache when Swift version changes.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 ##### Bug Fixes
 
 * Fix false positive on `force_unwrapping` rule when declaring

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -9,9 +9,9 @@
 import Foundation
 import SourceKittenFramework
 
-enum SwiftVersion {
-    case three
-    case four
+enum SwiftVersion: String {
+    case three = "3"
+    case four = "4"
 
     static let current: SwiftVersion = {
         // Allow forcing the Swift version, useful in cases where SourceKit isn't available

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -238,7 +238,8 @@ extension LinterCacheTests {
         ("testOptInRulesChangedOrAddedOrRemovedCausesAllFilesToBeReLinted", testOptInRulesChangedOrAddedOrRemovedCausesAllFilesToBeReLinted),
         ("testEnabledRulesChangedOrAddedOrRemovedCausesAllFilesToBeReLinted", testEnabledRulesChangedOrAddedOrRemovedCausesAllFilesToBeReLinted),
         ("testWhitelistRulesChangedOrAddedOrRemovedCausesAllFilesToBeReLinted", testWhitelistRulesChangedOrAddedOrRemovedCausesAllFilesToBeReLinted),
-        ("testRuleConfigurationChangedOrAddedOrRemovedCausesAllFilesToBeReLinted", testRuleConfigurationChangedOrAddedOrRemovedCausesAllFilesToBeReLinted)
+        ("testRuleConfigurationChangedOrAddedOrRemovedCausesAllFilesToBeReLinted", testRuleConfigurationChangedOrAddedOrRemovedCausesAllFilesToBeReLinted),
+        ("testSwiftVersionChangedRemovedCausesAllFilesToBeReLinted", testSwiftVersionChangedRemovedCausesAllFilesToBeReLinted)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -266,7 +266,7 @@ class LinterCacheTests: XCTestCase {
 
         // Change
         validateNewConfigDoesntHitCache(dict: ["opt_in_rules": ["empty_count"]], initialConfig: initialConfig)
-        // Aules addition
+        // Rules addition
         validateNewConfigDoesntHitCache(dict: ["opt_in_rules": ["attributes", "empty_count"]],
                                         initialConfig: initialConfig)
         // Removal
@@ -309,5 +309,21 @@ class LinterCacheTests: XCTestCase {
                                         initialConfig: initialConfig)
         // Removal
         validateNewConfigDoesntHitCache(dict: [:], initialConfig: initialConfig)
+    }
+
+    func testSwiftVersionChangedRemovedCausesAllFilesToBeReLinted() {
+        let fileManager = TestFileManager()
+        cache = LinterCache(fileManager: fileManager, swiftVersion: .three)
+        let helper = makeCacheTestHelper(dict: [:])
+        let file = "foo.swift"
+        let violations = helper.makeViolations(file: file)
+
+        cacheAndValidate(violations: violations, forFile: file, configuration: helper.configuration)
+        let swift3Cache = cache
+
+        cache = LinterCache(fileManager: fileManager, swiftVersion: .four)
+
+        XCTAssertNotNil(swift3Cache.violations(forFile: file, configuration: helper.configuration))
+        XCTAssertNil(cache.violations(forFile: file, configuration: helper.configuration))
     }
 }


### PR DESCRIPTION
This is a compromise until #1709 is properly resolved. 