### PR TITLE
Improve `type_name` rule violations to be positioned on the type name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2021](https://github.com/realm/SwiftLint/issues/2021)
 
+* Improve `type_name` rule violations to be positioned on the type name.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2021](https://github.com/realm/SwiftLint/issues/2021)
+
 ## 0.24.2: Dented Tumbler
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -15464,63 +15464,63 @@ case value
 <summary>Triggering Examples</summary>
 
 ```swift
-↓class myType {}
+class ↓myType {}
 ```
 
 ```swift
-↓class _MyType {}
+class ↓_MyType {}
 ```
 
 ```swift
-private ↓class MyType_ {}
+private class ↓MyType_ {}
 ```
 
 ```swift
-↓class My {}
+class ↓My {}
 ```
 
 ```swift
-↓class AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {}
+class ↓AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {}
 ```
 
 ```swift
-↓struct myType {}
+struct ↓myType {}
 ```
 
 ```swift
-↓struct _MyType {}
+struct ↓_MyType {}
 ```
 
 ```swift
-private ↓struct MyType_ {}
+private struct ↓MyType_ {}
 ```
 
 ```swift
-↓struct My {}
+struct ↓My {}
 ```
 
 ```swift
-↓struct AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {}
+struct ↓AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {}
 ```
 
 ```swift
-↓enum myType {}
+enum ↓myType {}
 ```
 
 ```swift
-↓enum _MyType {}
+enum ↓_MyType {}
 ```
 
 ```swift
-private ↓enum MyType_ {}
+private enum ↓MyType_ {}
 ```
 
 ```swift
-↓enum My {}
+enum ↓My {}
 ```
 
 ```swift
-↓enum AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {}
+enum ↓AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {}
 ```
 
 ```swift

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -40,7 +40,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
 
         guard typeKinds.contains(kind),
             let name = dictionary.name,
-            let offset = dictionary.offset else {
+            let offset = dictionary.nameOffset else {
                 return []
         }
 

--- a/Source/SwiftLintFramework/Rules/TypeNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRuleExamples.swift
@@ -33,11 +33,11 @@ internal struct TypeNameRuleExamples {
     static let triggeringExamples: [String] = {
         let typeExamples: [String] = types.flatMap { (type: String) -> [String] in
             [
-                "↓\(type) myType {}",
-                "↓\(type) _MyType {}",
-                "private ↓\(type) MyType_ {}",
-                "↓\(type) My {}",
-                "↓\(type) \(repeatElement("A", count: 41).joined()) {}"
+                "\(type) ↓myType {}",
+                "\(type) ↓_MyType {}",
+                "private \(type) ↓MyType_ {}",
+                "\(type) ↓My {}",
+                "\(type) ↓\(repeatElement("A", count: 41).joined()) {}"
             ]
         }
         let typeAliasAndAssociatedTypeExamples: [String] = [

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -32,7 +32,7 @@ class TypeNameRuleTests: XCTestCase {
     func testTypeNameWithAllowedSymbolsAndViolation() {
         let baseDescription = TypeNameRule.description
         let triggeringExamples = [
-            "class My_Type$ {}"
+            "class ↓My_Type$ {}"
         ]
 
         let description = baseDescription.with(triggeringExamples: triggeringExamples)
@@ -43,9 +43,9 @@ class TypeNameRuleTests: XCTestCase {
         let baseDescription = TypeNameRule.description
         let triggeringExamplesToRemove = [
             "private typealias ↓foo = Void",
-            "↓class myType {}",
-            "↓struct myType {}",
-            "↓enum myType {}"
+            "class ↓myType {}",
+            "struct ↓myType {}",
+            "enum ↓myType {}"
         ]
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples +
             triggeringExamplesToRemove.map { $0.replacingOccurrences(of: "↓", with: "") }


### PR DESCRIPTION
Part of #2021 

This unifies where violations are reported in `type_name` rule. Previously `typealias` and `associatedtype` were reported on `nameOffset`, but all the other types were reported on `offset`.

This will be useful to fix this rule when using Swift 4.1, as we'll no longer need to have the `typealias` and `associatedtype` validation using regexes.

I've decided to open a PR just for this because it'll cause a lot of noise in oss-check.