### PR TITLE
Run SwiftPM tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env: JOB=SPM
       os: osx
       osx_image: xcode8.3
-    - script: swift test
+    - script: swift test --parallel
       env: JOB=SPM-Swift4
       os: osx
       osx_image: xcode9

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docker_test:
 
 docker_test_4:
 	if [ -d $(XCTEST_LOCATION) ]; then rm -rf $(XCTEST_LOCATION); fi
-	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm norionomura/swift:4020170908a swift test --parallel
+	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm norionomura/swift:40 swift test --parallel
 
 docker_htop:
 	docker run -it --rm --pid=container:swiftlint terencewestphal/htop || reset

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docker_test:
 
 docker_test_4:
 	if [ -d $(XCTEST_LOCATION) ]; then rm -rf $(XCTEST_LOCATION); fi
-	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm norionomura/swift:4020170908a swift test
+	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm norionomura/swift:4020170908a swift test --parallel
 
 docker_htop:
 	docker run -it --rm --pid=container:swiftlint terencewestphal/htop || reset


### PR DESCRIPTION
**tl;dr; speeds up running tests by ~33%**

## macOS

```bash
$ # Before
$ time swift test
[...]
swift test  96.66s user 2.59s system 251% cpu 39.471 total
$ # After
$ time swift test --parallel
                                                                   Tests
100% [=======================================================================================================================]
[...]
swift test --parallel  108.38s user 12.39s system 455% cpu 26.495 total
```

## Docker

```bash
$ # Before
$ time make docker_test_4
make docker_test_4  0.03s user 0.02s system 0% cpu 50.688 total
$ # After
$ time make docker_test_4
make docker_test_4  0.03s user 0.03s system 0% cpu 35.552 total
```