### PR TITLE
Improve mark rule autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
   [Eric Horacek](https://github.com/erichoracek)
   [#2121](https://github.com/realm/SwiftLint/issues/2121)]
 
+* Improves the `mark` rule's autocorrection.  
+  [Eric Horacek](https://github.com/erichoracek)
+
 * Add `redundant_set_access_control` rule to warn against using redundant
   setter ACLs on variable declarations.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/Rules.md
+++ b/Rules.md
@@ -8918,6 +8918,22 @@ MARK comment should be in valid format. e.g. '// MARK: ...' or '// MARK: - ...'
 ```
 
 ```swift
+↓//MARK : bad
+```
+
+```swift
+↓// MARKL:
+```
+
+```swift
+↓// MARKR 
+```
+
+```swift
+↓// MARKK -
+```
+
+```swift
 ↓//MARK:- Top-Level bad mark
 ↓//MARK:- Another bad mark
 struct MarkTest {}

--- a/Source/SwiftLintFramework/Rules/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/MarkRule.swift
@@ -44,6 +44,10 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
             "↓// MARK bad",
             "↓//MARK bad",
             "↓// MARK - bad",
+            "↓//MARK : bad",
+            "↓// MARKL:",
+            "↓// MARKR ",
+            "↓// MARKK -",
             issue1029Example
         ],
         corrections: [
@@ -54,6 +58,15 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
             "↓//MARK: - comment": "// MARK: - comment",
             "↓// MARK:- comment": "// MARK: - comment",
             "↓// MARK: -comment": "// MARK: - comment",
+            "↓// MARK: -  comment": "// MARK: - comment",
+            "↓// Mark: comment": "// MARK: comment",
+            "↓// Mark: - comment": "// MARK: - comment",
+            "↓// MARK - comment": "// MARK: - comment",
+            "↓// MARK : comment": "// MARK: comment",
+            "↓// MARKL:": "// MARK:",
+            "↓// MARKL: -": "// MARK: -",
+            "↓// MARKK ": "// MARK: ",
+            "↓// MARKK -": "// MARK: -",
             issue1029Example: issue1029Correction
         ]
     )
@@ -73,6 +86,10 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
     private let invalidLowercasePattern = "(?:// ?[Mm]ark:)"
 
     private let missingColonPattern = "(?:// ?MARK[^:])"
+    // The below patterns more specifically describe some of the above pattern's failure cases for correction.
+    private let oneOrMoreSpacesBeforeColonPattern = "(?:// ?MARK +:)"
+    private let nonWhitespaceBeforeColonPattern = "(?:// ?MARK\\S+:)"
+    private let nonWhitespaceNorColonBeforeSpacesPattern = "(?:// ?MARK[^\\s:]* +)"
 
     private var pattern: String {
         return [
@@ -116,6 +133,25 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
                                           pattern: nonSpaceOrNewlineAfterHyphenPattern,
                                           replaceString: "// MARK: - ",
                                           keepLastChar: true))
+
+        result.append(contentsOf: correct(file: file,
+                                          pattern: oneOrMoreSpacesBeforeColonPattern,
+                                          replaceString: "// MARK:",
+                                          keepLastChar: false))
+
+        result.append(contentsOf: correct(file: file,
+                                          pattern: nonWhitespaceBeforeColonPattern,
+                                          replaceString: "// MARK:",
+                                          keepLastChar: false))
+
+        result.append(contentsOf: correct(file: file,
+                                          pattern: nonWhitespaceNorColonBeforeSpacesPattern,
+                                          replaceString: "// MARK: ",
+                                          keepLastChar: false))
+
+        result.append(contentsOf: correct(file: file,
+                                          pattern: invalidLowercasePattern,
+                                          replaceString: "// MARK:"))
 
         return result.unique
     }


### PR DESCRIPTION
Adds a few additional cases for the MARK rule to autocorrect.

In our project, this made it so that the all mark rule failures were corrected automatically. Before this change, we had over 30 failures that could not be autocorrected.