### PR TITLE
Speed up LetVarWhitespaceRule.attributeLineNumbers(file:)

### DIFF
--- a/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
@@ -212,10 +212,12 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule {
     // Collects all the line numbers containing attributes but not declarations
     // other than let/var
     private func attributeLineNumbers(file: File) -> Set<Int> {
-        let matches = file.match(pattern: "[@_a-z]+", with: [.attributeBuiltin])
-        let matchLines = matches.map { file.line(offset: $0.location) }
-
-        return Set<Int>(matchLines)
+        return Set(file.syntaxMap.tokens.flatMap({ token in
+            if token.type == SyntaxKind.attributeBuiltin.rawValue {
+                return file.line(byteOffset: token.offset)
+            }
+            return nil
+        }))
     }
 }
 


### PR DESCRIPTION
By treating each `.attributeBuiltin` as a match rather than performing a regular expression along with many byte offset to string offset conversions.

I used this example as the basis for my talk on Performance Profiling Swift on Linux at FrenchKit last weekend, so I have lots of graphs demonstrating the effect of this here: https://speakerdeck.com/jpsim/performance-profiling-swift-on-linux

The performance impact is also visible on macOS.

Here are some before/after flamegraphs that demonstrate the `let_var_whitespace` rule taking a disproportionate amount of time to run compared to other rules, and the fixed result:

**Before**

<img width="1200" alt="flamegraph_before" src="https://user-images.githubusercontent.com/474794/30995542-c8edbe38-a46f-11e7-8adc-f372e6b9f2ac.png">

**After**

<img width="1200" alt="flamegraph_after" src="https://user-images.githubusercontent.com/474794/30995547-d0a5a834-a46f-11e7-9087-6708b3354788.png">
