### PR TITLE
Adds opt-in rule discouraged_optional_collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,6 @@
 
 #### Enhancements
 
-* Adds `discouraged_optional_collection` opt-in rule to encourages the return
 * Adds `discouraged_optional_collection` opt-in rule to encourage the use
   of empty collections instead of optional collections.  
   [Ornithologist Coder](https://github.com/ornithocoder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,10 @@
 
 #### Enhancements
 
-* None.
+* Adds `discouraged_optional_collection` opt-in rule to encourages the return
+  of empty collections instead of optional collections.  
+  [Ornithologist Coder](https://github.com/ornithocoder)
+  [#1885](https://github.com/realm/SwiftLint/issues/1885)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 #### Enhancements
 
 * Adds `discouraged_optional_collection` opt-in rule to encourages the return
+* Adds `discouraged_optional_collection` opt-in rule to encourage the use
   of empty collections instead of optional collections.  
   [Ornithologist Coder](https://github.com/ornithocoder)
   [#1885](https://github.com/realm/SwiftLint/issues/1885)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@
 * Add `empty_string` opt-in rule to validate against comparing strings to `""`
   instead of using `.isEmpty`.  
   [Davide Sibilio](https://github.com/idevid)
-  
+
 * Add `untyped_error_in_catch` opt-in rule to warn against declaring errors
   without an explicit type in catch statements instead of using the implicit
   `error` variable.  
   [Daniel Metzing](https://github.com/dirtydanee)
   [#2045](https://github.com/realm/SwiftLint/issues/2045)
-  
+
 * Add `all` keyword for use in disable / enable statement:
   `// swiftlint:disable all`.
   It allows disabling SwiftLint entirely, in-code, for a particular section.  
@@ -32,6 +32,11 @@
   they are explicitly specified with `--path`.  
   [Ash Furrow](https://github.com/ashfurrow)
   [#2051](https://github.com/realm/SwiftLint/issues/2051)
+
+* Adds `discouraged_optional_collection` opt-in rule to encourage the use of
+  empty collections instead of optional collections.  
+  [Ornithologist Coder](https://github.com/ornithocoder)
+  [#1885](https://github.com/realm/SwiftLint/issues/1885)
 
 #### Bug Fixes
 
@@ -132,10 +137,7 @@
 
 #### Enhancements
 
-* Adds `discouraged_optional_collection` opt-in rule to encourage the use
-  of empty collections instead of optional collections.  
-  [Ornithologist Coder](https://github.com/ornithocoder)
-  [#1885](https://github.com/realm/SwiftLint/issues/1885)
+* None.
 
 #### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -2805,19 +2805,43 @@ Prefer empty collection over optional collection.
 <summary>Non Triggering Examples</summary>
 
 ```swift
-var foo: [Int] = []
+var foo: [Int]
 ```
 
 ```swift
-var foo: [String: Int] = [:]
+var foo: [String: Int]
 ```
 
 ```swift
-var foo: Set<String> = []
+var foo: Set<String>
 ```
 
 ```swift
-func foo() -> [] {}
+var foo: [String: [String: Int]]
+```
+
+```swift
+let foo: [Int] = []
+```
+
+```swift
+let foo: [String: Int] = [:]
+```
+
+```swift
+let foo: Set<String> = []
+```
+
+```swift
+let foo: [String: [String: Int]] = [:]
+```
+
+```swift
+var foo: [Int] { return [] }
+```
+
+```swift
+func foo() -> [Int] {}
 ```
 
 ```swift
@@ -2825,15 +2849,127 @@ func foo() -> [String: String] {}
 ```
 
 ```swift
+func foo() -> Set<Int> {}
+```
+
+```swift
+func foo(input: [String] = []) {}
+```
+
+```swift
 func foo(input: [String: String] = [:]) {}
 ```
 
 ```swift
-var foo: [String: [String: Int]] = [:]
+func foo(input: Set<String> = []) {}
 ```
 
 ```swift
-let foo = self[bar]?.toto
+class Foo {
+	func foo() -> [Int] {}
+}
+```
+
+```swift
+class Foo {
+	func foo() -> [String: String] {}
+}
+```
+
+```swift
+class Foo {
+	func foo() -> Set<Int> {}
+}
+```
+
+```swift
+struct Foo {
+	func foo() -> [Int] {}
+}
+```
+
+```swift
+struct Foo {
+	func foo() -> [String: String] {}
+}
+```
+
+```swift
+struct Foo {
+	func foo() -> Set<Int> {}
+}
+```
+
+```swift
+enum Foo {
+	func foo() -> [Int] {}
+}
+```
+
+```swift
+enum Foo {
+	func foo() -> [String: String] {}
+}
+```
+
+```swift
+enum Foo {
+	func foo() -> Set<Int> {}
+}
+```
+
+```swift
+class Foo {
+	func foo(input: [String] = []) {}
+}
+```
+
+```swift
+class Foo {
+	func foo(input: [String: String] = [:]) {}
+}
+```
+
+```swift
+class Foo {
+	func foo(input: Set<String> = []) {}
+}
+```
+
+```swift
+struct Foo {
+	func foo(input: [String] = []) {}
+}
+```
+
+```swift
+struct Foo {
+	func foo(input: [String: String] = [:]) {}
+}
+```
+
+```swift
+struct Foo {
+	func foo(input: Set<String> = []) {}
+}
+```
+
+```swift
+enum Foo {
+	func foo(input: [String] = []) {}
+}
+```
+
+```swift
+enum Foo {
+	func foo(input: [String: String] = [:]) {}
+}
+```
+
+```swift
+enum Foo {
+	func foo(input: Set<String> = []) {}
+}
 ```
 
 </details>
@@ -2853,6 +2989,26 @@ let foo = self[bar]?.toto
 ```
 
 ```swift
+↓let foo: [Int]? = nil
+```
+
+```swift
+↓let foo: [String: Int]? = nil
+```
+
+```swift
+↓let foo: Set<String>? = nil
+```
+
+```swift
+↓var foo: [Int]? { return nil }
+```
+
+```swift
+↓let foo: [Int]? { return nil }()
+```
+
+```swift
 func ↓foo() -> [T]? {}
 ```
 
@@ -2866,6 +3022,30 @@ func ↓foo() -> [String: [String: String]]? {}
 
 ```swift
 func ↓foo() -> [String: [String: String]?] {}
+```
+
+```swift
+func ↓foo() -> Set<Int>? {}
+```
+
+```swift
+static func ↓foo() -> [T]? {}
+```
+
+```swift
+static func ↓foo() -> [String: String]? {}
+```
+
+```swift
+static func ↓foo() -> [String: [String: String]]? {}
+```
+
+```swift
+static func ↓foo() -> [String: [String: String]?] {}
+```
+
+```swift
+static func ↓foo() -> Set<Int>? {}
 ```
 
 ```swift
@@ -2889,19 +3069,571 @@ func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
 ```
 
 ```swift
-var foo: Set<String>
-↓var bar: Set<String>?
+func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]
 ```
 
 ```swift
-var foo: [String: String] = [:]
-↓var bar: [String: Int]? = nil
+static func foo(↓input: [String: String]?) {}
 ```
 
 ```swift
-func foo(↓input: [
-                  String: String
-                 ]?) {}
+static func foo(↓input: [String: [String: String]]?) {}
+```
+
+```swift
+static func foo(↓input: [String: [String: String]?]) {}
+```
+
+```swift
+static func foo(↓↓input: [String: [String: String]?]?) {}
+```
+
+```swift
+static func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
+```
+
+```swift
+static func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]
+```
+
+```swift
+class Foo {
+	↓var foo: [Int]?
+}
+```
+
+```swift
+class Foo {
+	↓var foo: [String: Int]?
+}
+```
+
+```swift
+class Foo {
+	↓var foo: Set<String>?
+}
+```
+
+```swift
+class Foo {
+	↓let foo: [Int]? = nil
+}
+```
+
+```swift
+class Foo {
+	↓let foo: [String: Int]? = nil
+}
+```
+
+```swift
+class Foo {
+	↓let foo: Set<String>? = nil
+}
+```
+
+```swift
+struct Foo {
+	↓var foo: [Int]?
+}
+```
+
+```swift
+struct Foo {
+	↓var foo: [String: Int]?
+}
+```
+
+```swift
+struct Foo {
+	↓var foo: Set<String>?
+}
+```
+
+```swift
+struct Foo {
+	↓let foo: [Int]? = nil
+}
+```
+
+```swift
+struct Foo {
+	↓let foo: [String: Int]? = nil
+}
+```
+
+```swift
+struct Foo {
+	↓let foo: Set<String>? = nil
+}
+```
+
+```swift
+class Foo {
+	↓var foo: [Int]? { return nil }
+}
+```
+
+```swift
+class Foo {
+	↓let foo: [Int]? { return nil }()
+}
+```
+
+```swift
+class Foo {
+	↓var foo: Set<String>? { return nil }
+}
+```
+
+```swift
+class Foo {
+	↓let foo: Set<String>? { return nil }()
+}
+```
+
+```swift
+struct Foo {
+	↓var foo: [Int]? { return nil }
+}
+```
+
+```swift
+struct Foo {
+	↓let foo: [Int]? { return nil }()
+}
+```
+
+```swift
+struct Foo {
+	↓var foo: Set<String>? { return nil }
+}
+```
+
+```swift
+struct Foo {
+	↓let foo: Set<String>? { return nil }()
+}
+```
+
+```swift
+enum Foo {
+	↓var foo: [Int]? { return nil }
+}
+```
+
+```swift
+enum Foo {
+	↓let foo: [Int]? { return nil }()
+}
+```
+
+```swift
+enum Foo {
+	↓var foo: Set<String>? { return nil }
+}
+```
+
+```swift
+enum Foo {
+	↓let foo: Set<String>? { return nil }()
+}
+```
+
+```swift
+class Foo {
+	func ↓foo() -> [T]? {}
+}
+```
+
+```swift
+class Foo {
+	func ↓foo() -> [String: String]? {}
+}
+```
+
+```swift
+class Foo {
+	func ↓foo() -> [String: [String: String]]? {}
+}
+```
+
+```swift
+class Foo {
+	func ↓foo() -> [String: [String: String]?] {}
+}
+```
+
+```swift
+class Foo {
+	func ↓foo() -> Set<Int>? {}
+}
+```
+
+```swift
+class Foo {
+	static func ↓foo() -> [T]? {}
+}
+```
+
+```swift
+class Foo {
+	static func ↓foo() -> [String: String]? {}
+}
+```
+
+```swift
+class Foo {
+	static func ↓foo() -> [String: [String: String]]? {}
+}
+```
+
+```swift
+class Foo {
+	static func ↓foo() -> [String: [String: String]?] {}
+}
+```
+
+```swift
+class Foo {
+	static func ↓foo() -> Set<Int>? {}
+}
+```
+
+```swift
+struct Foo {
+	func ↓foo() -> [T]? {}
+}
+```
+
+```swift
+struct Foo {
+	func ↓foo() -> [String: String]? {}
+}
+```
+
+```swift
+struct Foo {
+	func ↓foo() -> [String: [String: String]]? {}
+}
+```
+
+```swift
+struct Foo {
+	func ↓foo() -> [String: [String: String]?] {}
+}
+```
+
+```swift
+struct Foo {
+	func ↓foo() -> Set<Int>? {}
+}
+```
+
+```swift
+struct Foo {
+	static func ↓foo() -> [T]? {}
+}
+```
+
+```swift
+struct Foo {
+	static func ↓foo() -> [String: String]? {}
+}
+```
+
+```swift
+struct Foo {
+	static func ↓foo() -> [String: [String: String]]? {}
+}
+```
+
+```swift
+struct Foo {
+	static func ↓foo() -> [String: [String: String]?] {}
+}
+```
+
+```swift
+struct Foo {
+	static func ↓foo() -> Set<Int>? {}
+}
+```
+
+```swift
+enum Foo {
+	func ↓foo() -> [T]? {}
+}
+```
+
+```swift
+enum Foo {
+	func ↓foo() -> [String: String]? {}
+}
+```
+
+```swift
+enum Foo {
+	func ↓foo() -> [String: [String: String]]? {}
+}
+```
+
+```swift
+enum Foo {
+	func ↓foo() -> [String: [String: String]?] {}
+}
+```
+
+```swift
+enum Foo {
+	func ↓foo() -> Set<Int>? {}
+}
+```
+
+```swift
+enum Foo {
+	static func ↓foo() -> [T]? {}
+}
+```
+
+```swift
+enum Foo {
+	static func ↓foo() -> [String: String]? {}
+}
+```
+
+```swift
+enum Foo {
+	static func ↓foo() -> [String: [String: String]]? {}
+}
+```
+
+```swift
+enum Foo {
+	static func ↓foo() -> [String: [String: String]?] {}
+}
+```
+
+```swift
+enum Foo {
+	static func ↓foo() -> Set<Int>? {}
+}
+```
+
+```swift
+class Foo {
+	func foo(↓input: [String: String]?) {}
+}
+```
+
+```swift
+class Foo {
+	func foo(↓input: [String: [String: String]]?) {}
+}
+```
+
+```swift
+class Foo {
+	func foo(↓input: [String: [String: String]?]) {}
+}
+```
+
+```swift
+class Foo {
+	func foo(↓↓input: [String: [String: String]?]?) {}
+}
+```
+
+```swift
+class Foo {
+	func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+class Foo {
+	func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+class Foo {
+	static func foo(↓input: [String: String]?) {}
+}
+```
+
+```swift
+class Foo {
+	static func foo(↓input: [String: [String: String]]?) {}
+}
+```
+
+```swift
+class Foo {
+	static func foo(↓input: [String: [String: String]?]) {}
+}
+```
+
+```swift
+class Foo {
+	static func foo(↓↓input: [String: [String: String]?]?) {}
+}
+```
+
+```swift
+class Foo {
+	static func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+class Foo {
+	static func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+struct Foo {
+	func foo(↓input: [String: String]?) {}
+}
+```
+
+```swift
+struct Foo {
+	func foo(↓input: [String: [String: String]]?) {}
+}
+```
+
+```swift
+struct Foo {
+	func foo(↓input: [String: [String: String]?]) {}
+}
+```
+
+```swift
+struct Foo {
+	func foo(↓↓input: [String: [String: String]?]?) {}
+}
+```
+
+```swift
+struct Foo {
+	func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+struct Foo {
+	func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+struct Foo {
+	static func foo(↓input: [String: String]?) {}
+}
+```
+
+```swift
+struct Foo {
+	static func foo(↓input: [String: [String: String]]?) {}
+}
+```
+
+```swift
+struct Foo {
+	static func foo(↓input: [String: [String: String]?]) {}
+}
+```
+
+```swift
+struct Foo {
+	static func foo(↓↓input: [String: [String: String]?]?) {}
+}
+```
+
+```swift
+struct Foo {
+	static func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+struct Foo {
+	static func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+enum Foo {
+	func foo(↓input: [String: String]?) {}
+}
+```
+
+```swift
+enum Foo {
+	func foo(↓input: [String: [String: String]]?) {}
+}
+```
+
+```swift
+enum Foo {
+	func foo(↓input: [String: [String: String]?]) {}
+}
+```
+
+```swift
+enum Foo {
+	func foo(↓↓input: [String: [String: String]?]?) {}
+}
+```
+
+```swift
+enum Foo {
+	func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+enum Foo {
+	func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+enum Foo {
+	static func foo(↓input: [String: String]?) {}
+}
+```
+
+```swift
+enum Foo {
+	static func foo(↓input: [String: [String: String]]?) {}
+}
+```
+
+```swift
+enum Foo {
+	static func foo(↓input: [String: [String: String]?]) {}
+}
+```
+
+```swift
+enum Foo {
+	static func foo(↓↓input: [String: [String: String]?]?) {}
+}
+```
+
+```swift
+enum Foo {
+	static func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
+}
+```
+
+```swift
+enum Foo {
+	static func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]
+}
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -2853,6 +2853,10 @@ func foo() -> Set<Int> {}
 ```
 
 ```swift
+func foo() -> ([Int]) -> String {}
+```
+
+```swift
 func foo(input: [String] = []) {}
 ```
 
@@ -2883,6 +2887,12 @@ class Foo {
 ```
 
 ```swift
+class Foo {
+	func foo() -> ([Int]) -> String {}
+}
+```
+
+```swift
 struct Foo {
 	func foo() -> [Int] {}
 }
@@ -2901,6 +2911,12 @@ struct Foo {
 ```
 
 ```swift
+struct Foo {
+	func foo() -> ([Int]) -> String {}
+}
+```
+
+```swift
 enum Foo {
 	func foo() -> [Int] {}
 }
@@ -2915,6 +2931,12 @@ enum Foo {
 ```swift
 enum Foo {
 	func foo() -> Set<Int> {}
+}
+```
+
+```swift
+enum Foo {
+	func foo() -> ([Int]) -> String {}
 }
 ```
 
@@ -3046,6 +3068,14 @@ static func ↓foo() -> [String: [String: String]?] {}
 
 ```swift
 static func ↓foo() -> Set<Int>? {}
+```
+
+```swift
+func ↓foo() -> ([Int]?) -> String {}
+```
+
+```swift
+func ↓foo() -> ([Int]) -> [String]? {}
 ```
 
 ```swift
@@ -3301,6 +3331,18 @@ class Foo {
 ```
 
 ```swift
+class Foo {
+	func ↓foo() -> ([Int]?) -> String {}
+}
+```
+
+```swift
+class Foo {
+	func ↓foo() -> ([Int]) -> [String]? {}
+}
+```
+
+```swift
 struct Foo {
 	func ↓foo() -> [T]? {}
 }
@@ -3361,6 +3403,18 @@ struct Foo {
 ```
 
 ```swift
+struct Foo {
+	func ↓foo() -> ([Int]?) -> String {}
+}
+```
+
+```swift
+struct Foo {
+	func ↓foo() -> ([Int]) -> [String]? {}
+}
+```
+
+```swift
 enum Foo {
 	func ↓foo() -> [T]? {}
 }
@@ -3417,6 +3471,18 @@ enum Foo {
 ```swift
 enum Foo {
 	static func ↓foo() -> Set<Int>? {}
+}
+```
+
+```swift
+enum Foo {
+	func ↓foo() -> ([Int]?) -> String {}
+}
+```
+
+```swift
+enum Foo {
+	func ↓foo() -> ([Int]) -> [String]? {}
 }
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -2866,6 +2866,11 @@ func foo(input: ↓[
                  ]?) {}
 ```
 
+```swift
+var: [String: String] = [:]
+var foo: ↓[String: Int]?
+```
+
 </details>
 
 

--- a/Rules.md
+++ b/Rules.md
@@ -2832,48 +2832,76 @@ func foo(input: [String: String] = [:]) {}
 var foo: [String: [String: Int]] = [:]
 ```
 
+```swift
+let foo = self[bar]?.toto
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
 
 ```swift
-var foo: ↓[Int]?
+↓var foo: [Int]?
 ```
 
 ```swift
-var foo: ↓[String: Int]?
+↓var foo: [String: Int]?
 ```
 
 ```swift
-var foo: ↓Set<String>?
+↓var foo: Set<String>?
 ```
 
 ```swift
-func foo() -> ↓[]? {}
+func ↓foo() -> [T]? {}
 ```
 
 ```swift
-func foo() -> ↓[String: String]? {}
+func ↓foo() -> [String: String]? {}
 ```
 
 ```swift
-func foo(input: ↓[String: String]?) {}
+func ↓foo() -> [String: [String: String]]? {}
 ```
 
 ```swift
-func foo(input: ↓[
-                  String: String
-                 ]?) {}
+func ↓foo() -> [String: [String: String]?] {}
+```
+
+```swift
+func foo(↓input: [String: String]?) {}
+```
+
+```swift
+func foo(↓input: [String: [String: String]]?) {}
+```
+
+```swift
+func foo(↓input: [String: [String: String]?]) {}
+```
+
+```swift
+func foo(↓↓input: [String: [String: String]?]?) {}
+```
+
+```swift
+func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]
 ```
 
 ```swift
 var foo: Set<String>
-var bar: ↓Set<String>?
+↓var bar: Set<String>?
 ```
 
 ```swift
 var foo: [String: String] = [:]
-var bar: ↓[String: Int]?
+↓var bar: [String: Int]? = nil
+```
+
+```swift
+func foo(↓input: [
+                  String: String
+                 ]?) {}
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -2867,8 +2867,13 @@ func foo(input: ↓[
 ```
 
 ```swift
-var: [String: String] = [:]
-var foo: ↓[String: Int]?
+var foo: Set<String>
+var bar: ↓Set<String>?
+```
+
+```swift
+var foo: [String: String] = [:]
+var bar: ↓[String: Int]?
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -21,6 +21,7 @@
 * [Discouraged Direct Initialization](#discouraged-direct-initialization)
 * [Discouraged Object Literal](#discouraged-object-literal)
 * [Discouraged Optional Boolean](#discouraged-optional-boolean)
+* [Discouraged Optional Collection](#discouraged-optional-collection)
 * [Dynamic Inline](#dynamic-inline)
 * [Empty Count](#empty-count)
 * [Empty Enum Arguments](#empty-enum-arguments)
@@ -2784,6 +2785,85 @@ enum Foo {
 enum Foo {
 	static func foo(input: [↓Bool?]) {}
 }
+```
+
+</details>
+
+
+
+## Discouraged Optional Collection
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`discouraged_optional_collection` | Disabled | No | idiomatic
+
+Prefer empty collection over optional collection.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+var foo: [Int] = []
+```
+
+```swift
+var foo: [String: Int] = [:]
+```
+
+```swift
+var foo: Set<String> = []
+```
+
+```swift
+func foo() -> [] {}
+```
+
+```swift
+func foo() -> [String: String] {}
+```
+
+```swift
+func foo(input: [String: String] = [:]) {}
+```
+
+```swift
+var foo: [String: [String: Int]] = [:]
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+var foo: ↓[Int]?
+```
+
+```swift
+var foo: ↓[String: Int]?
+```
+
+```swift
+var foo: ↓Set<String>?
+```
+
+```swift
+func foo() -> ↓[]? {}
+```
+
+```swift
+func foo() -> ↓[String: String]? {}
+```
+
+```swift
+func foo(input: ↓[String: String]?) {}
+```
+
+```swift
+func foo(input: ↓[
+                  String: String
+                 ]?) {}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -29,6 +29,7 @@ public let masterRuleList = RuleList(rules: [
     DiscouragedDirectInitRule.self,
     DiscouragedObjectLiteralRule.self,
     DiscouragedOptionalBooleanRule.self,
+    DiscouragedOptionalCollectionRule.self,
     DynamicInlineRule.self,
     EmptyCountRule.self,
     EmptyEnumArgumentsRule.self,

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -82,7 +82,7 @@ private extension String {
     ///                                    ^              ^
     /// = [[9, 14]]
     ///
-    /// Example: [String: [Int]?]
+    /// Example: [String: [Int]?]?
     ///
     ///         [  S  t  r  i  n  g  :     [  I  n  t  ]  ?  ]  ?
     ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -19,43 +19,8 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
         name: "Discouraged Optional Collection",
         description: "Prefer empty collection over optional collection.",
         kind: .idiomatic,
-        nonTriggeringExamples: [
-            "var foo: [Int] = []",
-            "var foo: [String: Int] = [:]",
-            "var foo: Set<String> = []",
-            "func foo() -> [] {}",
-            "func foo() -> [String: String] {}",
-            "func foo(input: [String: String] = [:]) {}",
-            "var foo: [String: [String: Int]] = [:]",
-            "let foo = self[bar]?.toto"
-        ],
-        triggeringExamples: [
-            "↓var foo: [Int]?",
-            "↓var foo: [String: Int]?",
-            "↓var foo: Set<String>?",
-            "func ↓foo() -> [T]? {}",
-            "func ↓foo() -> [String: String]? {}",
-            "func ↓foo() -> [String: [String: String]]? {}",
-            "func ↓foo() -> [String: [String: String]?] {}",
-            "func foo(↓input: [String: String]?) {}",
-            "func foo(↓input: [String: [String: String]]?) {}",
-            "func foo(↓input: [String: [String: String]?]) {}",
-            "func foo(↓↓input: [String: [String: String]?]?) {}",
-            "func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]",
-            """
-            var foo: Set<String>
-            ↓var bar: Set<String>?
-            """,
-            """
-            var foo: [String: String] = [:]
-            ↓var bar: [String: Int]? = nil
-            """,
-            """
-            func foo(↓input: [
-                              String: String
-                             ]?) {}
-            """
-        ]
+        nonTriggeringExamples: DiscouragedOptionalCollectionExamples.nonTriggeringExamples,
+        triggeringExamples: DiscouragedOptionalCollectionExamples.triggeringExamples
     )
 
     public func validate(file: File,
@@ -108,7 +73,7 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
     private let excludingKinds = SyntaxKind.allKinds.subtracting([.typeidentifier])
 }
 
-extension String {
+private extension String {
     /// Ranges of optional collections within the bounds of the string.
     ///
     /// - Returns: An array of ranges.

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -26,15 +26,9 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        var offsets: [Int] = []
 
-        if SwiftDeclarationKind.variableKinds.contains(kind) {
-            offsets.append(contentsOf: variableViolations(file: file, dictionary: dictionary))
-        }
-
-        if SwiftDeclarationKind.functionKinds.contains(kind) {
-            offsets.append(contentsOf: functionViolations(file: file, dictionary: dictionary))
-        }
+        let offsets = variableViolations(file: file, kind: kind, dictionary: dictionary) +
+            functionViolations(file: file, kind: kind, dictionary: dictionary)
 
         return offsets.map {
             StyleViolation(ruleDescription: type(of: self).description,
@@ -45,16 +39,22 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
 
     // MARK: - Private
 
-    private func variableViolations(file: File, dictionary: [String: SourceKitRepresentable]) -> [Int] {
+    private func variableViolations(file: File,
+                                    kind: SwiftDeclarationKind,
+                                    dictionary: [String: SourceKitRepresentable]) -> [Int] {
         guard
+            SwiftDeclarationKind.variableKinds.contains(kind),
             let offset = dictionary.offset,
             let typeName = dictionary.typeName else { return [] }
 
         return typeName.optionalCollectionRanges().map { _ in offset }
     }
 
-    private func functionViolations(file: File, dictionary: [String: SourceKitRepresentable]) -> [Int] {
+    private func functionViolations(file: File,
+                                    kind: SwiftDeclarationKind,
+                                    dictionary: [String: SourceKitRepresentable]) -> [Int] {
         guard
+            SwiftDeclarationKind.functionKinds.contains(kind),
             let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength,
             let length = dictionary.length,

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -1,0 +1,65 @@
+//
+//  DiscouragedOptinalCollection.swift
+//  SwiftLint
+//
+//  Created by Ornithologist Coder on 1/10/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct DiscouragedOptionalCollectionRule: OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "discouraged_optional_collection",
+        name: "Discouraged Optional Collection",
+        description: "Prefer empty collection over optional collection.",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            "var foo: [Int] = []",
+            "var foo: [String: Int] = [:]",
+            "var foo: Set<String> = []",
+            "func foo() -> [] {}",
+            "func foo() -> [String: String] {}",
+            "func foo(input: [String: String] = [:]) {}",
+            "var foo: [String: [String: Int]] = [:]"
+        ],
+        triggeringExamples: [
+            "var foo: ↓[Int]?",
+            "var foo: ↓[String: Int]?",
+            "var foo: ↓Set<String>?",
+            "func foo() -> ↓[]? {}",
+            "func foo() -> ↓[String: String]? {}",
+            "func foo(input: ↓[String: String]?) {}",
+            "func foo(input: ↓[\n" +
+            "                  String: String\n" +
+            "                 ]?) {}"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        let matches = violationMatchesLocations(in: file)
+
+        return matches.map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0))
+        }
+    }
+
+    private func violationMatchesLocations(in file: File) -> [Int] {
+        let bracketPattern = "\\[(.*[^\\]])?\\]\\?"
+        let setPattern = "Set<(.*[^>])?>\\?"
+        let pattern = [bracketPattern, setPattern].joined(separator: "|")
+        let excludingKinds = SyntaxKind.commentAndStringKinds
+
+        return file
+            .match(pattern: pattern)
+            .filter { $1.filter(excludingKinds.contains).isEmpty }
+            .map { $0.0.location }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -38,7 +38,8 @@ public struct DiscouragedOptionalCollectionRule: OptInRule, ConfigurationProvide
             "func foo(input: ↓[\n" +
             "                  String: String\n" +
             "                 ]?) {}",
-            "var: [String: String] = [:]\nvar foo: ↓[String: Int]?"
+            "var foo: Set<String>\nvar bar: ↓Set<String>?",
+            "var foo: [String: String] = [:]\nvar bar: ↓[String: Int]?"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -93,15 +93,15 @@ private extension String {
     ///
     /// Example: var x = Set<Int>?
     ///
-    ///         v  a  r     x  =     S  e  t  <  I  n  t  >  ?
-    ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15
-    ///                              ^                       ^
-    /// = [7, 15]
-    /// = [7, 16), mathematical interval, w/ lower and upper bounds.
+    ///         v  a  r     x     =     S  e  t  <  I  n  t  >  ?
+    ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
+    ///                                 ^                       ^
+    /// = [8, 16]
+    /// = [8, 17), mathematical interval, w/ lower and upper bounds.
     ///
     /// - Returns: An array of ranges.
     func optionalCollectionRanges() -> [Range<String.Index>] {
-        let squareBrackets = balancedRanges(between: "[", and: "]").flatMap { range -> Range<String.Index>? in
+        let squareBrackets = balancedRanges(from: "[", to: "]").flatMap { range -> Range<String.Index>? in
             guard
                 range.upperBound < endIndex,
                 let finalIndex = index(range.upperBound, offsetBy: 1, limitedBy: endIndex),
@@ -110,7 +110,7 @@ private extension String {
             return Range(range.lowerBound..<finalIndex)
         }
 
-        let angleBrackets = balancedRanges(between: "<", and: ">").flatMap { range -> Range<String.Index>? in
+        let angleBrackets = balancedRanges(from: "<", to: ">").flatMap { range -> Range<String.Index>? in
             guard
                 range.upperBound < endIndex,
                 let initialIndex = index(range.lowerBound, offsetBy: -3, limitedBy: startIndex),
@@ -152,7 +152,7 @@ private extension String {
     ///   - prefix: The prefix to look for.
     ///   - suffix: The suffix to look for.
     /// - Returns: Array of ranges of balanced substrings
-    private func balancedRanges(between prefix: Character, and suffix: Character) -> [Range<String.Index>] {
+    private func balancedRanges(from prefix: Character, to suffix: Character) -> [Range<String.Index>] {
         return indices(of: prefix).flatMap { prefixIndex in
             var pairCount = 0
             var currentIndex = prefixIndex

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -80,25 +80,21 @@ private extension String {
         let squareBrackets = balancedRanges(between: "[", and: "]").flatMap { range -> Range<String.Index>? in
             guard
                 range.upperBound < endIndex,
-                let nextIndex = index(range.upperBound, offsetBy: 1, limitedBy: endIndex)
-                else { return nil }
+                let finalIndex = index(range.upperBound, offsetBy: 1, limitedBy: endIndex),
+                self[range.upperBound] == "?" else { return nil }
 
-            let isOptional = self[range.upperBound] == "?"
-
-            return isOptional ? Range(range.lowerBound..<nextIndex) : nil
+            return Range(range.lowerBound..<finalIndex)
         }
 
         let angleBrackets = balancedRanges(between: "<", and: ">").flatMap { range -> Range<String.Index>? in
             guard
                 range.upperBound < endIndex,
                 let initialIndex = index(range.lowerBound, offsetBy: -3, limitedBy: startIndex),
-                let nextIndex = index(range.upperBound, offsetBy: 1, limitedBy: endIndex)
-                else { return nil }
+                let finalIndex = index(range.upperBound, offsetBy: 1, limitedBy: endIndex),
+                self[initialIndex..<range.lowerBound] == "Set",
+                self[range.upperBound] == "?" else { return nil }
 
-            let isSet = self[initialIndex..<range.lowerBound] == "Set"
-            let isOptional = self[range.upperBound] == "?"
-
-            return isSet && isOptional ? Range(initialIndex..<nextIndex) : nil
+            return Range(initialIndex..<finalIndex)
         }
 
         return squareBrackets + angleBrackets

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -37,7 +37,8 @@ public struct DiscouragedOptionalCollectionRule: OptInRule, ConfigurationProvide
             "func foo(input: ↓[String: String]?) {}",
             "func foo(input: ↓[\n" +
             "                  String: String\n" +
-            "                 ]?) {}"
+            "                 ]?) {}",
+            "var: [String: String] = [:]\nvar foo: ↓[String: Int]?"
         ]
     )
 
@@ -52,8 +53,8 @@ public struct DiscouragedOptionalCollectionRule: OptInRule, ConfigurationProvide
     }
 
     private func violationMatchesLocations(in file: File) -> [Int] {
-        let bracketPattern = "\\[(.*[^\\]])?\\]\\?"
-        let setPattern = "Set<(.*[^>])?>\\?"
+        let bracketPattern = "\\[(?:[^\\]\\[])*]\\?"
+        let setPattern = "Set<(?:[^<^>])*>\\?"
         let pattern = [bracketPattern, setPattern].joined(separator: "|")
         let excludingKinds = SyntaxKind.commentAndStringKinds
 

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -75,6 +75,27 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
 private extension String {
     /// Ranges of optional collections within the bounds of the string.
     ///
+    /// Example: [String: [Int]?]
+    ///
+    ///         [  S  t  r  i  n  g  :     [  I  n  t  ]  ?  ]
+    ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15
+    ///                                    ^              ^
+    /// = [[9, 14]]
+    ///
+    /// Example: [String: [Int]?]
+    ///
+    ///         [  S  t  r  i  n  g  :     [  I  n  t  ]  ?  ]  ?
+    ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
+    ///         ^                          ^              ^     ^
+    /// = [[0, 16], [9, 14]]
+    ///
+    /// Example: var x = Set<Int>?
+    ///
+    ///         v  a  r     x  =     S  e  t  <  I  n  t  >  ?
+    ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15
+    ///                              ^                       ^
+    /// = [[7, 15]]
+    ///
     /// - Returns: An array of ranges.
     func optionalCollectionRanges() -> [Range<String.Index>] {
         let squareBrackets = balancedRanges(between: "[", and: "]").flatMap { range -> Range<String.Index>? in
@@ -102,6 +123,12 @@ private extension String {
 
     /// Indices of character within the bounds of the string.
     ///
+    /// Example:
+    ///         a m a n h a
+    ///         0 1 2 3 4 5
+    ///         ^   ^     ^
+    /// = [0, 2, 5]
+    ///
     /// - Parameter character: The character to look for.
     /// - Returns: Array of indices.
     private func indices(of character: Character) -> [String.Index] {
@@ -109,6 +136,13 @@ private extension String {
     }
 
     /// Ranges of balanced substrings.
+    ///
+    /// Example: ((1+2)*(3+4))
+    ///
+    ///         (  (  1  +  2  )  *  (  3  +  4  )  )
+    ///         0  1  2  3  4  5  6  7  8  9  10 11 12
+    ///         ^  ^           ^     ^           ^  ^
+    /// = [[0, 12], [1, 5], [7, 11]]
     ///
     /// - Parameters:
     ///   - prefix: The prefix to look for.

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -79,15 +79,27 @@ private extension String {
     /// - Returns: An array of ranges.
     func optionalCollectionRanges() -> [Range<String.Index>] {
         let squareBrackets = balancedRanges(between: "[", and: "]").flatMap { range -> Range<String.Index>? in
-            guard range.upperBound < endIndex else { return nil }
-            return self[range.upperBound] == "?" ? range : nil
+            guard
+                range.upperBound < endIndex,
+                let nextIndex = index(range.upperBound, offsetBy: 1, limitedBy: endIndex)
+                else { return nil }
+
+            let isOptional = self[range.upperBound] == "?"
+
+            return isOptional ? Range(range.lowerBound..<nextIndex) : nil
         }
 
         let angleBrackets = balancedRanges(between: "<", and: ">").flatMap { range -> Range<String.Index>? in
             guard
+                range.upperBound < endIndex,
                 let initialIndex = index(range.lowerBound, offsetBy: -3, limitedBy: startIndex),
-                range.upperBound < endIndex else { return nil }
-            return self[initialIndex..<range.lowerBound] == "Set" && self[range.upperBound] == "?" ? range : nil
+                let nextIndex = index(range.upperBound, offsetBy: 1, limitedBy: endIndex)
+                else { return nil }
+
+            let isSet = self[initialIndex..<range.lowerBound] == "Set"
+            let isOptional = self[range.upperBound] == "?"
+
+            return isSet && isOptional ? Range(initialIndex..<nextIndex) : nil
         }
 
         return squareBrackets + angleBrackets

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -80,21 +80,24 @@ private extension String {
     ///         [  S  t  r  i  n  g  :     [  I  n  t  ]  ?  ]
     ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15
     ///                                    ^              ^
-    /// = [[9, 14]]
+    /// = [9, 14]
+    /// = [9, 15), mathematical interval, w/ lower and upper bounds.
     ///
     /// Example: [String: [Int]?]?
     ///
     ///         [  S  t  r  i  n  g  :     [  I  n  t  ]  ?  ]  ?
     ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
     ///         ^                          ^              ^     ^
-    /// = [[0, 16], [9, 14]]
+    /// = [0, 16], [9, 14]
+    /// = [0, 17), [9, 15), mathematical interval, w/ lower and upper bounds.
     ///
     /// Example: var x = Set<Int>?
     ///
     ///         v  a  r     x  =     S  e  t  <  I  n  t  >  ?
     ///         0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15
     ///                              ^                       ^
-    /// = [[7, 15]]
+    /// = [7, 15]
+    /// = [7, 16), mathematical interval, w/ lower and upper bounds.
     ///
     /// - Returns: An array of ranges.
     func optionalCollectionRanges() -> [Range<String.Index>] {
@@ -142,7 +145,8 @@ private extension String {
     ///         (  (  1  +  2  )  *  (  3  +  4  )  )
     ///         0  1  2  3  4  5  6  7  8  9  10 11 12
     ///         ^  ^           ^     ^           ^  ^
-    /// = [[0, 12], [1, 5], [7, 11]]
+    /// = [0, 12], [1, 5], [7, 11]
+    /// = [0, 13), [1, 6), [7, 12), mathematical interval, w/ lower and upper bounds.
     ///
     /// - Parameters:
     ///   - prefix: The prefix to look for.

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DiscouragedOptionalCollectionRule: OptInRule, ConfigurationProviderRule {
+public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -26,42 +26,139 @@ public struct DiscouragedOptionalCollectionRule: OptInRule, ConfigurationProvide
             "func foo() -> [] {}",
             "func foo() -> [String: String] {}",
             "func foo(input: [String: String] = [:]) {}",
-            "var foo: [String: [String: Int]] = [:]"
+            "var foo: [String: [String: Int]] = [:]",
+            "let foo = self[bar]?.toto"
         ],
         triggeringExamples: [
-            "var foo: ↓[Int]?",
-            "var foo: ↓[String: Int]?",
-            "var foo: ↓Set<String>?",
-            "func foo() -> ↓[]? {}",
-            "func foo() -> ↓[String: String]? {}",
-            "func foo(input: ↓[String: String]?) {}",
-            "func foo(input: ↓[\n" +
-            "                  String: String\n" +
-            "                 ]?) {}",
-            "var foo: Set<String>\nvar bar: ↓Set<String>?",
-            "var foo: [String: String] = [:]\nvar bar: ↓[String: Int]?"
+            "↓var foo: [Int]?",
+            "↓var foo: [String: Int]?",
+            "↓var foo: Set<String>?",
+            "func ↓foo() -> [T]? {}",
+            "func ↓foo() -> [String: String]? {}",
+            "func ↓foo() -> [String: [String: String]]? {}",
+            "func ↓foo() -> [String: [String: String]?] {}",
+            "func foo(↓input: [String: String]?) {}",
+            "func foo(↓input: [String: [String: String]]?) {}",
+            "func foo(↓input: [String: [String: String]?]) {}",
+            "func foo(↓↓input: [String: [String: String]?]?) {}",
+            "func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]",
+            """
+            var foo: Set<String>
+            ↓var bar: Set<String>?
+            """,
+            """
+            var foo: [String: String] = [:]
+            ↓var bar: [String: Int]? = nil
+            """,
+            """
+            func foo(↓input: [
+                              String: String
+                             ]?) {}
+            """
         ]
     )
 
-    public func validate(file: File) -> [StyleViolation] {
-        let matches = violationMatchesLocations(in: file)
+    public func validate(file: File,
+                         kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        var offsets: [Int] = []
 
-        return matches.map {
+        if SwiftDeclarationKind.variableKinds.contains(kind) {
+            offsets.append(contentsOf: variableViolations(file: file, dictionary: dictionary))
+        }
+
+        if SwiftDeclarationKind.functionKinds.contains(kind) {
+            offsets.append(contentsOf: functionViolations(file: file, dictionary: dictionary))
+        }
+
+        return offsets.map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
-                           location: Location(file: file, characterOffset: $0))
+                           location: Location(file: file, byteOffset: $0))
         }
     }
 
-    private func violationMatchesLocations(in file: File) -> [Int] {
-        let bracketPattern = "\\[(?:[^\\]\\[])*]\\?"
-        let setPattern = "Set<(?:[^<^>])*>\\?"
-        let pattern = [bracketPattern, setPattern].joined(separator: "|")
-        let excludingKinds = SyntaxKind.commentAndStringKinds
+    // MARK: - Private
 
-        return file
-            .match(pattern: pattern)
-            .filter { $1.filter(excludingKinds.contains).isEmpty }
-            .map { $0.0.location }
+    private func variableViolations(file: File, dictionary: [String: SourceKitRepresentable]) -> [Int] {
+        guard
+            let offset = dictionary.offset,
+            let typeName = dictionary.typeName else { return [] }
+
+        return typeName.optionalCollectionRanges().map { _ in offset }
+    }
+
+    private func functionViolations(file: File, dictionary: [String: SourceKitRepresentable]) -> [Int] {
+        guard
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let length = dictionary.length,
+            let offset = dictionary.offset,
+            case let start = nameOffset + nameLength,
+            case let end = dictionary.bodyOffset ?? offset + length,
+            case let contents = file.contents.bridge(),
+            let range = contents.byteRangeToNSRange(start: start, length: end - start),
+            file.match(pattern: "->", excludingSyntaxKinds: excludingKinds, range: range).count == 1,
+            let match = file.match(pattern: "->\\s*(.*?)\\{", excludingSyntaxKinds: excludingKinds, range: range).first
+            else { return [] }
+
+        return contents.substring(with: match).optionalCollectionRanges().map { _ in nameOffset }
+    }
+
+    private let excludingKinds = SyntaxKind.allKinds.subtracting([.typeidentifier])
+}
+
+extension String {
+    /// Ranges of optional collections within the bounds of the string.
+    ///
+    /// - Returns: An array of ranges.
+    func optionalCollectionRanges() -> [Range<String.Index>] {
+        let squareBrackets = balancedRanges(between: "[", and: "]").flatMap { range -> Range<String.Index>? in
+            guard range.upperBound < endIndex else { return nil }
+            return self[range.upperBound] == "?" ? range : nil
+        }
+
+        let angleBrackets = balancedRanges(between: "<", and: ">").flatMap { range -> Range<String.Index>? in
+            guard
+                let initialIndex = index(range.lowerBound, offsetBy: -3, limitedBy: startIndex),
+                range.upperBound < endIndex else { return nil }
+            return self[initialIndex..<range.lowerBound] == "Set" && self[range.upperBound] == "?" ? range : nil
+        }
+
+        return squareBrackets + angleBrackets
+    }
+
+    /// Indices of character within the bounds of the string.
+    ///
+    /// - Parameter character: The character to look for.
+    /// - Returns: Array of indices.
+    private func indices(of character: Character) -> [String.Index] {
+        return indices.flatMap { self[$0] == character ? $0 : nil }
+    }
+
+    /// Ranges of balanced substrings.
+    ///
+    /// - Parameters:
+    ///   - prefix: The prefix to look for.
+    ///   - suffix: The suffix to look for.
+    /// - Returns: Array of ranges of balanced substrings
+    private func balancedRanges(between prefix: Character, and suffix: Character) -> [Range<String.Index>] {
+        return indices(of: prefix).flatMap { prefixIndex in
+            var pairCount = 0
+            var currentIndex = prefixIndex
+            var foundCharacter = false
+
+            while currentIndex < endIndex {
+                let character = self[currentIndex]
+                currentIndex = index(after: currentIndex)
+
+                if character == prefix { pairCount += 1 }
+                if character == suffix { pairCount -= 1 }
+                if pairCount != 0 { foundCharacter = true }
+                if pairCount == 0 && foundCharacter { break }
+            }
+
+            return pairCount == 0 && foundCharacter ? Range(prefixIndex..<currentIndex) : nil
+        }
     }
 }

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -63,7 +63,6 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
             case let end = dictionary.bodyOffset ?? offset + length,
             case let contents = file.contents.bridge(),
             let range = contents.byteRangeToNSRange(start: start, length: end - start),
-            file.match(pattern: "->", excludingSyntaxKinds: excludingKinds, range: range).count == 1,
             let match = file.match(pattern: "->\\s*(.*?)\\{", excludingSyntaxKinds: excludingKinds, range: range).first
             else { return [] }
 

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRuleExamples.swift
@@ -29,6 +29,7 @@ internal struct DiscouragedOptionalCollectionExamples {
         "func foo() -> [Int] {}",
         "func foo() -> [String: String] {}",
         "func foo() -> Set<Int> {}",
+        "func foo() -> ([Int]) -> String {}",
 
         // Free function parameter
         "func foo(input: [String] = []) {}",
@@ -39,14 +40,17 @@ internal struct DiscouragedOptionalCollectionExamples {
         wrapExample("class", "func foo() -> [Int] {}"),
         wrapExample("class", "func foo() -> [String: String] {}"),
         wrapExample("class", "func foo() -> Set<Int> {}"),
+        wrapExample("class", "func foo() -> ([Int]) -> String {}"),
 
         wrapExample("struct", "func foo() -> [Int] {}"),
         wrapExample("struct", "func foo() -> [String: String] {}"),
         wrapExample("struct", "func foo() -> Set<Int> {}"),
+        wrapExample("struct", "func foo() -> ([Int]) -> String {}"),
 
         wrapExample("enum", "func foo() -> [Int] {}"),
         wrapExample("enum", "func foo() -> [String: String] {}"),
         wrapExample("enum", "func foo() -> Set<Int> {}"),
+        wrapExample("enum", "func foo() -> ([Int]) -> String {}"),
 
         // Method parameter
         wrapExample("class", "func foo(input: [String] = []) {}"),
@@ -87,6 +91,8 @@ internal struct DiscouragedOptionalCollectionExamples {
         "static func ↓foo() -> [String: [String: String]]? {}",
         "static func ↓foo() -> [String: [String: String]?] {}",
         "static func ↓foo() -> Set<Int>? {}",
+        "func ↓foo() -> ([Int]?) -> String {}",
+        "func ↓foo() -> ([Int]) -> [String]? {}",
 
         // Free function parameter
         "func foo(↓input: [String: String]?) {}",
@@ -144,6 +150,8 @@ internal struct DiscouragedOptionalCollectionExamples {
         wrapExample("class", "static func ↓foo() -> [String: [String: String]]? {}"),
         wrapExample("class", "static func ↓foo() -> [String: [String: String]?] {}"),
         wrapExample("class", "static func ↓foo() -> Set<Int>? {}"),
+        wrapExample("class", "func ↓foo() -> ([Int]?) -> String {}"),
+        wrapExample("class", "func ↓foo() -> ([Int]) -> [String]? {}"),
 
         wrapExample("struct", "func ↓foo() -> [T]? {}"),
         wrapExample("struct", "func ↓foo() -> [String: String]? {}"),
@@ -155,6 +163,8 @@ internal struct DiscouragedOptionalCollectionExamples {
         wrapExample("struct", "static func ↓foo() -> [String: [String: String]]? {}"),
         wrapExample("struct", "static func ↓foo() -> [String: [String: String]?] {}"),
         wrapExample("struct", "static func ↓foo() -> Set<Int>? {}"),
+        wrapExample("struct", "func ↓foo() -> ([Int]?) -> String {}"),
+        wrapExample("struct", "func ↓foo() -> ([Int]) -> [String]? {}"),
 
         wrapExample("enum", "func ↓foo() -> [T]? {}"),
         wrapExample("enum", "func ↓foo() -> [String: String]? {}"),
@@ -166,6 +176,8 @@ internal struct DiscouragedOptionalCollectionExamples {
         wrapExample("enum", "static func ↓foo() -> [String: [String: String]]? {}"),
         wrapExample("enum", "static func ↓foo() -> [String: [String: String]?] {}"),
         wrapExample("enum", "static func ↓foo() -> Set<Int>? {}"),
+        wrapExample("enum", "func ↓foo() -> ([Int]?) -> String {}"),
+        wrapExample("enum", "func ↓foo() -> ([Int]) -> [String]? {}"),
 
         // Method parameter
         wrapExample("class", "func foo(↓input: [String: String]?) {}"),

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRuleExamples.swift
@@ -1,0 +1,216 @@
+//
+//  DiscouragedOptionalCollectionRuleExamples.swift
+//  SwiftLint
+//
+//  Created by Ornithologist Coder on 1/15/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import Foundation
+
+internal struct DiscouragedOptionalCollectionExamples {
+
+    static let nonTriggeringExamples = [
+
+        // Global variable
+        "var foo: [Int]",
+        "var foo: [String: Int]",
+        "var foo: Set<String>",
+        "var foo: [String: [String: Int]]",
+        "let foo: [Int] = []",
+        "let foo: [String: Int] = [:]",
+        "let foo: Set<String> = []",
+        "let foo: [String: [String: Int]] = [:]",
+
+        // Computed get variable
+        "var foo: [Int] { return [] }",
+
+        // Free function return
+        "func foo() -> [Int] {}",
+        "func foo() -> [String: String] {}",
+        "func foo() -> Set<Int> {}",
+
+        // Free function parameter
+        "func foo(input: [String] = []) {}",
+        "func foo(input: [String: String] = [:]) {}",
+        "func foo(input: Set<String> = []) {}",
+
+        // Method return
+        wrapExample("class", "func foo() -> [Int] {}"),
+        wrapExample("class", "func foo() -> [String: String] {}"),
+        wrapExample("class", "func foo() -> Set<Int> {}"),
+
+        wrapExample("struct", "func foo() -> [Int] {}"),
+        wrapExample("struct", "func foo() -> [String: String] {}"),
+        wrapExample("struct", "func foo() -> Set<Int> {}"),
+
+        wrapExample("enum", "func foo() -> [Int] {}"),
+        wrapExample("enum", "func foo() -> [String: String] {}"),
+        wrapExample("enum", "func foo() -> Set<Int> {}"),
+
+        // Method parameter
+        wrapExample("class", "func foo(input: [String] = []) {}"),
+        wrapExample("class", "func foo(input: [String: String] = [:]) {}"),
+        wrapExample("class", "func foo(input: Set<String> = []) {}"),
+
+        wrapExample("struct", "func foo(input: [String] = []) {}"),
+        wrapExample("struct", "func foo(input: [String: String] = [:]) {}"),
+        wrapExample("struct", "func foo(input: Set<String> = []) {}"),
+
+        wrapExample("enum", "func foo(input: [String] = []) {}"),
+        wrapExample("enum", "func foo(input: [String: String] = [:]) {}"),
+        wrapExample("enum", "func foo(input: Set<String> = []) {}")
+    ]
+
+    static let triggeringExamples = [
+
+        // Global variable
+        "↓var foo: [Int]?",
+        "↓var foo: [String: Int]?",
+        "↓var foo: Set<String>?",
+        "↓let foo: [Int]? = nil",
+        "↓let foo: [String: Int]? = nil",
+        "↓let foo: Set<String>? = nil",
+
+        // Computed Get Variable
+        "↓var foo: [Int]? { return nil }",
+        "↓let foo: [Int]? { return nil }()",
+
+        // Free function return
+        "func ↓foo() -> [T]? {}",
+        "func ↓foo() -> [String: String]? {}",
+        "func ↓foo() -> [String: [String: String]]? {}",
+        "func ↓foo() -> [String: [String: String]?] {}",
+        "func ↓foo() -> Set<Int>? {}",
+        "static func ↓foo() -> [T]? {}",
+        "static func ↓foo() -> [String: String]? {}",
+        "static func ↓foo() -> [String: [String: String]]? {}",
+        "static func ↓foo() -> [String: [String: String]?] {}",
+        "static func ↓foo() -> Set<Int>? {}",
+
+        // Free function parameter
+        "func foo(↓input: [String: String]?) {}",
+        "func foo(↓input: [String: [String: String]]?) {}",
+        "func foo(↓input: [String: [String: String]?]) {}",
+        "func foo(↓↓input: [String: [String: String]?]?) {}",
+        "func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]",
+        "func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]",
+        "static func foo(↓input: [String: String]?) {}",
+        "static func foo(↓input: [String: [String: String]]?) {}",
+        "static func foo(↓input: [String: [String: String]?]) {}",
+        "static func foo(↓↓input: [String: [String: String]?]?) {}",
+        "static func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]",
+        "static func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]",
+
+        // Instance variable
+        wrapExample("class", "↓var foo: [Int]?"),
+        wrapExample("class", "↓var foo: [String: Int]?"),
+        wrapExample("class", "↓var foo: Set<String>?"),
+        wrapExample("class", "↓let foo: [Int]? = nil"),
+        wrapExample("class", "↓let foo: [String: Int]? = nil"),
+        wrapExample("class", "↓let foo: Set<String>? = nil"),
+
+        wrapExample("struct", "↓var foo: [Int]?"),
+        wrapExample("struct", "↓var foo: [String: Int]?"),
+        wrapExample("struct", "↓var foo: Set<String>?"),
+        wrapExample("struct", "↓let foo: [Int]? = nil"),
+        wrapExample("struct", "↓let foo: [String: Int]? = nil"),
+        wrapExample("struct", "↓let foo: Set<String>? = nil"),
+
+        // Instance computed variable
+        wrapExample("class", "↓var foo: [Int]? { return nil }"),
+        wrapExample("class", "↓let foo: [Int]? { return nil }()"),
+        wrapExample("class", "↓var foo: Set<String>? { return nil }"),
+        wrapExample("class", "↓let foo: Set<String>? { return nil }()"),
+
+        wrapExample("struct", "↓var foo: [Int]? { return nil }"),
+        wrapExample("struct", "↓let foo: [Int]? { return nil }()"),
+        wrapExample("struct", "↓var foo: Set<String>? { return nil }"),
+        wrapExample("struct", "↓let foo: Set<String>? { return nil }()"),
+
+        wrapExample("enum", "↓var foo: [Int]? { return nil }"),
+        wrapExample("enum", "↓let foo: [Int]? { return nil }()"),
+        wrapExample("enum", "↓var foo: Set<String>? { return nil }"),
+        wrapExample("enum", "↓let foo: Set<String>? { return nil }()"),
+
+        // Method return
+        wrapExample("class", "func ↓foo() -> [T]? {}"),
+        wrapExample("class", "func ↓foo() -> [String: String]? {}"),
+        wrapExample("class", "func ↓foo() -> [String: [String: String]]? {}"),
+        wrapExample("class", "func ↓foo() -> [String: [String: String]?] {}"),
+        wrapExample("class", "func ↓foo() -> Set<Int>? {}"),
+        wrapExample("class", "static func ↓foo() -> [T]? {}"),
+        wrapExample("class", "static func ↓foo() -> [String: String]? {}"),
+        wrapExample("class", "static func ↓foo() -> [String: [String: String]]? {}"),
+        wrapExample("class", "static func ↓foo() -> [String: [String: String]?] {}"),
+        wrapExample("class", "static func ↓foo() -> Set<Int>? {}"),
+
+        wrapExample("struct", "func ↓foo() -> [T]? {}"),
+        wrapExample("struct", "func ↓foo() -> [String: String]? {}"),
+        wrapExample("struct", "func ↓foo() -> [String: [String: String]]? {}"),
+        wrapExample("struct", "func ↓foo() -> [String: [String: String]?] {}"),
+        wrapExample("struct", "func ↓foo() -> Set<Int>? {}"),
+        wrapExample("struct", "static func ↓foo() -> [T]? {}"),
+        wrapExample("struct", "static func ↓foo() -> [String: String]? {}"),
+        wrapExample("struct", "static func ↓foo() -> [String: [String: String]]? {}"),
+        wrapExample("struct", "static func ↓foo() -> [String: [String: String]?] {}"),
+        wrapExample("struct", "static func ↓foo() -> Set<Int>? {}"),
+
+        wrapExample("enum", "func ↓foo() -> [T]? {}"),
+        wrapExample("enum", "func ↓foo() -> [String: String]? {}"),
+        wrapExample("enum", "func ↓foo() -> [String: [String: String]]? {}"),
+        wrapExample("enum", "func ↓foo() -> [String: [String: String]?] {}"),
+        wrapExample("enum", "func ↓foo() -> Set<Int>? {}"),
+        wrapExample("enum", "static func ↓foo() -> [T]? {}"),
+        wrapExample("enum", "static func ↓foo() -> [String: String]? {}"),
+        wrapExample("enum", "static func ↓foo() -> [String: [String: String]]? {}"),
+        wrapExample("enum", "static func ↓foo() -> [String: [String: String]?] {}"),
+        wrapExample("enum", "static func ↓foo() -> Set<Int>? {}"),
+
+        // Method parameter
+        wrapExample("class", "func foo(↓input: [String: String]?) {}"),
+        wrapExample("class", "func foo(↓input: [String: [String: String]]?) {}"),
+        wrapExample("class", "func foo(↓input: [String: [String: String]?]) {}"),
+        wrapExample("class", "func foo(↓↓input: [String: [String: String]?]?) {}"),
+        wrapExample("class", "func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]"),
+        wrapExample("class", "func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]"),
+        wrapExample("class", "static func foo(↓input: [String: String]?) {}"),
+        wrapExample("class", "static func foo(↓input: [String: [String: String]]?) {}"),
+        wrapExample("class", "static func foo(↓input: [String: [String: String]?]) {}"),
+        wrapExample("class", "static func foo(↓↓input: [String: [String: String]?]?) {}"),
+        wrapExample("class", "static func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]"),
+        wrapExample("class", "static func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]"),
+
+        wrapExample("struct", "func foo(↓input: [String: String]?) {}"),
+        wrapExample("struct", "func foo(↓input: [String: [String: String]]?) {}"),
+        wrapExample("struct", "func foo(↓input: [String: [String: String]?]) {}"),
+        wrapExample("struct", "func foo(↓↓input: [String: [String: String]?]?) {}"),
+        wrapExample("struct", "func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]"),
+        wrapExample("struct", "func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]"),
+        wrapExample("struct", "static func foo(↓input: [String: String]?) {}"),
+        wrapExample("struct", "static func foo(↓input: [String: [String: String]]?) {}"),
+        wrapExample("struct", "static func foo(↓input: [String: [String: String]?]) {}"),
+        wrapExample("struct", "static func foo(↓↓input: [String: [String: String]?]?) {}"),
+        wrapExample("struct", "static func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]"),
+        wrapExample("struct", "static func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]"),
+
+        wrapExample("enum", "func foo(↓input: [String: String]?) {}"),
+        wrapExample("enum", "func foo(↓input: [String: [String: String]]?) {}"),
+        wrapExample("enum", "func foo(↓input: [String: [String: String]?]) {}"),
+        wrapExample("enum", "func foo(↓↓input: [String: [String: String]?]?) {}"),
+        wrapExample("enum", "func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]"),
+        wrapExample("enum", "func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]"),
+        wrapExample("enum", "static func foo(↓input: [String: String]?) {}"),
+        wrapExample("enum", "static func foo(↓input: [String: [String: String]]?) {}"),
+        wrapExample("enum", "static func foo(↓input: [String: [String: String]?]) {}"),
+        wrapExample("enum", "static func foo(↓↓input: [String: [String: String]?]?) {}"),
+        wrapExample("enum", "static func foo<K, V>(_ dict1: [K: V], ↓_ dict2: [K: V]?) -> [K: V]"),
+        wrapExample("enum", "static func foo<K, V>(dict1: [K: V], ↓dict2: [K: V]?) -> [K: V]")
+    ]
+}
+
+// MARK: - Private
+
+private func wrapExample(_ type: String, _ test: String) -> String {
+    return "\(type) Foo {\n\t\(test)\n}"
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		626C16E21F948EBC00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626C16E01F948E1C00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift */; };
 		626D02971F31CBCC0054788D /* XCTFailMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */; };
 		627BC48D1F9405160004A6C2 /* QuickDiscouragedFocusedTestRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E54FED1F93AD57005B367B /* QuickDiscouragedFocusedTestRule.swift */; };
+		629ADD062006302D0009E362 /* DiscouragedOptionalCollectionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629ADD052006302D0009E362 /* DiscouragedOptionalCollectionRule.swift */; };
 		629C60D91F43906700B4AF92 /* SingleTestClassRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629C60D81F43906700B4AF92 /* SingleTestClassRule.swift */; };
 		62A498561F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A498551F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift */; };
 		62A6E7931F3317E3003A0479 /* JoinedDefaultRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A6E7911F3317E3003A0479 /* JoinedDefaultRule.swift */; };
@@ -443,6 +444,7 @@
 		6264015320155533005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalBooleanRuleExamples.swift; sourceTree = "<group>"; };
 		626C16E01F948E1C00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedFocusedTestRuleExamples.swift; sourceTree = "<group>"; };
 		626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTFailMessageRule.swift; sourceTree = "<group>"; };
+		629ADD052006302D0009E362 /* DiscouragedOptionalCollectionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalCollectionRule.swift; sourceTree = "<group>"; };
 		629C60D81F43906700B4AF92 /* SingleTestClassRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTestClassRule.swift; sourceTree = "<group>"; };
 		62A498551F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedDirectInitConfiguration.swift; sourceTree = "<group>"; };
 		62A6E7911F3317E3003A0479 /* JoinedDefaultRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedDefaultRule.swift; sourceTree = "<group>"; };
@@ -1058,6 +1060,7 @@
 				6258783A1FFC458100AC34F2 /* DiscouragedObjectLiteralRule.swift */,
 				62640150201552E0005B9C4A /* DiscouragedOptionalBooleanRule.swift */,
 				6264015320155533005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift */,
+				629ADD052006302D0009E362 /* DiscouragedOptionalCollectionRule.swift */,
 				E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */,
 				E847F0A81BFBBABD00EA9363 /* EmptyCountRule.swift */,
 				740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */,
@@ -1542,6 +1545,7 @@
 				E88198551BEA949A00333A11 /* ControlStatementRule.swift in Sources */,
 				E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */,
 				D4246D6D1F30D8620097E658 /* PrivateOverFilePrivateRuleConfiguration.swift in Sources */,
+				629ADD062006302D0009E362 /* DiscouragedOptionalCollectionRule.swift in Sources */,
 				E816194E1BFBFEAB00946723 /* ForceTryRule.swift in Sources */,
 				E88198541BEA945100333A11 /* CommaRule.swift in Sources */,
 				D4DA1DFE1E1A10DB0037413D /* NumberSeparatorConfiguration.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		62A6E7931F3317E3003A0479 /* JoinedDefaultRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A6E7911F3317E3003A0479 /* JoinedDefaultRule.swift */; };
 		62DADC481FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DADC471FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift */; };
 		62DEA1661FB21A9E00BCCCC6 /* PrivateActionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DEA1651FB21A9E00BCCCC6 /* PrivateActionRule.swift */; };
+		62FE5D32200CABDD00F68793 /* DiscouragedOptionalCollectionRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FE5D30200CAB6E00F68793 /* DiscouragedOptionalCollectionRuleExamples.swift */; };
 		67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */; };
 		67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */; };
 		67EB4DFC1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */; };
@@ -452,6 +453,7 @@
 		62DADC471FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedTopLevelConstantRule.swift; sourceTree = "<group>"; };
 		62DEA1651FB21A9E00BCCCC6 /* PrivateActionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateActionRule.swift; sourceTree = "<group>"; };
 		62E54FED1F93AD57005B367B /* QuickDiscouragedFocusedTestRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedFocusedTestRule.swift; sourceTree = "<group>"; };
+		62FE5D30200CAB6E00F68793 /* DiscouragedOptionalCollectionRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalCollectionRuleExamples.swift; sourceTree = "<group>"; };
 		65454F451B14D73800319A6C /* ControlStatementRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlStatementRule.swift; sourceTree = "<group>"; };
 		67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityConfigurationTests.swift; sourceTree = "<group>"; };
 		67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityConfiguration.swift; sourceTree = "<group>"; };
@@ -1061,6 +1063,7 @@
 				62640150201552E0005B9C4A /* DiscouragedOptionalBooleanRule.swift */,
 				6264015320155533005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift */,
 				629ADD052006302D0009E362 /* DiscouragedOptionalCollectionRule.swift */,
+				62FE5D30200CAB6E00F68793 /* DiscouragedOptionalCollectionRuleExamples.swift */,
 				E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */,
 				E847F0A81BFBBABD00EA9363 /* EmptyCountRule.swift */,
 				740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */,
@@ -1694,6 +1697,7 @@
 				4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */,
 				D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */,
 				827169B31F488181003FB9AF /* ExplicitEnumRawValueRule.swift in Sources */,
+				62FE5D32200CABDD00F68793 /* DiscouragedOptionalCollectionRuleExamples.swift in Sources */,
 				29FFC37A1F15764D007E4825 /* FileLengthRuleConfiguration.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
 				8FD216CC205584AF008ED13F /* CharacterSet+SwiftLint.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -432,6 +432,7 @@ extension RulesTests {
         ("testDiscardedNotificationCenterObserver", testDiscardedNotificationCenterObserver),
         ("testDiscouragedObjectLiteral", testDiscouragedObjectLiteral),
         ("testDiscouragedOptionalBoolean", testDiscouragedOptionalBoolean),
+        ("testDiscouragedOptionalCollection", testDiscouragedOptionalCollection),
         ("testDynamicInline", testDynamicInline),
         ("testEmptyCount", testEmptyCount),
         ("testEmptyEnumArguments", testEmptyEnumArguments),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -78,6 +78,10 @@ class RulesTests: XCTestCase {
         verifyRule(DiscouragedOptionalBooleanRule.description)
     }
 
+    func testDiscouragedOptionalCollection() {
+        verifyRule(DiscouragedOptionalCollectionRule.description)
+    }
+
     func testDynamicInline() {
         verifyRule(DynamicInlineRule.description)
     }


### PR DESCRIPTION
Implements #1885.

I tried to use regular expressions to match collections, but soon realized I would need recursion support - `?R` - to find and match nested collections, something Foundation doesn't offer.

So I decided to re-implement the rule as an `ASTRule`, looking for balanced optional collections in functions and variables declarations.

Example: `[String: [Int]?]`

```
[  S  t  r  i  n  g  :     [  I  n  t  ]  ?  ]
0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15
                           ^              ^
// [9, 14]
```

Example: `[String: [Int]?]?`

```
[  S  t  r  i  n  g  :     [  I  n  t  ]  ?  ]  ?
0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
^                          ^              ^     ^

// [0, 16], [9, 14]
```

Example: `var x = Set<Int>?`

```
v  a  r     x     =     S  e  t  <  I  n  t  >  ?
0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
                        ^                       ^
// [8, 16]
```

I've added similar examples to the private `String` extension used by the rule to illustrate the code.