### PR TITLE
Don’t validate local vars in let_var_whitespace rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,14 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2017](https://github.com/realm/SwiftLint/issues/2017)
 
-* Fix several rules that use attributes when linting with Swift 4.1 toolchain.
+* Fix several rules that use attributes when linting with a Swift 4.1 toolchain.
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2019](https://github.com/realm/SwiftLint/issues/2019)
+
+* Don't trigger violations in `let_var_whitespace` rule when using local
+  variables when linting with a Swift 4.1 toolchain.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2021](https://github.com/realm/SwiftLint/issues/2021)
 
 ## 0.24.2: Dented Tumbler
 

--- a/Rules.md
+++ b/Rules.md
@@ -6554,6 +6554,14 @@ var x = 0
 let x = bar as! Bar
 ```
 
+```swift
+var x: Int {
+	let a = 0
+	return a
+}
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -29,6 +29,7 @@ extension SwiftVersion: Comparable {
 extension SwiftVersion {
     static let three = SwiftVersion(rawValue: "3.0.0")
     static let four = SwiftVersion(rawValue: "4.0.0")
+    static let fourDotOne = SwiftVersion(rawValue: "4.1.0")
 
     static let current: SwiftVersion = {
         // Allow forcing the Swift version, useful in cases where SourceKit isn't available

--- a/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
@@ -33,13 +33,12 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule {
             "class C {\n\t@objc\n\tfunc a() {}\n}",
             "class C {\n\tvar x = 0\n\tlazy\n\tvar y = 0\n}\n",
             "@available(OSX, introduced: 10.6)\n@available(*, deprecated)\nvar x = 0\n",
-            "// swiftlint:disable superfluous_disable_command\n// swiftlint:disable force_cast\n\nlet x = bar as! Bar"
+            "// swiftlint:disable superfluous_disable_command\n// swiftlint:disable force_cast\n\nlet x = bar as! Bar",
+            "var x: Int {\n\tlet a = 0\n\treturn a\n}\n" // don't trigger on local vars
         ],
         triggeringExamples: [
             "var x = 1\n↓x = 2\n",
             "\na = 5\n↓var x = 1\n",
-            // This case doesn't work because of an apparent limitation in SourceKit
-            // "var x: Int {\n\tlet a = 0\n\t↓return a\n}\n",
             "struct X {\n\tlet a\n\t↓func x() {}\n}\n",
             "var x = 0\n↓@objc func f() {}\n",
             "var x = 0\n↓@objc\n\tfunc f() {}\n",
@@ -223,7 +222,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule {
 
 private extension SwiftDeclarationKind {
     // The various kinds of let/var declarations
-    static let varKinds: [SwiftDeclarationKind] = [.varGlobal, .varClass, .varLocal, .varStatic, .varInstance]
+    static let varKinds: [SwiftDeclarationKind] = [.varGlobal, .varClass, .varStatic, .varInstance]
     // Declarations other than let & var that can have attributes
     static let nonVarAttributableKinds: [SwiftDeclarationKind] = [
         .class, .struct,


### PR DESCRIPTION
As part of #2021 

I know that the original idea was to validate local variables, but that seemed not so useful in a real project (SwiftLint itself), triggering a lot of warnings.

Since this didn't work until Swift 4.1 anyways, I've just removed it for now. If people feel that this is useful, we can add it back as a configuration.