### PR TITLE
Fixes yoda_condition Rule Severity/Description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
   even if only 1 file changed.  
   [John Szumski](https://github.com/jszumski)
 
+* Fixes an issue with the `yoda_condition` rule where the severity would always
+  display as a warning, and the reason would display as the severity type.  
+  [Twig](https://github.com/Twigz)
+
 ## 0.25.0: Cleaning the Lint Filter
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 
 #### Bug Fixes
 
+* Fixes an issue with the `yoda_condition` rule where the severity would always
+  display as a warning, and the reason would display as the severity type.  
+  [Twig](https://github.com/Twigz)
+
 * Fix TODOs lint message to state that TODOs should be resolved instead of
   avoided.  
   [Adonis Peralta](https://github.com/donileo)
@@ -79,10 +83,6 @@
 * Fix issue where the autocorrect done message used the plural form of "files"
   even if only 1 file changed.  
   [John Szumski](https://github.com/jszumski)
-
-* Fixes an issue with the `yoda_condition` rule where the severity would always
-  display as a warning, and the reason would display as the severity type.  
-  [Twig](https://github.com/Twigz)
 
 ## 0.25.0: Cleaning the Lint Filter
 

--- a/Source/SwiftLintFramework/Rules/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/YodaConditionRule.swift
@@ -87,8 +87,8 @@ public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule {
         return matches.map { _ -> StyleViolation in
             let characterOffset = startOffset(of: offset, with: length, in: file)
             let location = Location(file: file, characterOffset: characterOffset)
-            return StyleViolation(ruleDescription: type(of: self).description, severity: .warning,
-                                  location: location, reason: configuration.consoleDescription)
+            return StyleViolation(ruleDescription: type(of: self).description, severity: configuration.severity,
+                                  location: location)
         }
     }
 


### PR DESCRIPTION
The `yoda_condition` rule was always displaying the severity of `warning`, even when it was set in a configuration file to be `error`. Additionally, rather than using the rule's description for the reason, it was using the severity type.

This pull request updates the `yoda_condition` to obey the `severity` of the `configuration`, and uses the default reason (which is the description of the rule), rather than passing in a reason.