### PR TITLE
Remove exception for static variables in identifier_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Breaking
 
-* None.
+* Validate that `static` variables also start with an uppercase letter
+  in `identifier_name` rule.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
 
 ##### Enhancements
 

--- a/Rules.md
+++ b/Rules.md
@@ -4821,7 +4821,7 @@ Identifier | Enabled by default | Supports autocorrection | Kind
 --- | --- | --- | ---
 `identifier_name` | Enabled | No | style
 
-Identifier names should only contain alphanumeric characters and start with a lowercase character or should only contain capital letters. In an exception to the above, variable names may start with a capital letter when they are declared static and immutable. Variable names should not be too long or too short.
+Identifier names should only contain alphanumeric characters and start with a lowercase character or should only contain capital letters. Variable names should not be too long or too short.
 
 ### Examples
 
@@ -4838,10 +4838,6 @@ var myVar = 0
 
 ```swift
 private let _myLet = 0
-```
-
-```swift
-class Abc { static let MyLet = 0 }
 ```
 
 ```swift
@@ -4922,6 +4918,10 @@ private ↓let _i = 0
 
 ```swift
 enum Foo { case ↓MyEnum }
+```
+
+```swift
+class Abc { ↓static let MyLet = 0 }
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -23,9 +23,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         name: "Identifier Name",
         description: "Identifier names should only contain alphanumeric characters and " +
             "start with a lowercase character or should only contain capital letters. " +
-            "In an exception to the above, variable names may start with a capital letter " +
-            "when they are declared static and immutable. Variable names should not be too " +
-            "long or too short.",
+            "Variable names should not be too long or too short.",
         kind: .style,
         nonTriggeringExamples: IdentifierNameRuleExamples.nonTriggeringExamples,
         triggeringExamples: IdentifierNameRuleExamples.triggeringExamples,
@@ -74,8 +72,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             }
 
             let requiresCaseCheck = configuration.validatesStartWithLowercase || isFunction
-            if requiresCaseCheck &&
-                kind != .varStatic && name.isViolatingCase && !name.isOperator {
+            if requiresCaseCheck && name.isViolatingCase && !name.isOperator {
                 let reason = "\(type) name should start with a lowercase character: '\(name)'"
                 return [
                     StyleViolation(ruleDescription: description,

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRuleExamples.swift
@@ -13,7 +13,6 @@ internal struct IdentifierNameRuleExamples {
         "let myLet = 0",
         "var myVar = 0",
         "private let _myLet = 0",
-        "class Abc { static let MyLet = 0 }",
         "let URL: NSURL? = nil",
         "let XMLString: String? = nil",
         "override var i = 0",
@@ -35,6 +34,7 @@ internal struct IdentifierNameRuleExamples {
         "↓var id = 0",
         "private ↓let _i = 0",
         "↓func IsOperator(name: String) -> Bool",
-        "enum Foo { case ↓MyEnum }"
+        "enum Foo { case ↓MyEnum }",
+        "class Abc { ↓static let MyLet = 0 }"
     ]
 }

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -31,7 +31,8 @@ class IdentifierNameRuleTests: XCTestCase {
         let baseDescription = IdentifierNameRule.description
         let triggeringExamplesToRemove = [
             "↓let MyLet = 0",
-            "enum Foo { case ↓MyEnum }"
+            "enum Foo { case ↓MyEnum }",
+            "class Abc { ↓static let MyLet = 0 }"
         ]
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples +
             triggeringExamplesToRemove.map { $0.replacingOccurrences(of: "↓", with: "") }


### PR DESCRIPTION
This probably is something that we added on the early days, before the community settles the preferred naming convention for `static` properties. 

From [Swift 3 API Design Guidelines](https://swift.org/documentation/api-design-guidelines/):

> **Follow case conventions**. Names of types and protocols are `UpperCamelCase`. Everything else is `lowerCamelCase`.