### PR TITLE
[WIP] Ignore colon rule on dictionary type declaration when apply_to_dictionaries configuration flag is false

### DIFF
--- a/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
@@ -92,7 +92,8 @@ class ColonRuleTests: XCTestCase {
             "let abc = [Void:  Void]()\n",
             "let abc = [Void :  Void]()\n",
             "let abc = [1: [3 : 2], 3: 4]\n",
-            "let abc = [1: [3 : 2], 3:  4]\n"
+            "let abc = [1: [3 : 2], 3:  4]\n",
+            "let abc: [String : Any]\n"
         ]
         let triggeringExamples = [
             "let ↓abc:Void\n",


### PR DESCRIPTION
As described in #1901 colon rule ignores dictionary literals when `apply_to_dictionaries`
is set to `false` but fails to ignore dictionary type declarations. This PR attempts to fix that issue.

This is marked as WIP because some tests still fail and I consider my fix a little bit rough. I'd like to get some help to better understand why some tests are failing and what would be the proper way to fix them. If the general logic is OK then I can clean the code and extract it into a separate function.

Also I'd like to check with a maintainer if the general direction of my fix is OK. This is my first dive in SwiftLint's code base and want to make sure that I'm not missing anything.

As far as I can tell, the colon rule is implemented by matching a regex against each file to check statements where the `:` character is used and there are white spaces to the left followed by an identifier. Both identifier on the left and on the right of the `:` character are captured on a group and then SourceKitten is used to see what type of token the captured identifier represents.

My first idea was to modify the regex expression but I think it would make the expression way more complicated. So the patch I'm proposing checks if the `apply_to_dictionaries` configuration flag is set to `false` and then it filters out matching violations (raised by the regex) if both identifiers to the left and the right of the `:` characters are type identifiers. The left type identifier should be preceded by a `[` (ignoring white spaces) and the right type identifier should be proceeded with a `]` (also ignoring white spaces). This is what I consider to be a valid dictionary type declaration. Is this definition of dictionary type declaration correct? Am I missing any edge cases?

I realize that this may have the performance overhead of capturing false positive by the regexp which would latter be discarded but I think is a reasonable trade off to be made for readability sake. But I guess some performance metrics should be used to decide whether my assumption is correct. 