### PR TITLE
Fix false positives for `explicit_init` when passing init as closure in multiline call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 * Fix compiler warnings when building with Swift 4.2 introduced in the last
   release.  
   [JP Simard](https://github.com/jpsim)
+* Fix false positive in explicit_init rule  
+  [Dominic Freeston](https://github.com/dominicfreeston)
 
 ## 0.28.1: EnviroBoost
 

--- a/Rules.md
+++ b/Rules.md
@@ -5487,6 +5487,18 @@ struct S { let n: Int }; extension S { init() { self.init(n: 1) } }
 [String.self].map { type in type.init(1) }
 ```
 
+```swift
+Observable.zip(obs1, obs2, resultSelector: MyType.init).asMaybe()
+```
+
+```swift
+Observable.zip(
+    obs1,
+    obs2,
+    resultSelector: MyType.init
+).asMaybe()
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -5503,6 +5515,14 @@ struct S { let n: Int }; extension S { init() { self.init(n: 1) } }
 func foo() -> [String] {
     return [1].flatMap { String↓.init($0) }
 }
+```
+
+```swift
+Observable.zip(
+    obs1,
+    obs2,
+    resultSelector: { MyType.init($0, $1) }
+).asMaybe()
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -17,12 +17,27 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
             "struct S { let n: Int }; extension S { init() { self.init(n: 1) } }",      // self
             "[1].flatMap(String.init)",                   // pass init as closure
             "[String.self].map { $0.init(1) }",           // initialize from a metatype value
-            "[String.self].map { type in type.init(1) }"  // initialize from a metatype value
+            "[String.self].map { type in type.init(1) }",  // initialize from a metatype value
+            "Observable.zip(obs1, obs2, resultSelector: MyType.init).asMaybe()",
+            """
+            Observable.zip(
+                obs1,
+                obs2,
+                resultSelector: MyType.init
+            ).asMaybe()
+            """
         ],
         triggeringExamples: [
             "[1].flatMap{String↓.init($0)}",
             "[String.self].map { Type in Type↓.init(1) }", // starting with capital assumes as type,
-            "func foo() -> [String] {\n    return [1].flatMap { String↓.init($0) }\n}"
+            "func foo() -> [String] {\n    return [1].flatMap { String↓.init($0) }\n}",
+            """
+            Observable.zip(
+                obs1,
+                obs2,
+                resultSelector: { MyType.init($0, $1) }
+            ).asMaybe()
+            """
         ],
         corrections: [
             "[1].flatMap{String↓.init($0)}": "[1].flatMap{String($0)}",
@@ -42,7 +57,7 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
         }
     }
 
-    private let initializerWithType = regex("^[A-Z].*\\.init$")
+    private let initializerWithType = regex("^[A-Z][^(]*\\.init$")
 
     private func violationRanges(in file: File, kind: SwiftExpressionKind,
                                  dictionary: [String: SourceKitRepresentable]) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -19,25 +19,13 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
             "[String.self].map { $0.init(1) }",           // initialize from a metatype value
             "[String.self].map { type in type.init(1) }",  // initialize from a metatype value
             "Observable.zip(obs1, obs2, resultSelector: MyType.init).asMaybe()",
-            """
-            Observable.zip(
-                obs1,
-                obs2,
-                resultSelector: MyType.init
-            ).asMaybe()
-            """
+            "Observable.zip(\n    obs1,\n    obs2,\n    resultSelector: MyType.init\n).asMaybe()"
         ],
         triggeringExamples: [
             "[1].flatMap{String↓.init($0)}",
             "[String.self].map { Type in Type↓.init(1) }", // starting with capital assumes as type,
             "func foo() -> [String] {\n    return [1].flatMap { String↓.init($0) }\n}",
-            """
-            Observable.zip(
-                obs1,
-                obs2,
-                resultSelector: { MyType.init($0, $1) }
-            ).asMaybe()
-            """
+            "Observable.zip(\n    obs1,\n    obs2,\n    resultSelector: { MyType.init($0, $1) }\n).asMaybe()"
         ],
         corrections: [
             "[1].flatMap{String↓.init($0)}": "[1].flatMap{String($0)}",


### PR DESCRIPTION
First time (attempting) contributor here, hope this is helpful 😄 

As it stands, the following two syntactically equivalent lines give two different results - the former successfully passes validation whilst the latter does not.

``` swift
Observable.zip(obs1, obs2, resultSelector: MyType.init).asMaybe()

Observable.zip(
    obs1,
    obs2,
    resultSelector: MyType.init
).asMaybe()
```

The proposed changes relies on the fact that a class name can't have `(` in it and so any expression passed to the validator that has `(` between the initial capital letter and `.init` can't be an explicit init. An alternative could be to strip out the newlines. Any thoughts?

I'm also aware I've expanded on the documentation (and made an implicit reference to RxSwift) just to expand the number of tests, is there a cleaner way to do this, or is this valuable?

Thanks!