### PR TITLE
Internal and Internal Set added

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -2,7 +2,9 @@ import Foundation
 import SourceKittenFramework
 
 public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = PrivateOutletRuleConfiguration(allowPrivateSet: false)
+    public var configuration = PrivateOutletRuleConfiguration(allowPrivateSet: false,
+                                                              allowInternal: false,
+                                                              allowInternalSet: false)
 
     public init() {}
 
@@ -38,7 +40,14 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
         let isPrivate = isPrivateLevel(identifier: dictionary.accessibility)
         let isPrivateSet = isPrivateLevel(identifier: dictionary.setterAccessibility)
 
-        if isPrivate || (configuration.allowPrivateSet && isPrivateSet) {
+        // Check if internal
+        let isInternal = isInternalLevel(identifier: dictionary.accessibility)
+        let isInternalSet = isInternalLevel(identifier: dictionary.setterAccessibility)
+
+        if isPrivate ||
+            (configuration.allowPrivateSet && isPrivateSet) ||
+            (configuration.allowInternal && isInternal) ||
+            (configuration.allowInternalSet && isInternalSet) {
             return []
         }
 
@@ -59,5 +68,9 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
     private func isPrivateLevel(identifier: String?) -> Bool {
         return identifier.flatMap(AccessControlLevel.init(identifier:))?.isPrivate ?? false
+    }
+
+    private func isInternalLevel(identifier: String?) -> Bool {
+        return identifier.flatMap(AccessControlLevel.init(identifier:)) == .internal
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -3,13 +3,20 @@ import Foundation
 public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.warning)
     var allowPrivateSet = false
+    var allowInternal = false
+    var allowInternalSet = false
 
     public var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", allow_private_set: \(allowPrivateSet)"
+        return severityConfiguration.consoleDescription +
+            ", allow_private_set: \(allowPrivateSet)" +
+            ", allow_internal: \(allowInternal)" +
+        ", allow_internal_set: \(allowInternalSet)"
     }
 
-    public init(allowPrivateSet: Bool) {
+    public init(allowPrivateSet: Bool, allowInternal: Bool, allowInternalSet: Bool) {
         self.allowPrivateSet = allowPrivateSet
+        self.allowInternal = allowInternal
+        self.allowInternalSet = allowInternalSet
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -18,6 +25,8 @@ public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
         }
 
         allowPrivateSet = (configuration["allow_private_set"] as? Bool == true)
+        allowInternal = (configuration["allow_internal"] as? Bool == true)
+        allowInternalSet = (configuration["allow_internal_set"] as? Bool == true)
 
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)
@@ -28,5 +37,7 @@ public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
 public func == (lhs: PrivateOutletRuleConfiguration,
                 rhs: PrivateOutletRuleConfiguration) -> Bool {
     return lhs.allowPrivateSet == rhs.allowPrivateSet &&
+        lhs.allowInternal == rhs.allowInternal &&
+        lhs.allowInternalSet == rhs.allowInternalSet &&
         lhs.severityConfiguration == rhs.severityConfiguration
 }


### PR DESCRIPTION
Internal access level didn't cause leak of UI components to higher layers, so it can be safely turned on if it is necessary