### PR TITLE
Fix required_enum_case rule when linting with Swift 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
   rule from applying.  
   [Allen Wu](https://github.com/allewun)
 
-* Fix `explicit_enum_raw_value`, `generic_type_name` and `implicit_return` 
-  rules when linting with Swift 4.2.  
+* Fix `explicit_enum_raw_value`, `generic_type_name`, `implicit_return` and
+  `required_enum_case` rules when linting with Swift 4.2.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
 * Fix `identifier_name` rule false positives with `enum` when linting


### PR DESCRIPTION
This also simplifies the implementation a bit.