### PR TITLE
Fix ignores_function_declarations of line_length doesn't work in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2021](https://github.com/realm/SwiftLint/issues/2021)
 
+* Fix ignores_function_declarations of line_length doesn't work in some cases.  
+  [Manabu Nakazawa](https://github.com/mshibanami)
+
 ## 0.24.2: Dented Tumbler
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -139,7 +139,7 @@ extension File {
                 results[line.index].append(swiftDeclarationKind)
             }
             let lineEnd = NSMaxRange(line.byteRange)
-            if structure.byteRange.location > lineEnd {
+            if structure.byteRange.location >= lineEnd {
                 maybeLine = lineIterator.next()
             } else {
                 maybeStructure = structureIterator.next()

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -12,11 +12,18 @@ import XCTest
 
 class LineLengthRuleTests: XCTestCase {
 
-    private let longFunctionDeclaration = "public func superDuperLongFunctionDeclaration(a: String, b: String, " +
-        "c: String, d: String, e: String, f: String, g: String, h: String, i: String, " +
-        "j: String, k: String, l: String, m: String, n: String, o: String, p: String, " +
-        "q: String, r: String, s: String, t: String, u: String, v: String, w: String, " +
-        "x: String, y: String, z: String) {\n"
+    private let longFunctionDeclarations = [
+        "public func superDuperLongFunctionDeclaration(a: String, b: String, " +
+            "c: String, d: String, e: String, f: String, g: String, h: String, i: String, " +
+            "j: String, k: String, l: String, m: String, n: String, o: String, p: String, " +
+            "q: String, r: String, s: String, t: String, u: String, v: String, w: String, " +
+            "x: String, y: String, z: String) {\n",
+        "func superDuperLongFunctionDeclaration(a: String, b: String, " +
+            "c: String, d: String, e: String, f: String, g: String, h: String, i: String, " +
+            "j: String, k: String, l: String, m: String, n: String, o: String, p: String, " +
+            "q: String, r: String, s: String, t: String, u: String, v: String, w: String, " +
+            "x: String, y: String, z: String) {\n"
+    ]
 
     private let longComment = String(repeating: "/", count: 121) + "\n"
     private let longBlockComment = "/*" + String(repeating: " ", count: 121) + "*/\n"
@@ -28,7 +35,7 @@ class LineLengthRuleTests: XCTestCase {
 
     func testLineLengthWithIgnoreFunctionDeclarationsEnabled() {
         let baseDescription = LineLengthRule.description
-        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [longFunctionDeclaration]
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + longFunctionDeclarations
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
 
         verifyRule(description, ruleConfiguration: ["ignores_function_declarations": true],
@@ -37,7 +44,7 @@ class LineLengthRuleTests: XCTestCase {
 
     func testLineLengthWithIgnoreCommentsEnabled() {
         let baseDescription = LineLengthRule.description
-        let triggeringExamples = [longFunctionDeclaration, declarationWithTrailingLongComment]
+        let triggeringExamples = longFunctionDeclarations + [declarationWithTrailingLongComment]
         let nonTriggeringExamples = [longComment, longBlockComment]
 
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)


### PR DESCRIPTION
The option `ignores_function_declarations` of `line_length` doesn't work for non-indent, non-acl and non-final functions, i.e. global free functions.

See the repros:

```swift
// Triggered (unexpected)
func abc(a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String, i: String, j: String, k: String, l: String, m: String, n: String, o: String, p: String, q: String, r: String, s: String) {
}

// Not triggered (expected)
public func def(a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String, i: String, j: String, k: String, l: String, m: String, n: String, o: String, p: String, q: String, r: String, s: String) {
}

// Not triggered (expected)
 func ghi(a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String, i: String, j: String, k: String, l: String, m: String, n: String, o: String, p: String, q: String, r: String, s: String) {
}

class JKL {
    // Not triggered (expected)
    func mno(a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String, i: String, j: String, k: String, l: String, m: String, n: String, o: String, p: String, q: String, r: String, s: String) {
    }

// Triggered (unexpected)
func pqr(a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String, i: String, j: String, k: String, l: String, m: String, n: String, o: String, p: String, q: String, r: String, s: String) {
}
}
```

My `.swiftlint.yml`:

```
line_length:
    ignores_function_declarations: true
```

I believe I fixed this problem. Check it ;-)