### PR TITLE
Fix generic_type_rule when using Swift 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   rule from applying.  
   [Allen Wu](https://github.com/allewun)
 
-* Fix `explicit_enum_raw_value` rule when linting with Swift 4.2.  
+* Fix `explicit_enum_raw_value` and `generic_type_name` rules when 
+  linting with Swift 4.2.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
 * Fix `identifier_name` rule false positives with `enum` when linting

--- a/Rules.md
+++ b/Rules.md
@@ -7014,7 +7014,7 @@ typealias BackwardTriple<T1, ↓T2_Bar, T3> = (T3, T2_Bar, T1)
 ```
 
 ```swift
-typealias DictionaryOfStrings<↓T_Foo: Hashable> = Dictionary<T, String>
+typealias DictionaryOfStrings<↓T_Foo: Hashable> = Dictionary<T_Foo, String>
 
 ```
 

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -22,6 +22,7 @@ public extension SwiftVersion {
     static let three = SwiftVersion(rawValue: "3.0.0")
     static let four = SwiftVersion(rawValue: "4.0.0")
     static let fourDotOne = SwiftVersion(rawValue: "4.1.0")
+    static let fourDotTwo = SwiftVersion(rawValue: "4.2.0")
 
     static let current: SwiftVersion = {
         // Allow forcing the Swift version, useful in cases where SourceKit isn't available


### PR DESCRIPTION
SourceKit includes `source.lang.swift.decl.generic_type_param` in the structure on Swift 4.2.

This makes the implementation much easier and more reliable.