### PR TITLE
Fix literal multiline element false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [SR-7954](https://bugs.swift.org/browse/SR-7954)
 
+* Fix `literal_expression_end_indentation` false positives with multiline 
+  literal elements.  
+  [Eric Horacek](https://github.com/erichoracek)
+
 ## 0.26.0: Maytagged Pointers
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -8810,6 +8810,20 @@ Array and dictionary literal end should have the same indentation as the line th
 ]
 ```
 
+```swift
+[
+  .init(
+    a: 1,
+    b: 2)]
+```
+
+```swift
+[
+  .normal: .init(
+    a: 1,
+    b: 2)]
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/LiteralExpressionEndIdentationRule.swift
@@ -34,7 +34,19 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
             "[\n" +
             "   key: 0,\n" +
             "   key2: 20\n" +
-            "]"
+            "]",
+            """
+            [
+              .init(
+                a: 1,
+                b: 2)]
+            """,
+            """
+            [
+              .normal: .init(
+                a: 1,
+                b: 2)]
+            """
         ],
         triggeringExamples: [
             "let x = [\n" +
@@ -215,7 +227,8 @@ extension LiteralExpressionEndIdentationRule {
             let (firstParamLine, _) = contents.lineAndCharacter(forByteOffset: firstParamOffset),
             startLine != firstParamLine,
             let lastParamOffset = elements.last?.offset,
-            let (lastParamLine, _) = contents.lineAndCharacter(forByteOffset: lastParamOffset),
+            let lastParamLength = elements.last?.length,
+            let (lastParamLine, _) = contents.lineAndCharacter(forByteOffset: lastParamOffset + lastParamLength),
             case let endOffset = offset + length - 1,
             let (endLine, endPosition) = contents.lineAndCharacter(forByteOffset: endOffset),
             lastParamLine != endLine else {
@@ -227,7 +240,7 @@ extension LiteralExpressionEndIdentationRule {
         let actual = endPosition - 1
         guard let match = regex.firstMatch(in: file.contents, options: [], range: range)?.range,
             case let expected = match.location - range.location,
-            expected != actual  else {
+            expected != actual else {
                 return nil
         }
 


### PR DESCRIPTION
The `literal_expression_end_indentation` rule was diagnosing multiline literal elements as failing, e.g. the following would trigger a failure:

```swift
[
  .init(
    a: 1,
    b: 2)]
```

While this would not:
```swift
[
  1]
```

This was triggering some larger issues where autocorrection of `literal_expression_end_indentation` could incorrectly remove parts of multiline literal elements.