### PR TITLE
Improve performance of multiple_closures_with_trailing_closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 #### Enhancements
 
-* Improve performance of `line_length` rule.  
+* Improve performance of `line_length` and
+  `multiple_closures_with_trailing_closure` rules.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
 #### Bug Fixes


### PR DESCRIPTION
This was taking ~1.3s on a real project. Now it takes ~0.6s when using Swift 4.1 and ~0.4 when using Swift 4.2 (as it avoids regexes completely) 🚀 