### PR TITLE
Prints the performance report before other messages

### DIFF
--- a/script/oss-check
+++ b/script/oss-check
@@ -214,6 +214,8 @@ def build(branch)
 end
 
 def diff_and_report_changes_to_danger
+  @repos.each { |repo| message repo.duration_report }
+
   @repos.each do |repo|
     if repo.master_exit_value != repo.branch_exit_value
       warn "This PR changed the exit value when running on #{repo.name}: " \
@@ -232,7 +234,6 @@ def diff_and_report_changes_to_danger
     (branch - master).each do |violation|
       warn "This PR introduced a violation in #{repo.name}: [#{violation}](#{convert_to_link(repo, violation)})"
     end
-    message repo.duration_report
   end
 end
 


### PR DESCRIPTION
This is a minor suggestion, but I believe it would be easier to review the performance report if it was grouped before all the other messages. Specially for changes with dozens or hundreds of messages. I didn't add this to the change log because this is a minor change to the CI script.