### PR TITLE
Add `comment_space` opt-in rule. Partially fixes #1310.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 #### Enhancements
 
-* None.
+* Add `comment_space` opt-in rule which warns against comments that
+  don't begin with spaces.  
+  [Coder-256](https://github.com/Coder-256)
+  [#1310 (partial fix)](https://github.com/realm/SwiftLint/issues/1310)
+
 
 #### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -11,6 +11,7 @@
 * [Closure Spacing](#closure-spacing)
 * [Colon](#colon)
 * [Comma Spacing](#comma-spacing)
+* [Comment Space](#comment-space)
 * [Compiler Protocol Init](#compiler-protocol-init)
 * [Conditional Returns on Newline](#conditional-returns-on-newline)
 * [Contains over first not nil](#contains-over-first-not-nil)
@@ -1488,6 +1489,93 @@ let result = plus(
     second: 4
 )
 
+```
+
+</details>
+
+
+
+## Comment Space
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`comment_space` | Disabled | Yes | style
+
+There should be a space around the contents of comments.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+func abc() // foo
+```
+
+```swift
+// I am a comment.
+func abc()
+```
+
+```swift
+/// This function is interesting.
+func abc()
+```
+
+```swift
+/* I am a
+multiline comment. */
+```
+
+```swift
+/*
+I am also a
+multiline comment.
+*/
+```
+
+```swift
+/**
+ Does something.
+ - parameter bar: A number.
+*/
+func foo(bar: Int) {}
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+func abc() //↓foo
+```
+
+```swift
+//↓I am a comment.
+func abc()
+```
+
+```swift
+///↓This function is interesting.
+func abc()
+```
+
+```swift
+/*↓I am a
+multiline comment.↓*/
+```
+
+```swift
+/*
+I am also a
+multiline comment.↓*/
+```
+
+```swift
+/**↓Does something.
+ - parameter bar: A number.
+*/
+func foo(bar: Int) {}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -5,7 +5,7 @@
 //  Created by Scott Hoyt on 12/28/15.
 //  Copyright © 2015 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
@@ -19,6 +19,7 @@ public let masterRuleList = RuleList(rules: [
     ClosureSpacingRule.self,
     ColonRule.self,
     CommaRule.self,
+    CommentSpaceRule.self,
     CompilerProtocolInitRule.self,
     ConditionalReturnsOnNewlineRule.self,
     ContainsOverFirstNotNilRule.self,

--- a/Source/SwiftLintFramework/Rules/CommentSpaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommentSpaceRule.swift
@@ -1,0 +1,94 @@
+//
+//  CommentSpaceRule.swift
+//  SwiftLint
+//
+//  Created by Coder-256 on 1/22/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct CommentSpaceRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "comment_space",
+        name: "Comment Space",
+        description: "There should be a space around the contents of comments.",
+        kind: .style,
+        nonTriggeringExamples: [
+            "func abc() // foo",
+            "// I am a comment.\nfunc abc()",
+            "/// This function is interesting.\nfunc abc()",
+            "/* I am a\nmultiline comment. */",
+            "/*\nI am also a\nmultiline comment.\n*/",
+            "/**\n Does something.\n - parameter bar: A number.\n*/\nfunc foo(bar: Int) {}"
+        ],
+        triggeringExamples: [
+            "func abc() //↓foo",
+            "//↓I am a comment.\nfunc abc()",
+            "///↓This function is interesting.\nfunc abc()",
+            "/*↓I am a\nmultiline comment.↓*/",
+            "/*\nI am also a\nmultiline comment.↓*/",
+            "/**↓Does something.\n - parameter bar: A number.\n*/\nfunc foo(bar: Int) {}"
+        ],
+        corrections: [
+            "func abc() //↓foo": "func abc() // foo",
+            "//↓I am a comment.\nfunc abc()": "// I am a comment.\nfunc abc()",
+            "///↓This function is interesting.\nfunc abc()": "/// This function is interesting.\nfunc abc()",
+            "/*↓I am a\nmultiline comment.*/": "/* I am a\nmultiline comment. */",
+            "/*\nI am also a\nmultiline comment.↓*/": "/*\nI am also a\nmultiline comment. */",
+            "/**↓Does something.\n - parameter bar: A number.\n*/\nfunc foo(bar: Int) {}":
+            "/** Does something.\n - parameter bar: A number.\n*/\nfunc foo(bar: Int) {}"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        return violationRanges(in: file).map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+
+    public func correct(file: File) -> [Correction] {
+        let violations = violationRanges(in: file)
+        let matches = file.ruleEnabled(violatingRanges: violations, for: self)
+        if matches.isEmpty { return [] }
+
+        let contents = NSMutableString(string: file.contents)
+        let description = type(of: self).description
+        var corrections = [Correction]()
+        for range in matches.reversed() {
+            contents.insert(" ", at: range.location)
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: description, location: location))
+        }
+        file.write(contents.bridge())
+        return corrections
+    }
+
+    private static let pattern = "(?:" + "\\/\\/[^\\w\\s]?+(\\S)" + // Single-line
+        "|" + "\\/\\*[^\\w\\s]?+(\\S)?.*?(?:\\S(\\*)|\\*)\\/" + // Multi-line
+    ")"
+
+    private static let regularExpression = regex(pattern, options: [])
+
+    private func rangesFromMatches(_ matches: [NSTextCheckingResult]) -> [NSRange] {
+        return matches.flatMap { match in
+            (1...match.numberOfRanges).map { match.range(at: $0) }
+        }
+    }
+
+    private func violationRanges(in file: File) -> [NSRange] {
+        let contents = file.contents
+        let range = NSRange(location: 0, length: contents.bridge().length)
+        let syntaxMap = file.syntaxMap
+        return rangesFromMatches(CommentSpaceRule.regularExpression.matches(in: contents, options: [], range: range))
+            .filter { syntaxMap.kinds(inByteRange: $0).contains(where: SyntaxKind.commentKinds.contains) }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
 		094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094384FF1D5D2382009168CF /* WeakDelegateRule.swift */; };
 		094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094385021D5D4F78009168CF /* PrivateOutletRule.swift */; };
+		1662BFA420167C21007EC610 /* CommentSpaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662BFA320167C21007EC610 /* CommentSpaceRule.swift */; };
 		187290721FC37CA50016BEA2 /* YodaConditionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */; };
 		1E18574B1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */; };
 		1E3C2D711EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */; };
@@ -363,6 +364,7 @@
 		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
 		094384FF1D5D2382009168CF /* WeakDelegateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
 		094385021D5D4F78009168CF /* PrivateOutletRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
+		1662BFA320167C21007EC610 /* CommentSpaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSpaceRule.swift; sourceTree = "<group>"; };
 		1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YodaConditionRule.swift; sourceTree = "<group>"; };
 		1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoExtensionAccessModifierRule.swift; sourceTree = "<group>"; };
 		1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRule.swift; sourceTree = "<group>"; };
@@ -1023,6 +1025,7 @@
 				D47EF47F1F69E3100012C4CA /* ColonRule+FunctionCall.swift */,
 				D47EF4831F69E3D60012C4CA /* ColonRule+Type.swift */,
 				695BE9CE1BDFD92B0071E985 /* CommaRule.swift */,
+				1662BFA320167C21007EC610 /* CommentSpaceRule.swift */,
 				D4DA1DF31E17511D0037413D /* CompilerProtocolInitRule.swift */,
 				93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */,
 				29AD4C641F6EA16C009B66E1 /* ContainsOverFirstNotNilRule.swift */,
@@ -1312,15 +1315,15 @@
 				TargetAttributes = {
 					D0D1216C19E87B05005E4BAA = {
 						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 0920;
 					};
 					D0D1217619E87B05005E4BAA = {
 						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 0920;
 					};
 					D0E7B63119E9C64500EDBA4D = {
 						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 0920;
 					};
 				};
 			};
@@ -1578,6 +1581,7 @@
 				E889D8C51F1D11A200058332 /* Configuration+LintableFiles.swift in Sources */,
 				094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */,
 				3B1DF0121C5148140011BCED /* CustomRules.swift in Sources */,
+				1662BFA420167C21007EC610 /* CommentSpaceRule.swift in Sources */,
 				2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */,
 				E86396C91BADB2B9002C9E88 /* JSONReporter.swift in Sources */,
 				E881985A1BEA96EA00333A11 /* OperatorFunctionWhitespaceRule.swift in Sources */,

--- a/SwiftLint.xcodeproj/xcshareddata/xcschemes/SwiftLintFramework.xcscheme
+++ b/SwiftLint.xcodeproj/xcshareddata/xcschemes/SwiftLintFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftLint.xcodeproj/xcshareddata/xcschemes/swiftlint.xcscheme
+++ b/SwiftLint.xcodeproj/xcshareddata/xcschemes/swiftlint.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
The rule checks to see if there is at least 1 space at the beginning and end of comments. See the examples to get a better idea of what triggers the rule.