### PR TITLE
Remove unused private declarations

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -116,7 +116,6 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
 }
 
 private extension SwiftDeclarationKind {
-
     var childsAreExemptFromACL: Bool {
         switch self {
         case .`associatedtype`, .enumcase, .enumelement, .functionAccessorAddress,
@@ -131,23 +130,6 @@ private extension SwiftDeclarationKind {
         case .`class`, .`enum`, .`extension`, .`extensionClass`, .`extensionEnum`,
              .extensionProtocol, .extensionStruct, .`struct`:
             return false
-        }
-    }
-
-    var shouldContainExplicitACL: Bool {
-        switch self {
-        case .`associatedtype`, .enumcase, .enumelement, .functionAccessorAddress,
-             .functionAccessorDidset, .functionAccessorGetter, .functionAccessorMutableaddress,
-             .functionAccessorSetter, .functionAccessorWillset, .functionDestructor, .genericTypeParam, .module,
-             .precedenceGroup, .varLocal, .varParameter:
-            return false
-        case .`class`, .`enum`, .`extension`, .`extensionClass`, .`extensionEnum`,
-             .extensionProtocol, .extensionStruct, .functionConstructor,
-             .functionFree, .functionMethodClass, .functionMethodInstance, .functionMethodStatic,
-             .functionOperator, .functionOperatorInfix, .functionOperatorPostfix, .functionOperatorPrefix,
-             .functionSubscript, .`protocol`, .`struct`, .`typealias`, .varClass,
-             .varGlobal, .varInstance, .varStatic:
-            return true
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -108,7 +108,6 @@ extension ClosureEndIndentationRule: CorrectableRule {
 extension ClosureEndIndentationRule {
 
     fileprivate struct Violation {
-        var location: Location
         var indentationRanges: (expected: NSRange, actual: NSRange)
         var endOffset: Int
         var range: NSRange
@@ -196,8 +195,7 @@ extension ClosureEndIndentationRule {
         var actualRange = file.lines[endLine - 1].range
         actualRange.length = actual
 
-        return Violation(location: Location(file: file, byteOffset: endOffset),
-                         indentationRanges: (expected: expectedRange, actual: actualRange),
+        return Violation(indentationRanges: (expected: expectedRange, actual: actualRange),
                          endOffset: endOffset,
                          range: NSRange(location: offset, length: length))
     }
@@ -257,8 +255,7 @@ extension ClosureEndIndentationRule {
         var actualRange = file.lines[endLine - 1].range
         actualRange.length = actual
 
-        return Violation(location: Location(file: file, byteOffset: endOffset),
-                         indentationRanges: (expected: expectedRange, actual: actualRange),
+        return Violation(indentationRanges: (expected: expectedRange, actual: actualRange),
                          endOffset: endOffset,
                          range: NSRange(location: offset, length: length))
     }

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -235,16 +235,4 @@ private extension File {
         }
         return -1
     }
-
-    // Zero-based line number for the given a character offset
-    func line(offset: Int, startFrom: Int = 0) -> Int {
-        for index in startFrom..<lines.count {
-            let line = lines[index]
-
-            if line.range.location + line.range.length > offset {
-                return index
-            }
-        }
-        return -1
-    }
 }

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -173,7 +173,6 @@ extension LiteralExpressionEndIdentationRule: CorrectableRule {
 
 extension LiteralExpressionEndIdentationRule {
     fileprivate struct Violation {
-        var location: Location
         var indentationRanges: (expected: NSRange, actual: NSRange)
         var endOffset: Int
         var range: NSRange
@@ -237,8 +236,7 @@ extension LiteralExpressionEndIdentationRule {
         var actualRange = file.lines[endLine - 1].range
         actualRange.length = actual
 
-        return Violation(location: Location(file: file, byteOffset: endOffset),
-                         indentationRanges: (expected: expectedRange, actual: actualRange),
+        return Violation(indentationRanges: (expected: expectedRange, actual: actualRange),
                          endOffset: endOffset,
                          range: NSRange(location: offset, length: length))
     }


### PR DESCRIPTION
Identified by running the following with #2385:

```shell
$ # Ensure derived data for SwiftLint is clean
$ xcodebuild -workspace SwiftLint.xcworkspace -scheme swiftlint > xcodebuild.log
$ echo "included:
  - Source
analyzer_rules:
  - unused_private_declaration" > .swiftlint.yml
$ swift run -c release swiftlint analyze --compiler-log-path xcodebuild.log
```