### PR TITLE
[WIP] proof of concept for merging individual rule's configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "Carthage/Checkouts/Yams"]
 	path = Carthage/Checkouts/Yams
 	url = https://github.com/jpsim/Yams.git
+[submodule "Carthage/Checkouts/Reflection"]
+	path = Carthage/Checkouts/Reflection
+	url = https://github.com/Zewo/Reflection.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 #### Enhancements
 
-* None.
+* Adds merging of individual rule's configurations
+  [gretzki](https://github.com/gretzki)
+  [#2058](https://github.com/realm/SwiftLint/issues/2058)
 
 #### Bug Fixes
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 github "jpsim/SourceKitten" ~> 0.19.1
 github "scottrhoyt/SwiftyTextTable" ~> 0.8.0
+github "Zewo/Reflection" ~> 0.15.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,5 @@
 github "Carthage/Commandant" "0.13.0"
+github "Zewo/Reflection" "0.15.0"
 github "antitypical/Result" "3.2.4"
 github "drmohundro/SWXMLHash" "4.3.6"
 github "jpsim/SourceKitten" "0.19.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "Reflection",
+        "repositoryURL": "https://github.com/Zewo/Reflection.git",
+        "state": {
+          "branch": null,
+          "revision": "8a90b157455d13b7cde036403a406b72a86f3ea9",
+          "version": "0.15.0"
+        }
+      },
+      {
         "package": "Result",
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.19.1"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "0.5.0"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.8.0"),
+        .package(url: "https://github.com/Zewo/Reflection.git", from: "0.15.0"),
     ],
     targets: [
         .target(
@@ -27,6 +28,7 @@ let package = Package(
             dependencies: [
                 "SourceKittenFramework",
                 "Yams",
+                "Reflection",
             ]
         ),
         .testTarget(

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -106,7 +106,7 @@ extension Configuration {
                     return optIn.contains(type(of: rule).description.identifier)
                 }
 
-            for rule in self.rules {
+            for var rule in self.rules {
                 let isDisabled = disabled.contains(type(of: rule).description.identifier)
                 if !isDisabled {
                     // find rule in nested configuration

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -99,10 +99,16 @@ extension Configuration {
         case let .default(disabled, optIn):
             // Same here
             var intermediateRules: [Rule] = []
+
+            intermediateRules = configuration.rules
+                // Enable rules that are opt-in by the nested configuration
+                .filter { rule in
+                    return optIn.contains(type(of: rule).description.identifier)
+                }
+
             for rule in self.rules {
-                let isOptedIn = optIn.contains(type(of: rule).description.identifier)
                 let isDisabled = disabled.contains(type(of: rule).description.identifier)
-                if isOptedIn || !isDisabled {
+                if !isDisabled {
                     // find rule in nested configuration
                     if let nestedRule = configuration.rules.first(where: {
                         // only check on RuleConfiguration's identifier

--- a/Source/SwiftLintFramework/Extensions/Rule+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Rule+Merging.swift
@@ -1,0 +1,52 @@
+//
+//  Rule+Merging.swift
+//  SwiftLint
+//
+//  Created by Christopher Gretzki on 22.02.18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import Foundation
+
+public extension Rule {
+    func overrideConfiguration(withRule secondRule: Rule) -> Rule {
+        guard let secondRule = secondRule as? Self else {
+            queuedFatalError("Call overrideConfiguration only on rule's of same type")
+        }
+        var parentRuleConfiguration = getConfiguration(of: self)
+        let nestedRuleConfiguration = getConfiguration(of: secondRule)
+        // check if rule's configuration exists
+        guard parentRuleConfiguration != nil, nestedRuleConfiguration != nil else {
+            // can't find any configuration - return nested rule
+            return secondRule
+        }
+        // override rule's configuration with nested rule's configuration
+        do {
+            try parentRuleConfiguration?.apply(configuration: nestedRuleConfiguration!)
+        } catch {
+            // RuleConfiguration is not ready to be configured via RuleConfiguration of own type as parameter, yet
+            // skip error to stay backward compatible
+            print("""
+                RuleConfiguration \(parentRuleConfiguration!) is not ready to be configured
+                via apply() with parameter of own type
+                """)
+        }
+        return self
+    }
+
+    /// This method is an ugly hack to check if rule: Rule also conforms to ConfigurationProviderRule
+    /// This workaround checks for a configuration property
+    ///
+    /// - Parameter rule: Anything conforming to Rule
+    /// - Returns: RuleConfiguration if given rule conforms to ConfigurationProviderRule
+    func getConfiguration(of rule: Rule) -> RuleConfiguration? {
+        var ruleConfig: RuleConfiguration?
+        let mirror = Mirror(reflecting: rule)
+        if let b = AnyBidirectionalCollection(mirror.children) {
+            ruleConfig = b.first(where: { (label: String?, _: Any) -> Bool in
+                label == "configuration"
+            }).map({ $0.value }) as? RuleConfiguration
+        }
+        return ruleConfig
+    }
+}

--- a/Source/SwiftLintFramework/Extensions/Rule+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Rule+Merging.swift
@@ -2,39 +2,42 @@
 //  Rule+Merging.swift
 //  SwiftLint
 //
-//  Created by Christopher Gretzki on 22.02.18.
+//  Created by Christopher Gretzki on 02/22/18.
 //  Copyright © 2018 Realm. All rights reserved.
 //
 
 import Foundation
+import Reflection
 
 public extension Rule {
-    func overrideConfiguration(withRule secondRule: Rule) -> Rule {
+    mutating func overrideConfiguration(withRule secondRule: Rule) -> Rule {
         guard let secondRule = secondRule as? Self else {
             queuedFatalError("Call overrideConfiguration only on rule's of same type")
         }
-        var parentRuleConfiguration = getConfiguration(of: self)
+        let parentRuleConfiguration = getConfiguration(of: self)
         let nestedRuleConfiguration = getConfiguration(of: secondRule)
         // check if rule's configuration exists
-        guard parentRuleConfiguration != nil, nestedRuleConfiguration != nil else {
-            // can't find any configuration - return nested rule
+        if var mergedRuleConfig = parentRuleConfiguration, nestedRuleConfiguration != nil {
+            // override rule's configuration with nested rule's configuration
+            do {
+                try mergedRuleConfig.apply(configuration: nestedRuleConfiguration!)
+                try set(mergedRuleConfig, key: "configuration", for: &self)
+            } catch {
+                // RuleConfiguration is not ready to be configured via RuleConfiguration of own type as parameter, yet
+                // skip error to stay backward compatible
+                print("""
+                    RuleConfiguration \(parentRuleConfiguration!) is not ready to be configured
+                    via apply() with parameter of own type
+                    """)
+            }
+            return self
+        } else {
+            // fallback to previous behaviour w/o merging rule's configuration
             return secondRule
         }
-        // override rule's configuration with nested rule's configuration
-        do {
-            try parentRuleConfiguration?.apply(configuration: nestedRuleConfiguration!)
-        } catch {
-            // RuleConfiguration is not ready to be configured via RuleConfiguration of own type as parameter, yet
-            // skip error to stay backward compatible
-            print("""
-                RuleConfiguration \(parentRuleConfiguration!) is not ready to be configured
-                via apply() with parameter of own type
-                """)
-        }
-        return self
     }
 
-    /// This method is an ugly hack to check if rule: Rule also conforms to ConfigurationProviderRule
+    /// This method is an ugly hack to check if rule: Rule also conforms to swift 
     /// This workaround checks for a configuration property
     ///
     /// - Parameter rule: Anything conforming to Rule

--- a/Source/SwiftLintFramework/Extensions/Rule+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Rule+Merging.swift
@@ -14,8 +14,8 @@ public extension Rule {
         guard let secondRule = secondRule as? Self else {
             queuedFatalError("Call overrideConfiguration only on rule's of same type")
         }
-        let parentRuleConfiguration = getConfiguration(of: self)
-        let nestedRuleConfiguration = getConfiguration(of: secondRule)
+        let parentRuleConfiguration = getConfiguration()
+        let nestedRuleConfiguration = secondRule.getConfiguration()
         // check if rule's configuration exists
         if var mergedRuleConfig = parentRuleConfiguration, nestedRuleConfiguration != nil {
             // override rule's configuration with nested rule's configuration
@@ -37,19 +37,14 @@ public extension Rule {
         }
     }
 
-    /// This method is an ugly hack to check if rule: Rule also conforms to swift 
-    /// This workaround checks for a configuration property
+    /// This method is a workaround to retrieve the `configuration` property of a ConfigurationProviderRule
+    /// Since Swift4 does not allow for checking conformance with protocols using associated types
+    /// this workaround uses reflection
     ///
     /// - Parameter rule: Anything conforming to Rule
     /// - Returns: RuleConfiguration if given rule conforms to ConfigurationProviderRule
-    func getConfiguration(of rule: Rule) -> RuleConfiguration? {
-        var ruleConfig: RuleConfiguration?
-        let mirror = Mirror(reflecting: rule)
-        if let b = AnyBidirectionalCollection(mirror.children) {
-            ruleConfig = b.first(where: { (label: String?, _: Any) -> Bool in
-                label == "configuration"
-            }).map({ $0.value }) as? RuleConfiguration
-        }
+    func getConfiguration() -> RuleConfiguration? {
+        let ruleConfig: RuleConfiguration? = try? get("configuration", from: self)
         return ruleConfig
     }
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */; };
 		31F1B6CC1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F1B6CB1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift */; };
 		37B3FA8B1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */; };
+		3A234E9C203ED16600F22F83 /* Rule+Merging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A234E9A203ED11700F22F83 /* Rule+Merging.swift */; };
 		3B034B6E1E0BE549005D49A9 /* LineLengthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */; };
 		3B0B14541C505D6300BE82F7 /* SeverityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */; };
 		3B12C9C11C3209CB000B423F /* test.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3B12C9BF1C3209AC000B423F /* test.yml */; };
@@ -382,6 +383,7 @@
 		2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRule.swift; sourceTree = "<group>"; };
 		31F1B6CB1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentRule.swift; sourceTree = "<group>"; };
 		37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+SwiftLint.swift"; sourceTree = "<group>"; };
+		3A234E9A203ED11700F22F83 /* Rule+Merging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Merging.swift"; sourceTree = "<group>"; };
 		3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineLengthConfiguration.swift; sourceTree = "<group>"; };
 		3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeverityConfiguration.swift; sourceTree = "<group>"; };
 		3B12C9BF1C3209AC000B423F /* test.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = test.yml; sourceTree = "<group>"; };
@@ -1213,6 +1215,7 @@
 				3BA79C9A1C4767910057E705 /* NSRange+SwiftLint.swift */,
 				3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */,
 				E81619521BFC162C00946723 /* QueuedPrint.swift */,
+				3A234E9A203ED11700F22F83 /* Rule+Merging.swift */,
 				E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */,
 				B39353F28BCCA39247B316BD /* String+XML.swift */,
 				6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */,
@@ -1691,6 +1694,7 @@
 				3B828E531C546468000D180E /* RuleConfiguration.swift in Sources */,
 				A73469421FB121BA009B57C7 /* CallPairRule.swift in Sources */,
 				D47079AF1DFE520000027086 /* VoidReturnRule.swift in Sources */,
+				3A234E9C203ED16600F22F83 /* Rule+Merging.swift in Sources */,
 				B3935EE74B1E8E14FBD65E7F /* String+XML.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */; };
 		31F1B6CC1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F1B6CB1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift */; };
 		37B3FA8B1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */; };
+		3A1A08292046B776008AA477 /* Reflection.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A1A082A2046B776008AA477 /* Reflection.framework */; };
 		3A234E9C203ED16600F22F83 /* Rule+Merging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A234E9A203ED11700F22F83 /* Rule+Merging.swift */; };
 		3B034B6E1E0BE549005D49A9 /* LineLengthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */; };
 		3B0B14541C505D6300BE82F7 /* SeverityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */; };
@@ -383,6 +384,7 @@
 		2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRule.swift; sourceTree = "<group>"; };
 		31F1B6CB1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentRule.swift; sourceTree = "<group>"; };
 		37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+SwiftLint.swift"; sourceTree = "<group>"; };
+		3A1A082A2046B776008AA477 /* Reflection.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Reflection.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A234E9A203ED11700F22F83 /* Rule+Merging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Merging.swift"; sourceTree = "<group>"; };
 		3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineLengthConfiguration.swift; sourceTree = "<group>"; };
 		3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeverityConfiguration.swift; sourceTree = "<group>"; };
@@ -684,6 +686,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A1A08292046B776008AA477 /* Reflection.framework in Frameworks */,
 				E876BFBE1B07828500114ED5 /* SourceKittenFramework.framework in Frameworks */,
 				E8C0DFCD1AD349DB007EE3D4 /* SWXMLHash.framework in Frameworks */,
 				3BBF2F9D1C640A0F006CD775 /* SwiftyTextTable.framework in Frameworks */,
@@ -711,6 +714,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3A1A08282046B776008AA477 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3A1A082A2046B776008AA477 /* Reflection.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		3B12C9BE1C3209AC000B423F /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -789,6 +800,7 @@
 				D0D1211A19E87861005E4BAA /* swiftlint */,
 				D0D1216E19E87B05005E4BAA /* SwiftLintFramework */,
 				D0D1217B19E87B05005E4BAA /* SwiftLintFrameworkTests */,
+				3A1A08282046B776008AA477 /* Frameworks */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";

--- a/SwiftLint.xcworkspace/contents.xcworkspacedata
+++ b/SwiftLint.xcworkspace/contents.xcworkspacedata
@@ -20,6 +20,9 @@
       location = "group:Carthage/Checkouts/SwiftyTextTable/SwiftyTextTable.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:Carthage/Checkouts/Reflection/Reflection.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:Carthage/Checkouts/Yams/Yams.xcodeproj">
    </FileRef>
 </Workspace>

--- a/SwiftLintFramework.podspec
+++ b/SwiftLintFramework.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
   s.dependency            'SourceKittenFramework', '~> 0.18'
   s.dependency            'Yams', '~> 0.4'
+  s.dependency            'Reflection', '~> 0.15'
 end

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -94,4 +94,25 @@ extension ConfigurationTests {
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceCastRule.self))
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceTryRule.self))
     }
+
+    func testMergingOfIndividualRulesConfiguration() {
+        let baseRuleIdentifier = CyclomaticComplexityRule.description.identifier
+        let baseRuleConfig = [baseRuleIdentifier: ["warning": 13, "error": 14, "ignores_case_statements": true]]
+        let baseConfiguration = Configuration(dict: baseRuleConfig)!
+
+        let nestedRuleConfig = [baseRuleIdentifier: ["warning": 5]]
+        let nestedConfiguration = Configuration(dict: nestedRuleConfig)!
+        let mergedConfiguration = baseConfiguration.merge(with: nestedConfiguration)
+        let mergedRule = mergedConfiguration.rules.first(where: {
+            type(of: $0).description.identifier == baseRuleIdentifier
+        })
+        XCTAssertNotNil(mergedRule)
+        if let mergedRuleConfiguration = mergedRule!.getConfiguration(of: mergedRule!) as? CyclomaticComplexityConfiguration {
+            XCTAssertEqual(mergedRuleConfiguration.length.warning, 5)
+            XCTAssertEqual(mergedRuleConfiguration.length.error, 14)
+            XCTAssertEqual(mergedRuleConfiguration.ignoresCaseStatements, true)
+        } else {
+            XCTFail("Could not retrieve rule's individual configuration")
+        }
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -107,7 +107,7 @@ extension ConfigurationTests {
             type(of: $0).description.identifier == baseRuleIdentifier
         })
         XCTAssertNotNil(mergedRule)
-        if let mergedRuleConfig = mergedRule!.getConfiguration(of: mergedRule!) as? CyclomaticComplexityConfiguration {
+        if let mergedRuleConfig = mergedRule!.getConfiguration() as? CyclomaticComplexityConfiguration {
             XCTAssertEqual(mergedRuleConfig.length.warning, 5)
             XCTAssertEqual(mergedRuleConfig.length.error, 14)
             XCTAssertEqual(mergedRuleConfig.ignoresCaseStatements, true)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -107,10 +107,10 @@ extension ConfigurationTests {
             type(of: $0).description.identifier == baseRuleIdentifier
         })
         XCTAssertNotNil(mergedRule)
-        if let mergedRuleConfiguration = mergedRule!.getConfiguration(of: mergedRule!) as? CyclomaticComplexityConfiguration {
-            XCTAssertEqual(mergedRuleConfiguration.length.warning, 5)
-            XCTAssertEqual(mergedRuleConfiguration.length.error, 14)
-            XCTAssertEqual(mergedRuleConfiguration.ignoresCaseStatements, true)
+        if let mergedRuleConfig = mergedRule!.getConfiguration(of: mergedRule!) as? CyclomaticComplexityConfiguration {
+            XCTAssertEqual(mergedRuleConfig.length.warning, 5)
+            XCTAssertEqual(mergedRuleConfig.length.error, 14)
+            XCTAssertEqual(mergedRuleConfig.ignoresCaseStatements, true)
         } else {
             XCTFail("Could not retrieve rule's individual configuration")
         }


### PR DESCRIPTION
This PR serves as proof of concept to demonstrate the merging of individual rule's configurations, as proposed here: #2058 .
It is marked work in progress since the discussion of the proposition is still open.

There's a new unit test to check the proposed merging policy. The current implementation fulfills this test.
Nevertheless, there are still some open todos:

- Adapt implementation
  - still depending on extending all ConfigurationProviderRule implementations, although it is not necessary (experimentally applied to CyclomaticComplexityConfiguration.swift)

- Check Reflection as a dependency
  - The current implementation uses reflection to retrieve the `configuration` property of a ConfigurationProviderRule. Since Swift4 does not allow to check conformance with protocols using associated types, that's currently a working solution.

- Fix circleCI checks
- PR on Reflection (if it stays) 
  - target’s “Require Only App-Extension-Safe API” build setting is set to false. But it compiles if activated too