### PR TITLE
New Rule - Explicit Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The next release will require Swift 4.0 or higher to build.
 * Add `UIOffsetMake` to `legacy_constructor` rule.  
   [Nealon Young](https://github.com/nealyoung)
   [#2126](https://github.com/realm/SwiftLint/issues/2126)
+
 * Add `explicit_final` opt-in rule to enforce final declarations on non-open
   types.  
   [Twig](https://github.com/Twigz)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The next release will require Swift 4.0 or higher to build.
 * Add `UIOffsetMake` to `legacy_constructor` rule.  
   [Nealon Young](https://github.com/nealyoung)
   [#2126](https://github.com/realm/SwiftLint/issues/2126)
+* Add `explicit_final` opt-in rule to enforce final declarations on non-open
+  types.  
+  [Twig](https://github.com/Twigz)
 
 * Add a new `excluded` config parameter to the `explicit_type_interface` rule
   to exempt certain types of variables from the rule.  

--- a/Rules.md
+++ b/Rules.md
@@ -30,6 +30,7 @@
 * [Empty String](#empty-string)
 * [Explicit ACL](#explicit-acl)
 * [Explicit Enum Raw Value](#explicit-enum-raw-value)
+* [Explicit Final](#explicit-final)
 * [Explicit Init](#explicit-init)
 * [Explicit Top Level ACL](#explicit-top-level-acl)
 * [Explicit Type Interface](#explicit-type-interface)
@@ -4359,6 +4360,107 @@ enum Numbers: Decimal {
  case ↓one, ↓two
 }
 
+```
+
+</details>
+
+
+
+## Explicit Final
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`explicit_final` | Disabled | No | idiomatic
+
+Non-open class types should always specify final to encourage composition over inheritance.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+final class A {}
+```
+
+```swift
+internal final class B {}
+```
+
+```swift
+private final class C {}
+```
+
+```swift
+public final class D {}
+```
+
+```swift
+open final class D {}
+```
+
+```swift
+open class D {}
+```
+
+```swift
+final class E {
+    final class F { }
+}
+```
+
+```swift
+final class G {
+    final class H {
+        final class I { }
+    }
+}
+```
+
+```swift
+enum J { }
+```
+
+```swift
+struct K { }
+```
+
+```swift
+protocol L { }
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+↓class A {}
+```
+
+```swift
+internal ↓class B {}
+```
+
+```swift
+private ↓class C {}
+```
+
+```swift
+public ↓class D {}
+```
+
+```swift
+final class E {
+    ↓class F { }
+}
+```
+
+```swift
+final class G {
+    final class H {
+        ↓class I { }
+    }
+}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -38,6 +38,7 @@ public let masterRuleList = RuleList(rules: [
     EmptyStringRule.self,
     ExplicitACLRule.self,
     ExplicitEnumRawValueRule.self,
+    ExplicitFinalRule.self,
     ExplicitInitRule.self,
     ExplicitTopLevelACLRule.self,
     ExplicitTypeInterfaceRule.self,

--- a/Source/SwiftLintFramework/Rules/ExplicitFinalRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitFinalRule.swift
@@ -56,12 +56,10 @@ public struct ExplicitFinalRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        guard kind == .class else { return [] }
-
-        guard let accessibility = dictionary.accessibility else { return [] }
-        guard AccessControlLevel(identifier: accessibility) != .open else { return [] }
-
-        guard !dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.final") else { return [] }
+        guard kind == .class,
+              let accessibility = dictionary.accessibility,
+              AccessControlLevel(identifier: accessibility) != .open,
+              !dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.final") else { return [] }
 
         guard let offset = dictionary.offset else { return [] }
 

--- a/Source/SwiftLintFramework/Rules/ExplicitFinalRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitFinalRule.swift
@@ -1,0 +1,72 @@
+//
+//  ExplicitFinalRule.swift
+//  SwiftLint
+//
+//  Created by Andrew Harrison on 3/30/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct ExplicitFinalRule: ASTRule, OptInRule, ConfigurationProviderRule {
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "explicit_final",
+        name: "Explicit Final",
+        description: "Non-open class types should always specify final to encourage composition over inheritance.",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            "final class A {}",
+            "internal final class B {}",
+            "private final class C {}",
+            "public final class D {}",
+            "open final class D {}",
+            "open class D {}",
+            "final class E {\n" +
+            "    final class F { }\n" +
+            "}",
+            "final class G {\n" +
+            "    final class H {\n" +
+            "        final class I { }\n" +
+            "    }\n" +
+            "}",
+            "enum J { }",
+            "struct K { }",
+            "protocol L { }"
+        ],
+        triggeringExamples: [
+            "↓class A {}",
+            "internal ↓class B {}",
+            "private ↓class C {}",
+            "public ↓class D {}",
+            "final class E {\n" +
+            "    ↓class F { }\n" +
+            "}",
+            "final class G {\n" +
+            "    final class H {\n" +
+            "        ↓class I { }\n" +
+            "    }\n" +
+            "}"
+        ])
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .class else { return [] }
+
+        guard let accessibility = dictionary.accessibility else { return [] }
+        guard AccessControlLevel(identifier: accessibility) != .open else { return [] }
+
+        guard !dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.final") else { return [] }
+
+        guard let offset = dictionary.offset else { return [] }
+
+        return [StyleViolation(ruleDescription: type(of: self).description,
+                               severity: configuration.severity,
+                               location: Location(file: file, byteOffset: offset))]
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -315,6 +315,7 @@
 		E8C0DFCD1AD349DB007EE3D4 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */; };
 		E8EA41171C2D1DBE004F9930 /* CheckstyleReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EA41161C2D1DBE004F9930 /* CheckstyleReporter.swift */; };
 		F22314B01D4FA4D7009AD165 /* LegacyNSGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */; };
+		F2B895D8206E6F5E0070B690 /* ExplicitFinalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B895D7206E6F5E0070B690 /* ExplicitFinalRule.swift */; };
 		F480DC7F1F26090000099465 /* ConfigurationTests+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */; };
 		F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */; };
 		F480DC831F2609D700099465 /* ConfigurationTests+ProjectMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */; };
@@ -698,6 +699,7 @@
 		E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8EA41161C2D1DBE004F9930 /* CheckstyleReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckstyleReporter.swift; sourceTree = "<group>"; };
 		F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyNSGeometryFunctionsRule.swift; sourceTree = "<group>"; };
+		F2B895D7206E6F5E0070B690 /* ExplicitFinalRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitFinalRule.swift; sourceTree = "<group>"; };
 		F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+Nested.swift"; sourceTree = "<group>"; };
 		F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+BundlePath.swift"; sourceTree = "<group>"; };
 		F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+ProjectMock.swift"; sourceTree = "<group>"; };
@@ -1081,6 +1083,7 @@
 				D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */,
 				72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */,
 				827169B21F488181003FB9AF /* ExplicitEnumRawValueRule.swift */,
+				F2B895D7206E6F5E0070B690 /* ExplicitFinalRule.swift */,
 				7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */,
 				1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */,
 				C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */,
@@ -1690,6 +1693,7 @@
 				B2902A0C1D66815600BFCCF7 /* PrivateUnitTestRule.swift in Sources */,
 				D47A51101DB2DD4800A4CC21 /* AttributesRule.swift in Sources */,
 				CE8178ED1EAC039D0063186E /* UnusedOptionalBindingConfiguration.swift in Sources */,
+				F2B895D8206E6F5E0070B690 /* ExplicitFinalRule.swift in Sources */,
 				62DEA1661FB21A9E00BCCCC6 /* PrivateActionRule.swift in Sources */,
 				D4FD58B21E12A0200019503C /* LinterCache.swift in Sources */,
 				3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -443,7 +443,7 @@ extension RulesTests {
         ("testEmptyString", testEmptyString),
         ("testExplicitACL", testExplicitACL),
         ("testExplicitEnumRawValue", testExplicitEnumRawValue),
-        ("testExplicitFinal", textExplicitFinal),
+        ("testExplicitFinal", testExplicitFinal),
         ("testExplicitInit", testExplicitInit),
         ("testExplicitTopLevelACL", testExplicitTopLevelACL),
         ("testExtensionAccessModifier", testExtensionAccessModifier),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -443,6 +443,7 @@ extension RulesTests {
         ("testEmptyString", testEmptyString),
         ("testExplicitACL", testExplicitACL),
         ("testExplicitEnumRawValue", testExplicitEnumRawValue),
+        ("testExplicitFinal", textExplicitFinal),
         ("testExplicitInit", testExplicitInit),
         ("testExplicitTopLevelACL", testExplicitTopLevelACL),
         ("testExtensionAccessModifier", testExtensionAccessModifier),

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -118,6 +118,10 @@ class RulesTests: XCTestCase {
         verifyRule(ExplicitEnumRawValueRule.description)
     }
 
+    func testExplicitFinal() {
+        verifyRule(ExplicitFinalRule.description)
+    }
+
     func testExplicitInit() {
         verifyRule(ExplicitInitRule.description)
     }


### PR DESCRIPTION
Adds a new `explicit_final` rule to require final on all non-open class types, to encourage composition over inheritance.