### PR TITLE
Improve line_length rule performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 #### Enhancements
 
-* None.
+* Improve performance of `line_length` rule.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
 
 #### Bug Fixes
 


### PR DESCRIPTION
Don’t calculate `swiftDeclarationKindsByLine` and `syntaxKindsByLine` if it’s not needed:

- When there are no lines that would trigger a violation
- When no configuration parameter that needs that information is set (e.g. the default configuration)

This rule was taking ~1s on a real project and now it takes ~0.025s.