### PR TITLE
Use default Equatable and Hashable implementations

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Configuration+IndentationStyle.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+IndentationStyle.swift
@@ -12,15 +12,5 @@ public extension Configuration {
             default: return nil
             }
         }
-
-        // MARK: Equatable
-
-        public static func == (lhs: IndentationStyle, rhs: IndentationStyle) -> Bool {
-            switch (lhs, rhs) {
-            case (.tabs, .tabs): return true
-            case let (.spaces(lhs), .spaces(rhs)): return lhs == rhs
-            case (_, _): return false
-            }
-        }
     }
 }

--- a/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/NSRegularExpression+SwiftLint.swift
@@ -6,13 +6,11 @@ private let regexCacheLock = NSLock()
 private struct RegexCacheKey: Hashable {
     let pattern: String
     let options: NSRegularExpression.Options
+}
 
-    var hashValue: Int {
-        return pattern.hashValue ^ options.rawValue.hashValue
-    }
-
-    static func == (lhs: RegexCacheKey, rhs: RegexCacheKey) -> Bool {
-        return lhs.options == rhs.options && lhs.pattern == rhs.pattern
+extension NSRegularExpression.Options: Hashable {
+    public var hashValue: Int {
+        return rawValue.hashValue
     }
 }
 

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -119,14 +119,4 @@ public struct Command: Equatable {
             ]
         }
     }
-
-    // MARK: Equatable
-
-    public static func == (lhs: Command, rhs: Command) -> Bool {
-        return lhs.action == rhs.action &&
-            lhs.ruleIdentifiers == rhs.ruleIdentifiers &&
-            lhs.line == rhs.line &&
-            lhs.character == rhs.character &&
-            lhs.modifier == rhs.modifier
-    }
 }

--- a/Source/SwiftLintFramework/Models/Correction.swift
+++ b/Source/SwiftLintFramework/Models/Correction.swift
@@ -5,11 +5,4 @@ public struct Correction: Equatable {
     public var consoleDescription: String {
         return "\(location) Corrected \(ruleDescription.name)"
     }
-
-    // MARK: Equatable
-
-    public static func == (lhs: Correction, rhs: Correction) -> Bool {
-        return lhs.ruleDescription == rhs.ruleDescription &&
-            lhs.location == rhs.location
-    }
 }

--- a/Source/SwiftLintFramework/Models/Location.swift
+++ b/Source/SwiftLintFramework/Models/Location.swift
@@ -45,14 +45,6 @@ public struct Location: CustomStringConvertible, Comparable {
         }
     }
 
-    // MARK: Comparable
-
-    public static func == (lhs: Location, rhs: Location) -> Bool {
-        return lhs.file == rhs.file &&
-            lhs.line == rhs.line &&
-            lhs.character == rhs.character
-    }
-
     public static func < (lhs: Location, rhs: Location) -> Bool {
         if lhs.file != rhs.file {
             return lhs.file < rhs.file

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -31,12 +31,4 @@ public struct Region: Equatable {
         let identifiers = type(of: rule).description.deprecatedAliases
         return Set(disabledRuleIdentifiers.map { $0.stringRepresentation }).intersection(identifiers)
     }
-
-    // MARK: Equatable
-
-    public static func == (lhs: Region, rhs: Region) -> Bool {
-        return lhs.start == rhs.start &&
-            lhs.end == rhs.end &&
-            lhs.disabledRuleIdentifiers == rhs.disabledRuleIdentifiers
-    }
 }

--- a/Source/SwiftLintFramework/Models/RuleIdentifier.swift
+++ b/Source/SwiftLintFramework/Models/RuleIdentifier.swift
@@ -4,10 +4,6 @@ public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral {
 
     private static let allStringRepresentation = "all"
 
-    public var hashValue: Int {
-        return stringRepresentation.hashValue
-    }
-
     public var stringRepresentation: String {
         switch self {
         case .all:
@@ -24,9 +20,5 @@ public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral {
 
     public init(stringLiteral value: String) {
         self = RuleIdentifier(value)
-    }
-
-    public static func == (lhs: RuleIdentifier, rhs: RuleIdentifier) -> Bool {
-        return lhs.stringRepresentation == rhs.stringRepresentation
     }
 }

--- a/Source/SwiftLintFramework/Models/RuleParameter.swift
+++ b/Source/SwiftLintFramework/Models/RuleParameter.swift
@@ -6,10 +6,4 @@ public struct RuleParameter<T: Equatable>: Equatable {
         self.severity = severity
         self.value = value
     }
-
-    // MARK: - Equatable
-
-    public static func == <T>(lhs: RuleParameter<T>, rhs: RuleParameter<T>) -> Bool {
-        return lhs.value == rhs.value && lhs.severity == rhs.severity
-    }
 }

--- a/Source/SwiftLintFramework/Models/StyleViolation.swift
+++ b/Source/SwiftLintFramework/Models/StyleViolation.swift
@@ -14,13 +14,4 @@ public struct StyleViolation: CustomStringConvertible, Equatable {
         self.location = location
         self.reason = reason ?? ruleDescription.description
     }
-
-    // MARK: Equatable
-
-    public static func == (lhs: StyleViolation, rhs: StyleViolation) -> Bool {
-        return lhs.ruleDescription == rhs.ruleDescription &&
-            lhs.location == rhs.location &&
-            lhs.severity == rhs.severity &&
-            lhs.reason == rhs.reason
-    }
 }

--- a/Source/SwiftLintFramework/Models/YamlParser.swift
+++ b/Source/SwiftLintFramework/Models/YamlParser.swift
@@ -5,13 +5,6 @@ import Yams
 
 internal enum YamlParserError: Error, Equatable {
     case yamlParsing(String)
-
-    static func == (lhs: YamlParserError, rhs: YamlParserError) -> Bool {
-        switch (lhs, rhs) {
-        case let (.yamlParsing(lhs), .yamlParsing(rhs)):
-            return lhs == rhs
-        }
-    }
 }
 
 // MARK: - YamlParser

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -32,11 +32,4 @@ public struct AttributesConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: AttributesConfiguration,
-                           rhs: AttributesConfiguration) -> Bool {
-        return lhs.severityConfiguration == rhs.severityConfiguration &&
-            lhs.alwaysOnSameLine == rhs.alwaysOnSameLine &&
-            lhs.alwaysOnNewLine == rhs.alwaysOnNewLine
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -19,10 +19,4 @@ public struct CollectionAlignmentConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: CollectionAlignmentConfiguration,
-                           rhs: CollectionAlignmentConfiguration) -> Bool {
-        return lhs.alignColons == rhs.alignColons &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -21,11 +21,4 @@ public struct ColonConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: ColonConfiguration,
-                           rhs: ColonConfiguration) -> Bool {
-        return lhs.severityConfiguration == rhs.severityConfiguration &&
-            lhs.flexibleRightSpacing == rhs.flexibleRightSpacing &&
-            lhs.applyToDictionaries == rhs.applyToDictionaries
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -1,4 +1,4 @@
-public struct ConditionalReturnsOnNewlineConfiguration: RuleConfiguration {
+public struct ConditionalReturnsOnNewlineConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var ifOnly = false
 
@@ -16,13 +16,5 @@ public struct ConditionalReturnsOnNewlineConfiguration: RuleConfiguration {
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)
         }
-    }
-}
-
-extension ConditionalReturnsOnNewlineConfiguration: Equatable {
-    public static func == (lhs: ConditionalReturnsOnNewlineConfiguration,
-                           rhs: ConditionalReturnsOnNewlineConfiguration) -> Bool {
-        return lhs.severityConfiguration == rhs.severityConfiguration &&
-            lhs.ifOnly == rhs.ifOnly
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -72,9 +72,4 @@ public struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
             throw ConfigurationError.unknownConfiguration
         }
     }
-
-    public static func == (lhs: CyclomaticComplexityConfiguration, rhs: CyclomaticComplexityConfiguration) -> Bool {
-        return lhs.length == rhs.length &&
-            lhs.ignoresCaseStatements == rhs.ignoresCaseStatements
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -39,10 +39,4 @@ public struct DiscouragedDirectInitConfiguration: RuleConfiguration, Equatable {
             discouragedInits = Set(types + types.map(toExplicitInitMethod))
         }
     }
-
-    // MARK: - Equatable
-
-    public static func == (lhs: DiscouragedDirectInitConfiguration, rhs: DiscouragedDirectInitConfiguration) -> Bool {
-        return lhs.discouragedInits == rhs.discouragedInits && lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -78,9 +78,4 @@ public struct ExplicitTypeInterfaceConfiguration: RuleConfiguration, Equatable {
             }
         }
     }
-
-    public static func == (lhs: ExplicitTypeInterfaceConfiguration, rhs: ExplicitTypeInterfaceConfiguration) -> Bool {
-        return lhs.allowedKinds == rhs.allowedKinds && lhs.severityConfiguration == rhs.severityConfiguration
-    }
-
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -133,9 +133,4 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
 
         return requiredPattern.flatMap { regexFromPattern(for: file, using: $0) }
     }
-
-    public static func == (lhs: FileHeaderConfiguration,
-                           rhs: FileHeaderConfiguration) -> Bool {
-        return lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
@@ -45,10 +45,4 @@ public struct FileLengthRuleConfiguration: RuleConfiguration, Equatable {
         }
 
     }
-
-    public static func == (lhs: FileLengthRuleConfiguration,
-                           rhs: FileLengthRuleConfiguration) -> Bool {
-        return lhs.ignoreCommentOnlyLines == rhs.ignoreCommentOnlyLines &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -35,11 +35,4 @@ public struct FileNameConfiguration: RuleConfiguration, Equatable {
             self.suffixPattern = suffixPattern
         }
     }
-
-    public static func == (lhs: FileNameConfiguration, rhs: FileNameConfiguration) -> Bool {
-        return lhs.severity == rhs.severity &&
-            lhs.excluded == rhs.excluded &&
-            lhs.prefixPattern == rhs.prefixPattern &&
-            lhs.suffixPattern == rhs.suffixPattern
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -44,10 +44,4 @@ public struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable 
             throw ConfigurationError.unknownConfiguration
         }
     }
-
-    public static func == (lhs: FunctionParameterCountConfiguration,
-                           rhs: FunctionParameterCountConfiguration) -> Bool {
-        return lhs.severityConfiguration == rhs.severityConfiguration &&
-            lhs.ignoresDefaultParameters == rhs.ignoresDefaultParameters
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -40,10 +40,4 @@ public struct ImplicitlyUnwrappedOptionalConfiguration: RuleConfiguration, Equat
             try severity.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: ImplicitlyUnwrappedOptionalConfiguration,
-                           rhs: ImplicitlyUnwrappedOptionalConfiguration) -> Bool {
-        return lhs.severity == rhs.severity &&
-            lhs.mode == rhs.mode
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -102,12 +102,4 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
             }
         }
     }
-
-    public static func == (lhs: LineLengthConfiguration, rhs: LineLengthConfiguration) -> Bool {
-        return lhs.length == rhs.length &&
-            lhs.ignoresURLs == rhs.ignoresURLs &&
-            lhs.ignoresComments == rhs.ignoresComments &&
-            lhs.ignoresFunctionDeclarations == rhs.ignoresFunctionDeclarations &&
-            lhs.ignoresInterpolatedStrings == rhs.ignoresInterpolatedStrings
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -33,8 +33,4 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
         }
         self.parameters = parameters
     }
-
-    public static func == (lhs: MissingDocsRuleConfiguration, rhs: MissingDocsRuleConfiguration) -> Bool {
-        return lhs.parameters == rhs.parameters
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -32,10 +32,4 @@ public struct ModifierOrderConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: ModifierOrderConfiguration,
-                           rhs: ModifierOrderConfiguration) -> Bool {
-        return lhs.preferredModifierOrder == rhs.preferredModifierOrder &&
-               lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -56,10 +56,4 @@ public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
             }
         }
     }
-
-    public static func == (lhs: MultilineArgumentsConfiguration,
-                           rhs: MultilineArgumentsConfiguration) -> Bool {
-        return lhs.severityConfiguration == rhs.severityConfiguration &&
-            lhs.firstArgumentLocation == rhs.firstArgumentLocation
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -67,14 +67,6 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
                 "\"validates_start_with_lowercase\" and will be removed in a future release.")
         }
     }
-
-    public static func == (lhs: NameConfiguration, rhs: NameConfiguration) -> Bool {
-        return lhs.minLength == rhs.minLength &&
-            lhs.maxLength == rhs.maxLength &&
-            zip(lhs.excluded, rhs.excluded).reduce(true) { $0 && ($1.0 == $1.1) } &&
-            zip(lhs.allowedSymbolsSet, rhs.allowedSymbolsSet).reduce(true) { $0 && ($1.0 == $1.1) } &&
-            lhs.validatesStartWithLowercase == rhs.validatesStartWithLowercase
-    }
 }
 
 // MARK: - ConfigurationProviderRule extensions

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -43,9 +43,4 @@ public struct NestingConfiguration: RuleConfiguration, Equatable {
         case .warning: return config.warning
         }
     }
-
-    public static func == (lhs: NestingConfiguration, rhs: NestingConfiguration) -> Bool {
-        return lhs.typeLevel == rhs.typeLevel
-            && lhs.statementLevel == rhs.statementLevel
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -37,11 +37,4 @@ public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: NumberSeparatorConfiguration,
-                           rhs: NumberSeparatorConfiguration) -> Bool {
-        return lhs.minimumLength == rhs.minimumLength &&
-            lhs.minimumFractionLength == rhs.minimumFractionLength &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -21,11 +21,4 @@ public struct ObjectLiteralConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: ObjectLiteralConfiguration,
-                           rhs: ObjectLiteralConfiguration) -> Bool {
-        return lhs.severityConfiguration == rhs.severityConfiguration &&
-            lhs.imageLiteral == rhs.imageLiteral &&
-            lhs.colorLiteral == rhs.colorLiteral
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
@@ -81,11 +81,4 @@ public struct OverridenSuperCallConfiguration: RuleConfiguration, Equatable {
         names = names.filter { !excluded.contains($0) }
         return names
     }
-
-    public static func == (lhs: OverridenSuperCallConfiguration,
-                           rhs: OverridenSuperCallConfiguration) -> Bool {
-        return lhs.excluded == rhs.excluded &&
-            lhs.included == rhs.included &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrefixedConstantRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrefixedConstantRuleConfiguration.swift
@@ -21,10 +21,4 @@ public struct PrefixedConstantRuleConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: PrefixedConstantRuleConfiguration,
-                           rhs: PrefixedConstantRuleConfiguration) -> Bool {
-        return lhs.onlyPrivateMembers == rhs.onlyPrivateMembers &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -21,10 +21,4 @@ public struct PrivateOutletRuleConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: PrivateOutletRuleConfiguration,
-                           rhs: PrivateOutletRuleConfiguration) -> Bool {
-        return lhs.allowPrivateSet == rhs.allowPrivateSet &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
@@ -19,12 +19,4 @@ public struct PrivateOverFilePrivateRuleConfiguration: RuleConfiguration, Equata
 
         validateExtensions = configuration["validate_extensions"] as? Bool ?? false
     }
-
-    // MARK: - Equatable
-
-    public static func == (lhs: PrivateOverFilePrivateRuleConfiguration,
-                           rhs: PrivateOverFilePrivateRuleConfiguration) -> Bool {
-        return lhs.validateExtensions == rhs.validateExtensions &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -56,12 +56,4 @@ public struct PrivateUnitTestConfiguration: RuleConfiguration, Equatable, CacheD
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: PrivateUnitTestConfiguration, rhs: PrivateUnitTestConfiguration) -> Bool {
-        return lhs.identifier == rhs.identifier &&
-            lhs.message == rhs.message &&
-            lhs.regex == rhs.regex &&
-            lhs.included?.pattern == rhs.included?.pattern &&
-            lhs.severity == rhs.severity
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -55,11 +55,4 @@ public struct ProhibitedSuperConfiguration: RuleConfiguration, Equatable {
         names = names.filter { !excluded.contains($0) }
         return names
     }
-
-    public static func == (lhs: ProhibitedSuperConfiguration,
-                           rhs: ProhibitedSuperConfiguration) -> Bool {
-        return lhs.excluded == rhs.excluded &&
-            lhs.included == rhs.included &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -75,14 +75,4 @@ public struct RegexConfiguration: RuleConfiguration, Equatable, CacheDescription
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: RegexConfiguration, rhs: RegexConfiguration) -> Bool {
-        return lhs.identifier == rhs.identifier &&
-            lhs.message == rhs.message &&
-            lhs.regex == rhs.regex &&
-            lhs.included?.pattern == rhs.included?.pattern &&
-            lhs.excluded?.pattern == rhs.excluded?.pattern &&
-            lhs.matchKinds == rhs.matchKinds &&
-            lhs.severity == rhs.severity
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
@@ -7,14 +7,6 @@ public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
             self.name = name
             self.severity = severity
         }
-
-        var hashValue: Int {
-            return name.hashValue
-        }
-
-        static func == (lhs: RequiredCase, rhs: RequiredCase) -> Bool {
-            return lhs.name == rhs.name && lhs.severity == rhs.severity
-        }
     }
 
     var protocols: [String: Set<RequiredCase>] = [:]
@@ -61,11 +53,5 @@ public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
         }
 
         protocols[name] = requiredCases
-    }
-
-    public static func == (lhs: RequiredEnumCaseRuleConfiguration,
-                           rhs: RequiredEnumCaseRuleConfiguration) -> Bool {
-
-        return lhs.protocols == rhs.protocols
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
@@ -22,8 +22,4 @@ public struct SeverityConfiguration: RuleConfiguration, Equatable {
     private func severity(fromString string: String) -> ViolationSeverity? {
         return ViolationSeverity(rawValue: string.lowercased())
     }
-
-    public static func == (lhs: SeverityConfiguration, rhs: SeverityConfiguration) -> Bool {
-        return lhs.severity == rhs.severity
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -39,8 +39,4 @@ public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {
             throw ConfigurationError.unknownConfiguration
         }
     }
-
-    public static func == (lhs: SeverityLevelsConfiguration, rhs: SeverityLevelsConfiguration) -> Bool {
-        return lhs.warning == rhs.warning && lhs.error == rhs.error
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementModeConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementModeConfiguration.swift
@@ -39,8 +39,4 @@ public struct StatementConfiguration: RuleConfiguration, Equatable {
             try severity.apply(configuration: severityConfiguration)
         }
     }
-
-    public static func == (lhs: StatementConfiguration, rhs: StatementConfiguration) -> Bool {
-        return lhs.statementMode == rhs.statementMode && lhs.severity == rhs.severity
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -19,10 +19,4 @@ public struct SwitchCaseAlignmentConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: SwitchCaseAlignmentConfiguration,
-                           rhs: SwitchCaseAlignmentConfiguration) -> Bool {
-        return lhs.indentedCases == rhs.indentedCases &&
-               lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -21,10 +21,4 @@ public struct TrailingCommaConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: TrailingCommaConfiguration,
-                           rhs: TrailingCommaConfiguration) -> Bool {
-        return lhs.mandatoryComma == rhs.mandatoryComma &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -26,11 +26,4 @@ public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: TrailingWhitespaceConfiguration,
-                           rhs: TrailingWhitespaceConfiguration) -> Bool {
-        return lhs.ignoresEmptyLines == rhs.ignoresEmptyLines &&
-            lhs.ignoresComments == rhs.ignoresComments &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -23,10 +23,4 @@ public struct UnusedOptionalBindingConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: UnusedOptionalBindingConfiguration,
-                           rhs: UnusedOptionalBindingConfiguration) -> Bool {
-        return lhs.ignoreOptionalTry == rhs.ignoreOptionalTry &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -23,10 +23,4 @@ public struct VerticalWhitespaceConfiguration: RuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
     }
-
-    public static func == (lhs: VerticalWhitespaceConfiguration,
-                           rhs: VerticalWhitespaceConfiguration) -> Bool {
-        return lhs.maxEmptyLines == rhs.maxEmptyLines &&
-            lhs.severityConfiguration == rhs.severityConfiguration
-    }
 }

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -39,10 +39,6 @@ public struct CustomRulesConfiguration: RuleConfiguration, Equatable, CacheDescr
             customRuleConfigurations.append(ruleConfiguration)
         }
     }
-
-    public static func == (lhs: CustomRulesConfiguration, rhs: CustomRulesConfiguration) -> Bool {
-        return lhs.customRuleConfigurations == rhs.customRuleConfigurations
-    }
 }
 
 // MARK: - CustomRules

--- a/Tests/SwiftLintFrameworkTests/RequiredEnumCaseRuleTestCase.swift
+++ b/Tests/SwiftLintFrameworkTests/RequiredEnumCaseRuleTestCase.swift
@@ -24,7 +24,7 @@ class RequiredEnumCaseRuleTestCase: XCTestCase {
 
     func testRequiredCaseHashValue() {
         let requiredCase = RequiredCase(name: "success")
-        XCTAssertEqual(requiredCase.hashValue, "success".hashValue)
+        XCTAssertEqual(requiredCase.hashValue, RequiredCase(name: "success").hashValue)
     }
 
     func testRequiredCaseEquatableReturnsTrue() {


### PR DESCRIPTION
Since [we now require Swift 4.2 to build](https://github.com/realm/SwiftLint/pull/2466), we can use the compiler-generated implementations for `Equatable` and `Hashable` 🎉