### PR TITLE
Fix TrailingCommaRuleTests for Swift < 4.1

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -14222,16 +14222,6 @@ let foo = ["אבג", "αβγ", "🇺🇸"↓,]
 
 ```
 
-```swift
-class C {
- #if true
- func f() {
- let foo = [1, 2, 3↓,]
- }
- #endif
-}
-```
-
 </details>
 
 

--- a/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/TrailingCommaRule.swift
@@ -21,8 +21,8 @@ public struct TrailingCommaRule: ASTRule, CorrectableRule, ConfigurationProvider
         "struct Bar {\n let foo = [1: 2, 2: 3↓, ]\n}\n",
         "let foo = [1, 2, 3↓,] + [4, 5, 6↓,]\n",
         "let example = [ 1,\n2↓,\n // 3,\n]",
-        "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\"↓,]\n",
-        "class C {\n #if true\n func f() {\n let foo = [1, 2, 3↓,]\n }\n #endif\n}"
+        "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\"↓,]\n"
+        // Swift 4.1 or later: "class C {\n #if true\n func f() {\n let foo = [1, 2, 3↓,]\n }\n #endif\n}"
         // "foo([1: \"\\(error)\"↓,])\n"
     ]
 

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -5,7 +5,13 @@ class TrailingCommaRuleTests: XCTestCase {
 
     func testTrailingCommaRuleWithDefaultConfiguration() {
         // Verify TrailingCommaRule with test values for when mandatory_comma is false (default).
-        verifyRule(TrailingCommaRule.description)
+        if SwiftVersion.current >= .fourDotOne {
+            let triggeringExamples = TrailingCommaRule.description.triggeringExamples +
+                ["class C {\n #if true\n func f() {\n let foo = [1, 2, 3↓,]\n }\n #endif\n}"]
+            verifyRule(TrailingCommaRule.description.with(triggeringExamples: triggeringExamples))
+        } else {
+            verifyRule(TrailingCommaRule.description)
+        }
 
         // Ensure the rule produces the correct reason string.
         let failingCase = "let array = [\n\t1,\n\t2,\n]\n"


### PR DESCRIPTION
Master is broken because of this.