### PR TITLE
Making `UntypedErrorInCatchRule` correctable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 #### Enhancements
 
+* Updates the `untyped_error_in_catch` rule to support autocorrection.  
+  [Daniel Metzing](https://github.com/dirtydanee)
+
 * Add `indented_cases` support to `switch_case_alignment` rule.  
   [Shai Mishali](https://github.com/freak4pc)
   [#2119](https://github.com/realm/SwiftLint/issues/2119)

--- a/Rules.md
+++ b/Rules.md
@@ -18271,7 +18271,7 @@ foo.bar { [weak self] ↓(x, y) in }
 
 Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift Compiler Version
 --- | --- | --- | --- | ---
-`untyped_error_in_catch` | Disabled | No | idiomatic | 3.0.0 
+`untyped_error_in_catch` | Disabled | Yes | idiomatic | 3.0.0 
 
 Catch statements should not declare error variables without type casting.
 

--- a/Source/SwiftLintFramework/Rules/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/UntypedErrorInCatchRule.swift
@@ -49,17 +49,48 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule {
             "do {\n    try foo() \n} ↓catch let e {}",
             "do {\n    try foo() \n} ↓catch(let error) {}",
             "do {\n    try foo() \n} ↓catch (let error) {}"
+        ],
+        corrections: [
+            "do {\n    try foo() \n} ↓catch var error {}": "do {\n    try foo() \n} catch {}",
+            "do {\n    try foo() \n} ↓catch let error {}": "do {\n    try foo() \n} catch {}",
+            "do {\n    try foo() \n} ↓catch let someError {}": "do {\n    try foo() \n} catch {}",
+            "do {\n    try foo() \n} ↓catch var someError {}": "do {\n    try foo() \n} catch {}",
+            "do {\n    try foo() \n} ↓catch let e {}": "do {\n    try foo() \n} catch {}",
+            "do {\n    try foo() \n} ↓catch(let error) {}": "do {\n    try foo() \n} catch {}",
+            "do {\n    try foo() \n} ↓catch (let error) {}": "do {\n    try foo() \n} catch {}"
         ])
 
     public func validate(file: File) -> [StyleViolation] {
-        let matches = file.match(pattern: type(of: self).regularExpression,
-                                 with: [.keyword, .keyword, .identifier])
-
-        return matches.map {
+        return violationRanges(in: file).map {
             return StyleViolation(ruleDescription: type(of: self).description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: $0.location),
                                   reason: configuration.consoleDescription)
         }
+    }
+
+    fileprivate func violationRanges(in file: File) -> [NSRange] {
+        return file.match(pattern: type(of: self).regularExpression,
+                          with: [.keyword, .keyword, .identifier])
+    }
+}
+
+extension UntypedErrorInCatchRule: CorrectableRule {
+    public func correct(file: File) -> [Correction] {
+         let violations = violationRanges(in: file)
+         let matches = file.ruleEnabled(violatingRanges: violations, for: self)
+         if matches.isEmpty { return [] }
+
+        var contents = file.contents.bridge()
+        let description = type(of: self).description
+        var corrections = [Correction]()
+
+        for range in matches.reversed() {
+            contents = contents.replacingCharacters(in: range, with: "catch {").bridge()
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: description, location: location))
+        }
+        file.write(contents.bridge())
+        return corrections
     }
 }

--- a/Source/SwiftLintFramework/Rules/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/UntypedErrorInCatchRule.swift
@@ -77,9 +77,9 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule {
 
 extension UntypedErrorInCatchRule: CorrectableRule {
     public func correct(file: File) -> [Correction] {
-         let violations = violationRanges(in: file)
-         let matches = file.ruleEnabled(violatingRanges: violations, for: self)
-         if matches.isEmpty { return [] }
+        let violations = violationRanges(in: file)
+        let matches = file.ruleEnabled(violatingRanges: violations, for: self)
+        if matches.isEmpty { return [] }
 
         var contents = file.contents.bridge()
         let description = type(of: self).description


### PR DESCRIPTION
No issue link, just made the existing `UntypedErrorInCatchRule` correctable.