### PR TITLE
Add pattern_matching_keywords rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,7 @@ opt_in_rules:
   - let_var_whitespace
   - unneeded_parentheses_in_closure_argument
   - extension_access_modifier
+  - pattern_matching_keywords
 
 file_header:
   required_pattern: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
 
 * Invalidate cache when Swift version changes.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  
+* Add `pattern_matching_keywords` rule to enforce moving `let` and `var`
+  keywords outside tuples in a `switch`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#202](https://github.com/realm/SwiftLint/issues/202)
 
 * Add `explicit_enum_raw_value` opt-in rule to allow refactoring the
   Swift API without breaking the API contract.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 * Invalidate cache when Swift version changes.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   
-* Add `pattern_matching_keywords` rule to enforce moving `let` and `var`
+* Add `pattern_matching_keywords` opt-in rule to enforce moving `let` and `var`
   keywords outside tuples in a `switch`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#202](https://github.com/realm/SwiftLint/issues/202)

--- a/Rules.md
+++ b/Rules.md
@@ -7694,7 +7694,7 @@ class VC: UIViewController {
 
 Identifier | Enabled by default | Supports autocorrection | Kind 
 --- | --- | --- | ---
-`pattern_matching_keywords` | Enabled | No | idiomatic
+`pattern_matching_keywords` | Disabled | No | idiomatic
 
 Combine multiple pattern matching bindings by moving keywords out of tuples.
 

--- a/Rules.md
+++ b/Rules.md
@@ -64,6 +64,7 @@
 * [Operator Usage Whitespace](#operator-usage-whitespace)
 * [Operator Function Whitespace](#operator-function-whitespace)
 * [Overridden methods call super](#overridden-methods-call-super)
+* [Pattern Matching Keywords](#pattern-matching-keywords)
 * [Private Outlets](#private-outlets)
 * [Private over fileprivate](#private-over-fileprivate)
 * [Private Unit Test](#private-unit-test)
@@ -7683,6 +7684,129 @@ class VC: UIViewController {
 	}
 }
 
+```
+
+</details>
+
+
+
+## Pattern Matching Keywords
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`pattern_matching_keywords` | Enabled | No | idiomatic
+
+Combine multiple pattern matching bindings by moving keywords out of tuples.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+switch foo {
+    default: break
+}
+```
+
+```swift
+switch foo {
+    case 1: break
+}
+```
+
+```swift
+switch foo {
+    case bar: break
+}
+```
+
+```swift
+switch foo {
+    case let (x, y): break
+}
+```
+
+```swift
+switch foo {
+    case .foo(let x): break
+}
+```
+
+```swift
+switch foo {
+    case let .foo(x, y): break
+}
+```
+
+```swift
+switch foo {
+    case .foo(let x), .bar(let x): break
+}
+```
+
+```swift
+switch foo {
+    case .foo(let x, var y): break
+}
+```
+
+```swift
+switch foo {
+    case var (x, y): break
+}
+```
+
+```swift
+switch foo {
+    case .foo(var x): break
+}
+```
+
+```swift
+switch foo {
+    case var .foo(x, y): break
+}
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+switch foo {
+    case (↓let x,  ↓let y): break
+}
+```
+
+```swift
+switch foo {
+    case .foo(↓let x, ↓let y): break
+}
+```
+
+```swift
+switch foo {
+    case (.yamlParsing(↓let x), .yamlParsing(↓let y)): break
+}
+```
+
+```swift
+switch foo {
+    case (↓var x,  ↓var y): break
+}
+```
+
+```swift
+switch foo {
+    case .foo(↓var x, ↓var y): break
+}
+```
+
+```swift
+switch foo {
+    case (.yamlParsing(↓var x), .yamlParsing(↓var y)): break
+}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -96,7 +96,7 @@ extension Configuration {
                 .filter { rule in
                     return whitelistedRules.contains(type(of: rule).description.identifier)
                 }
-        case .default(let disabled, let optIn):
+        case let .default(disabled, optIn):
             // Same here
             return Set(
                 configuration.rules

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -76,7 +76,7 @@ public struct Configuration: Equatable {
             rules = configuredRules.filter { rule in
                 return validWhitelistedRuleIdentifiers.contains(type(of: rule).description.identifier)
             }
-        case .default(let disabledRuleIdentifiers, let optInRuleIdentifiers):
+        case let .default(disabledRuleIdentifiers, optInRuleIdentifiers):
             let validDisabledRuleIdentifiers = validateRuleIdentifiers(
                 ruleIdentifiers: disabledRuleIdentifiers.map(handleAliasWithRuleList),
                 validRuleIdentifiers: validRuleIdentifiers)

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -72,6 +72,7 @@ public let masterRuleList = RuleList(rules: [
     OperatorFunctionWhitespaceRule.self,
     OperatorUsageWhitespaceRule.self,
     OverriddenSuperCallRule.self,
+    PatternMatchingKeywordsRule.self,
     PrivateOutletRule.self,
     PrivateOverFilePrivateRule.self,
     PrivateUnitTestRule.self,

--- a/Source/SwiftLintFramework/Models/YamlParser.swift
+++ b/Source/SwiftLintFramework/Models/YamlParser.swift
@@ -17,7 +17,7 @@ internal enum YamlParserError: Error, Equatable {
 
 internal func == (lhs: YamlParserError, rhs: YamlParserError) -> Bool {
     switch (lhs, rhs) {
-    case (.yamlParsing(let x), .yamlParsing(let y)):
+    case let (.yamlParsing(x), .yamlParsing(y)):
         return x == y
     }
 }

--- a/Source/SwiftLintFramework/Rules/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/PatternMatchingKeywordsRule.swift
@@ -1,0 +1,84 @@
+//
+//  PatternMatchingKeywordsRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 08/23/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "pattern_matching_keywords",
+        name: "Pattern Matching Keywords",
+        description: "Combine multiple pattern matching bindings by moving keywords out of tuples.",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            "default",
+            "case 1",
+            "case bar",
+            "case let (x, y)",
+            "case .foo(let x)",
+            "case let .foo(x, y)",
+            "case .foo(let x), .bar(let x)",
+            "case .foo(let x, var y)",
+            "case var (x, y)",
+            "case .foo(var x)",
+            "case var .foo(x, y)"
+        ].map(wrapInSwitch),
+        triggeringExamples: [
+            "case (↓let x,  ↓let y)",
+            "case .foo(↓let x, ↓let y)",
+            "case (.yamlParsing(↓let x), .yamlParsing(↓let y))",
+            "case (↓var x,  ↓var y)",
+            "case .foo(↓var x, ↓var y)",
+            "case (.yamlParsing(↓var x), .yamlParsing(↓var y))"
+        ].map(wrapInSwitch)
+    )
+
+    public func validate(file: File, kind: StatementKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .case else {
+            return []
+        }
+
+        let contents = file.contents.bridge()
+        return dictionary.elements.flatMap { subDictionary -> [StyleViolation] in
+            guard subDictionary.kind == "source.lang.swift.structure.elem.pattern",
+                let offset = subDictionary.offset,
+                let length = subDictionary.length,
+                let caseRange = contents.byteRangeToNSRange(start: offset, length: length) else {
+                    return []
+            }
+
+            let letMatches = file.match(pattern: "\\blet\\b", with: [.keyword], range: caseRange)
+            let varMatches = file.match(pattern: "\\bvar\\b", with: [.keyword], range: caseRange)
+
+            if !letMatches.isEmpty && !varMatches.isEmpty {
+                return []
+            }
+
+            guard letMatches.count > 1 || varMatches.count > 1 else {
+                return []
+            }
+
+            return (letMatches + varMatches).map {
+                StyleViolation(ruleDescription: type(of: self).description,
+                               severity: configuration.severity,
+                               location: Location(file: file, characterOffset: $0.location))
+            }
+        }
+    }
+}
+
+private func wrapInSwitch(_ str: String) -> String {
+    return  "switch foo {\n" +
+            "    \(str): break\n" +
+            "}"
+}

--- a/Source/SwiftLintFramework/Rules/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/PatternMatchingKeywordsRule.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule {
+public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		D286EC021E02DF6F0003CF72 /* SortedImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286EC001E02DA190003CF72 /* SortedImportsRule.swift */; };
 		D401D9261ED85EF0005DA5D4 /* RuleKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D401D9251ED85EF0005DA5D4 /* RuleKind.swift */; };
+		D403A4A31F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D403A4A21F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift */; };
 		D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */; };
 		D40E041C1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40E041B1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift */; };
 		D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */; };
@@ -456,6 +457,7 @@
 		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D286EC001E02DA190003CF72 /* SortedImportsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedImportsRule.swift; sourceTree = "<group>"; };
 		D401D9251ED85EF0005DA5D4 /* RuleKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleKind.swift; sourceTree = "<group>"; };
+		D403A4A21F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatternMatchingKeywordsRule.swift; sourceTree = "<group>"; };
 		D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedClosureParameterRule.swift; sourceTree = "<group>"; };
 		D40E041B1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuperfluousDisableCommandRule.swift; sourceTree = "<group>"; };
 		D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaConfiguration.swift; sourceTree = "<group>"; };
@@ -1005,6 +1007,7 @@
 				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
 				D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */,
 				78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */,
+				D403A4A21F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift */,
 				094385021D5D4F78009168CF /* PrivateOutletRule.swift */,
 				1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */,
 				B2902A0B1D66815600BFCCF7 /* PrivateUnitTestRule.swift */,
@@ -1412,6 +1415,7 @@
 				D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */,
 				006204DC1E1E492F00FFFBE1 /* VerticalWhitespaceConfiguration.swift in Sources */,
 				E88198441BEA93D200333A11 /* ColonRule.swift in Sources */,
+				D403A4A31F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift in Sources */,
 				E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */,
 				D4DABFD51E2B350F009617B6 /* TrailingClosureRule.swift in Sources */,
 				D4B022981E102EE8007E5297 /* ObjectLiteralRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -392,6 +392,7 @@ extension RulesTests {
         ("testOpeningBrace", testOpeningBrace),
         ("testOperatorFunctionWhitespace", testOperatorFunctionWhitespace),
         ("testOperatorUsageWhitespace", testOperatorUsageWhitespace),
+        ("testPatternMatchingKeywords", testPatternMatchingKeywords),
         ("testPrivateOutlet", testPrivateOutlet),
         ("testPrivateUnitTest", testPrivateUnitTest),
         ("testProhibitedSuper", testProhibitedSuper),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -218,6 +218,10 @@ class RulesTests: XCTestCase {
         verifyRule(OperatorUsageWhitespaceRule.description)
     }
 
+    func testPatternMatchingKeywords() {
+        verifyRule(PatternMatchingKeywordsRule.description)
+    }
+
     func testPrivateOutlet() {
         verifyRule(PrivateOutletRule.description)
 


### PR DESCRIPTION
Closes #202.

This rule should also be applied in other cases of pattern matching, but I guess supporting only `switch`es is reasonable for now.

Let's see how much oss-check complains to decide if this should be opt-in or enabled by default.