### PR TITLE
Add option to autocorrect command to set indent width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ##### Enhancements
 
+* Add `--indent-width` option to `AutoCorrectOptions`.  
+  [RubenSandwich](https://github.com/RubenSandwich)
+  [#319](https://github.com/realm/SwiftLint/issues/319)
+
 * Invalidate cache when Swift patch version changes.  
   [Norio Nomura](https://github.com/norio-nomura)
 

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -29,7 +29,7 @@ struct AutoCorrectCommand: CommandProtocol {
             }
             if options.format {
                 let formattedContents = linter.file.format(trimmingTrailingWhitespace: true,
-                                                           useTabs: options.useTabs, indentWidth: 4)
+                                                           useTabs: options.useTabs, indentWidth: options.indentWidth)
                 _ = try? formattedContents
                     .write(toFile: linter.file.path!, atomically: true, encoding: .utf8)
             }
@@ -51,12 +51,13 @@ struct AutoCorrectOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let useTabs: Bool
+    let indentWidth: Int
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
-        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in
-            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
-        }}}}}}}
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> (_ indentWidth: Int) -> AutoCorrectOptions {
+        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in { indentWidth in
+            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs, indentWidth: indentWidth)
+        }}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
@@ -76,5 +77,8 @@ struct AutoCorrectOptions: OptionsProtocol {
             <*> mode <| Option(key: "use-tabs",
                                defaultValue: false,
                                usage: "should use tabs over spaces when reformatting")
+            <*> mode <| Option(key: "indent-width",
+                               defaultValue: 4,
+                               usage: "number of spaces or tabs to indent with")
     }
 }


### PR DESCRIPTION
This pull request adds an option to set the indent width when reformating code.

```
$ swiftlint  autocorrect --format --indent-width 2
```

This partially resolves the issue: #319, specifically the part related to:

> Spacing: Indent using 2 spaces. Should be parametrizable, and probably 4 by default.