### PR TITLE
Add "Is Disjoint" rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ##### Enhancements
 
+* Add `is_disjoint` rule to encourage using `Set.isDisjoint(with:)` over
+  `Set.intersection(_:).isEmpty`.  
+  [JP Simard](https://github.com/jpsim)
+
 * Add `xctfail_message` rule to enforce XCTFail
   calls to include a description of the assertion.  
   [Ornithologist Coder](https://github.com/ornithocoder)

--- a/Rules.md
+++ b/Rules.md
@@ -41,6 +41,7 @@
 * [Implicit Getter](#implicit-getter)
 * [Implicit Return](#implicit-return)
 * [Implicitly Unwrapped Optional](#implicitly-unwrapped-optional)
+* [Is Disjoint](#is-disjoint)
 * [Joined Default Parameter](#joined-default-parameter)
 * [Large Tuple](#large-tuple)
 * [Leading Whitespace](#leading-whitespace)
@@ -4817,6 +4818,51 @@ let collection: AnyCollection<Int!>
 
 ```swift
 func foo(int: Int!) {}
+```
+
+</details>
+
+
+
+## Is Disjoint
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`is_disjoint` | Enabled | No | idiomatic
+
+Prefer using `Set.isDisjoint(with:)` over `Set.intersection(_:).isEmpty`.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+_ = Set(syntaxKinds).isDisjoint(with: commentAndStringKindsSet)
+```
+
+```swift
+let isObjc = !objcAttributes.isDisjoint(with: dictionary.enclosedSwiftAttributes)
+```
+
+```swift
+_ = Set(syntaxKinds).intersection(commentAndStringKindsSet)
+```
+
+```swift
+_ = !objcAttributes.intersection(dictionary.enclosedSwiftAttributes)
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+_ = Set(syntaxKinds).↓intersection(commentAndStringKindsSet).isEmpty
+```
+
+```swift
+let isObjc = !objcAttributes.↓intersection(dictionary.enclosedSwiftAttributes).isEmpty
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -25,7 +25,7 @@ private extension Rule {
         }
         let allIDs = description.allIdentifiers
         let regionsDisablingCurrentRule = regions.filter { region in
-            return !region.disabledRuleIdentifiers.intersection(allIDs).isEmpty
+            return !region.disabledRuleIdentifiers.isDisjoint(with: allIDs)
         }
 
         return regionsDisablingCurrentRule.flatMap { region -> StyleViolation? in

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -49,6 +49,7 @@ public let masterRuleList = RuleList(rules: [
     ImplicitGetterRule.self,
     ImplicitReturnRule.self,
     ImplicitlyUnwrappedOptionalRule.self,
+    IsDisjointRule.self,
     JoinedDefaultParameterRule.self,
     LargeTupleRule.self,
     LeadingWhitespaceRule.self,

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -5,7 +5,7 @@
 //  Created by Scott Hoyt on 12/28/15.
 //  Copyright © 2015 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.8.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -30,7 +30,7 @@ public struct Region: Equatable {
 
     public func isRuleDisabled(_ rule: Rule) -> Bool {
         let identifiers = type(of: rule).description.allIdentifiers
-        return !disabledRuleIdentifiers.intersection(identifiers).isEmpty
+        return !disabledRuleIdentifiers.isDisjoint(with: identifiers)
     }
 
     public func deprecatedAliasesDisabling(rule: Rule) -> Set<String> {

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -122,8 +122,8 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
                                                 attributesTokens: attributesTokensWithRanges,
                                                 line: line, file: file)
 
-            guard attributesTokens.intersection(alwaysOnNewLineAttributes).isEmpty &&
-                previousAttributes.intersection(alwaysOnSameLineAttributes).isEmpty else {
+            guard attributesTokens.isDisjoint(with: alwaysOnNewLineAttributes) &&
+                previousAttributes.isDisjoint(with: alwaysOnSameLineAttributes) else {
                 return true
             }
 

--- a/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
@@ -52,7 +52,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
         // Check if @objc
         let objcAttributes: Set<String> = ["source.decl.attribute.objc",
                                            "source.decl.attribute.objc.name"]
-        let isObjc = !objcAttributes.intersection(dictionary.enclosedSwiftAttributes).isEmpty
+        let isObjc = !objcAttributes.isDisjoint(with: dictionary.enclosedSwiftAttributes)
         guard !isObjc else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -201,7 +201,7 @@ private extension ColonRule {
             if !syntaxKinds.starts(with: [.identifier, .typeidentifier]) {
                 return false
             }
-            return Set(syntaxKinds).intersection(commentAndStringKindsSet).isEmpty
+            return Set(syntaxKinds).isDisjoint(with: commentAndStringKindsSet)
         }.flatMap { range, syntaxTokens in
             let identifierRange = nsstring
                 .byteRangeToNSRange(start: syntaxTokens[0].offset, length: 0)

--- a/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
@@ -70,7 +70,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule {
             let kinds = tokens.flatMap { SyntaxKind(rawValue: $0.type) }
             guard let token = tokens.last,
                 SyntaxKind(rawValue: token.type) == .keyword,
-                attributesKinds.intersection(kinds).isEmpty else {
+                attributesKinds.isDisjoint(with: kinds) else {
                     return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/IsDisjointRule.swift
+++ b/Source/SwiftLintFramework/Rules/IsDisjointRule.swift
@@ -1,0 +1,42 @@
+//
+//  IsDisjointRule.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 8/21/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct IsDisjointRule: ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "is_disjoint",
+        name: "Is Disjoint",
+        description: "Prefer using `Set.isDisjoint(with:)` over `Set.intersection(_:).isEmpty`.",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            "_ = Set(syntaxKinds).isDisjoint(with: commentAndStringKindsSet)",
+            "let isObjc = !objcAttributes.isDisjoint(with: dictionary.enclosedSwiftAttributes)",
+            "_ = Set(syntaxKinds).intersection(commentAndStringKindsSet)",
+            "_ = !objcAttributes.intersection(dictionary.enclosedSwiftAttributes)"
+        ],
+        triggeringExamples: [
+            "_ = Set(syntaxKinds).↓intersection(commentAndStringKindsSet).isEmpty",
+            "let isObjc = !objcAttributes.↓intersection(dictionary.enclosedSwiftAttributes).isEmpty"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        let pattern = "\\bintersection\\(\\S+\\)\\.isEmpty"
+        let excludingKinds = SyntaxKind.commentAndStringKinds()
+        return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -122,7 +122,7 @@ public struct LineLengthRule: ConfigurationProviderRule {
         if index >= kindsByLine.count {
             return false
         }
-        return !kinds.intersection(kindsByLine[index]).isEmpty
+        return !kinds.isDisjoint(with: kindsByLine[index])
     }
 
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
 		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
 		85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856651A61D6B395F005E6B29 /* MarkRule.swift */; };
+		8FC9F5111F4B8E48006826C1 /* IsDisjointRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */; };
 		92CCB2D71E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */; };
 		93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */; };
 		A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */; };
@@ -406,6 +407,7 @@
 		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
 		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
 		856651A61D6B395F005E6B29 /* MarkRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
+		8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsDisjointRule.swift; sourceTree = "<group>"; };
 		92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRule.swift; sourceTree = "<group>"; };
 		93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineRule.swift; sourceTree = "<group>"; };
 		A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralConfiguration.swift; sourceTree = "<group>"; };
@@ -974,6 +976,7 @@
 				D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */,
 				47FF3BDF1E7C745100187E6D /* ImplicitlyUnwrappedOptionalRule.swift */,
 				D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */,
+				8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */,
 				62A6E7911F3317E3003A0479 /* JoinedDefaultRule.swift */,
 				D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
@@ -1510,6 +1513,7 @@
 				3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */,
 				D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */,
 				C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */,
+				8FC9F5111F4B8E48006826C1 /* IsDisjointRule.swift in Sources */,
 				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
 				E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */,
 				A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,7 +5,7 @@
 //  Created by JP Simard on 12/11/16.
 //  Copyright © 2016 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.7.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.8.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -373,6 +373,7 @@ extension RulesTests {
         ("testImplicitGetter", testImplicitGetter),
         ("testImplicitlyUnwrappedOptional", testImplicitlyUnwrappedOptional),
         ("testImplicitReturn", testImplicitReturn),
+        ("testIsDisjoint", testIsDisjoint),
         ("testJoinedDefaultParameter", testJoinedDefaultParameter),
         ("testLargeTuple", testLargeTuple),
         ("testLeadingWhitespace", testLeadingWhitespace),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -141,6 +141,10 @@ class RulesTests: XCTestCase {
         verifyRule(ImplicitReturnRule.description)
     }
 
+    func testIsDisjoint() {
+        verifyRule(IsDisjointRule.description)
+    }
+
     func testJoinedDefaultParameter() {
         verifyRule(JoinedDefaultParameterRule.description)
     }


### PR DESCRIPTION
to encourage using `Set.isDisjoint(with:)` over `Set.intersection(_:).isEmpty`.