### PR TITLE
Add array_init opt-in rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,6 +26,7 @@ opt_in_rules:
   - unneeded_parentheses_in_closure_argument
   - extension_access_modifier
   - pattern_matching_keywords
+  - array_init
 
 file_header:
   required_pattern: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   statements are vertically aligned with their enclosing `switch` statement.  
   [Austin Lu](https://github.com/austinlu)
 
+* Add `array_init` opt-in rule to validate that `Array(foo)` should be preferred
+  over `foo.map({ $0 })`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1271](https://github.com/realm/SwiftLint/issues/1271)
+
 ##### Bug Fixes
 
 * Improve how `opening_brace` rule reports violations locations.  

--- a/Rules.md
+++ b/Rules.md
@@ -140,7 +140,22 @@ foo.map { $1 }
 ```
 
 ```swift
-let set = Set(array)
+foo.map { $0() }
+
+```
+
+```swift
+foo.map { ((), $0) }
+
+```
+
+```swift
+foo.map { $0! }
+
+```
+
+```swift
+foo.map { $0! /* force unwrap */ }
 
 ```
 
@@ -154,12 +169,12 @@ let set = Set(array)
 ```
 
 ```swift
-↓foo.map { $0 } 
+↓foo.map { $0 }
 
 ```
 
 ```swift
-↓foo.map { return $0 } 
+↓foo.map { return $0 }
 
 ```
 
@@ -188,6 +203,11 @@ let set = Set(array)
 ↓foo.map { elem -> String in
    elem
 }
+
+```
+
+```swift
+↓foo.map { $0 /* a comment */ }
 
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -1,6 +1,7 @@
 
 # Rules
 
+* [Array Init](#array-init)
 * [Attributes](#attributes)
 * [Block Based KVO](#block-based-kvo)
 * [Class Delegate Protocol](#class-delegate-protocol)
@@ -109,6 +110,90 @@
 * [Weak Delegate](#weak-delegate)
 * [XCTFail Message](#xctfail-message)
 --------
+
+## Array Init
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`array_init` | Disabled | No | lint
+
+Prefer using Array(seq) than seq.map { $0 } to convert a sequence into an Array.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+Array(foo)
+
+```
+
+```swift
+foo.map { $0.0 }
+
+```
+
+```swift
+foo.map { $1 }
+
+```
+
+```swift
+let set = Set(array)
+
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+↓foo.map({ $0 })
+
+```
+
+```swift
+↓foo.map { $0 } 
+
+```
+
+```swift
+↓foo.map { return $0 } 
+
+```
+
+```swift
+↓foo.map { elem in
+   elem
+}
+
+```
+
+```swift
+↓foo.map { elem in
+   return elem
+}
+
+```
+
+```swift
+↓foo.map { (elem: String) in
+   elem
+}
+
+```
+
+```swift
+↓foo.map { elem -> String in
+   elem
+}
+
+```
+
+</details>
+
+
 
 ## Attributes
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -9,6 +9,7 @@
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
+    ArrayInitRule.self,
     AttributesRule.self,
     BlockBasedKVORule.self,
     ClassDelegateProtocolRule.self,

--- a/Source/SwiftLintFramework/Rules/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ArrayInitRule.swift
@@ -101,8 +101,10 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule {
                 return
             }
 
-            let set = CharacterSet(charactersIn: "{}").union(.whitespacesAndNewlines)
-            let processedSubstring = substring.trimmingCharacters(in: set)
+            let processedSubstring = substring
+                .trimmingCharacters(in: CharacterSet(charactersIn: "{}"))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
             if !processedSubstring.isEmpty {
                 stop.pointee = true
                 containsContent = true

--- a/Source/SwiftLintFramework/Rules/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ArrayInitRule.swift
@@ -1,0 +1,134 @@
+//
+//  ArrayInitRule.swift
+//  SwiftLint
+//
+//  Created by Marcelo Fabri on 09/16/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "array_init",
+        name: "Array Init",
+        description: "Prefer using Array(seq) than seq.map { $0 } to convert a sequence into an Array.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            "Array(foo)\n",
+            "foo.map { $0.0 }\n",
+            "foo.map { $1 }\n",
+            "let set = Set(array)\n"
+        ],
+        triggeringExamples: [
+            "↓foo.map({ $0 })\n",
+            "↓foo.map { $0 } \n",
+            "↓foo.map { return $0 } \n",
+            "↓foo.map { elem in\n" +
+            "   elem\n" +
+            "}\n",
+            "↓foo.map { elem in\n" +
+            "   return elem\n" +
+            "}\n",
+            "↓foo.map { (elem: String) in\n" +
+                "   elem\n" +
+            "}\n",
+            "↓foo.map { elem -> String in\n" +
+            "   elem\n" +
+            "}\n"
+        ]
+    )
+
+    public func validate(file: File, kind: SwiftExpressionKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .call, let name = dictionary.name, name.hasSuffix(".map"),
+            let bodyOffset = dictionary.bodyOffset,
+            let bodyLength = dictionary.bodyLength,
+            let offset = dictionary.offset else {
+                return []
+        }
+
+        let range = NSRange(location: bodyOffset, length: bodyLength)
+        let tokens = file.syntaxMap.tokens(inByteRange: range).filter { token in
+            guard let kind = SyntaxKind(rawValue: token.type) else {
+                return false
+            }
+
+            return !SyntaxKind.commentKinds().contains(kind)
+        }
+
+        guard isShortParameterStyleViolation(file: file, tokens: tokens) ||
+            isParameterStyleViolation(file: file, dictionary: dictionary, tokens: tokens) else {
+                return []
+        }
+
+        return [
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: offset))
+        ]
+    }
+
+    private func isShortParameterStyleViolation(file: File, tokens: [SyntaxToken]) -> Bool {
+        let kinds = tokens.flatMap { SyntaxKind(rawValue: $0.type) }
+        switch kinds {
+        case [.identifier]:
+            let identifier = file.contents(for: tokens[0])
+            return identifier == "$0"
+        case [.keyword, .identifier]:
+            let keyword = file.contents(for: tokens[0])
+            let identifier = file.contents(for: tokens[1])
+            return keyword == "return" && identifier == "$0"
+        default:
+            return false
+        }
+    }
+
+    private func isParameterStyleViolation(file: File, dictionary: [String: SourceKitRepresentable],
+                                           tokens: [SyntaxToken]) -> Bool {
+        let parameters = dictionary.enclosedVarParameters
+        guard parameters.count == 1,
+            let offset = parameters[0].offset,
+            let length = parameters[0].length,
+            let parameterName = parameters[0].name else {
+                return false
+        }
+
+        let parameterEnd = offset + length
+        let tokens = Array(tokens.filter { $0.offset >= parameterEnd }.drop { token in
+            let isKeyword = SyntaxKind(rawValue: token.type) == .keyword
+            return !isKeyword || file.contents(for: token) != "in"
+        })
+
+        let kinds = tokens.flatMap { SyntaxKind(rawValue: $0.type) }
+        switch kinds {
+        case [.keyword, .identifier]:
+            let keyword = file.contents(for: tokens[0])
+            let identifier = file.contents(for: tokens[1])
+            return keyword == "in" && identifier == parameterName
+        case [.keyword, .keyword, .identifier]:
+            let firstKeyword = file.contents(for: tokens[0])
+            let secondKeyword = file.contents(for: tokens[1])
+            let identifier = file.contents(for: tokens[2])
+            return firstKeyword == "in" && secondKeyword == "return" && identifier == parameterName
+        default:
+            return false
+        }
+    }
+}
+
+private func ~= (array: [SyntaxKind], value: [SyntaxKind]) -> Bool {
+    return array == value
+}
+
+private extension File {
+    func contents(for token: SyntaxToken) -> String? {
+        return contents.bridge().substringWithByteRange(start: token.offset,
+                                                        length: token.length)
+    }
+}

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -12,13 +12,7 @@ import SourceKittenFramework
 public extension SyntaxKind {
     /// Returns if the syntax kind is comment-like.
     var isCommentLike: Bool {
-        return [
-            SyntaxKind.comment,
-            .commentMark,
-            .commentURL,
-            .docComment,
-            .docCommentField
-        ].contains(self)
+        return SyntaxKind.commentKinds().contains(self)
     }
 }
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		D4DABFD91E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */; };
 		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
 		D4DB92251E628898005DE9C1 /* TodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */; };
+		D4E2BA851F6CD77B00E8E184 /* ArrayInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */; };
 		D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */; };
 		D4FD4C851F2A260A00DD8AA8 /* BlockBasedKVORule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD4C841F2A260A00DD8AA8 /* BlockBasedKVORule.swift */; };
 		D4FD58B21E12A0200019503C /* LinterCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD58B11E12A0200019503C /* LinterCache.swift */; };
@@ -544,6 +545,7 @@
 		D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenterDetachmentRuleExamples.swift; sourceTree = "<group>"; };
 		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
 		D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoRuleTests.swift; sourceTree = "<group>"; };
+		D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayInitRule.swift; sourceTree = "<group>"; };
 		D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorUsageWhitespaceRule.swift; sourceTree = "<group>"; };
 		D4FD4C841F2A260A00DD8AA8 /* BlockBasedKVORule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockBasedKVORule.swift; sourceTree = "<group>"; };
 		D4FD58B11E12A0200019503C /* LinterCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinterCache.swift; sourceTree = "<group>"; };
@@ -957,6 +959,7 @@
 		E88DEA7A1B098D7300A66CB0 /* Rules */ = {
 			isa = PBXGroup;
 			children = (
+				D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */,
 				D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */,
 				D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */,
 				D4FD4C841F2A260A00DD8AA8 /* BlockBasedKVORule.swift */,
@@ -1433,6 +1436,7 @@
 				BB00B4E91F5216090079869F /* MultipleClosuresWithTrailingClosureRule.swift in Sources */,
 				E88198531BEA944400333A11 /* LineLengthRule.swift in Sources */,
 				D47F31151EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift in Sources */,
+				D4E2BA851F6CD77B00E8E184 /* ArrayInitRule.swift in Sources */,
 				92CCB2D71E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift in Sources */,
 				E847F0A91BFBBABD00EA9363 /* EmptyCountRule.swift in Sources */,
 				D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -346,6 +346,7 @@ extension RuleTests {
 
 extension RulesTests {
     static var allTests: [(String, (RulesTests) -> () throws -> Void)] = [
+        ("testArrayInit", testArrayInit),
         ("testBlockBasedKVO", testBlockBasedKVO),
         ("testClassDelegateProtocol", testClassDelegateProtocol),
         ("testClosingBrace", testClosingBrace),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -14,6 +14,10 @@ import XCTest
 
 class RulesTests: XCTestCase {
 
+    func testArrayInit() {
+        verifyRule(ArrayInitRule.description)
+    }
+
     func testBlockBasedKVO() {
         #if swift(>=3.2)
             verifyRule(BlockBasedKVORule.description)


### PR DESCRIPTION
Fixes #1271

This is opt-in because there're types that have `.map` and can't be converted to `Array`. However, i expect this to not give lots of false positives.

Also I'm not super happy about the rule name, so feel free to make suggestions!