### PR TITLE
Fix enclosedSwiftAttributes in Swift 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2017](https://github.com/realm/SwiftLint/issues/2017)
 
+* Fix several rules that use attributes when linting with Swift 4.1 toolchain.
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2019](https://github.com/realm/SwiftLint/issues/2019)
+
 ## 0.24.2: Dented Tumbler
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -74,7 +74,8 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
 
     var enclosedSwiftAttributes: [String] {
         let array = self["key.attributes"] as? [SourceKitRepresentable] ?? []
-        return array.flatMap { ($0 as? [String: String])?["key.attribute"] }
+        let dictionaries = array.flatMap { ($0 as? [String: SourceKitRepresentable]) }
+        return dictionaries.flatMap { $0["key.attribute"] as? String }
     }
 
     var substructure: [[String: SourceKitRepresentable]] {


### PR DESCRIPTION
Fixes #2019

`key.attributes` now contains `key.offset` and `key.length`, which are numbers.