### PR TITLE
Fix false positive in force_unwrapping when returning collection from function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@
 * Fix false positive in `empty_enum_arguments` rule when using closures.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2041](https://github.com/realm/SwiftLint/issues/2041)
+  
+* Fix false positives in `force_unwrapping` rule when declaring functions that
+  return implicitly unwrapped collections (for example `[Int]!` or
+  `[AnyHashable: Any]!`).  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2042](https://github.com/realm/SwiftLint/issues/2042)
 
 ## 0.24.2: Dented Tumbler
 

--- a/Rules.md
+++ b/Rules.md
@@ -5358,6 +5358,18 @@ private var myProperty: (Void -> Void)!
 func foo(_ options: [AnyHashable: Any]!) {
 ```
 
+```swift
+func foo() -> [Int]!
+```
+
+```swift
+func foo() -> [AnyHashable: Any]!
+```
+
+```swift
+func foo() -> [Int]! { return [] }
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -36,7 +36,10 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
             "var test = (!bar)",
             "var a: [Int]!",
             "private var myProperty: (Void -> Void)!",
-            "func foo(_ options: [AnyHashable: Any]!) {"
+            "func foo(_ options: [AnyHashable: Any]!) {",
+            "func foo() -> [Int]!",
+            "func foo() -> [AnyHashable: Any]!",
+            "func foo() -> [Int]! { return [] }"
         ],
         triggeringExamples: [
             "let url = NSURL(string: query)↓!",
@@ -73,6 +76,8 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
     // But that does not compromise the filtering for var declarations
     private static let varDeclarationPattern = "\\s?(?:let|var)\\s+[^=\\v{]*!"
 
+    private static let functionReturnPattern = "\\)\\s*->\\s*[^\\n\\{=]*!"
+
     private static let regularExpression = regex(pattern)
     private static let varDeclarationRegularExpression = regex(varDeclarationPattern)
     private static let excludingSyntaxKindsForFirstCapture =
@@ -91,10 +96,16 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
                 return match.range
             }
 
+        let functionDeclarationRanges = regex(ForceUnwrappingRule.functionReturnPattern)
+            .matches(in: contents, options: [], range: range)
+            .flatMap { match -> NSRange? in
+                return match.range
+            }
+
         return ForceUnwrappingRule.regularExpression
             .matches(in: contents, options: [], range: range)
             .flatMap { match -> NSRange? in
-                if match.range.intersects(varDeclarationRanges) {
+                if match.range.intersects(varDeclarationRanges) || match.range.intersects(functionDeclarationRanges) {
                     return nil
                 }
 


### PR DESCRIPTION
Fixes #2042

This is not ideal, but I tried to follow how variables are handled in this rule.