### PR TITLE
 Fix for isWarningThresholdBroken failing when threshold set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@
 
 #### Bug Fixes
 
+* Fix for isWarningThresholdBroken failing when threshold set to 0.  
+  [mrkd](https://github.com/mrkd)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/2403)
+
 * Fix `comma` rule false positives on object literals (for example, images).  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2345](https://github.com/realm/SwiftLint/issues/2345)

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -92,7 +92,7 @@ struct LintOrAnalyzeCommand {
                                                  violations: [StyleViolation]) -> Bool {
         guard let warningThreshold = configuration.warningThreshold else { return false }
         let numberOfWarningViolations = violations.filter({ $0.severity == .warning }).count
-        return numberOfWarningViolations >= warningThreshold
+        return numberOfWarningViolations > warningThreshold
     }
 
     private static func createThresholdViolation(threshold: Int) -> StyleViolation {


### PR DESCRIPTION
* Fix for isWarningThresholdBroken failing when threshold set to 0.  
  [mrkd](https://github.com/mrkd)
  [#issue_number](https://github.com/realm/SwiftLint/issues/2403)