### PR TITLE
Add literal_expression_end_indentation opt-in rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,6 +27,7 @@ opt_in_rules:
   - extension_access_modifier
   - pattern_matching_keywords
   - array_init
+  - literal_expression_end_indentation
 
 file_header:
   required_pattern: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1870](https://github.com/realm/SwiftLint/issues/1870)
 
+* Add `literal_expression_end_indentation` opt-in rule to validate that
+  array and dictionary literals ends have the same indentation as the line
+  that started them.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1435](https://github.com/realm/SwiftLint/issues/1435)
+
 ##### Bug Fixes
 
 * Improve how `opening_brace` rule reports violations locations.  

--- a/Rules.md
+++ b/Rules.md
@@ -55,6 +55,7 @@
 * [Legacy NSGeometry Functions](#legacy-nsgeometry-functions)
 * [Variable Declaration Whitespace](#variable-declaration-whitespace)
 * [Line Length](#line-length)
+* [Literal Expression End Indentation](#literal-expression-end-indentation)
 * [Mark](#mark)
 * [Multiline Arguments](#multiline-arguments)
 * [Multiline Parameters](#multiline-parameters)
@@ -6400,6 +6401,95 @@ Lines should not span too many characters.
 ```swift
 #imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")#imageLiteral(resourceName: "image.jpg")
 
+```
+
+</details>
+
+
+
+## Literal Expression End Indentation
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`literal_expression_end_indentation` | Disabled | No | style
+
+Array and dictionary literal end should have the same indentation as the line that started it.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+[1, 2, 3]
+```
+
+```swift
+[1,
+ 2
+]
+```
+
+```swift
+[
+   1,
+   2
+]
+```
+
+```swift
+[
+   1,
+   2]
+
+```
+
+```swift
+   let x = [
+       1,
+       2
+   ]
+```
+
+```swift
+[key: 2, key2: 3]
+```
+
+```swift
+[key: 1,
+ key2: 2
+]
+```
+
+```swift
+[
+   key: 0,
+   key2: 20
+]
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+let x = [
+   1,
+   2
+   ↓]
+```
+
+```swift
+   let x = [
+       1,
+       2
+↓]
+```
+
+```swift
+let x = [
+   key: value
+   ↓]
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -63,6 +63,7 @@ public let masterRuleList = RuleList(rules: [
     LegacyNSGeometryFunctionsRule.self,
     LetVarWhitespaceRule.self,
     LineLengthRule.self,
+    LiteralExpressionEndIdentationRule.self,
     MarkRule.self,
     MultilineArgumentsRule.self,
     MultilineParametersRule.self,

--- a/Source/SwiftLintFramework/Rules/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/LiteralExpressionEndIdentationRule.swift
@@ -1,0 +1,9 @@
+//
+//  LiteralExpressionEndIdentationRule.swift
+//  SwiftLintFramework
+//
+//  Created by Marcelo Fabri on 02/10/2017.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation

--- a/Source/SwiftLintFramework/Rules/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/LiteralExpressionEndIdentationRule.swift
@@ -1,9 +1,106 @@
 //
 //  LiteralExpressionEndIdentationRule.swift
-//  SwiftLintFramework
+//  SwiftLint
 //
-//  Created by Marcelo Fabri on 02/10/2017.
+//  Created by Marcelo Fabri on 10/02/17.
 //  Copyright © 2017 Realm. All rights reserved.
 //
 
 import Foundation
+import SourceKittenFramework
+
+public struct LiteralExpressionEndIdentationRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "literal_expression_end_indentation",
+        name: "Literal Expression End Indentation",
+        description: "Array and dictionary literal end should have the same indentation as the line that started it.",
+        kind: .style,
+        nonTriggeringExamples: [
+            "[1, 2, 3]",
+            "[1,\n" +
+            " 2\n" +
+            "]",
+            "[\n" +
+            "   1,\n" +
+            "   2\n" +
+            "]",
+            "[\n" +
+            "   1,\n" +
+            "   2]\n",
+            "   let x = [\n" +
+            "       1,\n" +
+            "       2\n" +
+            "   ]",
+            "[key: 2, key2: 3]",
+            "[key: 1,\n" +
+            " key2: 2\n" +
+            "]",
+            "[\n" +
+            "   key: 0,\n" +
+            "   key2: 20\n" +
+            "]"
+        ],
+        triggeringExamples: [
+            "let x = [\n" +
+            "   1,\n" +
+            "   2\n" +
+            "   ↓]",
+            "   let x = [\n" +
+            "       1,\n" +
+            "       2\n" +
+            "↓]",
+            "let x = [\n" +
+            "   key: value\n" +
+            "   ↓]"
+        ]
+    )
+
+    private static let notWhitespace = regex("[^\\s]")
+
+    public func validate(file: File, kind: SwiftExpressionKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .dictionary || kind == .array else {
+            return []
+        }
+
+        let elements = dictionary.elements.filter { $0.kind == "source.lang.swift.structure.elem.expr" }
+
+        let contents = file.contents.bridge()
+        guard !elements.isEmpty,
+            let offset = dictionary.offset,
+            let length = dictionary.length,
+            let (startLine, _) = contents.lineAndCharacter(forByteOffset: offset),
+            let firstParamOffset = elements[0].offset,
+            let (firstParamLine, _) = contents.lineAndCharacter(forByteOffset: firstParamOffset),
+            startLine != firstParamLine,
+            let lastParamOffset = elements.last?.offset,
+            let (lastParamLine, _) = contents.lineAndCharacter(forByteOffset: lastParamOffset),
+            case let endOffset = offset + length - 1,
+            let (endLine, endPosition) = contents.lineAndCharacter(forByteOffset: endOffset),
+            lastParamLine != endLine else {
+                return []
+        }
+
+        let range = file.lines[startLine - 1].range
+        let regex = LiteralExpressionEndIdentationRule.notWhitespace
+        let actual = endPosition - 1
+        guard let match = regex.firstMatch(in: file.contents, options: [], range: range)?.range,
+            case let expected = match.location - range.location,
+            expected != actual  else {
+                return []
+        }
+
+        let reason = "\(LiteralExpressionEndIdentationRule.description.description) " +
+                     "Expected \(expected), got \(actual)."
+        return [
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: endOffset),
+                           reason: reason)
+        ]
+    }
+}

--- a/Source/SwiftLintFramework/Rules/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/NoExtensionAccessModifierRule.swift
@@ -22,7 +22,7 @@ public struct NoExtensionAccessModifierRule: ASTRule, OptInRule, ConfigurationPr
         nonTriggeringExamples: [
             "extension String {}",
             "\n\n extension String {}"
-            ],
+        ],
         triggeringExamples: [
             "↓private extension String {}",
             "↓public \n extension String {}",

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		D4DB92251E628898005DE9C1 /* TodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */; };
 		D4E2BA851F6CD77B00E8E184 /* ArrayInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */; };
 		D4EA77C81F817FD200C315FB /* UnneededBreakInSwitchRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EA77C71F817FD200C315FB /* UnneededBreakInSwitchRule.swift */; };
+		D4EA77CA1F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */; };
 		D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */; };
 		D4FD4C851F2A260A00DD8AA8 /* BlockBasedKVORule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD4C841F2A260A00DD8AA8 /* BlockBasedKVORule.swift */; };
 		D4FD58B21E12A0200019503C /* LinterCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD58B11E12A0200019503C /* LinterCache.swift */; };
@@ -558,6 +559,7 @@
 		D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoRuleTests.swift; sourceTree = "<group>"; };
 		D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayInitRule.swift; sourceTree = "<group>"; };
 		D4EA77C71F817FD200C315FB /* UnneededBreakInSwitchRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnneededBreakInSwitchRule.swift; sourceTree = "<group>"; };
+		D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiteralExpressionEndIdentationRule.swift; sourceTree = "<group>"; };
 		D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorUsageWhitespaceRule.swift; sourceTree = "<group>"; };
 		D4FD4C841F2A260A00DD8AA8 /* BlockBasedKVORule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockBasedKVORule.swift; sourceTree = "<group>"; };
 		D4FD58B11E12A0200019503C /* LinterCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinterCache.swift; sourceTree = "<group>"; };
@@ -1033,6 +1035,7 @@
 				F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */,
 				C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */,
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
+				D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */,
 				856651A61D6B395F005E6B29 /* MarkRule.swift */,
 				B25DCD0D1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift */,
 				B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */,
@@ -1497,6 +1500,7 @@
 				D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */,
 				6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */,
 				D4C0E46F1E3D973600C560F2 /* ForWhereRule.swift in Sources */,
+				D4EA77CA1F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift in Sources */,
 				E86396C51BADAC15002C9E88 /* XcodeReporter.swift in Sources */,
 				E889D8C51F1D11A200058332 /* Configuration+LintableFiles.swift in Sources */,
 				094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -401,6 +401,7 @@ extension RulesTests {
         ("testLegacyConstant", testLegacyConstant),
         ("testLegacyConstructor", testLegacyConstructor),
         ("testLetVarWhitespace", testLetVarWhitespace),
+        ("testLiteralExpressionEndIdentation", testLiteralExpressionEndIdentation),
         ("testMark", testMark),
         ("testMultilineParameters", testMultilineParameters),
         ("testMultipleClosuresWithTrailingClosure", testMultipleClosuresWithTrailingClosure),

--- a/Tests/SwiftLintFrameworkTests/RegionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RegionTests.swift
@@ -109,7 +109,7 @@ class RegionTests: XCTestCase {
             Region(start: Location(file: nil, line: 6, character: 22),
                    end: Location(file: nil, line: .max, character: .max),
                    disabledRuleIdentifiers: [])
-            ])
+        ])
     }
 
 }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -197,6 +197,10 @@ class RulesTests: XCTestCase {
         verifyRule(LetVarWhitespaceRule.description)
     }
 
+    func testLiteralExpressionEndIdentation() {
+        verifyRule(LiteralExpressionEndIdentationRule.description)
+    }
+
     func testMark() {
         verifyRule(MarkRule.description, skipCommentTests: true)
     }

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -22,8 +22,8 @@ class TrailingCommaRuleTests: XCTestCase {
                 ruleDescription: TrailingCommaRule.description,
                 location: Location(file: nil, line: 3, character: 3),
                 reason: "Collection literals should not have trailing commas."
-            )]
-        )
+            )
+        ])
     }
 
     private static let triggeringExamples = [
@@ -80,8 +80,8 @@ class TrailingCommaRuleTests: XCTestCase {
                 ruleDescription: TrailingCommaRule.description,
                 location: Location(file: nil, line: 3, character: 3),
                 reason: "Multi-line collection literals should have trailing commas."
-            )]
-        )
+            )
+        ])
     }
 
     private func trailingCommaViolations(_ string: String, ruleConfiguration: Any? = nil) -> [StyleViolation] {


### PR DESCRIPTION
Partially implements #1435.

This is opt-in to be consistent to `closure_end_indentation`. I also expect lots of existing violations in `oss-check`.

I didn't implement the check for function calls because Xcode (9 at least) formats it as expected:

```swift
foo(
    bar
) // this should be enforced to be here
```

Also, I think this rule shouldn't actually validate that the end is on a new line.

PS: I've named it `literal_expression_end_indentation` and not `collection_literal_end_indentation` because we'll have `source.lang.swift.expr.tuple` [soon](https://github.com/apple/swift/pull/12089) and this rule could also support it.