### PR TITLE
Sorted imports auto correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   [Samuel Susla](https://github.com/sammy-sc)
   [#1514](https://github.com/realm/SwiftLint/issues/1514)
 
+* Make `sorted_imports` correctable.  
+  [Samuel Susla](https://github.com/sammy-sc)
+  [#1822](https://github.com/realm/SwiftLint/issues/1822)
+
 * Add `fallthrough` rule that flags usage of `fallthrough`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1834](https://github.com/realm/SwiftLint/issues/1834)

--- a/Rules.md
+++ b/Rules.md
@@ -9811,6 +9811,13 @@ import labc
 import Ldef
 ```
 
+```swift
+import BBB
+// comment
+import AAA
+import CCC
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -9820,6 +9827,13 @@ import AAA
 import ZZZ
 import ↓BBB
 import CCC
+```
+
+```swift
+import BBB
+// comment
+import CCC
+import ↓AAA
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -9785,7 +9785,7 @@ class TotoTests {  }
 
 Identifier | Enabled by default | Supports autocorrection | Kind 
 --- | --- | --- | ---
-`sorted_imports` | Disabled | No | style
+`sorted_imports` | Disabled | Yes | style
 
 Imports should be sorted.
 

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -9,7 +9,46 @@
 import Foundation
 import SourceKittenFramework
 
-public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
+private extension Line {
+    var contentRange: NSRange {
+        return NSRange(location: range.location, length: content.characters.count)
+    }
+
+    // `Line` in this rule always contains word import
+    // This method returns contents of line that are after import
+    private func afterImport() -> String {
+        guard let range = content.range(of: "import ") else { return "" }
+        return String(content.characters.suffix(from: range.upperBound))
+    }
+
+    // Case insensitive comparission of contents of the line
+    // after the word `import`
+    static func <= (lhs: Line, rhs: Line) -> Bool {
+        return lhs.afterImport().lowercased() <= rhs.afterImport().lowercased()
+    }
+}
+
+private extension Array where Element == Line {
+    // Groups lines, so that lines that are one after the other
+    // will end up in same group.
+    func grouped() -> [[Line]] {
+        return self.reduce([[Line]]()) { result, line in
+            if let last = result.last?.last {
+                var copy = result
+                if last.index == line.index - 1 {
+                    copy[copy.count - 1].append(line)
+                } else {
+                    copy.append([line])
+                }
+                return copy
+            } else {
+                return [[line]]
+            }
+        }
+    }
+}
+
+public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -26,13 +65,31 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
         ],
         triggeringExamples: [
             "import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC"
+        ],
+        corrections: [
+            "import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC": "import AAA\nimport BBB\nimport CCC\nimport ZZZ",
+            "import BBB // comment\nimport ↓AAA": "import AAA\nimport BBB // comment",
+            "import BBB\n// comment\nimport CCC\nimport ↓AAA": "import BBB\n// comment\nimport AAA\nimport CCC",
+            "@testable import CCC\nimport AAA": "import AAA\n@testable import CCC"
         ]
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let importRanges = file.match(pattern: "import\\s+\\w+", with: [.keyword, .identifier])
-        let contents = file.contents.bridge()
+        let violatingOffsets = findViolationOffsets(file: file)
 
+        return violatingOffsets.map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0))
+        }
+    }
+
+    private static let importPattern = "import\\s+\\w+"
+
+    private func findViolationOffsets(file: File) -> [Int] {
+        let importRanges = file.match(pattern: type(of: self).importPattern,
+                                      with: [.keyword, .identifier])
+        let contents = file.contents.bridge()
         let importLength = 6
         let modulesAndOffsets: [(String, Int)] = importRanges.map { range in
             let moduleRange = NSRange(location: range.location + importLength,
@@ -44,14 +101,65 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
         }
 
         let modulePairs = zip(modulesAndOffsets, modulesAndOffsets.dropFirst())
-        let violatingOffsets = modulePairs.flatMap { previous, current in
+        return modulePairs.flatMap { previous, current in
             return current < previous ? current.1 : nil
         }
+    }
 
-        return violatingOffsets.map {
-            StyleViolation(ruleDescription: type(of: self).description,
-                           severity: configuration.severity,
-                           location: Location(file: file, characterOffset: $0))
+    private func violatingOffsets(in groups: [[Line]]) -> [Int] {
+        var violatingOffsets = [Int]()
+        groups.forEach { group in
+            let pairs = zip(group, group.dropFirst())
+            pairs.forEach { previous, current in
+                let isOrderedCorrectly = previous <= current
+                if !isOrderedCorrectly {
+                    violatingOffsets.append(current.range.location + 7)
+                }
+            }
         }
+        return violatingOffsets
+    }
+
+    public func correct(file: File) -> [Correction] {
+        let importRanges = file.match(pattern: type(of: self).importPattern, with: [.keyword, .identifier])
+        let enabledImportRanges = file.ruleEnabled(violatingRanges: importRanges, for: self)
+        guard enabledImportRanges.count > 1 else {
+            return []
+        }
+
+        let contents = file.contents.bridge()
+        let lines = contents.lines()
+        let importLines: [Line] = enabledImportRanges.flatMap { range in
+            guard let line = contents.lineAndCharacter(forCharacterOffset: range.location)?.line
+                else { return nil }
+            return lines[line - 1]
+        }
+
+        var groups = importLines.grouped()
+        let description = type(of: self).description
+        let corrections = self.violatingOffsets(in: groups).map { index -> Correction in
+            let location = Location(file: file, characterOffset: index)
+            return Correction(ruleDescription: description, location: location)
+        }
+
+        groups.enumerated().forEach { index, group in
+            groups[index] = group.sorted { previous, current in
+                previous <= current
+            }
+        }
+
+        let correctedContents = NSMutableString(string: file.contents)
+        groups.forEach { group in
+            if let first = group.first?.contentRange {
+                let result = group.map { $0.content }.joined(separator: "\n")
+                let union = group.dropFirst().reduce(first, { result, line in
+                    return NSUnionRange(result, line.contentRange)
+                })
+                correctedContents.replaceCharacters(in: union, with: result)
+            }
+        }
+        file.write(correctedContents.bridge())
+
+        return corrections
     }
 }


### PR DESCRIPTION
Makes `sorted_imports` corractable.
Feature request: #1822 

I was not sure how to handle this case.

```
import BBB
// comment 
import CCC
import AAA
```
the code above will generate warning from `sorted_imports` but autocorrection won't fix it because I am not sure what to do with the comment. The code above will result into following correction. Same thing happens if there is a code in place of the comment.
```
import BBB
// comment 
import AAA
import CCC
```

Any comments or suggestions are very welcome.
