### PR TITLE
Remove extensions from LowerACLThanBodyRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 
 #### Bug Fixes
 
-* None.
+* Update `LowerACLThanParent` rule to not lint extensions.  
+  [Keith Smiley](https://github.com/keith)
+  [#2164](https://github.com/realm/SwiftLint/pull/2164)
 
 ## 0.25.1: Lid Locked
 

--- a/Rules.md
+++ b/Rules.md
@@ -8484,6 +8484,14 @@ private struct Foo { private func bar(id: String) }
 ```
 
 ```swift
+extension Foo { public func bar() {} }
+```
+
+```swift
+private struct Foo { fileprivate func bar() {} }
+```
+
+```swift
 private func foo(id: String) {}
 ```
 
@@ -8496,19 +8504,11 @@ struct Foo { public func bar() {} }
 ```
 
 ```swift
-extension Foo { public func bar() {} }
-```
-
-```swift
 enum Foo { public func bar() {} }
 ```
 
 ```swift
 public class Foo { open func bar() }
-```
-
-```swift
-private struct Foo { fileprivate func bar() {} }
 ```
 
 ```swift

--- a/Source/SwiftLintFramework/Models/AccessControlLevel.swift
+++ b/Source/SwiftLintFramework/Models/AccessControlLevel.swift
@@ -46,3 +46,19 @@ public enum AccessControlLevel: String, CustomStringConvertible {
     }
 
 }
+
+extension AccessControlLevel: Comparable {
+    private var priority: Int {
+        switch self {
+        case .private: return 1
+        case .fileprivate: return 2
+        case .internal: return 3
+        case .public: return 4
+        case .open: return 5
+        }
+    }
+
+    public static func < (lhs: AccessControlLevel, rhs: AccessControlLevel) -> Bool {
+        return lhs.priority < rhs.priority
+    }
+}

--- a/Source/SwiftLintFramework/Models/AccessControlLevel.swift
+++ b/Source/SwiftLintFramework/Models/AccessControlLevel.swift
@@ -46,19 +46,3 @@ public enum AccessControlLevel: String, CustomStringConvertible {
     }
 
 }
-
-extension AccessControlLevel: Comparable {
-    private var priority: Int {
-        switch self {
-        case .private: return 1
-        case .fileprivate: return 1
-        case .internal: return 2
-        case .public: return 3
-        case .open: return 4
-        }
-    }
-
-    public static func < (lhs: AccessControlLevel, rhs: AccessControlLevel) -> Bool {
-        return lhs.priority < rhs.priority
-    }
-}

--- a/Source/SwiftLintFramework/Models/AccessControlLevel.swift
+++ b/Source/SwiftLintFramework/Models/AccessControlLevel.swift
@@ -51,10 +51,10 @@ extension AccessControlLevel: Comparable {
     private var priority: Int {
         switch self {
         case .private: return 1
-        case .fileprivate: return 2
-        case .internal: return 3
-        case .public: return 4
-        case .open: return 5
+        case .fileprivate: return 1
+        case .internal: return 2
+        case .public: return 3
+        case .open: return 4
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/LowerACLThanBodyRule.swift
+++ b/Source/SwiftLintFramework/Rules/LowerACLThanBodyRule.swift
@@ -58,7 +58,7 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule {
             var violationOffset: Int?
             let accessibility = element.accessibility.flatMap(AccessControlLevel.init(identifier:))
                 ?? .`internal`
-            if accessibility > parentAccessibility {
+            if accessibility.priority > parentAccessibility.priority {
                 violationOffset = element.offset
             }
 
@@ -81,6 +81,18 @@ private extension SwiftDeclarationKind {
              .functionOperatorPrefix, .functionSubscript, .`protocol`, .`struct`, .`typealias`, .varClass, .varGlobal,
              .varInstance, .varStatic:
             return true
+        }
+    }
+}
+
+private extension AccessControlLevel {
+    var priority: Int {
+        switch self {
+        case .private: return 1
+        case .fileprivate: return 1
+        case .internal: return 2
+        case .public: return 3
+        case .open: return 4
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/LowerACLThanBodyRule.swift
+++ b/Source/SwiftLintFramework/Rules/LowerACLThanBodyRule.swift
@@ -27,14 +27,14 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule {
             "open class Foo { open func bar() {} }",
             "fileprivate struct Foo { private func bar() {} }",
             "private struct Foo { private func bar(id: String) }",
+            "extension Foo { public func bar() {} }",
+            "private struct Foo { fileprivate func bar() {} }",
             "private func foo(id: String) {}"
         ],
         triggeringExamples: [
             "struct Foo { public func bar() {} }",
-            "extension Foo { public func bar() {} }",
             "enum Foo { public func bar() {} }",
             "public class Foo { open func bar() }",
-            "private struct Foo { fileprivate func bar() {} }",
             "class Foo { public private(set) var bar: String? }"
         ]
     )
@@ -70,17 +70,16 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule {
 private extension SwiftDeclarationKind {
     var isRelevantDeclaration: Bool {
         switch self {
-        case .`associatedtype`, .enumcase, .enumelement, .functionAccessorAddress,
-             .functionAccessorDidset, .functionAccessorGetter, .functionAccessorMutableaddress,
-             .functionAccessorSetter, .functionAccessorWillset, .functionDestructor, .genericTypeParam, .module,
-             .precedenceGroup, .varLocal, .varParameter:
+        case .`associatedtype`, .enumcase, .enumelement, .`extension`, .`extensionClass`, .`extensionEnum`,
+             .extensionProtocol, .extensionStruct, .functionAccessorAddress, .functionAccessorDidset,
+             .functionAccessorGetter, .functionAccessorMutableaddress, .functionAccessorSetter,
+             .functionAccessorWillset, .functionDestructor, .genericTypeParam, .module, .precedenceGroup, .varLocal,
+             .varParameter:
             return false
-        case .`class`, .`enum`, .`extension`, .`extensionClass`, .`extensionEnum`,
-             .extensionProtocol, .extensionStruct, .functionConstructor,
-             .functionFree, .functionMethodClass, .functionMethodInstance, .functionMethodStatic,
-             .functionOperator, .functionOperatorInfix, .functionOperatorPostfix, .functionOperatorPrefix,
-             .functionSubscript, .`protocol`, .`struct`, .`typealias`, .varClass,
-             .varGlobal, .varInstance, .varStatic:
+        case .`class`, .`enum`, .functionConstructor, .functionFree, .functionMethodClass, .functionMethodInstance,
+             .functionMethodStatic, .functionOperator, .functionOperatorInfix, .functionOperatorPostfix,
+             .functionOperatorPrefix, .functionSubscript, .`protocol`, .`struct`, .`typealias`, .varClass, .varGlobal,
+             .varInstance, .varStatic:
             return true
         }
     }


### PR DESCRIPTION
Because of some oddities in the Swift extension ACL rules, linting ACL
inside extensions isn't trivial because of a few cases:

1. Extensions cannot be open, but members inside them can:

```
open extension Foo { // Not valid
    open func bar() {}
}
```

2. Extensions cannot have an ACL modifier if they conform to a protocol:

```
public extension Foo: Bar {} // Not valid
```

3. Extensions that do have an ACL modifier affects the inner body,
making changes to this slightly riskier:

```
public extension Foo {
    func bar() {} // implicitly public
}
```

With this change we just sidestep all these problems, and instead opt to
only lint non extension types. I think this tradeoff is worth it so that
this can be enabled and catch issues in classes/structs/enums