### PR TITLE
Add `missing_docs` rule back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2127](https://github.com/realm/SwiftLint/issues/2127)
 
+* Add `redundant_set_access_control` rule to warn against using redundant
+  setter ACLs on variable declarations.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#1869](https://github.com/realm/SwiftLint/issues/1869)
+
 #### Bug Fixes
 
 * None.
@@ -144,11 +149,6 @@ The next release will require Swift 4.0 or higher to build.
   the use of optional booleans.  
   [Ornithologist Coder](https://github.com/ornithocoder)
   [#2011](https://github.com/realm/SwiftLint/issues/2011)
-
-* Add `redundant_set_access_control` rule to warn against using redundant
-  setter ACLs on variable declarations.  
-  [Marcelo Fabri](https://github.com/marcelofabri)
-  [#1869](https://github.com/realm/SwiftLint/issues/1869)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1869](https://github.com/realm/SwiftLint/issues/1869)
 
+* Add `missing_docs` rule to warn against undocumented declarations.  
+  [Nef10](https://github.com/Nef10)
+  [#1652](https://github.com/realm/SwiftLint/issues/1652)
+
 #### Bug Fixes
 
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
   [Nef10](https://github.com/Nef10)
   [Andrés Cecilia Luque](https://github.com/acecilia)
   [#1652](https://github.com/realm/SwiftLint/issues/1652)
+
 * Add a new `ignores_interpolated_strings` config parameter to the `line_length`
   rule to ignore lines that include interpolated strings from this rule.  
   [Michael Gray](https://github.com/mishagray)

--- a/Rules.md
+++ b/Rules.md
@@ -63,6 +63,7 @@
 * [Literal Expression End Indentation](#literal-expression-end-indentation)
 * [Lower ACL than parent](#lower-acl-than-parent)
 * [Mark](#mark)
+* [Missing Docs](#missing-docs)
 * [Multiline Arguments](#multiline-arguments)
 * [Multiline Parameters](#multiline-parameters)
 * [Multiple Closures with Trailing Closure](#multiple-closures-with-trailing-closure)
@@ -8640,6 +8641,76 @@ struct MarkTest {}
 ↓// MARK:- Bad mark
 extension MarkTest {}
 
+```
+
+</details>
+
+
+
+## Missing Docs
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift Compiler Version
+--- | --- | --- | --- | ---
+`missing_docs` | Disabled | No | lint | 4.1.0 
+
+Declarations should be documented.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+/// docs
+public class A {
+/// docs
+public func b() {}
+}
+/// docs
+public class B: A { override public func b() {} }
+
+```
+
+```swift
+import Foundation
+/// docs
+public class B: NSObject {
+// no docs
+override public var description: String { fatalError() } }
+
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+public func a() {}
+
+```
+
+```swift
+// regular comment
+public func a() {}
+
+```
+
+```swift
+/* regular comment */
+public func a() {}
+
+```
+
+```swift
+/// docs
+public protocol A {
+// no docs
+var b: Int { get } }
+/// docs
+public struct C: A {
+
+public let b: Int
+}
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -8956,24 +8956,21 @@ Declarations should be documented.
 ```swift
 /// docs
 public class A {
-    /// docs
-    public func b() {}
-}
-
 /// docs
-public class B: A {
-    override public func b() {}
+public func b() {}
 }
+/// docs
+public class B: A { override public func b() {} }
+
 ```
 
 ```swift
 import Foundation
-
 /// docs
 public class B: NSObject {
-    // no docs
-    override public var description: String { fatalError() }
-}
+// no docs
+override public var description: String { fatalError() } }
+
 ```
 
 </details>
@@ -8982,28 +8979,30 @@ public class B: NSObject {
 
 ```swift
 public func a() {}
+
 ```
 
 ```swift
 // regular comment
 public func a() {}
+
 ```
 
 ```swift
 /* regular comment */
 public func a() {}
+
 ```
 
 ```swift
 /// docs
 public protocol A {
-    // no docs
-    var b: Int { get } }
-    
+// no docs
+var b: Int { get } }
 /// docs
 public struct C: A {
 
-    public let b: Int
+public let b: Int
 }
 ```
 

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -71,6 +71,10 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
     var usr: Int? {
         return (self["key.usr"] as? Int64).flatMap({ Int($0) })
     }
+    /// Documentation length.
+    var docLength: Int? {
+        return (self["key.doclength"] as? Int64).flatMap({ Int($0) })
+    }
 
     var attribute: String? {
         return self["key.attribute"] as? String

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -5,7 +5,7 @@
 //  Created by Scott Hoyt on 12/28/15.
 //  Copyright © 2015 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
@@ -71,6 +71,7 @@ public let masterRuleList = RuleList(rules: [
     LiteralExpressionEndIdentationRule.self,
     LowerACLThanParentRule.self,
     MarkRule.self,
+    MissingDocsRule.self,
     MultilineArgumentsRule.self,
     MultilineParametersRule.self,
     MultipleClosuresWithTrailingClosureRule.self,

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -1,0 +1,115 @@
+//
+//  MissingDocsRule.swift
+//  SwiftLint
+//
+//  Created by JP Simard on 11/15/15.
+//  Copyright © 2015 Realm. All rights reserved.
+//
+
+import SourceKittenFramework
+
+internal extension File {
+    func missingDocOffsets(in dictionary: [String: SourceKitRepresentable],
+                           acls: [AccessControlLevel]) -> [(Int, AccessControlLevel)] {
+        if dictionary.enclosedSwiftAttributes.contains(.override) ||
+            !dictionary.inheritedTypes.isEmpty {
+            return []
+        }
+        let substructureOffsets = dictionary.substructure.flatMap {
+            missingDocOffsets(in: $0, acls: acls)
+        }
+        guard (dictionary.kind).flatMap(SwiftDeclarationKind.init) != nil,
+            let offset = dictionary.offset,
+            let accessibility = dictionary.accessibility,
+            let acl = AccessControlLevel(identifier: accessibility),
+            acls.contains(acl) else {
+                return substructureOffsets
+        }
+        if dictionary.docLength != nil {
+            return substructureOffsets
+        }
+        return substructureOffsets + [(offset, acl)]
+    }
+}
+
+public struct MissingDocsRule: OptInRule {
+    public init(configuration: Any) throws {
+        guard let dict = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+        parameters = try dict.flatMap { (key: String, value: Any) -> [RuleParameter<AccessControlLevel>] in
+            guard let severity = ViolationSeverity(rawValue: key) else {
+                throw ConfigurationError.unknownConfiguration
+            }
+            if let array = [String].array(of: value) {
+                return try array.map {
+                    guard let acl = AccessControlLevel(description: $0) else {
+                        throw ConfigurationError.unknownConfiguration
+                    }
+                    return RuleParameter<AccessControlLevel>(severity: severity, value: acl)
+                }
+            } else if let string = value as? String, let acl = AccessControlLevel(description: string) {
+                return [RuleParameter<AccessControlLevel>(severity: severity, value: acl)]
+            }
+            throw ConfigurationError.unknownConfiguration
+        }
+    }
+
+    public var configurationDescription: String {
+        return parameters.map({
+            "\($0.severity.rawValue): \($0.value.rawValue)"
+        }).joined(separator: ", ")
+    }
+
+    public init() {
+        parameters = [RuleParameter(severity: .warning, value: .public),
+                      RuleParameter(severity: .warning, value: .open)]
+    }
+
+    public let parameters: [RuleParameter<AccessControlLevel>]
+
+    public static let description = RuleDescription(
+        identifier: "missing_docs",
+        name: "Missing Docs",
+        description: "Declarations should be documented.",
+        kind: .lint,
+        minSwiftVersion: .fourDotOne,
+        nonTriggeringExamples: [
+            // locally-defined superclass member is documented, but subclass member is not
+            "/// docs\npublic class A {\n/// docs\npublic func b() {}\n}\n" +
+            "/// docs\npublic class B: A { override public func b() {} }\n",
+            // externally-defined superclass member is documented, but subclass member is not
+            "import Foundation\n/// docs\npublic class B: NSObject {\n" +
+            "// no docs\noverride public var description: String { fatalError() } }\n"
+        ],
+        triggeringExamples: [
+            // public, undocumented
+            "public func a() {}\n",
+            // public, undocumented
+            "// regular comment\npublic func a() {}\n",
+            // public, undocumented
+            "/* regular comment */\npublic func a() {}\n",
+            // protocol member and inherited member are both undocumented
+            "/// docs\npublic protocol A {\n// no docs\nvar b: Int { get } }\n" +
+            "/// docs\npublic struct C: A {\n\npublic let b: Int\n}"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        let acls = parameters.map { $0.value }
+        return file.missingDocOffsets(in: file.structure.dictionary,
+                                      acls: acls).map { (offset: Int, acl: AccessControlLevel) in
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: parameters.first { $0.value == acl }?.severity ?? .warning,
+                           location: Location(file: file, byteOffset: offset),
+                           reason: "\(acl.description) declarations should be documented.")
+        }
+    }
+
+    public func isEqualTo(_ rule: Rule) -> Bool {
+        if let rule = rule as? MissingDocsRule {
+            return rule.parameters == parameters
+        }
+        return false
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -1,0 +1,54 @@
+//
+//  MissingDocsRuleConfiguration.swift
+//  SwiftLint
+//
+//  Created by Steffen Kötte on 04/26/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+import Foundation
+
+public struct MissingDocsRuleConfiguration: RuleConfiguration {
+
+    private(set) var parameters = [RuleParameter<AccessControlLevel>]()
+
+    public var consoleDescription: String {
+        return parameters.group { $0.severity }.map {
+            "\($0.rawValue): \($1.map { $0.value.description }.joined(separator: ", "))"
+        }.joined(separator: ", ")
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let dict = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+        let parameters = try dict.flatMap { (key: String, value: Any) -> [RuleParameter<AccessControlLevel>] in
+            guard let severity = ViolationSeverity(rawValue: key) else {
+                throw ConfigurationError.unknownConfiguration
+            }
+            if let array = [String].array(of: value) {
+                return try array.map {
+                    guard let acl = AccessControlLevel(description: $0) else {
+                        throw ConfigurationError.unknownConfiguration
+                    }
+                    return RuleParameter<AccessControlLevel>(severity: severity, value: acl)
+                }
+            } else if let string = value as? String, let acl = AccessControlLevel(description: string) {
+                return [RuleParameter<AccessControlLevel>(severity: severity, value: acl)]
+            }
+            throw ConfigurationError.unknownConfiguration
+        }
+        guard parameters.count == parameters.map({ $0.value }).unique.count else {
+            throw ConfigurationError.unknownConfiguration
+        }
+        self.parameters = parameters
+    }
+
+    public func isEqualTo(_ ruleConfiguration: RuleConfiguration) -> Bool {
+        guard let config = ruleConfiguration as? MissingDocsRuleConfiguration else {
+            return false
+        }
+        return parameters == config.parameters
+    }
+
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -13,8 +13,8 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration {
     private(set) var parameters = [RuleParameter<AccessControlLevel>]()
 
     public var consoleDescription: String {
-        return parameters.group { $0.severity }.map {
-            "\($0.rawValue): \($1.map { $0.value.description }.joined(separator: ", "))"
+        return parameters.group { $0.severity }.sorted { $0.key.rawValue < $1.key.rawValue }.map {
+            "\($0.rawValue): \($1.map { $0.value.description }.sorted(by: <).joined(separator: ", "))"
         }.joined(separator: ", ")
     }
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -320,6 +320,8 @@
 		F480DC7F1F26090000099465 /* ConfigurationTests+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */; };
 		F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */; };
 		F480DC831F2609D700099465 /* ConfigurationTests+ProjectMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */; };
+		F90DBD7F2092E669002CC310 /* MissingDocsRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */; };
+		F90DBD812092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */; };
 		F9D73F031D0CF15E00222FC4 /* test.txt in Resources */ = {isa = PBXBuildFile; fileRef = F9D73F021D0CF15E00222FC4 /* test.txt */; };
 		F9E691282091952E0085B53E /* MissingDocsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E691272091952E0085B53E /* MissingDocsRule.swift */; };
 /* End PBXBuildFile section */
@@ -706,6 +708,8 @@
 		F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+Nested.swift"; sourceTree = "<group>"; };
 		F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+BundlePath.swift"; sourceTree = "<group>"; };
 		F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+ProjectMock.swift"; sourceTree = "<group>"; };
+		F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRuleConfiguration.swift; sourceTree = "<group>"; };
+		F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRuleConfigurationTests.swift; sourceTree = "<group>"; };
 		F9D73F021D0CF15E00222FC4 /* test.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = test.txt; sourceTree = "<group>"; };
 		F9E691272091952E0085B53E /* MissingDocsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRule.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -772,6 +776,7 @@
 				29FFC3781F1574FD007E4825 /* FileLengthRuleConfiguration.swift */,
 				47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */,
 				3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */,
+				F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */,
 				3BCC04D01C4F56D3006073C3 /* NameConfiguration.swift */,
 				D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */,
 				D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */,
@@ -977,6 +982,7 @@
 				3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */,
 				D4C27BFF1E12DFF500DF713E /* LinterCacheTests.swift */,
 				D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */,
+				F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */,
 				B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */,
 				825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */,
 				D4246D6E1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift */,
@@ -1121,6 +1127,7 @@
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
 				D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */,
 				856651A61D6B395F005E6B29 /* MarkRule.swift */,
+				F9E691272091952E0085B53E /* MissingDocsRule.swift */,
 				B25DCD0D1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift */,
 				B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */,
 				B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */,
@@ -1198,7 +1205,6 @@
 				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
 				626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */,
 				1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */,
-				F9E691272091952E0085B53E /* MissingDocsRule.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -1618,6 +1624,7 @@
 				E88198591BEA95F100333A11 /* LeadingWhitespaceRule.swift in Sources */,
 				D42B45D91F0AF5E30086B683 /* StrictFilePrivateRule.swift in Sources */,
 				1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */,
+				F90DBD7F2092E669002CC310 /* MissingDocsRuleConfiguration.swift in Sources */,
 				67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */,
 				57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */,
 				D43B04691E072291004016AF /* ColonConfiguration.swift in Sources */,
@@ -1801,6 +1808,7 @@
 				E88198631BEA9A5400333A11 /* RulesTests.swift in Sources */,
 				47ACC89A1E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift in Sources */,
 				67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */,
+				F90DBD812092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift in Sources */,
 				D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */,
 				F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */,
 				B89F3BCE1FD5EE0200931E59 /* RequiredEnumCaseRuleTestCase.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 		F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */; };
 		F480DC831F2609D700099465 /* ConfigurationTests+ProjectMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */; };
 		F9D73F031D0CF15E00222FC4 /* test.txt in Resources */ = {isa = PBXBuildFile; fileRef = F9D73F021D0CF15E00222FC4 /* test.txt */; };
+		F9E691282091952E0085B53E /* MissingDocsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E691272091952E0085B53E /* MissingDocsRule.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -706,6 +707,7 @@
 		F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+BundlePath.swift"; sourceTree = "<group>"; };
 		F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+ProjectMock.swift"; sourceTree = "<group>"; };
 		F9D73F021D0CF15E00222FC4 /* test.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = test.txt; sourceTree = "<group>"; };
+		F9E691272091952E0085B53E /* MissingDocsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRule.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1196,6 +1198,7 @@
 				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
 				626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */,
 				1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */,
+				F9E691272091952E0085B53E /* MissingDocsRule.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -1722,6 +1725,7 @@
 				29FFC37A1F15764D007E4825 /* FileLengthRuleConfiguration.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
 				8FD216CC205584AF008ED13F /* CharacterSet+SwiftLint.swift in Sources */,
+				F9E691282091952E0085B53E /* MissingDocsRule.swift in Sources */,
 				D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */,
 				62A498561F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift in Sources */,
 				29AD4C661F6EA1D5009B66E1 /* ContainsOverFirstNotNilRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,7 +5,7 @@
 //  Created by JP Simard on 12/11/16.
 //  Copyright © 2016 Realm. All rights reserved.
 //
-// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -526,7 +526,8 @@ extension RulesTests {
         ("testSuperCall", testSuperCall),
         ("testWeakDelegate", testWeakDelegate),
         ("testXCTFailMessage", testXCTFailMessage),
-        ("testYodaCondition", testYodaCondition)
+        ("testYodaCondition", testYodaCondition),
+        ("testMissingDocs", testMissingDocs)
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -297,6 +297,21 @@ extension LinterCacheTests {
     ]
 }
 
+extension MissingDocsRuleConfigurationTests {
+    static var allTests: [(String, (MissingDocsRuleConfigurationTests) -> () throws -> Void)] = [
+        ("testDescriptionEmpty", testDescriptionEmpty),
+        ("testDescriptionSingleServety", testDescriptionSingleServety),
+        ("testDescriptionMultipleSeverities", testDescriptionMultipleSeverities),
+        ("testDescriptionMultipleAcls", testDescriptionMultipleAcls),
+        ("testParsingSingleServety", testParsingSingleServety),
+        ("testParsingMultipleSeverities", testParsingMultipleSeverities),
+        ("testParsingMultipleAcls", testParsingMultipleAcls),
+        ("testInvalidServety", testInvalidServety),
+        ("testInvalidAcl", testInvalidAcl),
+        ("testInvalidDuplicateAcl", testInvalidDuplicateAcl)
+    ]
+}
+
 extension MultilineArgumentsRuleTests {
     static var allTests: [(String, (MultilineArgumentsRuleTests) -> () throws -> Void)] = [
         ("testMultilineArgumentsWithDefaultConfiguration", testMultilineArgumentsWithDefaultConfiguration),
@@ -469,6 +484,7 @@ extension RulesTests {
         ("testLetVarWhitespace", testLetVarWhitespace),
         ("testLiteralExpressionEndIdentation", testLiteralExpressionEndIdentation),
         ("testMark", testMark),
+        ("testMissingDocs", testMissingDocs),
         ("testMultilineParameters", testMultilineParameters),
         ("testMultipleClosuresWithTrailingClosure", testMultipleClosuresWithTrailingClosure),
         ("testNesting", testNesting),
@@ -526,8 +542,7 @@ extension RulesTests {
         ("testSuperCall", testSuperCall),
         ("testWeakDelegate", testWeakDelegate),
         ("testXCTFailMessage", testXCTFailMessage),
-        ("testYodaCondition", testYodaCondition),
-        ("testMissingDocs", testMissingDocs)
+        ("testYodaCondition", testYodaCondition)
     ]
 }
 
@@ -624,6 +639,7 @@ XCTMain([
     testCase(LineLengthConfigurationTests.allTests),
     testCase(LineLengthRuleTests.allTests),
     testCase(LinterCacheTests.allTests),
+    testCase(MissingDocsRuleConfigurationTests.allTests),
     testCase(MultilineArgumentsRuleTests.allTests),
     testCase(NumberSeparatorRuleTests.allTests),
     testCase(ObjectLiteralRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
@@ -26,7 +26,7 @@ class MissingDocsRuleConfigurationTests: XCTestCase {
         let configuration = MissingDocsRuleConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open),
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
-        XCTAssertEqual(configuration.consoleDescription, "warning: public, error: open")
+        XCTAssertEqual(configuration.consoleDescription, "error: open, warning: public")
     }
 
     func testDescriptionMultipleAcls() {
@@ -45,15 +45,17 @@ class MissingDocsRuleConfigurationTests: XCTestCase {
     func testParsingMultipleSeverities() {
         var configuration = MissingDocsRuleConfiguration()
         try? configuration.apply(configuration: ["warning": "public", "error": "open"])
-        XCTAssertEqual(configuration.parameters, [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
-                                                  RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
+        XCTAssertEqual(configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
+                       [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+                        RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
     }
 
     func testParsingMultipleAcls() {
         var configuration = MissingDocsRuleConfiguration()
         try? configuration.apply(configuration: ["warning": ["public", "open"]])
-        XCTAssertEqual(configuration.parameters, [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
-                                                  RuleParameter<AccessControlLevel>(severity: .warning, value: .open)])
+        XCTAssertEqual(configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
+                       [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+                        RuleParameter<AccessControlLevel>(severity: .warning, value: .open)])
     }
 
     func testInvalidServety() {

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
@@ -1,0 +1,74 @@
+//
+//  MissingDocsRuleConfigurationTests.swift
+//  SwiftLint
+//
+//  Created by Steffen Kötte on 04/26/18.
+//  Copyright © 2018 Realm. All rights reserved.
+//
+
+@testable import SwiftLintFramework
+import XCTest
+
+class MissingDocsRuleConfigurationTests: XCTestCase {
+
+    func testDescriptionEmpty() {
+        let configuration = MissingDocsRuleConfiguration()
+        XCTAssertEqual(configuration.consoleDescription, "")
+    }
+
+    func testDescriptionSingleServety() {
+        let configuration = MissingDocsRuleConfiguration(
+            parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
+        XCTAssertEqual(configuration.consoleDescription, "error: open")
+    }
+
+    func testDescriptionMultipleSeverities() {
+        let configuration = MissingDocsRuleConfiguration(
+            parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open),
+                         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
+        XCTAssertEqual(configuration.consoleDescription, "warning: public, error: open")
+    }
+
+    func testDescriptionMultipleAcls() {
+        let configuration = MissingDocsRuleConfiguration(
+            parameters: [RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
+                         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
+        XCTAssertEqual(configuration.consoleDescription, "warning: open, public")
+    }
+
+    func testParsingSingleServety() {
+        var configuration = MissingDocsRuleConfiguration()
+        try? configuration.apply(configuration: ["warning": "open"])
+        XCTAssertEqual(configuration.parameters, [RuleParameter<AccessControlLevel>(severity: .warning, value: .open)])
+    }
+
+    func testParsingMultipleSeverities() {
+        var configuration = MissingDocsRuleConfiguration()
+        try? configuration.apply(configuration: ["warning": "public", "error": "open"])
+        XCTAssertEqual(configuration.parameters, [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+                                                  RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
+    }
+
+    func testParsingMultipleAcls() {
+        var configuration = MissingDocsRuleConfiguration()
+        try? configuration.apply(configuration: ["warning": ["public", "open"]])
+        XCTAssertEqual(configuration.parameters, [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+                                                  RuleParameter<AccessControlLevel>(severity: .warning, value: .open)])
+    }
+
+    func testInvalidServety() {
+        var configuration = MissingDocsRuleConfiguration()
+        XCTAssertThrowsError(try configuration.apply(configuration: ["warning": ["public", "closed"]]))
+    }
+
+    func testInvalidAcl() {
+        var configuration = MissingDocsRuleConfiguration()
+        XCTAssertThrowsError(try configuration.apply(configuration: ["debug": ["public", "open"]]))
+    }
+
+    func testInvalidDuplicateAcl() {
+        var configuration = MissingDocsRuleConfiguration()
+        XCTAssertThrowsError(try configuration.apply(configuration: ["warning": ["public", "open"], "error": "public"]))
+    }
+
+}

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -492,5 +492,4 @@ class RulesTests: XCTestCase {
     func testYodaCondition() {
         verifyRule(YodaConditionRule.description)
     }
-
 }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -223,6 +223,10 @@ class RulesTests: XCTestCase {
         verifyRule(MarkRule.description, skipCommentTests: true)
     }
 
+    func testMissingDocs() {
+        verifyRule(MissingDocsRule.description)
+    }
+
     func testMultilineParameters() {
         verifyRule(MultilineParametersRule.description)
     }
@@ -489,7 +493,4 @@ class RulesTests: XCTestCase {
         verifyRule(YodaConditionRule.description)
     }
 
-    func testMissingDocs() {
-        verifyRule(MissingDocsRule.description)
-    }
 }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -488,4 +488,8 @@ class RulesTests: XCTestCase {
     func testYodaCondition() {
         verifyRule(YodaConditionRule.description)
     }
+
+    func testMissingDocs() {
+        verifyRule(MissingDocsRule.description)
+    }
 }


### PR DESCRIPTION
This opt-in rule is based on the [old code](https://github.com/realm/SwiftLint/blob/80b0c96dd721da67657a04eb50e92c2936b2a1c9/Source/SwiftLintFramework/Rules/MissingDocsRule.swift)

Configuration works like this:
```
missing_docs:
  error: open
  warning:
  - internal
  - public
```

Open points:

- [x] run test on docker
- [ ] should we exclude test functions?
- [ ] should we exclude functions like `==`?
- [x] better configuration parsing 
- [x] unit tests for configuration parsing

fixes #1652