### PR TITLE
Improved autocorrect behavior of multiple rules when preprocessor macros are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@
 * Fix issue where the autocorrect done message used the plural form of "files"
   even if only 1 file changed.  
   [John Szumski](https://github.com/jszumski)
+  
+* Fix autocorrection for several rules (`empty_parentheses_with_trailing_closure`, 
+  `explicit_init`, `joined_default_parameter`, `redundant_optional_initialization` 
+  and `unused_closure_parameter `) when used with preprocessor macros.  
+  [John Szumski](https://github.com/jszumski)
 
 ## 0.25.0: Cleaning the Lint Filter
 

--- a/Rules.md
+++ b/Rules.md
@@ -13769,6 +13769,16 @@ let foo = ["אבג", "αβγ", "🇺🇸"↓,]
 
 ```
 
+```swift
+class C {
+ #if true
+ func f() {
+ let foo = [1, 2, 3↓,]
+ }
+ #endif
+}
+```
+
 </details>
 
 

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -15,7 +15,9 @@ public protocol ASTRule: Rule {
 
 public extension ASTRule where KindType.RawValue == String {
     func validate(file: File) -> [StyleViolation] {
-        return validate(file: file, dictionary: file.structure.dictionary)
+        let violations = validate(file: file, dictionary: file.structure.dictionary)
+
+        return violationsAreUnique ? violations.unique : violations
     }
 
     func validate(file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -12,6 +12,9 @@ public protocol Rule {
     static var description: RuleDescription { get }
     var configurationDescription: String { get }
 
+    /// Indicates whether multiple violations in the same location should be treated as one violation
+    var violationsAreUnique: Bool { get }
+
     init() // Rules need to be able to be initialized with default values
     init(configuration: Any) throws
 
@@ -26,6 +29,10 @@ extension Rule {
 
     internal var cacheDescription: String {
         return (self as? CacheDescriptionProvider)?.cacheDescription ?? configurationDescription
+    }
+
+    public var violationsAreUnique: Bool {
+        return true
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/ColonRule+Dictionary.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule+Dictionary.swift
@@ -17,7 +17,7 @@ extension ColonRule {
             return []
         }
 
-        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges: [NSRange] = []
             if let kind = subDict.kind.flatMap(KindType.init(rawValue:)) {
                 ranges += dictionaryColonViolationRanges(in: file, kind: kind, dictionary: subDict)
@@ -25,7 +25,9 @@ extension ColonRule {
             ranges += dictionaryColonViolationRanges(in: file, dictionary: subDict)
 
             return ranges
-        }.unique
+        }
+
+        return violationsAreUnique ? ranges.unique : ranges
     }
 
     internal func dictionaryColonViolationRanges(in file: File, kind: SwiftExpressionKind,

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -11,6 +11,9 @@ import SourceKittenFramework
 
 public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
+    public var violationsAreUnique: Bool {
+        return false
+    }
 
     public init() {}
 

--- a/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
@@ -45,7 +45,9 @@ public struct EmptyParenthesesWithTrailingClosureRule: ASTRule, CorrectableRule,
             "[1, 2].map↓() { number in\n number + 1 \n}\n": "[1, 2].map { number in\n number + 1 \n}\n",
             "[1, 2].map↓(  ) { number in\n number + 1 \n}\n": "[1, 2].map { number in\n number + 1 \n}\n",
             "func foo() -> [Int] {\n    return [1, 2].map↓() { $0 + 1 }\n}\n":
-            "func foo() -> [Int] {\n    return [1, 2].map { $0 + 1 }\n}\n"
+                "func foo() -> [Int] {\n    return [1, 2].map { $0 + 1 }\n}\n",
+            "class C {\n#if true\nfunc f() {\n[1, 2].map↓() { $0 + 1 }\n}\n#endif\n}":
+                "class C {\n#if true\nfunc f() {\n[1, 2].map { $0 + 1 }\n}\n#endif\n}"
         ]
     )
 
@@ -96,7 +98,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: ASTRule, CorrectableRule,
             }
 
             return ranges
-        }
+        }.unique
     }
 
     private func violationRanges(in file: File) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
@@ -91,14 +91,16 @@ public struct EmptyParenthesesWithTrailingClosureRule: ASTRule, CorrectableRule,
     }
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
             if let kind = subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) {
                 ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
             }
 
             return ranges
-        }.unique
+        }
+
+        return violationsAreUnique ? ranges.unique : ranges
     }
 
     private func violationRanges(in file: File) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
@@ -35,7 +35,9 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
         corrections: [
             "[1].flatMap{String↓.init($0)}": "[1].flatMap{String($0)}",
             "func foo() -> [String] {\n    return [1].flatMap { String↓.init($0) }\n}":
-            "func foo() -> [String] {\n    return [1].flatMap { String($0) }\n}"
+                "func foo() -> [String] {\n    return [1].flatMap { String($0) }\n}",
+            "class C {\n#if true\nfunc f() {\n[1].flatMap{String.init($0)}\n}\n#endif\n}":
+                "class C {\n#if true\nfunc f() {\n[1].flatMap{String($0)}\n}\n#endif\n}"
         ]
     )
 
@@ -78,7 +80,7 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
             }
 
             return ranges
-        }
+        }.unique
     }
 
     private func violationRanges(in file: File) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
@@ -73,14 +73,16 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
     }
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
             if let kind = subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) {
                 ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
             }
 
             return ranges
-        }.unique
+        }
+
+        return violationsAreUnique ? ranges.unique : ranges
     }
 
     private func violationRanges(in file: File) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/JoinedDefaultRule.swift
+++ b/Source/SwiftLintFramework/Rules/JoinedDefaultRule.swift
@@ -34,7 +34,9 @@ public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, Op
             "let foo = bar.joined(↓separator: \"\")": "let foo = bar.joined()",
             "let foo = bar.filter(toto)\n.joined(↓separator: \"\")": "let foo = bar.filter(toto)\n.joined()",
             "func foo() -> String {\n   return [\"1\", \"2\"].joined(↓separator: \"\")\n}":
-            "func foo() -> String {\n   return [\"1\", \"2\"].joined()\n}"
+                "func foo() -> String {\n   return [\"1\", \"2\"].joined()\n}",
+            "class C {\n#if true\nlet foo = bar.joined(↓separator: \"\")\n#endif\n}":
+                "class C {\n#if true\nlet foo = bar.joined()\n#endif\n}"
         ]
     )
 
@@ -86,7 +88,7 @@ public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, Op
             }
 
             return ranges
-        }
+        }.unique
     }
 
     private func violationRanges(in file: File,

--- a/Source/SwiftLintFramework/Rules/JoinedDefaultRule.swift
+++ b/Source/SwiftLintFramework/Rules/JoinedDefaultRule.swift
@@ -81,14 +81,16 @@ public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, Op
 
     private func violationRanges(in file: File,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
             if let kind = subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) {
                 ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
             }
 
             return ranges
-        }.unique
+        }
+
+        return violationsAreUnique ? ranges.unique : ranges
     }
 
     private func violationRanges(in file: File,

--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -125,7 +125,7 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
                                           replaceString: "// MARK: - ",
                                           keepLastChar: true))
 
-        return result.unique
+        return violationsAreUnique ? result.unique : result
     }
 
     private func correct(file: File,

--- a/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
@@ -51,7 +51,9 @@ public struct RedundantOptionalInitializationRule: ASTRule, CorrectableRule, Con
             "var myVar: Int?↓ = nil\n": "var myVar: Int?\n",
             "var myVar: Optional<Int>↓ = nil\n": "var myVar: Optional<Int>\n",
             "var myVar: Int?↓=nil\n": "var myVar: Int?\n",
-            "var myVar: Optional<Int>↓=nil\n": "var myVar: Optional<Int>\n"
+            "var myVar: Optional<Int>↓=nil\n": "var myVar: Optional<Int>\n",
+            "class C {\n#if true\nvar myVar: Int?↓ = nil\n#endif\n}":
+                "class C {\n#if true\nvar myVar: Int?\n#endif\n}"
         ]
     )
 
@@ -104,7 +106,7 @@ public struct RedundantOptionalInitializationRule: ASTRule, CorrectableRule, Con
             }
 
             return ranges
-        }
+        }.unique
     }
 
     private func violationRanges(in file: File) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
@@ -99,14 +99,16 @@ public struct RedundantOptionalInitializationRule: ASTRule, CorrectableRule, Con
     }
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
             if let kind = subDict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) {
                 ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
             }
 
             return ranges
-        }.unique
+        }
+
+        return violationsAreUnique ? ranges.unique : ranges
     }
 
     private func violationRanges(in file: File) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -82,14 +82,16 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
     private let excludingKinds = SyntaxKind.allKinds.subtracting([.typeidentifier])
 
     private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
             if let kind = subDict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) {
                 ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
             }
 
             return ranges
-        }.unique
+        }
+
+        return violationsAreUnique ? ranges.unique : ranges
     }
 
     private func violationRanges(in file: File) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -29,7 +29,8 @@ public struct TrailingCommaRule: ASTRule, CorrectableRule, ConfigurationProvider
         "struct Bar {\n let foo = [1: 2, 2: 3↓, ]\n}\n",
         "let foo = [1, 2, 3↓,] + [4, 5, 6↓,]\n",
         "let example = [ 1,\n2↓,\n // 3,\n]",
-        "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\"↓,]\n"
+        "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\"↓,]\n",
+        "class C {\n #if true\n func f() {\n let foo = [1, 2, 3↓,]\n }\n #endif\n}"
         // "foo([1: \"\\(error)\"↓,])\n"
     ]
 
@@ -151,7 +152,7 @@ public struct TrailingCommaRule: ASTRule, CorrectableRule, ConfigurationProvider
 
     private func violationRanges(in file: File,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var violations = violationRanges(in: file, dictionary: subDict)
 
             if let kindString = subDict.kind,
@@ -162,6 +163,8 @@ public struct TrailingCommaRule: ASTRule, CorrectableRule, ConfigurationProvider
 
             return violations
         }
+
+        return violationsAreUnique ? ranges.unique : ranges
     }
 
     public func correct(file: File) -> [Correction] {

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -167,14 +167,16 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
 
     private func violationRanges(in file: File,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
             if let kind = subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) {
                 ranges += violationRanges(in: file, dictionary: subDict, kind: kind).map { $0.0 }
             }
 
             return ranges
-        }.unique
+        }
+
+        return violationsAreUnique ? ranges.unique : ranges
     }
 
     private func violationRanges(in file: File) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -84,7 +84,9 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
             "hoge(arg: num) { ↓num in\n}\n":
                 "hoge(arg: num) { _ in\n}\n",
             "func foo () {\n bar { ↓number in\n return 3\n}\n":
-                "func foo () {\n bar { _ in\n return 3\n}\n"
+                "func foo () {\n bar { _ in\n return 3\n}\n",
+            "class C {\n #if true\n func f() {\n [1, 2].map { ↓number in\n return 3\n }\n }\n #endif\n}":
+                "class C {\n #if true\n func f() {\n [1, 2].map { _ in\n return 3\n }\n }\n #endif\n}"
         ]
     )
 
@@ -172,7 +174,7 @@ public struct UnusedClosureParameterRule: ASTRule, ConfigurationProviderRule, Co
             }
 
             return ranges
-        }
+        }.unique
     }
 
     private func violationRanges(in file: File) -> [NSRange] {


### PR DESCRIPTION
I audited the autocorrect behavior of correctable AST rules when preprocessor macros are present:
* `EmptyEnumArgumentsRule`: no change needed
* `EmptyParenthesesWithTrailingClosureRule`: fixed with `.unique`
* `ExplicitInitRule`: fixed with `.unique`
* `JoinedDefaultParameterRule`: fixed with `.unique`
* `RedundantOptionalInitializationRule`: fixed with `.unique`
* `TrailingCommaRule`: has issues, see below
* `UnusedClosureParameterRule`: fixed with `.unique`


**Known issue:**

`TrailingCommaRule` seems to be organized a little differently (older?) than the other updated tests.  Adding a new triggering example:

```
class C {\n #if true\n func f() {\n let foo = [1, 2, 3↓,]\n }\n #endif\n}
```

and applying the fix:

```
    private func violationRanges(in file: File,
                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
        return dictionary.substructure.flatMap { subDict -> [NSRange] in
            var violations = violationRanges(in: file, dictionary: subDict)

            if let kindString = subDict.kind,
                let kind = KindType(rawValue: kindString),
                let index = violationIndexAndReason(in: file, kind: kind, dictionary: subDict)?.index {
                violations += [NSRange(location: index, length: 1)]
            }

            return violations
        }.unique
    }
```

fixes the duplicate correction, but ends up causing `testTrailingCommaRuleWithDefaultConfiguration` to fail for the example:

```
"let foo = [1, 2, 3↓,]\n"
```

It looks like linting and correcting don't go through the same code path.

It almost seems as if we want to apply `.unique` to the results of `ASTRule`'s `validate(file:dictionary:)` in one place rather than sprinkling it throughout various rules.  I realize this would break rules that can have multiple valid results at the same location (for example `DiscouragedOptionalCollectionRule`).  Should we have rules opt into the uniqueness restriction where it makes sense? Something like adding this to `Rule`:

```
var violationsAreUnique: Bool { get }
```

If you'd like me to investigate that approach I'm happy to file an issue and tackle it in another PR.