### PR TITLE
Fix identifier_name check enum-element-with-associated-value error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
   when linting with Swift 4.2.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
-* Fix `identifier_name` rule false positives with `enum` when linting
-  using Swift 4.2.  
+* Fix `identifier_name` rule false positives with `enum`-with-associated-value when linting.
+  [Mingyu Cui](https://github.com/gnou)
   [Marcelo Fabri](https://github.com/marcelofabri)
   [Jacob Greenfield](https://github.com/Coder-256)
   [#2231](https://github.com/realm/SwiftLint/issues/2231)

--- a/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/IdentifierNameRule.swift
@@ -90,7 +90,6 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         if kind == .enumelement,
-            SwiftVersion.current > .fourDotOne,
             let parenIndex = name.index(of: "("),
             parenIndex > name.startIndex {
             let index = name.index(before: parenIndex)


### PR DESCRIPTION
#2255 was the fix of #2231 , but in this(#2255) fix, @marcelofabri set a Swift lang version check, only check >4.1, which makes it ineffectual if you're using Xcode 10 & Swift 4.1, I removed that constraint in my pull request.