### PR TITLE
#2077 - New rule for comment lines in function bodies.

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 
 #### Enhancements
 
+* Adds `function_body_comments` opt-in rule to prohibit
+  the use of comments in function bodies.  
+  [Mikhail Yakushin](https://github.com/driver733)
+  [#2077](https://github.com/realm/SwiftLint/issues/2077)
+
 * Adds `discouraged_optional_boolean` opt-in rule to discourage
   the use of optional booleans.  
   [Ornithologist Coder](https://github.com/ornithocoder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 #### Enhancements
 
+* Adds `function_body_comments` opt-in rule to prohibit
+  the use of comments in function bodies.  
+  [Mikhail Yakushin](https://github.com/driver733)
+  [#2077](https://github.com/realm/SwiftLint/issues/2077)
+
 * Add a new `excluded` config parameter to the `explicit_type_interface` rule
   to exempt certain types of variables from the rule.  
   [Rounak Jain](https://github.com/rounak)
@@ -24,11 +29,6 @@
 * None.
 
 #### Enhancements
-
-* Adds `function_body_comments` opt-in rule to prohibit
-  the use of comments in function bodies.  
-  [Mikhail Yakushin](https://github.com/driver733)
-  [#2077](https://github.com/realm/SwiftLint/issues/2077)
 
 * Adds `discouraged_optional_boolean` opt-in rule to discourage
   the use of optional booleans.  

--- a/Rules.md
+++ b/Rules.md
@@ -41,6 +41,7 @@
 * [Force Cast](#force-cast)
 * [Force Try](#force-try)
 * [Force Unwrapping](#force-unwrapping)
+* [Function Body Comments](#function-body-comments)
 * [Function Body Length](#function-body-length)
 * [Function Parameter Count](#function-parameter-count)
 * [Generic Type Name](#generic-type-name)
@@ -5437,6 +5438,16 @@ open var computed: String { return foo.bar↓! }
 ```
 
 </details>
+
+
+
+## Function Body Comments
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`function_body_comments` | Disabled | No | style
+
+Functions bodies should not have comments.
 
 
 

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -275,6 +275,18 @@ extension File {
         }.count
     }
 
+    fileprivate func numberOfCommentLines(startLine: Int, endLine: Int) -> Int {
+        let commentKinds = SyntaxKind.commentKinds
+        var count = 0
+        for arr: [SyntaxKind] in syntaxKindsByLines[startLine...endLine] {
+            let set: Set<SyntaxKind> = Set(arr)
+            if !set.isDisjoint(with: commentKinds) {
+                count += 1
+            }
+        }
+        return count
+    }
+
     internal func exceedsLineCountExcludingCommentsAndWhitespace(_ start: Int, _ end: Int,
                                                                  _ limit: Int) -> (Bool, Int) {
         guard end - start > limit else {
@@ -282,6 +294,15 @@ extension File {
         }
 
         let count = end - start - numberOfCommentAndWhitespaceOnlyLines(startLine: start, endLine: end)
+        return (count > limit, count)
+    }
+
+    internal func exceedsCommentLines(_ start: Int, _ end: Int,
+                                      _ limit: Int) -> (Bool, Int) {
+        guard end - start > limit else {
+            return (false, end - start)
+        }
+        let count = numberOfCommentLines(startLine: start, endLine: end)
         return (count > limit, count)
     }
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -50,6 +50,7 @@ public let masterRuleList = RuleList(rules: [
     ForceTryRule.self,
     ForceUnwrappingRule.self,
     FunctionBodyLengthRule.self,
+    FunctionBodyCommentsRule.self,
     FunctionParameterCountRule.self,
     GenericTypeNameRule.self,
     IdentifierNameRule.self,

--- a/Source/SwiftLintFramework/Rules/FunctionBodyCommentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyCommentsRule.swift
@@ -1,0 +1,53 @@
+//
+//  FunctionBodyCommentsRule.swift
+//  SwiftLint
+//
+//  Created by Mikhail Yakushin on 02/28/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+public struct FunctionBodyCommentsRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    public var configuration = SeverityLevelsConfiguration(warning: 0, error: 0)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+            identifier: "function_body_comments",
+            name: "Function Body Comments",
+            description: "Functions bodies should not have comments.",
+            kind: .style
+    )
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard SwiftDeclarationKind.functionKinds.contains(kind),
+              let offset = dictionary.offset,
+              let bodyOffset = dictionary.bodyOffset,
+              let bodyLength = dictionary.bodyLength,
+              case let contentsNSString = file.contents.bridge(),
+              let startLine = contentsNSString.lineAndCharacter(forByteOffset: bodyOffset)?.line,
+              let endLine = contentsNSString.lineAndCharacter(forByteOffset: bodyOffset + bodyLength)?.line
+                else {
+            return []
+        }
+        for parameter in configuration.params {
+            let (exceeds, lineCount) = file.exceedsCommentLines(
+                    startLine, endLine, parameter.value
+            )
+            guard exceeds else { continue }
+            return [
+                StyleViolation(
+                    ruleDescription: type(of: self).description,
+                    severity: parameter.severity,
+                    location: Location(file: file, byteOffset: offset),
+                    reason: "Function body should span \(configuration.warning) lines or less " +
+                        "of comments: currently spans \(lineCount) " +
+                        "lines"
+                )
+            ]
+        }
+        return []
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 		B89F3BCF1FD5EE1400931E59 /* RequiredEnumCaseRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89F3BC71FD5ED7D00931E59 /* RequiredEnumCaseRuleConfiguration.swift */; };
 		BB00B4E91F5216090079869F /* MultipleClosuresWithTrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00B4E71F5216070079869F /* MultipleClosuresWithTrailingClosureRule.swift */; };
 		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
+		C2E099B1FFD283BEA0EBC5B0 /* FunctionBodyCommentsRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E09082757235CF0E6120EA /* FunctionBodyCommentsRuleTests.swift */; };
+		C2E09BF91C6D1C09AFF557F4 /* FunctionBodyCommentsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E099E6FF20FE33D0EC8488 /* FunctionBodyCommentsRule.swift */; };
 		C328A2F71E6759AE00A9E4D7 /* ExplicitTypeInterfaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */; };
 		C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */; };
 		C946FECB1EAE67EE007DD778 /* LetVarWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */; };
@@ -492,6 +494,8 @@
 		B89F3BCB1FD5EDA900931E59 /* RequiredEnumCaseRuleTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRuleTestCase.swift; sourceTree = "<group>"; };
 		BB00B4E71F5216070079869F /* MultipleClosuresWithTrailingClosureRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleClosuresWithTrailingClosureRule.swift; sourceTree = "<group>"; };
 		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
+		C2E09082757235CF0E6120EA /* FunctionBodyCommentsRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyCommentsRuleTests.swift; sourceTree = "<group>"; };
+		C2E099E6FF20FE33D0EC8488 /* FunctionBodyCommentsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyCommentsRule.swift; sourceTree = "<group>"; };
 		C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRule.swift; sourceTree = "<group>"; };
 		C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FatalErrorMessageRule.swift; sourceTree = "<group>"; };
 		C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LetVarWhitespaceRule.swift; sourceTree = "<group>"; };
@@ -971,6 +975,7 @@
 				D0D1212219E878CC005E4BAA /* Configuration */,
 				3B12C9BE1C3209AC000B423F /* Resources */,
 				D0D1217C19E87B05005E4BAA /* Supporting Files */,
+				C2E09082757235CF0E6120EA /* FunctionBodyCommentsRuleTests.swift */,
 			);
 			name = SwiftLintFrameworkTests;
 			path = Tests/SwiftLintFrameworkTests;
@@ -1162,6 +1167,7 @@
 				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
 				626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */,
 				1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */,
+				C2E099E6FF20FE33D0EC8488 /* FunctionBodyCommentsRule.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -1702,6 +1708,7 @@
 				A73469421FB121BA009B57C7 /* CallPairRule.swift in Sources */,
 				D47079AF1DFE520000027086 /* VoidReturnRule.swift in Sources */,
 				B3935EE74B1E8E14FBD65E7F /* String+XML.swift in Sources */,
+				C2E09BF91C6D1C09AFF557F4 /* FunctionBodyCommentsRule.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1755,6 +1762,7 @@
 				3B63D46F1E1F09DF0057BE35 /* LineLengthRuleTests.swift in Sources */,
 				3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */,
 				E809EDA31B8A73FB00399043 /* ConfigurationTests.swift in Sources */,
+				C2E099B1FFD283BEA0EBC5B0 /* FunctionBodyCommentsRuleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -183,7 +183,7 @@ extension FileLengthRuleTests {
     ]
 }
 
-extension FunctionBodyLengthRuleTests {
+extension FunctionBodyCommentsRuleTests {
     static var allTests: [(String, (FunctionBodyCommentsRuleTests) -> () throws -> Void)] = [
         ("testFunctionBodyCommentsValid", testFunctionBodyCommentsValid),
         ("testFunctionBodyCommentsInLine", testFunctionBodyCommentsInLine),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -184,6 +184,14 @@ extension FileLengthRuleTests {
 }
 
 extension FunctionBodyLengthRuleTests {
+    static var allTests: [(String, (FunctionBodyCommentsRuleTests) -> () throws -> Void)] = [
+        ("testFunctionBodyCommentsValid", testFunctionBodyCommentsValid),
+        ("testFunctionBodyCommentsInLine", testFunctionBodyCommentsInLine),
+        ("testFunctionBodyCommentsMultiLine", testFunctionBodyCommentsMultiLine)
+    ]
+}
+
+extension FunctionBodyLengthRuleTests {
     static var allTests: [(String, (FunctionBodyLengthRuleTests) -> () throws -> Void)] = [
         ("testFunctionBodyLengths", testFunctionBodyLengths),
         ("testFunctionBodyLengthsWithComments", testFunctionBodyLengthsWithComments),

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyCommentsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyCommentsRuleTests.swift
@@ -1,0 +1,49 @@
+//
+//  FunctionBodyCommentsRuleTests.swift
+//  SwiftLint
+//
+//  Created by Mikhail Yakushin on 02/28/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+import XCTest
+
+private func funcWithBody(_ body: String, violates: Bool = false) -> String {
+    let marker = violates ? "↓" : ""
+    return "func \(marker)abc() {\nvar x = 0\n\(body)}\n"
+}
+
+private func violatingFuncWithBody(_ body: String) -> String {
+    return funcWithBody(body, violates: true)
+}
+
+class FunctionBodyCommentsRuleTests: XCTestCase {
+
+    func testFunctionBodyCommentsValid() {
+        let longFunctionBody = funcWithBody(repeatElement("x = 0\n", count: 39).joined())
+        XCTAssertEqual(violations(longFunctionBody), [])
+    }
+
+    func testFunctionBodyCommentsInLine() {
+        let longFunctionBodyWithComments = violatingFuncWithBody(
+                repeatElement("x = 0\n", count: 40).joined() +
+                        "// in line comments are prohibited.\n"
+        )
+        XCTAssertNotEqual(violations(longFunctionBodyWithComments), [])
+    }
+
+    func testFunctionBodyCommentsMultiLine() {
+        let longFunctionBodyWithMultilineComments = funcWithBody(
+                repeatElement("x = 0\n", count: 40).joined() +
+                        "/* multi line comments are prohibited.\n*/\n"
+        )
+        XCTAssertNotEqual(violations(longFunctionBodyWithMultilineComments), [])
+    }
+
+    private func violations(_ string: String) -> [StyleViolation] {
+        let config = makeConfig(nil, FunctionBodyCommentsRule.description.identifier)!
+        return SwiftLintFrameworkTests.violations(string, config: config)
+    }
+
+}


### PR DESCRIPTION
As per #2077 
I have implemented a new rule that prohibits comment lines in function bodies.