### PR TITLE
Update CircleCI image to use Xcode 9.2 and use ruby from homebrew

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
 
   tsan:
     macos:
-      xcode: "9.0"
+      xcode: "9.2.0"
     steps:
       - checkout
       # Pre-cache
@@ -13,22 +13,23 @@ jobs:
 
   osscheck:
     macos:
-      xcode: "9.0"
+      xcode: "9.2.0"
     steps:
       - checkout
+      - run: brew install ruby
       - run: bundle install
       - run: bundle exec danger --verbose
 
   swiftpm_4:
     macos:
-      xcode: "9.0"
+      xcode: "9.2.0"
     steps:
       - checkout
       - run: swift test --parallel
 
   xcode_9:
     macos:
-      xcode: "9.0"
+      xcode: "9.2.0"
     steps:
       - checkout
       - run: set -o pipefail && script/cibuild | xcpretty -r junit
@@ -38,11 +39,13 @@ jobs:
 
   cocoapods:
     macos:
-      xcode: "9.0"
+      xcode: "9.2.0"
     steps:
       - checkout
+      - run: brew install ruby
+      - run: bundle install
       - run: curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
-      - run: echo "4.0" > .swift-version; pod lib lint SwiftLintFramework.podspec
+      - run: echo "4.0" > .swift-version; bundle exec pod lib lint SwiftLintFramework.podspec
 
   linux_swift_4:
     docker:


### PR DESCRIPTION
[GitHub removed support for TLSv1/TLSv1.1](https://github.com/blog/2507-weak-cryptographic-standards-removed), which breaks some jobs.

The system ruby from Sierra uses an old version of OpenSSL. Using a newer ruby (installed from Homebrew) fixes the issue.

Using High Sierra would also fix the issue, but no CircleCI image is using it currently.