### PR TITLE
Configurable indent width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   [Daniel Metzing](https://github.com/dirtydanee)
   [#1924](https://github.com/realm/SwiftLint/issues/1924)
   
-* Indentation can now be specified via a configuration file
+* Indentation can now be specified via a configuration file.  
   [Noah McCann](https://github.com/nmccann)
   [RubenSandwich](https://github.com/RubenSandwich)
   [#319](https://github.com/realm/SwiftLint/issues/319)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   conditional statement.  
   [Daniel Metzing](https://github.com/dirtydanee)
   [#1924](https://github.com/realm/SwiftLint/issues/1924)
+  
+* Add `--indent-width` option to `AutoCorrectOptions`  
+  [Noah McCann](https://github.com/nmccann)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@
   [Daniel Metzing](https://github.com/dirtydanee)
   [#1924](https://github.com/realm/SwiftLint/issues/1924)
   
-* Add `--indent-width` option to `AutoCorrectOptions`  
+* Indentation can now be specified via a configuration file
   [Noah McCann](https://github.com/nmccann)
+  [RubenSandwich](https://github.com/RubenSandwich)
+  [#319](https://github.com/realm/SwiftLint/issues/319)
 
 ##### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -129,7 +129,8 @@ extension Configuration {
             reporter: reporter, // Always use the parent reporter
             rules: mergingRules(with: configuration),
             cachePath: cachePath, // Always use the parent cache path
-            rootPath: configuration.rootPath
+            rootPath: configuration.rootPath,
+            indentationMode: configuration.indentationMode
         )
     }
 }

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -130,7 +130,7 @@ extension Configuration {
             rules: mergingRules(with: configuration),
             cachePath: cachePath, // Always use the parent cache path
             rootPath: configuration.rootPath,
-            indentationMode: configuration.indentationMode
+            indentation: configuration.indentation
         )
     }
 }

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -47,13 +47,13 @@ extension Configuration {
             return [String].array(of: object) ?? []
         }
 
-        func defaultIndentationMode(_ object: Any?) -> IndentationMode {
+        func defaultIndentation(_ object: Any?) -> Indentation {
             switch object {
             case let value as Int: return .spaces(count: value)
             case let value as String where value == "tabs": return .tabs
             default:
                 queuedPrintError("Invalid configuration for '\(Key.indentation)'. Falling back to default.")
-                return .spaces(count: 4)
+                return .default
             }
         }
 
@@ -72,7 +72,7 @@ extension Configuration {
         let whitelistRules = defaultStringArray(dict[Key.whitelistRules.rawValue])
         let included = defaultStringArray(dict[Key.included.rawValue])
         let excluded = defaultStringArray(dict[Key.excluded.rawValue])
-        let indentationMode = defaultIndentationMode(dict[Key.indentation.rawValue])
+        let indentation = defaultIndentation(dict[Key.indentation.rawValue])
 
         Configuration.warnAboutDeprecations(configurationDictionary: dict, disabledRules: disabledRules,
                                             optInRules: optInRules, whitelistRules: whitelistRules, ruleList: ruleList)
@@ -101,7 +101,7 @@ extension Configuration {
                   configuredRules: configuredRules,
                   swiftlintVersion: dict[Key.swiftlintVersion.rawValue] as? String,
                   cachePath: cachePath ?? dict[Key.cachePath.rawValue] as? String,
-                  indentationMode: indentationMode)
+                  indentation: indentation)
     }
 
     private init?(disabledRules: [String],
@@ -116,7 +116,7 @@ extension Configuration {
                   configuredRules: [Rule]?,
                   swiftlintVersion: String?,
                   cachePath: String?,
-                  indentationMode: IndentationMode) {
+                  indentation: Indentation) {
 
         let rulesMode: RulesMode
         if enableAllRules {
@@ -142,7 +142,7 @@ extension Configuration {
                   configuredRules: configuredRules,
                   swiftlintVersion: swiftlintVersion,
                   cachePath: cachePath,
-                  indentationMode: indentationMode)
+                  indentation: indentation)
     }
 
     private static func warnAboutDeprecations(configurationDictionary dict: [String: Any],

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -41,20 +41,20 @@ extension Configuration {
         ].map({ $0.rawValue }) + ruleList.allValidIdentifiers()
     }
 
+    private static func defaultIndentation(_ object: Any?) -> Indentation {
+        switch object {
+        case let value as Int: return .spaces(count: value)
+        case let value as String where value == "tabs": return .tabs
+        default:
+            queuedPrintError("Invalid configuration for '\(Key.indentation)'. Falling back to default.")
+            return .default
+        }
+    }
+
     public init?(dict: [String: Any], ruleList: RuleList = masterRuleList, enableAllRules: Bool = false,
                  cachePath: String? = nil) {
         func defaultStringArray(_ object: Any?) -> [String] {
             return [String].array(of: object) ?? []
-        }
-
-        func defaultIndentation(_ object: Any?) -> Indentation {
-            switch object {
-            case let value as Int: return .spaces(count: value)
-            case let value as String where value == "tabs": return .tabs
-            default:
-                queuedPrintError("Invalid configuration for '\(Key.indentation)'. Falling back to default.")
-                return .default
-            }
         }
 
         // Use either new 'opt_in_rules' or deprecated 'enabled_rules' for now.
@@ -72,7 +72,7 @@ extension Configuration {
         let whitelistRules = defaultStringArray(dict[Key.whitelistRules.rawValue])
         let included = defaultStringArray(dict[Key.included.rawValue])
         let excluded = defaultStringArray(dict[Key.excluded.rawValue])
-        let indentation = defaultIndentation(dict[Key.indentation.rawValue])
+        let indentation = Configuration.defaultIndentation(dict[Key.indentation.rawValue])
 
         Configuration.warnAboutDeprecations(configurationDictionary: dict, disabledRules: disabledRules,
                                             optInRules: optInRules, whitelistRules: whitelistRules, ruleList: ruleList)

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -17,13 +17,15 @@ public struct Configuration: Hashable {
         case allEnabled
     }
 
-    public enum IndentationMode: Equatable {
+    public enum Indentation: Equatable {
         case tabs
         case spaces(count: Int)
 
+        public static var `default` = spaces(count: 4)
+
         // MARK: Equatable
 
-        public static func == (lhs: IndentationMode, rhs: IndentationMode) -> Bool {
+        public static func == (lhs: Indentation, rhs: Indentation) -> Bool {
             switch (lhs, rhs) {
             case (.tabs, .tabs): return true
             case (.spaces(let lhs), .spaces(let rhs)): return lhs == rhs
@@ -36,7 +38,7 @@ public struct Configuration: Hashable {
 
     public static let fileName = ".swiftlint.yml"
 
-    public let indentationMode: IndentationMode        // mode to use when indenting
+    public let indentation: Indentation            // mode to use when indenting
     public let included: [String]                      // included
     public let excluded: [String]                      // excluded
     public let reporter: String                        // reporter (xcode, json, csv, checkstyle)
@@ -76,7 +78,7 @@ public struct Configuration: Hashable {
                  configuredRules: [Rule]? = nil,
                  swiftlintVersion: String? = nil,
                  cachePath: String? = nil,
-                 indentationMode: IndentationMode = .spaces(count: 4)) {
+                 indentation: Indentation = .default) {
 
         if let pinnedVersion = swiftlintVersion, pinnedVersion != Version.current.value {
             queuedPrintError("Currently running SwiftLint \(Version.current.value) but " +
@@ -132,7 +134,7 @@ public struct Configuration: Hashable {
                   reporter: reporter,
                   rules: rules,
                   cachePath: cachePath,
-                  indentationMode: indentationMode)
+                  indentation: indentation)
     }
 
     internal init(rulesMode: RulesMode,
@@ -143,7 +145,7 @@ public struct Configuration: Hashable {
                   rules: [Rule],
                   cachePath: String?,
                   rootPath: String? = nil,
-                  indentationMode: IndentationMode) {
+                  indentation: Indentation) {
 
         self.rulesMode = rulesMode
         self.included = included
@@ -152,7 +154,7 @@ public struct Configuration: Hashable {
         self.cachePath = cachePath
         self.rules = rules
         self.rootPath = rootPath
-        self.indentationMode = indentationMode
+        self.indentation = indentation
 
         // set the config threshold to the threshold provided in the config file
         self.warningThreshold = warningThreshold
@@ -167,7 +169,7 @@ public struct Configuration: Hashable {
         rules = configuration.rules
         cachePath = configuration.cachePath
         rootPath = configuration.rootPath
-        indentationMode = configuration.indentationMode
+        indentation = configuration.indentation
     }
 
     public init(path: String = Configuration.fileName, rootPath: String? = nil,
@@ -227,7 +229,7 @@ public struct Configuration: Hashable {
             (lhs.included == rhs.included) &&
             (lhs.excluded == rhs.excluded) &&
             (lhs.rules == rhs.rules) &&
-            (lhs.indentationMode == rhs.indentationMode)
+            (lhs.indentation == rhs.indentation)
     }
 }
 

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -17,10 +17,26 @@ public struct Configuration: Hashable {
         case allEnabled
     }
 
+    public enum IndentationMode: Equatable {
+        case tabs
+        case spaces(count: Int)
+
+        // MARK: Equatable
+
+        public static func == (lhs: IndentationMode, rhs: IndentationMode) -> Bool {
+            switch (lhs, rhs) {
+            case (.tabs, .tabs): return true
+            case (.spaces(let lhs), .spaces(let rhs)): return lhs == rhs
+            case (_, _): return false
+            }
+        }
+    }
+
     // MARK: Properties
 
     public static let fileName = ".swiftlint.yml"
 
+    public let indentationMode: IndentationMode        // mode to use when indenting
     public let included: [String]                      // included
     public let excluded: [String]                      // excluded
     public let reporter: String                        // reporter (xcode, json, csv, checkstyle)
@@ -59,7 +75,8 @@ public struct Configuration: Hashable {
                  ruleList: RuleList = masterRuleList,
                  configuredRules: [Rule]? = nil,
                  swiftlintVersion: String? = nil,
-                 cachePath: String? = nil) {
+                 cachePath: String? = nil,
+                 indentationMode: IndentationMode = .spaces(count: 4)) {
 
         if let pinnedVersion = swiftlintVersion, pinnedVersion != Version.current.value {
             queuedPrintError("Currently running SwiftLint \(Version.current.value) but " +
@@ -114,7 +131,8 @@ public struct Configuration: Hashable {
                   warningThreshold: warningThreshold,
                   reporter: reporter,
                   rules: rules,
-                  cachePath: cachePath)
+                  cachePath: cachePath,
+                  indentationMode: indentationMode)
     }
 
     internal init(rulesMode: RulesMode,
@@ -124,7 +142,8 @@ public struct Configuration: Hashable {
                   reporter: String,
                   rules: [Rule],
                   cachePath: String?,
-                  rootPath: String? = nil) {
+                  rootPath: String? = nil,
+                  indentationMode: IndentationMode) {
 
         self.rulesMode = rulesMode
         self.included = included
@@ -133,6 +152,7 @@ public struct Configuration: Hashable {
         self.cachePath = cachePath
         self.rules = rules
         self.rootPath = rootPath
+        self.indentationMode = indentationMode
 
         // set the config threshold to the threshold provided in the config file
         self.warningThreshold = warningThreshold
@@ -147,6 +167,7 @@ public struct Configuration: Hashable {
         rules = configuration.rules
         cachePath = configuration.cachePath
         rootPath = configuration.rootPath
+        indentationMode = configuration.indentationMode
     }
 
     public init(path: String = Configuration.fileName, rootPath: String? = nil,
@@ -205,7 +226,8 @@ public struct Configuration: Hashable {
             (lhs.cachePath == lhs.cachePath) &&
             (lhs.included == rhs.included) &&
             (lhs.excluded == rhs.excluded) &&
-            (lhs.rules == rhs.rules)
+            (lhs.rules == rhs.rules) &&
+            (lhs.indentationMode == rhs.indentationMode)
     }
 }
 

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -28,7 +28,7 @@ public struct Configuration: Hashable {
         public static func == (lhs: Indentation, rhs: Indentation) -> Bool {
             switch (lhs, rhs) {
             case (.tabs, .tabs): return true
-            case (.spaces(let lhs), .spaces(let rhs)): return lhs == rhs
+            case let (.spaces(lhs), .spaces(rhs)): return lhs == rhs
             case (_, _): return false
             }
         }

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -91,42 +91,12 @@ public struct Configuration: Hashable {
 
         let handleAliasWithRuleList: (String) -> String = { ruleList.identifier(for: $0) ?? $0 }
 
-        let validRuleIdentifiers = configuredRules.map { type(of: $0).description.identifier }
-
-        let rules: [Rule]
-        switch rulesMode {
-        case .allEnabled:
-            rules = configuredRules
-        case .whitelisted(let whitelistedRuleIdentifiers):
-            let validWhitelistedRuleIdentifiers = validateRuleIdentifiers(
-                ruleIdentifiers: whitelistedRuleIdentifiers.map(handleAliasWithRuleList),
-                validRuleIdentifiers: validRuleIdentifiers)
-            // Validate that rule identifiers aren't listed multiple times
-            if containsDuplicateIdentifiers(validWhitelistedRuleIdentifiers) {
-                return nil
-            }
-            rules = configuredRules.filter { rule in
-                return validWhitelistedRuleIdentifiers.contains(type(of: rule).description.identifier)
-            }
-        case let .default(disabledRuleIdentifiers, optInRuleIdentifiers):
-            let validDisabledRuleIdentifiers = validateRuleIdentifiers(
-                ruleIdentifiers: disabledRuleIdentifiers.map(handleAliasWithRuleList),
-                validRuleIdentifiers: validRuleIdentifiers)
-            let validOptInRuleIdentifiers = validateRuleIdentifiers(
-                ruleIdentifiers: optInRuleIdentifiers.map(handleAliasWithRuleList),
-                validRuleIdentifiers: validRuleIdentifiers)
-            // Same here
-            if containsDuplicateIdentifiers(validDisabledRuleIdentifiers)
-                || containsDuplicateIdentifiers(validOptInRuleIdentifiers) {
-
-                return nil
-            }
-            rules = configuredRules.filter { rule in
-                let id = type(of: rule).description.identifier
-                if validDisabledRuleIdentifiers.contains(id) { return false }
-                return validOptInRuleIdentifiers.contains(id) || !(rule is OptInRule)
-            }
+        guard let rules = enabledRules(from: configuredRules,
+                                       with: rulesMode,
+                                       aliasResolver: handleAliasWithRuleList) else {
+            return nil
         }
+
         self.init(rulesMode: rulesMode,
                   included: included,
                   excluded: excluded,
@@ -265,6 +235,46 @@ private func containsDuplicateIdentifiers(_ identifiers: [String]) -> Bool {
         "configuration error: '\(rule.0)' is listed \(rule.1) times"
     }.joined(separator: "\n"))
     return true
+}
+
+private func enabledRules(from configuredRules: [Rule],
+                          with mode: Configuration.RulesMode,
+                          aliasResolver: (String) -> String) -> [Rule]? {
+    let validRuleIdentifiers = configuredRules.map { type(of: $0).description.identifier }
+
+    switch mode {
+    case .allEnabled:
+        return configuredRules
+    case .whitelisted(let whitelistedRuleIdentifiers):
+        let validWhitelistedRuleIdentifiers = validateRuleIdentifiers(
+            ruleIdentifiers: whitelistedRuleIdentifiers.map(aliasResolver),
+            validRuleIdentifiers: validRuleIdentifiers)
+        // Validate that rule identifiers aren't listed multiple times
+        if containsDuplicateIdentifiers(validWhitelistedRuleIdentifiers) {
+            return nil
+        }
+        return configuredRules.filter { rule in
+            return validWhitelistedRuleIdentifiers.contains(type(of: rule).description.identifier)
+        }
+    case let .default(disabledRuleIdentifiers, optInRuleIdentifiers):
+        let validDisabledRuleIdentifiers = validateRuleIdentifiers(
+            ruleIdentifiers: disabledRuleIdentifiers.map(aliasResolver),
+            validRuleIdentifiers: validRuleIdentifiers)
+        let validOptInRuleIdentifiers = validateRuleIdentifiers(
+            ruleIdentifiers: optInRuleIdentifiers.map(aliasResolver),
+            validRuleIdentifiers: validRuleIdentifiers)
+        // Same here
+        if containsDuplicateIdentifiers(validDisabledRuleIdentifiers)
+            || containsDuplicateIdentifiers(validOptInRuleIdentifiers) {
+
+            return nil
+        }
+        return configuredRules.filter { rule in
+            let id = type(of: rule).description.identifier
+            if validDisabledRuleIdentifiers.contains(id) { return false }
+            return validOptInRuleIdentifiers.contains(id) || !(rule is OptInRule)
+        }
+    }
 }
 
 private extension String {

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -17,6 +17,17 @@ struct AutoCorrectCommand: CommandProtocol {
     func run(_ options: AutoCorrectOptions) -> Result<(), CommandantError<()>> {
         let configuration = Configuration(options: options)
         let cache = options.ignoreCache ? nil : LinterCache(configuration: configuration)
+        let indentWidth: Int
+        let useTabs: Bool
+
+        switch configuration.indentationMode {
+        case .tabs:
+            indentWidth = 4
+            useTabs = true
+        case .spaces(let count):
+            indentWidth = count
+            useTabs = false
+        }
 
         return configuration.visitLintableFiles(path: options.path, action: "Correcting",
                                                 quiet: options.quiet,
@@ -29,7 +40,8 @@ struct AutoCorrectCommand: CommandProtocol {
             }
             if options.format {
                 let formattedContents = linter.file.format(trimmingTrailingWhitespace: true,
-                                                           useTabs: options.useTabs, indentWidth: 4)
+                                                           useTabs: useTabs,
+                                                           indentWidth: indentWidth)
                 _ = try? formattedContents
                     .write(toFile: linter.file.path!, atomically: true, encoding: .utf8)
             }

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -29,8 +29,7 @@ struct AutoCorrectCommand: CommandProtocol {
             }
             if options.format {
                 let formattedContents = linter.file.format(trimmingTrailingWhitespace: true,
-                                                           useTabs: options.useTabs,
-                                                           indentWidth: options.indentWidth)
+                                                           useTabs: options.useTabs, indentWidth: 4)
                 _ = try? formattedContents
                     .write(toFile: linter.file.path!, atomically: true, encoding: .utf8)
             }
@@ -52,13 +51,12 @@ struct AutoCorrectOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let useTabs: Bool
-    let indentWidth: Int
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> (_ indentWidth: Int) -> AutoCorrectOptions {
-        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in { indentWidth in
-            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs, indentWidth: indentWidth)
-            }}}}}}}}
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
+        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in
+            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
+        }}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
@@ -78,8 +76,5 @@ struct AutoCorrectOptions: OptionsProtocol {
             <*> mode <| Option(key: "use-tabs",
                                defaultValue: false,
                                usage: "should use tabs over spaces when reformatting")
-            <*> mode <| Option(key: "indent-width",
-                               defaultValue: 4,
-                               usage: "the width to indent lines when reformatting")
     }
 }

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -20,7 +20,7 @@ struct AutoCorrectCommand: CommandProtocol {
         let indentWidth: Int
         let useTabs: Bool
 
-        switch configuration.indentationMode {
+        switch configuration.indentation {
         case .tabs:
             indentWidth = 4
             useTabs = true

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -29,7 +29,8 @@ struct AutoCorrectCommand: CommandProtocol {
             }
             if options.format {
                 let formattedContents = linter.file.format(trimmingTrailingWhitespace: true,
-                                                           useTabs: options.useTabs, indentWidth: 4)
+                                                           useTabs: options.useTabs,
+                                                           indentWidth: options.indentWidth)
                 _ = try? formattedContents
                     .write(toFile: linter.file.path!, atomically: true, encoding: .utf8)
             }
@@ -51,12 +52,13 @@ struct AutoCorrectOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let useTabs: Bool
+    let indentWidth: Int
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
-        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in
-            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
-        }}}}}}}
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> (_ indentWidth: Int) -> AutoCorrectOptions {
+        return { configurationFile in { useScriptInputFiles in { quiet in { format in { cachePath in { ignoreCache in { useTabs in { indentWidth in
+            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs, indentWidth: indentWidth)
+            }}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
@@ -76,5 +78,8 @@ struct AutoCorrectOptions: OptionsProtocol {
             <*> mode <| Option(key: "use-tabs",
                                defaultValue: false,
                                usage: "should use tabs over spaces when reformatting")
+            <*> mode <| Option(key: "indent-width",
+                               defaultValue: 4,
+                               usage: "the width to indent lines when reformatting")
     }
 }

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -18,7 +18,7 @@ struct AutoCorrectCommand: CommandProtocol {
         let configuration = Configuration(options: options)
         let cache = options.ignoreCache ? nil : LinterCache(configuration: configuration)
         let indentWidth: Int
-        let useTabs: Bool
+        var useTabs: Bool
 
         switch configuration.indentation {
         case .tabs:
@@ -27,6 +27,12 @@ struct AutoCorrectCommand: CommandProtocol {
         case .spaces(let count):
             indentWidth = count
             useTabs = false
+        }
+
+        if options.useTabs {
+            queuedPrintError("'use-tabs' is deprecated and will be completely removed" +
+                " in a future release. 'indentation' can now be defined in a configuration file.")
+            useTabs = options.useTabs
         }
 
         return configuration.visitLintableFiles(path: options.path, action: "Correcting",
@@ -87,6 +93,6 @@ struct AutoCorrectOptions: OptionsProtocol {
                                usage: "ignore cache when correcting")
             <*> mode <| Option(key: "use-tabs",
                                defaultValue: false,
-                               usage: "should use tabs over spaces when reformatting")
+                               usage: "should use tabs over spaces when reformatting. Deprecated.")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -212,6 +212,23 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.configuration(for: file), configuration)
     }
 
+    // MARK: - Testing custom indentation
+
+    func testIndentationTabs() {
+        let configuration = Configuration(dict: ["indentation": "tabs"])!
+        XCTAssertEqual(configuration.indentation, .tabs)
+    }
+
+    func testIndentationSpaces() {
+        let configuration = Configuration(dict: ["indentation": 2])!
+        XCTAssertEqual(configuration.indentation, .spaces(count: 2))
+    }
+
+    func testIndentationFallback() {
+        let configuration = Configuration(dict: ["indentation": "invalid"])!
+        XCTAssertEqual(configuration.indentation, .spaces(count: 4))
+    }
+
     // MARK: - Testing Rules from config dictionary
 
     let testRuleList = RuleList(rules: RuleWithLevelsMock.self)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -40,6 +40,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.disabledRules, [])
         XCTAssertEqual(config.included, [])
         XCTAssertEqual(config.excluded, [])
+        XCTAssertEqual(config.indentation, .spaces(count: 4))
         XCTAssertEqual(config.reporter, "xcode")
         XCTAssertEqual(reporterFrom(identifier: config.reporter).identifier, "xcode")
     }
@@ -56,6 +57,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.disabledRules, expectedConfig.disabledRules)
         XCTAssertEqual(config.included, expectedConfig.included)
         XCTAssertEqual(config.excluded, expectedConfig.excluded)
+        XCTAssertEqual(config.indentation, expectedConfig.indentation)
         XCTAssertEqual(config.reporter, expectedConfig.reporter)
 
         FileManager.default.changeCurrentDirectoryPath(previousWorkingDir)


### PR DESCRIPTION
This allows for more configurable formatting, using:

```
$ swiftlint autocorrect --format --indent-width 2
```