### PR TITLE
Add custom rule to enforce using queuedFatalError

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,3 +51,11 @@ custom_rules:
     message: Rule IDs must be all lowercase, snake case and not end with `rule`
     regex: identifier:\s*("\w+_rule"|"\S*[^a-z_]\S*")
     severity: error
+  fatal_error:
+    name: Fatal Error
+    excluded: "Tests/*"
+    message: Prefer using `queuedFatalError` over `fatalError` to avoid leaking compiler host machine paths.
+    regex: \bfatalError\b
+    match_kinds:
+      - identifier
+    severity: error

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -249,7 +249,7 @@ extension File {
         do {
             try stringData.write(to: URL(fileURLWithPath: path), options: .atomic)
         } catch {
-            fatalError("can't write file to \(path)")
+            queuedFatalError("can't write file to \(path)")
         }
         contents = string
         invalidateCache()


### PR DESCRIPTION
As suggested by @jpsim in https://github.com/realm/SwiftLint/pull/1867#issuecomment-333413014.

This actually already proved itself valuable as it caught one place that I missed!