### PR TITLE
add "allow_first_closure_on_same_line" configuration to "multiline_arguments"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2249](https://github.com/realm/SwiftLint/issues/2249)
   
-  * Add `allow_first_closure_on_same_line` configuration to 
-  `multiline_arguments`  
+  * Add `only_enforce_after_first_closure_on_first_line` configuration
+  to `multiline_arguments`  
   [Mike Ciesielka](https://github.com/maciesielka)
   [#1896](https://github.com/realm/SwiftLint/issues/1896)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   changed.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2249](https://github.com/realm/SwiftLint/issues/2249)
+  
+  * Add `allow_first_closure_on_same_line` configuration to 
+  `multiline_arguments`  
+  [Mike Ciesielka](https://github.com/maciesielka)
+  [#1896](https://github.com/realm/SwiftLint/issues/1896)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineArgumentsConfiguration.swift
@@ -28,9 +28,11 @@ public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
     private(set) var onlyEnforceAfterFirstClosureOnFirstLine = false
 
     public var consoleDescription: String {
+        // swiftlint:disable line_length
         return severityConfiguration.consoleDescription +
             ", \(ConfigurationKey.firstArgumentLocation.rawValue): \(firstArgumentLocation.rawValue)" +
             ", \(ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue): \(onlyEnforceAfterFirstClosureOnFirstLine)"
+        // swiftlint:enable line_length
     }
 
     public mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintFramework/Rules/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineArgumentsConfiguration.swift
@@ -3,7 +3,7 @@ import Foundation
 private enum ConfigurationKey: String {
     case severity = "severity"
     case firstArgumentLocation = "first_argument_location"
-    case allowFirstClosureOnSameLine = "allow_first_closure_on_same_line"
+    case onlyEnforceAfterFirstClosureOnFirstLine = "only_enforce_after_first_closure_on_first_line"
 }
 
 public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
@@ -25,12 +25,12 @@ public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
 
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var firstArgumentLocation = FirstArgumentLocation.anyLine
-    private(set) var allowFirstClosureOnSameLine = false
+    private(set) var onlyEnforceAfterFirstClosureOnFirstLine = false
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", \(ConfigurationKey.firstArgumentLocation.rawValue): \(firstArgumentLocation.rawValue)" +
-            ", \(ConfigurationKey.allowFirstClosureOnSameLine.rawValue): \(allowFirstClosureOnSameLine)"
+            ", \(ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue): \(onlyEnforceAfterFirstClosureOnFirstLine)"
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -50,8 +50,8 @@ public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
                 try firstArgumentLocation = FirstArgumentLocation(value: value)
             case (.severity, let stringValue as String):
                 try severityConfiguration.apply(configuration: stringValue)
-            case (.allowFirstClosureOnSameLine, let boolValue as Bool):
-                allowFirstClosureOnSameLine = boolValue
+            case (.onlyEnforceAfterFirstClosureOnFirstLine, let boolValue as Bool):
+                onlyEnforceAfterFirstClosureOnFirstLine = boolValue
             default:
                 throw error
             }

--- a/Source/SwiftLintFramework/Rules/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineArgumentsConfiguration.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 private enum ConfigurationKey: String {
+    case severity = "severity"
     case firstArgumentLocation = "first_argument_location"
+    case allowFirstClosureOnSameLine = "allow_first_closure_on_same_line"
 }
 
 public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
@@ -23,23 +25,36 @@ public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
 
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var firstArgumentLocation = FirstArgumentLocation.anyLine
+    private(set) var allowFirstClosureOnSameLine = false
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription +
-            ", \(ConfigurationKey.firstArgumentLocation.rawValue): \(firstArgumentLocation.rawValue)"
+            ", \(ConfigurationKey.firstArgumentLocation.rawValue): \(firstArgumentLocation.rawValue)" +
+            ", \(ConfigurationKey.allowFirstClosureOnSameLine.rawValue): \(allowFirstClosureOnSameLine)"
     }
 
     public mutating func apply(configuration: Any) throws {
+        let error = ConfigurationError.unknownConfiguration
+
         guard let configuration = configuration as? [String: Any] else {
-            throw ConfigurationError.unknownConfiguration
+            throw error
         }
 
-        if let modeString = configuration[ConfigurationKey.firstArgumentLocation.rawValue] {
-            try firstArgumentLocation = FirstArgumentLocation(value: modeString)
-        }
+        for (string, value) in configuration {
+            guard let key = ConfigurationKey(rawValue: string) else {
+                throw error
+            }
 
-        if let severityString = configuration["severity"] as? String {
-            try severityConfiguration.apply(configuration: severityString)
+            switch (key, value) {
+            case (.firstArgumentLocation, _):
+                try firstArgumentLocation = FirstArgumentLocation(value: value)
+            case (.severity, let stringValue as String):
+                try severityConfiguration.apply(configuration: stringValue)
+            case (.allowFirstClosureOnSameLine, let boolValue as Bool):
+                allowFirstClosureOnSameLine = boolValue
+            default:
+                throw error
+            }
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineArgumentsRule.swift
@@ -21,8 +21,39 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
         guard
             kind == .call,
             case let arguments = dictionary.enclosedArguments,
-            arguments.count > 1,
-            case let contents = file.contents.bridge(),
+            arguments.count > 1 else {
+                return []
+        }
+
+        let wrappedArguments: [Argument] = arguments
+            .enumerated()
+            .compactMap { idx, argument in
+                Argument(dictionary: argument, file: file, index: idx)
+            }
+
+        var violatingArguments = findViolations(in: wrappedArguments,
+                                                dictionary: dictionary,
+                                                file: file)
+
+        if configuration.allowFirstClosureOnSameLine {
+            violatingArguments = removeViolationsBeforeFirstClosure(arguments: wrappedArguments,
+                                                                    violations: violatingArguments,
+                                                                    file: file)
+        }
+
+        return violatingArguments.map {
+            return StyleViolation(ruleDescription: type(of: self).description,
+                                  severity: self.configuration.severityConfiguration.severity,
+                                  location: Location(file: file, byteOffset: $0.offset))
+        }
+    }
+
+    // MARK: - Violation Logic
+
+    private func findViolations(in arguments: [Argument],
+                                dictionary: [String: SourceKitRepresentable],
+                                file: File) -> [Argument] {
+        guard case let contents = file.contents.bridge(),
             let nameOffset = dictionary.nameOffset,
             let (nameLine, _) = contents.lineAndCharacter(forByteOffset: nameOffset) else {
                 return []
@@ -35,13 +66,9 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
         }
 
         let lastIndex = arguments.count - 1
-        let violatingOffsets: [Int] = arguments.enumerated().compactMap { idx, argument in
-            guard
-                let offset = argument.offset,
-                let (line, _) = contents.lineAndCharacter(forByteOffset: offset) else {
-                    return nil
-            }
 
+        let violations = arguments.compactMap { argument -> Argument? in
+            let (line, idx) = (argument.line, argument.index)
             let (firstVisit, _) = visitedLines.insert(line)
 
             if idx == lastIndex && isTrailingClosure(dictionary: dictionary, file: file) {
@@ -49,23 +76,39 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
             } else if idx == 0 {
                 switch configuration.firstArgumentLocation {
                 case .anyLine: return nil
-                case .nextLine: return line > nameLine ? nil : offset
-                case .sameLine: return line > nameLine ? offset : nil
+                case .nextLine: return line > nameLine ? nil : argument
+                case .sameLine: return line > nameLine ? argument : nil
                 }
             } else {
-                return firstVisit ? nil : offset
+                return firstVisit ? nil : argument
             }
         }
 
         // only report violations if multiline
-        guard visitedLines.count > 1 else { return [] }
-
-        return violatingOffsets.map {
-            StyleViolation(ruleDescription: type(of: self).description,
-                           severity: configuration.severityConfiguration.severity,
-                           location: Location(file: file, byteOffset: $0))
-        }
+        return visitedLines.count > 1 ? violations : []
     }
+
+    private func removeViolationsBeforeFirstClosure(arguments: [Argument],
+                                                    violations: [Argument],
+                                                    file: File) -> [Argument] {
+        guard let firstClosure = arguments.first(where: isClosure(in: file)),
+            let firstArgument = arguments.first else {
+            return violations
+        }
+
+        let violationSlice: ArraySlice<Argument> = violations
+            .drop { argument in
+                // drop violations if they precede the first closure,
+                // if that closure is in the first line
+                firstArgument.line == firstClosure.line &&
+                    argument.line == firstClosure.line &&
+                    argument.index <= firstClosure.index
+            }
+
+        return Array(violationSlice)
+    }
+
+    // MARK: - Syntax Helpers
 
     private func isTrailingClosure(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
         guard let offset = dictionary.offset,
@@ -76,5 +119,44 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
         }
 
         return !text.hasSuffix(")")
+    }
+
+    private func isClosure(in file: File) -> (Argument) -> Bool {
+        return { argument in
+            let contents = file.contents.bridge()
+            let closureMatcher = regex("^\\s*\\{")
+            guard let range = contents.byteRangeToNSRange(start: argument.bodyOffset,
+                                                          length: argument.bodyLength),
+                case let matches = closureMatcher.matches(in: file.contents,
+                                                          options: [],
+                                                          range: range) else {
+                return false
+            }
+
+            return matches.count == 1
+        }
+    }
+}
+
+private struct Argument {
+    let offset: Int
+    let line: Int
+    let index: Int
+    let bodyOffset: Int
+    let bodyLength: Int
+
+    init?(dictionary: [String: SourceKitRepresentable], file: File, index: Int) {
+        guard let offset = dictionary.offset,
+            let (line, _) = file.contents.bridge().lineAndCharacter(forByteOffset: offset),
+            let bodyOffset = dictionary.bodyOffset,
+            let bodyLength = dictionary.bodyLength else {
+            return nil
+        }
+
+        self.offset = offset
+        self.line = line
+        self.index = index
+        self.bodyOffset = bodyOffset
+        self.bodyLength = bodyLength
     }
 }

--- a/Source/SwiftLintFramework/Rules/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MultilineArgumentsRule.swift
@@ -35,7 +35,7 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
                                                 dictionary: dictionary,
                                                 file: file)
 
-        if configuration.allowFirstClosureOnSameLine {
+        if configuration.onlyEnforceAfterFirstClosureOnFirstLine {
             violatingArguments = removeViolationsBeforeFirstClosure(arguments: wrappedArguments,
                                                                     violations: violatingArguments,
                                                                     file: file)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -329,7 +329,8 @@ extension MultilineArgumentsRuleTests {
     static var allTests: [(String, (MultilineArgumentsRuleTests) -> () throws -> Void)] = [
         ("testMultilineArgumentsWithDefaultConfiguration", testMultilineArgumentsWithDefaultConfiguration),
         ("testMultilineArgumentsWithWithNextLine", testMultilineArgumentsWithWithNextLine),
-        ("testMultilineArgumentsWithWithSameLine", testMultilineArgumentsWithWithSameLine)
+        ("testMultilineArgumentsWithWithSameLine", testMultilineArgumentsWithWithSameLine),
+        ("testMultilineArgumentsWithAllowFirstClosureOnSameLine", testMultilineArgumentsWithAllowFirstClosureOnSameLine)
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -330,7 +330,7 @@ extension MultilineArgumentsRuleTests {
         ("testMultilineArgumentsWithDefaultConfiguration", testMultilineArgumentsWithDefaultConfiguration),
         ("testMultilineArgumentsWithWithNextLine", testMultilineArgumentsWithWithNextLine),
         ("testMultilineArgumentsWithWithSameLine", testMultilineArgumentsWithWithSameLine),
-        ("testMultilineArgumentsWithAllowFirstClosureOnSameLine", testMultilineArgumentsWithAllowFirstClosureOnSameLine)
+        ("testMultilineArgumentsWithOnlyEnforceAfterFirstClosureOnFirstLine", testMultilineArgumentsWithOnlyEnforceAfterFirstClosureOnFirstLine)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
@@ -58,4 +58,47 @@ class MultilineArgumentsRuleTests: XCTestCase {
 
         verifyRule(description, ruleConfiguration: ["first_argument_location": "same_line"])
     }
+
+    func testMultilineArgumentsWithAllowFirstClosureOnSameLine() {
+        let nonTriggeringExamples: [String] = [
+            "foo()",
+            "foo(0)",
+            "foo(1, bar: 1) { }",
+            "foo(\n" +
+            "    4, bar: baz) { }",
+            "foo(a: a, b: {\n" +
+            "}, c: {\n" +
+            "})",
+            "foo(\n" +
+            "    a: a, b: {\n" +
+            "    }, c: {\n" +
+            "})",
+            "foo(a: a, b: b, c: {\n" +
+            "}, d: {\n" +
+            "})",
+            "foo(\n" +
+            "    a: a, b: b, c: {\n" +
+            "    }, d: {\n" +
+            "})",
+            "foo(a: a, b: { [weak self] in\n" +
+            "}, c: { flag in\n" +
+            "})"
+        ]
+
+        let triggeringExamples = [
+            "foo(a: a,\n" +
+            "    b: b, c: {\n" +
+            "})",
+            "foo(a: a, b: b,\n" +
+            "    c: c, d: {\n" +
+            "    }, d: {\n" +
+            "})"
+        ]
+
+        let description = MultilineArgumentsRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+
+        verifyRule(description, ruleConfiguration: ["allow_first_closure_on_same_line": true])
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
@@ -59,7 +59,7 @@ class MultilineArgumentsRuleTests: XCTestCase {
         verifyRule(description, ruleConfiguration: ["first_argument_location": "same_line"])
     }
 
-    func testMultilineArgumentsWithAllowFirstClosureOnSameLine() {
+    func testMultilineArgumentsWithOnlyEnforceAfterFirstClosureOnFirstLine() {
         let nonTriggeringExamples: [String] = [
             "foo()",
             "foo(0)",
@@ -99,6 +99,6 @@ class MultilineArgumentsRuleTests: XCTestCase {
             .with(triggeringExamples: triggeringExamples)
             .with(nonTriggeringExamples: nonTriggeringExamples)
 
-        verifyRule(description, ruleConfiguration: ["allow_first_closure_on_same_line": true])
+        verifyRule(description, ruleConfiguration: ["only_enforce_after_first_closure_on_first_line": true])
     }
 }


### PR DESCRIPTION
Adds the functionality described in #1896. I opted for the `allow_first_closure_on_same_line` name for the new configuration as suggested in the rule request.

The gist of the change is to compute violations in the same manner as the existing logic, but remove those that occur before a closure in the first line of arguments if the configuration is set.