### PR TITLE
Fix closure-related rules when using Swift 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@
   [Allen Wu](https://github.com/allewun)
 
 * Fix `explicit_enum_raw_value`, `generic_type_name`, `implicit_return`,
-  `required_enum_case` and `quick_discouraged_call` rules when linting
-  with Swift 4.2.  
+  `required_enum_case`, `quick_discouraged_call`, `array_init`,
+  `closure_parameter_position` and `unused_closure_parameter` rules
+  when linting with Swift 4.2.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
 * Fix `identifier_name` rule false positives with `enum` when linting

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -97,7 +97,8 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
 
             if SwiftDeclarationKind(rawValue: kindString) == .varParameter {
                 return [subDict]
-            } else if SwiftExpressionKind(rawValue: kindString) == .argument {
+            } else if SwiftExpressionKind(rawValue: kindString) == .argument ||
+                SwiftExpressionKind(rawValue: kindString) == .closure {
                 return subDict.enclosedVarParameters
             }
 


### PR DESCRIPTION
We should revisit those rules later to use `source.lang.swift.expr.closure` directly instead of trying to figure out what is a closure.