### PR TITLE
New Rule - Toggle Bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2123](https://github.com/realm/SwiftLint/issues/2123)
 
+* Add `toggle_bool` opt-in rule which suggests using `Bool.toggle()` over 
+  `someBool = !someBool`. Requires Swift 4.2.
+  [Dalton Claybrook](https://github.com/daltonclaybrook)
+  [#2369](https://github.com/realm/SwiftLint/issues/2369)
+
 #### Bug Fixes
 
 * Fix `comma` rule false positives on object literals (for example, images).  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2123](https://github.com/realm/SwiftLint/issues/2123)
 
-* Add `toggle_bool` opt-in rule which suggests using `Bool.toggle()` over
+* Add `toggle_bool` opt-in rule which suggests using `someBool.toggle()` over
   `someBool = !someBool`. Requires Swift 4.2.  
   [Dalton Claybrook](https://github.com/daltonclaybrook)
   [#2369](https://github.com/realm/SwiftLint/issues/2369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2123](https://github.com/realm/SwiftLint/issues/2123)
 
-* Add `toggle_bool` opt-in rule which suggests using `Bool.toggle()` over 
-  `someBool = !someBool`. Requires Swift 4.2.
+* Add `toggle_bool` opt-in rule which suggests using `Bool.toggle()` over
+  `someBool = !someBool`. Requires Swift 4.2.  
   [Dalton Claybrook](https://github.com/daltonclaybrook)
   [#2369](https://github.com/realm/SwiftLint/issues/2369)
 

--- a/Rules.md
+++ b/Rules.md
@@ -121,6 +121,7 @@
 * [Switch Case on Newline](#switch-case-on-newline)
 * [Syntactic Sugar](#syntactic-sugar)
 * [Todo](#todo)
+* [Toggle Bool](#toggle-bool)
 * [Trailing Closure](#trailing-closure)
 * [Trailing Comma](#trailing-comma)
 * [Trailing Newline](#trailing-newline)
@@ -15701,6 +15702,55 @@ TODOs and FIXMEs should be resolved.
 ```swift
 /** ↓TODO: */
 
+```
+
+</details>
+
+
+
+## Toggle Bool
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift Compiler Version
+--- | --- | --- | --- | ---
+`toggle_bool` | Disabled | No | idiomatic | 4.2.0 
+
+Prefer `Bool.toggle()` over `someBool = !someBool`.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+isHidden.toggle()
+
+```
+
+```swift
+view.clipsToBounds.toggle()
+
+```
+
+```swift
+func foo() { abc.toggle() }
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+isHidden = ↓!isHidden
+
+```
+
+```swift
+view.clipsToBounds = ↓!view.clipsToBounds
+
+```
+
+```swift
+func foo() { abc = ↓!abc }
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -15740,17 +15740,17 @@ func foo() { abc.toggle() }
 <summary>Triggering Examples</summary>
 
 ```swift
-isHidden = ↓!isHidden
+↓isHidden = !isHidden
 
 ```
 
 ```swift
-view.clipsToBounds = ↓!view.clipsToBounds
+↓view.clipsToBounds = !view.clipsToBounds
 
 ```
 
 ```swift
-func foo() { abc = ↓!abc }
+func foo() { ↓abc = !abc }
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -15714,7 +15714,7 @@ Identifier | Enabled by default | Supports autocorrection | Kind | Minimum Swift
 --- | --- | --- | --- | ---
 `toggle_bool` | Disabled | No | idiomatic | 4.2.0 
 
-Prefer `Bool.toggle()` over `someBool = !someBool`.
+Prefer `someBool.toggle()` over `someBool = !someBool`.
 
 ### Examples
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.13.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.14.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
@@ -122,6 +122,7 @@ public let masterRuleList = RuleList(rules: [
     SwitchCaseOnNewlineRule.self,
     SyntacticSugarRule.self,
     TodoRule.self,
+    ToggleBoolRule.self,
     TrailingClosureRule.self,
     TrailingCommaRule.self,
     TrailingNewlineRule.self,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -8,7 +8,7 @@ public struct ToggleBoolRule: ConfigurationProviderRule, OptInRule, AutomaticTes
     public static var description = RuleDescription(
         identifier: "toggle_bool",
         name: "Toggle Bool",
-        description: "Prefer `Bool.toggle()` over `someBool = !someBool`.",
+        description: "Prefer `someBool.toggle()` over `someBool = !someBool`.",
         kind: .idiomatic,
         minSwiftVersion: .fourDotTwo,
         nonTriggeringExamples: [

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -1,0 +1,35 @@
+import SourceKittenFramework
+
+public struct ToggleBoolRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static var description = RuleDescription(
+        identifier: "toggle_bool",
+        name: "Toggle Bool",
+        description: "Prefer `Bool.toggle()` over `someBool = !someBool`.",
+        kind: .idiomatic,
+        minSwiftVersion: .fourDotTwo,
+        nonTriggeringExamples: [
+            "isHidden.toggle()\n",
+            "view.clipsToBounds.toggle()\n",
+            "func foo() { abc.toggle() }"
+        ],
+        triggeringExamples: [
+            "isHidden = ↓!isHidden\n",
+            "view.clipsToBounds = ↓!view.clipsToBounds\n",
+            "func foo() { abc = ↓!abc }"
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        let pattern = "\\b([\\w.]+) = !\\1\\b"
+        let excludingKinds = SyntaxKind.commentAndStringKinds
+        return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -17,9 +17,9 @@ public struct ToggleBoolRule: ConfigurationProviderRule, OptInRule, AutomaticTes
             "func foo() { abc.toggle() }"
         ],
         triggeringExamples: [
-            "isHidden = ↓!isHidden\n",
-            "view.clipsToBounds = ↓!view.clipsToBounds\n",
-            "func foo() { abc = ↓!abc }"
+            "↓isHidden = !isHidden\n",
+            "↓view.clipsToBounds = !view.clipsToBounds\n",
+            "func foo() { ↓abc = !abc }"
         ]
     )
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		7250948A1D0859260039B353 /* StatementModeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725094881D0855760039B353 /* StatementModeConfiguration.swift */; };
 		72EA17B61FD31F10009D5CE6 /* ExplicitACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */; };
 		740DF1B1203F62BB0081F694 /* EmptyStringRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */; };
+		7551DF6D21382C9A00AA1F4D /* ToggleBoolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7551DF6C21382C9A00AA1F4D /* ToggleBoolRule.swift */; };
 		787CDE39208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */; };
 		787CDE3B208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */; };
 		78F032461D7C877E00BE709A /* OverriddenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */; };
@@ -532,6 +533,7 @@
 		725094881D0855760039B353 /* StatementModeConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementModeConfiguration.swift; sourceTree = "<group>"; };
 		72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitACLRule.swift; sourceTree = "<group>"; };
 		740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyStringRule.swift; sourceTree = "<group>"; };
+		7551DF6C21382C9A00AA1F4D /* ToggleBoolRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleBoolRule.swift; sourceTree = "<group>"; };
 		787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentConfiguration.swift; sourceTree = "<group>"; };
 		787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentRuleTests.swift; sourceTree = "<group>"; };
 		78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverriddenSuperCallRule.swift; sourceTree = "<group>"; };
@@ -1092,6 +1094,7 @@
 				D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */,
 				D42B45D81F0AF5E30086B683 /* StrictFilePrivateRule.swift */,
 				D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */,
+				7551DF6C21382C9A00AA1F4D /* ToggleBoolRule.swift */,
 				E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */,
 				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
 				D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */,
@@ -1920,6 +1923,7 @@
 				E83530C61ED6328A00FBAF79 /* FileNameRule.swift in Sources */,
 				3BB47D831C514E8100AE6A10 /* RegexConfiguration.swift in Sources */,
 				D401D9261ED85EF0005DA5D4 /* RuleKind.swift in Sources */,
+				7551DF6D21382C9A00AA1F4D /* ToggleBoolRule.swift in Sources */,
 				626B01B620A173F100D2C42F /* EmptyXCTestMethodRuleExamples.swift in Sources */,
 				D4C889711E385B7B00BAE88D /* RedundantDiscardableLetRule.swift in Sources */,
 				D4D1B9BB1EAC2C910028BE6A /* AccessControlLevel.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.13.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.14.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -1090,6 +1090,12 @@ extension TodoRuleTests {
     ]
 }
 
+extension ToggleBoolRuleTests {
+    static var allTests: [(String, (ToggleBoolRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension TrailingClosureRuleTests {
     static var allTests: [(String, (TrailingClosureRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1384,6 +1390,7 @@ XCTMain([
     testCase(SwitchCaseOnNewlineRuleTests.allTests),
     testCase(SyntacticSugarRuleTests.allTests),
     testCase(TodoRuleTests.allTests),
+    testCase(ToggleBoolRuleTests.allTests),
     testCase(TrailingClosureRuleTests.allTests),
     testCase(TrailingCommaRuleTests.allTests),
     testCase(TrailingSemicolonRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.13.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.14.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import SwiftLintFramework
@@ -543,6 +543,12 @@ class SwitchCaseOnNewlineRuleTests: XCTestCase {
 class SyntacticSugarRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SyntacticSugarRule.description)
+    }
+}
+
+class ToggleBoolRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(ToggleBoolRule.description)
     }
 }
 


### PR DESCRIPTION
This PR adds a new rule for preferring `Bool.toggle()` over negation in Swift 4.2