### PR TITLE
Removes 'Rule' word from test functions

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,3 +60,9 @@ custom_rules:
     match_kinds:
       - identifier
     severity: error
+  rule_test_function:
+    included: Tests/SwiftLintFrameworkTests/RulesTests.swift
+    name: Rule Test Function
+    message: Rule Test Function mustn't end with `rule`
+    regex: func\s*test\w+(r|R)ule\(\)
+    severity: error

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -387,11 +387,11 @@ extension RulesTests {
         ("testComma", testComma),
         ("testCompilerProtocolInit", testCompilerProtocolInit),
         ("testConditionalReturnsOnNewline", testConditionalReturnsOnNewline),
-        ("testContainsOverFirstNotNilRule", testContainsOverFirstNotNilRule),
+        ("testContainsOverFirstNotNil", testContainsOverFirstNotNil),
         ("testControlStatement", testControlStatement),
         ("testCyclomaticComplexity", testCyclomaticComplexity),
         ("testDiscardedNotificationCenterObserver", testDiscardedNotificationCenterObserver),
-        ("testDiscouragedObjectLiteralRule", testDiscouragedObjectLiteralRule),
+        ("testDiscouragedObjectLiteral", testDiscouragedObjectLiteral),
         ("testDynamicInline", testDynamicInline),
         ("testEmptyCount", testEmptyCount),
         ("testEmptyEnumArguments", testEmptyEnumArguments),
@@ -429,7 +429,7 @@ extension RulesTests {
         ("testMultilineParameters", testMultilineParameters),
         ("testMultipleClosuresWithTrailingClosure", testMultipleClosuresWithTrailingClosure),
         ("testNesting", testNesting),
-        ("testNoExtensionAccessModifierRule", testNoExtensionAccessModifierRule),
+        ("testNoExtensionAccessModifier", testNoExtensionAccessModifier),
         ("testNoGroupingExtension", testNoGroupingExtension),
         ("testNotificationCenterDetachment", testNotificationCenterDetachment),
         ("testNimbleOperator", testNimbleOperator),
@@ -456,7 +456,7 @@ extension RulesTests {
         ("testReturnArrowWhitespace", testReturnArrowWhitespace),
         ("testShorthandOperator", testShorthandOperator),
         ("testSingleTestClass", testSingleTestClass),
-        ("testSortedFirstLastRule", testSortedFirstLastRule),
+        ("testSortedFirstLast", testSortedFirstLast),
         ("testSortedImports", testSortedImports),
         ("testStatementPosition", testStatementPosition),
         ("testStatementPositionUncuddled", testStatementPositionUncuddled),
@@ -480,7 +480,7 @@ extension RulesTests {
         ("testSuperCall", testSuperCall),
         ("testWeakDelegate", testWeakDelegate),
         ("testXCTFailMessage", testXCTFailMessage),
-        ("testYodaConditionRule", testYodaConditionRule)
+        ("testYodaCondition", testYodaCondition)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -54,7 +54,7 @@ class RulesTests: XCTestCase {
         verifyRule(ConditionalReturnsOnNewlineRule.description)
     }
 
-    func testContainsOverFirstNotNilRule() {
+    func testContainsOverFirstNotNil() {
         verifyRule(ContainsOverFirstNotNilRule.description)
     }
 
@@ -70,7 +70,7 @@ class RulesTests: XCTestCase {
         verifyRule(DiscardedNotificationCenterObserverRule.description)
     }
 
-    func testDiscouragedObjectLiteralRule() {
+    func testDiscouragedObjectLiteral() {
         verifyRule(DiscouragedObjectLiteralRule.description)
     }
 
@@ -223,7 +223,7 @@ class RulesTests: XCTestCase {
         verifyRule(NestingRule.description)
     }
 
-    func testNoExtensionAccessModifierRule() {
+    func testNoExtensionAccessModifier() {
         verifyRule(NoExtensionAccessModifierRule.description)
     }
 
@@ -343,7 +343,7 @@ class RulesTests: XCTestCase {
         verifyRule(SingleTestClassRule.description)
     }
 
-    func testSortedFirstLastRule() {
+    func testSortedFirstLast() {
         verifyRule(SortedFirstLastRule.description)
     }
 
@@ -461,7 +461,7 @@ class RulesTests: XCTestCase {
         verifyRule(XCTFailMessageRule.description)
     }
 
-    func testYodaConditionRule() {
+    func testYodaCondition() {
         verifyRule(YodaConditionRule.description)
     }
 }


### PR DESCRIPTION
and adds a custom rule to enforce that. No changelog entry needed.