### PR TITLE
Remove SwiftExpressionKind.other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * SwiftLint now requires Xcode 9 and Swift 3.2+ to build.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  
+* Remove `SwiftExpressionKind.other`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
 
 ##### Enhancements
 

--- a/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
@@ -14,22 +14,4 @@ public enum SwiftExpressionKind: String {
     case array = "source.lang.swift.expr.array"
     case dictionary = "source.lang.swift.expr.dictionary"
     case objectLiteral = "source.lang.swift.expr.object_literal"
-    case other
-
-    public init?(rawValue: String) {
-        switch rawValue {
-        case SwiftExpressionKind.call.rawValue:
-            self = .call
-        case SwiftExpressionKind.argument.rawValue:
-            self = .argument
-        case SwiftExpressionKind.array.rawValue:
-            self = .array
-        case SwiftExpressionKind.dictionary.rawValue:
-            self = .dictionary
-        case SwiftExpressionKind.objectLiteral.rawValue:
-            self = .objectLiteral
-        default:
-            self = .other
-        }
-    }
 }

--- a/Source/SwiftLintFramework/Rules/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyEnumArgumentsRule.swift
@@ -65,7 +65,7 @@ public struct EmptyEnumArgumentsRule: ASTRule, ConfigurationProviderRule, Correc
         let contents = file.contents.bridge()
 
         let callsRanges = dictionary.substructure.flatMap { dict -> NSRange? in
-            guard dict.kind.flatMap(SwiftExpressionKind.init) == .call,
+            guard dict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call,
                 let offset = dict.offset,
                 let length = dict.length,
                 let range = contents.byteRangeToNSRange(start: offset, length: length) else {

--- a/Source/SwiftLintFramework/Rules/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/NotificationCenterDetachmentRule.swift
@@ -39,19 +39,14 @@ public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRu
     private func violationOffsets(file: File,
                                   dictionary: [String: SourceKitRepresentable]) -> [Int] {
         return dictionary.substructure.flatMap { subDict -> [Int] in
-            guard let kindString = subDict.kind,
-                let kind = SwiftExpressionKind(rawValue: kindString) else {
-                    return []
-            }
-
             // complete detachment is allowed on `deinit`
-            if kind == .other,
-                SwiftDeclarationKind(rawValue: kindString) == .functionMethodInstance,
+            if subDict.kind.flatMap(SwiftDeclarationKind.init) == .functionMethodInstance,
                 subDict.name == "deinit" {
                 return []
             }
 
-            if kind == .call, subDict.name == methodName,
+            if subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call,
+                subDict.name == methodName,
                 parameterIsSelf(dictionary: subDict, file: file),
                 let offset = subDict.offset {
                 return [offset]

--- a/Source/SwiftLintFramework/Rules/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingClosureRule.swift
@@ -46,7 +46,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
     private func violationOffsets(for dictionary: [String: SourceKitRepresentable], file: File) -> [Int] {
         var results = [Int]()
 
-        if dictionary.kind.flatMap(SwiftExpressionKind.init) == .call,
+        if dictionary.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call,
             shouldBeTrailingClosure(dictionary: dictionary, file: file),
             let offset = dictionary.offset {
 


### PR DESCRIPTION
This was just a workaround due to the fact that we used to not dig into substructures from different kinds. We've fixed that a while ago, but I never came back to remove this case.