### PR TITLE
Improve empty_parentheses_with_trailing_closure performance on Swift 4.2

### DIFF
--- a/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/EmptyParenthesesWithTrailingClosureRule.swift
@@ -70,6 +70,12 @@ public struct EmptyParenthesesWithTrailingClosureRule: ASTRule, CorrectableRule,
                 return []
         }
 
+        // avoid the more expensive regex match if there's no trailing closure in the substructure
+        if SwiftVersion.current >= .fourDotTwo,
+            dictionary.substructure.last?.kind.flatMap(SwiftExpressionKind.init(rawValue:)) != .closure {
+            return []
+        }
+
         let rangeStart = nameOffset + nameLength
         let rangeLength = (offset + length) - (nameOffset + nameLength)
         let regex = EmptyParenthesesWithTrailingClosureRule.emptyParenthesesRegex


### PR DESCRIPTION
This reduced the time spent on this rule from ~1.1s to ~0.450s on a real project when linting with Swift 4.2.