### PR TITLE
 Fix directories with a '.swift' suffix being treated as files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,9 @@
   in parentheses.  
   [JP Simard](https://github.com/jpsim)
   [#1979](https://github.com/realm/SwiftLint/issues/1979)
+* Fix directories with a `.swift` suffix being treated as files.  
+  [Jamie Edge](https://github.com/JamieEdge)
+  [#1948](https://github.com/realm/SwiftLint/issues/1948)
 
 ## 0.24.0: Timed Dry
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2042](https://github.com/realm/SwiftLint/issues/2042)
 
+* Fix directories with a `.swift` suffix being treated as files.  
+  [Jamie Edge](https://github.com/JamieEdge)
+  [#1948](https://github.com/realm/SwiftLint/issues/1948)
+
 ## 0.24.2: Dented Tumbler
 
 #### Breaking
@@ -136,9 +140,6 @@
   in parentheses.  
   [JP Simard](https://github.com/jpsim)
   [#1979](https://github.com/realm/SwiftLint/issues/1979)
-* Fix directories with a `.swift` suffix being treated as files.  
-  [Jamie Edge](https://github.com/JamieEdge)
-  [#1948](https://github.com/realm/SwiftLint/issues/1948)
 
 ## 0.24.0: Timed Dry
 

--- a/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
@@ -26,7 +26,9 @@ extension FileManager: LintableFileManager {
         }
 
         return enumerator(atPath: absolutePath)?.flatMap { element -> String? in
-            if let element = element as? String, element.bridge().isSwiftFile() {
+            if let element = element as? String,
+                element.bridge().isSwiftFile() &&
+                    NSString.path(withComponents: [absolutePath, element]).isFile {
                 return absolutePath.bridge().appendingPathComponent(element)
             }
             return nil

--- a/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
@@ -27,8 +27,7 @@ extension FileManager: LintableFileManager {
 
         return enumerator(atPath: absolutePath)?.flatMap { element -> String? in
             if let element = element as? String,
-                element.bridge().isSwiftFile() &&
-                    NSString.path(withComponents: [absolutePath, element]).isFile {
+                element.bridge().isSwiftFile() && (absolutePath + "/" + element).isFile {
                 return absolutePath.bridge().appendingPathComponent(element)
             }
             return nil

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,7 +5,7 @@
 //  Created by JP Simard on 12/11/16.
 //  Copyright © 2016 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -66,6 +66,7 @@ extension ConfigurationTests {
         ("testDisabledRulesWithUnknownRule", testDisabledRulesWithUnknownRule),
         ("testDuplicatedRules", testDuplicatedRules),
         ("testExcludedPaths", testExcludedPaths),
+        ("testLintablePaths", testLintablePaths),
         ("testIsEqualTo", testIsEqualTo),
         ("testIsNotEqualTo", testIsNotEqualTo),
         ("testCustomConfiguration", testCustomConfiguration),

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -182,13 +182,13 @@ class ConfigurationTests: XCTestCase {
 
     func testLintablePaths() {
         let paths = Configuration().lintablePaths(inPath: projectMockPathLevel0)
-        let filenames = paths.map { $0.bridge().lastPathComponent }
+        let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         let expectedFilenames = [
             "DirectoryLevel1.swift",
             "Level0.swift",
             "Level1.swift",
-            "Level3.swift",
-            "Level2.swift"
+            "Level2.swift",
+            "Level3.swift"
         ]
 
         XCTAssertEqual(expectedFilenames, filenames)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -180,6 +180,20 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
     }
 
+    func testLintablePaths() {
+        let paths = Configuration().lintablePaths(inPath: projectMockPathLevel0)
+        let filenames = paths.map { $0.bridge().lastPathComponent }
+        let expectedFilenames = [
+            "DirectoryLevel1.swift",
+            "Level0.swift",
+            "Level1.swift",
+            "Level3.swift",
+            "Level2.swift"
+        ]
+
+        XCTAssertEqual(expectedFilenames, filenames)
+    }
+
     // MARK: - Testing Configuration Equality
 
     func testIsEqualTo() {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -181,7 +181,7 @@ class ConfigurationTests: XCTestCase {
     }
 
     func testLintablePaths() {
-        let paths = Configuration().lintablePaths(inPath: projectMockPathLevel0)
+        let paths = Configuration()!.lintablePaths(inPath: projectMockPathLevel0)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         let expectedFilenames = [
             "DirectoryLevel1.swift",

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Directory.swift/DirectoryLevel1.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Directory.swift/DirectoryLevel1.swift
@@ -1,0 +1,1 @@
+// This is just a mock Swift file


### PR DESCRIPTION
Continued from #1964.

I just rebased, fixed the failing test and updated LinuxMain. 


// cc @JamieEdge 