### PR TITLE
Fix some cases where `colon` rule wouldn't autocorrect dictionary literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix some cases where `colon` rule wouldn't autocorrect dictionary literals.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2050](https://github.com/realm/SwiftLint/issues/2050)
 
 ## 0.25.0: Cleaning the Lint Filter
 

--- a/Rules.md
+++ b/Rules.md
@@ -1180,6 +1180,10 @@ func abc(def: Void) { ghi(jkl: mno) }
 class ABC { let def = ghi(jkl: mno) } }
 ```
 
+```swift
+func foo() { let dict = [1: 1] }
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -1414,6 +1418,10 @@ func abc(def: Void) { ghi(jkl↓:mno) }
 
 ```swift
 class ABC { let def = ghi(jkl↓:mno) } }
+```
+
+```swift
+func foo() { let dict = [1↓ : 1] }
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/ColonRule+Dictionary.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule+Dictionary.swift
@@ -18,12 +18,13 @@ extension ColonRule {
         }
 
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
-            guard let kindString = subDict.kind,
-                let kind = KindType(rawValue: kindString) else {
-                    return []
+            var ranges: [NSRange] = []
+            if let kind = subDict.kind.flatMap(KindType.init(rawValue:)) {
+                ranges += dictionaryColonViolationRanges(in: file, kind: kind, dictionary: subDict)
             }
-            return dictionaryColonViolationRanges(in: file, dictionary: subDict) +
-                dictionaryColonViolationRanges(in: file, kind: kind, dictionary: subDict)
+            ranges += dictionaryColonViolationRanges(in: file, dictionary: subDict)
+
+            return ranges
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -61,7 +61,8 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             "object.method(5, y: \"string\")\n",
             "func abc() { def(ghi: jkl) }",
             "func abc(def: Void) { ghi(jkl: mno) }",
-            "class ABC { let def = ghi(jkl: mno) } }"
+            "class ABC { let def = ghi(jkl: mno) } }",
+            "func foo() { let dict = [1: 1] }"
         ],
         triggeringExamples: [
             "let ↓abc:Void\n",
@@ -110,7 +111,8 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             "object.method(x↓:  5, y: \"string\")\n",
             "func abc() { def(ghi↓:jkl) }",
             "func abc(def: Void) { ghi(jkl↓:mno) }",
-            "class ABC { let def = ghi(jkl↓:mno) } }"
+            "class ABC { let def = ghi(jkl↓:mno) } }",
+            "func foo() { let dict = [1↓ : 1] }"
         ],
         corrections: [
             "let ↓abc:Void\n": "let abc: Void\n",
@@ -159,7 +161,8 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             "object.method(x↓:  5, y: \"string\")\n": "object.method(x: 5, y: \"string\")\n",
             "func abc() { def(ghi↓:jkl) }": "func abc() { def(ghi: jkl) }",
             "func abc(def: Void) { ghi(jkl↓:mno) }": "func abc(def: Void) { ghi(jkl: mno) }",
-            "class ABC { let def = ghi(jkl↓:mno) } }": "class ABC { let def = ghi(jkl: mno) } }"
+            "class ABC { let def = ghi(jkl↓:mno) } }": "class ABC { let def = ghi(jkl: mno) } }",
+            "func foo() { let dict = [1↓ : 1] }": "func foo() { let dict = [1: 1] }"
         ]
     )
 


### PR DESCRIPTION
Fixes #2050.

#2007 fixed this for function calls, but I didn't realize we had the same issue with dictionary literals.

// cc @AliSoftware who provided a great issue description to reproduce this.