### PR TITLE
Added back 'missing_docs' (Nef10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#1869](https://github.com/realm/SwiftLint/issues/1869)
 
+* Add `missing_docs` rule to warn against undocumented declarations.  
+  [Nef10](https://github.com/Nef10)
+  [Andrés Cecilia Luque](https://github.com/acecilia)
+  [#1652](https://github.com/realm/SwiftLint/issues/1652)
+
 * Add a new `ignores_interpolated_strings` config parameter to the `line_length`
   rule to ignore lines that include interpolated strings from this rule.  
   [Michael Gray](https://github.com/mishagray)

--- a/Rules.md
+++ b/Rules.md
@@ -68,6 +68,7 @@
 * [Literal Expression End Indentation](#literal-expression-end-indentation)
 * [Lower ACL than parent](#lower-acl-than-parent)
 * [Mark](#mark)
+* [Missing Docs](#missing-docs)
 * [Modifier Order](#modifier-order)
 * [Multiline Arguments](#multiline-arguments)
 * [Multiline Function Chains](#multiline-function-chains)
@@ -9108,6 +9109,76 @@ struct MarkTest {}
 ↓// MARK:- Bad mark
 extension MarkTest {}
 
+```
+
+</details>
+
+
+
+## Missing Docs
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift Compiler Version
+--- | --- | --- | --- | ---
+`missing_docs` | Disabled | No | lint | 4.1.0 
+
+Declarations should be documented.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+/// docs
+public class A {
+/// docs
+public func b() {}
+}
+/// docs
+public class B: A { override public func b() {} }
+
+```
+
+```swift
+import Foundation
+/// docs
+public class B: NSObject {
+// no docs
+override public var description: String { fatalError() } }
+
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+public func a() {}
+
+```
+
+```swift
+// regular comment
+public func a() {}
+
+```
+
+```swift
+/* regular comment */
+public func a() {}
+
+```
+
+```swift
+/// docs
+public protocol A {
+// no docs
+var b: Int { get } }
+/// docs
+public struct C: A {
+
+public let b: Int
+}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -63,6 +63,10 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
     var usr: Int? {
         return (self["key.usr"] as? Int64).flatMap({ Int($0) })
     }
+    /// Documentation length.
+    var docLength: Int? {
+        return (self["key.doclength"] as? Int64).flatMap({ Int($0) })
+    }
 
     var attribute: String? {
         return self["key.attribute"] as? String

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -69,6 +69,7 @@ public let masterRuleList = RuleList(rules: [
     LiteralExpressionEndIdentationRule.self,
     LowerACLThanParentRule.self,
     MarkRule.self,
+    MissingDocsRule.self,
     ModifierOrderRule.self,
     MultilineArgumentsRule.self,
     MultilineFunctionChainsRule.self,

--- a/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/MissingDocsRule.swift
@@ -1,0 +1,82 @@
+import SourceKittenFramework
+
+private extension File {
+    func missingDocOffsets(in dictionary: [String: SourceKitRepresentable],
+                           acls: [AccessControlLevel]) -> [(Int, AccessControlLevel)] {
+        if dictionary.enclosedSwiftAttributes.contains(.override) ||
+            !dictionary.inheritedTypes.isEmpty {
+            return []
+        }
+        let substructureOffsets = dictionary.substructure.flatMap {
+            missingDocOffsets(in: $0, acls: acls)
+        }
+        guard (dictionary.kind).flatMap(SwiftDeclarationKind.init) != nil,
+            let offset = dictionary.offset,
+            let accessibility = dictionary.accessibility,
+            let acl = AccessControlLevel(identifier: accessibility),
+            acls.contains(acl) else {
+                return substructureOffsets
+        }
+        if dictionary.docLength != nil {
+            return substructureOffsets
+        }
+        return substructureOffsets + [(offset, acl)]
+    }
+}
+
+public struct MissingDocsRule: OptInRule, ConfigurationProviderRule {
+
+    public init() {
+        configuration = MissingDocsRuleConfiguration(
+            parameters: [RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
+                         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
+    }
+
+    public typealias ConfigurationType = MissingDocsRuleConfiguration
+    public var configuration: MissingDocsRuleConfiguration
+
+    public static let description = RuleDescription(
+        identifier: "missing_docs",
+        name: "Missing Docs",
+        description: "Declarations should be documented.",
+        kind: .lint,
+        minSwiftVersion: .fourDotOne,
+        nonTriggeringExamples: [
+            // locally-defined superclass member is documented, but subclass member is not
+            "/// docs\npublic class A {\n/// docs\npublic func b() {}\n}\n" +
+            "/// docs\npublic class B: A { override public func b() {} }\n",
+            // externally-defined superclass member is documented, but subclass member is not
+            "import Foundation\n/// docs\npublic class B: NSObject {\n" +
+            "// no docs\noverride public var description: String { fatalError() } }\n"
+        ],
+        triggeringExamples: [
+            // public, undocumented
+            "public func a() {}\n",
+            // public, undocumented
+            "// regular comment\npublic func a() {}\n",
+            // public, undocumented
+            "/* regular comment */\npublic func a() {}\n",
+            // protocol member and inherited member are both undocumented
+            "/// docs\npublic protocol A {\n// no docs\nvar b: Int { get } }\n" +
+            "/// docs\npublic struct C: A {\n\npublic let b: Int\n}"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        let acls = configuration.parameters.map { $0.value }
+        return file.missingDocOffsets(in: file.structure.dictionary,
+                                      acls: acls).map { (offset: Int, acl: AccessControlLevel) in
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.parameters.first { $0.value == acl }?.severity ?? .warning,
+                           location: Location(file: file, byteOffset: offset),
+                           reason: "\(acl.description) declarations should be documented.")
+        }
+    }
+
+    public func isEqualTo(_ rule: Rule) -> Bool {
+        if let rule = rule as? MissingDocsRule {
+            return rule.configuration.isEqualTo(configuration)
+        }
+        return false
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public struct MissingDocsRuleConfiguration: RuleConfiguration {
+
+    private(set) var parameters = [RuleParameter<AccessControlLevel>]()
+
+    public var consoleDescription: String {
+        return parameters.group { $0.severity }.sorted { $0.key.rawValue < $1.key.rawValue }.map {
+            "\($0.rawValue): \($1.map { $0.value.description }.sorted(by: <).joined(separator: ", "))"
+        }.joined(separator: ", ")
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let dict = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+        let parameters = try dict.flatMap { (key: String, value: Any) -> [RuleParameter<AccessControlLevel>] in
+            guard let severity = ViolationSeverity(rawValue: key) else {
+                throw ConfigurationError.unknownConfiguration
+            }
+            if let array = [String].array(of: value) {
+                return try array.map {
+                    guard let acl = AccessControlLevel(description: $0) else {
+                        throw ConfigurationError.unknownConfiguration
+                    }
+                    return RuleParameter<AccessControlLevel>(severity: severity, value: acl)
+                }
+            } else if let string = value as? String, let acl = AccessControlLevel(description: string) {
+                return [RuleParameter<AccessControlLevel>(severity: severity, value: acl)]
+            }
+            throw ConfigurationError.unknownConfiguration
+        }
+        guard parameters.count == parameters.map({ $0.value }).unique.count else {
+            throw ConfigurationError.unknownConfiguration
+        }
+        self.parameters = parameters
+    }
+
+    public func isEqualTo(_ ruleConfiguration: RuleConfiguration) -> Bool {
+        guard let config = ruleConfiguration as? MissingDocsRuleConfiguration else {
+            return false
+        }
+        return parameters == config.parameters
+    }
+
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -348,7 +348,10 @@
 		F480DC7F1F26090000099465 /* ConfigurationTests+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */; };
 		F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */; };
 		F480DC831F2609D700099465 /* ConfigurationTests+ProjectMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */; };
+		F90DBD7F2092E669002CC310 /* MissingDocsRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */; };
+		F90DBD812092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */; };
 		F9D73F031D0CF15E00222FC4 /* test.txt in Resources */ = {isa = PBXBuildFile; fileRef = F9D73F021D0CF15E00222FC4 /* test.txt */; };
+		F9E691282091952E0085B53E /* MissingDocsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E691272091952E0085B53E /* MissingDocsRule.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -761,7 +764,10 @@
 		F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+Nested.swift"; sourceTree = "<group>"; };
 		F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+BundlePath.swift"; sourceTree = "<group>"; };
 		F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+ProjectMock.swift"; sourceTree = "<group>"; };
+		F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRuleConfiguration.swift; sourceTree = "<group>"; };
+		F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRuleConfigurationTests.swift; sourceTree = "<group>"; };
 		F9D73F021D0CF15E00222FC4 /* test.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = test.txt; sourceTree = "<group>"; };
+		F9E691272091952E0085B53E /* MissingDocsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRule.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -829,6 +835,7 @@
 				8B01E4FB20A4183C00C9233E /* FunctionParameterCountConfiguration.swift */,
 				47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */,
 				3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */,
+				F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */,
 				188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */,
 				3BCC04D01C4F56D3006073C3 /* NameConfiguration.swift */,
 				D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */,
@@ -1044,6 +1051,8 @@
 				1EB7C8521F0C45C2004BAD22 /* ModifierOrderTests.swift */,
 				B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */,
 				D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */,
+				F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */,
+				B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */,
 				825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */,
 				C25EBBDD210787B200E27603 /* PrefixedTopLevelConstantRuleTests.swift */,
 				D4F5851820E99B5A0085C6D8 /* PrivateOutletRuleTests.swift */,
@@ -1198,6 +1207,7 @@
 				D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */,
 				C26330352073DAA200D7B4FD /* LowerACLThanParentRule.swift */,
 				856651A61D6B395F005E6B29 /* MarkRule.swift */,
+				F9E691272091952E0085B53E /* MissingDocsRule.swift */,
 				188B3FF1207D61040073C2D6 /* ModifierOrderRule.swift */,
 				B25DCD0D1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift */,
 				B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */,
@@ -1724,6 +1734,7 @@
 				E88198591BEA95F100333A11 /* LeadingWhitespaceRule.swift in Sources */,
 				D42B45D91F0AF5E30086B683 /* StrictFilePrivateRule.swift in Sources */,
 				1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */,
+				F90DBD7F2092E669002CC310 /* MissingDocsRuleConfiguration.swift in Sources */,
 				67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */,
 				57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */,
 				D43B04691E072291004016AF /* ColonConfiguration.swift in Sources */,
@@ -1841,6 +1852,7 @@
 				ED641C3820AA07B400212C62 /* NoFallthroughOnlyRule.swift in Sources */,
 				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
 				8FD216CC205584AF008ED13F /* CharacterSet+SwiftLint.swift in Sources */,
+				F9E691282091952E0085B53E /* MissingDocsRule.swift in Sources */,
 				D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */,
 				62A498561F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift in Sources */,
 				29AD4C661F6EA1D5009B66E1 /* ContainsOverFirstNotNilRule.swift in Sources */,
@@ -1923,6 +1935,7 @@
 				D4F5851720E99B260085C6D8 /* StatementPositionRuleTests.swift in Sources */,
 				1EB7C8531F0C45C2004BAD22 /* ModifierOrderTests.swift in Sources */,
 				67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */,
+				F90DBD812092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift in Sources */,
 				C25EBBDF2107884200E27603 /* PrefixedTopLevelConstantRuleTests.swift in Sources */,
 				D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */,
 				787CDE3B208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1166,10 +1166,10 @@ extension ValidIBInspectableRuleTests {
 extension VerticalParameterAlignmentOnCallRuleTests {
     static var allTests: [(String, (VerticalParameterAlignmentOnCallRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
-extension VerticalParameterAlignmentRuleTests {
     ]
 }
 
+extension VerticalParameterAlignmentRuleTests {
     static var allTests: [(String, (VerticalParameterAlignmentRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -401,7 +401,10 @@ extension FileNameRuleTests {
         ("testExtensionNameDoesntTrigger", testExtensionNameDoesntTrigger),
         ("testMisspelledNameDoesTrigger", testMisspelledNameDoesTrigger),
         ("testMisspelledNameDoesntTriggerWithOverride", testMisspelledNameDoesntTriggerWithOverride),
-        ("testMainDoesTriggerWithoutOverride", testMainDoesTriggerWithoutOverride)
+        ("testMainDoesTriggerWithoutOverride", testMainDoesTriggerWithoutOverride),
+        ("testCustomSuffixPattern", testCustomSuffixPattern),
+        ("testCustomPrefixPattern", testCustomPrefixPattern),
+        ("testCustomPrefixAndSuffixPatterns", testCustomPrefixAndSuffixPatterns)
     ]
 }
 
@@ -616,6 +619,12 @@ extension LiteralExpressionEndIdentationRuleTests {
     ]
 }
 
+extension LowerACLThanParentRuleTests {
+    static var allTests: [(String, (LowerACLThanParentRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension MissingDocsRuleConfigurationTests {
     static var allTests: [(String, (MissingDocsRuleConfigurationTests) -> () throws -> Void)] = [
         ("testDescriptionEmpty", testDescriptionEmpty),
@@ -628,12 +637,6 @@ extension MissingDocsRuleConfigurationTests {
         ("testInvalidServety", testInvalidServety),
         ("testInvalidAcl", testInvalidAcl),
         ("testInvalidDuplicateAcl", testInvalidDuplicateAcl)
-    ]
-}
-
-extension LowerACLThanParentRuleTests {
-    static var allTests: [(String, (LowerACLThanParentRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]
 }
 
@@ -982,18 +985,6 @@ extension RulesTests {
         ("testPrefixedTopLevelConstant", testPrefixedTopLevelConstant),
         ("testPrivateAction", testPrivateAction),
         ("testPrivateOutlet", testPrivateOutlet),
-        ("testPrivateUnitTest", testPrivateUnitTest),
-        ("testProhibitedSuper", testProhibitedSuper),
-        ("testProtocolPropertyAccessorsOrder", testProtocolPropertyAccessorsOrder),
-        ("testQuickDiscouragedCall", testQuickDiscouragedCall),
-        ("testQuickDiscouragedFocusedTest", testQuickDiscouragedFocusedTest),
-        ("testQuickDiscouragedPendingTest", testQuickDiscouragedPendingTest),
-        ("testRedundantDiscardableLet", testRedundantDiscardableLet),
-        ("testRedundantNilCoalescing", testRedundantNilCoalescing),
-        ("testRedundantOptionalInitialization", testRedundantOptionalInitialization),
-        ("testRedundantSetAccessControl", testRedundantSetAccessControl),
-        ("testRedundantStringEnumValue", testRedundantStringEnumValue),
-        ("testRedundantVoidReturn", testRedundantVoidReturn),
         ("testRequiredEnumCase", testRequiredEnumCase),
         ("testTrailingNewline", testTrailingNewline)
     ]
@@ -1303,9 +1294,9 @@ XCTMain([
     testCase(LineLengthConfigurationTests.allTests),
     testCase(LineLengthRuleTests.allTests),
     testCase(LinterCacheTests.allTests),
-    testCase(MissingDocsRuleConfigurationTests.allTests),
     testCase(LiteralExpressionEndIdentationRuleTests.allTests),
     testCase(LowerACLThanParentRuleTests.allTests),
+    testCase(MissingDocsRuleConfigurationTests.allTests),
     testCase(ModifierOrderTests.allTests),
     testCase(MultilineArgumentsRuleTests.allTests),
     testCase(MultilineFunctionChainsRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -616,6 +616,21 @@ extension LiteralExpressionEndIdentationRuleTests {
     ]
 }
 
+extension MissingDocsRuleConfigurationTests {
+    static var allTests: [(String, (MissingDocsRuleConfigurationTests) -> () throws -> Void)] = [
+        ("testDescriptionEmpty", testDescriptionEmpty),
+        ("testDescriptionSingleServety", testDescriptionSingleServety),
+        ("testDescriptionMultipleSeverities", testDescriptionMultipleSeverities),
+        ("testDescriptionMultipleAcls", testDescriptionMultipleAcls),
+        ("testParsingSingleServety", testParsingSingleServety),
+        ("testParsingMultipleSeverities", testParsingMultipleSeverities),
+        ("testParsingMultipleAcls", testParsingMultipleAcls),
+        ("testInvalidServety", testInvalidServety),
+        ("testInvalidAcl", testInvalidAcl),
+        ("testInvalidDuplicateAcl", testInvalidDuplicateAcl)
+    ]
+}
+
 extension LowerACLThanParentRuleTests {
     static var allTests: [(String, (LowerACLThanParentRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -950,6 +965,35 @@ extension RulesTests {
     static var allTests: [(String, (RulesTests) -> () throws -> Void)] = [
         ("testLeadingWhitespace", testLeadingWhitespace),
         ("testMark", testMark),
+        ("testMissingDocs", testMissingDocs),
+        ("testModifierOrder", testModifierOrder),
+        ("testMultilineParameters", testMultilineParameters),
+        ("testMultipleClosuresWithTrailingClosure", testMultipleClosuresWithTrailingClosure),
+        ("testNesting", testNesting),
+        ("testNoExtensionAccessModifier", testNoExtensionAccessModifier),
+        ("testNoGroupingExtension", testNoGroupingExtension),
+        ("testNotificationCenterDetachment", testNotificationCenterDetachment),
+        ("testNimbleOperator", testNimbleOperator),
+        ("testOpeningBrace", testOpeningBrace),
+        ("testOperatorFunctionWhitespace", testOperatorFunctionWhitespace),
+        ("testOperatorUsageWhitespace", testOperatorUsageWhitespace),
+        ("testOverrideInExtension", testOverrideInExtension),
+        ("testPatternMatchingKeywords", testPatternMatchingKeywords),
+        ("testPrefixedTopLevelConstant", testPrefixedTopLevelConstant),
+        ("testPrivateAction", testPrivateAction),
+        ("testPrivateOutlet", testPrivateOutlet),
+        ("testPrivateUnitTest", testPrivateUnitTest),
+        ("testProhibitedSuper", testProhibitedSuper),
+        ("testProtocolPropertyAccessorsOrder", testProtocolPropertyAccessorsOrder),
+        ("testQuickDiscouragedCall", testQuickDiscouragedCall),
+        ("testQuickDiscouragedFocusedTest", testQuickDiscouragedFocusedTest),
+        ("testQuickDiscouragedPendingTest", testQuickDiscouragedPendingTest),
+        ("testRedundantDiscardableLet", testRedundantDiscardableLet),
+        ("testRedundantNilCoalescing", testRedundantNilCoalescing),
+        ("testRedundantOptionalInitialization", testRedundantOptionalInitialization),
+        ("testRedundantSetAccessControl", testRedundantSetAccessControl),
+        ("testRedundantStringEnumValue", testRedundantStringEnumValue),
+        ("testRedundantVoidReturn", testRedundantVoidReturn),
         ("testRequiredEnumCase", testRequiredEnumCase),
         ("testTrailingNewline", testTrailingNewline)
     ]
@@ -1122,10 +1166,10 @@ extension ValidIBInspectableRuleTests {
 extension VerticalParameterAlignmentOnCallRuleTests {
     static var allTests: [(String, (VerticalParameterAlignmentOnCallRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+extension VerticalParameterAlignmentRuleTests {
     ]
 }
 
-extension VerticalParameterAlignmentRuleTests {
     static var allTests: [(String, (VerticalParameterAlignmentRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]
@@ -1259,6 +1303,7 @@ XCTMain([
     testCase(LineLengthConfigurationTests.allTests),
     testCase(LineLengthRuleTests.allTests),
     testCase(LinterCacheTests.allTests),
+    testCase(MissingDocsRuleConfigurationTests.allTests),
     testCase(LiteralExpressionEndIdentationRuleTests.allTests),
     testCase(LowerACLThanParentRuleTests.allTests),
     testCase(ModifierOrderTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
@@ -1,0 +1,68 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class MissingDocsRuleConfigurationTests: XCTestCase {
+
+    func testDescriptionEmpty() {
+        let configuration = MissingDocsRuleConfiguration()
+        XCTAssertEqual(configuration.consoleDescription, "")
+    }
+
+    func testDescriptionSingleServety() {
+        let configuration = MissingDocsRuleConfiguration(
+            parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
+        XCTAssertEqual(configuration.consoleDescription, "error: open")
+    }
+
+    func testDescriptionMultipleSeverities() {
+        let configuration = MissingDocsRuleConfiguration(
+            parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open),
+                         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
+        XCTAssertEqual(configuration.consoleDescription, "error: open, warning: public")
+    }
+
+    func testDescriptionMultipleAcls() {
+        let configuration = MissingDocsRuleConfiguration(
+            parameters: [RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
+                         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
+        XCTAssertEqual(configuration.consoleDescription, "warning: open, public")
+    }
+
+    func testParsingSingleServety() {
+        var configuration = MissingDocsRuleConfiguration()
+        try? configuration.apply(configuration: ["warning": "open"])
+        XCTAssertEqual(configuration.parameters, [RuleParameter<AccessControlLevel>(severity: .warning, value: .open)])
+    }
+
+    func testParsingMultipleSeverities() {
+        var configuration = MissingDocsRuleConfiguration()
+        try? configuration.apply(configuration: ["warning": "public", "error": "open"])
+        XCTAssertEqual(configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
+                       [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+                        RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
+    }
+
+    func testParsingMultipleAcls() {
+        var configuration = MissingDocsRuleConfiguration()
+        try? configuration.apply(configuration: ["warning": ["public", "open"]])
+        XCTAssertEqual(configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
+                       [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+                        RuleParameter<AccessControlLevel>(severity: .warning, value: .open)])
+    }
+
+    func testInvalidServety() {
+        var configuration = MissingDocsRuleConfiguration()
+        XCTAssertThrowsError(try configuration.apply(configuration: ["warning": ["public", "closed"]]))
+    }
+
+    func testInvalidAcl() {
+        var configuration = MissingDocsRuleConfiguration()
+        XCTAssertThrowsError(try configuration.apply(configuration: ["debug": ["public", "open"]]))
+    }
+
+    func testInvalidDuplicateAcl() {
+        var configuration = MissingDocsRuleConfiguration()
+        XCTAssertThrowsError(try configuration.apply(configuration: ["warning": ["public", "open"], "error": "public"]))
+    }
+
+}

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -11,6 +11,85 @@ class RulesTests: XCTestCase {
         verifyRule(MarkRule.description, skipCommentTests: true)
     }
 
+    func testMissingDocs() {
+        verifyRule(MissingDocsRule.description)
+    }
+
+    func testModifierOrder() {
+        verifyRule(ModifierOrderRule.description)
+    }
+
+    func testMultilineParameters() {
+        verifyRule(MultilineParametersRule.description)
+    }
+
+    func testMultipleClosuresWithTrailingClosure() {
+        verifyRule(MultipleClosuresWithTrailingClosureRule.description)
+    }
+
+    func testNesting() {
+        verifyRule(NestingRule.description)
+    }
+
+    func testNoExtensionAccessModifier() {
+        verifyRule(NoExtensionAccessModifierRule.description)
+    }
+
+    func testNoGroupingExtension() {
+        verifyRule(NoGroupingExtensionRule.description)
+    }
+
+    func testNotificationCenterDetachment() {
+        verifyRule(NotificationCenterDetachmentRule.description)
+    }
+
+    func testNimbleOperator() {
+        verifyRule(NimbleOperatorRule.description)
+    }
+
+    func testOpeningBrace() {
+        verifyRule(OpeningBraceRule.description)
+    }
+
+    func testOperatorFunctionWhitespace() {
+        verifyRule(OperatorFunctionWhitespaceRule.description)
+    }
+
+    func testOperatorUsageWhitespace() {
+        verifyRule(OperatorUsageWhitespaceRule.description)
+    }
+
+    func testOverrideInExtension() {
+        verifyRule(OverrideInExtensionRule.description)
+    }
+
+    func testPatternMatchingKeywords() {
+        verifyRule(PatternMatchingKeywordsRule.description)
+    }
+
+    func testPrefixedTopLevelConstant() {
+        verifyRule(PrefixedTopLevelConstantRule.description)
+    }
+
+    func testPrivateAction() {
+        verifyRule(PrivateActionRule.description)
+    }
+
+    func testPrivateOutlet() {
+        verifyRule(PrivateOutletRule.description)
+
+        let baseDescription = PrivateOutletRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
+            "class Foo {\n  @IBOutlet private(set) var label: UILabel?\n}\n",
+            "class Foo {\n  @IBOutlet private(set) var label: UILabel!\n}\n",
+            "class Foo {\n  @IBOutlet weak private(set) var label: UILabel?\n}\n",
+            "class Foo {\n  @IBOutlet private(set) weak var label: UILabel?\n}\n"
+        ]
+
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
+        verifyRule(description, ruleConfiguration: ["allow_private_set": true])
+    }
+
     func testRequiredEnumCase() {
         let configuration = ["NetworkResponsable": ["notConnected": "error"]]
         verifyRule(RequiredEnumCaseRule.description, ruleConfiguration: configuration)


### PR DESCRIPTION
Patch created from Nef10 (https://github.com/Nef10/SwiftLint.git) missing_docs branch, to remove merge commits that were preventing merging the PR (https://github.com/realm/SwiftLint/pull/2172).

These are not my changes, all credit goes to Nef10 (https://github.com/Nef10). This is replacing his PR (PR 2172: https://github.com/realm/SwiftLint/pull/2172), which couldn't be merged due to containing merge commits. I attempted to rebase his branch, but kept running into merge conflicts that I didn't know how to resolve. This is simply a patch created from the final git diff of his work.