### PR TITLE
Introduce queuedFatalError

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -44,7 +44,7 @@ extension Configuration {
             let jsonString = String(data: jsonData, encoding: .utf8) {
             return jsonString
         }
-        fatalError("Could not serialize configuration for cache")
+        queuedFatalError("Could not serialize configuration for cache")
     }
 
     internal var cacheURL: URL {

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -131,7 +131,7 @@ extension File {
                 handler()
                 return Structure(sourceKitResponse: [:])
             }
-            fatalError("Never call this for file that sourcekitd fails.")
+            queuedFatalError("Never call this for file that sourcekitd fails.")
         }
         return structure
     }
@@ -142,7 +142,7 @@ extension File {
                 handler()
                 return SyntaxMap(data: [])
             }
-            fatalError("Never call this for file that sourcekitd fails.")
+            queuedFatalError("Never call this for file that sourcekitd fails.")
         }
         return syntaxMap
     }
@@ -153,7 +153,7 @@ extension File {
                 handler()
                 return []
             }
-            fatalError("Never call this for file that sourcekitd fails.")
+            queuedFatalError("Never call this for file that sourcekitd fails.")
         }
         return syntaxTokensByLines
     }
@@ -164,7 +164,7 @@ extension File {
                 handler()
                 return []
             }
-            fatalError("Never call this for file that sourcekitd fails.")
+            queuedFatalError("Never call this for file that sourcekitd fails.")
         }
         return syntaxKindsByLines
     }

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -224,10 +224,10 @@ extension File {
 
     internal func append(_ string: String) {
         guard let stringData = string.data(using: .utf8) else {
-            fatalError("can't encode '\(string)' with UTF8")
+            queuedFatalError("can't encode '\(string)' with UTF8")
         }
         guard let path = path, let fileHandle = FileHandle(forWritingAtPath: path) else {
-            fatalError("can't write to path '\(String(describing: self.path))'")
+            queuedFatalError("can't write to path '\(String(describing: self.path))'")
         }
         _ = fileHandle.seekToEndOfFile()
         fileHandle.write(stringData)
@@ -241,10 +241,10 @@ extension File {
             return
         }
         guard let path = path else {
-            fatalError("file needs a path to call write(_:)")
+            queuedFatalError("file needs a path to call write(_:)")
         }
         guard let stringData = string.data(using: .utf8) else {
-            fatalError("can't encode '\(string)' with UTF8")
+            queuedFatalError("can't encode '\(string)' with UTF8")
         }
         do {
             try stringData.write(to: URL(fileURLWithPath: path), options: .atomic)

--- a/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
+++ b/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
@@ -47,3 +47,17 @@ public func queuedPrintError(_ string: String) {
         fputs(string + "\n", stderr)
     }
 }
+
+/**
+ A thread-safe, newline-terminated version of fatalError that doesn't leak
+ the source path from the compiled binary.
+ */
+public func queuedFatalError(_ string: String, file: StaticString = #file, line: UInt = #line) -> Never {
+    outputQueue.sync {
+        fflush(stdout)
+        let file = "\(file)".bridge().lastPathComponent
+        fputs("\(string): file \(file), line \(line)\n", stderr)
+    }
+
+    abort()
+}

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -49,7 +49,7 @@ extension String {
         if let indexRange = nsrangeToIndexRange(nsrange) {
             return String(self[indexRange])
         }
-        fatalError("invalid range")
+        queuedFatalError("invalid range")
     }
 
     internal func substring(from: Int, length: Int? = nil) -> String {

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -153,7 +153,7 @@ public struct Configuration: Equatable {
 
         let fail = { (msg: String) in
             queuedPrintError("\(fullPath):\(msg)")
-            fatalError("Could not read configuration file at path '\(fullPath)'")
+            queuedFatalError("Could not read configuration file at path '\(fullPath)'")
         }
         let rulesMode: RulesMode = enableAllRules ? .allEnabled : .default(disabled: [], optIn: [])
         if path.isEmpty || !FileManager.default.fileExists(atPath: fullPath) {

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -30,6 +30,6 @@ public func reporterFrom(identifier: String) -> Reporter.Type {
     case EmojiReporter.identifier:
         return EmojiReporter.self
     default:
-        fatalError("no reporter with identifier '\(identifier)' available.")
+        queuedFatalError("no reporter with identifier '\(identifier)' available.")
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -37,7 +37,7 @@ public struct PrivateUnitTestConfiguration: RuleConfiguration, Equatable, CacheD
           let jsonString = String(data: jsonData, encoding: .utf8) {
               return jsonString
         }
-        fatalError("Could not serialize private unit test configuration for cache")
+        queuedFatalError("Could not serialize private unit test configuration for cache")
     }
 
     public init(identifier: String) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -41,7 +41,7 @@ public struct RegexConfiguration: RuleConfiguration, Equatable, CacheDescription
           let jsonString = String(data: jsonData, encoding: .utf8) {
               return jsonString
         }
-        fatalError("Could not serialize regex configuration for cache")
+        queuedFatalError("Could not serialize regex configuration for cache")
     }
 
     public var description: RuleDescription {


### PR DESCRIPTION
`fatalError` prints the full path of the file, which leaks filesystem information from the machine that built the binary. Now that we release via CocoaPods, this is more critical.