### PR TITLE
Add `SWIFTLINT_DISABLE_SOURCEKIT` environment variable

### DIFF
--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private var responseCache = Cache({ file -> [String: SourceKitRepresentable]? in
     do {
-        return try Request.editorOpen(file: file).send()
+        return try Request.editorOpen(file: file).sendIfNotDisabled()
     } catch let error as Request.Error {
         queuedPrintError(error.description)
         return nil

--- a/Source/SwiftLintFramework/Extensions/Request+DisableSourceKit.swift
+++ b/Source/SwiftLintFramework/Extensions/Request+DisableSourceKit.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SourceKittenFramework
+
+extension Request {
+    static let disableSourceKit = ProcessInfo.processInfo.environment["SWIFTLINT_DISABLE_SOURCEKIT"] != nil
+
+    func sendIfNotDisabled() throws -> [String: SourceKitRepresentable] {
+        guard !Request.disableSourceKit else {
+            throw Request.Error.connectionInterrupted("SourceKit is disabled by `SWIFTLINT_DISABLE_SOURCEKIT`.")
+        }
+        return try send()
+    }
+}

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -85,7 +85,8 @@ public extension SwiftVersion {
         func isString(token: SyntaxToken) -> Bool {
             return token.type == SyntaxKind.string.rawValue
         }
-        if let decl = file.structure.kinds().first(where: { $0.kind == SwiftDeclarationKind.varGlobal.rawValue }),
+        if !Request.disableSourceKit,
+            let decl = file.structure.kinds().first(where: { $0.kind == SwiftDeclarationKind.varGlobal.rawValue }),
             let token = file.syntaxMap.tokens(inByteRange: decl.byteRange).first(where: isString ) {
             return .init(rawValue: file.contents.substring(from: token.offset + 1, length: token.length - 2))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -108,7 +108,7 @@ private extension File {
             }
             let cursorInfoRequest = Request.cursorInfo(file: path!, offset: Int64(token.offset),
                                                        arguments: compilerArguments)
-            guard let cursorInfo = try? cursorInfoRequest.send() else {
+            guard let cursorInfo = try? cursorInfoRequest.sendIfNotDisabled() else {
                 queuedPrintError("Could not get cursor info")
                 continue
             }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedPrivateDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedPrivateDeclarationRule.swift
@@ -54,14 +54,14 @@ public struct UnusedPrivateDeclarationRule: ConfigurationProviderRule, AnalyzerR
 
 private extension File {
     func allCursorInfo(compilerArguments: [String]) -> [[String: SourceKitRepresentable]] {
-        guard let path = path, let editorOpen = try? Request.editorOpen(file: self).send() else {
+        guard let path = path, let editorOpen = try? Request.editorOpen(file: self).sendIfNotDisabled() else {
             return []
         }
 
         return syntaxMap.tokens.compactMap { token in
             let offset = Int64(token.offset)
             var cursorInfo = try? Request.cursorInfo(file: path, offset: offset,
-                                                     arguments: compilerArguments).send()
+                                                     arguments: compilerArguments).sendIfNotDisabled()
             if let acl = File.aclAtOffset(offset, substructureElement: editorOpen) {
                 cursorInfo?["key.accessibility"] = acl
             }

--- a/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
@@ -161,7 +161,7 @@ private extension File {
         return try byteOffsets.compactMap { offset in
             if contents.bridge().substringWithByteRange(start: offset - 1, length: 1)! == "." { return nil }
             var cursorInfo = try Request.cursorInfo(file: self.path!, offset: Int64(offset),
-                                                    arguments: compilerArguments).send()
+                                                    arguments: compilerArguments).sendIfNotDisabled()
             cursorInfo["swiftlint.offset"] = Int64(offset)
             return cursorInfo
         }
@@ -196,7 +196,7 @@ private extension NSString {
 
 private func binaryOffsets(file: File, compilerArguments: [String]) throws -> [Int] {
     let absoluteFile = file.path!.bridge().absolutePathRepresentation()
-    let index = try Request.index(file: absoluteFile, arguments: compilerArguments).send()
+    let index = try Request.index(file: absoluteFile, arguments: compilerArguments).sendIfNotDisabled()
     let binaryOffsets = file.contents.bridge().recursiveByteOffsets(index)
     return binaryOffsets.sorted()
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		6C032EEE2027EA8D00CD7E8D /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C032EED2027EA8D00CD7E8D /* shim.swift */; };
 		6C032EF12027F79F00CD7E8D /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C032EF02027F79F00CD7E8D /* shim.swift */; };
+		6C1D763221A4E69600DEF783 /* Request+DisableSourceKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */; };
 		6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */; };
 		6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */; };
 		6CB8A80C1D11A7E10052816E /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8BA7E101B07A3EC003E02D0 /* Commandant.framework */; };
@@ -542,6 +543,7 @@
 		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
 		6C032EED2027EA8D00CD7E8D /* shim.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = shim.swift; sourceTree = "<group>"; };
 		6C032EF02027F79F00CD7E8D /* shim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = shim.swift; sourceTree = "<group>"; };
+		6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+DisableSourceKit.swift"; sourceTree = "<group>"; };
 		6C27B5FC2079D33F00353E17 /* Mac-XCTest.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Mac-XCTest.xcconfig"; sourceTree = "<group>"; };
 		6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceKitCrashTests.swift; sourceTree = "<group>"; };
 		6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Structure+SwiftLint.swift"; sourceTree = "<group>"; };
@@ -1482,6 +1484,7 @@
 				3BA79C9A1C4767910057E705 /* NSRange+SwiftLint.swift */,
 				3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */,
 				E81619521BFC162C00946723 /* QueuedPrint.swift */,
+				6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */,
 				6C032EED2027EA8D00CD7E8D /* shim.swift */,
 				E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */,
 				B39353F28BCCA39247B316BD /* String+XML.swift */,
@@ -1885,6 +1888,7 @@
 				62DADC481FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift in Sources */,
 				D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */,
 				24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */,
+				6C1D763221A4E69600DEF783 /* Request+DisableSourceKit.swift in Sources */,
 				47ACC8981E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift in Sources */,
 				787CDE39208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift in Sources */,
 				009E09281DFEE4C200B588A7 /* ProhibitedSuperRule.swift in Sources */,


### PR DESCRIPTION
This can be used for avoid "Test::Unit::AssertionFailedError" error in `libxpc.dylib` on calling `sourcekitd_send_request_sync` in sandbox environment.

This PR is against `release/0.28` branch that intended to using 0.28.x release for Homebrew.
/cc: @jpsim 