### PR TITLE
Fixes races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@
 * Fix caching on Linux.  
   [JP Simard](https://github.com/jpsim)
 
+* Fix crashes due to races.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.23.1: Rewash: Forgotten Load Edition
 
 ##### Breaking

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -53,7 +53,7 @@ private struct RebuildQueue {
 
 private var queueForRebuild = RebuildQueue()
 
-private struct Cache<T> {
+private class Cache<T> {
     private var values = [String: T]()
     private let factory: (File) -> T
     private let lock = NSLock()
@@ -62,7 +62,7 @@ private struct Cache<T> {
         self.factory = factory
     }
 
-    fileprivate mutating func get(_ file: File) -> T {
+    fileprivate func get(_ file: File) -> T {
         let key = file.cacheKey
         lock.lock()
         defer { lock.unlock() }
@@ -74,19 +74,19 @@ private struct Cache<T> {
         return value
     }
 
-    fileprivate mutating func invalidate(_ file: File) {
+    fileprivate func invalidate(_ file: File) {
         doLocked { values.removeValue(forKey: file.cacheKey) }
     }
 
-    fileprivate mutating func clear() {
+    fileprivate func clear() {
         doLocked { values.removeAll(keepingCapacity: false) }
     }
 
-    fileprivate mutating func set(key: String, value: T) {
+    fileprivate func set(key: String, value: T) {
         doLocked { values[key] = value }
     }
 
-    fileprivate mutating func unset(key: String) {
+    fileprivate func unset(key: String) {
         doLocked { values.removeValue(forKey: key) }
     }
 

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -92,8 +92,13 @@ extension Configuration {
             var filesAndConfigurations = [(File, Configuration)]()
             filesAndConfigurations.reserveCapacity(fileCount)
             for (config, files) in filesPerConfiguration {
-                let config = config.withPrecomputedCacheDescription()
-                filesAndConfigurations += files.map { ($0, config) }
+                let newConfig: Configuration
+                if cache != nil {
+                    newConfig = config.withPrecomputedCacheDescription()
+                } else {
+                    newConfig = config
+                }
+                filesAndConfigurations += files.map { ($0, newConfig) }
             }
             if parallel {
                 DispatchQueue.concurrentPerform(iterations: fileCount) { index in


### PR DESCRIPTION
Was seeing some crashes on Linux. So I ran thread sanitizer from the macOS side and saw two races.


Struct `mutating` functions require exclusive access even if the body of the function doesn't mutate the underlying storage.

[According to Joe Groff](https://twitter.com/jckarter/status/928714782038880256), this is because:

> "A mutating/inout access "locks" exclusive access to the storage for the duration of the call on the caller side."

Thread sanitizer found this:

```
WARNING: ThreadSanitizer: Swift access race (pid=83003)
  Modifying access at 0x000101a41158 by thread T3:
    #0 File.sourcekitdFailed.getter File+Cache.swift:108 (SwiftLintFramework:x86_64+0x26eea3)
    #1 Linter.getStyleViolations(benchmark:) Linter.swift:129 (SwiftLintFramework:x86_64+0xcb8f4)
    #2 Linter.styleViolations.getter Linter.swift:116 (SwiftLintFramework:x86_64+0xcb04e)
    #3 closure #1 in LintCommand.run(_:) LintCommand.swift:40 (swiftlint:x86_64+0x10002a9bd)
    #4 partial apply for closure #1 in LintCommand.run(_:) LintCommand.swift (swiftlint:x86_64+0x10002b1ec)
    #5 closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:89 (swiftlint:x86_64+0x10001257b)
    #6 partial apply for closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001b081)
    #7 thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x1000126f6)
    #8 partial apply for thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001b16f)
    #9 _T010ObjectiveC15autoreleasepoolxxyKc8invoking_tKlF <null>:2107840 (libswiftObjectiveC.dylib:x86_64+0x3987)
    #10 partial apply for closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x100019cc0)
    #11 closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:101 (swiftlint:x86_64+0x10001440d)
    #12 partial apply for closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001a26a)
    #13 _T0SiIxy_SiIyBy_TR <null>:2107840 (libswiftDispatch.dylib:x86_64+0xb5b6)
    #14 _dispatch_client_callout2 <null>:2107840 (libdispatch.dylib:x86_64+0xe8f3)
    #15 _swift_dispatch_apply_current <null>:2107840 (libswiftDispatch.dylib:x86_64+0x12f61)
    #16 partial apply for closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10000ea8c)
    #17 thunk for @callee_owned (@owned [Configuration : [File]]) -> (@owned Result<[File], CommandantError<()>>) Configuration+CommandLine.swift (swiftlint:x86_64+0x100015803)
    #18 partial apply for thunk for @callee_owned (@owned [Configuration : [File]]) -> (@owned Result<[File], CommandantError<()>>) Configuration+CommandLine.swift (swiftlint:x86_64+0x1000159c9)
    #19 Result.analysis<A>(ifSuccess:ifFailure:) Result.swift:60 (Result:x86_64+0x9f53)
    #20 protocol witness for ResultProtocol.analysis<A>(ifSuccess:ifFailure:) in conformance <A, B> Result<A, B> Result.swift (Result:x86_64+0xd006)
    #21 ResultProtocol.flatMap<A>(_:) ResultProtocol.swift:51 (Result:x86_64+0x23e5)
    #22 Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:107 (swiftlint:x86_64+0x100007581)
    #23 Configuration.visitLintableFiles(options:cache:visitorBlock:) Configuration+CommandLine.swift:142 (swiftlint:x86_64+0x1000176c7)
    #24 LintCommand.run(_:) LintCommand.swift:47 (swiftlint:x86_64+0x1000283b2)
    #25 protocol witness for CommandProtocol.run(_:) in conformance LintCommand LintCommand.swift (swiftlint:x86_64+0x1000356b6)
    #26 closure #1 in CommandWrapper.init<A>(_:) Command.swift:55 (Commandant:x86_64+0x25dd8)
    #27 partial apply for closure #1 in CommandWrapper.init<A>(_:) Command.swift (Commandant:x86_64+0x2c4cb)
    #28 CommandRegistry.run(command:arguments:) Command.swift:109 (Commandant:x86_64+0x28362)
    #29 CommandRegistry.main(arguments:defaultVerb:errorHandler:) Command.swift:174 (Commandant:x86_64+0x291ec)
    #30 CommandRegistry.main(defaultVerb:errorHandler:) Command.swift:138 (Commandant:x86_64+0x28aa0)
    #31 closure #1 in  main.swift:25 (swiftlint:x86_64+0x100043274)
    #32 thunk for @callee_owned () -> () Configuration+CommandLine.swift (swiftlint:x86_64+0x100011aac)
    #33 __tsan::invoke_and_release_block(void*) <null>:2107840 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x6657b)
    #34 _dispatch_client_callout <null>:2107840 (libdispatch.dylib:x86_64+0x178b)

  Previous modifying access at 0x000101a41158 by thread T1:
    #0 File.sourcekitdFailed.getter File+Cache.swift:108 (SwiftLintFramework:x86_64+0x26eea3)
    #1 Linter.getStyleViolations(benchmark:) Linter.swift:129 (SwiftLintFramework:x86_64+0xcb8f4)
    #2 Linter.styleViolations.getter Linter.swift:116 (SwiftLintFramework:x86_64+0xcb04e)
    #3 closure #1 in LintCommand.run(_:) LintCommand.swift:40 (swiftlint:x86_64+0x10002a9bd)
    #4 partial apply for closure #1 in LintCommand.run(_:) LintCommand.swift (swiftlint:x86_64+0x10002b1ec)
    #5 closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:89 (swiftlint:x86_64+0x10001257b)
    #6 partial apply for closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001b081)
    #7 thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x1000126f6)
    #8 partial apply for thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001b16f)
    #9 _T010ObjectiveC15autoreleasepoolxxyKc8invoking_tKlF <null>:2107840 (libswiftObjectiveC.dylib:x86_64+0x3987)
    #10 partial apply for closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x100019cc0)
    #11 closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:101 (swiftlint:x86_64+0x10001440d)
    #12 partial apply for closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001a26a)
    #13 _T0SiIxy_SiIyBy_TR <null>:2107840 (libswiftDispatch.dylib:x86_64+0xb5b6)
    #14 _dispatch_client_callout2 <null>:2107840 (libdispatch.dylib:x86_64+0xe8f3)

  Location is global 'responseCache' at 0x000101a41158 (SwiftLintFramework+0x000000627158)

  Thread T3 (tid=73574191, running) is a GCD worker thread

  Thread T1 (tid=73574189, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: Swift access race File+Cache.swift:108 in File.sourcekitdFailed.getter
```


We were directly mutating a dictionary without locking access (`assertHandlers`).

Thread sanitizer found this:

```
WARNING: ThreadSanitizer: Swift access race (pid=83291)
  Modifying access at 0x000101a412c0 by thread T5:
    #0 File.invalidateCache() File+Cache.swift:174 (SwiftLintFramework:x86_64+0x27148e)
    #1 closure #1 in LintCommand.run(_:) LintCommand.swift:45 (swiftlint:x86_64+0x10002ac4f)
    #2 partial apply for closure #1 in LintCommand.run(_:) LintCommand.swift (swiftlint:x86_64+0x10002b1ec)
    #3 closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:89 (swiftlint:x86_64+0x10001257b)
    #4 partial apply for closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001b081)
    #5 thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x1000126f6)
    #6 partial apply for thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001b16f)
    #7 _T010ObjectiveC15autoreleasepoolxxyKc8invoking_tKlF <null>:3738576 (libswiftObjectiveC.dylib:x86_64+0x3987)
    #8 partial apply for closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x100019cc0)
    #9 closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:101 (swiftlint:x86_64+0x10001440d)
    #10 partial apply for closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001a26a)
    #11 _T0SiIxy_SiIyBy_TR <null>:3738576 (libswiftDispatch.dylib:x86_64+0xb5b6)
    #12 _dispatch_client_callout2 <null>:3738576 (libdispatch.dylib:x86_64+0xe8f3)

  Previous modifying access at 0x000101a412c0 by thread T1:
    #0 File.invalidateCache() File+Cache.swift:174 (SwiftLintFramework:x86_64+0x27148e)
    #1 closure #1 in LintCommand.run(_:) LintCommand.swift:45 (swiftlint:x86_64+0x10002ac4f)
    #2 partial apply for closure #1 in LintCommand.run(_:) LintCommand.swift (swiftlint:x86_64+0x10002b1ec)
    #3 closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:89 (swiftlint:x86_64+0x10001257b)
    #4 partial apply for closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001b081)
    #5 thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x1000126f6)
    #6 partial apply for thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001b16f)
    #7 _T010ObjectiveC15autoreleasepoolxxyKc8invoking_tKlF <null>:3738576 (libswiftObjectiveC.dylib:x86_64+0x3987)
    #8 partial apply for closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x100019cc0)
    #9 closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:101 (swiftlint:x86_64+0x10001440d)
    #10 partial apply for closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10001a26a)
    #11 _T0SiIxy_SiIyBy_TR <null>:3738576 (libswiftDispatch.dylib:x86_64+0xb5b6)
    #12 _dispatch_client_callout2 <null>:3738576 (libdispatch.dylib:x86_64+0xe8f3)
    #13 _swift_dispatch_apply_current <null>:3738576 (libswiftDispatch.dylib:x86_64+0x12f61)
    #14 partial apply for closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x10000ea8c)
    #15 thunk for @callee_owned (@owned [Configuration : [File]]) -> (@owned Result<[File], CommandantError<()>>) Configuration+CommandLine.swift (swiftlint:x86_64+0x100015803)
    #16 partial apply for thunk for @callee_owned (@owned [Configuration : [File]]) -> (@owned Result<[File], CommandantError<()>>) Configuration+CommandLine.swift (swiftlint:x86_64+0x1000159c9)
    #17 Result.analysis<A>(ifSuccess:ifFailure:) Result.swift:60 (Result:x86_64+0x9f53)
    #18 protocol witness for ResultProtocol.analysis<A>(ifSuccess:ifFailure:) in conformance <A, B> Result<A, B> Result.swift (Result:x86_64+0xd006)
    #19 ResultProtocol.flatMap<A>(_:) ResultProtocol.swift:51 (Result:x86_64+0x23e5)
    #20 Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:107 (swiftlint:x86_64+0x100007581)
    #21 Configuration.visitLintableFiles(options:cache:visitorBlock:) Configuration+CommandLine.swift:142 (swiftlint:x86_64+0x1000176c7)
    #22 LintCommand.run(_:) LintCommand.swift:47 (swiftlint:x86_64+0x1000283b2)
    #23 protocol witness for CommandProtocol.run(_:) in conformance LintCommand LintCommand.swift (swiftlint:x86_64+0x1000356b6)
    #24 closure #1 in CommandWrapper.init<A>(_:) Command.swift:55 (Commandant:x86_64+0x25dd8)
    #25 partial apply for closure #1 in CommandWrapper.init<A>(_:) Command.swift (Commandant:x86_64+0x2c4cb)
    #26 CommandRegistry.run(command:arguments:) Command.swift:109 (Commandant:x86_64+0x28362)
    #27 CommandRegistry.main(arguments:defaultVerb:errorHandler:) Command.swift:174 (Commandant:x86_64+0x291ec)
    #28 CommandRegistry.main(defaultVerb:errorHandler:) Command.swift:138 (Commandant:x86_64+0x28aa0)
    #29 closure #1 in  main.swift:25 (swiftlint:x86_64+0x100043274)
    #30 thunk for @callee_owned () -> () Configuration+CommandLine.swift (swiftlint:x86_64+0x100011aac)
    #31 __tsan::invoke_and_release_block(void*) <null>:3738576 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x6657b)
    #32 _dispatch_client_callout <null>:3738576 (libdispatch.dylib:x86_64+0x178b)

  Location is global 'assertHandlers' at 0x000101a412c0 (SwiftLintFramework+0x0000006272c0)

  Thread T5 (tid=73593868, running) is a GCD worker thread

  Thread T1 (tid=73593689, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: Swift access race File+Cache.swift:174 in File.invalidateCache()
```