### PR TITLE
Add `testSimulateHomebrewTest()` to `IntegrationTests`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   with CommonCrypto.  
   [JP Simard](https://github.com/jpsim)
 
+* Add `testSimulateHomebrewTest()` to `IntegrationTests` that simulates test in
+  `homebrew-core/Formula/swiftlint.rb` within sandbox.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 #### Bug Fixes
 
 * Fix compiler warnings when building with Swift 4.2 introduced in the last

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ all: build
 sourcery: Source/SwiftLintFramework/Models/MasterRuleList.swift Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift Tests/LinuxMain.swift
 
 Tests/LinuxMain.swift: Tests/*/*.swift .sourcery/LinuxMain.stencil
-	sourcery --sources Tests --templates .sourcery/LinuxMain.stencil --output .sourcery --force-parse generated
+	sourcery --sources Tests --exclude-sources Tests/SwiftLintFrameworkTests/Resources --templates .sourcery/LinuxMain.stencil --output .sourcery --force-parse generated
 	mv .sourcery/LinuxMain.generated.swift Tests/LinuxMain.swift
 
 Source/SwiftLintFramework/Models/MasterRuleList.swift: Source/SwiftLintFramework/Rules/**/*.swift .sourcery/MasterRuleList.stencil

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "79ca340f609adee48defa966e6a3dd0e0acbeb08",
-          "version": "0.21.3"
+          "revision": "176f04295a09324673245d8ec0afcce21ace8722",
+          "version": "0.22.0"
         }
       },
       {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -33,12 +33,6 @@ extension BlockBasedKVORuleTests {
     ]
 }
 
-extension BoolExtensionTests {
-    static var allTests: [(String, (BoolExtensionTests) -> () throws -> Void)] = [
-        ("testExample", testExample)
-    ]
-}
-
 extension ClassDelegateProtocolRuleTests {
     static var allTests: [(String, (ClassDelegateProtocolRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1310,7 +1304,6 @@ XCTMain([
     testCase(ArrayInitRuleTests.allTests),
     testCase(AttributesRuleTests.allTests),
     testCase(BlockBasedKVORuleTests.allTests),
-    testCase(BoolExtensionTests.allTests),
     testCase(ClassDelegateProtocolRuleTests.allTests),
     testCase(ClosingBraceRuleTests.allTests),
     testCase(ClosureBodyLengthRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -561,7 +561,9 @@ extension InertDeferRuleTests {
 extension IntegrationTests {
     static var allTests: [(String, (IntegrationTests) -> () throws -> Void)] = [
         ("testSwiftLintLints", testSwiftLintLints),
-        ("testSwiftLintAutoCorrects", testSwiftLintAutoCorrects)
+        ("testSwiftLintAutoCorrects", testSwiftLintAutoCorrects),
+        ("testSimulateHomebrewTest", testSimulateHomebrewTest),
+        ("testSimulateHomebrewTestWithDisableSourceKit", testSimulateHomebrewTestWithDisableSourceKit)
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -33,6 +33,12 @@ extension BlockBasedKVORuleTests {
     ]
 }
 
+extension BoolExtensionTests {
+    static var allTests: [(String, (BoolExtensionTests) -> () throws -> Void)] = [
+        ("testExample", testExample)
+    ]
+}
+
 extension ClassDelegateProtocolRuleTests {
     static var allTests: [(String, (ClassDelegateProtocolRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1304,6 +1310,7 @@ XCTMain([
     testCase(ArrayInitRuleTests.allTests),
     testCase(AttributesRuleTests.allTests),
     testCase(BlockBasedKVORuleTests.allTests),
+    testCase(BoolExtensionTests.allTests),
     testCase(ClassDelegateProtocolRuleTests.allTests),
     testCase(ClosingBraceRuleTests.allTests),
     testCase(ClosureBodyLengthRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -38,6 +38,84 @@ class IntegrationTests: XCTestCase {
             }
         }
     }
+
+    func testSimulateHomebrewTest() {
+        // Since this test uses `swiftlint` that is built alongside on building `SwiftLintPackageTests`,
+        // it runs only on macOS using SwiftPM.
+    #if os(macOS) && SWIFT_PACKAGE
+        guard let swiftlintURL = swiftlintBuiltBySwiftPM() else { return }
+        guard let (testSwiftURL, seatbeltURL) = prepareSandbox() else { return }
+        defer {
+            try? FileManager.default.removeItem(at: testSwiftURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: seatbeltURL)
+        }
+        let swiftlintInSandboxArgs = ["sandbox-exec", "-f", seatbeltURL.path, "sh", "-c",
+                                      "SWIFTLINT_SWIFT_VERSION=3 \(swiftlintURL.path) --no-cache"]
+        let swiftlintResult = execute(swiftlintInSandboxArgs, in: testSwiftURL.deletingLastPathComponent())
+        if #available(macOS 10.14.1, *) {
+            // Within sandbox on macOS 10.14.1+, `swiftlint` crashes with "Test::Unit::AssertionFailedError"
+            // error in `libxpc.dylib` on calling `sourcekitd_send_request_sync`.
+            //
+            // Since Homebrew CI succeeded in bottling swiftlint 0.27.0 on release of macOS 10.14,
+            // `swiftlint` may not crash on macOS 10.14. But that is not confirmed.
+            XCTAssertEqual(swiftlintResult.status, 11, "It is expected to crash.")
+            XCTAssertEqual(swiftlintResult.stdout, "")
+            XCTAssertEqual(swiftlintResult.stderr, """
+                Linting Swift files at paths \n\
+                Linting 'Test.swift' (1/1)
+
+                """)
+        } else {
+            XCTAssertEqual(swiftlintResult.status, 0)
+            XCTAssertEqual(swiftlintResult.stdout, """
+                \(testSwiftURL.path):1: \
+                warning: Trailing Newline Violation: Files should have a single trailing newline. (trailing_newline)
+
+                """)
+            XCTAssertEqual(swiftlintResult.stderr, """
+                Linting Swift files at paths \n\
+                Linting 'Test.swift' (1/1)
+                Connection invalid
+                Most rules will be skipped because sourcekitd has failed.
+                Done linting! Found 1 violation, 0 serious in 1 file.
+
+                """)
+        }
+    #endif
+    }
+
+    func testSimulateHomebrewTestWithDisableSourceKit() {
+        // Since this test uses `swiftlint` that is built alongside on building `SwiftLintPackageTests`,
+        // it runs only on macOS using SwiftPM.
+    #if os(macOS) && SWIFT_PACKAGE
+        guard let swiftlint = swiftlintBuiltBySwiftPM() else { return }
+        guard let (testSwiftURL, seatbeltURL) = prepareSandbox() else { return }
+        defer {
+            try? FileManager.default.removeItem(at: testSwiftURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: seatbeltURL)
+        }
+
+        let swiftlintInSandboxArgs = [
+            "sandbox-exec", "-f", seatbeltURL.path, "sh", "-c",
+            "SWIFTLINT_SWIFT_VERSION=3 SWIFTLINT_DISABLE_SOURCEKIT=1 \(swiftlint.path) --no-cache"
+        ]
+        let swiftlintResult = execute(swiftlintInSandboxArgs, in: testSwiftURL.deletingLastPathComponent())
+        XCTAssertEqual(swiftlintResult.status, 0)
+        XCTAssertEqual(swiftlintResult.stdout, """
+            \(testSwiftURL.path):1: \
+            warning: Trailing Newline Violation: Files should have a single trailing newline. (trailing_newline)
+
+            """)
+        XCTAssertEqual(swiftlintResult.stderr, """
+                Linting Swift files at paths \n\
+                Linting 'Test.swift' (1/1)
+                SourceKit is disabled by `SWIFTLINT_DISABLE_SOURCEKIT`.
+                Most rules will be skipped because sourcekitd has failed.
+                Done linting! Found 1 violation, 0 serious in 1 file.
+
+                """)
+    #endif
+    }
 }
 
 extension String {
@@ -53,3 +131,124 @@ extension String {
         }
     }
 }
+
+#if os(macOS) && SWIFT_PACKAGE
+
+private func execute(_ args: [String],
+                     in directory: URL? = nil,
+                     input: Data? = nil) -> (status: Int32, stdout: String, stderr: String) {
+    // swiftlint:disable:previous large_tuple
+    let process = Process()
+    process.launchPath = "/usr/bin/env"
+    process.arguments = args
+    if let directory = directory {
+        process.currentDirectoryPath = directory.path
+    }
+    var environment = ProcessInfo.processInfo.environment
+    environment["DISCORD_TOKEN"] = nil
+    environment["DYNO"] = nil
+    environment["PORT"] = nil
+    environment["TIMEOUT"] = nil
+    process.environment = environment
+    let stdoutPipe = Pipe(), stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+    if let input = input {
+        let stdinPipe = Pipe()
+        process.standardInput = stdinPipe.fileHandleForReading
+        stdinPipe.fileHandleForWriting.write(input)
+        stdinPipe.fileHandleForWriting.closeFile()
+    }
+    let group = DispatchGroup(), queue = DispatchQueue.global()
+    var stdoutData: Data?, stderrData: Data?
+    process.launch()
+    queue.async(group: group) { stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile() }
+    queue.async(group: group) { stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile() }
+    process.waitUntilExit()
+    group.wait()
+    let stdout = stdoutData.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    let stderr = stderrData.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    return (process.terminationStatus, stdout, stderr)
+}
+
+private func prepareSandbox() -> (testSwiftURL: URL, seatbeltURL: URL)? {
+    // Since `/private/tmp` is hard coded in `/usr/local/Homebrew/Library/Homebrew/sandbox.rb`, we use them.
+    //    /private/tmp
+    //    ├── AADA6B05-2E06-4E7F-BA48-8B3AF44415E3
+    //    │   └── Test.swift
+    //    ├── AADA6B05-2E06-4E7F-BA48-8B3AF44415E3.sb
+    do {
+        // `/private/tmp` is standardized to `/tmp` that is symbolic link to `/private/tmp`.
+        let temporaryDirectoryURL = URL(fileURLWithPath: "/tmp").appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectoryURL, withIntermediateDirectories: true)
+
+        let seatbeltURL = temporaryDirectoryURL.appendingPathExtension("sb")
+        try sandboxProfile().write(to: seatbeltURL, atomically: true, encoding: .utf8)
+
+        let testSwiftURL = temporaryDirectoryURL.appendingPathComponent("Test.swift")
+        try "import Foundation".write(to: testSwiftURL, atomically: true, encoding: .utf8)
+        return (testSwiftURL, seatbeltURL)
+    } catch {
+        XCTFail("\(error)")
+        return nil
+    }
+}
+
+private func sandboxProfile() -> String {
+    let homeDirectory = NSHomeDirectory()
+    return """
+        (version 1)
+        (debug deny) ; log all denied operations to /var/log/system.log
+        (allow file-write* (subpath "/private/tmp"))
+        (allow file-write* (subpath "/private/var/tmp"))
+        (allow file-write* (regex #"^/private/var/folders/[^/]+/[^/]+/[C,T]/"))
+        (allow file-write* (subpath "/private/tmp"))
+        (allow file-write* (subpath "\(homeDirectory)/Library/Caches/Homebrew"))
+        (allow file-write* (subpath "\(homeDirectory)/Library/Logs/Homebrew/swiftlint"))
+        (allow file-write* (subpath "\(homeDirectory)/Library/Developer"))
+        (allow file-write* (subpath "/usr/local/var/cache"))
+        (allow file-write* (subpath "/usr/local/var/homebrew/locks"))
+        (allow file-write* (subpath "/usr/local/var/log"))
+        (allow file-write* (subpath "/usr/local/var/run"))
+        (allow file-write*
+            (literal "/dev/ptmx")
+            (literal "/dev/dtracehelper")
+            (literal "/dev/null")
+            (literal "/dev/random")
+            (literal "/dev/zero")
+            (regex #"^/dev/fd/[0-9]+$")
+            (regex #"^/dev/ttys?[0-9]*$")
+            )
+        (deny file-write*) ; deny non-whitelist file write operations
+        (allow process-exec
+            (literal "/bin/ps")
+            (with no-sandbox)
+            ) ; allow certain processes running without sandbox
+        (allow default) ; allow everything else
+
+        """
+}
+
+private func swiftlintBuiltBySwiftPM() -> URL? {
+#if DEBUG
+    let configuration = "debug"
+#else
+    let configuration = "release"
+#endif
+    let swiftBuildShowBinPathArgs = ["swift", "build", "--show-bin-path", "--configuration", configuration]
+    let binPathResult = execute(swiftBuildShowBinPathArgs)
+    guard binPathResult.status == 0 else {
+        let commandline = swiftBuildShowBinPathArgs.joined(separator: " ")
+        XCTFail("`\(commandline)` failed with status: \(binPathResult.status), error: \(binPathResult.stderr)")
+        return nil
+    }
+    let binPathString = binPathResult.stdout.components(separatedBy: CharacterSet.newlines).first!
+    let swiftlint = URL(fileURLWithPath: binPathString).appendingPathComponent("swiftlint")
+    guard FileManager.default.fileExists(atPath: swiftlint.path) else {
+        XCTFail("`swiftlint` does not exists.")
+        return nil
+    }
+    return swiftlint
+}
+
+#endif


### PR DESCRIPTION
Motivation:

Sometimes, Homebrew bottling CI fails because it runs in the sandbox.

Modifications:

Add `testSimulateHomebrewTest()` to `IntegrationTests` that simulates test in `homebrew-core/Formula/swiftlint.rb` within sandbox.

Result:

Confirm that a test equivalent to `brew test swiftlint` will pass in the sandbox before publishing to homebrew.