### PR TITLE
Fixed plurality of autocorrect done message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@
 * Fix `redundant_void_return` rule autocorrect when preprocessor macros are present.  
   [John Szumski](https://github.com/jszumski)
   [#2115](https://github.com/realm/SwiftLint/issues/2115)
+  
+* Fix issue where the autocorrect done message used the plural form of "files" even if only 1 file changed.  
+  [John Szumski](https://github.com/jszumski)
 
 ## 0.25.0: Cleaning the Lint Filter
 

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -54,7 +54,10 @@ struct AutoCorrectCommand: CommandProtocol {
             }
         }.flatMap { files in
             if !options.quiet {
-                queuedPrintError("Done correcting \(files.count) files!")
+                let pluralSuffix = { (collection: [Any]) -> String in
+                    return collection.count != 1 ? "s" : ""
+                }
+                queuedPrintError("Done correcting \(files.count) file\(pluralSuffix(files))!")
             }
             return .success(())
         }


### PR DESCRIPTION
Fixed issue where the autocorrect done message used the plural form of "files" even if only 1 file changed.