### PR TITLE
Use CommonCrypto if available to compute MD5 hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 
 #### Enhancements
 
-* None.
+* Improve the performance of saving or reading cached lint results on platforms
+  with CommonCrypto.  
+  [JP Simard](https://github.com/jpsim)
 
 #### Bug Fixes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "4be914be6fa49cd30b1e7ef5d32d06c037d8f469",
-          "version": "0.21.2"
+          "revision": "79ca340f609adee48defa966e6a3dd0e0acbeb08",
+          "version": "0.21.3"
         }
       },
       {

--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -1,5 +1,23 @@
+#if canImport(CommonCrypto)
+import CommonCrypto
+#else
 import CryptoSwift
+#endif
 import Foundation
+
+#if canImport(CommonCrypto)
+private extension String {
+    func md5() -> String {
+        let context = UnsafeMutablePointer<CC_MD5_CTX>.allocate(capacity: 1)
+        var digest = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
+        CC_MD5_Init(context)
+        CC_MD5_Update(context, self, CC_LONG(lengthOfBytes(using: .utf8)))
+        CC_MD5_Final(&digest, context)
+        context.deallocate()
+        return digest.reduce("") { $0 + String(format: "%02x", $1) }
+    }
+}
+#endif
 
 extension Configuration {
 
@@ -56,11 +74,11 @@ extension Configuration {
         if let path = cachePath {
             baseURL = URL(fileURLWithPath: path)
         } else {
-            #if os(Linux)
-                baseURL = URL(fileURLWithPath: "/var/tmp/")
-            #else
-                baseURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            #endif
+#if os(Linux)
+            baseURL = URL(fileURLWithPath: "/var/tmp/")
+#else
+            baseURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+#endif
         }
         let folder = baseURL.appendingPathComponent("SwiftLint/\(Version.current.value)")
 


### PR DESCRIPTION
It's significantly faster than CryptoSwift: 3% vs 19% of cached lint time for Lyft's iOS codebase.

### Before (CryptoSwift)

![CryptoSwift](https://user-images.githubusercontent.com/474794/48873531-3f2a7780-eda3-11e8-9cd9-c0ef796b061b.png)

### After (CommonCrypto)

![CommonCrypto](https://user-images.githubusercontent.com/474794/48873539-481b4900-eda3-11e8-8605-4fd009da3eb1.png)