### PR TITLE
Refactor sourcery targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ all: build
 
 sourcery: Tests/LinuxMain.swift Source/SwiftLintFramework/Models/MasterRuleList.swift
 
-Tests/LinuxMain.swift: Tests/*/*.swift
+Tests/LinuxMain.swift: Tests/*/*.swift .sourcery/LinuxMain.stencil
 	sourcery --sources Tests --templates .sourcery/LinuxMain.stencil --output .sourcery
 	sed -e 4,11d .sourcery/LinuxMain.generated.swift > .sourcery/LinuxMain.swift
 	sed -n 4,10p .sourcery/LinuxMain.generated.swift | cat - .sourcery/LinuxMain.swift > Tests/LinuxMain.swift
 	rm .sourcery/LinuxMain.swift .sourcery/LinuxMain.generated.swift
 
-Source/SwiftLintFramework/Models/MasterRuleList.swift: Source/SwiftLintFramework/Rules/*.swift
+Source/SwiftLintFramework/Models/MasterRuleList.swift: Source/SwiftLintFramework/Rules/*.swift .sourcery/MasterRuleList.stencil
 	sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/MasterRuleList.stencil --output .sourcery
 	sed -e 4,11d .sourcery/MasterRuleList.generated.swift > .sourcery/MasterRuleList.swift
 	sed -n 4,10p .sourcery/MasterRuleList.generated.swift | cat - .sourcery/MasterRuleList.swift > Source/SwiftLintFramework/Models/MasterRuleList.swift

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,15 @@ VERSION_STRING=$(shell /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionSt
 
 all: build
 
-sourcery:
+sourcery: Tests/LinuxMain.swift Source/SwiftLintFramework/Models/MasterRuleList.swift
+
+Tests/LinuxMain.swift: Tests/*/*.swift
 	sourcery --sources Tests --templates .sourcery/LinuxMain.stencil --output .sourcery
 	sed -e 4,11d .sourcery/LinuxMain.generated.swift > .sourcery/LinuxMain.swift
 	sed -n 4,10p .sourcery/LinuxMain.generated.swift | cat - .sourcery/LinuxMain.swift > Tests/LinuxMain.swift
 	rm .sourcery/LinuxMain.swift .sourcery/LinuxMain.generated.swift
+
+Source/SwiftLintFramework/Models/MasterRuleList.swift: Source/SwiftLintFramework/Rules/*.swift
 	sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/MasterRuleList.stencil --output .sourcery
 	sed -e 4,11d .sourcery/MasterRuleList.generated.swift > .sourcery/MasterRuleList.swift
 	sed -n 4,10p .sourcery/MasterRuleList.generated.swift | cat - .sourcery/MasterRuleList.swift > Source/SwiftLintFramework/Models/MasterRuleList.swift

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -1217,6 +1217,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D0D1218419E87B05005E4BAA /* Build configuration list for PBXNativeTarget "SwiftLintFramework" */;
 			buildPhases = (
+				6CF24C411FC9953E008CB0B1 /* Update Source/SwiftLintFramework/Models/MasterRuleList.swift */,
 				D0D1216819E87B05005E4BAA /* Sources */,
 				D0D1216919E87B05005E4BAA /* Frameworks */,
 				D0D1216A19E87B05005E4BAA /* Headers */,
@@ -1234,6 +1235,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D0D1218519E87B05005E4BAA /* Build configuration list for PBXNativeTarget "SwiftLintFrameworkTests" */;
 			buildPhases = (
+				6CF24C421FC99616008CB0B1 /* Update Tests/LinuxMain.swift */,
 				D0D1217319E87B05005E4BAA /* Sources */,
 				D0D1217419E87B05005E4BAA /* Frameworks */,
 				3B12C9C01C3209C4000B423F /* Resources */,
@@ -1260,7 +1262,6 @@
 				6CCFCF291CFEF6D3003239EB /* Embed Frameworks into SwiftLintFramework.framework */,
 				6CCFCF321CFEF768003239EB /* Embed Swift libraries into SwiftLintFramework.framework */,
 				E819854B1B09A3CB00CEB0D9 /* Run SwiftLint */,
-				E86C76171EE0CC1B0081860F /* Run Sourcery */,
 			);
 			buildRules = (
 			);
@@ -1353,6 +1354,40 @@
 			shellScript = "cd \"$TARGET_BUILD_DIR\"\nSWIFTLINTFRAMEWORK_BUNDLE=\"$FRAMEWORKS_FOLDER_PATH/SwiftLintFramework.framework\"\n\nxcrun swift-stdlib-tool --copy --verbose --Xcodesign --timestamp=none \\\n--scan-executable \"$EXECUTABLE_PATH\" \\\n--scan-folder \"$FRAMEWORKS_FOLDER_PATH\" \\\n--platform macosx --destination \"$SWIFTLINTFRAMEWORK_BUNDLE/Versions/Current/Frameworks\" \\\n--strip-bitcode\n";
 			showEnvVarsInLog = 0;
 		};
+		6CF24C411FC9953E008CB0B1 /* Update Source/SwiftLintFramework/Models/MasterRuleList.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Source/SwiftLintFramework/Rules/*.swift",
+			);
+			name = "Update Source/SwiftLintFramework/Models/MasterRuleList.swift";
+			outputPaths = (
+				"$(SRCROOT)/Source/SwiftLintFramework/Models/MasterRuleList.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which sourcery >/dev/null; then\n  make Source/SwiftLintFramework/Models/MasterRuleList.swift\nelse\n  echo \"Sourcery not found, install with 'brew install sourcery'\"\nfi";
+			showEnvVarsInLog = 0;
+		};
+		6CF24C421FC99616008CB0B1 /* Update Tests/LinuxMain.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Tests/*/*.swift",
+			);
+			name = "Update Tests/LinuxMain.swift";
+			outputPaths = (
+				"$(SRCROOT)/Tests/LinuxMain.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which sourcery >/dev/null; then\n  make Tests/LinuxMain.swift\nelse\n  echo \"Sourcery not found, install with 'brew install sourcery'\"\nfi";
+			showEnvVarsInLog = 0;
+		};
 		C2265FAB1A4B86AC00158358 /* Check Xcode Version */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1396,20 +1431,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
-		};
-		E86C76171EE0CC1B0081860F /* Run Sourcery */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Sourcery";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which sourcery >/dev/null; then\n  make sourcery\nelse\n  echo \"Sourcery not found, install with 'brew install sourcery'\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -1218,6 +1218,7 @@
 			buildConfigurationList = D0D1218419E87B05005E4BAA /* Build configuration list for PBXNativeTarget "SwiftLintFramework" */;
 			buildPhases = (
 				6CF24C411FC9953E008CB0B1 /* Update Source/SwiftLintFramework/Models/MasterRuleList.swift */,
+				6CF24C421FC99616008CB0B1 /* Update Tests/LinuxMain.swift */,
 				D0D1216819E87B05005E4BAA /* Sources */,
 				D0D1216919E87B05005E4BAA /* Frameworks */,
 				D0D1216A19E87B05005E4BAA /* Headers */,
@@ -1235,7 +1236,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D0D1218519E87B05005E4BAA /* Build configuration list for PBXNativeTarget "SwiftLintFrameworkTests" */;
 			buildPhases = (
-				6CF24C421FC99616008CB0B1 /* Update Tests/LinuxMain.swift */,
 				D0D1217319E87B05005E4BAA /* Sources */,
 				D0D1217419E87B05005E4BAA /* Frameworks */,
 				3B12C9C01C3209C4000B423F /* Resources */,


### PR DESCRIPTION
Set dependencies to generated targets and execute Sourcery only when necessary.

- Separate `sourcery` target into` MasterRuleList.swift` and `LinuxMain.swift` in `Makefile`  
  Also set dependencies on each targets.
- Separate `Run Sourcery` build phase in `swiftlint` target into `SwiftLintFramework` ~~and `SwiftLintFrameworkTests`~~ target~~s~~ in `xcodeproj`