### PR TITLE
Validate rules docs when running unit tests

### DIFF
--- a/Source/SwiftLintFramework/Models/RuleList+Documentation.swift
+++ b/Source/SwiftLintFramework/Models/RuleList+Documentation.swift
@@ -1,0 +1,97 @@
+//
+//  RuleList+Documentation.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 8/24/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+
+extension RuleList {
+    public func generateDocumentation() -> String {
+        let rules = list.sorted { $0.0 < $1.0 }.map { $0.value }
+        let rulesText = rules.map(ruleMarkdown)
+        let rulesSummary = rules.map(ruleSummary)
+
+        var text = h1("Rules")
+        text += rulesSummary.joined()
+        text += "--------\n"
+        text += rulesText.joined(separator: "\n\n")
+
+        return text
+    }
+
+    private func ruleSummary(_ rule: Rule.Type) -> String {
+        return summaryItem(rule.description.name)
+    }
+
+    private func ruleMarkdown(_ rule: Rule.Type) -> String {
+        let description = rule.description
+        var content = h2(description.name)
+        content += detailsSummary(rule.init())
+        content += description.description + "\n"
+
+        if !description.nonTriggeringExamples.isEmpty || !description.triggeringExamples.isEmpty {
+            content += h3("Examples")
+        }
+
+        if !description.nonTriggeringExamples.isEmpty {
+            let examples = description.nonTriggeringExamples.map(formattedCode).joined(separator: "\n")
+            content += details(summary: "Non Triggering Examples", details: examples)
+        }
+
+        if !description.triggeringExamples.isEmpty {
+            let examples = description.triggeringExamples.map(formattedCode).joined(separator: "\n")
+            content += details(summary: "Triggering Examples", details: examples)
+        }
+
+        return content
+    }
+
+    private func details(summary: String, details: String) -> String {
+        var content = "<details>\n"
+        content += "<summary>\(summary)</summary>\n\n"
+        content += details + "\n"
+        content += "</details>\n"
+
+        return content
+    }
+
+    private func formattedCode(_ code: String) -> String {
+        var content = "```swift\n"
+        content += code
+        content += "\n```\n"
+
+        return content
+    }
+
+    private func detailsSummary(_ rule: Rule) -> String {
+        var content = "Identifier | Enabled by default | Supports autocorrection | Kind \n"
+        content += "--- | --- | --- | ---\n"
+        let identifier = type(of: rule).description.identifier
+        let defaultStatus = rule is OptInRule ? "Disabled" : "Enabled"
+        let correctable = rule is CorrectableRule ? "Yes" : "No"
+        let kind = type(of: rule).description.kind
+        content += "`\(identifier)` | \(defaultStatus) | \(correctable) | \(kind)\n\n"
+
+        return content
+    }
+
+    private func h1(_ text: String) -> String {
+        return "\n# \(text)\n\n"
+    }
+
+    private func h2(_ text: String) -> String {
+        return "\n## \(text)\n\n"
+    }
+
+    private func h3(_ text: String) -> String {
+        return "\n### \(text)\n\n"
+    }
+
+    private func summaryItem(_ text: String) -> String {
+        let anchor = text.lowercased().components(separatedBy: .whitespaces).joined(separator: "-")
+        return "* [\(text)](#\(anchor))\n"
+    }
+}

--- a/Source/swiftlint/Commands/GenerateDocsCommand.swift
+++ b/Source/swiftlint/Commands/GenerateDocsCommand.swift
@@ -15,14 +15,7 @@ struct GenerateDocsCommand: CommandProtocol {
     let function = "Generates markdown documentation for all rules"
 
     func run(_ options: GenerateDocsOptions) -> Result<(), CommandantError<()>> {
-        let rules = masterRuleList.list.sorted { $0.0 < $1.0 }.map { $0.value }
-        let rulesText = rules.map(ruleMarkdown)
-        let rulesSummary = rules.map(ruleSummary)
-
-        var text = h1("Rules")
-        text += rulesSummary.joined()
-        text += "--------\n"
-        text += rulesText.joined(separator: "\n\n")
+        let text = masterRuleList.generateDocumentation()
 
         if let path = options.path {
             do {
@@ -35,79 +28,6 @@ struct GenerateDocsCommand: CommandProtocol {
         }
 
         return .success(())
-    }
-
-    private func ruleSummary(_ rule: Rule.Type) -> String {
-        return summaryItem(rule.description.name)
-    }
-
-    private func ruleMarkdown(_ rule: Rule.Type) -> String {
-        let description = rule.description
-        var content = h2(description.name)
-        content += detailsSummary(rule.init())
-        content += description.description + "\n"
-
-        if !description.nonTriggeringExamples.isEmpty || !description.triggeringExamples.isEmpty {
-            content += h3("Examples")
-        }
-
-        if !description.nonTriggeringExamples.isEmpty {
-            let examples = description.nonTriggeringExamples.map(formattedCode).joined(separator: "\n")
-            content += details(summary: "Non Triggering Examples", details: examples)
-        }
-
-        if !description.triggeringExamples.isEmpty {
-            let examples = description.triggeringExamples.map(formattedCode).joined(separator: "\n")
-            content += details(summary: "Triggering Examples", details: examples)
-        }
-
-        return content
-    }
-
-    private func details(summary: String, details: String) -> String {
-        var content = "<details>\n"
-        content += "<summary>\(summary)</summary>\n\n"
-        content += details + "\n"
-        content += "</details>\n"
-
-        return content
-    }
-
-    private func formattedCode(_ code: String) -> String {
-        var content = "```swift\n"
-        content += code
-        content += "\n```\n"
-
-        return content
-    }
-
-    private func detailsSummary(_ rule: Rule) -> String {
-        var content = "Identifier | Enabled by default | Supports autocorrection | Kind \n"
-        content += "--- | --- | --- | ---\n"
-        let identifier = type(of: rule).description.identifier
-        let defaultStatus = rule is OptInRule ? "Disabled" : "Enabled"
-        let correctable = rule is CorrectableRule ? "Yes" : "No"
-        let kind = type(of: rule).description.kind
-        content += "`\(identifier)` | \(defaultStatus) | \(correctable) | \(kind)\n\n"
-
-        return content
-    }
-
-    private func h1(_ text: String) -> String {
-        return "\n# \(text)\n\n"
-    }
-
-    private func h2(_ text: String) -> String {
-        return "\n## \(text)\n\n"
-    }
-
-    private func h3(_ text: String) -> String {
-        return "\n### \(text)\n\n"
-    }
-
-    private func summaryItem(_ text: String) -> String {
-        let anchor = text.lowercased().components(separatedBy: .whitespaces).joined(separator: "-")
-        return "* [\(text)](#\(anchor))\n"
     }
 }
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		D47A51101DB2DD4800A4CC21 /* AttributesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */; };
 		D47F31151EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47F31141EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift */; };
 		D48AE2CC1DFB58C5001C6A4A /* AttributesRulesExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */; };
+		D48B51211F4F5DEF0068AB98 /* RuleList+Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48B51201F4F5DEF0068AB98 /* RuleList+Documentation.swift */; };
+		D48B51231F4F5E4B0068AB98 /* DocumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48B51221F4F5E4B0068AB98 /* DocumentationTests.swift */; };
 		D4998DE71DF191380006E05D /* AttributesRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4998DE61DF191380006E05D /* AttributesRuleTests.swift */; };
 		D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */; };
 		D4A893351E15824100BF954D /* SwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A893341E15824100BF954D /* SwiftVersion.swift */; };
@@ -492,6 +494,8 @@
 		D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRule.swift; sourceTree = "<group>"; };
 		D47F31141EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtocolPropertyAccessorsOrderRule.swift; sourceTree = "<group>"; };
 		D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRulesExamples.swift; sourceTree = "<group>"; };
+		D48B51201F4F5DEF0068AB98 /* RuleList+Documentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RuleList+Documentation.swift"; sourceTree = "<group>"; };
+		D48B51221F4F5E4B0068AB98 /* DocumentationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentationTests.swift; sourceTree = "<group>"; };
 		D4998DE61DF191380006E05D /* AttributesRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRuleTests.swift; sourceTree = "<group>"; };
 		D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRuleTests.swift; sourceTree = "<group>"; };
 		D4A893341E15824100BF954D /* SwiftVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftVersion.swift; sourceTree = "<group>"; };
@@ -849,6 +853,7 @@
 				67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */,
 				67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */,
 				62AF35D71F30B183009B11EE /* DiscouragedDirectInitRuleTests.swift */,
+				D48B51221F4F5E4B0068AB98 /* DocumentationTests.swift */,
 				02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */,
 				D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */,
 				29FFC37B1F157BA8007E4825 /* FileLengthRuleTests.swift */,
@@ -1075,6 +1080,7 @@
 				E80E018E1B92C1350078EB70 /* Region.swift */,
 				83D71E261B131EB5000395DE /* RuleDescription.swift */,
 				E8BDE3FE1EDF91B6002EC12F /* RuleList.swift */,
+				D48B51201F4F5DEF0068AB98 /* RuleList+Documentation.swift */,
 				D401D9251ED85EF0005DA5D4 /* RuleKind.swift */,
 				E88DEA781B098D4400A66CB0 /* RuleParameter.swift */,
 				E88DEA6A1B0983FE00A66CB0 /* StyleViolation.swift */,
@@ -1513,6 +1519,7 @@
 				3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */,
 				D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */,
 				C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */,
+				D48B51211F4F5DEF0068AB98 /* RuleList+Documentation.swift in Sources */,
 				8FC9F5111F4B8E48006826C1 /* IsDisjointRule.swift in Sources */,
 				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
 				E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */,
@@ -1545,6 +1552,7 @@
 				29FFC37D1F157BDE007E4825 /* FileLengthRuleTests.swift in Sources */,
 				006204DE1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift in Sources */,
 				02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */,
+				D48B51231F4F5E4B0068AB98 /* DocumentationTests.swift in Sources */,
 				D4CA758F1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift in Sources */,
 				D4DB92251E628898005DE9C1 /* TodoRuleTests.swift in Sources */,
 				D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -130,6 +130,12 @@ extension DiscouragedDirectInitRuleTests {
     ]
 }
 
+extension DocumentationTests {
+    static var allTests: [(String, (DocumentationTests) -> () throws -> Void)] = [
+        ("testRulesDocumentationIsUpdated", testRulesDocumentationIsUpdated)
+    ]
+}
+
 extension ExtendedNSStringTests {
     static var allTests: [(String, (ExtendedNSStringTests) -> () throws -> Void)] = [
         ("testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters", testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters)
@@ -504,6 +510,7 @@ XCTMain([
     testCase(CyclomaticComplexityConfigurationTests.allTests),
     testCase(CyclomaticComplexityRuleTests.allTests),
     testCase(DiscouragedDirectInitRuleTests.allTests),
+    testCase(DocumentationTests.allTests),
     testCase(ExtendedNSStringTests.allTests),
     testCase(FileHeaderRuleTests.allTests),
     testCase(FileLengthRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -132,7 +132,6 @@ extension DiscouragedDirectInitRuleTests {
 
 extension DocumentationTests {
     static var allTests: [(String, (DocumentationTests) -> () throws -> Void)] = [
-        ("testRulesDocumentationIsUpdated", testRulesDocumentationIsUpdated)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/DocumentationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DocumentationTests.swift
@@ -16,6 +16,7 @@ private let projectRoot = #file.bridge()
     .deletingLastPathComponent
 
 class DocumentationTests: XCTestCase {
+    // sourcery:skipTestOnLinux
     func testRulesDocumentationIsUpdated() throws {
         let docsPath = "\(projectRoot)/Rules.md"
         let existingDocs = try String(contentsOfFile: docsPath)

--- a/Tests/SwiftLintFrameworkTests/DocumentationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DocumentationTests.swift
@@ -1,0 +1,31 @@
+//
+//  DocumentationTests.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 08/24/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SwiftLintFramework
+import XCTest
+
+private let projectRoot = #file.bridge()
+    .deletingLastPathComponent.bridge()
+    .deletingLastPathComponent.bridge()
+    .deletingLastPathComponent
+
+class DocumentationTests: XCTestCase {
+    func testRulesDocumentationIsUpdated() throws {
+        let docsPath = "\(projectRoot)/Rules.md"
+        let existingDocs = try String(contentsOfFile: docsPath)
+        let updatedDocs = masterRuleList.generateDocumentation()
+
+        XCTAssertEqual(existingDocs, updatedDocs)
+
+        let overwrite = false // set this to true to overwrite existing docs with the generated ones
+        if existingDocs != updatedDocs && overwrite {
+            try updatedDocs.data(using: .utf8)?.write(to: URL(fileURLWithPath: docsPath))
+        }
+    }
+}


### PR DESCRIPTION
Fix #1734

I'm not sure if this deserves a changelog entry.