### PR TITLE
Fixes `redundant_void_return` rule autocorrect when preprocessor macros are present. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
   `unused_closure_parameter`) rules autocorrection inside functions or other
   declarations.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  
+* Fix `redundant_void_return` rule autocorrect when preprocessor macros are present.  
+  [John Szumski](https://github.com/jszumski)
+  [#2115](https://github.com/realm/SwiftLint/issues/2115)
 
 ## 0.25.0: Cleaning the Lint Filter
 

--- a/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
@@ -84,7 +84,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
         let linesTokens = file.syntaxTokensByLines
         let kindsToExclude = SyntaxKind.commentAndStringKinds.map { $0.rawValue }
 
-        // find all lines and accurences of open { and closed } braces
+        // find all lines and occurences of open { and closed } braces
         var linesWithBraces = [[NSRange]]()
         for eachLine in file.lines {
             guard let nsrange = lineContainsBraces(in: eachLine.range, content: nsstring) else {

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -43,7 +43,9 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
             "func foo()↓ -> Void {}\n": "func foo() {}\n",
             "protocol Foo {\n func foo()↓ -> Void\n}\n": "protocol Foo {\n func foo()\n}\n",
             "func foo()↓ -> () {}\n": "func foo() {}\n",
-            "protocol Foo {\n func foo()↓ -> ()\n}\n": "protocol Foo {\n func foo()\n}\n"
+            "protocol Foo {\n func foo()↓ -> ()\n}\n": "protocol Foo {\n func foo()\n}\n",
+            "protocol Foo {\n    #if true\n    func foo()↓ -> Void\n    #endif\n}\n":
+            "protocol Foo {\n    #if true\n    func foo()\n    #endif\n}\n"
         ]
     )
 
@@ -87,7 +89,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
             }
 
             return ranges
-        }
+        }.unique
     }
 
     private func violationRanges(in file: File) -> [NSRange] {


### PR DESCRIPTION
Fixes #2115.  Very similar to https://github.com/realm/SwiftLint/pull/2105