### PR TITLE
Fix explicit_enum_raw_value rule with Swift 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   rule from applying.  
   [Allen Wu](https://github.com/allewun)
 
+* Fix `explicit_enum_raw_value` rule when linting with Swift 4.2.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 ## 0.26.0: Maytagged Pointers
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/ExplicitEnumRawValueRule.swift
@@ -34,14 +34,13 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
         }
 
         // Check if it's an enum which supports raw values
-        let implicitRawValueTypes: [Any] = [
-            Int.self, Int8.self, Int16.self, Int32.self, Int64.self,
-            UInt.self, UInt8.self, UInt16.self, UInt32.self, UInt64.self,
-            Double.self, Float.self, Float80.self, Decimal.self, NSNumber.self,
-            NSDecimalNumber.self, "NSInteger", String.self
+        let implicitRawValueSet: Set<String> = [
+            "Int", "Int8", "Int16", "Int32", "Int64",
+            "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+            "Double", "Float", "Float80", "Decimal", "NSNumber",
+            "NSDecimalNumber", "NSInteger", "String"
         ]
 
-        let implicitRawValueSet = Set(implicitRawValueTypes.map(String.init(describing:)))
         let enumInheritedTypesSet = Set(dictionary.inheritedTypes)
 
         guard !implicitRawValueSet.isDisjoint(with: enumInheritedTypesSet) else {


### PR DESCRIPTION
When building SwiftLint with Xcode 10:

```
(lldb) po String(describing: Decimal.self)
"NSDecimal"

(lldb) po String(describing: Float80.self)
"Float80"
```
