### PR TITLE
Fix `colon` autocorrect when preprocessor macros are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2098](https://github.com/realm/SwiftLint/issues/2098)
 
+* Fix `colon` rule autocorrect when preprocessor macros are present.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2099](https://github.com/realm/SwiftLint/issues/2099)
+
 ## 0.25.0: Cleaning the Lint Filter
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/ColonRule+Dictionary.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule+Dictionary.swift
@@ -25,7 +25,7 @@ extension ColonRule {
             ranges += dictionaryColonViolationRanges(in: file, dictionary: subDict)
 
             return ranges
-        }
+        }.unique
     }
 
     internal func dictionaryColonViolationRanges(in file: File, kind: SwiftExpressionKind,

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -162,7 +162,9 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             "func abc() { def(ghi↓:jkl) }": "func abc() { def(ghi: jkl) }",
             "func abc(def: Void) { ghi(jkl↓:mno) }": "func abc(def: Void) { ghi(jkl: mno) }",
             "class ABC { let def = ghi(jkl↓:mno) } }": "class ABC { let def = ghi(jkl: mno) } }",
-            "func foo() { let dict = [1↓ : 1] }": "func foo() { let dict = [1: 1] }"
+            "func foo() { let dict = [1↓ : 1] }": "func foo() { let dict = [1: 1] }",
+            "class Foo {\n    #if false\n    #else\n        let bar = [\"key\"↓   : \"value\"]\n    #endif\n}":
+            "class Foo {\n    #if false\n    #else\n        let bar = [\"key\": \"value\"]\n    #endif\n}"
         ]
     )
 


### PR DESCRIPTION
Fixes #2099