### PR TITLE
New Rule - Redundant XCTAssert Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
   `multiple_closures_with_trailing_closure` rules.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
+* Add `redundant_xctassert_parameter` opt-in rule to encourage the use
+  of XCTAssertTrue/False/Nil().  
+  [Josh Kaplan](https://github.com/yhkaplan)
+
 * Add `closure_body_length` opt-in rule to enforce the maximum number
   of lines a closure should have. Requires Swift 4.2.  
   [Ornithologist Coder](https://github.com/ornithocoder)

--- a/Rules.md
+++ b/Rules.md
@@ -15092,6 +15092,16 @@ XCTAssertEqual(tested, expected)
 ```
 
 ```swift
+XCTAssertEqual(functionWithArgumentSupplied(animated: false), tested)
+
+```
+
+```swift
+XCTAssertEqual(tested, functionWithArgumentSupplied(data: nil))
+
+```
+
+```swift
 XCTAssertTrue(tested)
 
 ```

--- a/Rules.md
+++ b/Rules.md
@@ -111,6 +111,7 @@
 * [Redundant String Enum Value](#redundant-string-enum-value)
 * [Redundant Type Annotation](#redundant-type-annotation)
 * [Redundant Void Return](#redundant-void-return)
+* [Redundant XCTAssert Parameter](#redundant-xctassert-parameter)
 * [Required Enum Case](#required-enum-case)
 * [Returning Whitespace](#returning-whitespace)
 * [Shorthand Operator](#shorthand-operator)
@@ -15065,6 +15066,113 @@ func foo()↓ -> () {}
 protocol Foo {
  func foo()↓ -> ()
 }
+
+```
+
+</details>
+
+
+
+## Redundant XCTAssert Parameter
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`redundant_xctassert_parameter` | Disabled | No | idiomatic | No | 3.0.0 
+
+XCTAssertNil/True/False() are preferred over using nil, true, or false as parameters.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+XCTAssertEqual(tested, expected)
+
+```
+
+```swift
+XCTAssertTrue(tested)
+
+```
+
+```swift
+XCTAssertFalse(tested)
+
+```
+
+```swift
+XCTAssertNil(tested)
+
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+↓XCTAssertEqual(tested, nil)
+
+```
+
+```swift
+↓XCTAssertEqual(tested, true)
+
+```
+
+```swift
+↓XCTAssertEqual(tested, false)
+
+```
+
+```swift
+↓XCTAssertEqual(nil, tested)
+
+```
+
+```swift
+↓XCTAssertEqual(true, tested)
+
+```
+
+```swift
+↓XCTAssertEqual(false, tested)
+
+```
+
+```swift
+↓XCTAssertEqual(reallyLongObjectName.parameter.toBeTested,
+ nil)
+
+```
+
+```swift
+↓XCTAssertEqual(reallyLongObjectName.parameter.toBeTested,
+ true)
+
+```
+
+```swift
+↓XCTAssertEqual(reallyLongObjectName.parameter.toBeTested,
+ false)
+
+```
+
+```swift
+↓XCTAssertEqual(nil,
+ reallyLongObjectName.parameter.toBeTested)
+
+```
+
+```swift
+↓XCTAssertEqual(true,
+ reallyLongObjectName.parameter.toBeTested)
+
+```
+
+```swift
+↓XCTAssertEqual(false,
+ reallyLongObjectName.parameter.toBeTested)
 
 ```
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.14.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
@@ -112,6 +112,7 @@ public let masterRuleList = RuleList(rules: [
     RedundantStringEnumValueRule.self,
     RedundantTypeAnnotationRule.self,
     RedundantVoidReturnRule.self,
+    RedundantXCTAssertParameterRule.self,
     RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,
     ShorthandOperatorRule.self,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantXCTAssertParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantXCTAssertParameterRule.swift
@@ -14,6 +14,8 @@ public struct RedundantXCTAssertParameterRule: ASTRule, OptInRule, Configuration
         kind: .idiomatic,
         nonTriggeringExamples: [
             "XCTAssertEqual(tested, expected)\n",
+            "XCTAssertEqual(functionWithArgumentSupplied(animated: false), tested)\n",
+            "XCTAssertEqual(tested, functionWithArgumentSupplied(data: nil))\n",
             "XCTAssertTrue(tested)\n",
             "XCTAssertFalse(tested)\n",
             "XCTAssertNil(tested)\n"
@@ -84,7 +86,7 @@ public struct RedundantXCTAssertParameterRule: ASTRule, OptInRule, Configuration
             return false
         }
 
-        return regex("(true|false|nil)").firstMatch(in: string, options: [], range: range) != nil
+        return regex("^(true|false|nil)$").firstMatch(in: string, options: [], range: range) != nil
     }
 
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantXCTAssertParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantXCTAssertParameterRule.swift
@@ -81,7 +81,7 @@ public struct RedundantXCTAssertParameterRule: ASTRule, OptInRule, Configuration
 
         guard let offset = argument.offset,
             let length = argument.length,
-            let range = string.byteRangeToNSRange(start: offset, length: length) else {
+            let range = string.bridge().byteRangeToNSRange(start: offset, length: length) else {
 
             return false
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantXCTAssertParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantXCTAssertParameterRule.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SourceKittenFramework
+
+public struct RedundantXCTAssertParameterRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "redundant_xctassert_parameter",
+        name: "Redundant XCTAssert Parameter",
+        description: "XCTAssertNil/True/False() are preferred over using nil, true, or false as parameters.",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            "XCTAssertEqual(tested, expected)\n",
+            "XCTAssertTrue(tested)\n",
+            "XCTAssertFalse(tested)\n",
+            "XCTAssertNil(tested)\n"
+        ],
+        triggeringExamples: [
+            "↓XCTAssertEqual(tested, nil)\n",
+            "↓XCTAssertEqual(tested, true)\n",
+            "↓XCTAssertEqual(tested, false)\n",
+            "↓XCTAssertEqual(nil, tested)\n",
+            "↓XCTAssertEqual(true, tested)\n",
+            "↓XCTAssertEqual(false, tested)\n",
+            "↓XCTAssertEqual(reallyLongObjectName.parameter.toBeTested,\n nil)\n",
+            "↓XCTAssertEqual(reallyLongObjectName.parameter.toBeTested,\n true)\n",
+            "↓XCTAssertEqual(reallyLongObjectName.parameter.toBeTested,\n false)\n",
+            "↓XCTAssertEqual(nil,\n reallyLongObjectName.parameter.toBeTested)\n",
+            "↓XCTAssertEqual(true,\n reallyLongObjectName.parameter.toBeTested)\n",
+            "↓XCTAssertEqual(false,\n reallyLongObjectName.parameter.toBeTested)\n"
+        ]
+    )
+
+    public func validate(
+        file: File,
+        kind: SwiftExpressionKind,
+        dictionary: [String: SourceKitRepresentable]
+    ) -> [StyleViolation] {
+        guard containsViolation(file: file, kind: kind, dictionary: dictionary),
+            let offset = dictionary.offset else {
+                return []
+        }
+
+        let location = Location(file: file, byteOffset: offset)
+        return [
+            StyleViolation(
+                ruleDescription: type(of: self).description,
+                severity: configuration.severity,
+                location: location
+            )
+        ]
+    }
+
+    private func containsViolation(
+        file: File,
+        kind: SwiftExpressionKind,
+        dictionary: [String: SourceKitRepresentable]
+    ) -> Bool {
+        guard kind == .call,
+            dictionary.offset != nil,
+            let name = dictionary.name,
+            name.hasPrefix("XCTAssertEqual") else {
+                return false
+        }
+
+        for argument in dictionary.enclosedArguments {
+            if containsViolatingArgument(argument, for: file.contents) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func containsViolatingArgument(_ argument: [String: SourceKitRepresentable], for string: String) -> Bool {
+
+        guard let offset = argument.offset,
+            let length = argument.length,
+            let range = string.byteRangeToNSRange(start: offset, length: length) else {
+
+            return false
+        }
+
+        return regex("(true|false|nil)").firstMatch(in: string, options: [], range: range) != nil
+    }
+
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		92CCB2D71E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */; };
 		93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */; };
 		A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */; };
+		A3F7685821689AED007B7F46 /* RedundantXCTAssertParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F7685721689AED007B7F46 /* RedundantXCTAssertParameterRule.swift */; };
 		A73469421FB121BA009B57C7 /* CallPairRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73469401FB12149009B57C7 /* CallPairRule.swift */; };
 		B25DCD0B1F7E9F9E0028A199 /* MultilineArgumentsRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */; };
 		B25DCD0C1F7E9FA20028A199 /* MultilineArgumentsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */; };
@@ -579,6 +580,7 @@
 		92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRule.swift; sourceTree = "<group>"; };
 		93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineRule.swift; sourceTree = "<group>"; };
 		A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralConfiguration.swift; sourceTree = "<group>"; };
+		A3F7685721689AED007B7F46 /* RedundantXCTAssertParameterRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantXCTAssertParameterRule.swift; sourceTree = "<group>"; };
 		A73469401FB12149009B57C7 /* CallPairRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallPairRule.swift; sourceTree = "<group>"; };
 		B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRule.swift; sourceTree = "<group>"; };
 		B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRuleExamples.swift; sourceTree = "<group>"; };
@@ -1134,6 +1136,7 @@
 				181D9E162038343D001F6887 /* UntypedErrorInCatchRule.swift */,
 				D43B04631E0620AB004016AF /* UnusedEnumeratedRule.swift */,
 				626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */,
+				A3F7685721689AED007B7F46 /* RedundantXCTAssertParameterRule.swift */,
 			);
 			path = Idiomatic;
 			sourceTree = "<group>";
@@ -1897,6 +1900,7 @@
 				3BCC04D21C4F56D3006073C3 /* NameConfiguration.swift in Sources */,
 				D4C27BFE1E12D53F00DF713E /* Version.swift in Sources */,
 				B2902A0E1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift in Sources */,
+				A3F7685821689AED007B7F46 /* RedundantXCTAssertParameterRule.swift in Sources */,
 				D4DE9133207B4750000FFAA8 /* UnavailableFunctionRule.swift in Sources */,
 				D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */,
 				D462021F1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.14.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -933,6 +933,12 @@ extension RedundantVoidReturnRuleTests {
     ]
 }
 
+extension RedundantXCTAssertParameterRuleTests {
+    static var allTests: [(String, (RedundantXCTAssertParameterRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension RegionTests {
     static var allTests: [(String, (RegionTests) -> () throws -> Void)] = [
         ("testNoRegionsInEmptyFile", testNoRegionsInEmptyFile),
@@ -1408,6 +1414,7 @@ XCTMain([
     testCase(RedundantStringEnumValueRuleTests.allTests),
     testCase(RedundantTypeAnnotationRuleTests.allTests),
     testCase(RedundantVoidReturnRuleTests.allTests),
+    testCase(RedundantXCTAssertParameterRuleTests.allTests),
     testCase(RegionTests.allTests),
     testCase(ReporterTests.allTests),
     testCase(RequiredEnumCaseRuleTestCase.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.14.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import SwiftLintFramework
@@ -507,6 +507,12 @@ class RedundantTypeAnnotationRuleTests: XCTestCase {
 class RedundantVoidReturnRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantVoidReturnRule.description)
+    }
+}
+
+class RedundantXCTAssertParameterRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RedundantXCTAssertParameterRule.description)
     }
 }
 


### PR DESCRIPTION
This PR adds a new rule for preferring the use of `XCTAssertTrue/False/Nil()` when usable. I'm also considering adding auto-correct functionality.