### PR TITLE
#2423 - Fix EmptyCountRule for binary, octal and hexadecimal integer literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@
   [Ornithologist Coder](https://github.com/ornithocoder)
   [#2374](https://github.com/realm/SwiftLint/issues/2374)
 
+* Fix false positive on `empty_count` rule when assesing binary, octal and
+  hexadecimal integer literals.  
+  [Timofey Solonin](https://github.com/biboran)
+  [#2423](https://github.com/realm/SwiftLint/issues/2423)
+
 ## 0.27.0: Heavy Duty
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -4713,16 +4713,6 @@ var count = 0
 ```
 
 ```swift
-discount == 0
-
-```
-
-```swift
-order.discount == 0
-
-```
-
-```swift
 [Int]().count == 0xff
 
 ```
@@ -4734,6 +4724,16 @@ order.discount == 0
 
 ```swift
 [Int]().count == 0o07
+
+```
+
+```swift
+discount == 0
+
+```
+
+```swift
+order.discount == 0
 
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -4722,6 +4722,21 @@ order.discount == 0
 
 ```
 
+```swift
+[Int]().count == 0xff
+
+```
+
+```swift
+[Int]().count == 0b01
+
+```
+
+```swift
+[Int]().count == 0o07
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -4738,6 +4753,26 @@ order.discount == 0
 
 ```swift
 [Int]().↓count != 0
+
+```
+
+```swift
+[Int]().↓count == 0x0
+
+```
+
+```swift
+[Int]().↓count == 0x00_00
+
+```
+
+```swift
+[Int]().↓count == 0b00
+
+```
+
+```swift
+[Int]().↓count == 0o00
 
 ```
 

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
@@ -15,6 +15,9 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule, AutomaticTes
             "[Int]().isEmpty\n",
             "[Int]().count > 1\n",
             "[Int]().count == 1\n",
+            "[Int]().count == 0xff\n",
+            "[Int]().count == 0b01\n",
+            "[Int]().count == 0o07\n",
             "discount == 0\n",
             "order.discount == 0\n"
         ],
@@ -22,12 +25,16 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule, AutomaticTes
             "[Int]().↓count == 0\n",
             "[Int]().↓count > 0\n",
             "[Int]().↓count != 0\n",
+            "[Int]().↓count == 0x0\n",
+            "[Int]().↓count == 0x00_00\n",
+            "[Int]().↓count == 0b00\n",
+            "[Int]().↓count == 0o00\n",
             "↓count == 0\n"
         ]
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let pattern = "\\bcount\\s*(==|!=|<|<=|>|>=)\\s*0"
+        let pattern = "\\bcount\\s*(==|!=|<|<=|>|>=)\\s*0(\\b|([box][0_]+\\b){1})"
         let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: type(of: self).description,


### PR DESCRIPTION
As per #2423 
* Added condition to `empty_count` regex to check whether 0 ends the word or represents a 0 as a binary, decimal or hex