### PR TITLE
Fix false negatives when using allowed_symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
   when running `swiftlint rules`.  
   [JP Simard](https://github.com/jpsim)
   [#1002](https://github.com/realm/SwiftLint/issues/1002)
+  
+* Fix false negatives in `generic_type_name`, `identifier_name` and `type_name`
+  rules when using `allowed_symbols`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
@@ -9,13 +9,16 @@
 import Foundation
 
 extension CharacterSet {
-    func isSuperset(ofCharactersIn string: String) -> Bool {
-#if swift(>=4.0)
-        return isSuperset(of: CharacterSet(charactersIn: string))
+    func isSuperset(ofCharactersIn string: String,
+                    union other: CharacterSet = CharacterSet()) -> Bool {
+#if swift(>=3.2)
+        let set = union(other)
+        return set.isSuperset(of: CharacterSet(charactersIn: string))
 #else
         // workaround for https://bugs.swift.org/browse/SR-3485
         return !Set(string.characters).contains { character in
-            !contains(String(character).unicodeScalars.first!)
+            let scalar = String(character).unicodeScalars.first!
+            return !contains(scalar) && !other.contains(scalar)
         }
 #endif
     }

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+LinuxHack.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension CharacterSet {
     func isSuperset(ofCharactersIn string: String) -> Bool {
-#if swift(>=4.0) || os(macOS)
+#if swift(>=4.0)
         return isSuperset(of: CharacterSet(charactersIn: string))
 #else
         // workaround for https://bugs.swift.org/browse/SR-3485

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -165,7 +165,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
             return []
         }
 
-        let allowedSymbols = CharacterSet.alphanumerics.union(configuration.allowedSymbols)
+        let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
         if !allowedSymbols.isSuperset(ofCharactersIn: name) {
             return [
                 StyleViolation(ruleDescription: type(of: self).description,

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -165,8 +165,8 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
             return []
         }
 
-        let containsAllowedSymbol = configuration.allowedSymbols.contains(where: name.contains)
-        if !containsAllowedSymbol && !CharacterSet.alphanumerics.isSuperset(ofCharactersIn: name) {
+        let allowedSymbols = CharacterSet.alphanumerics.union(configuration.allowedSymbols)
+        if !allowedSymbols.isSuperset(ofCharactersIn: name) {
             return [
                 StyleViolation(ruleDescription: type(of: self).description,
                                severity: .error,

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -165,8 +165,8 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
             return []
         }
 
-        let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
-        if !allowedSymbols.isSuperset(ofCharactersIn: name) {
+        let allowedSymbols = configuration.allowedSymbols
+        if !allowedSymbols.isSuperset(ofCharactersIn: name, union: .alphanumerics) {
             return [
                 StyleViolation(ruleDescription: type(of: self).description,
                                severity: .error,

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -48,8 +48,8 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
 
             let type = self.type(for: kind)
             if !isFunction {
-                let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
-                if !allowedSymbols.isSuperset(ofCharactersIn: name) {
+                let allowedSymbols = configuration.allowedSymbols
+                if !allowedSymbols.isSuperset(ofCharactersIn: name, union: .alphanumerics) {
                     return [
                         StyleViolation(ruleDescription: description,
                                        severity: .error,

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -48,9 +48,8 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
 
             let type = self.type(for: kind)
             if !isFunction {
-                let containsAllowedSymbol = configuration.allowedSymbols.contains(where: name.contains)
-                if !containsAllowedSymbol &&
-                    !CharacterSet.alphanumerics.isSuperset(ofCharactersIn: name) {
+                let allowedSymbols = CharacterSet.alphanumerics.union(configuration.allowedSymbols)
+                if !allowedSymbols.isSuperset(ofCharactersIn: name) {
                     return [
                         StyleViolation(ruleDescription: description,
                                        severity: .error,

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -48,7 +48,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
 
             let type = self.type(for: kind)
             if !isFunction {
-                let allowedSymbols = CharacterSet.alphanumerics.union(configuration.allowedSymbols)
+                let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
                 if !allowedSymbols.isSuperset(ofCharactersIn: name) {
                     return [
                         StyleViolation(ruleDescription: description,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -13,14 +13,14 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
         return "(min_length) \(minLength.shortConsoleDescription), " +
             "(max_length) \(maxLength.shortConsoleDescription), " +
             "excluded: \(excluded.sorted()), " +
-            "allowed_symbols: \(allowedSymbols.sorted()), " +
+            "allowed_symbols: \(allowedSymbolsSet.sorted()), " +
             "validates_start_with_lowercase: \(validatesStartWithLowercase)"
     }
 
     var minLength: SeverityLevelsConfiguration
     var maxLength: SeverityLevelsConfiguration
     var excluded: Set<String>
-    var allowedSymbols: Set<String>
+    private var allowedSymbolsSet: Set<String>
     var validatesStartWithLowercase: Bool
 
     var minLengthThreshold: Int {
@@ -29,6 +29,10 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
 
     var maxLengthThreshold: Int {
         return min(maxLength.warning, maxLength.error ?? maxLength.warning)
+    }
+
+    var allowedSymbols: CharacterSet {
+        return CharacterSet(charactersIn: allowedSymbolsSet.joined())
     }
 
     public init(minLengthWarning: Int,
@@ -41,7 +45,7 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
         minLength = SeverityLevelsConfiguration(warning: minLengthWarning, error: minLengthError)
         maxLength = SeverityLevelsConfiguration(warning: maxLengthWarning, error: maxLengthError)
         self.excluded = Set(excluded)
-        self.allowedSymbols = Set(allowedSymbols)
+        self.allowedSymbolsSet = Set(allowedSymbols)
         self.validatesStartWithLowercase = validatesStartWithLowercase
     }
 
@@ -60,7 +64,7 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
             self.excluded = Set(excluded)
         }
         if let allowedSymbols = [String].array(of: configurationDict["allowed_symbols"]) {
-            self.allowedSymbols = Set(allowedSymbols)
+            self.allowedSymbolsSet = Set(allowedSymbols)
         }
 
         if let validatesStartWithLowercase = configurationDict["validates_start_with_lowercase"] as? Bool {
@@ -71,14 +75,14 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
                 "\"validates_start_with_lowercase\" and will be removed in a future release.")
         }
     }
-}
 
-public func == (lhs: NameConfiguration, rhs: NameConfiguration) -> Bool {
-    return lhs.minLength == rhs.minLength &&
-           lhs.maxLength == rhs.maxLength &&
-           zip(lhs.excluded, rhs.excluded).reduce(true) { $0 && ($1.0 == $1.1) } &&
-           zip(lhs.allowedSymbols, rhs.allowedSymbols).reduce(true) { $0 && ($1.0 == $1.1) } &&
-           lhs.validatesStartWithLowercase == rhs.validatesStartWithLowercase
+    public static func == (lhs: NameConfiguration, rhs: NameConfiguration) -> Bool {
+        return lhs.minLength == rhs.minLength &&
+            lhs.maxLength == rhs.maxLength &&
+            zip(lhs.excluded, rhs.excluded).reduce(true) { $0 && ($1.0 == $1.1) } &&
+            zip(lhs.allowedSymbolsSet, rhs.allowedSymbolsSet).reduce(true) { $0 && ($1.0 == $1.1) } &&
+            lhs.validatesStartWithLowercase == rhs.validatesStartWithLowercase
+    }
 }
 
 // MARK: - ConfigurationProviderRule extensions

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -75,8 +75,8 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         let name = name.nameStrippingLeadingUnderscoreIfPrivate(dictionary)
-        let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
-        if !allowedSymbols.isSuperset(ofCharactersIn: name) {
+        let allowedSymbols = configuration.allowedSymbols
+        if !allowedSymbols.isSuperset(ofCharactersIn: name, union: .alphanumerics) {
             return [StyleViolation(ruleDescription: type(of: self).description,
                                    severity: .error,
                                    location: Location(file: file, byteOffset: offset),

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -75,8 +75,8 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         let name = name.nameStrippingLeadingUnderscoreIfPrivate(dictionary)
-        let containsAllowedSymbol = configuration.allowedSymbols.contains(where: name.contains)
-        if !containsAllowedSymbol && !CharacterSet.alphanumerics.isSuperset(ofCharactersIn: name) {
+        let allowedSymbols = CharacterSet.alphanumerics.union(configuration.allowedSymbols)
+        if !allowedSymbols.isSuperset(ofCharactersIn: name) {
             return [StyleViolation(ruleDescription: type(of: self).description,
                                    severity: .error,
                                    location: Location(file: file, byteOffset: offset),

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -75,7 +75,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         let name = name.nameStrippingLeadingUnderscoreIfPrivate(dictionary)
-        let allowedSymbols = CharacterSet.alphanumerics.union(configuration.allowedSymbols)
+        let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
         if !allowedSymbols.isSuperset(ofCharactersIn: name) {
             return [StyleViolation(ruleDescription: type(of: self).description,
                                    severity: .error,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -172,6 +172,7 @@ extension GenericTypeNameRuleTests {
     static var allTests: [(String, (GenericTypeNameRuleTests) -> () throws -> Void)] = [
         ("testGenericTypeName", testGenericTypeName),
         ("testGenericTypeNameWithAllowedSymbols", testGenericTypeNameWithAllowedSymbols),
+        ("testGenericTypeNameWithAllowedSymbolsAndViolation", testGenericTypeNameWithAllowedSymbolsAndViolation),
         ("testGenericTypeNameWithIgnoreStartWithLowercase", testGenericTypeNameWithIgnoreStartWithLowercase)
     ]
 }
@@ -180,6 +181,7 @@ extension IdentifierNameRuleTests {
     static var allTests: [(String, (IdentifierNameRuleTests) -> () throws -> Void)] = [
         ("testIdentifierName", testIdentifierName),
         ("testIdentifierNameWithAllowedSymbols", testIdentifierNameWithAllowedSymbols),
+        ("testIdentifierNameWithAllowedSymbolsAndViolation", testIdentifierNameWithAllowedSymbolsAndViolation),
         ("testIdentifierNameWithIgnoreStartWithLowercase", testIdentifierNameWithIgnoreStartWithLowercase)
     ]
 }
@@ -468,6 +470,7 @@ extension TypeNameRuleTests {
     static var allTests: [(String, (TypeNameRuleTests) -> () throws -> Void)] = [
         ("testTypeName", testTypeName),
         ("testTypeNameWithAllowedSymbols", testTypeNameWithAllowedSymbols),
+        ("testTypeNameWithAllowedSymbolsAndViolation", testTypeNameWithAllowedSymbolsAndViolation),
         ("testTypeNameWithIgnoreStartWithLowercase", testTypeNameWithIgnoreStartWithLowercase)
     ]
 }

--- a/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
@@ -30,6 +30,16 @@ class GenericTypeNameRuleTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%"]])
     }
 
+    func testGenericTypeNameWithAllowedSymbolsAndViolation() {
+        let baseDescription = GenericTypeNameRule.description
+        let triggeringExamples = [
+            "func foo<↓T_$>() {}\n"
+        ]
+
+        let description = baseDescription.with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%"]])
+    }
+
     func testGenericTypeNameWithIgnoreStartWithLowercase() {
         let baseDescription = GenericTypeNameRule.description
         let triggeringExamplesToRemove = [

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -27,6 +27,16 @@ class IdentifierNameRuleTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%"]])
     }
 
+    func testIdentifierNameWithAllowedSymbolsAndViolation() {
+        let baseDescription = IdentifierNameRule.description
+        let triggeringExamples = [
+            "↓let my_Let$ = 0"
+        ]
+
+        let description = baseDescription.with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%"]])
+    }
+
     func testIdentifierNameWithIgnoreStartWithLowercase() {
         let baseDescription = IdentifierNameRule.description
         let triggeringExamplesToRemove = [

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -29,6 +29,16 @@ class TypeNameRuleTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$"]])
     }
 
+    func testTypeNameWithAllowedSymbolsAndViolation() {
+        let baseDescription = TypeNameRule.description
+        let triggeringExamples = [
+            "class My_Type$ {}"
+        ]
+
+        let description = baseDescription.with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%"]])
+    }
+
     func testTypeNameWithIgnoreStartWithLowercase() {
         let baseDescription = TypeNameRule.description
         let triggeringExamplesToRemove = [


### PR DESCRIPTION
Previously, we were not generating violations if there's a symbol which is not alphanumeric and is not on `allowed_symbols`.