### PR TITLE
 Add `build` to `.PHONY` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SWIFTLINTFRAMEWORK_PLIST=Source/SwiftLintFramework/Supporting Files/Info.plist
 
 VERSION_STRING=$(shell /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$(SWIFTLINT_PLIST)")
 
-.PHONY: all bootstrap clean install package test uninstall
+.PHONY: all bootstrap clean build install package test uninstall
 
 all: build
 


### PR DESCRIPTION
This will make `make` not to be misled by the existence of `build` directory.