### PR TITLE
Update SourceKitten to 0.21.3

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "jpsim/SourceKitten" ~> 0.21.2
+github "jpsim/SourceKitten" ~> 0.21.3
 github "scottrhoyt/SwiftyTextTable" ~> 0.8.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "Carthage/Commandant" "0.15.0"
 github "antitypical/Result" "4.0.0"
 github "drmohundro/SWXMLHash" "4.7.4"
-github "jpsim/SourceKitten" "0.21.2"
+github "jpsim/SourceKitten" "0.21.3"
 github "jpsim/Yams" "1.0.1"
 github "jspahrsummers/xcconfigs" "0.12"
 github "krzyzanowskim/CryptoSwift" "0.13.0"

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Carthage/Commandant.git", from: "0.15.0"),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.21.2"),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.21.3"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "1.0.1"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "0.13.0"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.8.2"),


### PR DESCRIPTION
Might get faster performance on Linux due to `bridge()` calls now using Linux `as` bridging.