### PR TITLE
Introduction of enforced order of keywords upon defining access control while overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 * Invalidate cache when Swift patch version changes.  
   [Norio Nomura](https://github.com/norio-nomura)
+* Add `access_control_override_order` rule which warns upon violating Xcode's
+  order of keywords for access control level and override  
+  [Daniel Metzing](https://github.com/dirtydanee)
 
 ##### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -1,6 +1,7 @@
 
 # Rules
 
+* [Access Control Override Order](#access-control-override-order)
 * [Array Init](#array-init)
 * [Attributes](#attributes)
 * [Block Based KVO](#block-based-kvo)
@@ -118,6 +119,129 @@
 * [Weak Delegate](#weak-delegate)
 * [XCTFail Message](#xctfail-message)
 --------
+
+## Access Control Override Order
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`access_control_override_order` | Enabled | No | lint
+
+Access control property keywords should be followed by the override keyword.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+public override init()
+
+```
+
+```swift
+internal override init()
+
+```
+
+```swift
+private override init(){}
+
+```
+
+```swift
+open override var foo: String
+
+```
+
+```swift
+public override var foo: String
+
+```
+
+```swift
+internal override var foo: String
+
+```
+
+```swift
+private override var foo: String
+
+```
+
+```swift
+open override func foo() -> String
+```
+
+```swift
+public override func foo() -> String
+```
+
+```swift
+internal override func foo() -> String
+```
+
+```swift
+private override func foo() -> String
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+↓override public init()
+
+```
+
+```swift
+↓override internal init()
+
+```
+
+```swift
+↓override private init(){}
+
+```
+
+```swift
+↓override open var foo: String
+
+```
+
+```swift
+↓override public var foo: String
+
+```
+
+```swift
+↓override internal var foo: String
+
+```
+
+```swift
+↓override private var foo: String
+
+```
+
+```swift
+↓override open func foo() -> String
+```
+
+```swift
+↓override public func foo() -> String
+```
+
+```swift
+↓override internal func foo() -> String
+```
+
+```swift
+↓override private func foo() -> String
+```
+
+</details>
+
+
 
 ## Array Init
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -9,6 +9,7 @@
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
+    AccessControlOverrideOrderRule.self,
     ArrayInitRule.self,
     AttributesRule.self,
     BlockBasedKVORule.self,

--- a/Source/SwiftLintFramework/Rules/AccessControlOverrideOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/AccessControlOverrideOrderRule.swift
@@ -1,0 +1,97 @@
+//
+//  AccessControlOverrideOrderRule.swift
+//  SwiftLint
+//
+//  Created by Daniel.Metzing on 12/11/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct AccessControlOverrideOrderRule: ASTRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "access_control_override_order",
+        name: "Access Control Override Order",
+        description: "Access control property keywords should be followed by the override keyword.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            "public override init()\n",
+            "internal override init()\n",
+            "private override init(){}\n",
+            "open override var foo: String\n",
+            "public override var foo: String\n",
+            "internal override var foo: String\n",
+            "private override var foo: String\n",
+            "open override func foo() -> String",
+            "public override func foo() -> String",
+            "internal override func foo() -> String",
+            "private override func foo() -> String"
+        ],
+        triggeringExamples: [
+            "↓override public init()\n",
+            "↓override internal init()\n",
+            "↓override private init(){}\n",
+            "↓override open var foo: String\n",
+            "↓override public var foo: String\n",
+            "↓override internal var foo: String\n",
+            "↓override private var foo: String\n",
+            "↓override open func foo() -> String",
+            "↓override public func foo() -> String",
+            "↓override internal func foo() -> String",
+            "↓override private func foo() -> String"
+        ])
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard
+            isOverride(attributes: dictionary.enclosedSwiftAttributes),
+            let accessControlLevel = dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:)),
+            let keyOffset = dictionary.offset,
+            let syntaxTokens = syntaxTokens(at: keyOffset, in: file) else {
+                return []
+        }
+
+        let attributeTokens = syntaxTokens.filter { $0.type == SyntaxKind.attributeBuiltin.rawValue }
+        let contents = textContents(of: attributeTokens, in: file)
+
+        if let accessIndex = contents.index(of: accessControlLevel.description),
+           let overrideIndex = contents.index(of: "override"),
+           accessIndex > overrideIndex {
+                let offSet = safeOffSet(of: attributeTokens[overrideIndex], in: file)
+                return [StyleViolation(ruleDescription: type(of: self).description,
+                                       severity: .error,
+                                       location: Location(file: file, characterOffset: offSet),
+                                       reason: configuration.consoleDescription)]
+        }
+
+        return []
+    }
+
+    private func isOverride(attributes: [String]) -> Bool {
+        return attributes.contains("source.decl.attribute.override")
+    }
+
+    private func syntaxTokens(at keywordOffset: Int, in file: File) -> [SyntaxToken]? {
+        return file
+            .syntaxTokensByLine()
+            .flatMap { $0.first { $0.contains { $0.offset == keywordOffset } } }
+    }
+
+    private func textContents(of attributeTokens: [SyntaxToken], in file: File) -> [String] {
+        return attributeTokens.flatMap {
+            file.contents.bridge().substringWithByteRange(start: $0.offset, length: $0.length)
+        }
+    }
+
+    private func safeOffSet(of token: SyntaxToken, in file: File) -> Int {
+        let start = token.offset
+        let length = token.length
+        let convertedRange = file.contents.bridge().byteRangeToNSRange(start: start, length: length)
+        return convertedRange?.location ?? 0
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
 		094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094384FF1D5D2382009168CF /* WeakDelegateRule.swift */; };
 		094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094385021D5D4F78009168CF /* PrivateOutletRule.swift */; };
+		184365301FB8E12C00457C19 /* AccessControlOverrideOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1843652F1FB8E12C00457C19 /* AccessControlOverrideOrderRule.swift */; };
 		1E18574B1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */; };
 		1E3C2D711EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */; };
 		1E82D5591D7775C7009553D7 /* ClosureSpacingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */; };
@@ -354,6 +355,7 @@
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
 		094384FF1D5D2382009168CF /* WeakDelegateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
 		094385021D5D4F78009168CF /* PrivateOutletRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
+		1843652F1FB8E12C00457C19 /* AccessControlOverrideOrderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessControlOverrideOrderRule.swift; sourceTree = "<group>"; };
 		1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoExtensionAccessModifierRule.swift; sourceTree = "<group>"; };
 		1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRule.swift; sourceTree = "<group>"; };
 		1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureSpacingRule.swift; sourceTree = "<group>"; };
@@ -989,6 +991,7 @@
 		E88DEA7A1B098D7300A66CB0 /* Rules */ = {
 			isa = PBXGroup;
 			children = (
+				1843652F1FB8E12C00457C19 /* AccessControlOverrideOrderRule.swift */,
 				D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */,
 				D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */,
 				D48AE2CB1DFB58C5001C6A4A /* AttributesRulesExamples.swift */,
@@ -1528,6 +1531,7 @@
 				E889D8C51F1D11A200058332 /* Configuration+LintableFiles.swift in Sources */,
 				094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */,
 				3B1DF0121C5148140011BCED /* CustomRules.swift in Sources */,
+				184365301FB8E12C00457C19 /* AccessControlOverrideOrderRule.swift in Sources */,
 				2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */,
 				E86396C91BADB2B9002C9E88 /* JSONReporter.swift in Sources */,
 				E881985A1BEA96EA00333A11 /* OperatorFunctionWhitespaceRule.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -14,6 +14,10 @@ import XCTest
 
 class RulesTests: XCTestCase {
 
+    func testAccessControlOverrideOrderRule() {
+        verifyRule(AccessControlOverrideOrderRule.description)
+    }
+
     func testArrayInit() {
         verifyRule(ArrayInitRule.description)
     }


### PR DESCRIPTION
I have attempted to introduce a new rule for SwiftLint. The rule is designed to warn against violations of the order of keywords upon defining access control and overriding on any type of property or function.
Using Xcode's autocompletion, will result the definition of the access control to be put first, and the override keyword second. I would to like enforce this order, and make it a standard for every Swift project. 