### PR TITLE
Add autocorrect for control_statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   to specify that the rule should only be applied to `if` statements.  
   [Cihat Gündüz](https://github.com/Dschee)
   [#2307](https://github.com/realm/SwiftLint/issues/2307)
+* Add autocorrect support for `control_statement`.  
+  [Jonathan Cole](https://github.com/colejd)
 
 #### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -1814,7 +1814,7 @@ let first = myList.first { $0 % 2 == 0 }
 
 Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift Compiler Version
 --- | --- | --- | --- | ---
-`control_statement` | Enabled | No | style | 3.0.0 
+`control_statement` | Enabled | Yes | style | 3.0.0 
 
 `if`, `for`, `guard`, `switch`, `while`, and `catch` statements shouldn't unnecessarily wrap their conditionals or arguments in parentheses.
 

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -89,6 +89,15 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
         ]
     )
 
+    let statementPatterns: [String] = ["if", "for", "guard", "switch", "while", "catch"]
+        .map { statement -> String in
+            let isGuard = statement == "guard"
+            let isSwitch = statement == "switch"
+            let elsePattern = isGuard ? "else\\s*" : ""
+            let clausePattern = isSwitch ? "[^,{]*" : "[^{]*"
+            return "\(statement)\\s*\\(\(clausePattern)\\)\\s*\(elsePattern)\\{"
+        }
+
     public func validate(file: File) -> [StyleViolation] {
         return violatingControlBracesRanges(file: file)
             .map { match -> StyleViolation in
@@ -199,14 +208,6 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
     }
 
     fileprivate func violatingControlBracesRanges(file: File) -> [NSRange] {
-        let statements = ["if", "for", "guard", "switch", "while", "catch"]
-        let statementPatterns: [String] = statements.map { statement -> String in
-            let isGuard = statement == "guard"
-            let isSwitch = statement == "switch"
-            let elsePattern = isGuard ? "else\\s*" : ""
-            let clausePattern = isSwitch ? "[^,{]*" : "[^{]*"
-            return "\(statement)\\s*\\(\(clausePattern)\\)\\s*\(elsePattern)\\{"
-        }
 
         return statementPatterns.flatMap { pattern -> [NSRange] in
             return file.match(pattern: pattern)

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestableRule, CorrectableRule {
 
     public var configuration = SeverityConfiguration(.warning)
 
@@ -54,39 +54,115 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
             "↓switch (foo) {\n",
             "do {\n} ↓catch(let error as NSError) {\n}",
             "↓if (max(a, b) < c) {\n"
+        ],
+        corrections: [
+            "↓if (condition) {\n": "if condition {\n",
+            "↓if(condition) {\n": "if condition {\n",
+            "↓if (condition == endIndex) {\n": "if condition == endIndex {\n",
+            "↓if ((a || b) && (c || d)) {\n": "if (a || b) && (c || d) {\n",
+            "↓if ((min...max).contains(value)) {\n": "if (min...max).contains(value) {\n",
+            "↓for (item in collection) {\n": "for item in collection {\n",
+            "↓for (var index = 0; index < 42; index++) {\n": "for var index = 0; index < 42; index++ {\n",
+            "↓for(item in collection) {\n": "for item in collection {\n",
+            "↓for(var index = 0; index < 42; index++) {\n": "for var index = 0; index < 42; index++ {\n",
+            "↓guard (condition) else {\n": "guard condition else {\n",
+            "↓while (condition) {\n": "while condition {\n",
+            "↓while(condition) {\n": "while condition {\n",
+            "} ↓while (condition) {\n": "} while condition {\n",
+            "} ↓while(condition) {\n": "} while condition {\n",
+            "do { ; } ↓while(condition) {\n": "do { ; } while condition {\n",
+            "do { ; } ↓while (condition) {\n": "do { ; } while condition {\n",
+            "↓switch (foo) {\n": "switch foo {\n",
+            "do {\n} ↓catch(let error as NSError) {\n}": "do {\n} catch let error as NSError {\n}",
+            "↓if (max(a, b) < c) {\n": "if max(a, b) < c {\n"
         ]
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let statements = ["if", "for", "guard", "switch", "while", "catch"]
-        let statementPatterns: [String] = statements.map { statement -> String in
-            let isGuard = statement == "guard"
-            let isSwitch = statement == "switch"
-            let elsePattern = isGuard ? "else\\s*" : ""
-            let clausePattern = isSwitch ? "[^,{]*" : "[^{]*"
-            return "\(statement)\\s*\\(\(clausePattern)\\)\\s*\(elsePattern)\\{"
-        }
-        return statementPatterns.flatMap { pattern -> [StyleViolation] in
-            return file.match(pattern: pattern)
-                .filter { match, syntaxKinds -> Bool in
-                    let matchString = file.contents.substring(from: match.location, length: match.length)
-                    return !isFalsePositive(matchString, syntaxKind: syntaxKinds.first)
-                }
-                .filter { match, _ -> Bool in
-                    let contents = file.contents.bridge()
-                    guard let byteOffset = contents.NSRangeToByteRange(start: match.location, length: 1)?.location,
-                        let outerKind = file.structure.kinds(forByteOffset: byteOffset).last else {
-                            return true
+        return violatingControlBracesRanges(file: file)
+            .map { match -> StyleViolation in
+                return StyleViolation(ruleDescription: type(of: self).description,
+                                      severity: configuration.severity,
+                                      location: Location(file: file, characterOffset: match.location))
+            }
+    }
+
+    public func correct(file: File) -> [Correction] {
+        let rawRanges = violatingControlBracesRanges(file: file)
+        let violatingRanges = file.ruleEnabled(violatingRanges: rawRanges, for: self)
+        var correctedContents = file.contents
+        var adjustedLocations = [Int]()
+
+        for violatingRange in violatingRanges.reversed() {
+            if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
+
+                let text = correctedContents[indexRange]
+
+                if let firstParenIndex = text.index(of: "("),
+                    let matches = getMatchingParens(text: text),
+                    let lastParenIndex = matches[firstParenIndex] {
+
+                    // After last paren
+                    let indexAfter = correctedContents.index(lastParenIndex, offsetBy: 1,
+                                                             limitedBy: correctedContents.endIndex)
+                    var nextChar: Character? = nil
+                    if let after = indexAfter {
+                        nextChar = correctedContents[after]
+                    }
+                    if nextChar == " " {
+                        // Remove paren
+                        correctedContents.remove(at: lastParenIndex)
+                    } else {
+                        // Replace paren with space
+                        correctedContents.replaceSubrange(lastParenIndex...lastParenIndex, with: " ")
                     }
 
-                    return SwiftExpressionKind(rawValue: outerKind.kind) != .call
+                    // Before first paren
+                    let indexBefore = correctedContents.index(firstParenIndex, offsetBy: -1,
+                                                              limitedBy: correctedContents.startIndex)
+                    var prevChar: Character? = nil
+                    if let before = indexBefore {
+                        prevChar = correctedContents[before]
+                    }
+                    if prevChar == " " {
+                        // Remove paren
+                        correctedContents.remove(at: firstParenIndex)
+                    } else {
+                        // Replace paren with space
+                        correctedContents.replaceSubrange(firstParenIndex...firstParenIndex, with: " ")
+                    }
+
                 }
-                .map { match, _ -> StyleViolation in
-                    return StyleViolation(ruleDescription: type(of: self).description,
-                                          severity: configuration.severity,
-                                          location: Location(file: file, characterOffset: match.location))
-                }
+
+                adjustedLocations.insert(violatingRange.location, at: 0)
+            }
         }
+
+        file.write(correctedContents)
+
+        return adjustedLocations.map {
+            Correction(ruleDescription: type(of: self).description,
+                       location: Location(file: file, characterOffset: $0))
+        }
+    }
+
+    fileprivate func getMatchingParens(text: Substring) -> [String.Index: String.Index]? {
+        var stack: [String.Index] = []
+        var dict: [String.Index: String.Index] = [:]
+
+        for index in text.indices {
+            let char = text[index]
+            if char == "(" {
+                stack.append(index)
+            } else if char == ")" {
+                if let last = stack.popLast() {
+                    dict[last] = index
+                } else {
+                    return nil
+                }
+            }
+        }
+        return dict
     }
 
     fileprivate func isFalsePositive(_ content: String, syntaxKind: SyntaxKind?) -> Bool {
@@ -113,4 +189,38 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
         }
         return false
     }
+
+    fileprivate func violatingControlBracesRanges(file: File) -> [NSRange] {
+        let statements = ["if", "for", "guard", "switch", "while", "catch"]
+        let statementPatterns: [String] = statements.map { statement -> String in
+            let isGuard = statement == "guard"
+            let isSwitch = statement == "switch"
+            let elsePattern = isGuard ? "else\\s*" : ""
+            let clausePattern = isSwitch ? "[^,{]*" : "[^{]*"
+            return "\(statement)\\s*\\(\(clausePattern)\\)\\s*\(elsePattern)\\{"
+        }
+
+        return statementPatterns.flatMap { pattern -> [NSRange] in
+            return file.match(pattern: pattern)
+                // Filter out false positives
+                .filter { match, syntaxKinds -> Bool in
+                    let matchString = file.contents.substring(from: match.location, length: match.length)
+                    return !isFalsePositive(matchString, syntaxKind: syntaxKinds.first)
+                }
+                // Filter out call expressions
+                .filter { match, _ -> Bool in
+                    let contents = file.contents.bridge()
+                    guard let byteOffset = contents.NSRangeToByteRange(start: match.location, length: 1)?.location,
+                        let outerKind = file.structure.kinds(forByteOffset: byteOffset).last else {
+                            return true
+                    }
+                    return SwiftExpressionKind(rawValue: outerKind.kind) != .call
+                }
+                .map { match, _ in
+                    return match
+                }
+        }
+
+    }
+
 }

--- a/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/ControlStatementRule.swift
@@ -1,4 +1,15 @@
+import Foundation
 import SourceKittenFramework
+
+fileprivate extension String {
+    // Safely index string
+    subscript (safe index: String.Index?) -> Element? {
+        guard let index = index else {
+            return nil
+        }
+        return self.indices.contains(index) ? self[index] : nil
+    }
+}
 
 public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestableRule, CorrectableRule {
 
@@ -105,11 +116,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
                     // After last paren
                     let indexAfter = correctedContents.index(lastParenIndex, offsetBy: 1,
                                                              limitedBy: correctedContents.endIndex)
-                    var nextChar: Character? = nil
-                    if let after = indexAfter {
-                        nextChar = correctedContents[after]
-                    }
-                    if nextChar == " " {
+                    if correctedContents[safe: indexAfter] == " " {
                         // Remove paren
                         correctedContents.remove(at: lastParenIndex)
                     } else {
@@ -120,11 +127,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
                     // Before first paren
                     let indexBefore = correctedContents.index(firstParenIndex, offsetBy: -1,
                                                               limitedBy: correctedContents.startIndex)
-                    var prevChar: Character? = nil
-                    if let before = indexBefore {
-                        prevChar = correctedContents[before]
-                    }
-                    if prevChar == " " {
+                    if correctedContents[safe: indexBefore] == " " {
                         // Remove paren
                         correctedContents.remove(at: firstParenIndex)
                     } else {


### PR DESCRIPTION
Hello! This adds autocorrect support for the `control_statement` rule. 

Caveat: 
As of now, it only seems to get the outermost control blocks it can find that break the rule; to fully correct, you need to run autocorrect a few times. If anyone has a way around this, I'd love to get that in here.

Thank you!