### PR TITLE
Fix #2231

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@
 
 #### Bug Fixes
 
+* Fix identifier name false positive for enum cases with associated values in Xcode 10.
+  [Jacob Greenfield](https://github.com/Coder-256)
+  [#2231](https://github.com/realm/SwiftLint/issues/2231)
+
 * Update `LowerACLThanParent` rule to not lint extensions.  
   [Keith Smiley](https://github.com/keith)
   [#2164](https://github.com/realm/SwiftLint/pull/2164)

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -35,7 +35,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
                 return []
             }
 
-            let isFunction = SwiftDeclarationKind.functionKinds.contains(kind) || kind == .enumelement
+            let isFunction = SwiftDeclarationKind.functionKinds.contains(kind)
             let description = Swift.type(of: self).description
 
             let type = self.type(for: kind)
@@ -88,8 +88,16 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             !name.hasPrefix("$") else {
                 return nil
         }
+        
+        let newName: String
+        if kind == .enumelement, let length = dictionary.nameLength {
+            let maxIndex = name.index(name.startIndex, offsetBy: length)
+            newName = String(name[name.startIndex..<maxIndex])
+        } else {
+            newName = name
+        }
 
-        return (name.nameStrippingLeadingUnderscoreIfPrivate(dictionary), offset)
+        return (newName.nameStrippingLeadingUnderscoreIfPrivate(dictionary), offset)
     }
 
     private let kinds: Set<SwiftDeclarationKind> = {

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -88,7 +88,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             !name.hasPrefix("$") else {
                 return nil
         }
-        
+
         let newName: String
         if kind == .enumelement, let length = dictionary.nameLength {
             let maxIndex = name.index(name.startIndex, offsetBy: length)

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -24,28 +24,18 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         deprecatedAliases: ["variable_name"]
     )
 
-    private func mapName(name: String, kind: SwiftDeclarationKind) -> String {
-        if kind == .enumelement, let index = name.firstIndex(of: "(") {
-            return String(name[name.startIndex..<index])
-        } else {
-            return name
-        }
-    }
-
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
         guard !dictionary.enclosedSwiftAttributes.contains(.override) else {
             return []
         }
 
-        return validateName(dictionary: dictionary, kind: kind).map { originalName, offset in
-            let name = mapName(name: originalName, kind: kind)
-
+        return validateName(dictionary: dictionary, kind: kind).map { name, offset in
             guard !configuration.excluded.contains(name) else {
                 return []
             }
 
-            let isFunction = SwiftDeclarationKind.functionKinds.contains(kind)
+            let isFunction = SwiftDeclarationKind.functionKinds.contains(kind) || kind == .enumelement
             let description = Swift.type(of: self).description
 
             let type = self.type(for: kind)

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -39,7 +39,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             let description = Swift.type(of: self).description
 
             let type = self.type(for: kind)
-            if !isFunction {
+            if !isFunction && kind != .enumelement {
                 let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
                 if !allowedSymbols.isSuperset(of: CharacterSet(safeCharactersIn: name)) {
                     return [


### PR DESCRIPTION
SwiftLint fails with an error in enums with associated types in Xcode 10 due to the `identifier_name` rule. This fixes that error.