### PR TITLE
Fix `empty_enum_arguments` rule autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2032](https://github.com/realm/SwiftLint/issues/2032)
 
+* Fix `empty_enum_arguments` rule autocorrection inside functions or other
+  declarations.
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 ## 0.25.0: Cleaning the Lint Filter
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -3019,6 +3019,15 @@ switch foo {
 }
 ```
 
+```swift
+func example(foo: Foo) {
+    switch foo {
+    case case .bar↓(_):
+        break
+    }
+}
+```
+
 </details>
 
 


### PR DESCRIPTION
Reported by @jszumski in https://github.com/realm/SwiftLint/issues/2103#issuecomment-376389954