### PR TITLE
Make vertical_parameter_alignment(_on_call) expand tabs to 4 spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
   [JP Simard](https://github.com/jpsim)
   [#1822](https://github.com/realm/SwiftLint/issues/1822)
 
+* Make `vertical_parameter_alignment(_on_call)` expand tabs to 4 spaces
+  and add `indent-width` to `autocorrect` command.  
+  [Marcel Jackwerth](https://github.com/sirlantis)
+
 ##### Bug Fixes
 
 * Correct equality tests for `Configuration` values. They previously didn't
@@ -72,8 +76,6 @@
 ##### Enhancements
 
 * None.
-* Make `vertical_parameter_alignment(_on_call)` expand tabs to 4 spaces.  
-  [Marcel Jackwerth](https://github.com/sirlantis)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 ##### Enhancements
 
 * None.
+* Make `vertical_parameter_alignment(_on_call)` expand tabs to 4 spaces.  
+  [Marcel Jackwerth](https://github.com/sirlantis)
 
 ##### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -15631,6 +15631,12 @@ foo(param1: 1, param2: bar
 ```
 
 ```swift
+foo(param1: 1, param2: bar
+	param3: false,
+    param4: true)
+```
+
+```swift
 foo(
    param1: 1
 ) { _ in }

--- a/Rules.md
+++ b/Rules.md
@@ -781,9 +781,27 @@ foo(abc, 123)
 
 ```
 
+```swift
+	mixedTabsAndSpaces(abc, 123) { _ in
+    }
+
+```
+
+```swift
+    mixedSpacesAndTabs(abc, 123) { _ in
+	}
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
+
+```swift
+foo(abc, 123) { _ in
+    ↓}
+
+```
 
 ```swift
 SignalProducer(values: [1, 2, 3])
@@ -10835,6 +10853,15 @@ case 1:
 default:
     print('Some other number')
 }
+```
+
+```swift
+	switch mixedTabsAndSpaces {
+	case 0:
+		print('Zero')
+    case 1:
+        print('Zero')
+    }
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -322,4 +322,12 @@ extension File {
                                                                  length: token.length)
         return aclString.flatMap(AccessControlLevel.init(description:)) != nil
     }
+
+    internal var useTabs: Bool {
+        return true
+    }
+
+    internal var indentWidth: Int {
+        return 4
+    }
 }

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -51,7 +51,13 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
             "    print('One')\n" +
             "default:\n" +
             "    print('Some other number')\n" +
-            "}"
+            "}",
+            "\tswitch mixedTabsAndSpaces {\n" +
+            "\tcase 0:\n" +
+            "\t\tprint('Zero')\n" +
+            "    case 1:\n" +
+            "        print('Zero')\n" +
+            "    }"
         ],
         triggeringExamples: [
             "switch someBool {\n" +
@@ -84,7 +90,8 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
         let contents = file.contents.bridge()
         guard kind == .switch,
             let offset = dictionary.offset,
-            let (_, switchCharacter) = contents.lineAndCharacter(forByteOffset: offset) else {
+            let (_, switchCharacter) = contents.lineAndCharacter(forByteOffset: offset,
+                                                                 expandingTabsToWidth: file.indentWidth) else {
                 return []
         }
 
@@ -99,7 +106,8 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
 
         let caseLocations = caseStatements.flatMap { caseDict -> Location? in
             guard let byteOffset = caseDict.offset,
-                let (line, char) = contents.lineAndCharacter(forByteOffset: byteOffset) else {
+                let (line, char) = contents.lineAndCharacter(forByteOffset: byteOffset,
+                                                             expandingTabsToWidth: file.indentWidth) else {
                     return nil
             }
             return Location(file: file.path, line: line, character: char)

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
@@ -9,8 +9,6 @@
 import Foundation
 import SourceKittenFramework
 
-private let tabWidth = 4
-
 public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -86,7 +84,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             let firstArgumentOffset = arguments.first?.offset,
             case let contents = file.contents.bridge(),
             var firstArgumentPosition = contents.lineAndCharacter(forByteOffset: firstArgumentOffset,
-                                                                  expandingTabsToWidth: tabWidth) else {
+                                                                  expandingTabsToWidth: file.indentWidth) else {
                 return []
         }
 
@@ -101,7 +99,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
 
             guard let offset = argument.offset,
                 let (line, character) = contents.lineAndCharacter(forByteOffset: offset,
-                                                                  expandingTabsToWidth: tabWidth),
+                                                                  expandingTabsToWidth: file.indentWidth),
                 line > firstArgumentPosition.line else {
                     return nil
             }
@@ -137,9 +135,8 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
         guard let offset = argument.bodyOffset,
             let length = argument.bodyLength,
             case let contents = file.contents.bridge(),
-            let (startLine, _) = contents.lineAndCharacter(forByteOffset: offset, expandingTabsToWidth: tabWidth),
-            let (endLine, _) = contents.lineAndCharacter(forByteOffset: offset + length,
-                                                         expandingTabsToWidth: tabWidth) else {
+            let (startLine, _) = contents.lineAndCharacter(forByteOffset: offset),
+            let (endLine, _) = contents.lineAndCharacter(forByteOffset: offset + length) else {
                 return false
         }
 

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
@@ -9,6 +9,8 @@
 import Foundation
 import SourceKittenFramework
 
+private let tabWidth = 4
+
 public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -25,6 +27,9 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             "foo(param1: 1, param2: bar)",
             "foo(param1: 1, param2: bar\n" +
             "    param3: false,\n" +
+            "    param4: true)",
+            "foo(param1: 1, param2: bar\n" +
+            "\tparam3: false,\n" +
             "    param4: true)",
             "foo(\n" +
             "   param1: 1\n" +
@@ -80,7 +85,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             arguments.count > 1,
             let firstArgumentOffset = arguments.first?.offset,
             case let contents = file.contents.bridge(),
-            var firstArgumentPosition = contents.lineAndCharacter(forByteOffset: firstArgumentOffset) else {
+            var firstArgumentPosition = contents.lineAndCharacter(forByteOffset: firstArgumentOffset, expandingTabsToWidth: tabWidth) else {
                 return []
         }
 
@@ -94,7 +99,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             }
 
             guard let offset = argument.offset,
-                let (line, character) = contents.lineAndCharacter(forByteOffset: offset),
+                let (line, character) = contents.lineAndCharacter(forByteOffset: offset, expandingTabsToWidth: tabWidth),
                 line > firstArgumentPosition.line else {
                     return nil
             }
@@ -130,8 +135,8 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
         guard let offset = argument.bodyOffset,
             let length = argument.bodyLength,
             case let contents = file.contents.bridge(),
-            let (startLine, _) = contents.lineAndCharacter(forByteOffset: offset),
-            let (endLine, _) = contents.lineAndCharacter(forByteOffset: offset + length) else {
+            let (startLine, _) = contents.lineAndCharacter(forByteOffset: offset, expandingTabsToWidth: tabWidth),
+            let (endLine, _) = contents.lineAndCharacter(forByteOffset: offset + length, expandingTabsToWidth: tabWidth) else {
                 return false
         }
 

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
@@ -85,7 +85,8 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             arguments.count > 1,
             let firstArgumentOffset = arguments.first?.offset,
             case let contents = file.contents.bridge(),
-            var firstArgumentPosition = contents.lineAndCharacter(forByteOffset: firstArgumentOffset, expandingTabsToWidth: tabWidth) else {
+            var firstArgumentPosition = contents.lineAndCharacter(forByteOffset: firstArgumentOffset,
+                                                                  expandingTabsToWidth: tabWidth) else {
                 return []
         }
 
@@ -99,7 +100,8 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             }
 
             guard let offset = argument.offset,
-                let (line, character) = contents.lineAndCharacter(forByteOffset: offset, expandingTabsToWidth: tabWidth),
+                let (line, character) = contents.lineAndCharacter(forByteOffset: offset,
+                                                                  expandingTabsToWidth: tabWidth),
                 line > firstArgumentPosition.line else {
                     return nil
             }
@@ -136,7 +138,8 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             let length = argument.bodyLength,
             case let contents = file.contents.bridge(),
             let (startLine, _) = contents.lineAndCharacter(forByteOffset: offset, expandingTabsToWidth: tabWidth),
-            let (endLine, _) = contents.lineAndCharacter(forByteOffset: offset + length, expandingTabsToWidth: tabWidth) else {
+            let (endLine, _) = contents.lineAndCharacter(forByteOffset: offset + length,
+                                                         expandingTabsToWidth: tabWidth) else {
                 return false
         }
 

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
@@ -78,7 +78,8 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
 
         let paramLocations = params.flatMap { paramDict -> Location? in
             guard let byteOffset = paramDict.offset,
-                let lineAndChar = contents.lineAndCharacter(forByteOffset: byteOffset, expandingTabsToWidth: tabWidth) else {
+                let lineAndChar = contents.lineAndCharacter(forByteOffset: byteOffset,
+                                                            expandingTabsToWidth: tabWidth) else {
                 return nil
             }
             return Location(file: file.path, line: lineAndChar.line, character: lineAndChar.character)

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
@@ -9,6 +9,8 @@
 import Foundation
 import SourceKittenFramework
 
+private let tabWidth = 4
+
 public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -76,7 +78,7 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
 
         let paramLocations = params.flatMap { paramDict -> Location? in
             guard let byteOffset = paramDict.offset,
-                let lineAndChar = contents.lineAndCharacter(forByteOffset: byteOffset) else {
+                let lineAndChar = contents.lineAndCharacter(forByteOffset: byteOffset, expandingTabsToWidth: tabWidth) else {
                 return nil
             }
             return Location(file: file.path, line: lineAndChar.line, character: lineAndChar.character)

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
@@ -9,8 +9,6 @@
 import Foundation
 import SourceKittenFramework
 
-private let tabWidth = 4
-
 public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -79,7 +77,7 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
         let paramLocations = params.flatMap { paramDict -> Location? in
             guard let byteOffset = paramDict.offset,
                 let lineAndChar = contents.lineAndCharacter(forByteOffset: byteOffset,
-                                                            expandingTabsToWidth: tabWidth) else {
+                                                            expandingTabsToWidth: file.indentWidth) else {
                 return nil
             }
             return Location(file: file.path, line: lineAndChar.line, character: lineAndChar.character)

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -18,10 +18,12 @@ struct AutoCorrectCommand: CommandProtocol {
         let configuration = Configuration(options: options)
         let cache = options.ignoreCache ? nil : LinterCache(configuration: configuration)
 
-        return configuration.visitLintableFiles(path: options.path, action: "Correcting",
+        return configuration.visitLintableFiles(path: options.path,
+                                                action: "Correcting",
                                                 quiet: options.quiet,
                                                 useScriptInputFiles: options.useScriptInputFiles,
-                                                cache: cache, parallel: true) { linter in
+                                                cache: cache,
+                                                parallel: true) { linter in
             let corrections = linter.correct()
             if !corrections.isEmpty && !options.quiet {
                 let correctionLogs = corrections.map({ $0.consoleDescription })
@@ -29,7 +31,8 @@ struct AutoCorrectCommand: CommandProtocol {
             }
             if options.format {
                 let formattedContents = linter.file.format(trimmingTrailingWhitespace: true,
-                                                           useTabs: options.useTabs, indentWidth: 4)
+                                                           useTabs: options.useTabs,
+                                                           indentWidth: options.indentWidth)
                 _ = try? formattedContents
                     .write(toFile: linter.file.path!, atomically: true, encoding: .utf8)
             }
@@ -51,12 +54,13 @@ struct AutoCorrectOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let useTabs: Bool
+    let indentWidth: Int
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
-        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in
-            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
-        }}}}}}}
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> (_ indentWidth: Int) -> AutoCorrectOptions {
+        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in { indentWidth in
+            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs, indentWidth: indentWidth)
+        }}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
@@ -76,5 +80,8 @@ struct AutoCorrectOptions: OptionsProtocol {
             <*> mode <| Option(key: "use-tabs",
                                defaultValue: false,
                                usage: "should use tabs over spaces when reformatting")
+            <*> mode <| Option(key: "indent-width",
+                               defaultValue: 4,
+                               usage: "number of spaces to indent (or interpreted width of tabs)")
     }
 }


### PR DESCRIPTION
After my pull request on SourceKitten a new parameter
is available for the lineAndCharacter APIs allowing us
to handle tabs when it comes to vertical parameter alignment.

Right now this pull-request hard-codes a width of 4.
