### PR TITLE
Fix false positive on `unused_enumerated` rule with complex variable bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1744](https://github.com/realm/SwiftLint/issues/1744)
 
+* Fix false positive on `unused_enumerated` rule with complex variable
+  bindings.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1787](https://github.com/realm/SwiftLint/issues/1787)
+
 ## 0.21.0: Vintage Washboard
 
 ##### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -13399,6 +13399,11 @@ for idx in bar.indices { }
 
 ```
 
+```swift
+for (section, (event, _)) in data.enumerated() {}
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedEnumeratedRule.swift
@@ -27,7 +27,8 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule {
             "for foo in bar { }\n",
             "for (idx, _) in bar.enumerated().something() { }\n",
             "for (idx, _) in bar.something() { }\n",
-            "for idx in bar.indices { }\n"
+            "for idx in bar.indices { }\n",
+            "for (section, (event, _)) in data.enumerated() {}\n"
         ],
         triggeringExamples: [
             "for (↓_, foo) in bar.enumerated() { }\n",
@@ -44,12 +45,12 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule {
             isEnumeratedCall(dictionary: dictionary),
             let byteRange = byteRangeForVariables(dictionary: dictionary),
             case let tokens = file.syntaxMap.tokens(inByteRange: byteRange),
-            tokens.count > 1,
+            tokens.count == 2,
             let lastToken = tokens.last,
             case let firstTokenIsUnderscore = isTokenUnderscore(tokens[0], file: file),
             case let lastTokenIsUnderscore = isTokenUnderscore(lastToken, file: file),
             firstTokenIsUnderscore || lastTokenIsUnderscore else {
-            return []
+                return []
         }
 
         let offset: Int


### PR DESCRIPTION
Fix #1787

This will likely introduce false negatives, so I'm curious to see oss-check running.