### PR TITLE
Remove `DispatchQueue.sync` from `Array.parallelMap`

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -60,15 +60,12 @@ extension Array {
     }
 
     func parallelMap<T>(transform: (Element) -> T) -> [T] {
-        var result = [T?](repeating: nil, count: count)
-        let resultAccumulatorQueue = DispatchQueue(label: "io.realm.SwiftLintFramework.map.resultAccumulator")
-        DispatchQueue.concurrentPerform(iterations: count) { idx in
-            let element = self[idx]
-            let transformed = transform(element)
-            resultAccumulatorQueue.sync {
-                result[idx] = transformed
+        var result = ContiguousArray<T?>(repeating: nil, count: count)
+        return result.withUnsafeMutableBufferPointer { buffer in
+            DispatchQueue.concurrentPerform(iterations: buffer.count) { idx in
+                buffer[idx] = transform(self[idx])
             }
+            return buffer.map { $0! }
         }
-        return result.map { $0! }
     }
 }


### PR DESCRIPTION
`DispatchQueue.sync` was required to avoid CoW on calling `subscript` from multiple copied instances of `Array`.
Since `UnsafeMutableBufferPointer` does not cause CoW on same situation, `DispatchQueue.sync` can be removed.