### PR TITLE
Filter excluded files after discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@
 * Fix a crash when running with Swift 4.2.  
   [Norio Nomura](https://github.com/norio-nomura)
   [SR-7954](https://bugs.swift.org/browse/SR-7954)
+  
+* Fix an issue where excluded files in the configuration are not taken into account
+  when processing input files from the `--path` or `--use-script-input-files` parameters,
+  despite specifying `--force-exclude`.
+  [Mahdi Bchatnia](https://github.com/inket)
+  [#2275](https://github.com/realm/SwiftLint/issues/2275)
+  [#987](https://github.com/realm/SwiftLint/issues/987)
 
 ## 0.26.0: Maytagged Pointers
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -2,6 +2,13 @@ import Foundation
 import SourceKittenFramework
 
 extension Configuration {
+    public func lintableFiles(in files: [File], forceExclude: Bool) -> [File] {
+        return files.compactMap { file -> File? in
+            guard let filePath = file.path else { return nil }
+            return lintableFiles(inPath: filePath, forceExclude: forceExclude).first
+        }
+    }
+
     public func lintableFiles(inPath path: String, forceExclude: Bool) -> [File] {
         return lintablePaths(inPath: path, forceExclude: forceExclude).compactMap(File.init(pathDeferringReading:))
     }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -62,7 +62,7 @@ extension Configuration {
             }
             return .success(Dictionary(grouping: files, by: configuration(for:)))
         }.flatMap { filesPerConfig -> Result<[Configuration: [File]], CommandantError<()>> in
-            guard !useSTDIN else { return .success(filesPerConfig) }
+            guard !useSTDIN, forceExclude else { return .success(filesPerConfig) }
 
             let filteredFilesPerConfiguration = filesPerConfig.compactMap { config, files -> (Configuration, [File])? in
                 let filteredFiles = config.lintableFiles(in: files, forceExclude: forceExclude)


### PR DESCRIPTION
This is a PR fixing the long-standing bug (or unexpected behavior) of SwiftLint where excluded files in the configuration are not taken into account when processing files from the `--path` or `--use-script-input-files` parameters.

---

These are the issues and PRs referencing this behavior that I could find:

Issues:
https://github.com/realm/SwiftLint/issues/2275
https://github.com/realm/SwiftLint/issues/987

Previous attempts:
https://github.com/realm/SwiftLint/pull/1847

---

I hope I got it right, and if not, please point me towards the right way for doing it so we can get this fixed once and for all. 👍 