### PR TITLE
Speed up reading cached results by about 200%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 * Make `Configuration` conform to `Hashable`.  
   [JP Simard](https://github.com/jpsim)
 
+* Speed up reading cached results by about 200%.  
+  [JP Simard](https://github.com/jpsim)
+
 ##### Bug Fixes
 
 * Correct equality tests for `Configuration` values. They previously didn't

--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -28,9 +28,19 @@ extension Configuration {
         return cachedConfigurationsByPath[path]
     }
 
+    public func withPrecomputedCacheDescription() -> Configuration {
+        var result = self
+        result.computedCacheDescription = result.cacheDescription
+        return result
+    }
+
     // MARK: SwiftLint Cache (On-Disk)
 
     internal var cacheDescription: String {
+        if let computedCacheDescription = computedCacheDescription {
+            return computedCacheDescription
+        }
+
         let cacheRulesDescriptions: [String: Any] = rules.reduce([:]) { accu, element in
             var accu = accu
             accu[type(of: element).description.identifier] = element.cacheDescription

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 
 extension Configuration {
     public func lintableFiles(inPath path: String) -> [File] {
-        return lintablePaths(inPath: path).flatMap(File.init(path:))
+        return lintablePaths(inPath: path).flatMap(File.init(pathDeferringReading:))
     }
 
     internal func lintablePaths(inPath path: String,

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -40,6 +40,8 @@ public struct Configuration: Hashable {
         return (included + excluded + [reporter]).reduce(0, { $0 ^ $1.hashValue })
     }
 
+    internal var computedCacheDescription: String?
+
     // MARK: Rules Properties
 
     // All rules enabled in this configuration, derived from disabled, opt-in and whitelist rules

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -37,8 +37,8 @@ private func scriptInputFiles() -> Result<[File], CommandantError<()>> {
         let inputFiles = (0..<count).flatMap { fileNumber -> File? in
             switch getEnvironmentVariable("SCRIPT_INPUT_FILE_\(fileNumber)") {
             case let .success(path):
-                if let file = File(path: path), path.bridge().isSwiftFile() {
-                    return file
+                if path.bridge().isSwiftFile() {
+                    return File(pathDeferringReading: path)
                 }
                 return nil
             case let .failure(error):
@@ -62,17 +62,17 @@ extension Configuration {
                             visitorBlock: @escaping (Linter) -> Void) -> Result<[File], CommandantError<()>> {
         return getFiles(path: path, action: action, useSTDIN: useSTDIN, quiet: quiet,
                         useScriptInputFiles: useScriptInputFiles)
-        .flatMap { files -> Result<[File], CommandantError<()>> in
+        .flatMap { files -> Result<[Configuration: [File]], CommandantError<()>> in
             if files.isEmpty {
                 let errorMessage = "No lintable files found at path '\(path)'"
                 return .failure(.usageError(description: errorMessage))
             }
-            return .success(files)
-        }.flatMap { files in
+            return .success(Dictionary(grouping: files, by: configuration(for:)))
+        }.flatMap { filesPerConfiguration in
             let queue = DispatchQueue(label: "io.realm.swiftlint.indexIncrementer")
             var index = 0
-            let fileCount = files.count
-            let visit = { (file: File) -> Void in
+            let fileCount = filesPerConfiguration.reduce(0) { $0 + $1.value.count }
+            let visit = { (file: File, config: Configuration) -> Void in
                 if !quiet, let path = file.path {
                     let increment = {
                         index += 1
@@ -86,17 +86,24 @@ extension Configuration {
                     }
                 }
                 autoreleasepool {
-                    visitorBlock(Linter(file: file, configuration: self.configuration(for: file), cache: cache))
+                    visitorBlock(Linter(file: file, configuration: config, cache: cache))
                 }
+            }
+            var filesAndConfigurations = [(File, Configuration)]()
+            filesAndConfigurations.reserveCapacity(fileCount)
+            for (config, files) in filesPerConfiguration {
+                let config = config.withPrecomputedCacheDescription()
+                filesAndConfigurations += files.map { ($0, config) }
             }
             if parallel {
-                DispatchQueue.concurrentPerform(iterations: files.count) { index in
-                    visit(files[index])
+                DispatchQueue.concurrentPerform(iterations: fileCount) { index in
+                    let (file, config) = filesAndConfigurations[index]
+                    visit(file, config)
                 }
             } else {
-                files.forEach(visit)
+                filesAndConfigurations.forEach(visit)
             }
-            return .success(files)
+            return .success(filesAndConfigurations.flatMap({ $0.0 }))
         }
     }
 


### PR DESCRIPTION
also slightly speed up writing to the cache.

For example, on the Lyft codebase with 1,500 Swift files:

**Before**

```
$ time swiftlint lint --quiet
swiftlint --quiet  3.53s user 0.27s system 388% cpu 0.979 total
$ rm -rf ~/Library/Caches/SwiftLint && time swiftlint lint --quiet
swiftlint --quiet  35.20s user 1.22s system 371% cpu 9.806 total
```

**After**

```
$ time swiftlint lint --quiet
swiftlint lint --quiet  0.90s user 0.13s system 218% cpu 0.472 total
$ rm -rf ~/Library/Caches/SwiftLint && time swiftlint lint --quiet
swiftlint lint --quiet  31.78s user 1.18s system 360% cpu 9.146 total
```