### PR TITLE
Fix identifier_name rule when using Swift 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 * Fix `explicit_enum_raw_value` rule when linting with Swift 4.2.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
+* Fix `identifier_name` rule false positives with `enum` when linting
+  using Swift 4.2.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [Jacob Greenfield](https://github.com/Coder-256)
+  [#2231](https://github.com/realm/SwiftLint/issues/2231)
+
 ## 0.26.0: Maytagged Pointers
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -7158,6 +7158,14 @@ func == (lhs: SyntaxToken, rhs: SyntaxToken) -> Bool
 override func IsOperator(name: String) -> Bool
 ```
 
+```swift
+enum Foo { case `private` }
+```
+
+```swift
+enum Foo { case value(String) }
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -82,11 +82,19 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
 
     private func validateName(dictionary: [String: SourceKitRepresentable],
                               kind: SwiftDeclarationKind) -> (name: String, offset: Int)? {
-        guard let name = dictionary.name,
+        guard var name = dictionary.name,
             let offset = dictionary.offset,
             kinds.contains(kind),
             !name.hasPrefix("$") else {
                 return nil
+        }
+
+        if kind == .enumelement,
+            SwiftVersion.current > .fourDotOne,
+            let parenIndex = name.index(of: "("),
+            parenIndex > name.startIndex {
+            let index = name.index(before: parenIndex)
+            name = String(name[...index])
         }
 
         return (name.nameStrippingLeadingUnderscoreIfPrivate(dictionary), offset)

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRuleExamples.swift
@@ -13,7 +13,9 @@ internal struct IdentifierNameRuleExamples {
         "func isOperator(name: String) -> Bool",
         "func typeForKind(_ kind: SwiftDeclarationKind) -> String",
         "func == (lhs: SyntaxToken, rhs: SyntaxToken) -> Bool",
-        "override func IsOperator(name: String) -> Bool"
+        "override func IsOperator(name: String) -> Bool",
+        "enum Foo { case `private` }",
+        "enum Foo { case value(String) }"
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
Fixes #2231

Continued from #2232 // cc @Coder-256 