### PR TITLE
Fix some autocorrects of `colon` doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 #### Bug Fixes
 
-* None.
+* Fix some autocorrects of `colon` doesn't work.  
+  [Manabu Nakazawa](https://github.com/mshibanami)
 
 ## 0.24.2: Dented Tumbler
 

--- a/Rules.md
+++ b/Rules.md
@@ -1167,6 +1167,18 @@ object.method(5, y: "string")
 
 ```
 
+```swift
+func abc() { def(ghi: jkl) }
+```
+
+```swift
+func abc(def: Void) { ghi(jkl: mno) }
+```
+
+```swift
+class ABC { let def = ghi(jkl: mno) } }
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -1389,6 +1401,18 @@ object.method(x↓:5, y: "string")
 ```swift
 object.method(x↓:  5, y: "string")
 
+```
+
+```swift
+func abc() { def(ghi↓:jkl) }
+```
+
+```swift
+func abc(def: Void) { ghi(jkl↓:mno) }
+```
+
+```swift
+class ABC { let def = ghi(jkl↓:mno) } }
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/ColonRule+FunctionCall.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule+FunctionCall.swift
@@ -14,12 +14,13 @@ extension ColonRule {
     internal func functionCallColonViolationRanges(in file: File,
                                                    dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
-            guard let kindString = subDict.kind,
-                let kind = KindType(rawValue: kindString) else {
-                    return []
+            var ranges: [NSRange] = []
+            if let kindString = subDict.kind,
+                let kind = KindType(rawValue: kindString) {
+                    ranges += functionCallColonViolationRanges(in: file, kind: kind, dictionary: subDict)
             }
-            return functionCallColonViolationRanges(in: file, dictionary: subDict) +
-                functionCallColonViolationRanges(in: file, kind: kind, dictionary: subDict)
+            ranges += functionCallColonViolationRanges(in: file, dictionary: subDict)
+            return ranges
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -58,7 +58,10 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             "object.method(x: 5, y: \"string\")\n",
             "object.method(x: 5, y:\n" +
             "              \"string\")",
-            "object.method(5, y: \"string\")\n"
+            "object.method(5, y: \"string\")\n",
+            "func abc() { def(ghi: jkl) }",
+            "func abc(def: Void) { ghi(jkl: mno) }",
+            "class ABC { let def = ghi(jkl: mno) } }"
         ],
         triggeringExamples: [
             "let ↓abc:Void\n",
@@ -104,7 +107,10 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             "class Foo<↓T : Equatable> {}\n",
             "object.method(x: 5, y↓ : \"string\")\n",
             "object.method(x↓:5, y: \"string\")\n",
-            "object.method(x↓:  5, y: \"string\")\n"
+            "object.method(x↓:  5, y: \"string\")\n",
+            "func abc() { def(ghi↓:jkl) }",
+            "func abc(def: Void) { ghi(jkl↓:mno) }",
+            "class ABC { let def = ghi(jkl↓:mno) } }"
         ],
         corrections: [
             "let ↓abc:Void\n": "let abc: Void\n",
@@ -150,7 +156,10 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             "class Foo<↓T : Equatable> {}\n": "class Foo<T: Equatable> {}\n",
             "object.method(x: 5, y↓ : \"string\")\n": "object.method(x: 5, y: \"string\")\n",
             "object.method(x↓:5, y: \"string\")\n": "object.method(x: 5, y: \"string\")\n",
-            "object.method(x↓:  5, y: \"string\")\n": "object.method(x: 5, y: \"string\")\n"
+            "object.method(x↓:  5, y: \"string\")\n": "object.method(x: 5, y: \"string\")\n",
+            "func abc() { def(ghi↓:jkl) }": "func abc() { def(ghi: jkl) }",
+            "func abc(def: Void) { ghi(jkl↓:mno) }": "func abc(def: Void) { ghi(jkl: mno) }",
+            "class ABC { let def = ghi(jkl↓:mno) } }": "class ABC { let def = ghi(jkl: mno) } }"
         ]
     )
 


### PR DESCRIPTION
Currently `colon`'s autocorrect doesn't work if colons of function-calls are in other functions or classes like this:

```swift
func abc() {
    def(ghi:jkl) // ← This isn't corrected to "def(ghi: jkl)".
}

class ABC {
    let x = def(ghi:jkl) // ← This isn't corrected to "let x = def(ghi: jkl)".
}
```

I believe this PR will fix the problem.