### PR TITLE
#2471 - Fix false positive toggle_bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   release.  
   [JP Simard](https://github.com/jpsim)
 
+* Fix `toggle_bool` false positive violation when comparing object parameter to
+  an equally named variable.  
+  [Timofey Solonin](https://github.com/biboran)
+  [#2471](https://github.com/realm/SwiftLint/issues/2471)
+
 ## 0.28.1: EnviroBoost
 
 This is the last release to support building with Swift 4.0 and Swift 4.1.

--- a/Rules.md
+++ b/Rules.md
@@ -16668,6 +16668,16 @@ view.clipsToBounds.toggle()
 func foo() { abc.toggle() }
 ```
 
+```swift
+view.clipsToBounds = !clipsToBounds
+
+```
+
+```swift
+disconnected = !connected
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -14,7 +14,9 @@ public struct ToggleBoolRule: ConfigurationProviderRule, OptInRule, AutomaticTes
         nonTriggeringExamples: [
             "isHidden.toggle()\n",
             "view.clipsToBounds.toggle()\n",
-            "func foo() { abc.toggle() }"
+            "func foo() { abc.toggle() }",
+            "view.clipsToBounds = !clipsToBounds\n",
+            "disconnected = !connected\n"
         ],
         triggeringExamples: [
             "↓isHidden = !isHidden\n",
@@ -24,7 +26,7 @@ public struct ToggleBoolRule: ConfigurationProviderRule, OptInRule, AutomaticTes
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let pattern = "\\b([\\w.]+) = !\\1\\b"
+        let pattern = "(?<![\\w.])([\\w.]+) = !\\1\\b"
         let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: type(of: self).description,


### PR DESCRIPTION
As per #2471 
* Replaced word boundary with a negative lookbehind on a word character or a dot
* Added 2 relevant test cases