### PR TITLE
Fix false positive in `array_init` when using `map` without closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix false positive in `array_init` rule when using a `map` that
+  doesn't take a closure.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1878](https://github.com/realm/SwiftLint/issues/1878)
 
 ## 0.23.0: Permanent Press Cycle
 

--- a/Rules.md
+++ b/Rules.md
@@ -163,6 +163,11 @@ foo.map { $0! /* force unwrap */ }
 
 ```
 
+```swift
+foo.something { RouteMapper.map($0) }
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>


### PR DESCRIPTION
Fixes #1878