### PR TITLE
Fix false positive in `multiline_parameters` rule when parameter is a closure has default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@
   account for `warningThreshold` or `cachePath`.  
   [JP Simard](https://github.com/jpsim)
 
+* Fix false positive in `multiline_parameters` rule when parameter is a closure
+  with default value.  
+  [Ornithologist Coder](https://github.com/ornithocoder)
+  [#1912](https://github.com/realm/SwiftLint/issues/1912)
+
 ## 0.23.1: Rewash: Forgotten Load Edition
 
 ##### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -7075,6 +7075,22 @@ class Foo {
 }
 ```
 
+```swift
+class Foo {
+   class func foo(param1: Int,
+                  param2: Bool,
+                  param3: @escaping (Int) -> Void = { (x: Int) in }) { }
+}
+```
+
+```swift
+class Foo {
+   class func foo(param1: Int,
+                  param2: Bool,
+                  param3: @escaping (Int, (Int) -> Void) -> Void = { (x: Int, f: (Int) -> Void) in }) { }
+}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -7209,6 +7225,20 @@ class Foo {
 class Foo {
    class func ↓foo(param1: Int, param2: Bool,
                    param3: [String]) { }
+}
+```
+
+```swift
+class Foo {
+   class func ↓foo(param1: Int,
+                  param2: Bool, param3: @escaping (Int, Int) -> Void = { _, _ in }) { }
+}
+```
+
+```swift
+class Foo {
+   class func ↓foo(param1: Int,
+                  param2: Bool, param3: @escaping (Int) -> Void = { (x: Int) in }) { }
 }
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -7027,6 +7027,38 @@ class Foo {
 }
 ```
 
+```swift
+class Foo {
+   class func foo(param1: Int,
+                  param2: Bool,
+                  param3: @escaping (Int, Int) -> Void = { _, _ in }) { }
+}
+```
+
+```swift
+class Foo {
+   class func foo(param1: Int,
+                  param2: Bool,
+                  param3: @escaping (Int) -> Void = { _ in }) { }
+}
+```
+
+```swift
+class Foo {
+   class func foo(param1: Int,
+                  param2: Bool,
+                  param3: @escaping ((Int) -> Void)? = nil) { }
+}
+```
+
+```swift
+class Foo {
+   class func foo(param1: Int,
+                  param2: Bool,
+                  param3: @escaping ((Int) -> Void)? = { _ in }) { }
+}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -7059,6 +7059,22 @@ class Foo {
 }
 ```
 
+```swift
+class Foo {
+   class func foo(param1: Int,
+                  param2: @escaping ((Int) -> Void)? = { _ in },
+                  param3: Bool) { }
+}
+```
+
+```swift
+class Foo {
+   class func foo(param1: Int,
+                  param2: @escaping ((Int) -> Void)? = { _ in },
+                  param3: @escaping (Int, Int) -> Void = { _, _ in }) { }
+}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRule.swift
@@ -40,6 +40,7 @@ public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProvider
         for structure in dictionary.substructure {
             guard
                 let structureOffset = structure.offset,
+                structure.typeName != nil,
                 let structureKind = structure.kind, SwiftDeclarationKind(rawValue: structureKind) == .varParameter,
                 let (line, _) = file.contents.bridge().lineAndCharacter(forByteOffset: structureOffset),
                 offset..<(offset + length) ~= structureOffset

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
@@ -92,6 +92,26 @@ internal struct MultilineParametersRuleExamples {
         "   class func foo(param1: Int,\n" +
         "                  param2: Bool,\n" +
         "                  param3: [String]) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: Bool,\n" +
+        "                  param3: @escaping (Int, Int) -> Void = { _, _ in }) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: Bool,\n" +
+        "                  param3: @escaping (Int) -> Void = { _ in }) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: Bool,\n" +
+        "                  param3: @escaping ((Int) -> Void)? = nil) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: Bool,\n" +
+        "                  param3: @escaping ((Int) -> Void)? = { _ in }) { }\n" +
         "}"
     ]
 

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+// swiftlint:disable type_body_length
+
 internal struct MultilineParametersRuleExamples {
     static let nonTriggeringExamples = [
         "func foo() { }",
@@ -122,6 +124,16 @@ internal struct MultilineParametersRuleExamples {
         "   class func foo(param1: Int,\n" +
         "                  param2: @escaping ((Int) -> Void)? = { _ in },\n" +
         "                  param3: @escaping (Int, Int) -> Void = { _, _ in }) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: Bool,\n" +
+        "                  param3: @escaping (Int) -> Void = { (x: Int) in }) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: Bool,\n" +
+        "                  param3: @escaping (Int, (Int) -> Void) -> Void = { (x: Int, f: (Int) -> Void) in }) { }\n" +
         "}"
     ]
 
@@ -201,6 +213,14 @@ internal struct MultilineParametersRuleExamples {
         "class Foo {\n" +
         "   class func ↓foo(param1: Int, param2: Bool,\n" +
         "                   param3: [String]) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func ↓foo(param1: Int,\n" +
+        "                  param2: Bool, param3: @escaping (Int, Int) -> Void = { _, _ in }) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func ↓foo(param1: Int,\n" +
+        "                  param2: Bool, param3: @escaping (Int) -> Void = { (x: Int) in }) { }\n" +
         "}"
     ]
 }

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
@@ -112,6 +112,16 @@ internal struct MultilineParametersRuleExamples {
         "   class func foo(param1: Int,\n" +
         "                  param2: Bool,\n" +
         "                  param3: @escaping ((Int) -> Void)? = { _ in }) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: @escaping ((Int) -> Void)? = { _ in },\n" +
+        "                  param3: Bool) { }\n" +
+        "}",
+        "class Foo {\n" +
+        "   class func foo(param1: Int,\n" +
+        "                  param2: @escaping ((Int) -> Void)? = { _ in },\n" +
+        "                  param3: @escaping (Int, Int) -> Void = { _, _ in }) { }\n" +
         "}"
     ]
 


### PR DESCRIPTION
Fixes #1912.