### PR TITLE
Exclude files also when using the '-—use-script-input-files' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1271](https://github.com/realm/SwiftLint/issues/1271)
 
+* Exclude files defined in the configuration also when using the
+  `--use-script-input-files` option.  
+  [Stefan Pühringer](https://github.com/b-ray)
+  [#591](https://github.com/realm/SwiftLint/issues/591)
+
 ##### Bug Fixes
 
 * Improve how `opening_brace` rule reports violations locations.  

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -14,6 +14,18 @@ extension Configuration {
         return lintablePaths(inPath: path).flatMap(File.init(path:))
     }
 
+    public func lintableFiles(ofFiles files: [File]) -> [File] {
+        let excludedPaths = excluded.flatMap {
+            FileManager.default.filesToLint(inPath: $0, rootDirectory: rootPath)
+        }
+        return files.filter {
+            guard let path = $0.path else {
+                return true
+            }
+            return !excludedPaths.contains(path)
+        }
+    }
+
     internal func lintablePaths(inPath path: String,
                                 fileManager: LintableFileManager = FileManager.default) -> [String] {
         // If path is a file, skip filtering with excluded/included paths

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -67,6 +67,9 @@ extension Configuration {
                 let errorMessage = "No lintable files found at path '\(path)'"
                 return .failure(.usageError(description: errorMessage))
             }
+            if useScriptInputFiles {
+                return .success(lintableFiles(ofFiles: files))
+            }
             return .success(files)
         }.flatMap { files in
             let queue = DispatchQueue(label: "io.realm.swiftlint.indexIncrementer")


### PR DESCRIPTION
Fixes #591 

I use this to lint files that are staged for a commit as part of a pre-commit-hook (like also mentioned [here](https://github.com/realm/SwiftLint/issues/1823)).
As I don't want to abort the commit if all changed files are filtered, I perform the filter after the check if the `files` array is empty.