### PR TITLE
Fix operator usage spacing nested generics false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@
   [Keith Smiley](https://github.com/keith)
   [#2164](https://github.com/realm/SwiftLint/pull/2164)
 
+* Fix operator usage spacing nested generics false positive.  
+  [Eric Horacek](https://github.com/erichoracek)
+  [#2196](https://github.com/realm/SwiftLint/pull/2196)
+
 * Fix autocorrection for several rules
   (`empty_parentheses_with_trailing_closure`, `explicit_init`,
   `joined_default_parameter`, `redundant_optional_initialization` and

--- a/Rules.md
+++ b/Rules.md
@@ -10602,6 +10602,11 @@ let foo: Array<String>
 ```
 
 ```swift
+let model = CustomView<Container<Button>, NSAttributedString>(
+
+```
+
+```swift
 let foo: [String]
 
 ```

--- a/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/OperatorUsageWhitespaceRule.swift
@@ -19,6 +19,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             "let foo = !false\n",
             "let foo: Int?\n",
             "let foo: Array<String>\n",
+            "let model = CustomView<Container<Button>, NSAttributedString>(\n",
             "let foo: [String]\n",
             "let foo = 1 + \n  2\n",
             "let range = 1...3\n",
@@ -96,7 +97,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         }
         let pattern = "(?:\(patterns.joined(separator: "|")))"
 
-        let genericPattern = "<(?:\(oneSpace)|\\S)+?>" // not using dot to avoid matching new line
+        let genericPattern = "<(?:\(oneSpace)|\\S)*>" // not using dot to avoid matching new line
         let validRangePattern = leadingVariableOrNumber + zeroSpaces + rangePattern +
             zeroSpaces + trailingVariableOrNumber
         let excludingPattern = "(?:\(genericPattern)|\(validRangePattern))"


### PR DESCRIPTION
This was being corrected to:
```swift
let model = Generic<Container<Button>, NSAttributedString > (
```
