### PR TITLE
Fix false positives and invalid corrections with unused import rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@
   `rules` command when there are one or more configured custom rules.  
   [jhildensperger](https://github.com/jhildensperger)
 
+* Fix wrong correction when removing testable imports with the `unused_import`
+  rule.  
+  [JP Simard](https://github.com/jpsim)
+
+* Fix false positive with the `unused_import` rule when importing Foundation
+  when there are attributes in that file requiring Foundation.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.29.0: A Laundry List of Changes
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -21447,6 +21447,17 @@ import Dispatch
 dispatchMain()
 ```
 
+```swift
+@testable import Dispatch
+dispatchMain()
+```
+
+```swift
+import Foundation
+@objc
+class A {}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -21462,6 +21473,12 @@ A.dispatchMain()
 ```swift
 ↓import Foundation
 dispatchMain()
+```
+
+```swift
+↓import Foundation
+// @objc
+class A {}
 ```
 
 </details>


### PR DESCRIPTION
Previously, removing an unused testable import would leave the `@testable` attribute, leading to changes like these:

```diff
-@testable import ModuleA
-import ModuleB
+@testable import ModuleB
```

This PR fixes this by also removing the testable attribute.

---

Also, if no Foundation declarations were used in a file that used the `@objc` family of attributes, those still require Foundation to be imported. This PR special cases Foundation to check for these keywords.