### PR TITLE
Remove unused imports

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SourceKittenFramework
 
 extension Configuration {
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension Configuration {
     private enum Key: String {
         case cachePath = "cache_path"

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 extension Dictionary where Key: ExpressibleByStringLiteral {

--- a/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum SwiftExpressionKind: String {
     case call = "source.lang.swift.expr.call"
     case argument = "source.lang.swift.expr.argument"

--- a/Source/SwiftLintFramework/Helpers/NamespaceCollector.swift
+++ b/Source/SwiftLintFramework/Helpers/NamespaceCollector.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 struct NamespaceCollector {

--- a/Source/SwiftLintFramework/Models/AccessControlLevel.swift
+++ b/Source/SwiftLintFramework/Models/AccessControlLevel.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum AccessControlLevel: String, CustomStringConvertible {
     case `private` = "source.lang.swift.accessibility.private"
     case `fileprivate` = "source.lang.swift.accessibility.fileprivate"

--- a/Source/SwiftLintFramework/Models/ConfigurationError.swift
+++ b/Source/SwiftLintFramework/Models/ConfigurationError.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum ConfigurationError: Error {
     case unknownConfiguration
 }

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -1,4 +1,3 @@
-import Dispatch
 import Foundation
 import SourceKittenFramework
 

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -1,6 +1,3 @@
-import Foundation
-import SourceKittenFramework
-
 public struct Region: Equatable {
     public let start: Location
     public let end: Location

--- a/Source/SwiftLintFramework/Models/RuleIdentifier.swift
+++ b/Source/SwiftLintFramework/Models/RuleIdentifier.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral {
     case all
     case single(identifier: String)

--- a/Source/SwiftLintFramework/Models/RuleKind.swift
+++ b/Source/SwiftLintFramework/Models/RuleKind.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum RuleKind: String {
     case lint
     case idiomatic

--- a/Source/SwiftLintFramework/Models/RuleList.swift
+++ b/Source/SwiftLintFramework/Models/RuleList.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum RuleListError: Error {
     case duplicatedConfigurations(rule: Rule.Type)
 }

--- a/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct CheckstyleReporter: Reporter {
     public static let identifier = "checkstyle"
     public static let isRealtime = false

--- a/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct EmojiReporter: Reporter {
     public static let identifier = "emoji"
     public static let isRealtime = false

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct JUnitReporter: Reporter {
     public static let identifier = "junit"
     public static let isRealtime = false

--- a/Source/SwiftLintFramework/Reporters/SonarQubeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/SonarQubeReporter.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct SonarQubeReporter: Reporter {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct DiscouragedObjectLiteralRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct DiscouragedOptionalBooleanRuleExamples {
 
     static let nonTriggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct DiscouragedOptionalCollectionExamples {
 
     static let nonTriggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct LegacyConstantRuleExamples {
 
     static let nonTriggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct NoExtensionAccessModifierRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct RedundantSetAccessControlRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 private func children(of dict: [String: SourceKitRepresentable],

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct TypeNameRuleExamples {
 
     private static let types = ["class", "struct", "enum"]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct XCTFailMessageRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct DiscouragedDirectInitRule: ASTRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct EmptyXCTestMethodRuleExamples {
 
     static let nonTriggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct PrivateActionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // swiftlint:disable type_body_length
 
 internal struct QuickDiscouragedCallRuleExamples {

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct QuickDiscouragedFocusedTestRuleExamples {
     static let nonTriggeringExamples = [
         "class TotoTests: QuickSpec {\n" +

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct QuickDiscouragedPendingTestRuleExamples {
     static let nonTriggeringExamples = [
         "class TotoTests: QuickSpec {\n" +

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 /// Allows for Enums that conform to a protocol to require that a specific case be present.

--- a/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct SuperfluousDisableCommandRule: ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct ClosureBodyLengthRuleExamples {
     static let nonTriggeringExamples: [String] = [
         singleLineClosure(),

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct AttributesConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var alwaysOnSameLine = Set<String>()

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct ColonConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var flexibleRightSpacing = false

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct ConditionalReturnsOnNewlineConfiguration: RuleConfiguration {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var ifOnly = false

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 private enum ConfigurationKey: String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -1,6 +1,3 @@
-import Foundation
-import SourceKittenFramework
-
 private func toExplicitInitMethod(typeName: String) -> String {
     return "\(typeName).init"
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 private enum VariableKind: String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 private enum ConfigurationKey: String {
     case warning = "warning"
     case error = "error"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 private enum ConfigurationKey: String {
     case warning = "warning"
     case error = "error"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // swiftlint:disable:next type_name
 public enum ImplicitlyUnwrappedOptionalModeConfiguration: String {
     case all = "all"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct LineLengthRuleOptions: OptionSet {
     public let rawValue: Int
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
 
     private(set) var parameters = [RuleParameter<AccessControlLevel>]()

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 private enum ConfigurationKey: String {
     case severity = "severity"
     case firstArgumentLocation = "first_argument_location"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct NestingConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
         return "(type_level) \(typeLevel.shortConsoleDescription), " +

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct ObjectLiteralConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var imageLiteral = true

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct OverridenSuperCallConfiguration: RuleConfiguration, Equatable {
     private let defaultIncluded = [
         //NSObject

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrefixedConstantRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrefixedConstantRuleConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct PrefixedConstantRuleConfiguration: RuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.warning)
     var onlyPrivateMembers = false

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.warning)
     var allowPrivateSet = false

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct PrivateOverFilePrivateRuleConfiguration: RuleConfiguration, Equatable {
     public var severityConfiguration = SeverityConfiguration(.warning)
     public var validateExtensions = false

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SourceKittenFramework
 
 public struct PrivateUnitTestConfiguration: RuleConfiguration, Equatable, CacheDescriptionProvider {
     public let identifier: String

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct ProhibitedSuperConfiguration: RuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.warning)
     var excluded = [String]()

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
     struct RequiredCase: Equatable, Hashable {
         var name: String

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct SeverityConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
         return severity.rawValue

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
         let errorString: String

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementModeConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementModeConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum StatementModeConfiguration: String {
     case `default` = "default"
     case uncuddledElse = "uncuddled_else"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct TrailingCommaConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var mandatoryComma: Bool

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.warning)
     var ignoresEmptyLines = false

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct IdentifierNameRuleExamples {
     static let nonTriggeringExamples = [
         "let myLet = 0",

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct MultilineArgumentsRuleExamples {
     static let nonTriggeringExamples = [
         "foo()",

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // swiftlint:disable type_body_length
 
 internal struct MultilineParametersRuleExamples {

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct NumberSeparatorRuleExamples {
 
     static let nonTriggeringExamples: [String] = {

--- a/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule,

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/swiftlint/main.swift
+++ b/Source/swiftlint/main.swift
@@ -1,6 +1,5 @@
 import Commandant
 import Dispatch
-import Foundation
 import SwiftLintFramework
 
 DispatchQueue.global().async {


### PR DESCRIPTION
Generated by running the following with #2381:

```shell
$ # Ensure derived data for SwiftLint is clean
$ xcodebuild -workspace SwiftLint.xcworkspace -scheme swiftlint > xcodebuild.log
$ echo "included:
  - Source
analyzer_rules:
  - unused_import" > .swiftlint.yml
$ swift build -c release
$ .build/release/swiftlint analyze --autocorrect --compiler-log-path xcodebuild.log
```