### PR TITLE
Make SortedImportsRule auto-correctable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@
 
 * Make `sorted_imports` correctable.  
   [Samuel Susla](https://github.com/sammy-sc)
+  [JP Simard](https://github.com/jpsim)
+  [#1822](https://github.com/realm/SwiftLint/issues/1822)
+
+* Make `sorted_imports` only validate within import "groups" of imports on
+  directly adjacent lines.  
+  [Samuel Susla](https://github.com/sammy-sc)
+  [JP Simard](https://github.com/jpsim)
   [#1822](https://github.com/realm/SwiftLint/issues/1822)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
 * Add `catch` to the statements checked by the `control_statement` rule.  
   [JP Simard](https://github.com/jpsim)
 
+* Make `sorted_imports` correctable.  
+  [Samuel Susla](https://github.com/sammy-sc)
+  [#1822](https://github.com/realm/SwiftLint/issues/1822)
+
 ##### Bug Fixes
 
 * Correct equality tests for `Configuration` values. They previously didn't

--- a/Rules.md
+++ b/Rules.md
@@ -10544,6 +10544,13 @@ import labc
 import Ldef
 ```
 
+```swift
+import BBB
+// comment
+import AAA
+import CCC
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -10553,6 +10560,13 @@ import AAA
 import ZZZ
 import ↓BBB
 import CCC
+```
+
+```swift
+import BBB
+// comment
+import CCC
+import ↓AAA
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -10551,6 +10551,30 @@ import AAA
 import CCC
 ```
 
+```swift
+@testable import AAA
+import   CCC
+```
+
+```swift
+import AAA
+@testable import   CCC
+```
+
+```swift
+import EEE.A
+import FFF.B
+#if os(Linux)
+import DDD.A
+import EEE.B
+#else
+import CCC
+import DDD.B
+#endif
+import AAA
+import BBB
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -10563,10 +10587,34 @@ import CCC
 ```
 
 ```swift
-import BBB
+import DDD
 // comment
 import CCC
 import ↓AAA
+```
+
+```swift
+@testable import CCC
+import   ↓AAA
+```
+
+```swift
+import CCC
+@testable import   ↓AAA
+```
+
+```swift
+import FFF.B
+import ↓EEE.A
+#if os(Linux)
+import DDD.A
+import EEE.B
+#else
+import DDD.B
+import ↓CCC
+#endif
+import AAA
+import BBB
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -10518,7 +10518,7 @@ class TotoTests {  }
 
 Identifier | Enabled by default | Supports autocorrection | Kind 
 --- | --- | --- | ---
-`sorted_imports` | Disabled | No | style
+`sorted_imports` | Disabled | Yes | style
 
 Imports should be sorted.
 

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -9,7 +9,46 @@
 import Foundation
 import SourceKittenFramework
 
-public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
+private extension Line {
+    var contentRange: NSRange {
+        return NSRange(location: range.location, length: content.characters.count)
+    }
+
+    // `Line` in this rule always contains word import
+    // This method returns contents of line that are after import
+    private func afterImport() -> String {
+        guard let range = content.range(of: "import ") else { return "" }
+        return String(content.characters.suffix(from: range.upperBound))
+    }
+
+    // Case insensitive comparission of contents of the line
+    // after the word `import`
+    static func <= (lhs: Line, rhs: Line) -> Bool {
+        return lhs.afterImport().lowercased() <= rhs.afterImport().lowercased()
+    }
+}
+
+private extension Array where Element == Line {
+    // Groups lines, so that lines that are one after the other
+    // will end up in same group.
+    func grouped() -> [[Line]] {
+        return self.reduce([[Line]]()) { result, line in
+            if let last = result.last?.last {
+                var copy = result
+                if last.index == line.index - 1 {
+                    copy[copy.count - 1].append(line)
+                } else {
+                    copy.append([line])
+                }
+                return copy
+            } else {
+                return [[line]]
+            }
+        }
+    }
+}
+
+public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -26,13 +65,31 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
         ],
         triggeringExamples: [
             "import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC"
+        ],
+        corrections: [
+            "import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC": "import AAA\nimport BBB\nimport CCC\nimport ZZZ",
+            "import BBB // comment\nimport ↓AAA": "import AAA\nimport BBB // comment",
+            "import BBB\n// comment\nimport CCC\nimport ↓AAA": "import BBB\n// comment\nimport AAA\nimport CCC",
+            "@testable import CCC\nimport AAA": "import AAA\n@testable import CCC"
         ]
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let importRanges = file.match(pattern: "import\\s+\\w+", with: [.keyword, .identifier])
-        let contents = file.contents.bridge()
+        let violatingOffsets = findViolationOffsets(file: file)
 
+        return violatingOffsets.map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0))
+        }
+    }
+
+    private static let importPattern = "import\\s+\\w+"
+
+    private func findViolationOffsets(file: File) -> [Int] {
+        let importRanges = file.match(pattern: type(of: self).importPattern,
+                                      with: [.keyword, .identifier])
+        let contents = file.contents.bridge()
         let importLength = 6
         let modulesAndOffsets: [(String, Int)] = importRanges.map { range in
             let moduleRange = NSRange(location: range.location + importLength,
@@ -44,14 +101,65 @@ public struct SortedImportsRule: ConfigurationProviderRule, OptInRule {
         }
 
         let modulePairs = zip(modulesAndOffsets, modulesAndOffsets.dropFirst())
-        let violatingOffsets = modulePairs.flatMap { previous, current in
+        return modulePairs.flatMap { previous, current in
             return current < previous ? current.1 : nil
         }
+    }
 
-        return violatingOffsets.map {
-            StyleViolation(ruleDescription: type(of: self).description,
-                           severity: configuration.severity,
-                           location: Location(file: file, characterOffset: $0))
+    private func violatingOffsets(in groups: [[Line]]) -> [Int] {
+        var violatingOffsets = [Int]()
+        groups.forEach { group in
+            let pairs = zip(group, group.dropFirst())
+            pairs.forEach { previous, current in
+                let isOrderedCorrectly = previous <= current
+                if !isOrderedCorrectly {
+                    violatingOffsets.append(current.range.location + 7)
+                }
+            }
         }
+        return violatingOffsets
+    }
+
+    public func correct(file: File) -> [Correction] {
+        let importRanges = file.match(pattern: type(of: self).importPattern, with: [.keyword, .identifier])
+        let enabledImportRanges = file.ruleEnabled(violatingRanges: importRanges, for: self)
+        guard enabledImportRanges.count > 1 else {
+            return []
+        }
+
+        let contents = file.contents.bridge()
+        let lines = contents.lines()
+        let importLines: [Line] = enabledImportRanges.flatMap { range in
+            guard let line = contents.lineAndCharacter(forCharacterOffset: range.location)?.line
+                else { return nil }
+            return lines[line - 1]
+        }
+
+        var groups = importLines.grouped()
+        let description = type(of: self).description
+        let corrections = self.violatingOffsets(in: groups).map { index -> Correction in
+            let location = Location(file: file, characterOffset: index)
+            return Correction(ruleDescription: description, location: location)
+        }
+
+        groups.enumerated().forEach { index, group in
+            groups[index] = group.sorted { previous, current in
+                previous <= current
+            }
+        }
+
+        let correctedContents = NSMutableString(string: file.contents)
+        groups.forEach { group in
+            if let first = group.first?.contentRange {
+                let result = group.map { $0.content }.joined(separator: "\n")
+                let union = group.dropFirst().reduce(first, { result, line in
+                    return NSUnionRange(result, line.contentRange)
+                })
+                correctedContents.replaceCharacters(in: union, with: result)
+            }
+        }
+        file.write(correctedContents.bridge())
+
+        return corrections
     }
 }

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -68,17 +68,74 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
             "import AAA\nimport BBB\nimport CCC\nimport DDD",
             "import Alamofire\nimport API",
             "import labc\nimport Ldef",
-            "import BBB\n// comment\nimport AAA\nimport CCC"
+            "import BBB\n// comment\nimport AAA\nimport CCC",
+            "@testable import AAA\nimport   CCC",
+            "import AAA\n@testable import   CCC",
+            """
+            import EEE.A
+            import FFF.B
+            #if os(Linux)
+            import DDD.A
+            import EEE.B
+            #else
+            import CCC
+            import DDD.B
+            #endif
+            import AAA
+            import BBB
+            """
         ],
         triggeringExamples: [
             "import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC",
-            "import BBB\n// comment\nimport CCC\nimport ↓AAA"
+            "import DDD\n// comment\nimport CCC\nimport ↓AAA",
+            "@testable import CCC\nimport   ↓AAA",
+            "import CCC\n@testable import   ↓AAA",
+            """
+            import FFF.B
+            import ↓EEE.A
+            #if os(Linux)
+            import DDD.A
+            import EEE.B
+            #else
+            import DDD.B
+            import ↓CCC
+            #endif
+            import AAA
+            import BBB
+            """
         ],
         corrections: [
             "import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC": "import AAA\nimport BBB\nimport CCC\nimport ZZZ",
             "import BBB // comment\nimport ↓AAA": "import AAA\nimport BBB // comment",
             "import BBB\n// comment\nimport CCC\nimport ↓AAA": "import BBB\n// comment\nimport AAA\nimport CCC",
-            "@testable import CCC\nimport AAA": "import AAA\n@testable import CCC"
+            "@testable import CCC\nimport  ↓AAA": "import  AAA\n@testable import CCC",
+            "import CCC\n@testable import  ↓AAA": "@testable import  AAA\nimport CCC",
+            """
+            import FFF.B
+            import ↓EEE.A
+            #if os(Linux)
+            import DDD.A
+            import EEE.B
+            #else
+            import DDD.B
+            import ↓CCC
+            #endif
+            import AAA
+            import BBB
+            """:
+            """
+            import EEE.A
+            import FFF.B
+            #if os(Linux)
+            import DDD.A
+            import EEE.B
+            #else
+            import CCC
+            import DDD.B
+            #endif
+            import AAA
+            import BBB
+            """
         ]
     )
 

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2015 Realm. All rights reserved.
 //
 
-// swiftlint:disable sorted_imports
 import Commandant
 #if os(Linux)
 import Glibc


### PR DESCRIPTION
Addresses #1822. Continued from @sammy-SC's work in #1845.

Fixes some issues with the implementation in #1845:

* Fix superfluous disable command producing false positives
* Fix import formatting assumptions:
   * Exactly once space after `import`
   * No support for `@testable import`
* Reduce indentation
* Omit types when they can be inferred
* Omit explicit references to `self.`
* Fix typos in comments
* Make constrained extensions more generic
* Use explicit ACLs for all declarations