### PR TITLE
Fix directories with a '.swift' suffix being treated as files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix directories with a `.swift` suffix being treated as files.  
+  [Jamie Edge](https://github.com/JamieEdge)
+  [#1948](https://github.com/realm/SwiftLint/issues/1948)
 
 ## 0.24.0: Timed Dry
 

--- a/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
@@ -26,7 +26,7 @@ extension FileManager: LintableFileManager {
         }
 
         return enumerator(atPath: absolutePath)?.flatMap { element -> String? in
-            if let element = element as? String, element.bridge().isSwiftFile() {
+            if let element = element as? String, element.bridge().isSwiftFile() && element.isFile {
                 return absolutePath.bridge().appendingPathComponent(element)
             }
             return nil


### PR DESCRIPTION
Fixes #1948.