### PR TITLE
Add file name matching to file_header rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 #### Enhancements
 
 * Add optional filename verification to the `file_header` rule.
-  The first occurrence in the pattern of the `SWIFTLINT_CURRENT_FILENAME`
-  placeholder is replaced by the name of the validated file.  
+  All occurrences in the pattern of the `SWIFTLINT_CURRENT_FILENAME`
+  placeholder are replaced by the name of the validated file.  
   [Anders Hasselqvist](https://github.com/nevil)
   [#1079](https://github.com/realm/SwiftLint/issues/1079)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 #### Enhancements
 
+* Add optional filename verification to the `file_header` rule.  
+  [Anders Hasselqvist](https://github.com/nevil)
+  [#1079](https://github.com/realm/SwiftLint/issues/1079)
+
 * Updates the `untyped_error_in_catch` rule to support autocorrection.  
   [Daniel Metzing](https://github.com/dirtydanee)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 
 #### Enhancements
 
-* Add optional filename verification to the `file_header` rule.  
+* Add optional filename verification to the `file_header` rule.
+  The first occurrence in the pattern of the `SWIFTLINT_CURRENT_FILENAME`
+  placeholder is replaced by the name of the validated file.  
   [Anders Hasselqvist](https://github.com/nevil)
   [#1079](https://github.com/realm/SwiftLint/issues/1079)
 

--- a/Rules.md
+++ b/Rules.md
@@ -4976,7 +4976,7 @@ Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift
 --- | --- | --- | --- | ---
 `file_header` | Disabled | No | style | 3.0.0 
 
-Header comments should be consistent with project patterns.
+Header comments should be consistent with project patterns. The SWIFTLINT_CURRENT_FILENAME placeholder can optionally be used in the required and forbidden patterns. It will be replaced by the real file name.
 
 ### Examples
 

--- a/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
@@ -31,6 +31,8 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
         ]
     )
 
+    private static let reason = "Header comments should be consistent with project patterns."
+
     public func validate(file: File) -> [StyleViolation] {
         var firstToken: SyntaxToken?
         var lastToken: SyntaxToken?
@@ -80,20 +82,18 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
                 Location(file: file, byteOffset: $0.offset)
             } ?? Location(file: file.path, line: 1)
             return [
-                StyleViolation(
-                    ruleDescription: type(of: self).description,
-                    severity: configuration.severityConfiguration.severity,
-                    location: location
-                )
+                StyleViolation(ruleDescription: type(of: self).description,
+                               severity: configuration.severityConfiguration.severity,
+                               location: location,
+                               reason: type(of: self).reason)
             ]
         }
 
         return violationsOffsets.map {
-            StyleViolation(
-                ruleDescription: type(of: self).description,
-                severity: configuration.severityConfiguration.severity,
-                location: Location(file: file, characterOffset: $0)
-            )
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severityConfiguration.severity,
+                           location: Location(file: file, characterOffset: $0),
+                           reason: type(of: self).reason)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -74,15 +74,17 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
 
     private func makeRegex(for file: File, using pattern: String,
                            options: NSRegularExpression.Options, escapeFileName: Bool) -> NSRegularExpression? {
-        // Recompile the regex for this file
-        guard let fileName = file.path?.bridge().lastPathComponent else {
-            queuedFatalError("Expected to validate a file.")
-        }
 
-        // Replace SWIFTLINT_CURRENT_FILENAME with the filename.
-        let escapedName = escapeFileName ? NSRegularExpression.escapedPattern(for: fileName) : fileName
-        let replacedPattern = pattern.replacingOccurrences(of: FileHeaderConfiguration.fileNamePlaceholder,
-                                                           with: escapedName)
+        // Recompile the regex for this file...
+        let replacedPattern = file.path.map { path in
+            let fileName = path.bridge().lastPathComponent
+
+            // Replace SWIFTLINT_CURRENT_FILENAME with the filename.
+            let escapedName = escapeFileName ? NSRegularExpression.escapedPattern(for: fileName) : fileName
+            return pattern.replacingOccurrences(of: FileHeaderConfiguration.fileNamePlaceholder,
+                                                with: escapedName)
+        } ?? pattern
+
         do {
             return try NSRegularExpression(pattern: replacedPattern, options: options)
         } catch {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private var requiredString: String?
-    private var requiredPattern: String?
+    private(set) var requiredPattern: String?
     private var forbiddenString: String?
     private var forbiddenPattern: String?
 
@@ -27,6 +27,9 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
         }
     }
 
+    /// Used for unit tests of SWIFTLINT_CURRENT_FILENAME when File.path is nil
+    internal let filenameForTest: String = "Default.swift"
+
     private static let defaultRegex = regex("\\bCopyright\\b", options: [.caseInsensitive])
 
     public var consoleDescription: String {
@@ -34,6 +37,7 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
         let requiredPatternDescription = requiredPattern ?? "None"
         let forbiddenStringDescription = forbiddenString ?? "None"
         let forbiddenPatternDescription = forbiddenPattern ?? "None"
+
         return severityConfiguration.consoleDescription +
             ", required_string: \(requiredStringDescription)" +
             ", required_pattern: \(requiredPatternDescription)" +
@@ -54,6 +58,8 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
                                                     options: [.ignoreMetacharacters])
         } else if let requiredPattern = configuration["required_pattern"] {
             self.requiredPattern = requiredPattern
+            // For requiredPattern the regex might be recompiled in FileHeaderRule
+            // as it could contain the SWIFTLINT_CURRENT_FILENAME placeholder.
             requiredRegex = try .cached(pattern: requiredPattern)
         }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -1,22 +1,23 @@
 import Foundation
+import SourceKittenFramework
 
 public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
+    private static let fileNamePlaceholder = "SWIFTLINT_CURRENT_FILENAME"
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private var requiredString: String?
-    private(set) var requiredPattern: String?
+    private var requiredPattern: String?
     private var forbiddenString: String?
     private var forbiddenPattern: String?
 
     private var _forbiddenRegex: NSRegularExpression?
-
-    private(set) var requiredRegex: NSRegularExpression?
-    private(set) var forbiddenRegex: NSRegularExpression? {
+    private var _requiredRegex: NSRegularExpression?
+    private(set) var forbiddenRegexQ: NSRegularExpression? {
         get {
             if _forbiddenRegex != nil {
                 return _forbiddenRegex
             }
 
-            if requiredRegex == nil {
+            if _requiredRegex == nil {
                 return FileHeaderConfiguration.defaultRegex
             }
 
@@ -26,9 +27,6 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
             _forbiddenRegex = newValue
         }
     }
-
-    /// Used for unit tests of SWIFTLINT_CURRENT_FILENAME when File.path is nil
-    internal let filenameForTest: String = "Default.swift"
 
     private static let defaultRegex = regex("\\bCopyright\\b", options: [.caseInsensitive])
 
@@ -54,27 +52,79 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
 
         if let requiredString = configuration["required_string"] {
             self.requiredString = requiredString
-            requiredRegex = try NSRegularExpression(pattern: requiredString,
-                                                    options: [.ignoreMetacharacters])
+            _requiredRegex = try NSRegularExpression(pattern: requiredString,
+                                                     options: [.ignoreMetacharacters])
         } else if let requiredPattern = configuration["required_pattern"] {
             self.requiredPattern = requiredPattern
-            // For requiredPattern the regex might be recompiled in FileHeaderRule
-            // as it could contain the SWIFTLINT_CURRENT_FILENAME placeholder.
-            requiredRegex = try .cached(pattern: requiredPattern)
+
+            // Cache the created regex of requiredPattern if possible.
+            // If requiredPattern contains the SWIFTLINT_CURRENT_FILENAME placeholder,
+            // the regex will be recompiled for each validated file.
+            if !requiredPattern.contains(FileHeaderConfiguration.fileNamePlaceholder) {
+                _requiredRegex = try .cached(pattern: requiredPattern)
+            }
         }
 
         if let forbiddenString = configuration["forbidden_string"] {
             self.forbiddenString = forbiddenString
-            forbiddenRegex = try NSRegularExpression(pattern: forbiddenString,
-                                                     options: [.ignoreMetacharacters])
+            _forbiddenRegex = try NSRegularExpression(pattern: forbiddenString,
+                                                      options: [.ignoreMetacharacters])
         } else if let forbiddenPattern = configuration["forbidden_pattern"] {
             self.forbiddenPattern = forbiddenPattern
-            forbiddenRegex = try .cached(pattern: forbiddenPattern)
+
+            // Cache the created regex of forbiddenPattern if possible.
+            // If forbiddenPattern contains the SWIFTLINT_CURRENT_FILENAME placeholder,
+            // the regex will be recompiled for each validated file.
+            if !forbiddenPattern.contains(FileHeaderConfiguration.fileNamePlaceholder) {
+                _forbiddenRegex = try .cached(pattern: forbiddenPattern)
+            }
         }
 
         if let severityString = configuration["severity"] {
             try severityConfiguration.apply(configuration: severityString)
         }
+    }
+
+    private func makeRegex(for file: File, using pattern: String) -> NSRegularExpression? {
+        // Recompile the regex for this file
+        guard let fileName = file.path?.bridge().lastPathComponent else {
+            queuedFatalError("Expected to validate a file.")
+        }
+
+        // Replace SWIFTLINT_CURRENT_FILENAME with the filename.
+        let escapedName = NSRegularExpression.escapedPattern(for: fileName)
+        let replacedPattern = pattern.replacingOccurrences(of: FileHeaderConfiguration.fileNamePlaceholder,
+                                                           with: escapedName)
+        do {
+            return try NSRegularExpression(pattern: replacedPattern,
+                                           options: [.anchorsMatchLines, .dotMatchesLineSeparators])
+        } catch {
+            queuedFatalError("Failed to compile pattern '\(replacedPattern)'")
+        }
+    }
+
+    func forbiddenRegex(for file: File) -> NSRegularExpression? {
+        if _forbiddenRegex != nil {
+            return _forbiddenRegex
+        }
+
+        if let regex = forbiddenPattern.flatMap({ makeRegex(for: file, using: $0) }) {
+            return regex
+        }
+
+        if requiredPattern == nil, requiredString == nil {
+            return FileHeaderConfiguration.defaultRegex
+        }
+
+        return nil
+    }
+
+    func requiredRegex(for file: File) -> NSRegularExpression? {
+        if _requiredRegex != nil {
+            return _requiredRegex
+        }
+
+        return requiredPattern.flatMap { makeRegex(for: file, using: $0) }
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -120,4 +120,27 @@ class FileHeaderRuleTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["forbidden_pattern": "[tT]ests"],
                    skipCommentTests: true, testMultiByteOffsets: false)
     }
+
+    func testFileHeaderWithRequiredPatternAndFilenamePlaceholder() {
+        let nonTriggeringExamples = [
+            "// Default.swift\n// Copyright © 2016 Realm",
+            "//\n// Default.swift\n// Copyright © 2016 Realm"
+        ]
+
+        let triggeringExamples = [
+            "↓// Default.Swift\n// Copyright © 2016 Realm",
+            "↓// ADefault.swift\n// Copyright © 2016 Realm",
+            "↓//\n// Default.Swift\n// Copyright © 2016 Realm",
+            "↓// Copyright © 2016 Realm\n// Default.swift",
+            "↓//\n// Copyright © 2016 Realm\n// Default.swift"
+        ]
+
+        let description = FileHeaderRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+
+        verifyRule(description,
+                   ruleConfiguration: ["required_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4} Realm"],
+                   stringDoesntViolate: false, skipCommentTests: true, testMultiByteOffsets: false)
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -132,6 +132,30 @@ class FileHeaderRuleTests: XCTestCase {
                    skipCommentTests: true, testMultiByteOffsets: false)
     }
 
+    func testFileHeaderWithRequiredStringUsingFilenamePlaceholder() {
+        let configuration = ["required_string": "// SWIFTLINT_CURRENT_FILENAME"]
+
+        // Non triggering tests
+        XCTAssert(try validate(fileName: "FileNameMatchingSimple.swift", using: configuration).isEmpty)
+
+        // Triggering tests
+        XCTAssertEqual(try validate(fileName: "FileNameCaseMismatch.swift", using: configuration).count, 1)
+        XCTAssertEqual(try validate(fileName: "FileNameMismatch.swift", using: configuration).count, 1)
+        XCTAssertEqual(try validate(fileName: "FileNameMissing.swift", using: configuration).count, 1)
+    }
+
+    func testFileHeaderWithForbiddenStringUsingFilenamePlaceholder() {
+        let configuration = ["forbidden_string": "// SWIFTLINT_CURRENT_FILENAME"]
+
+        // Non triggering tests
+        XCTAssert(try validate(fileName: "FileNameCaseMismatch.swift", using: configuration).isEmpty)
+        XCTAssert(try validate(fileName: "FileNameMismatch.swift", using: configuration).isEmpty)
+        XCTAssert(try validate(fileName: "FileNameMissing.swift", using: configuration).isEmpty)
+
+        // Triggering tests
+        XCTAssertEqual(try validate(fileName: "FileNameMatchingSimple.swift", using: configuration).count, 1)
+    }
+
     func testFileHeaderWithRequiredPatternUsingFilenamePlaceholder() {
         let configuration1 = ["required_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
         let configuration2 = ["required_pattern": "// Copyright © \\d{4}\n// File: \"SWIFTLINT_CURRENT_FILENAME\""]

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -1,7 +1,18 @@
+import SourceKittenFramework
 import SwiftLintFramework
 import XCTest
 
+private let fixturesDirectory = #file.bridge()
+    .deletingLastPathComponent.bridge()
+    .appendingPathComponent("Resources/FileHeaderRuleFixtures")
+
 class FileHeaderRuleTests: XCTestCase {
+
+    private func validate(fileName: String, using configuration: Any) throws -> [StyleViolation] {
+        let file = File(path: fixturesDirectory.stringByAppendingPathComponent(fileName))!
+        let rule = try FileHeaderRule(configuration: configuration)
+        return rule.validate(file: file)
+    }
 
     func testFileHeaderWithDefaultConfiguration() {
         verifyRule(FileHeaderRule.description, skipCommentTests: true)
@@ -121,26 +132,35 @@ class FileHeaderRuleTests: XCTestCase {
                    skipCommentTests: true, testMultiByteOffsets: false)
     }
 
-    func testFileHeaderWithRequiredPatternAndFilenamePlaceholder() {
-        let nonTriggeringExamples = [
-            "// Default.swift\n// Copyright © 2016 Realm",
-            "//\n// Default.swift\n// Copyright © 2016 Realm"
-        ]
+    func testFileHeaderWithRequiredPatternUsingFilenamePlaceholder() {
+        let configuration1 = ["required_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
+        let configuration2 = ["required_pattern": "// Copyright © \\d{4}\n// File: \"SWIFTLINT_CURRENT_FILENAME\""]
 
-        let triggeringExamples = [
-            "↓// Default.Swift\n// Copyright © 2016 Realm",
-            "↓// ADefault.swift\n// Copyright © 2016 Realm",
-            "↓//\n// Default.Swift\n// Copyright © 2016 Realm",
-            "↓// Copyright © 2016 Realm\n// Default.swift",
-            "↓//\n// Copyright © 2016 Realm\n// Default.swift"
-        ]
+        // Non triggering tests
+        XCTAssert(try validate(fileName: "FileNameMatchingSimple.swift", using: configuration1).isEmpty)
+        XCTAssert(try validate(fileName: "FileNameMatchingComplex.swift", using: configuration2).isEmpty)
 
-        let description = FileHeaderRule.description
-            .with(nonTriggeringExamples: nonTriggeringExamples)
-            .with(triggeringExamples: triggeringExamples)
+        // Triggering tests
+        XCTAssertEqual(try validate(fileName: "FileNameCaseMismatch.swift", using: configuration1).count, 1)
+        XCTAssertEqual(try validate(fileName: "FileNameMismatch.swift", using: configuration1).count, 1)
+        XCTAssertEqual(try validate(fileName: "FileNameMissing.swift", using: configuration1).count, 1)
+    }
 
-        verifyRule(description,
-                   ruleConfiguration: ["required_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4} Realm"],
-                   stringDoesntViolate: false, skipCommentTests: true, testMultiByteOffsets: false)
+    func testFileHeaderWithForbiddenPatternUsingFilenamePlaceholder() {
+        let configuration1 = ["forbidden_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
+        let configuration2 = ["forbidden_pattern": "//.*(\\s|\")SWIFTLINT_CURRENT_FILENAME(\\s|\").*"]
+
+        // Non triggering tests
+        XCTAssert(try validate(fileName: "FileNameCaseMismatch.swift", using: configuration1).isEmpty)
+        XCTAssert(try validate(fileName: "FileNameMismatch.swift", using: configuration1).isEmpty)
+        XCTAssert(try validate(fileName: "FileNameMissing.swift", using: configuration1).isEmpty)
+
+        XCTAssert(try validate(fileName: "FileNameCaseMismatch.swift", using: configuration2).isEmpty)
+        XCTAssert(try validate(fileName: "FileNameMismatch.swift", using: configuration2).isEmpty)
+        XCTAssert(try validate(fileName: "FileNameMissing.swift", using: configuration2).isEmpty)
+
+        // Triggering tests
+        XCTAssertEqual(try validate(fileName: "FileNameMatchingSimple.swift", using: configuration1).count, 1)
+        XCTAssertEqual(try validate(fileName: "FileNameMatchingComplex.swift", using: configuration2).count, 1)
     }
 }

--- a/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameCaseMismatch.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameCaseMismatch.swift
@@ -1,0 +1,3 @@
+// FileNameCaseMismatch.Swift
+// Copyright © 2016
+struct A {}

--- a/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameMatchingComplex.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameMatchingComplex.swift
@@ -1,0 +1,3 @@
+// Copyright © 2016
+// File: "FileNameMatchingComplex.swift"
+struct A {}

--- a/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameMatchingSimple.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameMatchingSimple.swift
@@ -1,0 +1,3 @@
+// FileNameMatchingSimple.swift
+// Copyright © 2016
+struct A {}

--- a/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameMismatch.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameMismatch.swift
@@ -1,0 +1,3 @@
+// AFileNameMismatch.swift
+// Copyright © 2016
+struct A {}

--- a/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameMissing.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileNameMissing.swift
@@ -1,0 +1,3 @@
+// 
+// Copyright © 2016
+struct A {}


### PR DESCRIPTION
Add support of inserting a SWIFTLINT_CURRENT_FILENAME placeholder in the required_pattern.
The placeholder will be replaced by the lastPathComponent of the file's path.
