### PR TITLE
Opt-in rule to check for redundant type annotations

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -98,6 +98,7 @@
 * [Redundant Optional Initialization](#redundant-optional-initialization)
 * [Redundant Set Access Control Rule](#redundant-set-access-control-rule)
 * [Redundant String Enum Value](#redundant-string-enum-value)
+* [Redundant Type Annotation](#redundant-type-annotation)
 * [Redundant Void Return](#redundant-void-return)
 * [Required Enum Case](#required-enum-case)
 * [Returning Whitespace](#returning-whitespace)
@@ -12928,6 +12929,59 @@ enum Numbers: String {
  case one, two = ↓"two"
 }
 
+```
+
+</details>
+
+
+
+## Redundant Type Annotation
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift Compiler Version
+--- | --- | --- | --- | ---
+`redundant_type_annotation` | Disabled | Yes | idiomatic | 3.0.0 
+
+Variables should not have redundant type annotation
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+var url = URL()
+```
+
+```swift
+var url: CustomStringConvertible = URL()
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+↓var url:URL=URL()
+```
+
+```swift
+↓var url:URL = URL(string: "")
+```
+
+```swift
+↓var url: URL = URL()
+```
+
+```swift
+↓let url: URL = URL()
+```
+
+```swift
+lazy ↓var url: URL = URL()
+```
+
+```swift
+↓let alphanumerics: CharacterSet = CharacterSet.alphanumerics
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -99,6 +99,7 @@ public let masterRuleList = RuleList(rules: [
     RedundantOptionalInitializationRule.self,
     RedundantSetAccessControlRule.self,
     RedundantStringEnumValueRule.self,
+    RedundantTypeAnnotationRule.self,
     RedundantVoidReturnRule.self,
     RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,

--- a/Source/SwiftLintFramework/Rules/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/RedundantTypeAnnotationRule.swift
@@ -1,0 +1,98 @@
+import Foundation
+import SourceKittenFramework
+
+public struct RedundantTypeAnnotationRule: Rule, OptInRule, CorrectableRule, ConfigurationProviderRule {
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "redundant_type_annotation",
+        name: "Redundant Type Annotation",
+        description: "Variables should not have redundant type annotation",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            "var url = URL()",
+            "var url: CustomStringConvertible = URL()"
+        ],
+        triggeringExamples: [
+            "↓var url:URL=URL()",
+            "↓var url:URL = URL(string: \"\")",
+            "↓var url: URL = URL()",
+            "↓let url: URL = URL()",
+            "lazy ↓var url: URL = URL()",
+            "↓let alphanumerics: CharacterSet = CharacterSet.alphanumerics"
+        ],
+        corrections: [
+            "var url↓: URL = URL()": "var url = URL()",
+            "let url↓: URL = URL()": "let url = URL()",
+            "let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics":
+                "let alphanumerics = CharacterSet.alphanumerics"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+
+        return violationRanges(in: file).map { range in
+            StyleViolation(
+                ruleDescription: type(of: self).description,
+                severity: configuration.severity,
+                location: Location(file: file, characterOffset: range.location)
+            )
+        }
+    }
+
+    public func correct(file: File) -> [Correction] {
+
+        let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
+        let typeAnnotationRanges = violatingRanges.map { typeAnnotationRange(in: file, violationRange: $0) }
+        var correctedContents = file.contents
+        var adjustedLocations = [Int]()
+
+        for typeAnnotationRange in typeAnnotationRanges.reversed() {
+            if let indexRange = correctedContents.nsrangeToIndexRange(typeAnnotationRange) {
+                correctedContents = correctedContents.replacingCharacters(in: indexRange, with: "")
+                adjustedLocations.insert(typeAnnotationRange.location, at: 0)
+            }
+        }
+
+        file.write(correctedContents)
+
+        return adjustedLocations.map {
+            Correction(ruleDescription: type(of: self).description, location: Location(file: file, characterOffset: $0))
+        }
+    }
+
+    private func violationRanges(in file: File) -> [NSRange] {
+
+        let pattern = "(var|let)\\s?\\w+:\\s?\\w+\\s?=\\s?\\w+(\\(|.)"
+
+        let foundRanges = file.match(pattern: pattern, with: [.keyword, .identifier, .typeidentifier, .identifier])
+
+        return foundRanges.filter { range in !isFalsePositive(in: file, range: range) }
+    }
+
+    private func typeAnnotationRange(in file: File, violationRange: NSRange) -> NSRange {
+        return file.match(pattern: ":\\s?\\w+", excludingSyntaxKinds: [])[0]
+    }
+
+    private func isFalsePositive(in file: File, range: NSRange) -> Bool {
+
+        let substring = file.contents.bridge().substring(with: range)
+
+        let components = substring.components(separatedBy: "=")
+        let charactersToTrimFromRhs = CharacterSet(charactersIn: ".(").union(.whitespaces)
+
+        guard
+            components.count == 2,
+            let lhsTypeName = components[0].components(separatedBy: ":").last?.trimmingCharacters(in: .whitespaces)
+        else {
+            return true
+        }
+
+        let rhsTypeName = components[1].trimmingCharacters(in: charactersToTrimFromRhs)
+
+        return lhsTypeName != rhsTypeName
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
 		57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED82791CF65183002B3513 /* JUnitReporter.swift */; };
 		621061BF1ED57E640082D51E /* MultilineParametersRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */; };
+		621C8EA420CBC7A10007DA74 /* RedundantTypeAnnotationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6208ED4E20C297AC004E78D1 /* RedundantTypeAnnotationRule.swift */; };
 		62329C2B1F30B2310035737E /* DiscouragedDirectInitRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AF35D71F30B183009B11EE /* DiscouragedDirectInitRuleTests.swift */; };
 		623675B01F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623675AF1F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift */; };
 		623675B21F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623675B11F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift */; };
@@ -458,6 +459,7 @@
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		57ED82791CF65183002B3513 /* JUnitReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JUnitReporter.swift; sourceTree = "<group>"; };
+		6208ED4E20C297AC004E78D1 /* RedundantTypeAnnotationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantTypeAnnotationRule.swift; sourceTree = "<group>"; };
 		621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineParametersRuleExamples.swift; sourceTree = "<group>"; };
 		623675AF1F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedPendingTestRule.swift; sourceTree = "<group>"; };
 		623675B11F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedPendingTestRuleExamples.swift; sourceTree = "<group>"; };
@@ -1202,6 +1204,7 @@
 				D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */,
 				D49896F02026B36C00814A83 /* RedundantSetAccessControlRule.swift */,
 				D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */,
+				6208ED4E20C297AC004E78D1 /* RedundantTypeAnnotationRule.swift */,
 				D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */,
 				B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */,
 				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
@@ -1671,6 +1674,7 @@
 				57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */,
 				D43B04691E072291004016AF /* ColonConfiguration.swift in Sources */,
 				E82367E01ED3BD1E0040A88E /* Configuration+Cache.swift in Sources */,
+				621C8EA420CBC7A10007DA74 /* RedundantTypeAnnotationRule.swift in Sources */,
 				62DADC481FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift in Sources */,
 				D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */,
 				24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -342,6 +342,10 @@ class RulesTests: XCTestCase {
         verifyRule(RedundantStringEnumValueRule.description)
     }
 
+    func testRedundantTypeAnnotation() {
+        verifyRule(RedundantTypeAnnotationRule.description)
+    }
+
     func testRedundantVoidReturn() {
         verifyRule(RedundantVoidReturnRule.description)
     }


### PR DESCRIPTION
This rule checks for redundant type annotations, e.g. `var view: UIView = UIView()`. Violations are only triggered when it is the same type (e.g., `view: UIControl = UIView()` will not trigger).

This is my first rule and my first ever pull request on github, so feedback is welcome.