### PR TITLE
Add `indented_cases` to `switch_case_alignment` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,16 @@
 
 #### Enhancements
 
+* Add `indented_cases` support to `switch_case_alignment` rule.  
+  [Shai Mishali](https://github.com/freak4pc)
+  [#2119](https://github.com/realm/SwiftLint/issues/2119)
+
 * Add opt-in `modifier_order` to enforce the order of declaration modifiers.
   Requires Swift 4.1 or later.  
   [Jose Cheyo Jimenez](https://github.com/masters3d)
   [Daniel Metzing](https://github.com/dirtydanee)
   [#1472](https://github.com/realm/SwiftLint/issues/1472)
   [#1585](https://github.com/realm/SwiftLint/issues/1585)
-* Add `indented_cases` support to `switch_case_alignment` rule.
-  [Shai Mishali](https://github.com/freak4pc)
-  [#2119](https://github.com/realm/SwiftLint/issues/2119)
 
 * Validate implicit `subscript` getter in `implicit_getter` rule when using
   Swift 4.1 or later.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   [Daniel Metzing](https://github.com/dirtydanee)
   [#1472](https://github.com/realm/SwiftLint/issues/1472)
   [#1585](https://github.com/realm/SwiftLint/issues/1585)
+* Add `indented_cases` support to `switch_case_alignment` rule.
+  [Shai Mishali](https://github.com/freak4pc)
+  [#2119](https://github.com/realm/SwiftLint/issues/2119)
 
 * Validate implicit `subscript` getter in `implicit_getter` rule when using
   Swift 4.1 or later.  

--- a/Rules.md
+++ b/Rules.md
@@ -13581,7 +13581,7 @@ Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift
 --- | --- | --- | --- | ---
 `switch_case_alignment` | Enabled | No | style | 3.0.0 
 
-Case statements should vertically align with the enclosing switch statement, or indented if configured otherwise.
+Case statements should vertically align with their enclosing switch statement, or indented if configured otherwise.
 
 ### Examples
 

--- a/Rules.md
+++ b/Rules.md
@@ -13636,9 +13636,9 @@ default:
 ```swift
 switch someBool {
     ↓case true:
-         print('red')
+        print("red")
     ↓case false:
-         print('blue')
+        print("blue")
 }
 ```
 
@@ -13647,8 +13647,8 @@ if aBool {
     switch someBool {
         ↓case true:
             print('red')
-    case false:
-        print('blue')
+        ↓case false:
+            print('blue')
     }
 }
 ```
@@ -13656,11 +13656,11 @@ if aBool {
 ```swift
 switch someInt {
     ↓case 0:
-    print('Zero')
-case 1:
-    print('One')
+        print('Zero')
+    ↓case 1:
+        print('One')
     ↓default:
-    print('Some other number')
+        print('Some other number')
 }
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -13581,7 +13581,7 @@ Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift
 --- | --- | --- | --- | ---
 `switch_case_alignment` | Enabled | No | style | 3.0.0 
 
-Case statements should vertically align with the enclosing switch statement.
+Case statements should vertically align with the enclosing switch statement, or indented if configured otherwise.
 
 ### Examples
 

--- a/Rules.md
+++ b/Rules.md
@@ -13664,6 +13664,26 @@ switch someInt {
 }
 ```
 
+```swift
+switch someBool {
+case true:
+    print('red')
+    ↓case false:
+        print('blue')
+}
+```
+
+```swift
+if aBool {
+    switch someBool {
+        ↓case true:
+        print('red')
+    case false:
+    print('blue')
+    }
+}
+```
+
 </details>
 
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,10 +1,3 @@
-//
-//  MasterRuleList.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 12/28/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
 // Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,11 @@
-// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
+//
+//  MasterRuleList.swift
+//  SwiftLint
+//
+//  Created by Scott Hoyt on 12/28/15.
+//  Copyright © 2015 Realm. All rights reserved.
+//
+// Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -16,6 +16,20 @@ public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
         return severityConfiguration.consoleDescription + ", indented_cases: \(indentedCases)"
     }
 
+    public var ruleDescription: RuleDescription {
+        let examples = SwitchCaseAlignmentRule.Examples(indentedCases: indentedCases)
+
+        let reason = indentedCases ? "Case statements should be indented within their enclosing switch statement"
+                                   : "Case statements should vertically align with their enclosing switch statement"
+
+        return RuleDescription(identifier: "switch_case_alignment",
+                               name: "Switch and Case Statement Alignment",
+                               description: reason,
+                               kind: .style,
+                               nonTriggeringExamples: examples.nonTriggeringExamples,
+                               triggeringExamples: examples.triggeringExamples)
+    }
+
     public mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -1,0 +1,32 @@
+//
+//  SwitchCaseAlignmentRuleConfiguration.swift
+//  SwiftLint
+//
+//  Created by Shai Mishali on 4/23/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var indentation: Int = 0
+
+    init() {}
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription + ", indentation: \(indentation)"
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        self.indentation = configuration["indentation"] as? Int ?? 0
+    }
+
+    public static func == (lhs: SwitchCaseAlignmentConfiguration,
+                           rhs: SwitchCaseAlignmentConfiguration) -> Bool {
+        return lhs.indentation == rhs.indentation &&
+               lhs.severityConfiguration == rhs.severityConfiguration
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -13,7 +13,7 @@ public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
     init() {}
 
     public var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", indented cases: \(indentedCases)"
+        return severityConfiguration.consoleDescription + ", indented_cases: \(indentedCases)"
     }
 
     public mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -8,12 +8,12 @@
 
 public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
-    private(set) var indentation: Int = 0
+    private(set) var indentedCases = false
 
     init() {}
 
     public var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", indentation: \(indentation)"
+        return severityConfiguration.consoleDescription + ", indented cases: \(indentedCases)"
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -21,12 +21,12 @@ public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
             throw ConfigurationError.unknownConfiguration
         }
 
-        self.indentation = configuration["indentation"] as? Int ?? 0
+        self.indentedCases = configuration["indented_cases"] as? Bool ?? false
     }
 
     public static func == (lhs: SwitchCaseAlignmentConfiguration,
                            rhs: SwitchCaseAlignmentConfiguration) -> Bool {
-        return lhs.indentation == rhs.indentation &&
+        return lhs.indentedCases == rhs.indentedCases &&
                lhs.severityConfiguration == rhs.severityConfiguration
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -13,7 +13,11 @@ public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
             throw ConfigurationError.unknownConfiguration
         }
 
-        self.indentedCases = configuration["indented_cases"] as? Bool ?? false
+        indentedCases = configuration["indented_cases"] as? Bool ?? false
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
     }
 
     public static func == (lhs: SwitchCaseAlignmentConfiguration,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -8,20 +8,6 @@ public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
         return severityConfiguration.consoleDescription + ", indented_cases: \(indentedCases)"
     }
 
-    public var ruleDescription: RuleDescription {
-        let examples = SwitchCaseAlignmentRule.Examples(indentedCases: indentedCases)
-
-        let reason = indentedCases ? "Case statements should be indented within their enclosing switch statement"
-                                   : "Case statements should vertically align with their enclosing switch statement"
-
-        return RuleDescription(identifier: "switch_case_alignment",
-                               name: "Switch and Case Statement Alignment",
-                               description: reason,
-                               kind: .style,
-                               nonTriggeringExamples: examples.nonTriggeringExamples,
-                               triggeringExamples: examples.triggeringExamples)
-    }
-
     public mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  SwitchCaseAlignmentRuleConfiguration.swift
-//  SwiftLint
-//
-//  Created by Shai Mishali on 4/23/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var indentedCases = false

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -62,8 +62,8 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
 
     private func locationToViolation(_ location: Location) -> StyleViolation {
         let reason = """
-                    Case statements should
-                    \(configuration.indentedCases ? " be indented within " : " vertically align with ")
+                    Case statements should \
+                    \(configuration.indentedCases ? "be indented within" : "vertically align with") \
                     their enclosing switch statement.
                     """
 

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -62,7 +62,7 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func locationToViolation(_ location: Location) -> StyleViolation {
-        return StyleViolation(ruleDescription: type(of: self).description,
+        return StyleViolation(ruleDescription: configuration.ruleDescription,
                               severity: configuration.severityConfiguration.severity,
                               location: location)
     }

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -44,12 +44,11 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
             return Location(file: file.path, line: line, character: char)
         }
 
-        guard let firstCase = caseLocations.first,
-              let firstCaseCharacter = firstCase.character else {
+        guard let firstCaseCharacter = caseLocations.first?.character else {
             return []
         }
 
-        // If indent_cases is on, the first case should be indented from its containing switch.
+        // If indented_cases is on, the first case should be indented from its containing switch.
         if configuration.indentedCases, firstCaseCharacter <= switchCharacter {
             return caseLocations.map(locationToViolation)
         }
@@ -62,10 +61,11 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func locationToViolation(_ location: Location) -> StyleViolation {
-        // swiftlint:disable line_length
-        let reason = configuration.indentedCases ? "Case statements should be indented within their enclosing switch statement"
-                                                 : "Case statements should vertically align with their enclosing switch statement"
-        // swiftlint:enable line_length
+        let reason = """
+                    Case statements should
+                    \(configuration.indentedCases ? " be indented within " : " vertically align with ")
+                    their enclosing switch statement.
+                    """
 
         return StyleViolation(ruleDescription: SwitchCaseAlignmentRule.description,
                               severity: configuration.severityConfiguration.severity,

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -9,11 +9,11 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
     public static let description = RuleDescription(
         identifier: "switch_case_alignment",
         name: "Switch and Case Statement Alignment",
-        description: "Case statements should vertically align with the enclosing switch statement, " +
+        description: "Case statements should vertically align with their enclosing switch statement, " +
                      "or indented if configured otherwise.",
         kind: .style,
-        nonTriggeringExamples: Examples(indentedCases: false).nonIndentedCases,
-        triggeringExamples: Examples(indentedCases: false).indentedCases
+        nonTriggeringExamples: Examples(indentedCases: false).nonTriggeringExamples,
+        triggeringExamples: Examples(indentedCases: false).triggeringExamples
     )
 
     public func validate(file: File, kind: StatementKind,
@@ -68,16 +68,24 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
     }
 }
 
-public extension SwitchCaseAlignmentRule {
+extension SwitchCaseAlignmentRule {
     struct Examples {
         private let indentedCasesOption: Bool
         private let violationMarker = "↓"
 
-        public init(indentedCases: Bool) {
+        init(indentedCases: Bool) {
             self.indentedCasesOption = indentedCases
         }
 
-        public var indentedCases: [String] {
+        var triggeringExamples: [String] {
+            return indentedCasesOption ? nonIndentedCases : indentedCases
+        }
+
+        var nonTriggeringExamples: [String] {
+            return indentedCasesOption ? indentedCases : nonIndentedCases
+        }
+
+        private var indentedCases: [String] {
             let violationMarker = indentedCasesOption ? "" : self.violationMarker
 
             return [
@@ -112,7 +120,7 @@ public extension SwitchCaseAlignmentRule {
             ]
         }
 
-        public var nonIndentedCases: [String] {
+        private var nonIndentedCases: [String] {
             let violationMarker = indentedCasesOption ? self.violationMarker : ""
 
             return [

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -84,7 +84,7 @@ extension SwitchCaseAlignmentRule {
         }
 
         var triggeringExamples: [String] {
-            return indentedCasesOption ? nonIndentedCases : indentedCases
+            return (indentedCasesOption ? nonIndentedCases : indentedCases) + invalidCases
         }
 
         var nonTriggeringExamples: [String] {
@@ -166,6 +166,31 @@ extension SwitchCaseAlignmentRule {
                     print('One')
                 \(violationMarker)default:
                     print('Some other number')
+                }
+                """
+            ]
+        }
+
+        private var invalidCases: [String] {
+            let indentation = indentedCasesOption ? "    " : ""
+
+            return [
+                """
+                switch someBool {
+                \(indentation)case true:
+                    \(indentation)print('red')
+                    \(indentation)\(violationMarker)case false:
+                        \(indentation)print('blue')
+                }
+                """,
+                """
+                if aBool {
+                    switch someBool {
+                        \(indentation)\(indentedCasesOption ? "" : violationMarker)case true:
+                        \(indentation)print('red')
+                    \(indentation)\(indentedCasesOption ? violationMarker : "")case false:
+                    \(indentation)print('blue')
+                    }
                 }
                 """
             ]

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -62,9 +62,15 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func locationToViolation(_ location: Location) -> StyleViolation {
-        return StyleViolation(ruleDescription: configuration.ruleDescription,
+        // swiftlint:disable line_length
+        let reason = configuration.indentedCases ? "Case statements should be indented within their enclosing switch statement"
+                                                 : "Case statements should vertically align with their enclosing switch statement"
+        // swiftlint:enable line_length
+
+        return StyleViolation(ruleDescription: SwitchCaseAlignmentRule.description,
                               severity: configuration.severityConfiguration.severity,
-                              location: location)
+                              location: location,
+                              reason: reason)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -12,64 +12,8 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
         description: "Case statements should vertically align with the enclosing switch statement, " +
                      "or indented if configured otherwise.",
         kind: .style,
-        nonTriggeringExamples: [
-            "switch someBool {\n" +
-            "case true: // case 1\n" +
-            "    print('red')\n" +
-            "case false:\n" +
-            "    /*\n" +
-            "    case 2\n" +
-            "    */\n" +
-            "    if case let .someEnum(val) = someFunc() {\n" +
-            "        print('blue')\n" +
-            "    }\n" +
-            "}\n" +
-            "enum SomeEnum {\n" +
-            "    case innocent\n" +
-            "}",
-            "if aBool {\n" +
-            "    switch someBool {\n" +
-            "    case true:\n" +
-            "        print('red')\n" +
-            "    case false:\n" +
-            "        print('blue')\n" +
-            "    }\n" +
-            "}",
-            "switch someInt {\n" +
-            "// comments ignored\n" +
-            "case 0:\n" +
-            "    // zero case\n" +
-            "    print('Zero')\n" +
-            "case 1:\n" +
-            "    print('One')\n" +
-            "default:\n" +
-            "    print('Some other number')\n" +
-            "}"
-        ],
-        triggeringExamples: [
-            "switch someBool {\n" +
-            "    ↓case true:\n" +
-            "         print('red')\n" +
-            "    ↓case false:\n" +
-            "         print('blue')\n" +
-            "}",
-            "if aBool {\n" +
-            "    switch someBool {\n" +
-            "        ↓case true:\n" +
-            "            print('red')\n" +
-            "    case false:\n" +
-            "        print('blue')\n" +
-            "    }\n" +
-            "}",
-            "switch someInt {\n" +
-            "    ↓case 0:\n" +
-            "    print('Zero')\n" +
-            "case 1:\n" +
-            "    print('One')\n" +
-            "    ↓default:\n" +
-            "    print('Some other number')\n" +
-            "}"
-        ]
+        nonTriggeringExamples: Examples.nonIndentedCases,
+        triggeringExamples: Examples.indentedCases
     )
 
     public func validate(file: File, kind: StatementKind,
@@ -121,5 +65,82 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
                                severity: configuration.severityConfiguration.severity,
                                location: $0)
             }
+    }
+}
+
+public extension SwitchCaseAlignmentRule {
+    struct Examples {
+        static public let indentedCases = [
+            """
+            switch someBool {
+                case true:
+                    print("red")
+                case false:
+                    print("blue")
+            }
+            """,
+            """
+            if aBool {
+                switch someBool {
+                    case true:
+                        print('red')
+                    case false:
+                        print('blue')
+                }
+            }
+            """,
+            """
+            switch someInt {
+                case 0:
+                    print('Zero')
+                case 1:
+                    print('One')
+                default:
+                    print('Some other number')
+            }
+            """
+        ]
+
+
+        static public let nonIndentedCases = [
+            """
+            switch someBool {
+            case true: // case 1
+                print('red')
+            case false:
+                /*
+                case 2
+                */
+                if case let .someEnum(val) = someFunc() {
+                    print('blue')
+                }
+            }
+            enum SomeEnum {
+                case innocent
+            }
+            """,
+            """
+            if aBool {
+                switch someBool {
+                case true:
+                    print('red')
+                case false:
+                    print('blue')
+                }
+            }
+            """,
+            """
+            switch someInt {
+            // comments ignored
+            case 0:
+                // zero case
+                print('Zero')
+            case 1:
+                print('One')
+            default:
+                print('Some other number')
+            }
+            """
+        ]
     }
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		72EA17B61FD31F10009D5CE6 /* ExplicitACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */; };
 		740DF1B1203F62BB0081F694 /* EmptyStringRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */; };
 		787CDE39208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */; };
+		787CDE3B208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */; };
 		78F032461D7C877E00BE709A /* OverriddenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */; };
 		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
 		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
@@ -486,6 +487,7 @@
 		72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitACLRule.swift; sourceTree = "<group>"; };
 		740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyStringRule.swift; sourceTree = "<group>"; };
 		787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentConfiguration.swift; sourceTree = "<group>"; };
+		787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentRuleTests.swift; sourceTree = "<group>"; };
 		78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverriddenSuperCallRule.swift; sourceTree = "<group>"; };
 		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
 		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
@@ -999,6 +1001,7 @@
 				E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */,
 				3B12C9C61C3361CB000B423F /* RuleTests.swift */,
 				6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */,
+				787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */,
 				E81224991B04F85B001783D2 /* TestHelpers.swift */,
 				D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */,
 				C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */,
@@ -1818,6 +1821,7 @@
 				1EB7C8531F0C45C2004BAD22 /* ModifierOrderTests.swift in Sources */,
 				67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */,
 				D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */,
+				787CDE3B208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift in Sources */,
 				F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */,
 				B89F3BCE1FD5EE0200931E59 /* RequiredEnumCaseRuleTestCase.swift in Sources */,
 				C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		7250948A1D0859260039B353 /* StatementPositionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725094881D0855760039B353 /* StatementPositionConfiguration.swift */; };
 		72EA17B61FD31F10009D5CE6 /* ExplicitACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */; };
 		740DF1B1203F62BB0081F694 /* EmptyStringRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */; };
+		787CDE39208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */; };
 		78F032461D7C877E00BE709A /* OverriddenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */; };
 		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
 		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
@@ -484,6 +485,7 @@
 		725094881D0855760039B353 /* StatementPositionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionConfiguration.swift; sourceTree = "<group>"; };
 		72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitACLRule.swift; sourceTree = "<group>"; };
 		740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyStringRule.swift; sourceTree = "<group>"; };
+		787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentConfiguration.swift; sourceTree = "<group>"; };
 		78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverriddenSuperCallRule.swift; sourceTree = "<group>"; };
 		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
 		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
@@ -678,7 +680,7 @@
 		E889D8C41F1D11A200058332 /* Configuration+LintableFiles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Configuration+LintableFiles.swift"; sourceTree = "<group>"; };
 		E889D8C61F1D357B00058332 /* Configuration+Merging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Configuration+Merging.swift"; sourceTree = "<group>"; };
 		E88DEA6A1B0983FE00A66CB0 /* StyleViolation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleViolation.swift; sourceTree = "<group>"; };
-		E88DEA6E1B09843F00A66CB0 /* Location.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
+		E88DEA6E1B09843F00A66CB0 /* Location.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; tabWidth = 4; };
 		E88DEA701B09847500A66CB0 /* ViolationSeverity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViolationSeverity.swift; sourceTree = "<group>"; };
 		E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SwiftLint.swift"; sourceTree = "<group>"; };
 		E88DEA741B09852000A66CB0 /* File+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+SwiftLint.swift"; sourceTree = "<group>"; };
@@ -797,6 +799,7 @@
 				BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */,
 				CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */,
 				006204DA1E1E48F900FFFBE1 /* VerticalWhitespaceConfiguration.swift */,
+				787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */,
 			);
 			path = RuleConfigurations;
 			sourceTree = "<group>";
@@ -1637,6 +1640,7 @@
 				D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */,
 				24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */,
 				47ACC8981E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift in Sources */,
+				787CDE39208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift in Sources */,
 				009E09281DFEE4C200B588A7 /* ProhibitedSuperRule.swift in Sources */,
 				E80E018F1B92C1350078EB70 /* Region.swift in Sources */,
 				E88198581BEA956C00333A11 /* FunctionBodyLengthRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,10 +1,3 @@
-//
-//  LinuxMain.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 12/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
 // Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
@@ -255,6 +248,7 @@ extension LineLengthConfigurationTests {
         ("testLineLengthConfigurationInitialiserSetsIgnoresURLs", testLineLengthConfigurationInitialiserSetsIgnoresURLs),
         ("testLineLengthConfigurationInitialiserSetsIgnoresFunctionDeclarations", testLineLengthConfigurationInitialiserSetsIgnoresFunctionDeclarations),
         ("testLineLengthConfigurationInitialiserSetsIgnoresComments", testLineLengthConfigurationInitialiserSetsIgnoresComments),
+        ("testLineLengthConfigurationInitialiserSetsIgnoresInterpolatedStrings", testLineLengthConfigurationInitialiserSetsIgnoresInterpolatedStrings),
         ("testLineLengthConfigurationParams", testLineLengthConfigurationParams),
         ("testLineLengthConfigurationPartialParams", testLineLengthConfigurationPartialParams),
         ("testLineLengthConfigurationThrowsOnBadConfig", testLineLengthConfigurationThrowsOnBadConfig),
@@ -270,7 +264,9 @@ extension LineLengthRuleTests {
         ("testLineLength", testLineLength),
         ("testLineLengthWithIgnoreFunctionDeclarationsEnabled", testLineLengthWithIgnoreFunctionDeclarationsEnabled),
         ("testLineLengthWithIgnoreCommentsEnabled", testLineLengthWithIgnoreCommentsEnabled),
-        ("testLineLengthWithIgnoreURLsEnabled", testLineLengthWithIgnoreURLsEnabled)
+        ("testLineLengthWithIgnoreURLsEnabled", testLineLengthWithIgnoreURLsEnabled),
+        ("testLineLengthWithIgnoreInterpolatedStringsTrue", testLineLengthWithIgnoreInterpolatedStringsTrue),
+        ("testLineLengthWithIgnoreInterpolatedStringsFalse", testLineLengthWithIgnoreInterpolatedStringsFalse)
     ]
 }
 
@@ -297,19 +293,19 @@ extension LinterCacheTests {
     ]
 }
 
-extension MultilineArgumentsRuleTests {
-    static var allTests: [(String, (MultilineArgumentsRuleTests) -> () throws -> Void)] = [
-        ("testMultilineArgumentsWithDefaultConfiguration", testMultilineArgumentsWithDefaultConfiguration),
-        ("testMultilineArgumentsWithWithNextLine", testMultilineArgumentsWithWithNextLine),
-        ("testMultilineArgumentsWithWithSameLine", testMultilineArgumentsWithWithSameLine)
-    ]
-}
-
 extension ModifierOrderTests {
     static var allTests: [(String, (ModifierOrderTests) -> () throws -> Void)] = [
         ("testAttributeTypeMethod", testAttributeTypeMethod),
         ("testRightOrderedModifierGroups", testRightOrderedModifierGroups),
         ("testAtPrefixedGroup", testAtPrefixedGroup)
+    ]
+}
+
+extension MultilineArgumentsRuleTests {
+    static var allTests: [(String, (MultilineArgumentsRuleTests) -> () throws -> Void)] = [
+        ("testMultilineArgumentsWithDefaultConfiguration", testMultilineArgumentsWithDefaultConfiguration),
+        ("testMultilineArgumentsWithWithNextLine", testMultilineArgumentsWithWithNextLine),
+        ("testMultilineArgumentsWithWithSameLine", testMultilineArgumentsWithWithSameLine)
     ]
 }
 
@@ -403,7 +399,10 @@ extension RuleConfigurationsTests {
         ("testTrailingWhitespaceConfigurationApplyConfigurationSetsIgnoresComments", testTrailingWhitespaceConfigurationApplyConfigurationSetsIgnoresComments),
         ("testTrailingWhitespaceConfigurationCompares", testTrailingWhitespaceConfigurationCompares),
         ("testTrailingWhitespaceConfigurationApplyConfigurationUpdatesSeverityConfiguration", testTrailingWhitespaceConfigurationApplyConfigurationUpdatesSeverityConfiguration),
-        ("testOverridenSuperCallConfigurationFromDictionary", testOverridenSuperCallConfigurationFromDictionary)
+        ("testOverridenSuperCallConfigurationFromDictionary", testOverridenSuperCallConfigurationFromDictionary),
+        ("testModifierOrderConfigurationFromDictionary", testModifierOrderConfigurationFromDictionary),
+        ("testModifierOrderConfigurationThrowsOnUnrecognizedModifierGroup", testModifierOrderConfigurationThrowsOnUnrecognizedModifierGroup),
+        ("testModifierOrderConfigurationThrowsOnNonModifiableGroup", testModifierOrderConfigurationThrowsOnNonModifiableGroup)
     ]
 }
 
@@ -476,8 +475,8 @@ extension RulesTests {
         ("testLegacyConstructor", testLegacyConstructor),
         ("testLetVarWhitespace", testLetVarWhitespace),
         ("testLiteralExpressionEndIdentation", testLiteralExpressionEndIdentation),
-        ("testModifierOrder", testModifierOrder),
         ("testMark", testMark),
+        ("testModifierOrder", testModifierOrder),
         ("testMultilineParameters", testMultilineParameters),
         ("testMultipleClosuresWithTrailingClosure", testMultipleClosuresWithTrailingClosure),
         ("testNesting", testNesting),
@@ -640,8 +639,8 @@ XCTMain([
     testCase(LineLengthConfigurationTests.allTests),
     testCase(LineLengthRuleTests.allTests),
     testCase(LinterCacheTests.allTests),
-    testCase(MultilineArgumentsRuleTests.allTests),
     testCase(ModifierOrderTests.allTests),
+    testCase(MultilineArgumentsRuleTests.allTests),
     testCase(NumberSeparatorRuleTests.allTests),
     testCase(ObjectLiteralRuleTests.allTests),
     testCase(PrivateOverFilePrivateRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,11 @@
-// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
+//
+//  LinuxMain.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 12/11/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+// Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -540,6 +547,14 @@ extension SourceKitCrashTests {
     ]
 }
 
+extension SwitchCaseAlignmentRuleTests {
+    static var allTests: [(String, (SwitchCaseAlignmentRuleTests) -> () throws -> Void)] = [
+        ("testSwitchCaseAlignment", testSwitchCaseAlignment),
+        ("testSwitchCaseAlignmentWithoutIndentedCases", testSwitchCaseAlignmentWithoutIndentedCases),
+        ("testSwitchCaseAlignmentWithIndentedCases", testSwitchCaseAlignmentWithIndentedCases)
+    ]
+}
+
 extension TodoRuleTests {
     static var allTests: [(String, (TodoRuleTests) -> () throws -> Void)] = [
         ("testTodo", testTodo),
@@ -637,6 +652,7 @@ XCTMain([
     testCase(RuleTests.allTests),
     testCase(RulesTests.allTests),
     testCase(SourceKitCrashTests.allTests),
+    testCase(SwitchCaseAlignmentRuleTests.allTests),
     testCase(TodoRuleTests.allTests),
     testCase(TrailingCommaRuleTests.allTests),
     testCase(TypeNameRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -548,7 +548,6 @@ extension SourceKitCrashTests {
 
 extension SwitchCaseAlignmentRuleTests {
     static var allTests: [(String, (SwitchCaseAlignmentRuleTests) -> () throws -> Void)] = [
-        ("testSwitchCaseAlignment", testSwitchCaseAlignment),
         ("testSwitchCaseAlignmentWithoutIndentedCases", testSwitchCaseAlignmentWithoutIndentedCases),
         ("testSwitchCaseAlignmentWithIndentedCases", testSwitchCaseAlignmentWithIndentedCases)
     ]

--- a/Tests/SwiftLintFrameworkTests/RuleDescription+Examples.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleDescription+Examples.swift
@@ -1,7 +1,8 @@
 import SwiftLintFramework
 
 extension RuleDescription {
-    func with(nonTriggeringExamples: [String]) -> RuleDescription {
+    func with(nonTriggeringExamples: [String],
+              triggeringExamples: [String]) -> RuleDescription {
         return RuleDescription(identifier: identifier,
                                name: name,
                                description: description,
@@ -12,15 +13,14 @@ extension RuleDescription {
                                deprecatedAliases: deprecatedAliases)
     }
 
+    func with(nonTriggeringExamples: [String]) -> RuleDescription {
+        return with(nonTriggeringExamples: nonTriggeringExamples,
+                    triggeringExamples: triggeringExamples)
+    }
+
     func with(triggeringExamples: [String]) -> RuleDescription {
-        return RuleDescription(identifier: identifier,
-                               name: name,
-                               description: description,
-                               kind: kind,
-                               nonTriggeringExamples: nonTriggeringExamples,
-                               triggeringExamples: triggeringExamples,
-                               corrections: corrections,
-                               deprecatedAliases: deprecatedAliases)
+        return with(nonTriggeringExamples: nonTriggeringExamples,
+                    triggeringExamples: triggeringExamples)
     }
 
     func with(corrections: [String: String]) -> RuleDescription {

--- a/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
@@ -16,28 +16,20 @@ class SwitchCaseAlignmentRuleTests: XCTestCase {
 
     func testSwitchCaseAlignmentWithoutIndentedCases() {
         let baseDescription = SwitchCaseAlignmentRule.description
+        let examples = SwitchCaseAlignmentRule.Examples(indentedCases: false)
 
-        let description = baseDescription.with(nonTriggeringExamples: SwitchCaseAlignmentRule.Examples.nonIndentedCases)
-        verifyRule(description)
-    }
+        let description = baseDescription.with(nonTriggeringExamples: examples.nonIndentedCases,
+                                               triggeringExamples: examples.indentedCases)
 
-    func testSwitchCaseAlignmentWithoutIndentedCasesAndViolation() {
-        let baseDescription = SwitchCaseAlignmentRule.description
-
-        let description = baseDescription.with(triggeringExamples: SwitchCaseAlignmentRule.Examples.indentedCases)
         verifyRule(description)
     }
 
     func testSwitchCaseAlignmentWithIndentedCases() {
         let baseDescription = SwitchCaseAlignmentRule.description
-        let description = baseDescription.with(nonTriggeringExamples: SwitchCaseAlignmentRule.Examples.indentedCases)
+        let examples = SwitchCaseAlignmentRule.Examples(indentedCases: true)
 
-        verifyRule(description, ruleConfiguration: ["indented_cases": true])
-    }
-
-    func testSwitchCaseAlignmentWithIndentedCasesAndViolation() {
-        let baseDescription = SwitchCaseAlignmentRule.description
-        let description = baseDescription.with(nonTriggeringExamples: SwitchCaseAlignmentRule.Examples.nonIndentedCases)
+        let description = baseDescription.with(nonTriggeringExamples: examples.indentedCases,
+                                               triggeringExamples: examples.nonIndentedCases)
 
         verifyRule(description, ruleConfiguration: ["indented_cases": true])
     }

--- a/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Realm. All rights reserved.
 //
 
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class SwitchCaseAlignmentRuleTests: XCTestCase {
@@ -18,8 +18,8 @@ class SwitchCaseAlignmentRuleTests: XCTestCase {
         let baseDescription = SwitchCaseAlignmentRule.description
         let examples = SwitchCaseAlignmentRule.Examples(indentedCases: false)
 
-        let description = baseDescription.with(nonTriggeringExamples: examples.nonIndentedCases,
-                                               triggeringExamples: examples.indentedCases)
+        let description = baseDescription.with(nonTriggeringExamples: examples.nonTriggeringExamples,
+                                               triggeringExamples: examples.triggeringExamples)
 
         verifyRule(description)
     }
@@ -28,8 +28,8 @@ class SwitchCaseAlignmentRuleTests: XCTestCase {
         let baseDescription = SwitchCaseAlignmentRule.description
         let examples = SwitchCaseAlignmentRule.Examples(indentedCases: true)
 
-        let description = baseDescription.with(nonTriggeringExamples: examples.indentedCases,
-                                               triggeringExamples: examples.nonIndentedCases)
+        let description = baseDescription.with(nonTriggeringExamples: examples.nonTriggeringExamples,
+                                               triggeringExamples: examples.triggeringExamples)
 
         verifyRule(description, ruleConfiguration: ["indented_cases": true])
     }

--- a/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
@@ -1,0 +1,44 @@
+//
+//  SwitchCaseAlignmentRuleTests.swift
+//  SwiftLint
+//
+//  Created by Shai Mishali on 4/24/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import SwiftLintFramework
+import XCTest
+
+class SwitchCaseAlignmentRuleTests: XCTestCase {
+    func testSwitchCaseAlignment() {
+        verifyRule(SwitchCaseAlignmentRule.description)
+    }
+
+    func testSwitchCaseAlignmentWithoutIndentedCases() {
+        let baseDescription = SwitchCaseAlignmentRule.description
+
+        let description = baseDescription.with(nonTriggeringExamples: SwitchCaseAlignmentRule.Examples.nonIndentedCases)
+        verifyRule(description)
+    }
+
+    func testSwitchCaseAlignmentWithoutIndentedCasesAndViolation() {
+        let baseDescription = SwitchCaseAlignmentRule.description
+
+        let description = baseDescription.with(triggeringExamples: SwitchCaseAlignmentRule.Examples.indentedCases)
+        verifyRule(description)
+    }
+
+    func testSwitchCaseAlignmentWithIndentedCases() {
+        let baseDescription = SwitchCaseAlignmentRule.description
+        let description = baseDescription.with(nonTriggeringExamples: SwitchCaseAlignmentRule.Examples.indentedCases)
+
+        verifyRule(description, ruleConfiguration: ["indented_cases": true])
+    }
+
+    func testSwitchCaseAlignmentWithIndentedCasesAndViolation() {
+        let baseDescription = SwitchCaseAlignmentRule.description
+        let description = baseDescription.with(nonTriggeringExamples: SwitchCaseAlignmentRule.Examples.nonIndentedCases)
+
+        verifyRule(description, ruleConfiguration: ["indented_cases": true])
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  SwitchCaseAlignmentRuleTests.swift
-//  SwiftLint
-//
-//  Created by Shai Mishali on 4/24/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 @testable import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
@@ -2,10 +2,6 @@
 import XCTest
 
 class SwitchCaseAlignmentRuleTests: XCTestCase {
-    func testSwitchCaseAlignment() {
-        verifyRule(SwitchCaseAlignmentRule.description)
-    }
-
     func testSwitchCaseAlignmentWithoutIndentedCases() {
         let baseDescription = SwitchCaseAlignmentRule.description
         let examples = SwitchCaseAlignmentRule.Examples(indentedCases: false)


### PR DESCRIPTION
Fixes #2119. 

This PR adds the following configuration: 

```yaml
switch_case_alignment:
    indented_cases: true
```

Thanks and appreciate your review :)
Shai. 