### PR TITLE
Fix false positives in `unused_closure_parameter` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1968](https://github.com/realm/SwiftLint/issues/1968)
 
+* Fix false positives in `unused_closure_parameter` rule when closure is wrapped
+  in parentheses.  
+  [JP Simard](https://github.com/jpsim)
+  [#1979](https://github.com/realm/SwiftLint/issues/1979)
+
 ## 0.24.0: Timed Dry
 
 ##### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -15391,6 +15391,12 @@ hoge(arg: num) { num in
 
 ```
 
+```swift
+({ (manager: FileManager) in
+  print(manager)
+})(FileManager.default)
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -41,7 +41,12 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
             "}(UILabel())\n",
             "hoge(arg: num) { num in\n" +
             "  return num\n" +
-            "}\n"
+            "}\n",
+            """
+            ({ (manager: FileManager) in
+              print(manager)
+            })(FileManager.default)
+            """
         ],
         triggeringExamples: [
             "[1, 2].map { ↓number in\n return 3\n}\n",
@@ -151,7 +156,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
         return dictionary.name.flatMap { name -> Bool in
             let length = name.bridge().length
             let range = NSRange(location: 0, length: length)
-            return regex("\\A\\s*\\{").firstMatch(in: name, options: [], range: range) != nil
+            return regex("\\A[\\s\\(]*?\\{").firstMatch(in: name, options: [], range: range) != nil
         } ?? false
     }
 


### PR DESCRIPTION
when closure is wrapped in parentheses. Fixes #1979.

Definitely not elegant, but it should help.