### PR TITLE
Fix false positives in `attributes` rule with Swift 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@
   even if only 1 file changed.  
   [John Szumski](https://github.com/jszumski)
 
+* Fix false positives in `attributes` rule when using Swift 4.1.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2125](https://github.com/realm/SwiftLint/issues/2125)
+  [#2141](https://github.com/realm/SwiftLint/issues/2141)
+
 ## 0.25.0: Cleaning the Lint Filter
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -412,6 +412,16 @@ func increase(f: @autoclosure () -> Int) -> Int
 func foo(completionHandler: @escaping () -> Void)
 ```
 
+```swift
+private struct DefaultError: Error {}
+```
+
+```swift
+@testable import foo
+
+private let bar = 1
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -311,7 +311,17 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
             "source.decl.attribute.postfix",
             "source.decl.attribute.prefix",
             "source.decl.attribute.required",
-            "source.decl.attribute.weak"
+            "source.decl.attribute.weak",
+            "source.decl.attribute.private",
+            "source.decl.attribute.fileprivate",
+            "source.decl.attribute.internal",
+            "source.decl.attribute.public",
+            "source.decl.attribute.open",
+            "source.decl.attribute.setter_access.private",
+            "source.decl.attribute.setter_access.fileprivate",
+            "source.decl.attribute.setter_access.internal",
+            "source.decl.attribute.setter_access.public",
+            "source.decl.attribute.setter_access.open"
         ]
         return attributes.filter { !blacklist.contains($0) }
     }

--- a/Source/SwiftLintFramework/Rules/AttributesRulesExamples.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRulesExamples.swift
@@ -44,7 +44,9 @@ internal struct AttributesRuleExamples {
         "@discardableResult\n func a() -> Int",
         "@objc\n @discardableResult\n func a() -> Int",
         "func increase(f: @autoclosure () -> Int) -> Int",
-        "func foo(completionHandler: @escaping () -> Void)"
+        "func foo(completionHandler: @escaping () -> Void)",
+        "private struct DefaultError: Error {}",
+        "@testable import foo\n\nprivate let bar = 1"
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
Fixes #2125 and #2141 

This was a side effect of https://github.com/apple/swift/pull/12086.