### PR TITLE
Run thread sanitizer (TSan) job on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,16 @@
 version: 2
 jobs:
 
+  tsan:
+    macos:
+      xcode: "9.0"
+    steps:
+      - checkout
+      # Pre-cache
+      - run: swift run -Xswiftc -sanitize=thread swiftlint lint --lenient
+      # Post-cache
+      - run: swift run -Xswiftc -sanitize=thread swiftlint lint --lenient
+
   osscheck:
     macos:
       xcode: "9.0"
@@ -43,6 +53,7 @@ workflows:
   version: 2
   workflow:
     jobs:
+      - tsan
       - osscheck
       - swiftpm_4
       - xcode_9


### PR DESCRIPTION
This would have caught the races fixed in #1941.

In the case of a race, the job will fail with a TSan report similar to this:

```
WARNING: ThreadSanitizer: Swift access race (pid=85084)
  Modifying access at 0x0001081e9f98 by thread T5:
    #0 File.invalidateCache() File+Cache.swift:173 (swiftlint:x86_64+0x10024616f)
    #1 closure #1 in LintCommand.run(_:) LintCommand.swift:45 (swiftlint:x86_64+0x1007b705c)
    #2 partial apply for closure #1 in LintCommand.run(_:) LintCommand.swift (swiftlint:x86_64+0x1007b75fc)
    #3 closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:89 (swiftlint:x86_64+0x1007edcea)
    #4 partial apply for closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x1007f6501)
    #5 thunk for @callee_owned () -> (@error @owned Error) QueuedPrint.swift (swiftlint:x86_64+0x100268a66)
    #6 partial apply for thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x1007f65ef)
    #7 _T010ObjectiveC15autoreleasepoolxxyKc8invoking_tKlF <null>:3202064 (libswiftObjectiveC.dylib:x86_64+0x3977)
    #8 partial apply for closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x1007f5140)
    #9 closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:101 (swiftlint:x86_64+0x1007efa9c)
    #10 partial apply for closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x1007f56ea)
    #11 _T0SiIxy_SiIyBy_TR <null>:3202064 (libswiftDispatch.dylib:x86_64+0xb5a6)
    #12 _dispatch_client_callout2 <null>:3202064 (libdispatch.dylib:x86_64+0xd8f7)

  Previous modifying access at 0x0001081e9f98 by thread T3:
    #0 File.invalidateCache() File+Cache.swift:173 (swiftlint:x86_64+0x10024616f)
    #1 closure #1 in LintCommand.run(_:) LintCommand.swift:45 (swiftlint:x86_64+0x1007b705c)
    #2 partial apply for closure #1 in LintCommand.run(_:) LintCommand.swift (swiftlint:x86_64+0x1007b75fc)
    #3 closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:89 (swiftlint:x86_64+0x1007edcea)
    #4 partial apply for closure #2 in closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x1007f6501)
    #5 thunk for @callee_owned () -> (@error @owned Error) QueuedPrint.swift (swiftlint:x86_64+0x100268a66)
    #6 partial apply for thunk for @callee_owned () -> (@error @owned Error) Configuration+CommandLine.swift (swiftlint:x86_64+0x1007f65ef)
    #7 _T010ObjectiveC15autoreleasepoolxxyKc8invoking_tKlF <null>:3202064 (libswiftObjectiveC.dylib:x86_64+0x3977)
    #8 partial apply for closure #2 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x1007f5140)
    #9 closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift:101 (swiftlint:x86_64+0x1007efa9c)
    #10 partial apply for closure #4 in closure #2 in Configuration.visitLintableFiles(path:action:useSTDIN:quiet:useScriptInputFiles:cache:parallel:visitorBlock:) Configuration+CommandLine.swift (swiftlint:x86_64+0x1007f56ea)
    #11 _T0SiIxy_SiIyBy_TR <null>:3202064 (libswiftDispatch.dylib:x86_64+0xb5a6)
    #12 _dispatch_client_callout2 <null>:3202064 (libdispatch.dylib:x86_64+0xd8f7)

  Location is global 'responseCache' at 0x0001081e9f98 (swiftlint+0x00010096af98)

  Thread T5 (tid=76019111, running) is a GCD worker thread

  Thread T3 (tid=76019109, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: Swift access race File+Cache.swift:173 in File.invalidateCache()
```