### PR TITLE
Fix TODOs violation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 #### Bug Fixes
 
+* Fix TODOs lint message to state that TODOs should be resolved instead of
+  avoided.  
+  [Adonis Peralta](https://github.com/donileo)
+  [#150](https://github.com/realm/SwiftLint/issues/150)
+
 * Fix some cases where `colon` rule wouldn't autocorrect dictionary literals.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2050](https://github.com/realm/SwiftLint/issues/2050)

--- a/Rules.md
+++ b/Rules.md
@@ -12542,7 +12542,7 @@ Identifier | Enabled by default | Supports autocorrection | Kind
 --- | --- | --- | ---
 `todo` | Enabled | No | lint
 
-TODOs and FIXMEs should be avoided.
+TODOs and FIXMEs should be resolved.
 
 ### Examples
 

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -25,7 +25,7 @@ public struct TodoRule: ConfigurationProviderRule {
     public static let description = RuleDescription(
         identifier: "todo",
         name: "Todo",
-        description: "TODOs and FIXMEs should be avoided.",
+        description: "TODOs and FIXMEs should be resolved.",
         kind: .lint,
         nonTriggeringExamples: [
             "// notaTODO:\n",
@@ -72,9 +72,9 @@ public struct TodoRule: ConfigurationProviderRule {
         }
 
         if message.isEmpty {
-            reason = "\(kind) should be avoided."
+            reason = "\(kind) should be resolved."
         } else {
-            reason = "\(kind) should be avoided (\(message))."
+            reason = "\(kind) should be resolved (\(message))."
         }
 
         return reason

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -19,14 +19,14 @@ class TodoRuleTests: XCTestCase {
         let string = "fatalError() // TODO: Implement"
         let violations = self.violations(string)
         XCTAssertEqual(violations.count, 1)
-        XCTAssertEqual(violations.first!.reason, "TODOs should be avoided (Implement).")
+        XCTAssertEqual(violations.first!.reason, "TODOs should be resolved (Implement).")
     }
 
     func testFixMeMessage() {
         let string = "fatalError() // FIXME: Implement"
         let violations = self.violations(string)
         XCTAssertEqual(violations.count, 1)
-        XCTAssertEqual(violations.first!.reason, "FIXMEs should be avoided (Implement).")
+        XCTAssertEqual(violations.first!.reason, "FIXMEs should be resolved (Implement).")
     }
 
     private func violations(_ string: String) -> [StyleViolation] {


### PR DESCRIPTION
Change lint message for TODOs/FIXMEs to state that they should be
"resolved"/implemented instead of "avoided"/not used.