### PR TITLE
Fix caching on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
   [Ornithologist Coder](https://github.com/ornithocoder)
   [#1912](https://github.com/realm/SwiftLint/issues/1912)
 
+* Fix caching on Linux.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.23.1: Rewash: Forgotten Load Edition
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -41,16 +41,18 @@ extension Configuration {
             return computedCacheDescription
         }
 
-        let cacheRulesDescriptions: [String: Any] = rules.reduce([:]) { accu, element in
-            var accu = accu
-            accu[type(of: element).description.identifier] = element.cacheDescription
-            return accu
-        }
-        let dict: [String: Any] = [
-            "root": rootPath ?? FileManager.default.currentDirectoryPath,
-            "rules": cacheRulesDescriptions
+        let cacheRulesDescriptions = rules
+            .map { rule in
+                return [type(of: rule).description.identifier, rule.cacheDescription]
+            }
+            .sorted { rule1, rule2 in
+                return rule1[0] < rule2[0]
+            }
+        let jsonObject: [Any] = [
+            rootPath ?? FileManager.default.currentDirectoryPath,
+            cacheRulesDescriptions
         ]
-        if let jsonData = try? JSONSerialization.data(withJSONObject: dict),
+        if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),
             let jsonString = String(data: jsonData, encoding: .utf8) {
             return jsonString
         }

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -20,7 +20,10 @@ private extension Region {
 public struct CustomRulesConfiguration: RuleConfiguration, Equatable, CacheDescriptionProvider {
     public var consoleDescription: String { return "user-defined" }
     internal var cacheDescription: String {
-        return customRuleConfigurations.map({ $0.cacheDescription }).joined(separator: "\n")
+        return customRuleConfigurations
+            .sorted { $0.identifier < $1.identifier }
+            .map { $0.cacheDescription }
+            .joined(separator: "\n")
     }
     public var customRuleConfigurations = [RegexConfiguration]()
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -17,7 +17,7 @@ public struct DiscouragedDirectInitConfiguration: RuleConfiguration, Equatable {
     public var severityConfiguration = SeverityConfiguration(.warning)
 
     public var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", types: \(discouragedInits)"
+        return severityConfiguration.consoleDescription + ", types: \(discouragedInits.sorted(by: <))"
     }
 
     public var severity: ViolationSeverity {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -26,14 +26,15 @@ public struct PrivateUnitTestConfiguration: RuleConfiguration, Equatable, CacheD
     }
 
     internal var cacheDescription: String {
-        var dict = [String: Any]()
-        dict["identifier"] = identifier
-        dict["name"] = name
-        dict["message"] = message
-        dict["regex"] = regex.pattern
-        dict["included"] = included?.pattern
-        dict["severity"] = severityConfiguration.consoleDescription
-        if let jsonData = try? JSONSerialization.data(withJSONObject: dict),
+        let jsonObject: [String] = [
+            identifier,
+            name ?? "",
+            message,
+            regex.pattern,
+            included?.pattern ?? "",
+            severityConfiguration.consoleDescription
+        ]
+        if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),
           let jsonString = String(data: jsonData, encoding: .utf8) {
               return jsonString
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -28,16 +28,17 @@ public struct RegexConfiguration: RuleConfiguration, Equatable, CacheDescription
     }
 
     internal var cacheDescription: String {
-        var dict = [String: Any]()
-        dict["identifier"] = identifier
-        dict["name"] = name
-        dict["message"] = message
-        dict["regex"] = regex.pattern
-        dict["included"] = included?.pattern
-        dict["excluded"] = excluded?.pattern
-        dict["match_kinds"] = matchKinds.map { $0.rawValue }
-        dict["severity"] = severityConfiguration.consoleDescription
-        if let jsonData = try? JSONSerialization.data(withJSONObject: dict),
+        let jsonObject: [String] = [
+            identifier,
+            name ?? "",
+            message,
+            regex.pattern,
+            included?.pattern ?? "",
+            excluded?.pattern ?? "",
+            matchKinds.map({ $0.rawValue }).sorted(by: <).joined(separator: ","),
+            severityConfiguration.consoleDescription
+        ]
+        if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),
           let jsonString = String(data: jsonData, encoding: .utf8) {
               return jsonString
         }


### PR DESCRIPTION
This has never worked for two reasons:

1. We've used dictionaries to represent cache descriptions, which don't guarantee stable ordering of keys across invocations. This is true both on Darwin and Linux, but in practice ordering varies significantly more on Linux.
2. Storing a `TimeInterval` value in a `[String: Any]` dictionary and retrieving it again will not be dynamically castable to `Double` or `TimeInterval` but will be castable to `Int`.