### PR TITLE
Command-line option to disable merging of nested configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 #### Enhancements
 
+* Add an option to disable nested config merges with the `--disable-nested-config-merge` command-line option
+  [Akshay Venkatesh](https://github.com/aksvenk)
+
 * Add optional filename verification to the `file_header` rule.
   All occurrences in the pattern of the `SWIFTLINT_CURRENT_FILENAME`
   placeholder are replaced by the name of the validated file.  

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -23,7 +23,8 @@ extension Configuration {
             let fullPath = pathNSString.absolutePathRepresentation()
             let config = Configuration.getCached(atPath: fullPath) ??
                 Configuration(path: configurationSearchPath, rootPath: fullPath, optional: false, quiet: true)
-            return merge(with: config)
+            let shouldMergeNestedConfigs = mergeNestedConfigs ?? true
+            return shouldMergeNestedConfigs ? merge(with: config) : config
         }
 
         // If we are not at the root path, continue down the tree

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -20,6 +20,7 @@ public struct Configuration: Hashable {
     public let warningThreshold: Int?                  // warning threshold
     public private(set) var rootPath: String?          // the root path to search for nested configurations
     public private(set) var configurationPath: String? // if successfully loaded from a path
+    public private(set) var mergeNestedConfigs: Bool?  // merge configurations in nested folders
     public let cachePath: String?
 
     public var hashValue: Int {
@@ -118,7 +119,8 @@ public struct Configuration: Hashable {
     }
 
     public init(path: String = Configuration.fileName, rootPath: String? = nil,
-                optional: Bool = true, quiet: Bool = false, enableAllRules: Bool = false, cachePath: String? = nil) {
+                optional: Bool = true, quiet: Bool = false, enableAllRules: Bool = false, cachePath: String? = nil,
+                mergeNestedConfigs: Bool = true) {
         let fullPath: String
         if let rootPath = rootPath, rootPath.isDirectory() {
             fullPath = path.bridge().absolutePathRepresentation(rootDirectory: rootPath)
@@ -141,6 +143,7 @@ public struct Configuration: Hashable {
             if !optional { fail("File not found.") }
             self.init(rulesMode: rulesMode, cachePath: cachePath)!
             self.rootPath = rootPath
+            self.mergeNestedConfigs = mergeNestedConfigs
             return
         }
         do {
@@ -152,6 +155,7 @@ public struct Configuration: Hashable {
             self.init(dict: dict, enableAllRules: enableAllRules, cachePath: cachePath)!
             configurationPath = fullPath
             self.rootPath = rootPath
+            self.mergeNestedConfigs = mergeNestedConfigs
             setCached(atPath: fullPath)
             return
         } catch YamlParserError.yamlParsing(let message) {
@@ -174,7 +178,8 @@ public struct Configuration: Hashable {
             (lhs.included == rhs.included) &&
             (lhs.excluded == rhs.excluded) &&
             (lhs.rules == rhs.rules) &&
-            (lhs.indentation == rhs.indentation)
+            (lhs.indentation == rhs.indentation) &&
+            (lhs.mergeNestedConfigs == rhs.mergeNestedConfigs)
     }
 }
 

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -116,6 +116,7 @@ public struct Configuration: Hashable {
         cachePath = configuration.cachePath
         rootPath = configuration.rootPath
         indentation = configuration.indentation
+        mergeNestedConfigs = configuration.mergeNestedConfigs
     }
 
     public init(path: String = Configuration.fileName, rootPath: String? = nil,

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -66,12 +66,13 @@ struct AutoCorrectOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let useTabs: Bool
+    let disableNestedConfigMerge: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ forceExclude: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> AutoCorrectOptions {
-        return { configurationFile in { useScriptInputFiles in { quiet in { forceExclude in { format in { cachePath in { ignoreCache in { useTabs in
-            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, forceExclude: forceExclude, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs)
-        }}}}}}}}
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ useScriptInputFiles: Bool) -> (_ quiet: Bool) -> (_ forceExclude: Bool) -> (_ format: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ useTabs: Bool) -> (_ disableNestedConfigMerge: Bool) -> AutoCorrectOptions {
+        return { configurationFile in { useScriptInputFiles in { quiet in { forceExclude in { format in { cachePath in { ignoreCache in { useTabs in { disableNestedConfigMerge in
+            self.init(path: path, configurationFile: configurationFile, useScriptInputFiles: useScriptInputFiles, quiet: quiet, forceExclude: forceExclude, format: format, cachePath: cachePath, ignoreCache: ignoreCache, useTabs: useTabs, disableNestedConfigMerge: disableNestedConfigMerge)
+        }}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>> {
@@ -94,5 +95,7 @@ struct AutoCorrectOptions: OptionsProtocol {
             <*> mode <| Option(key: "use-tabs",
                                defaultValue: false,
                                usage: "should use tabs over spaces when reformatting. Deprecated.")
+            <*> mode <| Option(key: "disable-nested-config-merge", defaultValue: false,
+                               usage: "do not attempt to merge nested configurations")
     }
 }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -130,12 +130,13 @@ struct LintOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let enableAllRules: Bool
+    let disableNestedConfigMerge: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> LintOptions {
-        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in
-            self.init(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
-        }}}}}}}}}}}}
+    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> (_ disableNestedConfigMerge: Bool) -> LintOptions {
+        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in { disableNestedConfigMerge in
+            self.init(path: path, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules, disableNestedConfigMerge: disableNestedConfigMerge)
+        }}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<LintOptions, CommandantError<CommandantError<()>>> {
@@ -164,5 +165,7 @@ struct LintOptions: OptionsProtocol {
                                usage: "ignore cache when linting")
             <*> mode <| Option(key: "enable-all-rules", defaultValue: false,
                                usage: "run all rules, even opt-in and disabled ones, ignoring `whitelist_rules`")
+            <*> mode <| Option(key: "disable-nested-config-merge", defaultValue: false,
+                               usage: "do not attempt to merge nested configurations")
     }
 }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -131,7 +131,8 @@ extension Configuration {
         let optional = !CommandLine.arguments.contains("--config")
         self.init(path: options.configurationFile, rootPath: options.path.absolutePathStandardized(),
                   optional: optional, quiet: options.quiet,
-                  enableAllRules: options.enableAllRules, cachePath: cachePath)
+                  enableAllRules: options.enableAllRules, cachePath: cachePath,
+                  mergeNestedConfigs: !options.disableNestedConfigMerge)
     }
 
     func visitLintableFiles(options: LintOptions, cache: LinterCache? = nil,
@@ -148,7 +149,8 @@ extension Configuration {
         let cachePath = options.cachePath.isEmpty ? nil : options.cachePath
         let optional = !CommandLine.arguments.contains("--config")
         self.init(path: options.configurationFile, rootPath: options.path.absolutePathStandardized(),
-                  optional: optional, quiet: options.quiet, cachePath: cachePath)
+                  optional: optional, quiet: options.quiet, cachePath: cachePath,
+                  mergeNestedConfigs: !options.disableNestedConfigMerge)
     }
 
     // MARK: Rules command


### PR DESCRIPTION
This PR adds an option to disable merging configurations in nested folders.
Usage: `swiftlint lint --disable-nested-config-merge`

**Motivation**
Sometimes nested configurations in a project may have vastly different rules from the parent. 
The current strategy of always merging nested configs might not cut it in the above case. The nested configs would inherit rules that are not expected from the parent.

**Solution**
A command-line flag has been added to disable merging of nested configurations. When the said flag is used, nested configurations are 'disconnected' from the parent and the rule-sets are not merged. 

**Potential use-case**
The change in the project structure below:
- allows nested config files to operate in a standalone manner without being affected by the root
- allows the preparation of an aggregate SwiftLint report which includes the project and its frameworks by running the `swiftlint` command from `Project A`'s root folder

```
Project A
   +-.swiftlint.yml (root)
   |
   +--+-Framework A
   |  +-.swiftlint.yml (nested)
   |
   +--+-Framework B
   |  +-.swiftlint.yml (nested)
   |
   +--+-Framework C
      +-.swiftlint.yml (nested)
```

