### PR TITLE
Remove all file headers

### DIFF
--- a/.sourcery/LinuxMain.stencil
+++ b/.sourcery/LinuxMain.stencil
@@ -1,11 +1,3 @@
-//
-//  LinuxMain.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 12/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 @testable import SwiftLintFrameworkTests
 import XCTest
 

--- a/.sourcery/MasterRuleList.stencil
+++ b/.sourcery/MasterRuleList.stencil
@@ -1,11 +1,3 @@
-//
-//  MasterRuleList.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 12/28/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 public let masterRuleList = RuleList(rules: [
 {% for rule in types.structs where rule.name|hasSuffix:"Rule" or rule.name|hasSuffix:"Rules" %}    {{ rule.name }}.self{% if not forloop.last %},{% endif %}
 {% endfor %}])

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -39,15 +39,6 @@ opt_in_rules:
   - sorted_first_last
   - yoda_condition
 
-file_header:
-  required_pattern: |
-                    \/\/
-                    \/\/  .*?\.swift
-                    \/\/  SwiftLint
-                    \/\/
-                    \/\/  Created by .*? on \d{1,2}\/\d{1,2}\/\d{2}\.
-                    \/\/  Copyright © \d{4} Realm\. All rights reserved\.
-                    \/\/
 identifier_name:
   excluded:
     - id

--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,11 @@ sourcery: Tests/LinuxMain.swift Source/SwiftLintFramework/Models/MasterRuleList.
 
 Tests/LinuxMain.swift: Tests/*/*.swift .sourcery/LinuxMain.stencil
 	sourcery --sources Tests --templates .sourcery/LinuxMain.stencil --output .sourcery
-	sed -e 4,11d .sourcery/LinuxMain.generated.swift > .sourcery/LinuxMain.swift
-	sed -n 4,10p .sourcery/LinuxMain.generated.swift | cat - .sourcery/LinuxMain.swift > Tests/LinuxMain.swift
-	rm .sourcery/LinuxMain.swift .sourcery/LinuxMain.generated.swift
+	mv .sourcery/LinuxMain.generated.swift Tests/LinuxMain.swift
 
 Source/SwiftLintFramework/Models/MasterRuleList.swift: Source/SwiftLintFramework/Rules/*.swift .sourcery/MasterRuleList.stencil
 	sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/MasterRuleList.stencil --output .sourcery
-	sed -e 4,11d .sourcery/MasterRuleList.generated.swift > .sourcery/MasterRuleList.swift
-	sed -n 4,10p .sourcery/MasterRuleList.generated.swift | cat - .sourcery/MasterRuleList.swift > Source/SwiftLintFramework/Models/MasterRuleList.swift
-	rm .sourcery/MasterRuleList.swift .sourcery/MasterRuleList.generated.swift
+	mv .sourcery/MasterRuleList.generated.swift Source/SwiftLintFramework/Models/MasterRuleList.swift
 
 bootstrap:
 	script/bootstrap

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  Array+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Dispatch
 import Foundation
 

--- a/Source/SwiftLintFramework/Extensions/CharacterSet+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/CharacterSet+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  CharacterSet+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by Cyril Lashkevich on 3/11/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 
 // This is workaround for https://bugs.swift.org/browse/SR-5971

--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -1,11 +1,3 @@
-//
-//  Configuration+Cache.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/22/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+IndentationStyle.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+IndentationStyle.swift
@@ -1,11 +1,3 @@
-//
-//  Configuration+IndentationStyle.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 1/3/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 public extension Configuration {
     enum IndentationStyle: Equatable {
         case tabs

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -1,11 +1,3 @@
-//
-//  Configuration+LintableFiles.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 7/17/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -1,11 +1,3 @@
-//
-//  Configuration+Merging.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 7/17/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -1,11 +1,3 @@
-//
-//  Configuration+Parsing.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 7/17/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 extension Configuration {

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  DynamicInlineRule.swift
-//  SwiftLint
-//
-//  Created by Daniel Duan on 12/08/16.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -1,11 +1,3 @@
-//
-//  File+Cache.swift
-//  SwiftLint
-//
-//  Created by Nikolaj Schumacher on 5/26/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  File+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSFileManager+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  NSFileManager+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/28/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 
 public protocol LintableFileManager {

--- a/Source/SwiftLintFramework/Extensions/NSRange+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRange+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  NSRange+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/13/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 extension NSRange {

--- a/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  NSRegularExpression+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/21/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 #if os(Linux)

--- a/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
+++ b/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
@@ -1,11 +1,3 @@
-//
-//  QueuedPrint.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 11/17/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Dispatch
 import Foundation
 

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  String+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/String+XML.swift
+++ b/Source/SwiftLintFramework/Extensions/String+XML.swift
@@ -1,11 +1,3 @@
-//
-//  String+XML.swift
-//  SwiftLint
-//
-//  Created by Fabian Ehrentraud on 12/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 extension String {
     func escapedForXML() -> String {
         // & needs to go first, otherwise other replacements will be replaced again

--- a/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  Structure+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by Norio Nomura on 2/18/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  SwiftDeclarationKind+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 11/17/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 extension SwiftDeclarationKind {

--- a/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
@@ -1,11 +1,3 @@
-//
-//  SwiftExpressionKind.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public enum SwiftExpressionKind: String {

--- a/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  SyntaxKind+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 11/17/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 extension SyntaxKind {

--- a/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
@@ -1,11 +1,3 @@
-//
-//  SyntaxMap+SwiftLint.swift
-//  SwiftLint
-//
-//  Created by Norio Nomura on 2/19/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Extensions/shim.swift
+++ b/Source/SwiftLintFramework/Extensions/shim.swift
@@ -1,11 +1,3 @@
-//
-//  shim.swift
-//  SwiftLint
-//
-//  Created by Norio Nomura on 2/5/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 #if (!swift(>=4.1) && swift(>=4.0)) || !swift(>=3.3)
 
     extension Sequence {

--- a/Source/SwiftLintFramework/Helpers/NamespaceCollector.swift
+++ b/Source/SwiftLintFramework/Helpers/NamespaceCollector.swift
@@ -1,11 +1,3 @@
-//
-//  NamespaceCollector.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 10/07/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
+++ b/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
@@ -1,11 +1,3 @@
-//
-//  RegexHelpers.swift
-//  SwiftLint
-//
-//  Created by Blaise Sarr on 13/04/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 struct RegexHelpers {
     // A single variable
     static let varName = "[a-zA-Z_][a-zA-Z0-9_]+"

--- a/Source/SwiftLintFramework/Models/AccessControlLevel.swift
+++ b/Source/SwiftLintFramework/Models/AccessControlLevel.swift
@@ -1,11 +1,3 @@
-//
-//  AccessControlLevel.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 23/04/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 public enum AccessControlLevel: String, CustomStringConvertible {

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -1,11 +1,3 @@
-//
-//  Command.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 8/29/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 
 #if os(Linux)

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -1,11 +1,3 @@
-//
-//  Configuration.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 8/23/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Models/ConfigurationError.swift
+++ b/Source/SwiftLintFramework/Models/ConfigurationError.swift
@@ -1,11 +1,3 @@
-//
-//  ConfigurationError.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/19/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public enum ConfigurationError: Error {

--- a/Source/SwiftLintFramework/Models/Correction.swift
+++ b/Source/SwiftLintFramework/Models/Correction.swift
@@ -1,11 +1,3 @@
-//
-//  Correction.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 11/27/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 public struct Correction: Equatable {
     public let ruleDescription: RuleDescription
     public let location: Location

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -1,11 +1,3 @@
-//
-//  Linter.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Dispatch
 import Foundation
 import SourceKittenFramework

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -1,11 +1,3 @@
-//
-//  LinterCache.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/27/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal enum LinterCacheError: Error {

--- a/Source/SwiftLintFramework/Models/Location.swift
+++ b/Source/SwiftLintFramework/Models/Location.swift
@@ -1,11 +1,3 @@
-//
-//  Location.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,10 +1,3 @@
-//
-//  MasterRuleList.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 12/28/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
 // Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -1,11 +1,3 @@
-//
-//  Region.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 8/29/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -1,11 +1,3 @@
-//
-//  RuleDescription.swift
-//  SwiftLint
-//
-//  Created by Chris Eidhof on 25/05/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 public struct RuleDescription: Equatable {
     public let identifier: String
     public let name: String

--- a/Source/SwiftLintFramework/Models/RuleIdentifier.swift
+++ b/Source/SwiftLintFramework/Models/RuleIdentifier.swift
@@ -1,11 +1,3 @@
-//
-//  RuleIdentifier.swift
-//  SwiftLint
-//
-//  Created by Frederick Pietschmann on 3/5/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 
 public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral {

--- a/Source/SwiftLintFramework/Models/RuleKind.swift
+++ b/Source/SwiftLintFramework/Models/RuleKind.swift
@@ -1,11 +1,3 @@
-//
-//  RuleKind.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 05/26/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 public enum RuleKind: String {

--- a/Source/SwiftLintFramework/Models/RuleList+Documentation.swift
+++ b/Source/SwiftLintFramework/Models/RuleList+Documentation.swift
@@ -1,11 +1,3 @@
-//
-//  RuleList+Documentation.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 8/24/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 extension RuleList {

--- a/Source/SwiftLintFramework/Models/RuleList.swift
+++ b/Source/SwiftLintFramework/Models/RuleList.swift
@@ -1,11 +1,3 @@
-//
-//  RuleList.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/31/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 public enum RuleListError: Error {

--- a/Source/SwiftLintFramework/Models/RuleParameter.swift
+++ b/Source/SwiftLintFramework/Models/RuleParameter.swift
@@ -1,11 +1,3 @@
-//
-//  RuleParameter.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 public struct RuleParameter<T: Equatable>: Equatable {
     public let severity: ViolationSeverity
     public let value: T

--- a/Source/SwiftLintFramework/Models/StyleViolation.swift
+++ b/Source/SwiftLintFramework/Models/StyleViolation.swift
@@ -1,11 +1,3 @@
-//
-//  StyleViolation.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 public struct StyleViolation: CustomStringConvertible, Equatable {
     public let ruleDescription: RuleDescription
     public let severity: ViolationSeverity

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -1,11 +1,3 @@
-//
-//  SwiftVersion.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/29/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Models/Version.swift
+++ b/Source/SwiftLintFramework/Models/Version.swift
@@ -1,11 +1,3 @@
-//
-//  Version.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/27/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 public struct Version {
     public let value: String
 

--- a/Source/SwiftLintFramework/Models/ViolationSeverity.swift
+++ b/Source/SwiftLintFramework/Models/ViolationSeverity.swift
@@ -1,11 +1,3 @@
-//
-//  ViolationSeverity.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 public enum ViolationSeverity: String, Comparable {
     case warning
     case error

--- a/Source/SwiftLintFramework/Models/YamlParser.swift
+++ b/Source/SwiftLintFramework/Models/YamlParser.swift
@@ -1,11 +1,3 @@
-//
-//  YAMLLoader.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/1/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import Yams
 

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -1,11 +1,3 @@
-//
-//  ASTRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public protocol ASTRule: Rule {

--- a/Source/SwiftLintFramework/Protocols/CacheDescriptionProvider.swift
+++ b/Source/SwiftLintFramework/Protocols/CacheDescriptionProvider.swift
@@ -1,11 +1,3 @@
-//
-//  CacheDescriptionProvider.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 internal protocol CacheDescriptionProvider {
     var cacheDescription: String { get }
 }

--- a/Source/SwiftLintFramework/Protocols/CallPairRule.swift
+++ b/Source/SwiftLintFramework/Protocols/CallPairRule.swift
@@ -1,11 +1,3 @@
-//
-//  CallPairRule.swift
-//  SwiftLint
-//
-//  Created by Tom Quist on 11/07/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -1,11 +1,3 @@
-//
-//  Reporter.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 9/19/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 public protocol Reporter: CustomStringConvertible {
     static var identifier: String { get }
     static var isRealtime: Bool { get }

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -1,11 +1,3 @@
-//
-//  Rule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public protocol Rule {

--- a/Source/SwiftLintFramework/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Protocols/RuleConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  RuleConfiguration.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/19/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 public protocol RuleConfiguration {
     var consoleDescription: String { get }
 

--- a/Source/SwiftLintFramework/Reporters/CSVReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CSVReporter.swift
@@ -1,11 +1,3 @@
-//
-//  CSVReporter.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 9/19/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 
 private extension String {

--- a/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
@@ -1,11 +1,3 @@
-//
-//  CheckstyleReporter.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 12/25/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct CheckstyleReporter: Reporter {

--- a/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
@@ -1,11 +1,3 @@
-//
-//  EmojiReporter.swift
-//  SwiftLint
-//
-//  Created by Michał Kałużny on 12/01/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct EmojiReporter: Reporter {

--- a/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
@@ -1,11 +1,3 @@
-//
-//  HTMLReporter.swift
-//  SwiftLint
-//
-//  Created by Johnykutty on 10/27/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 private let formatter: DateFormatter = {

--- a/Source/SwiftLintFramework/Reporters/JSONReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JSONReporter.swift
@@ -1,11 +1,3 @@
-//
-//  JSONReporter.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 9/19/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -1,11 +1,3 @@
-//
-//  JUnitReporter.swift
-//  SwiftLint
-//
-//  Created by Matthew Ellis on 5/25/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct JUnitReporter: Reporter {

--- a/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
@@ -1,11 +1,3 @@
-//
-//  XcodeReporter.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 9/19/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 public struct XcodeReporter: Reporter {
     public static let identifier = "xcode"
     public static let isRealtime = true

--- a/Source/SwiftLintFramework/Rules/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ArrayInitRule.swift
@@ -1,11 +1,3 @@
-//
-//  ArrayInitRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 09/16/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRule.swift
@@ -1,11 +1,3 @@
-//
-//  AttributesRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 10/15/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/AttributesRulesExamples.swift
+++ b/Source/SwiftLintFramework/Rules/AttributesRulesExamples.swift
@@ -1,11 +1,3 @@
-//
-//  AttributesRulesExamples.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/09/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 internal struct AttributesRuleExamples {
 
     static let nonTriggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/BlockBasedKVORule.swift
+++ b/Source/SwiftLintFramework/Rules/BlockBasedKVORule.swift
@@ -1,11 +1,3 @@
-//
-//  BlockBasedKVORule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 07/27/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClassDelegateProtocolRule.swift
@@ -1,11 +1,3 @@
-//
-//  ClassDelegateProtocolRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/23/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosingBraceRule.swift
@@ -1,11 +1,3 @@
-//
-//  ClosingBraceRule.swift
-//  SwiftLint
-//
-//  Created by Yasuhiro Inami on 12/19/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureEndIndentationRule.swift
@@ -1,11 +1,3 @@
-//
-//  ClosureEndIndentationRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/18/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureParameterPositionRule.swift
@@ -1,11 +1,3 @@
-//
-//  ClosureParameterPositionRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ClosureSpacingRule.swift
@@ -1,11 +1,3 @@
-//
-//  ClosureSpacingRule.swift
-//  SwiftLint
-//
-//  Created by J. Cheyo Jimenez on 8/26/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ColonRule+Dictionary.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule+Dictionary.swift
@@ -1,11 +1,3 @@
-//
-//  ColonRule+Dictionary.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 09/13/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ColonRule+FunctionCall.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule+FunctionCall.swift
@@ -1,11 +1,3 @@
-//
-//  ColonRule+FunctionCall.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 09/13/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ColonRule+Type.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule+Type.swift
@@ -1,11 +1,3 @@
-//
-//  ColonRule+Type.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 09/13/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/ColonRule.swift
@@ -1,11 +1,3 @@
-//
-//  ColonRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/CommaRule.swift
@@ -1,11 +1,3 @@
-//
-//  Comma.swift
-//  SwiftLint
-//
-//  Created by Alex Culeva on 10/22/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/CompilerProtocolInitRule.swift
@@ -1,11 +1,3 @@
-//
-//  CompilerProtocolInitRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/31/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/ConditionalReturnsOnNewlineRule.swift
@@ -1,11 +1,3 @@
-//
-//  ConditionalReturnsOnNewlineRule.swift
-//  SwiftLint
-//
-//  Created by Rohan Dhaimade on 12/8/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintFramework/Rules/ContainsOverFirstNotNilRule.swift
@@ -1,11 +1,3 @@
-//
-//  ContainsOverFirstNotNilRule.swift
-//  SwiftLint
-//
-//  Created by Samuel Susla on 17/09/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct ContainsOverFirstNotNilRule: CallPairRule, OptInRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -1,11 +1,3 @@
-//
-//  ControlStatementRule.swift
-//  SwiftLint
-//
-//  Created by Andrea Mazzini on 26/05/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct ControlStatementRule: ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -1,11 +1,3 @@
-//
-//  CustomRules.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/21/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/CyclomaticComplexityRule.swift
@@ -1,11 +1,3 @@
-//
-//  CyclomaticComplexityRule.swift
-//  SwiftLint
-//
-//  Created by Denis Lebedev on 24/1/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscardedNotificationCenterObserverRule.swift
@@ -1,11 +1,3 @@
-//
-//  DiscardedNotificationCenterObserverRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/13/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedDirectInitRule.swift
@@ -1,11 +1,3 @@
-//
-//  DiscourageInitRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 8/1/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedObjectLiteralRule.swift
@@ -1,11 +1,3 @@
-//
-//  DiscouragedObjectLiteralRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 1/3/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalBooleanRule.swift
@@ -1,11 +1,3 @@
-//
-//  DiscouragedOptionalBoolean.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 1/21/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalBooleanRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalBooleanRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  DiscouragedOptionalBooleanExamples.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 1/21/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct DiscouragedOptionalBooleanRuleExamples {

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRule.swift
@@ -1,11 +1,3 @@
-//
-//  DiscouragedOptinalCollection.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 1/10/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/DiscouragedOptionalCollectionRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  DiscouragedOptionalCollectionRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 1/15/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct DiscouragedOptionalCollectionExamples {

--- a/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/DynamicInlineRule.swift
@@ -1,11 +1,3 @@
-//
-//  DynamicInlineRule.swift
-//  SwiftLint
-//
-//  Created by Daniel Duan on 12/08/16.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyCountRule.swift
@@ -1,11 +1,3 @@
-//
-//  EmptyCountRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 11/17/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {

--- a/Source/SwiftLintFramework/Rules/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyEnumArgumentsRule.swift
@@ -1,11 +1,3 @@
-//
-//  EmptyEnumArgumentsRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 05/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParametersRule.swift
@@ -1,11 +1,3 @@
-//
-//  EmptyParametersRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
@@ -1,11 +1,3 @@
-//
-//  EmptyParenthesesWithTrailingClosureRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/EmptyStringRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyStringRule.swift
@@ -1,11 +1,3 @@
-//
-//  EmptyStringRule.swift
-//  SwiftLint
-//
-//  Created by Davide Sibilio on 02/22/18.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct EmptyStringRule: ConfigurationProviderRule, OptInRule {

--- a/Source/SwiftLintFramework/Rules/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitACLRule.swift
@@ -1,11 +1,3 @@
-//
-//  ExplicitACLRule.swift
-//  SwiftLint
-//
-//  Created by Josep Rodriguez on 02/12/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitEnumRawValueRule.swift
@@ -1,11 +1,3 @@
-//
-//  ExplicitEnumRawValueRule.swift
-//  SwiftLint
-//
-//  Created by Mazyad Alabduljaleel on 8/19/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift
@@ -1,11 +1,3 @@
-//
-//  ExplicitInitRule.swift
-//  SwiftLint
-//
-//  Created by Matt Taube on 7/2/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitTopLevelACLRule.swift
@@ -1,11 +1,3 @@
-//
-//  ExplicitTopLevelACLRule.swift
-//  SwiftLint
-//
-//  Created by Jose Cheyo Jimenez on 4/28/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitTypeInterfaceRule.swift
@@ -1,11 +1,3 @@
-//
-//  ExplicitTypeInterfaceRule.swift
-//  SwiftLint
-//
-//  Created by Kim de Vos on 02/28/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExtensionAccessModifierRule.swift
@@ -1,11 +1,3 @@
-//
-//  ExtensionAccessModifierRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 26/05/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/FallthroughRule.swift
+++ b/Source/SwiftLintFramework/Rules/FallthroughRule.swift
@@ -1,11 +1,3 @@
-//
-//  FallthroughRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 09/11/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct FallthroughRule: ConfigurationProviderRule, OptInRule {

--- a/Source/SwiftLintFramework/Rules/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/FatalErrorMessageRule.swift
@@ -1,11 +1,3 @@
-//
-//  FatalErrorMessageRule.swift
-//  SwiftLint
-//
-//  Created by Kim de Vos on 03/18/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileHeaderRule.swift
@@ -1,11 +1,3 @@
-//
-//  FileHeaderRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 27/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FileLengthRule.swift
@@ -1,11 +1,3 @@
-//
-//  FileLengthRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct FileLengthRule: ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/FirstWhereRule.swift
@@ -1,11 +1,3 @@
-//
-//  FirstWhereRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/20/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForWhereRule.swift
@@ -1,11 +1,3 @@
-//
-//  ForWhereRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/29/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceCastRule.swift
@@ -1,11 +1,3 @@
-//
-//  ForceCastRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct ForceCastRule: ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceTryRule.swift
@@ -1,11 +1,3 @@
-//
-//  ForceTryRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 11/17/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct ForceTryRule: ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/ForceUnwrappingRule.swift
@@ -1,11 +1,3 @@
-//
-//  ForceUnwrappingRule.swift
-//  SwiftLint
-//
-//  Created by Benjamin Otto on 14/01/16.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionBodyLengthRule.swift
@@ -1,11 +1,3 @@
-//
-//  FunctionBodyLengthRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/FunctionParameterCountRule.swift
@@ -1,11 +1,3 @@
-//
-//  FunctionParameterCountRule.swift
-//  SwiftLint
-//
-//  Created by Denis Lebedev on 26/1/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/GenericTypeNameRule.swift
@@ -1,11 +1,3 @@
-//
-//  GenericTypeNameRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/25/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -1,11 +1,3 @@
-//
-//  IdentifierNameRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  IdentifierNameRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/30/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct IdentifierNameRuleExamples {

--- a/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitGetterRule.swift
@@ -1,11 +1,3 @@
-//
-//  ImplicitGetterRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 29/10/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitReturnRule.swift
@@ -1,11 +1,3 @@
-//
-//  ImplicitReturnRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 04/30/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintFramework/Rules/ImplicitlyUnwrappedOptionalRule.swift
@@ -1,11 +1,3 @@
-//
-//  ImplicitlyUnwrappedOptionalRule.swift
-//  SwiftLint
-//
-//  Created by Siarhei Fedartsou on 17/03/17.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/IsDisjointRule.swift
+++ b/Source/SwiftLintFramework/Rules/IsDisjointRule.swift
@@ -1,11 +1,3 @@
-//
-//  IsDisjointRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 8/21/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct IsDisjointRule: ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/JoinedDefaultRule.swift
+++ b/Source/SwiftLintFramework/Rules/JoinedDefaultRule.swift
@@ -1,11 +1,3 @@
-//
-//  JoinedDefaultRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 8/3/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/LargeTupleRule.swift
@@ -1,11 +1,3 @@
-//
-//  LargeTupleRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LeadingWhitespaceRule.swift
@@ -1,11 +1,3 @@
-//
-//  LeadingWhitespaceRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyCGGeometryFunctionsRule.swift
@@ -1,11 +1,3 @@
-//
-//  LegacyCGGeometryFunctionsRule.swift
-//  SwiftLint
-//
-//  Created by Blaise Sarr on 31/03/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstantRule.swift
@@ -1,11 +1,3 @@
-//
-//  LegacyConstantRule.swift
-//  SwiftLint
-//
-//  Created by Aaron McTavish on 12/1/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LegacyConstantRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstantRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  LegacyConstantRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Aaron McTavish on 01/16/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct LegacyConstantRuleExamples {

--- a/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyConstructorRule.swift
@@ -1,11 +1,3 @@
-//
-//  LegacyConstructorRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 29/11/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/LegacyNSGeometryFunctionsRule.swift
@@ -1,11 +1,3 @@
-//
-//  LegacyNSGeometryFunctionsRule.swift
-//  SwiftLint
-//
-//  Created by David Rönnqvist on 01/08/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/LetVarWhitespaceRule.swift
@@ -1,11 +1,3 @@
-//
-//  LetVarWhitespaceRule.swift
-//  SwiftLint
-//
-//  Created by David Catmull on 4/24/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/LineLengthRule.swift
@@ -1,11 +1,3 @@
-//
-//  LineLengthRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/LiteralExpressionEndIdentationRule.swift
@@ -1,11 +1,3 @@
-//
-//  LiteralExpressionEndIdentationRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 10/02/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/LowerACLThanBodyRule.swift
+++ b/Source/SwiftLintFramework/Rules/LowerACLThanBodyRule.swift
@@ -1,11 +1,3 @@
-//
-//  LowerACLThanParentRule.swift
-//  SwiftLint
-//
-//  Created by Keith Smiley on 4/3/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -1,11 +1,3 @@
-//
-//  MarkRule.swift
-//  SwiftLint
-//
-//  Created by Krzysztof Rodak on 08/22/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineArgumentsConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  MultilineArgumentsConfiguration.swift
-//  SwiftLint
-//
-//  Created by Marcel Jackwerth on 9/29/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 private enum ConfigurationKey: String {

--- a/Source/SwiftLintFramework/Rules/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineArgumentsRule.swift
@@ -1,11 +1,3 @@
-//
-//  MultilineArgumentsRule.swift
-//  SwiftLint
-//
-//  Created by Marcel Jackwerth on 09/29/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/MultilineArgumentsRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineArgumentsRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  MultilineArgumentsRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Marcel Jackwerth on 09/29/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct MultilineArgumentsRuleExamples {

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRule.swift
@@ -1,11 +1,3 @@
-//
-//  MultilineParametersRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 22/05/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineParametersRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  MultilineParametersRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 22/05/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 // swiftlint:disable type_body_length

--- a/Source/SwiftLintFramework/Rules/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultipleClosuresWithTrailingClosureRule.swift
@@ -1,11 +1,3 @@
-//
-//  MultipleClosuresWithTrailingClosureRule.swift
-//  SwiftLint
-//
-//  Created by Erik Strottmann on 8/26/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/NestingRule.swift
@@ -1,11 +1,3 @@
-//
-//  NestingRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct NestingRule: ASTRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NimbleOperatorRule.swift
@@ -1,11 +1,3 @@
-//
-//  NimbleOperatorRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 20/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/NoExtensionAccessModifierRule.swift
@@ -1,11 +1,3 @@
-//
-//  NoExtensionAccessModifier.swift
-//  SwiftLint
-//
-//  Created by Jose Cheyo Jimenez on 04/23/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/NoGroupingExtensionRule.swift
@@ -1,11 +1,3 @@
-//
-//  NoGroupingExtensionRule.swift
-//  SwiftLint
-//
-//  Created by Mazyad Alabduljaleel on 8/20/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/NotificationCenterDetachmentRule.swift
@@ -1,11 +1,3 @@
-//
-//  NotificationCenterDetachmentRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/15/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/NotificationCenterDetachmentRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/NotificationCenterDetachmentRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  NotificationCenterDetachmentRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/15/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 internal struct NotificationCenterDetachmentRuleExamples {
 
     static let nonTriggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/NumberSeparatorRule.swift
@@ -1,11 +1,3 @@
-//
-//  NumberSeparatorRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/05/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/NumberSeparatorRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/NumberSeparatorRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  NumberSeparatorRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/29/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct NumberSeparatorRuleExamples {

--- a/Source/SwiftLintFramework/Rules/ObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/ObjectLiteralRule.swift
@@ -1,11 +1,3 @@
-//
-//  ObjectLiteralRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/25/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OpeningBraceRule.swift
@@ -1,11 +1,3 @@
-//
-//  OpeningBraceRule.swift
-//  SwiftLint
-//
-//  Created by Alex Culeva on 10/21/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorFunctionWhitespaceRule.swift
@@ -1,11 +1,3 @@
-//
-//  OperatorWhitespaceRule.swift
-//  SwiftLint
-//
-//  Created by Akira Hirakawa on 8/6/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
@@ -1,11 +1,3 @@
-//
-//  OperatorUsageWhitespaceRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/13/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/OverriddenSuperCallRule.swift
@@ -1,11 +1,3 @@
-//
-//  OverriddenSuperCallRule.swift
-//  SwiftLint
-//
-//  Created by Angel Garcia on 04/09/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptInRule {

--- a/Source/SwiftLintFramework/Rules/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/OverrideInExtensionRule.swift
@@ -1,11 +1,3 @@
-//
-//  OverrideInExtensionRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 10/05/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/PatternMatchingKeywordsRule.swift
@@ -1,11 +1,3 @@
-//
-//  PatternMatchingKeywordsRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 08/23/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrefixedTopLevelConstantRule.swift
@@ -1,11 +1,3 @@
-//
-//  PrefixedTopLevelConstantRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 1/5/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/PrivateActionRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateActionRule.swift
@@ -1,11 +1,3 @@
-//
-//  PrivateActionRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 11/7/17.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOutletRule.swift
@@ -1,11 +1,3 @@
-//
-//  PrivateOutletRule.swift
-//  SwiftLint
-//
-//  Created by Olivier Halligon on 12/8/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateOverFilePrivateRule.swift
@@ -1,11 +1,3 @@
-//
-//  PrivateOverFilePrivateRule.swift
-//  SwiftLint
-//
-//  Created by Jose Cheyo Jimenez on 05/02/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/PrivateUnitTestRule.swift
@@ -1,11 +1,3 @@
-//
-//  ClassVisibilityRule.swift
-//  SwiftLint
-//
-//  Created by Cristian Filipov on 8/3/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/ProhibitedSuperRule.swift
@@ -1,11 +1,3 @@
-//
-//  ProhibitedSuperRule.swift
-//  SwiftLint
-//
-//  Created by Aaron McTavish on 12/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule {

--- a/Source/SwiftLintFramework/Rules/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/ProtocolPropertyAccessorsOrderRule.swift
@@ -1,11 +1,3 @@
-//
-//  ProtocolPropertyAccessorsOrderRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 15/05/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/QuickDiscouragedCallRule.swift
@@ -1,11 +1,3 @@
-//
-//  QuickDiscouragedCallRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 8/11/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/QuickDiscouragedCallRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/QuickDiscouragedCallRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  QuickDiscouragedCallRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 8/11/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 // swiftlint:disable type_body_length

--- a/Source/SwiftLintFramework/Rules/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/QuickDiscouragedFocusedTestRule.swift
@@ -1,11 +1,3 @@
-//
-//  QuickDiscouragedFocusedTestRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 10/15/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/QuickDiscouragedFocusedTestRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/QuickDiscouragedFocusedTestRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  QuickDiscouragedFocusedTestRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 10/16/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct QuickDiscouragedFocusedTestRuleExamples {

--- a/Source/SwiftLintFramework/Rules/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/QuickDiscouragedPendingTestRule.swift
@@ -1,11 +1,3 @@
-//
-//  QuickDiscouragedPendingTestRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 10/15/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/QuickDiscouragedPendingTestRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/QuickDiscouragedPendingTestRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  QuickDiscouragedPendingTestRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 10/16/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct QuickDiscouragedPendingTestRuleExamples {

--- a/Source/SwiftLintFramework/Rules/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantDiscardableLetRule.swift
@@ -1,11 +1,3 @@
-//
-//  RedundantDiscardableLetRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/25/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantNilCoalescingRule.swift
@@ -1,11 +1,3 @@
-//
-//  RedundantNilCoalescingRule.swift
-//  SwiftLint
-//
-//  Created by Daniel Beard on 8/24/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantOptionalInitializationRule.swift
@@ -1,11 +1,3 @@
-//
-//  RedundantOptionalInitializationRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/24/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantSetAccessControlRule.swift
@@ -1,11 +1,3 @@
-//
-//  RedundantSetAccessControlRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 02/03/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantStringEnumValueRule.swift
@@ -1,11 +1,3 @@
-//
-//  RedundantStringEnumValueRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 08/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantVoidReturnRule.swift
@@ -1,11 +1,3 @@
-//
-//  RedundantVoidReturnRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/26/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/RequiredEnumCaseRule.swift
@@ -1,11 +1,3 @@
-//
-//  RequiredEnumCaseRule.swift
-//  SwiftLint
-//
-//  Created by Ritter, Donald on 9/13/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/ReturnArrowWhitespaceRule.swift
@@ -1,11 +1,3 @@
-//
-//  ReturningWhitespaceRule.swift
-//  SwiftLint
-//
-//  Created by Akira Hirakawa on 2/6/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  AttributesConfiguration.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 11/26/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct AttributesConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  ColonConfiguration.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/18/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct ColonConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -1,10 +1,3 @@
-//
-//  CyclomaticComplexityConfiguration.swift
-//  SwiftLint
-//
-//  Created by Mike Welles on 2/9/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  DiscouragedInitConfiguration.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 8/1/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  ExplicitTypeInterfaceConfiguration.swift
-//  SwiftLint
-//
-//  Created by Rounak Jain on 2/18/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  FileHeaderConfiguration.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct FileHeaderConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  FileLengthRuleConfiguration.swift
-//  SwiftLint
-//
-//  Created by Samuel Susla on 11/07/17.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 private enum ConfigurationKey: String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  ImplicitlyUnwrappedOptionalConfiguration.swift
-//  SwiftLint
-//
-//  Created by Siarhei Fedartsou on 18/03/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 // swiftlint:disable:next type_name

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  LineLengthConfiguration.swift
-//  SwiftLint
-//
-//  Created by Javier Hernández on 21/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct LineLengthRuleOptions: OptionSet {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  NameConfiguration.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/19/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct NameConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  NestingConfiguration.swift
-//  SwiftLint
-//
-//  Created by 林達也 on 03/03/16.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct NestingConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  NumberSeparatorConfiguration.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/02/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var minimumLength: Int

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  ObjectLiteralConfiguration.swift
-//  SwiftLint
-//
-//  Created by Cihat Gündüz on 06/03/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct ObjectLiteralConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  OverridenSuperCallConfiguration.swift
-//  SwiftLint
-//
-//  Created by Angel Garcia on 05/09/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct OverridenSuperCallConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  PrivateOutletRuleConfiguration.swift
-//  SwiftLint
-//
-//  Created by Rohan Dhaimade on 24/8/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  PrivateOverFilePrivateRuleConfiguration.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 08/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct PrivateOverFilePrivateRuleConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  PrivateUnitTestConfiguration.swift
-//  SwiftLint
-//
-//  Created by Cristian Filipov on 8/5/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  ProhibitedSuperConfiguration.swift
-//  SwiftLint
-//
-//  Created by Aaron McTavish on 12/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct ProhibitedSuperConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  RegexConfiguration.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/21/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  RequiredEnumCaseRuleConfiguration.swift
-//  SwiftLint
-//
-//  Created by Ritter, Donald on 9/13/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  SeverityConfiguration.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/20/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct SeverityConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  SeverityLevelsConfiguration.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/19/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementPositionConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementPositionConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  StatementPositionConfiguration.swift
-//  SwiftLint
-//
-//  Created by Michael Skiba on 6/8/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public enum StatementModeConfiguration: String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  TrailingCommaConfiguration.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 25/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct TrailingCommaConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  TrailingWhitespaceConfiguration.swift
-//  SwiftLint
-//
-//  Created by Reimar Twelker on 12/4/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  UnusedOptionalBindingConfiguration.swift
-//  SwiftLint
-//
-//  Created by Sergey Galezdinov on 23/04/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 public struct UnusedOptionalBindingConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var ignoreOptionalTry: Bool

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -1,11 +1,3 @@
-//
-//  VerticalWhitespaceConfiguration.swift
-//  SwiftLint
-//
-//  Created by Aaron McTavish on 01/05/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 public struct VerticalWhitespaceConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var maxEmptyLines: Int

--- a/Source/SwiftLintFramework/Rules/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/ShorthandOperatorRule.swift
@@ -1,11 +1,3 @@
-//
-//  ShorthandOperatorRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/06/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/SingleTestClassRule.swift
@@ -1,11 +1,3 @@
-//
-//  SingleTestClassRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 8/15/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/SortedFirstLastRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedFirstLastRule.swift
@@ -1,11 +1,3 @@
-//
-//  SortedFirstLastRule.swift
-//  SwiftLint
-//
-//  Created by Tom Quist on 11/06/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 public struct SortedFirstLastRule: CallPairRule, OptInRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/SortedImportsRule.swift
@@ -1,11 +1,3 @@
-//
-//  SortedImportsRule.swift
-//  SwiftLint
-//
-//  Created by Scott Berrevoets on 12/15/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/StatementPositionRule.swift
@@ -1,11 +1,3 @@
-//
-//  StatementPositionRule.swift
-//  SwiftLint
-//
-//  Created by Alex Culeva on 10/22/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/StrictFilePrivateRule.swift
@@ -1,11 +1,3 @@
-//
-//  StrictFilePrivateRule.swift
-//  SwiftLint
-//
-//  Created by Jose Cheyo Jimenez on 05/02/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintFramework/Rules/SuperfluousDisableCommandRule.swift
@@ -1,11 +1,3 @@
-//
-//  SuperfluousDisableCommandRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 08/18/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseAlignmentRule.swift
@@ -1,11 +1,3 @@
-//
-//  SwitchCaseAlignmentRule.swift
-//  SwiftLint
-//
-//  Created by Austin Lu on 9/6/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/SwitchCaseOnNewlineRule.swift
@@ -1,11 +1,3 @@
-//
-//  SwitchCaseOnNewlineRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 10/15/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/SyntacticSugarRule.swift
@@ -1,11 +1,3 @@
-//
-//  SyntacticSugarRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 21/10/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/TodoRule.swift
@@ -1,11 +1,3 @@
-//
-//  TodoRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingClosureRule.swift
@@ -1,11 +1,3 @@
-//
-//  TrailingClosureRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/15/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -1,11 +1,3 @@
-//
-//  TrailingCommaRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 21/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingNewlineRule.swift
@@ -1,11 +1,3 @@
-//
-//  TrailingNewlineRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingSemicolonRule.swift
@@ -1,11 +1,3 @@
-//
-//  TrailingSemiColonRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 11/17/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingWhitespaceRule.swift
@@ -1,11 +1,3 @@
-//
-//  TrailingWhitespaceRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeBodyLengthRule.swift
@@ -1,11 +1,3 @@
-//
-//  TypeBodyLengthRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 
 private func example(_ type: String,

--- a/Source/SwiftLintFramework/Rules/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRule.swift
@@ -1,11 +1,3 @@
-//
-//  TypeNameRule.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/TypeNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/TypeNameRuleExamples.swift
@@ -1,11 +1,3 @@
-//
-//  TypeNameRuleExamples.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 30/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 
 internal struct TypeNameRuleExamples {

--- a/Source/SwiftLintFramework/Rules/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnavailableFunctionRule.swift
@@ -1,11 +1,3 @@
-//
-//  UnavailableFunctionRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 04/09/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnneededBreakInSwitchRule.swift
@@ -1,11 +1,3 @@
-//
-//  UnneededBreakInSwitchRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 10/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnneededParenthesesInClosureArgumentRule.swift
@@ -1,11 +1,3 @@
-//
-//  UnneededParenthesesInClosureArgumentRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 07/17/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/UntypedErrorInCatchRule.swift
@@ -1,11 +1,3 @@
-//
-//  UntypedErrorInCatchRule.swift
-//  SwiftLint
-//
-//  Created by Daniel.Metzing on 17/02/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedClosureParameterRule.swift
@@ -1,11 +1,3 @@
-//
-//  UnusedClosureParameterRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/15/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedEnumeratedRule.swift
@@ -1,11 +1,3 @@
-//
-//  UnusedEnumeratedRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/17/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/UnusedOptionalBindingRule.swift
@@ -1,11 +1,3 @@
-//
-//  UnusedOptionalBindingRule.swift
-//  SwiftLint
-//
-//  Created by Rafael Machado on 1/5/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/ValidIBInspectableRule.swift
@@ -1,11 +1,3 @@
-//
-//  ValidIBInspectableRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 10/20/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentOnCallRule.swift
@@ -1,11 +1,3 @@
-//
-//  VerticalParameterAlignmentOnCallRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 02/05/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalParameterAlignmentRule.swift
@@ -1,11 +1,3 @@
-//
-//  VerticalParameterAlignmentRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/22/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/VerticalWhitespaceRule.swift
@@ -1,11 +1,3 @@
-//
-//  VerticalWhitespaceRule.swift
-//  SwiftLint
-//
-//  Created by J. Cheyo Jimenez on 5/16/15.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/VoidReturnRule.swift
@@ -1,11 +1,3 @@
-//
-//  VoidReturnRule.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/WeakDelegateRule.swift
@@ -1,11 +1,3 @@
-//
-//  WeakDelegate.swift
-//  SwiftLint
-//
-//  Created by Olivier Halligon on 11/8/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/XCTFailMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/XCTFailMessageRule.swift
@@ -1,11 +1,3 @@
-//
-//  XCTFailMessageRule.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 8/2/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Rules/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/YodaConditionRule.swift
@@ -1,11 +1,3 @@
-//
-//  YodaConditionRule.swift
-//  SwiftLint
-//
-//  Created by Daniel.Metzing on 20/11/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -1,11 +1,3 @@
-//
-//  AutoCorrectCommand.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 12/5/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Commandant
 import Result
 import SwiftLintFramework

--- a/Source/swiftlint/Commands/GenerateDocsCommand.swift
+++ b/Source/swiftlint/Commands/GenerateDocsCommand.swift
@@ -1,11 +1,3 @@
-//
-//  RulesDocsCommand.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Commandant
 import Result
 import SwiftLintFramework

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -1,11 +1,3 @@
-//
-//  LintCommand.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Commandant
 import Dispatch
 import Foundation

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -1,11 +1,3 @@
-//
-//  RulesCommand.swift
-//  SwiftLint
-//
-//  Created by Chris Eidhof on 20/05/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Commandant
 #if os(Linux)
 import Glibc

--- a/Source/swiftlint/Commands/VersionCommand.swift
+++ b/Source/swiftlint/Commands/VersionCommand.swift
@@ -1,11 +1,3 @@
-//
-//  VersionCommand.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Commandant
 import Result
 import SwiftLintFramework

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -1,11 +1,3 @@
-//
-//  Configuration+CommandLine.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 12/5/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Commandant
 import Dispatch
 import Foundation

--- a/Source/swiftlint/Extensions/Reporter+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Reporter+CommandLine.swift
@@ -1,11 +1,3 @@
-//
-//  Reporter+CommandLine.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 12/30/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 
 extension Reporter {

--- a/Source/swiftlint/Extensions/shim.swift
+++ b/Source/swiftlint/Extensions/shim.swift
@@ -1,11 +1,3 @@
-//
-//  shim.swift
-//  SwiftLint
-//
-//  Created by Norio Nomura on 2/5/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 #if (!swift(>=4.1) && swift(>=4.0)) || !swift(>=3.3)
 
     extension Sequence {

--- a/Source/swiftlint/Helpers/Benchmark.swift
+++ b/Source/swiftlint/Helpers/Benchmark.swift
@@ -1,11 +1,3 @@
-//
-//  Benchmark.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 1/25/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Source/swiftlint/Helpers/CommonOptions.swift
+++ b/Source/swiftlint/Helpers/CommonOptions.swift
@@ -1,11 +1,3 @@
-//
-//  CommonOptions.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 2/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Commandant
 import SwiftLintFramework
 

--- a/Source/swiftlint/main.swift
+++ b/Source/swiftlint/main.swift
@@ -1,11 +1,3 @@
-//
-//  main.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Commandant
 import Dispatch
 import Foundation

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,10 +1,3 @@
-//
-//  LinuxMain.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 12/11/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
 // Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 

--- a/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  AttributesRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 11/30/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 @testable import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  ColonRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/18/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -1,11 +1,3 @@
-//
-//  CommandTests.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/24/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -1,11 +1,3 @@
-//
-//  ConfigurationTests+Nested.swift
-//  SwiftLint
-//
-//  Created by Stéphane Copin on 7/24/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+ProjectMock.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+ProjectMock.swift
@@ -1,11 +1,3 @@
-//
-//  ConfigurationTests+ProjectMock.swift
-//  SwiftLint
-//
-//  Created by Stéphane Copin on 7/24/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 @testable import SwiftLintFramework
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -1,11 +1,3 @@
-//
-//  ConfigurationTests.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 8/23/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -1,11 +1,3 @@
-//
-//  CustomRulesTests.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/21/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
@@ -1,11 +1,3 @@
-//
-//  CyclomaticComplexityConfigurationTests.swift
-//  SwiftLint
-//
-//  Created by Michael  Welles on 2/15/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  CyclomaticComplexityRuleTests.swift
-//  SwiftLint
-//
-//  Created by Mike Welles on 2/9/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/DisableAllTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DisableAllTests.swift
@@ -1,11 +1,3 @@
-//
-//  DisableAllTests.swift
-//  SwiftLint
-//
-//  Created by Frederick Pietschmann on 3/11/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import Foundation
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  DiscouragedDirectInitRuleTests.swift
-//  SwiftLint
-//
-//  Created by Ornithologist Coder on 8/1/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/DocumentationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DocumentationTests.swift
@@ -1,11 +1,3 @@
-//
-//  DocumentationTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 08/24/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -1,11 +1,3 @@
-//
-//  ExplicitTypeInterfaceConfigurationTests.swift
-//  SwiftLint
-//
-//  Created by Rounak Jain on 2/24/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 @testable import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  ExplicitTypeInterfaceRuleTests.swift
-//  SwiftLint
-//
-//  Created by Rounak Jain on 2/24/18.
-//  Copyright © 2018 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
@@ -1,11 +1,3 @@
-//
-//  ExtendedNSStringTests.swift
-//  SwiftLint
-//
-//  Created by crimsonwoods on 11/18/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  FileHeaderRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/12/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  FileLengthRuleTests.swift
-//  SwiftLint
-//
-//  Created by Samuel Susla on 11/07/17.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  FunctionBodyLengthRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/01/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  GenericTypeNameRuleTests.swift
-//  SwiftLint
-//
-//  Created by Javier Hernandez on 30/04/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  IdentifierNameRuleTests.swift
-//  SwiftLint
-//
-//  Created by Javier Hernandez on 16/04/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
@@ -1,11 +1,3 @@
-//
-//  ImplicitlyUnwrappedOptionalConfigurationTests.swift
-//  SwiftLint
-//
-//  Created by Siarhei Fedartsou on 18/03/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  ImplicitlyUnwrappedOptionalRuleTests.swift
-//  SwiftLint
-//
-//  Created by Siarhei Fedartsou on 18/03/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -1,11 +1,3 @@
-//
-//  IntegrationTests.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/28/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -1,11 +1,3 @@
-//
-//  LineLengthConfigurationTests.swift
-//  SwiftLint
-//
-//  Created by Javier Hernández on 05/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  LineLengthRuleTests.swift
-//  SwiftLint
-//
-//  Created by Javier Hernández on 06/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -1,11 +1,3 @@
-//
-//  LinterCacheTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/27/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  MultilineArgumentsRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcel Jackwerth on 09/29/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  NumberSeparatorRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 01/17/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  ObjectLiteralRuleTests.swift
-//  SwiftLint
-//
-//  Created by Cihat Gündüz on 06/13/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/PrivateOverFilePrivateRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/PrivateOverFilePrivateRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  PrivateOverFilePrivateRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 08/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/RegionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RegionTests.swift
@@ -1,11 +1,3 @@
-//
-//  RegionTests.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/24/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -1,11 +1,3 @@
-//
-//  ReporterTests.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 9/19/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/RequiredEnumCaseRuleTestCase.swift
+++ b/Tests/SwiftLintFrameworkTests/RequiredEnumCaseRuleTestCase.swift
@@ -1,11 +1,3 @@
-//
-//  RequiredEnumCaseRuleTestCase.swift
-//  SwiftLint
-//
-//  Created by Ritter, Donald (CONT) on 9/13/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -1,11 +1,3 @@
-//
-//  RuleConfigurationTests.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/20/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/RuleDescription+Examples.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleDescription+Examples.swift
@@ -1,11 +1,3 @@
-//
-//  RuleDescription+Examples.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 02/07/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 
 extension RuleDescription {

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  RuleTests.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 12/29/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -1,11 +1,3 @@
-//
-//  RulesTests.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/28/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -1,11 +1,3 @@
-//
-//  SourceKitCrashTests.swift
-//  SwiftLint
-//
-//  Created by 野村 憲男 on 2/10/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -1,11 +1,3 @@
-//
-//  TestHelpers.swift
-//  SwiftLint
-//
-//  Created by JP Simard on 5/16/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  TodoRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 02/26/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  TrailingCommaRuleTests.swift
-//  SwiftLint
-//
-//  Created by Matt Rubin on 12/22/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  TypeNameRuleTests.swift
-//  SwiftLint
-//
-//  Created by Javier Hernandez on 30/04/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  UnusedOptionalBindingRuleTests.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 05/01/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -1,11 +1,3 @@
-//
-//  VerticalWhitespaceRuleTests.swift
-//  SwiftLint
-//
-//  Created by Aaron McTavish on 01/05/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 @testable import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/XCTestCase+BundlePath.swift
+++ b/Tests/SwiftLintFrameworkTests/XCTestCase+BundlePath.swift
@@ -1,11 +1,3 @@
-//
-//  XCTestCase+BundlePath.swift
-//  SwiftLint
-//
-//  Created by Stéphane Copin on 7/24/17.
-//  Copyright © 2017 Realm. All rights reserved.
-//
-
 import Foundation
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
+++ b/Tests/SwiftLintFrameworkTests/Yaml+SwiftLintTests.swift
@@ -1,11 +1,3 @@
-//
-//  Yaml+SwiftLintTests.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 12/28/15.
-//  Copyright © 2015 Realm. All rights reserved.
-//
-
 import Foundation
 @testable import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/YamlParserTests.swift
+++ b/Tests/SwiftLintFrameworkTests/YamlParserTests.swift
@@ -1,11 +1,3 @@
-//
-//  YamlParserTests.swift
-//  SwiftLint
-//
-//  Created by Scott Hoyt on 1/1/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 @testable import SwiftLintFramework
 import XCTest
 

--- a/script/Version.swift.template
+++ b/script/Version.swift.template
@@ -1,11 +1,3 @@
-//
-//  Version.swift
-//  SwiftLint
-//
-//  Created by Marcelo Fabri on 12/27/16.
-//  Copyright © 2016 Realm. All rights reserved.
-//
-
 public struct Version {
     public let value: String
 


### PR DESCRIPTION
The MIT license doesn't require that all files be prepended with this licensing or copyright information. Realm confirmed that they're ok with this change. This will enable some companies to contribute to SwiftLint and the date & authorship information will remain accessible via git source control.

Addresses #2106.