### PR TITLE
Improve Array.parallelMap

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -59,18 +59,16 @@ extension Array {
         return parallelMap(transform: transform).flatMap { $0 }
     }
 
-    func parallelMap<T>(transform: @escaping ((Element) -> T)) -> [T] {
-        var result = [(Int, T)]()
-        result.reserveCapacity(count)
-
-        let queueLabelPrefix = "io.realm.SwiftLintFramework.map.\(NSUUID().uuidString)"
-        let resultAccumulatorQueue = DispatchQueue(label: "\(queueLabelPrefix).resultAccumulator")
-        DispatchQueue.concurrentPerform(iterations: count) { index in
-            let jobIndexAndResults = (index, transform(self[index]))
+    func parallelMap<T>(transform: (Element) -> T) -> [T] {
+        var result = [T?](repeating: nil, count: count)
+        let resultAccumulatorQueue = DispatchQueue(label: "io.realm.SwiftLintFramework.map.resultAccumulator")
+        DispatchQueue.concurrentPerform(iterations: count) { idx in
+            let element = self[idx]
+            let transformed = transform(element)
             resultAccumulatorQueue.sync {
-                result.append(jobIndexAndResults)
+                result[idx] = transformed
             }
         }
-        return result.sorted { $0.0 < $1.0 }.map { $0.1 }
+        return result.map { $0! }
     }
 }


### PR DESCRIPTION
By applying concepts from Swift Talk 90: https://talk.objc.io/episodes/S01E90-concurrent-map

Notably:
* Removing `@escaping` from block parameter
* Avoiding Array.append & sorting
* Using a constant DispatchQueue label