### PR TITLE
Make fallthrough rule opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Breaking
 
-* None.
+* `fallthrough` rule is now opt-in.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1892](https://github.com/realm/SwiftLint/issues/1892)
 
 #### Enhancements
 

--- a/Rules.md
+++ b/Rules.md
@@ -3033,7 +3033,7 @@ public extension Foo {
 
 Identifier | Enabled by default | Supports autocorrection | Kind 
 --- | --- | --- | ---
-`fallthrough` | Enabled | No | idiomatic
+`fallthrough` | Disabled | No | idiomatic
 
 Fallthrough should be avoided.
 

--- a/Source/SwiftLintFramework/Rules/FallthroughRule.swift
+++ b/Source/SwiftLintFramework/Rules/FallthroughRule.swift
@@ -8,7 +8,7 @@
 
 import SourceKittenFramework
 
-public struct FallthroughRule: ConfigurationProviderRule {
+public struct FallthroughRule: ConfigurationProviderRule, OptInRule {
 
     public var configuration = SeverityConfiguration(.warning)
 


### PR DESCRIPTION
Fixes #1892

I think this is the first time we change whether a rule is opt-in or default, so I'm not sure if there's anything else we should do other than adding it as a breaking change in `CHANGELOG`.