### PR TITLE
Created Weak View Controller Rules similar to Weak Delegate

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -126,6 +126,7 @@
 * [Vertical Whitespace](#vertical-whitespace)
 * [Void Return](#void-return)
 * [Weak Delegate](#weak-delegate)
+* [Weak View Controller](#weak-view-controller)
 * [XCTFail Message](#xctfail-message)
 * [Yoda condition rule](#yoda-condition-rule)
 --------
@@ -18530,6 +18531,107 @@ class Foo {
 ```swift
 class Foo {
   ↓var scrollDelegate: ScrollDelegate?
+}
+
+```
+
+</details>
+
+
+
+## Weak View Controller
+
+Identifier | Enabled by default | Supports autocorrection | Kind 
+--- | --- | --- | ---
+`weak_view_controller` | Disabled | No | lint
+
+View Controllers should be weak to avoid reference cycles.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+class Foo {
+  weak var viewController: SomeVC?
+}
+
+```
+
+```swift
+class Foo {
+  weak var someViewController: SomeViewControllerProtocol?
+}
+
+```
+
+```swift
+class Foo {
+  weak var viewControllerScroll: ScrollViewController?
+}
+
+```
+
+```swift
+class Foo {
+  var scrollHandler: ScrollViewController?
+}
+
+```
+
+```swift
+func foo() {
+  var viewController: SomeViewController
+}
+
+```
+
+```swift
+class Foo {
+  var viewControllerNotified: Bool?
+}
+
+```
+
+```swift
+protocol P {
+ var viewController: AnyObject? { get set }
+}
+
+```
+
+```swift
+class Foo {
+ protocol P {
+ var viewController: AnyObject? { get set }
+}
+}
+
+```
+
+```swift
+class Foo {
+ var computedViewController: ComputedViewController {
+ return bar() 
+} 
+}
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+class Foo {
+  ↓var viewController: SomeVC?
+}
+
+```
+
+```swift
+class Foo {
+  ↓var scrollViewController: ScrollViewController?
 }
 
 ```

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -5,7 +5,7 @@
 //  Created by Scott Hoyt on 12/28/15.
 //  Copyright © 2015 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
@@ -134,6 +134,7 @@ public let masterRuleList = RuleList(rules: [
     VerticalWhitespaceRule.self,
     VoidReturnRule.self,
     WeakDelegateRule.self,
+    WeakViewControllerRule.self,
     XCTFailMessageRule.self,
     YodaConditionRule.self
 ])

--- a/Source/SwiftLintFramework/Rules/WeakViewControllerRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakViewControllerRule.swift
@@ -1,0 +1,109 @@
+//
+//  WeakViewControllerRule.swift
+//  SwiftLint
+//
+//  Created by Romans Karpelcevs on 13/4/18.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+import Foundation
+import SourceKittenFramework
+
+public struct WeakViewControllerRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "weak_view_controller",
+        name: "Weak View Controller",
+        description: "View Controllers should be weak to avoid reference cycles.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            "class Foo {\n  weak var viewController: SomeVC?\n}\n",
+            "class Foo {\n  weak var someViewController: SomeViewControllerProtocol?\n}\n",
+            "class Foo {\n  weak var viewControllerScroll: ScrollViewController?\n}\n",
+            // We only consider properties to be a vulnerable if they have "viewController" in their name
+            "class Foo {\n  var scrollHandler: ScrollViewController?\n}\n",
+            // Only trigger on instance variables, not local variables
+            "func foo() {\n  var viewController: SomeViewController\n}\n",
+            // Only trigger when variable has the suffix "-viewController" to avoid false positives
+            "class Foo {\n  var viewControllerNotified: Bool?\n}\n",
+            // There's no way to declare a property weak in a protocol
+            "protocol P {\n var viewController: AnyObject? { get set }\n}\n",
+            "class Foo {\n protocol P {\n var viewController: AnyObject? { get set }\n}\n}\n",
+            "class Foo {\n var computedViewController: ComputedViewController {\n return bar() \n} \n}"
+        ],
+        triggeringExamples: [
+            "class Foo {\n  ↓var viewController: SomeVC?\n}\n",
+            "class Foo {\n  ↓var scrollViewController: ScrollViewController?\n}\n"
+        ]
+    )
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .varInstance else {
+            return []
+        }
+
+        // Check if name contains "viewcontroller"
+        guard let name = dictionary.name,
+            name.lowercased().hasSuffix("viewcontroller") else {
+                return []
+        }
+
+        // Check if non-weak
+        let isWeak = dictionary.enclosedSwiftAttributes.contains("source.decl.attribute.weak")
+        guard !isWeak else { return [] }
+
+        // if the declaration is inside a protocol
+        if let offset = dictionary.offset,
+            !protocolDeclarations(forByteOffset: offset, structure: file.structure).isEmpty {
+            return []
+        }
+
+        // Check if non-computed
+        let isComputed = dictionary.bodyLength ?? 0 > 0
+        guard !isComputed else { return [] }
+
+        // Violation found!
+        let location: Location
+        if let offset = dictionary.offset {
+            location = Location(file: file, byteOffset: offset)
+        } else {
+            location = Location(file: file.path)
+        }
+
+        return [
+            StyleViolation(
+                ruleDescription: type(of: self).description,
+                severity: configuration.severity,
+                location: location
+            )
+        ]
+    }
+
+    private func protocolDeclarations(forByteOffset byteOffset: Int,
+                                      structure: Structure) -> [[String: SourceKitRepresentable]] {
+        var results = [[String: SourceKitRepresentable]]()
+
+        func parse(dictionary: [String: SourceKitRepresentable]) {
+
+            // Only accepts protocols declarations which contains a body and contains the
+            // searched byteOffset
+            if let kindString = (dictionary.kind),
+                SwiftDeclarationKind(rawValue: kindString) == .protocol,
+                let offset = dictionary.bodyOffset,
+                let length = dictionary.bodyLength {
+                let byteRange = NSRange(location: offset, length: length)
+
+                if NSLocationInRange(byteOffset, byteRange) {
+                    results.append(dictionary)
+                }
+            }
+            dictionary.substructure.forEach(parse)
+        }
+        parse(dictionary: structure.dictionary)
+        return results
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		8FD216CC205584AF008ED13F /* CharacterSet+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD216CB205584AF008ED13F /* CharacterSet+SwiftLint.swift */; };
 		92CCB2D71E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */; };
 		93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */; };
+		9CE8AA742080D0820067E06D /* WeakViewControllerRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE8AA722080CF220067E06D /* WeakViewControllerRule.swift */; };
 		A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */; };
 		A73469421FB121BA009B57C7 /* CallPairRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73469401FB12149009B57C7 /* CallPairRule.swift */; };
 		B25DCD0B1F7E9F9E0028A199 /* MultilineArgumentsRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */; };
@@ -488,6 +489,7 @@
 		8FD216CB205584AF008ED13F /* CharacterSet+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CharacterSet+SwiftLint.swift"; sourceTree = "<group>"; };
 		92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRule.swift; sourceTree = "<group>"; };
 		93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineRule.swift; sourceTree = "<group>"; };
+		9CE8AA722080CF220067E06D /* WeakViewControllerRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakViewControllerRule.swift; sourceTree = "<group>"; };
 		A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralConfiguration.swift; sourceTree = "<group>"; };
 		A73469401FB12149009B57C7 /* CallPairRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallPairRule.swift; sourceTree = "<group>"; };
 		B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRule.swift; sourceTree = "<group>"; };
@@ -1188,6 +1190,7 @@
 				1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */,
 				D47079AE1DFE520000027086 /* VoidReturnRule.swift */,
 				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
+				9CE8AA722080CF220067E06D /* WeakViewControllerRule.swift */,
 				626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */,
 				1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */,
 			);
@@ -1543,6 +1546,7 @@
 				B25DCD0C1F7E9FA20028A199 /* MultilineArgumentsRule.swift in Sources */,
 				6258783B1FFC458100AC34F2 /* DiscouragedObjectLiteralRule.swift in Sources */,
 				D4C4A34C1DEA4FF000E0E04C /* AttributesConfiguration.swift in Sources */,
+				9CE8AA742080D0820067E06D /* WeakViewControllerRule.swift in Sources */,
 				83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */,
 				D4470D571EB69225008A1B2E /* ImplicitReturnRule.swift in Sources */,
 				6C032EEE2027EA8D00CD7E8D /* shim.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,7 +5,7 @@
 //  Created by JP Simard on 12/11/16.
 //  Copyright © 2016 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -523,6 +523,7 @@ extension RulesTests {
         ("testVoidReturn", testVoidReturn),
         ("testSuperCall", testSuperCall),
         ("testWeakDelegate", testWeakDelegate),
+        ("testWeakViewController", testWeakViewController),
         ("testXCTFailMessage", testXCTFailMessage),
         ("testYodaCondition", testYodaCondition)
     ]

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -473,6 +473,10 @@ class RulesTests: XCTestCase {
         verifyRule(WeakDelegateRule.description)
     }
 
+    func testWeakViewController() {
+        verifyRule(WeakViewControllerRule.description)
+    }
+
     func testXCTFailMessage() {
         verifyRule(XCTFailMessageRule.description)
     }


### PR DESCRIPTION
We noticed that it's often needed (and forgotted) to mark view controller properties as `weak`. This rule is very similar to `weak_delegate`.