### PR TITLE
Enable more opt-in rules on SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -28,6 +28,16 @@ opt_in_rules:
   - pattern_matching_keywords
   - array_init
   - literal_expression_end_indentation
+  - joined_default_parameter
+  - contains_over_first_not_nil
+  - override_in_extension
+  - private_action
+  - quick_discouraged_call
+  - quick_discouraged_focused_test
+  - quick_discouraged_pending_test
+  - single_test_class
+  - sorted_first_last
+  - yoda_condition
 
 file_header:
   required_pattern: |


### PR DESCRIPTION
Some rules like `quick_discouraged_call` are not really useful for the project itself, but I think it's worth enabling them just to make sure we don't have any obvious false positives.