### PR TITLE
Use SourceKit to validate `associatedtype` and `typealias` in `type_name` rule  when linting with Swift 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2021](https://github.com/realm/SwiftLint/issues/2021)
 
+* Use SourceKit to validate `associatedtype` and `typealias` in `type_name` rule
+  when linting with Swift 4.1.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2021](https://github.com/realm/SwiftLint/issues/2021)
+
 ## 0.24.2: Dented Tumbler
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
@@ -39,6 +39,7 @@ extension SwiftDeclarationKind {
         .`class`,
         .`struct`,
         .`typealias`,
+        .`associatedtype`,
         .`enum`
     ]
 

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -48,6 +48,10 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func validateTypeAliasesAndAssociatedTypes(in file: File) -> [StyleViolation] {
+        guard SwiftVersion.current < .fourDotOne else {
+            return []
+        }
+
         let rangesAndTokens = file.rangesAndTokens(matching: "(typealias|associatedtype)\\s+.+?\\b")
         return rangesAndTokens.flatMap { _, tokens -> [StyleViolation] in
             guard tokens.count == 2,


### PR DESCRIPTION
Part of #2021