### PR TITLE
Move functions to properties and Sets instead of Arrays

### DIFF
--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -197,7 +197,7 @@ extension File {
      file contents.
      */
     internal func match(pattern: String,
-                        excludingSyntaxKinds syntaxKinds: [SyntaxKind],
+                        excludingSyntaxKinds syntaxKinds: Set<SyntaxKind>,
                         range: NSRange? = nil) -> [NSRange] {
         return match(pattern: pattern, range: range)
             .filter { $0.1.filter(syntaxKinds.contains).isEmpty }
@@ -208,7 +208,7 @@ extension File {
 
     internal func match(pattern: String,
                         range: NSRange? = nil,
-                        excludingSyntaxKinds: [SyntaxKind],
+                        excludingSyntaxKinds: Set<SyntaxKind>,
                         excludingPattern: String,
                         exclusionMapping: MatchMapping = { $0.range }) -> [NSRange] {
         let matches = match(pattern: pattern, excludingSyntaxKinds: excludingSyntaxKinds)
@@ -268,7 +268,7 @@ extension File {
     }
 
     fileprivate func numberOfCommentAndWhitespaceOnlyLines(startLine: Int, endLine: Int) -> Int {
-        let commentKinds = Set(SyntaxKind.commentKinds())
+        let commentKinds = SyntaxKind.commentKinds
         return syntaxKindsByLines[startLine...endLine].filter { kinds in
             kinds.filter { !commentKinds.contains($0) }.isEmpty
         }.count

--- a/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
@@ -9,43 +9,37 @@
 import SourceKittenFramework
 
 extension SwiftDeclarationKind {
-    internal static func variableKinds() -> [SwiftDeclarationKind] {
-        return [
-            .varClass,
-            .varGlobal,
-            .varInstance,
-            .varLocal,
-            .varParameter,
-            .varStatic
-        ]
-    }
+    internal static let variableKinds: Set<SwiftDeclarationKind> = [
+        .varClass,
+        .varGlobal,
+        .varInstance,
+        .varLocal,
+        .varParameter,
+        .varStatic
+    ]
 
-    internal static func functionKinds() -> [SwiftDeclarationKind] {
-        return [
-            .functionAccessorAddress,
-            .functionAccessorDidset,
-            .functionAccessorGetter,
-            .functionAccessorMutableaddress,
-            .functionAccessorSetter,
-            .functionAccessorWillset,
-            .functionConstructor,
-            .functionDestructor,
-            .functionFree,
-            .functionMethodClass,
-            .functionMethodInstance,
-            .functionMethodStatic,
-            .functionOperator,
-            .functionSubscript
-        ]
-    }
+    internal static let functionKinds: Set<SwiftDeclarationKind> = [
+        .functionAccessorAddress,
+        .functionAccessorDidset,
+        .functionAccessorGetter,
+        .functionAccessorMutableaddress,
+        .functionAccessorSetter,
+        .functionAccessorWillset,
+        .functionConstructor,
+        .functionDestructor,
+        .functionFree,
+        .functionMethodClass,
+        .functionMethodInstance,
+        .functionMethodStatic,
+        .functionOperator,
+        .functionSubscript
+    ]
 
-    internal static func typeKinds() -> [SwiftDeclarationKind] {
-        return [
-            .`class`,
-            .`struct`,
-            .`typealias`,
-            .`enum`
-        ]
-    }
+    internal static let typeKinds: Set<SwiftDeclarationKind> = [
+        .`class`,
+        .`struct`,
+        .`typealias`,
+        .`enum`
+    ]
 
 }

--- a/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
@@ -17,22 +17,14 @@ extension SyntaxKind {
         self = kind
     }
 
-    static func commentKeywordStringAndTypeidentifierKinds() -> [SyntaxKind] {
-        return commentAndStringKinds() + [.keyword, .typeidentifier]
-    }
+    static let commentAndStringKinds: Set<SyntaxKind> = commentKinds.union([.string])
 
-    static func commentAndStringKinds() -> [SyntaxKind] {
-        return commentKinds() + [.string]
-    }
+    static let commentKinds: Set<SyntaxKind> = [.comment, .commentMark, .commentURL,
+                                                .docComment, .docCommentField]
 
-    static func commentKinds() -> [SyntaxKind] {
-        return [.comment, .commentMark, .commentURL, .docComment, .docCommentField]
-    }
-
-    static func allKinds() -> [SyntaxKind] {
-        return [.argument, .attributeBuiltin, .attributeID, .buildconfigID, .buildconfigKeyword,
-                .comment, .commentMark, .commentURL, .docComment, .docCommentField, .identifier,
-                .keyword, .number, .objectLiteral, .parameter, .placeholder, .string,
-                .stringInterpolationAnchor, .typeidentifier]
-    }
+    static let allKinds: Set<SyntaxKind> = [.argument, .attributeBuiltin, .attributeID, .buildconfigID,
+                                            .buildconfigKeyword, .comment, .commentMark, .commentURL,
+                                            .docComment, .docCommentField, .identifier, .keyword, .number,
+                                            .objectLiteral, .parameter, .placeholder, .string,
+                                            .stringInterpolationAnchor, .typeidentifier]
 }

--- a/Source/SwiftLintFramework/Rules/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ArrayInitRule.swift
@@ -63,7 +63,7 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule {
                 return false
             }
 
-            return !SyntaxKind.commentKinds().contains(kind)
+            return !SyntaxKind.commentKinds.contains(kind)
         }
 
         guard isShortParameterStyleViolation(file: file, tokens: tokens) ||

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -41,11 +41,11 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
 
         let attributeShouldBeOnSameLine: Bool?
-        if SwiftDeclarationKind.variableKinds().contains(kind) {
+        if SwiftDeclarationKind.variableKinds.contains(kind) {
             attributeShouldBeOnSameLine = true
-        } else if SwiftDeclarationKind.typeKinds().contains(kind) {
+        } else if SwiftDeclarationKind.typeKinds.contains(kind) {
             attributeShouldBeOnSameLine = false
-        } else if SwiftDeclarationKind.functionKinds().contains(kind) {
+        } else if SwiftDeclarationKind.functionKinds.contains(kind) {
             attributeShouldBeOnSameLine = false
         } else {
             attributeShouldBeOnSameLine = nil

--- a/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 
 private extension File {
     func violatingClosingBraceRanges() -> [NSRange] {
-        return match(pattern: "(\\}[ \\t]+\\))", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
+        return match(pattern: "(\\}[ \\t]+\\))", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
@@ -82,7 +82,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
         let nsstring = file.contents.bridge()
         let bracePattern = regex("\\{|\\}")
         let linesTokens = file.syntaxTokensByLines
-        let kindsToExclude = SyntaxKind.commentAndStringKinds().map { $0.rawValue }
+        let kindsToExclude = SyntaxKind.commentAndStringKinds.map { $0.rawValue }
 
         // find all lines and accurences of open { and closed } braces
         var linesWithBraces = [[NSRange]]()

--- a/Source/SwiftLintFramework/Rules/ColonRule+Type.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule+Type.swift
@@ -32,7 +32,7 @@ internal extension ColonRule {
 
     func typeColonViolationRanges(in file: File, matching pattern: String) -> [NSRange] {
         let nsstring = file.contents.bridge()
-        let commentAndStringKindsSet = Set(SyntaxKind.commentAndStringKinds())
+        let commentAndStringKindsSet = SyntaxKind.commentAndStringKinds
         return file.rangesAndTokens(matching: pattern).filter { _, syntaxTokens in
             let syntaxKinds = syntaxTokens.flatMap { SyntaxKind(rawValue: $0.type) }
 

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -90,8 +90,8 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule {
         "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
 
     private static let regularExpression = regex(pattern, options: [])
-    private static let excludingSyntaxKindsForFirstCapture = SyntaxKind.commentAndStringKinds()
-    private static let excludingSyntaxKindsForSecondCapture = SyntaxKind.commentKinds()
+    private static let excludingSyntaxKindsForFirstCapture = SyntaxKind.commentAndStringKinds
+    private static let excludingSyntaxKindsForSecondCapture = SyntaxKind.commentKinds
 
     private func violationRanges(in file: File) -> [NSRange] {
         let contents = file.contents

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -98,7 +98,7 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
 
         return configurations.flatMap { configuration -> [StyleViolation] in
             let pattern = configuration.regex.pattern
-            let excludingKinds = Array(Set(SyntaxKind.allKinds()).subtracting(configuration.matchKinds))
+            let excludingKinds = SyntaxKind.allKinds.subtracting(configuration.matchKinds)
             return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map({
                 StyleViolation(ruleDescription: configuration.description,
                                severity: configuration.severity,

--- a/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
@@ -41,7 +41,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard SwiftDeclarationKind.functionKinds().contains(kind) else {
+        guard SwiftDeclarationKind.functionKinds.contains(kind) else {
             return []
         }
 
@@ -69,7 +69,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
             }
 
             if let declarationKind = SwiftDeclarationKind(rawValue: kind),
-                SwiftDeclarationKind.functionKinds().contains(declarationKind) {
+                SwiftDeclarationKind.functionKinds.contains(declarationKind) {
                 return complexity
             }
 

--- a/Source/SwiftLintFramework/Rules/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscardedNotificationCenterObserverRule.swift
@@ -87,7 +87,7 @@ private extension Structure {
             }
 
             if let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
-                SwiftDeclarationKind.functionKinds().contains(kind) {
+                SwiftDeclarationKind.functionKinds.contains(kind) {
                 results.append(dictionary)
             }
             dictionary.substructure.forEach(parse)

--- a/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
@@ -36,7 +36,7 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
 
     public func validate(file: File) -> [StyleViolation] {
         let pattern = "\\bcount\\s*(==|!=|<|<=|>|>=)\\s*0"
-        let excludingKinds = SyntaxKind.commentAndStringKinds()
+        let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,

--- a/Source/SwiftLintFramework/Rules/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParametersRule.swift
@@ -56,7 +56,7 @@ public struct EmptyParametersRule: ConfigurationProviderRule, CorrectableRule {
         let excludingPattern = "->\\s*" + pattern // excludes curried functions
 
         return file.match(pattern: pattern,
-                          excludingSyntaxKinds: SyntaxKind.commentAndStringKinds(),
+                          excludingSyntaxKinds: SyntaxKind.commentAndStringKinds,
                           excludingPattern: excludingPattern).flatMap { range in
             let voidRegex = regex(voidPattern)
             return voidRegex.firstMatch(in: file.contents, options: [], range: range)?.range

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -29,7 +29,7 @@ public struct FileLengthRule: ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         func lineCountWithoutComments() -> Int {
-            let commentKinds = Set(SyntaxKind.commentKinds())
+            let commentKinds = SyntaxKind.commentKinds
             let lineCount = file.syntaxKindsByLines.filter { kinds in
                 return !Set(kinds).isSubset(of: commentKinds)
             }.count

--- a/Source/SwiftLintFramework/Rules/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForWhereRule.swift
@@ -65,7 +65,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule {
         ]
     )
 
-    private static let commentKinds = Set(SyntaxKind.commentAndStringKinds())
+    private static let commentKinds = SyntaxKind.commentAndStringKinds
 
     public func validate(file: File, kind: StatementKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -75,8 +75,10 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
 
     private static let regularExpression = regex(pattern)
     private static let varDeclarationRegularExpression = regex(varDeclarationPattern)
-    private static let excludingSyntaxKindsForFirstCapture = SyntaxKind.commentKeywordStringAndTypeidentifierKinds()
-    private static let excludingSyntaxKindsForSecondCapture = SyntaxKind.commentAndStringKinds()
+    private static let excludingSyntaxKindsForFirstCapture: Set<SyntaxKind> = {
+        return SyntaxKind.commentAndStringKinds.union([.keyword, .typeidentifier])
+    }()
+    private static let excludingSyntaxKindsForSecondCapture = SyntaxKind.commentAndStringKinds
 
     private func violationRanges(in file: File) -> [NSRange] {
         let contents = file.contents
@@ -154,7 +156,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
         let kinds = file.structure.kinds(forByteOffset: byteRange.location)
         guard let lastItem = kinds.last,
             let lastKind = SwiftDeclarationKind(rawValue: lastItem.kind),
-            SwiftDeclarationKind.variableKinds().contains(lastKind) else {
+            SwiftDeclarationKind.variableKinds.contains(lastKind) else {
                 return false
         }
 

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -22,7 +22,7 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard SwiftDeclarationKind.functionKinds().contains(kind),
+        guard SwiftDeclarationKind.functionKinds.contains(kind),
             let offset = dictionary.offset,
             let bodyOffset = dictionary.bodyOffset,
             let bodyLength = dictionary.bodyLength,

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -44,7 +44,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard SwiftDeclarationKind.functionKinds().contains(kind) else {
+        guard SwiftDeclarationKind.functionKinds.contains(kind) else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -93,7 +93,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
 
     private func genericTypesForType(in file: File, kind: SwiftDeclarationKind,
                                      dictionary: [String: SourceKitRepresentable]) -> [(String, Int)] {
-        guard SwiftDeclarationKind.typeKinds().contains(kind),
+        guard SwiftDeclarationKind.typeKinds.contains(kind),
             let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength,
             let bodyOffset = dictionary.bodyOffset,
@@ -111,7 +111,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
 
     private func genericTypesForFunction(in file: File, kind: SwiftDeclarationKind,
                                          dictionary: [String: SourceKitRepresentable]) -> [(String, Int)] {
-        guard SwiftDeclarationKind.functionKinds().contains(kind),
+        guard SwiftDeclarationKind.functionKinds.contains(kind),
             let offset = dictionary.nameOffset,
             let length = dictionary.nameLength,
             case let contents = file.contents.bridge(),

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -43,7 +43,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
                 return []
             }
 
-            let isFunction = SwiftDeclarationKind.functionKinds().contains(kind)
+            let isFunction = SwiftDeclarationKind.functionKinds.contains(kind)
             let description = Swift.type(of: self).description
 
             let type = self.type(for: kind)
@@ -101,12 +101,14 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         return (name.nameStrippingLeadingUnderscoreIfPrivate(dictionary), offset)
     }
 
-    private let kinds: [SwiftDeclarationKind] = {
-        return SwiftDeclarationKind.variableKinds() + SwiftDeclarationKind.functionKinds() + [.enumelement]
+    private let kinds: Set<SwiftDeclarationKind> = {
+        return SwiftDeclarationKind.variableKinds
+            .union(SwiftDeclarationKind.functionKinds)
+            .union([.enumelement])
     }()
 
     private func type(for kind: SwiftDeclarationKind) -> String {
-        if SwiftDeclarationKind.functionKinds().contains(kind) {
+        if SwiftDeclarationKind.functionKinds.contains(kind) {
             return "Function"
         } else if kind == .enumelement {
             return "Enum element"

--- a/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
@@ -100,7 +100,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule {
     private func variableDeclarations(forByteOffset byteOffset: Int,
                                       structure: Structure) -> [[String: SourceKitRepresentable]] {
         var results = [[String: SourceKitRepresentable]]()
-        let allowedKinds = Set(SwiftDeclarationKind.variableKinds()).subtracting([.varParameter])
+        let allowedKinds = SwiftDeclarationKind.variableKinds.subtracting([.varParameter])
 
         func parse(dictionary: [String: SourceKitRepresentable], parentKind: SwiftDeclarationKind?) {
 

--- a/Source/SwiftLintFramework/Rules/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitlyUnwrappedOptionalRule.swift
@@ -49,7 +49,7 @@ public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRul
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard SwiftDeclarationKind.variableKinds().contains(kind) else {
+        guard SwiftDeclarationKind.variableKinds.contains(kind) else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/IsDisjointRule.swift
+++ b/Source/SwiftLintFramework/Rules/IsDisjointRule.swift
@@ -32,7 +32,7 @@ public struct IsDisjointRule: ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         let pattern = "\\bintersection\\(\\S+\\)\\.isEmpty"
-        let excludingKinds = SyntaxKind.commentAndStringKinds()
+        let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -83,7 +83,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
 
     private func violationOffsetsForTypes(in file: File, dictionary: [String: SourceKitRepresentable],
                                           kind: SwiftDeclarationKind) -> [(offset: Int, size: Int)] {
-        let kinds = SwiftDeclarationKind.variableKinds().filter { $0 != .varLocal }
+        let kinds = SwiftDeclarationKind.variableKinds.subtracting([.varLocal])
         guard kinds.contains(kind),
             let type = dictionary.typeName,
             let offset = dictionary.offset else {
@@ -97,7 +97,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
     private func violationOffsetsForFunctions(in file: File, dictionary: [String: SourceKitRepresentable],
                                               kind: SwiftDeclarationKind) -> [(offset: Int, size: Int)] {
         let contents = file.contents.bridge()
-        guard SwiftDeclarationKind.functionKinds().contains(kind),
+        guard SwiftDeclarationKind.functionKinds.contains(kind),
             let returnRange = returnRangeForFunction(dictionary: dictionary),
             let returnSubstring = contents.substringWithByteRange(start: returnRange.location,
                                                                   length: returnRange.length) else {

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -14,9 +14,9 @@ public struct LineLengthRule: ConfigurationProviderRule {
 
     public init() {}
 
-    private let commentKinds = Set(SyntaxKind.commentKinds())
-    private let nonCommentKinds = Set(SyntaxKind.allKinds()).subtracting(SyntaxKind.commentKinds())
-    private let functionKinds = Set(SwiftDeclarationKind.functionKinds())
+    private let commentKinds = SyntaxKind.commentKinds
+    private let nonCommentKinds = SyntaxKind.allKinds.subtracting(SyntaxKind.commentKinds)
+    private let functionKinds = SwiftDeclarationKind.functionKinds
 
     public static let description = RuleDescription(
         identifier: "line_length",

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRule.swift
@@ -27,7 +27,7 @@ public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProvider
                          kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         guard
-            SwiftDeclarationKind.functionKinds().contains(kind),
+            SwiftDeclarationKind.functionKinds.contains(kind),
             let offset = dictionary.nameOffset,
             let length = dictionary.nameLength
             else {

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -44,7 +44,7 @@ public struct NestingRule: ASTRule, ConfigurationProviderRule {
     private func validate(file: File, kind: SwiftDeclarationKind, dictionary: [String: SourceKitRepresentable],
                           level: Int) -> [StyleViolation] {
         var violations = [StyleViolation]()
-        let typeKinds = SwiftDeclarationKind.typeKinds()
+        let typeKinds = SwiftDeclarationKind.typeKinds
         if let offset = dictionary.offset {
             let (targetName, targetLevel) = typeKinds.contains(kind)
                 ? ("Types", configuration.typeLevel) : ("Statements", configuration.statementLevel)

--- a/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
@@ -86,7 +86,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
         let variablePattern = "(.(?!expect\\())+?"
         let pattern = "expect\\(\(variablePattern)\\)\\.to(Not)?\\(\(operatorsPattern)\\(\(variablePattern)\\)\\)"
 
-        let excludingKinds = SyntaxKind.commentKinds()
+        let excludingKinds = SyntaxKind.commentKinds
 
         return file.match(pattern: pattern)
             .filter { _, kinds in

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -14,7 +14,7 @@ private let whitespaceAndNewlineCharacterSet = CharacterSet.whitespacesAndNewlin
 private extension File {
     func violatingOpeningBraceRanges() -> [(range: NSRange, location: Int)] {
         return match(pattern: "(?:[^( ]|[\\s(][\\s]+)\\{",
-                     excludingSyntaxKinds: SyntaxKind.commentAndStringKinds(),
+                     excludingSyntaxKinds: SyntaxKind.commentAndStringKinds,
                      excludingPattern: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{").map {
             let branceRange = contents.bridge().range(of: "{", options: .literal, range: $0)
             return ($0, branceRange.location)

--- a/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
@@ -109,7 +109,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             zeroSpaces + trailingVariableOrNumber
         let excludingPattern = "(?:\(genericPattern)|\(validRangePattern))"
 
-        let excludingKinds = SyntaxKind.commentAndStringKinds() + [.objectLiteral]
+        let excludingKinds = SyntaxKind.commentAndStringKinds.union([.objectLiteral])
 
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds,
                           excludingPattern: excludingPattern).flatMap { range in

--- a/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
@@ -68,7 +68,7 @@ public struct RedundantOptionalInitializationRule: ASTRule, CorrectableRule, Con
 
     private func violationRanges(in file: File, kind: SwiftDeclarationKind,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        guard SwiftDeclarationKind.variableKinds().contains(kind),
+        guard SwiftDeclarationKind.variableKinds.contains(kind),
             dictionary.setterAccessibility != nil,
             let type = dictionary.typeName,
             typeIsOptional(type),

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -60,7 +60,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
 
     private func violationRanges(in file: File, kind: SwiftDeclarationKind,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        guard SwiftDeclarationKind.functionKinds().contains(kind),
+        guard SwiftDeclarationKind.functionKinds.contains(kind),
             let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength,
             let length = dictionary.length,
@@ -69,18 +69,15 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
             case let end = dictionary.bodyOffset ?? offset + length,
             case let contents = file.contents.bridge(),
             let range = contents.byteRangeToNSRange(start: start, length: end - start),
-            case let kinds = excludingKinds(),
-            file.match(pattern: "->", excludingSyntaxKinds: kinds, range: range).count == 1,
-            let match = file.match(pattern: pattern, excludingSyntaxKinds: kinds, range: range).first else {
+            file.match(pattern: "->", excludingSyntaxKinds: excludingKinds, range: range).count == 1,
+            let match = file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds, range: range).first else {
                 return []
         }
 
         return [match]
     }
 
-    private func excludingKinds() -> [SyntaxKind] {
-        return SyntaxKind.allKinds().filter { $0 != .typeidentifier }
-    }
+    private let excludingKinds = SyntaxKind.allKinds.subtracting([.typeidentifier])
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -16,7 +16,7 @@ public struct RegexConfiguration: RuleConfiguration, Equatable, CacheDescription
     public var regex: NSRegularExpression!
     public var included: NSRegularExpression?
     public var excluded: NSRegularExpression?
-    public var matchKinds = Set(SyntaxKind.allKinds())
+    public var matchKinds = SyntaxKind.allKinds
     public var severityConfiguration = SeverityConfiguration(.warning)
 
     public var severity: ViolationSeverity {

--- a/Source/SwiftLintFramework/Rules/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseOnNewlineRule.swift
@@ -88,7 +88,7 @@ public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptIn
                 return false
             }
 
-            return !SyntaxKind.commentKinds().contains(kind)
+            return !SyntaxKind.commentKinds.contains(kind)
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -51,7 +51,7 @@ public struct SyntacticSugarRule: ConfigurationProviderRule {
         let types = ["Optional", "ImplicitlyUnwrappedOptional", "Array", "Dictionary"]
         let negativeLookBehind = "(?:(?<!\\.)|Swift\\.)"
         let pattern = negativeLookBehind + "\\b(" + types.joined(separator: "|") + ")\\s*<.*?>"
-        let excludingKinds = Set(SyntaxKind.commentAndStringKinds())
+        let excludingKinds = SyntaxKind.commentAndStringKinds
         let contents = file.contents.bridge()
         let range = NSRange(location: 0, length: contents.length)
 

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -12,7 +12,7 @@ import SourceKittenFramework
 public extension SyntaxKind {
     /// Returns if the syntax kind is comment-like.
     var isCommentLike: Bool {
-        return SyntaxKind.commentKinds().contains(self)
+        return SyntaxKind.commentKinds.contains(self)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -143,7 +143,7 @@ public struct TrailingCommaRule: ASTRule, CorrectableRule, ConfigurationProvider
         return ranges.filter {
             let range = NSRange(location: $0.location + offset, length: $0.length)
             let kinds = file.syntaxMap.kinds(inByteRange: range)
-            return !kinds.contains(where: SyntaxKind.commentKinds().contains)
+            return SyntaxKind.commentKinds.isDisjoint(with: kinds)
         }.last.flatMap {
             nsstring.NSRangeToByteRange(start: $0.location, length: $0.length)
         }?.location

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -12,7 +12,7 @@ import SourceKittenFramework
 private extension File {
     func violatingTrailingSemicolonRanges() -> [NSRange] {
         return match(pattern: "(;+([^\\S\\n]?)*)+;?$",
-                     excludingSyntaxKinds: SyntaxKind.commentAndStringKinds())
+                     excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -32,7 +32,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         let filteredLines = file.lines.filter {
             guard $0.content.hasTrailingWhitespace() else { return false }
 
-            let commentKinds = SyntaxKind.commentKinds()
+            let commentKinds = SyntaxKind.commentKinds
             if configuration.ignoresComments,
                 let lastSyntaxKind = file.syntaxKindsByLines[$0.index].last,
                 commentKinds.contains(lastSyntaxKind) {
@@ -61,7 +61,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
                 continue
             }
 
-            let commentKinds = SyntaxKind.commentKinds()
+            let commentKinds = SyntaxKind.commentKinds
             if configuration.ignoresComments,
                 let lastSyntaxKind = file.syntaxKindsByLines[line.index].last,
                 commentKinds.contains(lastSyntaxKind) {

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -41,7 +41,7 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard SwiftDeclarationKind.typeKinds().contains(kind) else {
+        guard SwiftDeclarationKind.typeKinds.contains(kind) else {
             return []
         }
         if let offset = dictionary.offset,

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -28,7 +28,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         triggeringExamples: TypeNameRuleExamples.triggeringExamples
     )
 
-    private let typeKinds = SwiftDeclarationKind.typeKinds()
+    private let typeKinds = SwiftDeclarationKind.typeKinds
 
     public func validate(file: File) -> [StyleViolation] {
         return validateTypeAliasesAndAssociatedTypes(in: file) +

--- a/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
@@ -76,7 +76,7 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func violations(in range: NSRange, of file: File, with kind: StatementKind) -> [NSRange] {
-        let kinds = SyntaxKind.commentAndStringKinds()
+        let kinds = SyntaxKind.commentAndStringKinds
 
         let underscorePattern = "(_\\s*[=,)]\\s*(try\\?)?)"
         let underscoreTuplePattern = "(\\((\\s*[_,]\\s*)+\\)\\s*=\\s*(try\\?)?)"

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
@@ -56,7 +56,7 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard SwiftDeclarationKind.functionKinds().contains(kind),
+        guard SwiftDeclarationKind.functionKinds.contains(kind),
             let startOffset = dictionary.nameOffset,
             let length = dictionary.nameLength,
             case let endOffset = startOffset + length else {

--- a/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
@@ -78,7 +78,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         let blankLinesSections = extractSections(from: filteredLines)
 
         // filtering out violations in comments and strings
-        let stringAndComments = Set(SyntaxKind.commentAndStringKinds())
+        let stringAndComments = SyntaxKind.commentAndStringKinds
         let syntaxMap = file.syntaxMap
         let result = blankLinesSections.flatMap { eachSection -> (lastLine: Line, linesToRemove: Int)? in
             guard let lastLine = eachSection.last else {

--- a/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
@@ -58,7 +58,7 @@ public struct VoidReturnRule: ConfigurationProviderRule, CorrectableRule {
     }
 
     private func violationRanges(file: File) -> [NSRange] {
-        let kinds = SyntaxKind.commentAndStringKinds()
+        let kinds = SyntaxKind.commentAndStringKinds
         let parensPattern = "\\(\\s*(?:Void)?\\s*\\)"
         let pattern = "->\\s*\(parensPattern)\\s*(?!->)"
         let excludingPattern = "(\(pattern))\\s*(throws\\s+)?->"


### PR DESCRIPTION
Running locally I didn't observe a speed gain, but at least we're more consistent.

```
Message: Linting Aerial with this PR took 0.29s vs 0.28s on master (3% slower)
Message: Linting Alamofire with this PR took 2.05s vs 2.08s on master (1% faster)
Message: Linting Firefox with this PR took 8.14s vs 8.1s on master (0% slower)
Message: Linting Kickstarter with this PR took 12.84s vs 12.81s on master (0% slower)
Message: Linting Moya with this PR took 0.95s vs 0.95s on master (0% slower)
Message: Linting Nimble with this PR took 1.13s vs 1.13s on master (0% slower)
Message: Linting Quick with this PR took 0.35s vs 0.35s on master (0% slower)
Message: Linting Realm with this PR took 1.85s vs 1.85s on master (0% slower)
Message: Linting SourceKitten with this PR took 0.68s vs 0.68s on master (0% slower)
Message: Linting Sourcery with this PR took 2.96s vs 2.95s on master (0% slower)
Message: Linting Swift with this PR took 8.97s vs 9.04s on master (0% faster)
Message: Linting WordPress with this PR took 7.42s vs 7.51s on master (1% faster)
```