### PR TITLE
Fix for crash on Linux on sources with surrogate characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2050](https://github.com/realm/SwiftLint/issues/2050)
 
+* Fix linux crash on sources with surrogate pair emojis as variable names.  
+  [Cyril Lashkevich](https://github.com/notorca)
+
 ## 0.25.0: Cleaning the Lint Filter
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+SwiftLint.swift
@@ -1,0 +1,23 @@
+//
+//  CharacterSet+SwiftLint.swift
+//  SwiftLint
+//
+//  Created by Cyril Lashkevich on 3/11/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import Foundation
+
+// This is workaround for https://bugs.swift.org/browse/SR-5971
+// Can be removed when 
+// https://github.com/apple/swift-corelibs-foundation/pull/1471 is merged
+internal extension CharacterSet {
+    init(safeCharactersIn string: String) {
+#if os(Linux)
+        self.init()
+        insert(charactersIn: string)
+#else
+        self.init(charactersIn: string)
+#endif
+    }
+}

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -166,7 +166,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
-        if !allowedSymbols.isSuperset(of: CharacterSet(charactersIn: name)) {
+        if !allowedSymbols.isSuperset(of: CharacterSet(safeCharactersIn: name)) {
             return [
                 StyleViolation(ruleDescription: type(of: self).description,
                                severity: .error,

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -49,7 +49,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             let type = self.type(for: kind)
             if !isFunction {
                 let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
-                if !allowedSymbols.isSuperset(of: CharacterSet(charactersIn: name)) {
+                if !allowedSymbols.isSuperset(of: CharacterSet(safeCharactersIn: name)) {
                     return [
                         StyleViolation(ruleDescription: description,
                                        severity: .error,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -32,7 +32,7 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
     }
 
     var allowedSymbols: CharacterSet {
-        return CharacterSet(charactersIn: allowedSymbolsSet.joined())
+        return CharacterSet(safeCharactersIn: allowedSymbolsSet.joined())
     }
 
     public init(minLengthWarning: Int,

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -80,7 +80,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
 
         let name = name.nameStrippingLeadingUnderscoreIfPrivate(dictionary)
         let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
-        if !allowedSymbols.isSuperset(of: CharacterSet(charactersIn: name)) {
+        if !allowedSymbols.isSuperset(of: CharacterSet(safeCharactersIn: name)) {
             return [StyleViolation(ruleDescription: type(of: self).description,
                                    severity: .error,
                                    location: Location(file: file, byteOffset: offset),

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856651A61D6B395F005E6B29 /* MarkRule.swift */; };
 		8F8050821FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8050811FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift */; };
 		8FC9F5111F4B8E48006826C1 /* IsDisjointRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */; };
+		8FD216CC205584AF008ED13F /* CharacterSet+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD216CB205584AF008ED13F /* CharacterSet+SwiftLint.swift */; };
 		92CCB2D71E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */; };
 		93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */; };
 		A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */; };
@@ -468,6 +469,7 @@
 		856651A61D6B395F005E6B29 /* MarkRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
 		8F8050811FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+IndentationStyle.swift"; sourceTree = "<group>"; };
 		8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsDisjointRule.swift; sourceTree = "<group>"; };
+		8FD216CB205584AF008ED13F /* CharacterSet+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CharacterSet+SwiftLint.swift"; sourceTree = "<group>"; };
 		92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRule.swift; sourceTree = "<group>"; };
 		93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineRule.swift; sourceTree = "<group>"; };
 		A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralConfiguration.swift; sourceTree = "<group>"; };
@@ -1210,6 +1212,7 @@
 			isa = PBXGroup;
 			children = (
 				3B5B9FE01C444DA20009AD27 /* Array+SwiftLint.swift */,
+				8FD216CB205584AF008ED13F /* CharacterSet+SwiftLint.swift */,
 				E82367DF1ED3BD1E0040A88E /* Configuration+Cache.swift */,
 				8F8050811FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift */,
 				E889D8C41F1D11A200058332 /* Configuration+LintableFiles.swift */,
@@ -1674,6 +1677,7 @@
 				827169B31F488181003FB9AF /* ExplicitEnumRawValueRule.swift in Sources */,
 				29FFC37A1F15764D007E4825 /* FileLengthRuleConfiguration.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
+				8FD216CC205584AF008ED13F /* CharacterSet+SwiftLint.swift in Sources */,
 				D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */,
 				62A498561F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift in Sources */,
 				29AD4C661F6EA1D5009B66E1 /* ContainsOverFirstNotNilRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -205,7 +205,8 @@ extension IdentifierNameRuleTests {
         ("testIdentifierName", testIdentifierName),
         ("testIdentifierNameWithAllowedSymbols", testIdentifierNameWithAllowedSymbols),
         ("testIdentifierNameWithAllowedSymbolsAndViolation", testIdentifierNameWithAllowedSymbolsAndViolation),
-        ("testIdentifierNameWithIgnoreStartWithLowercase", testIdentifierNameWithIgnoreStartWithLowercase)
+        ("testIdentifierNameWithIgnoreStartWithLowercase", testIdentifierNameWithIgnoreStartWithLowercase),
+        ("testLinuxCrashOnEmojiNames", testLinuxCrashOnEmojiNames)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -53,4 +53,14 @@ class IdentifierNameRuleTests: XCTestCase {
 
         verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": false])
     }
+
+    func testLinuxCrashOnEmojiNames() {
+        let baseDescription = IdentifierNameRule.description
+        let triggeringExamples = [
+            "let 👦🏼 = \"👦🏼\""
+        ]
+
+        let description = baseDescription.with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%"]])
+    }
 }


### PR DESCRIPTION
Because of the bug https://bugs.swift.org/browse/SR-5971 SwiftLint
crashes when linting on Linux files like https://github.com/xmartlabs/Eureka/blob/master/Example/Example/ViewController.swift