### PR TITLE
Required Enum Case Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   [Daniel Metzing](https://github.com/dirtydanee)
   [#1924](https://github.com/realm/SwiftLint/issues/1924)
 
+* Add `required_enum_case` opt-in rule which allows enums that
+  conform to protocols to require one or more cases.  Useful for
+  result enums.  
+  [Donald Ritter](https://github.com/donald-m-ritter)
+
 ##### Bug Fixes
 
 * Fix false positives in `control_statement` rule when methods with keyword

--- a/Rules.md
+++ b/Rules.md
@@ -88,6 +88,7 @@
 * [Redundant Optional Initialization](#redundant-optional-initialization)
 * [Redundant String Enum Value](#redundant-string-enum-value)
 * [Redundant Void Return](#redundant-void-return)
+* [Required Enum Case](#required-enum-case)
 * [Returning Whitespace](#returning-whitespace)
 * [Shorthand Operator](#shorthand-operator)
 * [Single Test Class](#single-test-class)
@@ -10341,6 +10342,81 @@ protocol Foo {
  func foo()↓ -> ()
 }
 
+```
+
+</details>
+
+
+
+## Required Enum Case
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`required_enum_case` | Disabled | No | lint
+
+Enums conforming to a specified protocol must implement a specific case(s).
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+enum MyNetworkResponse: String, NetworkResponsable {
+    case success, error, notConnected 
+}
+```
+
+```swift
+enum MyNetworkResponse: String, NetworkResponsable {
+    case success, error, notConnected(error: Error) 
+}
+```
+
+```swift
+enum MyNetworkResponse: String, NetworkResponsable {
+    case success
+    case error
+    case notConnected
+}
+```
+
+```swift
+enum MyNetworkResponse: String, NetworkResponsable {
+    case success
+    case error
+    case notConnected(error: Error)
+}
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+enum MyNetworkResponse: String, NetworkResponsable {
+    case success, error 
+}
+```
+
+```swift
+enum MyNetworkResponse: String, NetworkResponsable {
+    case success, error 
+}
+```
+
+```swift
+enum MyNetworkResponse: String, NetworkResponsable {
+    case success
+    case error
+}
+```
+
+```swift
+enum MyNetworkResponse: String, NetworkResponsable {
+    case success
+    case error
+}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -5,7 +5,7 @@
 //  Created by Scott Hoyt on 12/28/15.
 //  Copyright © 2015 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.8.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
@@ -96,6 +96,7 @@ public let masterRuleList = RuleList(rules: [
     RedundantOptionalInitializationRule.self,
     RedundantStringEnumValueRule.self,
     RedundantVoidReturnRule.self,
+    RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,

--- a/Source/SwiftLintFramework/Rules/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/RequiredEnumCaseRule.swift
@@ -11,7 +11,7 @@ import SourceKittenFramework
 
 /// Allows for Enums that conform to a protocol to require that a specific case be present.
 ///
-/// This is primarily for result enums where a specific case is common but cannot be inherited due cases not being
+/// This is primarily for result enums where a specific case is common but cannot be inherited due to cases not being
 /// inheritable.
 ///
 /// For example: A result enum is used to define all of the responses a client must handle from a specific service call

--- a/Source/SwiftLintFramework/Rules/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/RequiredEnumCaseRule.swift
@@ -1,0 +1,243 @@
+//
+//  RequiredEnumCaseRule.swift
+//  SwiftLint
+//
+//  Created by Ritter, Donald on 9/13/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+/// Allows for Enums that conform to a protocol to require that a specific case be present.
+///
+/// This is primarily for result enums where a specific case is common but cannot be inherited due cases not being
+/// inheritable.
+///
+/// For example: A result enum is used to define all of the responses a client must handle from a specific service call
+/// in an API.
+///
+/// ````
+/// enum MyServiceCallResponse: String {
+///     case unauthorized
+///     case unknownError
+///     case accountCreated
+/// }
+///
+/// // An exhaustive switch can be used so any new scenarios added cause compile errors.
+/// switch response {
+///    case unauthorized:
+///        ...
+///    case unknownError:
+///        ...
+///    case accountCreated:
+///        ...
+/// }
+/// ````
+///
+/// If cases could be inherited you could put all of the common ones in an enum and then inherit from that enum:
+///
+/// ````
+/// enum MyServiceResponse: String {
+///     case unauthorized
+///     case unknownError
+/// }
+///
+/// enum MyServiceCallResponse: MyServiceResponse {
+///     case accountCreated
+/// }
+/// ````
+///
+/// Which would result in MyServiceCallResponse having all of the cases when compiled:
+///
+/// ```
+/// enum MyServiceCallResponse: MyServiceResponse {
+///     case unauthorized
+///     case unknownError
+///     case accountCreated
+/// }
+/// ```
+///
+/// Since that cannot be done this rule allows you to define cases that should be present if conforming to a protocol.
+///
+/// `.swiftlint.yml`
+/// ````
+/// required_enum_case:
+///   MyServiceResponse:
+///     unauthorized: error
+///     unknownError: error
+/// ````
+///
+/// ````
+/// protocol MyServiceResponse {}
+///
+/// // This will now have errors because `unauthorized` and `unknownError` are not present.
+/// enum MyServiceCallResponse: String, MyServiceResponse {
+///     case accountCreated
+/// }
+/// ````
+public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    public typealias KindType = SwiftDeclarationKind
+    typealias RequiredCase = RequiredEnumCaseRuleConfiguration.RequiredCase
+
+    /// Keys needed to parse the information from the SourceKitRepresentable dictionary.
+    struct Keys {
+        static let offset = "key.offset"
+        static let inheritedTypes = "key.inheritedtypes"
+        static let name = "key.name"
+        static let substructure = "key.substructure"
+        static let kind = "key.kind"
+        static let enumCase = "source.lang.swift.decl.enumcase"
+    }
+
+    /// Simple representation of parsed information from the SourceKitRepresentable dictionary.
+    struct Enum {
+        let file: File
+        let location: Location
+        let inheritedTypes: [String]
+        let cases: [String]
+
+        init(from dictionary: [String: SourceKitRepresentable], in file: File) {
+            self.file = file
+            location = Enum.location(from: dictionary, in: file)
+            inheritedTypes = Enum.inheritedTypes(from: dictionary)
+            cases = Enum.cases(from: dictionary)
+        }
+
+        /// Determines the location of where the enum declaration starts.
+        ///
+        /// - Parameters:
+        ///   - dictionary: Parsed source for the enum.
+        ///   - file: File that contains the enum.
+        /// - Returns: Location of where the enum declaration starts.
+        static func location(from dictionary: [String: SourceKitRepresentable], in file: File) -> Location {
+            guard let offset = dictionary[Keys.offset] as? Int64 else {
+                return Location(file: file, characterOffset: 0)
+            }
+
+            return Location(file: file, characterOffset: Int(offset))
+        }
+
+        /// Determines all of the inherited types the enum has.
+        ///
+        /// - Parameter dictionary: Parsed source for the enum.
+        /// - Returns: All of the inherited types the enum has.
+        static func inheritedTypes(from dictionary: [String: SourceKitRepresentable]) -> [String] {
+            guard let inheritedTypes = dictionary[Keys.inheritedTypes] as? [SourceKitRepresentable] else {
+                return []
+            }
+
+            return inheritedTypes.flatMap { $0 as? [String: SourceKitRepresentable] }.flatMap {
+                $0[Keys.name] as? String
+            }
+        }
+
+        /// Determines the names of cases found in the enum.
+        ///
+        /// - Parameter dictionary: Parsed source for the enum.
+        /// - Returns: Names of cases found in the enum.
+        static func cases(from dictionary: [String: SourceKitRepresentable]) -> [String] {
+            guard let elements = dictionary[Keys.substructure] as? [SourceKitRepresentable] else {
+                return []
+            }
+
+            let caseSubstructures = elements.flatMap { $0 as? [String: SourceKitRepresentable] }.filter {
+                $0.filter {
+                    $0.0 == Keys.kind && $0.1 as? String == SwiftDeclarationKind.enumcase.rawValue
+                }.isEmpty == false
+            }.flatMap { $0[Keys.substructure] as? [SourceKitRepresentable] }
+
+            return caseSubstructures.flatMap { $0 }.flatMap { $0 as? [String: SourceKitRepresentable] }.flatMap {
+                $0[Keys.name] as? String
+            }
+        }
+    }
+
+    public var configuration = RequiredEnumCaseRuleConfiguration()
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "required_enum_case",
+        name: "Required Enum Case",
+        description: "Enums conforming to a specified protocol must implement a specific case(s).",
+        kind: .lint,
+        nonTriggeringExamples: [
+            "enum MyNetworkResponse: String, NetworkResponsable {\n" +
+            "    case success, error, notConnected \n" +
+            "}",
+            "enum MyNetworkResponse: String, NetworkResponsable {\n" +
+            "    case success, error, notConnected(error: Error) \n" +
+            "}",
+            "enum MyNetworkResponse: String, NetworkResponsable {\n" +
+            "    case success\n" +
+            "    case error\n" +
+            "    case notConnected\n" +
+            "}",
+            "enum MyNetworkResponse: String, NetworkResponsable {\n" +
+            "    case success\n" +
+            "    case error\n" +
+            "    case notConnected(error: Error)\n" +
+            "}"
+        ],
+        triggeringExamples: [
+            "enum MyNetworkResponse: String, NetworkResponsable {\n" +
+            "    case success, error \n" +
+            "}",
+            "enum MyNetworkResponse: String, NetworkResponsable {\n" +
+            "    case success, error \n" +
+            "}",
+            "enum MyNetworkResponse: String, NetworkResponsable {\n" +
+            "    case success\n" +
+            "    case error\n" +
+            "}",
+            "enum MyNetworkResponse: String, NetworkResponsable {\n" +
+            "    case success\n" +
+            "    case error\n" +
+            "}"
+        ]
+    )
+
+    public func validate(file: File, kind: KindType, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .enum else {
+            return []
+        }
+
+        return violations(for: Enum(from: dictionary, in: file))
+    }
+
+    /// Iterates over all of the protocols in the configuration and creates violations for missing cases.
+    ///
+    /// - Parameters:
+    ///   - parsed: Enum information parsed from the SourceKitRepresentable dictionary.
+    /// - Returns: Violations for missing cases.
+    func violations(for parsed: Enum) -> [StyleViolation] {
+        var violations: [StyleViolation] = []
+
+        for (type, requiredCases) in configuration.protocols where parsed.inheritedTypes.contains(type) {
+            for requiredCase in requiredCases where !parsed.cases.contains(requiredCase.name) {
+                violations.append(create(violationIn: parsed, for: type, missing: requiredCase))
+            }
+        }
+
+        return violations
+    }
+
+    /// Creates the violation for a missing case.
+    ///
+    /// - Parameters:
+    ///   - parsed: Enum information parsed from the SourceKitRepresentable dictionary.
+    ///   - protocolName: Name of the protocol that is missing the case.
+    ///   - requiredCase: Information about the case and the severity of the violation.
+    /// - Returns: Created violation.
+    func create(violationIn parsed: Enum,
+                for protocolName: String,
+                missing requiredCase: RequiredCase) -> StyleViolation {
+
+        return StyleViolation(
+            ruleDescription: type(of: self).description,
+            severity: requiredCase.severity,
+            location: parsed.location,
+            reason: "Enums conforming to \"\(protocolName)\" must have a \"\(requiredCase.name)\" case")
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
@@ -1,0 +1,81 @@
+//
+//  RequiredEnumCaseRuleConfiguration.swift
+//  SwiftLint
+//
+//  Created by Ritter, Donald on 9/13/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+
+public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
+    struct RequiredCase: Equatable, Hashable {
+        var name: String
+        var severity: ViolationSeverity
+
+        init(name: String, severity: ViolationSeverity = .warning) {
+            self.name = name
+            self.severity = severity
+        }
+
+        var hashValue: Int {
+            return name.hashValue
+        }
+
+        static func == (lhs: RequiredCase, rhs: RequiredCase) -> Bool {
+            return lhs.name == rhs.name && lhs.severity == rhs.severity
+        }
+    }
+
+    var protocols: [String: Set<RequiredCase>] = [:]
+
+    public var consoleDescription: String {
+        let protocols = self.protocols.sorted(by: { $0.key < $1.key }) .flatMap { name, required in
+            let caseNames: [String] = required.sorted(by: { $0.name < $1.name }).flatMap {
+                "[name: \"\($0.name)\", severity: \"\($0.severity.rawValue)\"]"
+            }
+
+            return "[protocol: \"\(name)\", cases: [\(caseNames.joined(separator: ", "))]]"
+        }.joined(separator: ", ")
+
+        let instructions = "No protocols configured.  In config add 'required_enum_case' to 'opt_in_rules' and " +
+            "config using :\n\n" +
+            "'required_enum_case:\n" +
+            "  {Protocol Name}:\n" +
+            "    {Case Name}:{warning|error}\n" +
+            "    {Case Name}:{warning|error}\n"
+
+        return protocols.isEmpty ? instructions : protocols
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let config = configuration as? [String: [String: String]] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        register(protocols: config)
+    }
+
+    mutating func register(protocols: [String: [String: String]]) {
+        for (name, cases) in protocols {
+            register(protocol: name, cases: cases)
+        }
+    }
+
+    mutating func register(protocol name: String, cases: [String: String]) {
+        var requiredCases: Set<RequiredCase> = []
+
+        for (caseName, severity) in cases {
+            let parsedSeverity: ViolationSeverity = (severity == "error") ? .error : .warning
+            requiredCases.insert(RequiredCase(name: caseName, severity: parsedSeverity))
+        }
+
+        protocols[name] = requiredCases
+    }
+
+    public static func == (lhs: RequiredEnumCaseRuleConfiguration,
+                           rhs: RequiredEnumCaseRuleConfiguration) -> Bool {
+
+        return lhs.protocols == rhs.protocols
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -129,6 +129,9 @@
 		B3935A32BE03C4D11B4364D6 /* CannedCSVReporterOutput.csv in Resources */ = {isa = PBXBuildFile; fileRef = B3935939C8366514D2694722 /* CannedCSVReporterOutput.csv */; };
 		B3935EE74B1E8E14FBD65E7F /* String+XML.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39353F28BCCA39247B316BD /* String+XML.swift */; };
 		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
+		B89F3BCD1FD5EDFB00931E59 /* RequiredEnumCaseRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */; };
+		B89F3BCE1FD5EE0200931E59 /* RequiredEnumCaseRuleTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89F3BCB1FD5EDA900931E59 /* RequiredEnumCaseRuleTestCase.swift */; };
+		B89F3BCF1FD5EE1400931E59 /* RequiredEnumCaseRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89F3BC71FD5ED7D00931E59 /* RequiredEnumCaseRuleConfiguration.swift */; };
 		BB00B4E91F5216090079869F /* MultipleClosuresWithTrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00B4E71F5216070079869F /* MultipleClosuresWithTrailingClosureRule.swift */; };
 		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
 		C328A2F71E6759AE00A9E4D7 /* ExplicitTypeInterfaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */; };
@@ -468,6 +471,9 @@
 		B3935939C8366514D2694722 /* CannedCSVReporterOutput.csv */ = {isa = PBXFileReference; lastKnownFileType = file.csv; path = CannedCSVReporterOutput.csv; sourceTree = "<group>"; };
 		B39359A325FE84B7EDD1C455 /* CannedJunitReporterOutput.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = CannedJunitReporterOutput.xml; sourceTree = "<group>"; };
 		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
+		B89F3BC71FD5ED7D00931E59 /* RequiredEnumCaseRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRuleConfiguration.swift; sourceTree = "<group>"; };
+		B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRule.swift; sourceTree = "<group>"; };
+		B89F3BCB1FD5EDA900931E59 /* RequiredEnumCaseRuleTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRuleTestCase.swift; sourceTree = "<group>"; };
 		BB00B4E71F5216070079869F /* MultipleClosuresWithTrailingClosureRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleClosuresWithTrailingClosureRule.swift; sourceTree = "<group>"; };
 		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
 		C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRule.swift; sourceTree = "<group>"; };
@@ -732,6 +738,7 @@
 				B2902A0D1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift */,
 				009E09291DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift */,
 				3BB47D821C514E8100AE6A10 /* RegexConfiguration.swift */,
+				B89F3BC71FD5ED7D00931E59 /* RequiredEnumCaseRuleConfiguration.swift */,
 				3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */,
 				3BCC04CF1C4F56D3006073C3 /* SeverityLevelsConfiguration.swift */,
 				725094881D0855760039B353 /* StatementPositionConfiguration.swift */,
@@ -927,6 +934,7 @@
 				D4246D6E1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift */,
 				E81ADD711ED5ED9D000CD451 /* RegionTests.swift */,
 				E86396C61BADAFE6002C9E88 /* ReporterTests.swift */,
+				B89F3BCB1FD5EDA900931E59 /* RequiredEnumCaseRuleTestCase.swift */,
 				3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */,
 				D45255C71F0932F8003C9B56 /* RuleDescription+Examples.swift */,
 				E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */,
@@ -1096,6 +1104,7 @@
 				D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */,
 				D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */,
 				D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */,
+				B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */,
 				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
 				3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */,
 				D4D5A5FE1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift */,
@@ -1625,6 +1634,7 @@
 				094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */,
 				E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */,
 				62622F6B1F2F2E3500D5D099 /* DiscouragedDirectInitRule.swift in Sources */,
+				B89F3BCD1FD5EDFB00931E59 /* RequiredEnumCaseRule.swift in Sources */,
 				3BB47D831C514E8100AE6A10 /* RegexConfiguration.swift in Sources */,
 				D401D9261ED85EF0005DA5D4 /* RuleKind.swift in Sources */,
 				D4C889711E385B7B00BAE88D /* RedundantDiscardableLetRule.swift in Sources */,
@@ -1646,6 +1656,7 @@
 				D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */,
 				C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */,
 				626C16E21F948EBC00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift in Sources */,
+				B89F3BCF1FD5EE1400931E59 /* RequiredEnumCaseRuleConfiguration.swift in Sources */,
 				D48B51211F4F5DEF0068AB98 /* RuleList+Documentation.swift in Sources */,
 				8FC9F5111F4B8E48006826C1 /* IsDisjointRule.swift in Sources */,
 				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
@@ -1707,6 +1718,7 @@
 				67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */,
 				D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */,
 				F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */,
+				B89F3BCE1FD5EE0200931E59 /* RequiredEnumCaseRuleTestCase.swift in Sources */,
 				C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */,
 				3B63D46F1E1F09DF0057BE35 /* LineLengthRuleTests.swift in Sources */,
 				3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,7 +5,7 @@
 //  Created by JP Simard on 12/11/16.
 //  Copyright © 2016 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.8.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -311,6 +311,23 @@ extension ReporterTests {
     ]
 }
 
+extension RequiredEnumCaseRuleTestCase {
+    static var allTests: [(String, (RequiredEnumCaseRuleTestCase) -> () throws -> Void)] = [
+        ("testRequiredCaseHashValue", testRequiredCaseHashValue),
+        ("testRequiredCaseEquatableReturnsTrue", testRequiredCaseEquatableReturnsTrue),
+        ("testRequiredCaseEquatableReturnsFalseBecauseOfDifferentName", testRequiredCaseEquatableReturnsFalseBecauseOfDifferentName),
+        ("testConsoleDescriptionReturnsAllConfiguredProtocols", testConsoleDescriptionReturnsAllConfiguredProtocols),
+        ("testConsoleDescriptionReturnsNoConfiguredProtocols", testConsoleDescriptionReturnsNoConfiguredProtocols),
+        ("testRegisterProtocolCasesRegistersCasesWithSpecifiedSeverity", testRegisterProtocolCasesRegistersCasesWithSpecifiedSeverity),
+        ("testRegisterProtocols", testRegisterProtocols),
+        ("testApplyThrowsErrorBecausePassedConfigurationCantBeCast", testApplyThrowsErrorBecausePassedConfigurationCantBeCast),
+        ("testApplyRegistersProtocols", testApplyRegistersProtocols),
+        ("testEqualsReturnsTrue", testEqualsReturnsTrue),
+        ("testEqualsReturnsFalseBecauseProtocolsArentEqual", testEqualsReturnsFalseBecauseProtocolsArentEqual),
+        ("testEqualsReturnsFalseBecauseSeverityIsntEqual", testEqualsReturnsFalseBecauseSeverityIsntEqual)
+    ]
+}
+
 extension RuleConfigurationsTests {
     static var allTests: [(String, (RuleConfigurationsTests) -> () throws -> Void)] = [
         ("testNameConfigurationSetsCorrectly", testNameConfigurationSetsCorrectly),
@@ -429,6 +446,7 @@ extension RulesTests {
         ("testRedundantOptionalInitialization", testRedundantOptionalInitialization),
         ("testRedundantStringEnumValue", testRedundantStringEnumValue),
         ("testRedundantVoidReturn", testRedundantVoidReturn),
+        ("testRequiredEnumCase", testRequiredEnumCase),
         ("testReturnArrowWhitespace", testReturnArrowWhitespace),
         ("testShorthandOperator", testShorthandOperator),
         ("testSingleTestClass", testSingleTestClass),
@@ -555,6 +573,7 @@ XCTMain([
     testCase(PrivateOverFilePrivateRuleTests.allTests),
     testCase(RegionTests.allTests),
     testCase(ReporterTests.allTests),
+    testCase(RequiredEnumCaseRuleTestCase.allTests),
     testCase(RuleConfigurationsTests.allTests),
     testCase(RuleTests.allTests),
     testCase(RulesTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/RequiredEnumCaseRuleTestCase.swift
+++ b/Tests/SwiftLintFrameworkTests/RequiredEnumCaseRuleTestCase.swift
@@ -1,0 +1,144 @@
+//
+//  RequiredEnumCaseRuleTestCase.swift
+//  SwiftLint
+//
+//  Created by Ritter, Donald (CONT) on 9/13/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+import Foundation
+@testable import SwiftLintFramework
+import XCTest
+
+class RequiredEnumCaseRuleTestCase: XCTestCase {
+    typealias RuleConfiguration = RequiredEnumCaseRuleConfiguration
+    typealias RequiredCase = RuleConfiguration.RequiredCase
+
+    let protocol1 = "RequiredProtocol"
+    let protocol2 = "NetworkResults"
+    let protocol3 = "RequiredProtocolWithSeverity"
+    let rule1 = RuleConfiguration.RequiredCase(name: "success", severity: .warning)
+    let rule2 = RuleConfiguration.RequiredCase(name: "error", severity: .warning)
+    let rule3 = RuleConfiguration.RequiredCase(name: "success", severity: .error)
+
+    var config: RuleConfiguration!
+
+    override func setUp() {
+        super.setUp()
+        config = RuleConfiguration()
+        config.protocols[protocol1] = [rule1, rule2]
+        config.protocols[protocol2] = [rule2]
+    }
+
+    func testRequiredCaseHashValue() {
+        let requiredCase = RequiredCase(name: "success")
+        XCTAssertEqual(requiredCase.hashValue, "success".hashValue)
+    }
+
+    func testRequiredCaseEquatableReturnsTrue() {
+        let lhs = RequiredCase(name: "success")
+        let rhs = RequiredCase(name: "success")
+        XCTAssertEqual(lhs, rhs)
+    }
+
+    func testRequiredCaseEquatableReturnsFalseBecauseOfDifferentName() {
+        let lhs = RequiredCase(name: "success")
+        let rhs = RequiredCase(name: "error")
+        XCTAssertNotEqual(lhs, rhs)
+    }
+
+    func testConsoleDescriptionReturnsAllConfiguredProtocols() {
+        let expected = "[" +
+            "protocol: \"NetworkResults\", " +
+            "cases: [" +
+                "[name: \"error\", severity: \"warning\"]" +
+            "]" +
+        "], [" +
+            "protocol: \"RequiredProtocol\", " +
+            "cases: [" +
+                "[name: \"error\", severity: \"warning\"], " +
+                "[name: \"success\", severity: \"warning\"]" +
+            "]" +
+        "]"
+        XCTAssertEqual(config.consoleDescription, expected)
+    }
+
+    func testConsoleDescriptionReturnsNoConfiguredProtocols() {
+        let expected = "No protocols configured.  In config add 'required_enum_case' to 'opt_in_rules' and " +
+            "config using :\n\n" +
+            "'required_enum_case:\n" +
+            "  {Protocol Name}:\n" +
+            "    {Case Name}:{warning|error}\n" +
+            "    {Case Name}:{warning|error}\n"
+
+        config.protocols.removeAll()
+        XCTAssertEqual(config.consoleDescription, expected)
+    }
+
+    func validateRulesExistForProtocol1() {
+        XCTAssertTrue(self.config.protocols[protocol1]?.contains(self.rule1) ?? false)
+        XCTAssertTrue(self.config.protocols[protocol1]?.contains(self.rule2) ?? false)
+    }
+
+    func testRegisterProtocolCasesRegistersCasesWithSpecifiedSeverity() {
+        config.register(protocol: protocol3, cases: ["success": "error", "error": "warning"])
+        validateRulesExistForProtocol3()
+    }
+
+    func validateRulesExistForProtocol3() {
+        XCTAssertTrue(self.config.protocols[protocol3]?.contains(self.rule3) ?? false)
+        XCTAssertTrue(self.config.protocols[protocol3]?.contains(self.rule2) ?? false)
+    }
+
+    func testRegisterProtocols() {
+        config.register(protocols: [protocol1: ["success": "warning", "error": "warning"]])
+        validateRulesExistForProtocol1()
+    }
+
+    func testApplyThrowsErrorBecausePassedConfigurationCantBeCast() {
+        var errorThrown = false
+
+        do {
+            try config.apply(configuration: "Howdy")
+        } catch {
+            errorThrown = true
+        }
+
+        XCTAssertTrue(errorThrown)
+    }
+
+    func testApplyRegistersProtocols() {
+        try? config.apply(configuration: [protocol1: ["success": "warning", "error": "warning"]])
+        validateRulesExistForProtocol1()
+    }
+
+    func testEqualsReturnsTrue() {
+        var lhs = RuleConfiguration()
+        try? lhs.apply(configuration: [protocol1: ["success", "error"]])
+
+        var rhs = RuleConfiguration()
+        try? rhs.apply(configuration: [protocol1: ["success", "error"]])
+
+        XCTAssertEqual(lhs, rhs)
+    }
+
+    func testEqualsReturnsFalseBecauseProtocolsArentEqual() {
+        var lhs = RuleConfiguration()
+        try? lhs.apply(configuration: [protocol1: ["success": "error"]])
+
+        var rhs = RuleConfiguration()
+        try? rhs.apply(configuration: [protocol2: ["success": "error", "error": "warning"]])
+
+        XCTAssertNotEqual(lhs, rhs)
+    }
+
+    func testEqualsReturnsFalseBecauseSeverityIsntEqual() {
+        var lhs = RuleConfiguration()
+        try? lhs.apply(configuration: [protocol1: ["success": "error", "error": "error"]])
+
+        var rhs = RuleConfiguration()
+        try? rhs.apply(configuration: [protocol1: ["success": "warning", "error": "error"]])
+
+        XCTAssertNotEqual(lhs, rhs)
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -318,6 +318,11 @@ class RulesTests: XCTestCase {
         verifyRule(RedundantVoidReturnRule.description)
     }
 
+    func testRequiredEnumCase() {
+        let configuration = ["NetworkResponsable": ["notConnected": "error"]]
+        verifyRule(RequiredEnumCaseRule.description, ruleConfiguration: configuration)
+    }
+
     func testReturnArrowWhitespace() {
         verifyRule(ReturnArrowWhitespaceRule.description)
     }


### PR DESCRIPTION
# Required Enum Case Rule
Allows for Enums that conform to a protocol to require that a specific case be present.

This is primarily for result enums where a specific case is common but cannot be inherited due cases not being
inheritable.

For example: A result enum is used to define all of the responses a client must handle from a specific service call
in an API.

````
enum MyServiceCallResponse: String {
    case unauthorized
    case unknownError
    case accountCreated
}

// An exhaustive switch can be used so any new scenarios added cause compile errors.
switch response {
   case unauthorized:
       ...
   case unknownError:
       ...
   case accountCreated:
       ...
}
````

If cases could be inherited you could put all of the common ones in an enum and then inherit from that enum:

````
enum MyServiceResponse: String {
    case unauthorized
    case unknownError
}

enum MyServiceCallResponse: MyServiceResponse {
    case accountCreated
}
````

Which would result in MyServiceCallResponse having all of the cases when compiled:

```
enum MyServiceCallResponse: MyServiceResponse {
    case unauthorized
    case unknownError
    case accountCreated
}
```

Since that cannot be done this rule allows you to define cases that should be present if conforming to a protocol.

`.swiftlint.yml`
````
required_enum_case:
  MyServiceResponse:
    unauthorized: error
    unknownError: error
````

````
protocol MyServiceResponse {}

// This will now have errors because `unauthorized` and `unknownError` are not present.
enum MyServiceCallResponse: String, MyServiceResponse {
    case accountCreated
}
````