### PR TITLE
Converted idiomatic triggers and nonTriggers to multiline string literals

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -713,17 +713,17 @@ let observer = foo.observe(\.value, options: [.new]) { (foo, change) in
 
 ```swift
 class Foo: NSObject {
-   override ↓func observeValue(forKeyPath keyPath: String?, of object: Any?,
-                               change: [NSKeyValueChangeKey : Any]?,
-                               context: UnsafeMutableRawPointer?) {}
+  override ↓func observeValue(forKeyPath keyPath: String?, of object: Any?,
+                              change: [NSKeyValueChangeKey : Any]?,
+                              context: UnsafeMutableRawPointer?) {}
 }
 ```
 
 ```swift
 class Foo: NSObject {
-   override ↓func observeValue(forKeyPath keyPath: String?, of object: Any?,
-                               change: Dictionary<NSKeyValueChangeKey, Any>?,
-                               context: UnsafeMutableRawPointer?) {}
+  override ↓func observeValue(forKeyPath keyPath: String?, of object: Any?,
+                              change: Dictionary<NSKeyValueChangeKey, Any>?,
+                              context: UnsafeMutableRawPointer?) {}
 }
 ```
 
@@ -2737,27 +2737,27 @@ Types used for hosting only static members should be implemented as a caseless e
 
 ```swift
 enum Math { // enum
-    public static let pi = 3.14
+  public static let pi = 3.14
 }
 ```
 
 ```swift
 // class with inheritance
 class MathViewController: UIViewController {
-    public static let pi = 3.14
+  public static let pi = 3.14
 }
 ```
 
 ```swift
 @objc class Math: NSObject { // class visible to Obj-C
-    public static let pi = 3.14
+  public static let pi = 3.14
 }
 ```
 
 ```swift
 struct Math { // type with non-static declarations
-    public static let pi = 3.14
-    public let randomNumber = 2
+  public static let pi = 3.14
+  public let randomNumber = 2
 }
 ```
 
@@ -2771,20 +2771,20 @@ class DummyClass {}
 
 ```swift
 ↓struct Math {
-    public static let pi = 3.14
+  public static let pi = 3.14
 }
 ```
 
 ```swift
 ↓class Math {
-    public static let pi = 3.14
+  public static let pi = 3.14
 }
 ```
 
 ```swift
 ↓struct Math {
-    public static let pi = 3.14
-    @available(*, unavailable) init() {}
+  public static let pi = 3.14
+  @available(*, unavailable) init() {}
 }
 ```
 
@@ -5380,42 +5380,37 @@ Enums should be explicitly assigned their raw values.
 
 ```swift
 enum Numbers {
- case int(Int)
- case short(Int16)
+  case int(Int)
+  case short(Int16)
 }
-
 ```
 
 ```swift
 enum Numbers: Int {
- case one = 1
- case two = 2
+  case one = 1
+  case two = 2
 }
-
 ```
 
 ```swift
 enum Numbers: Double {
- case one = 1.1
- case two = 2.2
+  case one = 1.1
+  case two = 2.2
 }
-
 ```
 
 ```swift
 enum Numbers: String {
- case one = "one"
- case two = "two"
+  case one = "one"
+  case two = "two"
 }
-
 ```
 
 ```swift
 protocol Algebra {}
 enum Numbers: Algebra {
- case one
+  case one
 }
-
 ```
 
 </details>
@@ -5424,38 +5419,33 @@ enum Numbers: Algebra {
 
 ```swift
 enum Numbers: Int {
- case one = 10, ↓two, three = 30
+  case one = 10, ↓two, three = 30
 }
-
 ```
 
 ```swift
 enum Numbers: NSInteger {
- case ↓one
+  case ↓one
 }
-
 ```
 
 ```swift
 enum Numbers: String {
- case ↓one
- case ↓two
+  case ↓one
+  case ↓two
 }
-
 ```
 
 ```swift
 enum Numbers: String {
- case ↓one, two = "two"
+   case ↓one, two = "two"
 }
-
 ```
 
 ```swift
 enum Numbers: Decimal {
- case ↓one, ↓two
+  case ↓one, ↓two
 }
-
 ```
 
 </details>
@@ -5784,49 +5774,49 @@ Prefer to use extension access modifiers
 
 ```swift
 extension Foo: SomeProtocol {
-   public var bar: Int { return 1 }
+  public var bar: Int { return 1 }
 }
 ```
 
 ```swift
 extension Foo {
-   private var bar: Int { return 1 }
-   public var baz: Int { return 1 }
+  private var bar: Int { return 1 }
+  public var baz: Int { return 1 }
 }
 ```
 
 ```swift
 extension Foo {
-   private var bar: Int { return 1 }
-   public func baz() {}
+  private var bar: Int { return 1 }
+  public func baz() {}
 }
 ```
 
 ```swift
 extension Foo {
-   var bar: Int { return 1 }
-   var baz: Int { return 1 }
+  var bar: Int { return 1 }
+  var baz: Int { return 1 }
 }
 ```
 
 ```swift
 public extension Foo {
-   var bar: Int { return 1 }
-   var baz: Int { return 1 }
+  var bar: Int { return 1 }
+  var baz: Int { return 1 }
 }
 ```
 
 ```swift
 extension Foo {
-   private bar: Int { return 1 }
-   private baz: Int { return 1 }
+  private bar: Int { return 1 }
+  private baz: Int { return 1 }
 }
 ```
 
 ```swift
 extension Foo {
-   open bar: Int { return 1 }
-   open baz: Int { return 1 }
+  open bar: Int { return 1 }
+  open baz: Int { return 1 }
 }
 ```
 
@@ -5875,7 +5865,7 @@ Fallthrough should be avoided.
 ```swift
 switch foo {
 case .bar, .bar2, .bar3:
-    something()
+  something()
 }
 ```
 
@@ -5886,9 +5876,9 @@ case .bar, .bar2, .bar3:
 ```swift
 switch foo {
 case .bar:
-    ↓fallthrough
+  ↓fallthrough
 case .bar2:
-    something()
+  something()
 }
 ```
 
@@ -5913,14 +5903,12 @@ A fatalError call should have a message.
 func foo() {
   fatalError("Foo")
 }
-
 ```
 
 ```swift
 func foo() {
   fatalError(x)
 }
-
 ```
 
 </details>
@@ -5929,16 +5917,14 @@ func foo() {
 
 ```swift
 func foo() {
-  ↓fatalError("")
+  fatalError("")
 }
-
 ```
 
 ```swift
 func foo() {
-  ↓fatalError()
+  fatalError()
 }
-
 ```
 
 </details>
@@ -7336,76 +7322,66 @@ Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Mi
 
 ```swift
 for user in users where user.id == 1 { }
-
 ```
 
 ```swift
 for user in users {
-   if let id = user.id { }
+  if let id = user.id { }
 }
-
 ```
 
 ```swift
 for user in users {
-   if var id = user.id { }
+  if var id = user.id { }
 }
-
 ```
 
 ```swift
 for user in users {
-   if user.id == 1 { } else { }
-}
-
+  if user.id == 1 { } else { }
+"}
 ```
 
 ```swift
 for user in users {
-   if user.id == 1 {
-} else if user.id == 2 { }
+  if user.id == 1 {
+  } else if user.id == 2 { }
 }
-
 ```
 
 ```swift
 for user in users {
-   if user.id == 1 { }
-   print(user)
+  if user.id == 1 { }
+  print(user)
 }
-
 ```
 
 ```swift
 for user in users {
-   let id = user.id
-   if id == 1 { }
+  let id = user.id
+  if id == 1 { }
 }
-
 ```
 
 ```swift
 for user in users {
-   if user.id == 1 { }
-   return true
+  if user.id == 1 { }
+  return true
 }
-
 ```
 
 ```swift
 for user in users {
-   if user.id == 1 && user.age > 18 { }
+  if user.id == 1 && user.age > 18 { }
 }
-
 ```
 
 ```swift
 for (index, value) in array.enumerated() {
-   if case .valueB(_) = value {
-       return index
-   }
+  if case .valueB(_) = value {
+    return index
+  }
 }
-
 ```
 
 </details>
@@ -7414,9 +7390,8 @@ for (index, value) in array.enumerated() {
 
 ```swift
 for user in users {
-   ↓if user.id == 1 { return true }
+  ↓if user.id == 1 { return true }
 }
-
 ```
 
 </details>
@@ -7468,7 +7443,10 @@ Force tries should be avoided.
 <summary>Non Triggering Examples</summary>
 
 ```swift
-func a() throws {}; do { try a() } catch {}
+func a() throws {};
+do {
+  try a()
+} catch {}
 ```
 
 </details>
@@ -7476,7 +7454,8 @@ func a() throws {}; do { try a() } catch {}
 <summary>Triggering Examples</summary>
 
 ```swift
-func a() throws {}; ↓try! a()
+func a() throws {};
+↓try! a()
 ```
 
 </details>
@@ -7675,7 +7654,7 @@ func foo() {}
 
 ```swift
 class A: B {
-    override func foo(bar: Int = 0, baz: String) {}
+  override func foo(bar: Int = 0, baz: String) {}
 ```
 
 ```swift
@@ -7684,7 +7663,7 @@ func foo(bar: Int = 0, completion: @escaping CompletionHandler) {}
 
 ```swift
 func foo(a: Int, b: CGFloat = 0) {
-    let block = { (error: Error?) in }
+  let block = { (error: Error?) in }
 }
 ```
 
@@ -9174,12 +9153,12 @@ let foo = bar.joined(↓separator: "")
 
 ```swift
 let foo = bar.filter(toto)
-             .joined(↓separator: "")
+             .joined(↓separator: ""),
 ```
 
 ```swift
 func foo() -> String {
-   return ["1", "2"].joined(↓separator: "")
+  return ["1", "2"].joined(↓separator: "")
 }
 ```
 
@@ -9888,21 +9867,21 @@ Prefer using the `hash(into:)` function instead of overriding `hashValue`
 
 ```swift
 struct Foo: Hashable {
-    let bar: Int = 10
+  let bar: Int = 10
 
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(bar)
-      }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(bar)
+  }
 }
 ```
 
 ```swift
 class Foo: Hashable {
-    let bar: Int = 10
+  let bar: Int = 10
 
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(bar)
-      }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(bar)
+  }
 }
 ```
 
@@ -9914,22 +9893,22 @@ class Foo: Hashable {
 
 ```swift
 class Foo: Hashable {
-    let bar: String = "Foo"
+  let bar: String = "Foo"
 
-    public var hashValue: String {
-        return bar
-    }
+  public var hashValue: String {
+    return bar
+  }
 }
 ```
 
 ```swift
 class Foo: Hashable {
-    let bar: String = "Foo"
+  let bar: String = "Foo"
 
-    public var hashValue: String {
-        get { return bar }
-        set { bar = newValue }
-    }
+  public var hashValue: String {
+    get { return bar }
+    set { bar = newValue }
+  }
 }
 ```
 
@@ -12458,51 +12437,51 @@ Fallthroughs can only be used if the `case` contains at least one other statemen
 ```swift
 switch myvar {
 case 1:
-    var a = 1
-    fallthrough
+  var a = 1
+  fallthrough
 case 2:
-    var a = 2
+  var a = 2
 }
 ```
 
 ```swift
 switch myvar {
 case "a":
-    var one = 1
-    var two = 2
-    fallthrough
+  var one = 1
+  var two = 2
+  fallthrough
 case "b": /* comment */
-    var three = 3
+  var three = 3
 }
 ```
 
 ```swift
 switch myvar {
 case 1:
-   let one = 1
+  let one = 1
 case 2:
-   // comment
-   var two = 2
+  // comment
+  var two = 2
 }
 ```
 
 ```swift
 switch myvar {
 case MyFunc(x: [1, 2, YourFunc(a: 23)], y: 2):
-    var three = 3
-    fallthrough
+  var three = 3
+  fallthrough
 default:
-    var three = 4
+  var three = 4
 }
 ```
 
 ```swift
 switch myvar {
 case .alpha:
-    var one = 1
+  var one = 1
 case .beta:
-    var three = 3
-    fallthrough
+  var three = 3
+  fallthrough
 default:
     var four = 4
 }
@@ -12512,22 +12491,22 @@ default:
 let aPoint = (1, -1)
 switch aPoint {
 case let (x, y) where x == y:
-    let A = "A"
+  let A = "A"
 case let (x, y) where x == -y:
-    let B = "B"
-    fallthrough
+  let B = "B"
+  fallthrough
 default:
-    let C = "C"
+  let C = "C"
 }
 ```
 
 ```swift
 switch myvar {
 case MyFun(with: { $1 }):
-    let one = 1
-    fallthrough
+  let one = 1
+  fallthrough
 case "abc":
-    let two = 2
+  let two = 2
 }
 ```
 
@@ -12538,58 +12517,58 @@ case "abc":
 ```swift
 switch myvar {
 case 1:
-    ↓fallthrough
+  ↓fallthrough
 case 2:
-    var a = 1
+  var a = 1
 }
 ```
 
 ```swift
 switch myvar {
 case 1:
-    var a = 2
+  var a = 2
 case 2:
-    ↓fallthrough
+  ↓fallthrough
 case 3:
-    var a = 3
+  var a = 3
 }
 ```
 
 ```swift
 switch myvar {
 case 1: // comment
-    ↓fallthrough
+  ↓fallthrough
 }
 ```
 
 ```swift
 switch myvar {
 case 1: /* multi
-    line
-    comment */
-    ↓fallthrough
+  line
+  comment */
+  ↓fallthrough
 case 2:
-    var a = 2
+  var a = 2
 }
 ```
 
 ```swift
 switch myvar {
 case MyFunc(x: [1, 2, YourFunc(a: 23)], y: 2):
-    ↓fallthrough
+  ↓fallthrough
 default:
-    var three = 4
+  var three = 4
 }
 ```
 
 ```swift
 switch myvar {
 case .alpha:
-    var one = 1
+  var one = 1
 case .beta:
-    ↓fallthrough
+  ↓fallthrough
 case .gamma:
-    var three = 3
+  var three = 3
 default:
   var four = 4
 }
@@ -12599,20 +12578,20 @@ default:
 let aPoint = (1, -1)
 switch aPoint {
 case let (x, y) where x == y:
-    let A = "A"
+  let A = "A"
 case let (x, y) where x == -y:
-    ↓fallthrough
+  ↓fallthrough
 default:
-    let B = "B"
+  let B = "B"
 }
 ```
 
 ```swift
 switch myvar {
 case MyFun(with: { $1 }):
-    ↓fallthrough
+  ↓fallthrough
 case "abc":
-    let two = 2
+  let two = 2
 }
 ```
 
@@ -15247,9 +15226,9 @@ extension Foo {
 ```swift
 @IBDesignable
 extension Foo {
-   @objc
-   var bar: Int { return 0 }
-   var fooBar: Int { return 1 }
+  @objc
+  var bar: Int { return 0 }
+  var fooBar: Int { return 1 }
 }
 ```
 
@@ -15407,18 +15386,16 @@ var myVar: Optional<Int> = 0
 
 ```swift
 var foo: Int? {
-   if bar != nil { }
-   return 0
+  if bar != nil { }
+  return 0
 }
-
 ```
 
 ```swift
 var foo: Int? = {
-   if bar != nil { }
-   return 0
+  if bar != nil { }
+  return 0
 }()
-
 ```
 
 ```swift
@@ -15427,13 +15404,13 @@ lazy var test: Int? = nil
 
 ```swift
 func funcName() {
-    var myVar: String?
+  var myVar: String?
 }
 ```
 
 ```swift
 func funcName() {
-    let myVar: String? = nil
+  let myVar: String? = nil
 }
 ```
 
@@ -15502,7 +15479,7 @@ var foo: Int
 
 ```swift
 private final class A {
-    private(set) var value: Int
+  private(set) var value: Int
 }
 ```
 
@@ -15528,19 +15505,19 @@ private final class A {
 
 ```swift
 open class Foo {
-    ↓open(set) open var bar: Int
+  ↓open(set) open var bar: Int
 }
 ```
 
 ```swift
 class A {
-    ↓internal(set) var value: Int
+  ↓internal(set) var value: Int
 }
 ```
 
 ```swift
 fileprivate class A {
-    ↓fileprivate(set) var value: Int
+  ↓fileprivate(set) var value: Int
 }
 ```
 
@@ -15563,41 +15540,36 @@ String enum values can be omitted when they are equal to the enumcase name.
 
 ```swift
 enum Numbers: String {
- case one
- case two
+  case one
+  case two
 }
-
 ```
 
 ```swift
 enum Numbers: Int {
- case one = 1
- case two = 2
+  case one = 1
+  case two = 2
 }
-
 ```
 
 ```swift
 enum Numbers: String {
- case one = "ONE"
- case two = "TWO"
+  case one = "ONE"
+  case two = "TWO"
 }
-
 ```
 
 ```swift
 enum Numbers: String {
- case one = "ONE"
- case two = "two"
+  case one = "ONE"
+  case two = "two"
 }
-
 ```
 
 ```swift
 enum Numbers: String {
- case one, two
+  case one, two
 }
-
 ```
 
 </details>
@@ -15606,24 +15578,15 @@ enum Numbers: String {
 
 ```swift
 enum Numbers: String {
- case one = ↓"one"
- case two = ↓"two"
+  case one = ↓"one"
+  case two = ↓"two"
 }
-
 ```
 
 ```swift
 enum Numbers: String {
- case one = ↓"one", two = ↓"two"
+  case one, two = ↓"two"
 }
-
-```
-
-```swift
-enum Numbers: String {
- case one, two = ↓"two"
-}
-
 ```
 
 </details>
@@ -15681,9 +15644,9 @@ let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics
 
 ```swift
 class ViewController: UIViewController {
-    func someMethod() {
-        let myVar↓: Int = Int(5)
-    }
+  func someMethod() {
+    let myVar↓: Int = Int(5)
+  }
 }
 ```
 
@@ -16606,9 +16569,9 @@ Operators should be declared as static functions, not free functions.
 
 ```swift
 class A: Equatable {
-    static func == (lhs: A, rhs: A) -> Bool {
-        return false
-    }
+  static func == (lhs: A, rhs: A) -> Bool {
+    return false
+  }
 ```
 
 ```swift
@@ -16620,25 +16583,25 @@ class A<T>: Equatable {
 
 ```swift
 public extension Array where Element == Rule {
-    static func == (lhs: Array, rhs: Array) -> Bool {
-        if lhs.count != rhs.count { return false }
-        return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
-    }
+  static func == (lhs: Array, rhs: Array) -> Bool {
+    if lhs.count != rhs.count { return false }
+    return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
+  }
 }
 ```
 
 ```swift
 private extension Optional where Wrapped: Comparable {
-    static func < (lhs: Optional, rhs: Optional) -> Bool {
-        switch (lhs, rhs) {
-        case let (lhs?, rhs?):
-            return lhs < rhs
-        case (nil, _?):
-            return true
-        default:
-            return false
-        }
+  static func < (lhs: Optional, rhs: Optional) -> Bool {
+    switch (lhs, rhs) {
+    case let (lhs?, rhs?):
+      return lhs < rhs
+    case (nil, _?):
+      return true
+    default:
+      return false
     }
+  }
 }
 ```
 
@@ -16648,33 +16611,33 @@ private extension Optional where Wrapped: Comparable {
 
 ```swift
 ↓func == (lhs: A, rhs: A) -> Bool {
-    return false
+  return false
 }
 ```
 
 ```swift
 ↓func == <T>(lhs: A<T>, rhs: A<T>) -> Bool {
-    return false
+  return false
 }
 ```
 
 ```swift
 ↓func == (lhs: [Rule], rhs: [Rule]) -> Bool {
-    if lhs.count != rhs.count { return false }
-    return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
+  if lhs.count != rhs.count { return false }
+  return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
 }
 ```
 
 ```swift
 private ↓func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-    switch (lhs, rhs) {
-    case let (lhs?, rhs?):
-        return lhs < rhs
-    case (nil, _?):
-        return true
-    default:
-        return false
-    }
+  switch (lhs, rhs) {
+  case let (lhs?, rhs?):
+    return lhs < rhs
+  case (nil, _?):
+    return true
+  default:
+    return false
+  }
 }
 ```
 
@@ -16704,13 +16667,13 @@ private extension String {}
 ```
 
 ```swift
-public 
- extension String {}
+public
+extension String {}
 ```
 
 ```swift
-open extension 
- String {}
+open extension
+  String {}
 ```
 
 ```swift
@@ -16726,38 +16689,38 @@ internal extension String {}
 ```
 
 ```swift
-↓fileprivate 
- extension String {}
+↓fileprivate
+  extension String {}
 ```
 
 ```swift
-↓fileprivate extension 
- String {}
+↓fileprivate extension
+  String {}
 ```
 
 ```swift
 extension String {
-↓fileprivate func Something(){}
+  ↓fileprivate func Something(){}
 }
 ```
 
 ```swift
 class MyClass {
-↓fileprivate let myInt = 4
+  ↓fileprivate let myInt = 4
 }
 ```
 
 ```swift
 class MyClass {
-↓fileprivate(set) var myInt = 4
+  ↓fileprivate(set) var myInt = 4
 }
 ```
 
 ```swift
 struct Outter {
-struct Inter {
-↓fileprivate struct Inner {}
-}
+  struct Inter {
+    ↓fileprivate struct Inner {}
+  }
 }
 ```
 
@@ -20849,14 +20812,14 @@ private typealias Foo = Void
 
 ```swift
 protocol Foo {
- associatedtype Bar
- }
+  associatedtype Bar
+}
 ```
 
 ```swift
 protocol Foo {
- associatedtype Bar: Equatable
- }
+  associatedtype Bar: Equatable
+}
 ```
 
 ```swift
@@ -20947,20 +20910,20 @@ typealias ↓AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA = Void
 
 ```swift
 protocol Foo {
- associatedtype ↓X
- }
+  associatedtype ↓X
+}
 ```
 
 ```swift
 protocol Foo {
- associatedtype ↓Foo_Bar: Equatable
- }
+  associatedtype ↓Foo_Bar: Equatable
+}
 ```
 
 ```swift
 protocol Foo {
- associatedtype ↓AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
- }
+  associatedtype ↓AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+}
 ```
 
 </details>
@@ -20982,23 +20945,23 @@ Unimplemented functions should be marked as unavailable.
 
 ```swift
 class ViewController: UIViewController {
-    @available(*, unavailable)
-    public required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+  @available(*, unavailable)
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 }
 ```
 
 ```swift
 func jsonValue(_ jsonString: String) -> NSObject {
-    let data = jsonString.data(using: .utf8)!
-    let result = try! JSONSerialization.jsonObject(with: data, options: [])
-    if let dict = (result as? [String: Any])?.bridge() {
-        return dict
-    } else if let array = (result as? [Any])?.bridge() {
-        return array
-    }
-    fatalError()
+   let data = jsonString.data(using: .utf8)!
+   let result = try! JSONSerialization.jsonObject(with: data, options: [])
+   if let dict = (result as? [String: Any])?.bridge() {
+    return dict
+   } else if let array = (result as? [Any])?.bridge() {
+    return array
+   }
+   fatalError()
 }
 ```
 
@@ -21008,18 +20971,18 @@ func jsonValue(_ jsonString: String) -> NSObject {
 
 ```swift
 class ViewController: UIViewController {
-    public required ↓init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+  public required ↓init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 }
 ```
 
 ```swift
 class ViewController: UIViewController {
-    public required ↓init?(coder aDecoder: NSCoder) {
-        let reason = "init(coder:) has not been implemented"
-        fatalError(reason)
-    }
+  public required ↓init?(coder aDecoder: NSCoder) {
+    let reason = "init(coder:) has not been implemented"
+    fatalError(reason)
+  }
 }
 ```
 
@@ -21220,27 +21183,27 @@ Catch statements should not declare error variables without type casting.
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } catch {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } catch Error.invalidOperation {
 } catch {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } catch let error as MyError {
 } catch {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } catch var error as MyError {
 } catch {}
 ```
@@ -21251,43 +21214,43 @@ do {
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } ↓catch var error {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } ↓catch let error {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } ↓catch let someError {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } ↓catch var someError {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } ↓catch let e {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } ↓catch(let error) {}
 ```
 
 ```swift
 do {
-    try foo() 
+  try foo()
 } ↓catch (let error) {}
 ```
 
@@ -22823,13 +22786,13 @@ An XCTFail call should include a description of the assertion.
 
 ```swift
 func testFoo() {
-    XCTFail("bar")
+  XCTFail("bar")
 }
 ```
 
 ```swift
 func testFoo() {
-    XCTFail(bar)
+  XCTFail(bar)
 }
 ```
 
@@ -22839,13 +22802,13 @@ func testFoo() {
 
 ```swift
 func testFoo() {
-    ↓XCTFail()
+  ↓XCTFail()
 }
 ```
 
 ```swift
 func testFoo() {
-    ↓XCTFail("")
+  ↓XCTFail("")
 }
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -7329,7 +7329,7 @@ for user in users {
 ```swift
 for user in users {
   if user.id == 1 { } else { }
-"}
+}
 ```
 
 ```swift
@@ -7433,7 +7433,7 @@ Force tries should be avoided.
 <summary>Non Triggering Examples</summary>
 
 ```swift
-func a() throws {};
+func a() throws {}
 do {
   try a()
 } catch {}
@@ -7444,7 +7444,7 @@ do {
 <summary>Triggering Examples</summary>
 
 ```swift
-func a() throws {};
+func a() throws {}
 ↓try! a()
 ```
 
@@ -15570,6 +15570,12 @@ enum Numbers: String {
 enum Numbers: String {
   case one = ↓"one"
   case two = ↓"two"
+}
+```
+
+```swift
+enum Numbers: String {
+  case one = ↓"one", two = ↓"two"
 }
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -5907,13 +5907,13 @@ func foo() {
 
 ```swift
 func foo() {
-  fatalError("")
+  ↓fatalError("")
 }
 ```
 
 ```swift
 func foo() {
-  fatalError()
+  ↓fatalError()
 }
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -5290,7 +5290,9 @@ internal final class Foo {}
 
 ```swift
 internal
-class Foo {  private let bar = 5 }
+class Foo {
+  private let bar = 5
+}
 ```
 
 ```swift
@@ -5312,13 +5314,13 @@ private struct C { let d = 5 }
 
 ```swift
 internal protocol A {
-    func b()
+  func b()
 }
 ```
 
 ```swift
 internal protocol A {
-    var b: Int
+  var b: Int
 }
 ```
 
@@ -5491,9 +5493,9 @@ Observable.zip(obs1, obs2, resultSelector: MyType.init).asMaybe()
 
 ```swift
 Observable.zip(
-    obs1,
-    obs2,
-    resultSelector: MyType.init
+  obs1,
+  obs2,
+  resultSelector: MyType.init
 ).asMaybe()
 ```
 
@@ -5511,15 +5513,15 @@ Observable.zip(
 
 ```swift
 func foo() -> [String] {
-    return [1].flatMap { String↓.init($0) }
+  return [1].flatMap { String↓.init($0) }
 }
 ```
 
 ```swift
 Observable.zip(
-    obs1,
-    obs2,
-    resultSelector: { MyType.init($0, $1) }
+  obs1,
+  obs2,
+  resultSelector: { MyType.init($0, $1) }
 ).asMaybe()
 ```
 
@@ -5683,28 +5685,24 @@ Properties should have a type interface
 class Foo {
   var myVar: Int? = 0
 }
-
 ```
 
 ```swift
 class Foo {
   let myVar: Int? = 0
 }
-
 ```
 
 ```swift
 class Foo {
   static var myVar: Int? = 0
 }
-
 ```
 
 ```swift
 class Foo {
   class var myVar: Int? = 0
 }
-
 ```
 
 </details>
@@ -5714,45 +5712,37 @@ class Foo {
 ```swift
 class Foo {
   ↓var myVar = 0
-
 }
-
 ```
 
 ```swift
 class Foo {
   ↓let mylet = 0
-
 }
-
 ```
 
 ```swift
 class Foo {
   ↓static var myStaticVar = 0
 }
-
 ```
 
 ```swift
 class Foo {
   ↓class var myClassVar = 0
 }
-
 ```
 
 ```swift
 class Foo {
   ↓let myVar = Int(0)
 }
-
 ```
 
 ```swift
 class Foo {
   ↓let myVar = Set<Int>(0)
 }
-
 ```
 
 </details>
@@ -14168,27 +14158,27 @@ internal extension String {}
 
 ```swift
 extension String {
-fileprivate func Something(){}
+  fileprivate func Something(){}
 }
 ```
 
 ```swift
 class MyClass {
-fileprivate let myInt = 4
+  fileprivate let myInt = 4
 }
 ```
 
 ```swift
 class MyClass {
-fileprivate(set) var myInt = 4
+  fileprivate(set) var myInt = 4
 }
 ```
 
 ```swift
 struct Outter {
-struct Inter {
-fileprivate struct Inner {}
-}
+  struct Inter {
+    fileprivate struct Inner {}
+  }
 }
 ```
 
@@ -14202,7 +14192,7 @@ fileprivate struct Inner {}
 
 ```swift
 ↓fileprivate class MyClass {
-fileprivate(set) var myInt = 4
+  fileprivate(set) var myInt = 4
 }
 ```
 
@@ -15733,9 +15723,8 @@ func foo()↓ -> Void {}
 
 ```swift
 protocol Foo {
- func foo()↓ -> Void
+  func foo()↓ -> Void
 }
-
 ```
 
 ```swift
@@ -15745,9 +15734,8 @@ func foo()↓ -> () {}
 
 ```swift
 protocol Foo {
- func foo()↓ -> ()
+  func foo()↓ -> ()
 }
-
 ```
 
 </details>
@@ -17086,15 +17074,15 @@ let x: Int!
 ```
 
 ```swift
-extension Array { 
- func x() { } 
- }
+extension Array {
+  func x() { }
+}
 ```
 
 ```swift
-extension Dictionary { 
- func x() { } 
- }
+extension Dictionary {
+  func x() { }
+}
 ```
 
 ```swift

--- a/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -12,21 +12,28 @@ public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule, AutomaticTe
         description: "Prefer the new block based KVO API with keypaths when using Swift 3.2 or later.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "let observer = foo.observe(\\.value, options: [.new]) { (foo, change) in\n" +
-            "   print(change.newValue)\n" +
-            "}"
+            """
+            let observer = foo.observe(\\.value, options: [.new]) { (foo, change) in
+               print(change.newValue)
+            }
+            """
         ],
         triggeringExamples: [
-            "class Foo: NSObject {\n" +
-            "   override ↓func observeValue(forKeyPath keyPath: String?, of object: Any?,\n" +
-            "                               change: [NSKeyValueChangeKey : Any]?,\n" +
-            "                               context: UnsafeMutableRawPointer?) {}\n" +
-            "}",
-            "class Foo: NSObject {\n" +
-            "   override ↓func observeValue(forKeyPath keyPath: String?, of object: Any?,\n" +
-            "                               change: Dictionary<NSKeyValueChangeKey, Any>?,\n" +
-            "                               context: UnsafeMutableRawPointer?) {}\n" +
-            "}"
+            """
+            class Foo: NSObject {
+              override ↓func observeValue(forKeyPath keyPath: String?, of object: Any?,
+                                          change: [NSKeyValueChangeKey : Any]?,
+                                          context: UnsafeMutableRawPointer?) {}
+            }
+            """
+           ,
+            """
+            class Foo: NSObject {
+              override ↓func observeValue(forKeyPath keyPath: String?, of object: Any?,
+                                          change: Dictionary<NSKeyValueChangeKey, Any>?,
+                                          context: UnsafeMutableRawPointer?) {}
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -15,24 +15,24 @@ public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule
         nonTriggeringExamples: [
             """
             enum Math { // enum
-                public static let pi = 3.14
+              public static let pi = 3.14
             }
             """,
             """
             // class with inheritance
             class MathViewController: UIViewController {
-                public static let pi = 3.14
+              public static let pi = 3.14
             }
             """,
             """
             @objc class Math: NSObject { // class visible to Obj-C
-                public static let pi = 3.14
+              public static let pi = 3.14
             }
             """,
             """
             struct Math { // type with non-static declarations
-                public static let pi = 3.14
-                public let randomNumber = 2
+              public static let pi = 3.14
+              public let randomNumber = 2
             }
             """,
             "class DummyClass {}"
@@ -40,18 +40,18 @@ public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule
         triggeringExamples: [
             """
             ↓struct Math {
-                public static let pi = 3.14
+              public static let pi = 3.14
             }
             """,
             """
             ↓class Math {
-                public static let pi = 3.14
+              public static let pi = 3.14
             }
             """,
             """
             ↓struct Math {
-                public static let pi = 3.14
-                @available(*, unavailable) init() {}
+              public static let pi = 3.14
+              @available(*, unavailable) init() {}
             }
             """
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -19,13 +19,26 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
             "private struct C {}\n",
             "internal enum A {\n internal enum B {}\n}",
             "internal final class Foo {}",
-            "internal\nclass Foo {  private let bar = 5 }",
+            """
+            internal
+            class Foo {
+              private let bar = 5
+            }
+            """,
             "internal func a() { let a =  }\n",
             "private func a() { func innerFunction() { } }",
             "private enum Foo { enum Bar { } }",
             "private struct C { let d = 5 }",
-            "internal protocol A {\n    func b()\n}",
-            "internal protocol A {\n    var b: Int\n}",
+            """
+            internal protocol A {
+              func b()
+            }
+            """,
+            """
+            internal protocol A {
+              var b: Int
+            }
+            """,
             "internal class A { deinit {} }"
         ],
         triggeringExamples: [

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -11,18 +11,64 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
         description: "Enums should be explicitly assigned their raw values.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "enum Numbers {\n case int(Int)\n case short(Int16)\n}\n",
-            "enum Numbers: Int {\n case one = 1\n case two = 2\n}\n",
-            "enum Numbers: Double {\n case one = 1.1\n case two = 2.2\n}\n",
-            "enum Numbers: String {\n case one = \"one\"\n case two = \"two\"\n}\n",
-            "protocol Algebra {}\nenum Numbers: Algebra {\n case one\n}\n"
+            """
+            enum Numbers {
+              case int(Int)
+              case short(Int16)
+            }
+            """,
+            """
+            enum Numbers: Int {
+              case one = 1
+              case two = 2
+            }
+            """,
+            """
+            enum Numbers: Double {
+              case one = 1.1
+              case two = 2.2
+            }
+            """,
+            """
+            enum Numbers: String {
+              case one = "one"
+              case two = "two"
+            }
+            """,
+            """
+            protocol Algebra {}
+            enum Numbers: Algebra {
+              case one
+            }
+            """
         ],
         triggeringExamples: [
-            "enum Numbers: Int {\n case one = 10, ↓two, three = 30\n}\n",
-            "enum Numbers: NSInteger {\n case ↓one\n}\n",
-            "enum Numbers: String {\n case ↓one\n case ↓two\n}\n",
-            "enum Numbers: String {\n case ↓one, two = \"two\"\n}\n",
-            "enum Numbers: Decimal {\n case ↓one, ↓two\n}\n"
+            """
+            enum Numbers: Int {
+              case one = 10, ↓two, three = 30
+            }
+            """,
+            """
+            enum Numbers: NSInteger {
+              case ↓one
+            }
+            """,
+            """
+            enum Numbers: String {
+              case ↓one
+              case ↓two
+            }
+            """,
+            """
+            enum Numbers: String {
+               case ↓one, two = "two"
+            }
+            """,
+            """
+            enum Numbers: Decimal {
+              case ↓one, ↓two
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -18,13 +18,29 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
             "[String.self].map { $0.init(1) }",           // initialize from a metatype value
             "[String.self].map { type in type.init(1) }",  // initialize from a metatype value
             "Observable.zip(obs1, obs2, resultSelector: MyType.init).asMaybe()",
-            "Observable.zip(\n    obs1,\n    obs2,\n    resultSelector: MyType.init\n).asMaybe()"
+            """
+            Observable.zip(
+              obs1,
+              obs2,
+              resultSelector: MyType.init
+            ).asMaybe()
+            """
         ],
         triggeringExamples: [
             "[1].flatMap{String↓.init($0)}",
             "[String.self].map { Type in Type↓.init(1) }", // starting with capital assumes as type,
-            "func foo() -> [String] {\n    return [1].flatMap { String↓.init($0) }\n}",
-            "Observable.zip(\n    obs1,\n    obs2,\n    resultSelector: { MyType.init($0, $1) }\n).asMaybe()"
+            """
+            func foo() -> [String] {
+              return [1].flatMap { String↓.init($0) }
+            }
+            """,
+            """
+            Observable.zip(
+              obs1,
+              obs2,
+              resultSelector: { MyType.init($0, $1) }
+            ).asMaybe()
+            """
         ],
         corrections: [
             "[1].flatMap{String↓.init($0)}": "[1].flatMap{String($0)}",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -12,18 +12,58 @@ public struct ExplicitTypeInterfaceRule: ASTRule, OptInRule, ConfigurationProvid
         description: "Properties should have a type interface",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "class Foo {\n  var myVar: Int? = 0\n}\n",
-            "class Foo {\n  let myVar: Int? = 0\n}\n",
-            "class Foo {\n  static var myVar: Int? = 0\n}\n",
-            "class Foo {\n  class var myVar: Int? = 0\n}\n"
+            """
+            class Foo {
+              var myVar: Int? = 0
+            }
+            """,
+            """
+            class Foo {
+              let myVar: Int? = 0
+            }
+            """,
+            """
+            class Foo {
+              static var myVar: Int? = 0
+            }
+            """,
+            """
+            class Foo {
+              class var myVar: Int? = 0
+            }
+            """
         ],
         triggeringExamples: [
-            "class Foo {\n  ↓var myVar = 0\n\n}\n",
-            "class Foo {\n  ↓let mylet = 0\n\n}\n",
-            "class Foo {\n  ↓static var myStaticVar = 0\n}\n",
-            "class Foo {\n  ↓class var myClassVar = 0\n}\n",
-            "class Foo {\n  ↓let myVar = Int(0)\n}\n",
-            "class Foo {\n  ↓let myVar = Set<Int>(0)\n}\n"
+            """
+            class Foo {
+              ↓var myVar = 0
+            }
+            """,
+            """
+            class Foo {
+              ↓let mylet = 0
+            }
+            """,
+            """
+            class Foo {
+              ↓static var myStaticVar = 0
+            }
+            """,
+            """
+            class Foo {
+              ↓class var myClassVar = 0
+            }
+            """,
+            """
+            class Foo {
+              ↓let myVar = Int(0)
+            }
+            """,
+            """
+            class Foo {
+              ↓let myVar = Set<Int>(0)
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -12,47 +12,67 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
         description: "Prefer to use extension access modifiers",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "extension Foo: SomeProtocol {\n" +
-            "   public var bar: Int { return 1 }\n" +
-            "}",
-            "extension Foo {\n" +
-            "   private var bar: Int { return 1 }\n" +
-            "   public var baz: Int { return 1 }\n" +
-            "}",
-            "extension Foo {\n" +
-            "   private var bar: Int { return 1 }\n" +
-            "   public func baz() {}\n" +
-            "}",
-            "extension Foo {\n" +
-            "   var bar: Int { return 1 }\n" +
-            "   var baz: Int { return 1 }\n" +
-            "}",
-            "public extension Foo {\n" +
-            "   var bar: Int { return 1 }\n" +
-            "   var baz: Int { return 1 }\n" +
-            "}",
-            "extension Foo {\n" +
-            "   private bar: Int { return 1 }\n" +
-            "   private baz: Int { return 1 }\n" +
-            "}",
-            "extension Foo {\n" +
-            "   open bar: Int { return 1 }\n" +
-            "   open baz: Int { return 1 }\n" +
-            "}"
+            """
+            extension Foo: SomeProtocol {
+              public var bar: Int { return 1 }
+            }
+            """,
+            """
+            extension Foo {
+              private var bar: Int { return 1 }
+              public var baz: Int { return 1 }
+            }
+            """,
+            """
+            extension Foo {
+              private var bar: Int { return 1 }
+              public func baz() {}
+            }
+            """,
+            """
+            extension Foo {
+              var bar: Int { return 1 }
+              var baz: Int { return 1 }
+            }
+            """,
+            """
+            public extension Foo {
+              var bar: Int { return 1 }
+              var baz: Int { return 1 }
+            }
+            """,
+            """
+            extension Foo {
+              private bar: Int { return 1 }
+              private baz: Int { return 1 }
+            }
+            """,
+            """
+            extension Foo {
+              open bar: Int { return 1 }
+              open baz: Int { return 1 }
+            }
+            """
         ],
         triggeringExamples: [
-            "↓extension Foo {\n" +
-            "   public var bar: Int { return 1 }\n" +
-            "   public var baz: Int { return 1 }\n" +
-            "}",
-            "↓extension Foo {\n" +
-            "   public var bar: Int { return 1 }\n" +
-            "   public func baz() {}\n" +
-            "}",
-            "public extension Foo {\n" +
-            "   public ↓func bar() {}\n" +
-            "   public ↓func baz() {}\n" +
-            "}"
+            """
+            ↓extension Foo {
+               public var bar: Int { return 1 }
+               public var baz: Int { return 1 }
+            }
+            """,
+            """
+            ↓extension Foo {
+               public var bar: Int { return 1 }
+               public func baz() {}
+            }
+            """,
+            """
+            public extension Foo {
+               public ↓func bar() {}
+               public ↓func baz() {}
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
@@ -11,18 +11,22 @@ public struct FallthroughRule: ConfigurationProviderRule, OptInRule, AutomaticTe
         description: "Fallthrough should be avoided.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "switch foo {\n" +
-            "case .bar, .bar2, .bar3:\n" +
-            "    something()\n" +
-            "}"
+            """
+            switch foo {
+            case .bar, .bar2, .bar3:
+              something()
+            }
+            """
         ],
         triggeringExamples: [
-            "switch foo {\n" +
-            "case .bar:\n" +
-            "    ↓fallthrough\n" +
-            "case .bar2:\n" +
-            "    something()\n" +
-            "}"
+            """
+            switch foo {
+            case .bar:
+              ↓fallthrough
+            case .bar2:
+              something()
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -11,12 +11,28 @@ public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRu
         description: "A fatalError call should have a message.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "func foo() {\n  fatalError(\"Foo\")\n}\n",
-            "func foo() {\n  fatalError(x)\n}\n"
+            """
+            func foo() {
+              fatalError("Foo")
+            }
+            """,
+            """
+            func foo() {
+              fatalError(x)
+            }
+            """
         ],
         triggeringExamples: [
-            "func foo() {\n  ↓fatalError(\"\")\n}\n",
-            "func foo() {\n  ↓fatalError()\n}\n"
+            """
+            func foo() {
+              fatalError("")
+            }
+            """,
+            """
+            func foo() {
+              fatalError()
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -25,12 +25,12 @@ public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRu
         triggeringExamples: [
             """
             func foo() {
-              fatalError("")
+              ↓fatalError("")
             }
             """,
             """
             func foo() {
-              fatalError()
+              ↓fatalError()
             }
             """
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -12,54 +12,76 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
         description: "`where` clauses are preferred over a single `if` inside a `for`.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "for user in users where user.id == 1 { }\n",
+            """
+            for user in users where user.id == 1 { }
+            """,
             // if let
-            "for user in users {\n" +
-            "   if let id = user.id { }\n" +
-            "}\n",
+            """
+            for user in users {
+              if let id = user.id { }
+            }
+            """,
             // if var
-            "for user in users {\n" +
-            "   if var id = user.id { }\n" +
-            "}\n",
+            """
+            for user in users {
+              if var id = user.id { }
+            }
+            """,
             // if with else
-            "for user in users {\n" +
-            "   if user.id == 1 { } else { }\n" +
-            "}\n",
+            """
+            for user in users {
+              if user.id == 1 { } else { }
+            "}
+            """,
             // if with else if
-            "for user in users {\n" +
-            "   if user.id == 1 {\n" +
-            "} else if user.id == 2 { }\n" +
-            "}\n",
+            """
+            for user in users {
+              if user.id == 1 {
+              } else if user.id == 2 { }
+            }
+            """,
             // if is not the only expression inside for
-            "for user in users {\n" +
-            "   if user.id == 1 { }\n" +
-            "   print(user)\n" +
-            "}\n",
+            """
+            for user in users {
+              if user.id == 1 { }
+              print(user)
+            }
+            """,
             // if a variable is used
-            "for user in users {\n" +
-            "   let id = user.id\n" +
-            "   if id == 1 { }\n" +
-            "}\n",
+            """
+            for user in users {
+              let id = user.id
+              if id == 1 { }
+            }
+            """,
             // if something is after if
-            "for user in users {\n" +
-            "   if user.id == 1 { }\n" +
-            "   return true\n" +
-            "}\n",
+            """
+            for user in users {
+              if user.id == 1 { }
+              return true
+            }
+            """,
             // condition with multiple clauses
-            "for user in users {\n" +
-            "   if user.id == 1 && user.age > 18 { }\n" +
-            "}\n",
+            """
+            for user in users {
+              if user.id == 1 && user.age > 18 { }
+            }
+            """,
             // if case
-            "for (index, value) in array.enumerated() {\n" +
-            "   if case .valueB(_) = value {\n" +
-            "       return index\n" +
-            "   }\n" +
-            "}\n"
+            """
+            for (index, value) in array.enumerated() {
+              if case .valueB(_) = value {
+                return index
+              }
+            }
+            """
         ],
         triggeringExamples: [
-            "for user in users {\n" +
-            "   ↓if user.id == 1 { return true }\n" +
-            "}\n"
+            """
+            for user in users {
+              ↓if user.id == 1 { return true }
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -31,7 +31,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
             """
             for user in users {
               if user.id == 1 { } else { }
-            "}
+            }
             """,
             // if with else if
             """

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
@@ -11,10 +11,18 @@ public struct ForceTryRule: ConfigurationProviderRule, AutomaticTestableRule {
         description: "Force tries should be avoided.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "func a() throws {}; do { try a() } catch {}"
+            """
+            func a() throws {};
+            do {
+              try a()
+            } catch {}
+            """
         ],
         triggeringExamples: [
-            "func a() throws {}; ↓try! a()"
+            """
+            func a() throws {};
+            ↓try! a()
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
@@ -12,7 +12,7 @@ public struct ForceTryRule: ConfigurationProviderRule, AutomaticTestableRule {
         kind: .idiomatic,
         nonTriggeringExamples: [
             """
-            func a() throws {};
+            func a() throws {}
             do {
               try a()
             } catch {}
@@ -20,7 +20,7 @@ public struct ForceTryRule: ConfigurationProviderRule, AutomaticTestableRule {
         ],
         triggeringExamples: [
             """
-            func a() throws {};
+            func a() throws {}
             ↓try! a()
             """
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -44,9 +44,11 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
             "dict[\"abc\"]↓!.bar(\"B\")",
             "if dict[\"a\"]↓!!!! {",
             "var foo: [Bool]! = dict[\"abc\"]↓!",
-            "context(\"abc\") {\n" +
-            "  var foo: [Bool]! = dict[\"abc\"]↓!\n" +
-            "}",
+            """
+            context(\"abc\") {
+              var foo: [Bool]! = dict[\"abc\"]↓!
+            }
+            """,
             "open var computed: String { return foo.bar↓! }"
         ]
     )

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -19,12 +19,12 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
             "func foo() {}",
             """
             class A: B {
-                override func foo(bar: Int = 0, baz: String) {}
+              override func foo(bar: Int = 0, baz: String) {}
             """,
             "func foo(bar: Int = 0, completion: @escaping CompletionHandler) {}",
             """
             func foo(a: Int, b: CGFloat = 0) {
-                let block = { (error: Error?) in }
+              let block = { (error: Error?) in }
             }
             """
         ],

--- a/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -19,9 +19,15 @@ public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, Op
         ],
         triggeringExamples: [
             "let foo = bar.joined(↓separator: \"\")",
-            "let foo = bar.filter(toto)\n" +
-            "             .joined(↓separator: \"\")",
-            "func foo() -> String {\n   return [\"1\", \"2\"].joined(↓separator: \"\")\n}"
+            """
+            let foo = bar.filter(toto)
+                         .joined(↓separator: ""),
+            """,
+            """
+            func foo() -> String {
+              return ["1", "2"].joined(↓separator: "")
+            }
+            """
         ],
         corrections: [
             "let foo = bar.joined(↓separator: \"\")": "let foo = bar.joined()",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
@@ -15,20 +15,20 @@ public struct LegacyHashingRule: ASTRule, ConfigurationProviderRule, AutomaticTe
         nonTriggeringExamples: [
             """
             struct Foo: Hashable {
-                let bar: Int = 10
+              let bar: Int = 10
 
-                func hash(into hasher: inout Hasher) {
-                    hasher.combine(bar)
-                  }
+              func hash(into hasher: inout Hasher) {
+                hasher.combine(bar)
+              }
             }
             """,
             """
             class Foo: Hashable {
-                let bar: Int = 10
+              let bar: Int = 10
 
-                func hash(into hasher: inout Hasher) {
-                    hasher.combine(bar)
-                  }
+              func hash(into hasher: inout Hasher) {
+                hasher.combine(bar)
+              }
             }
             """,
             """
@@ -37,21 +37,21 @@ public struct LegacyHashingRule: ASTRule, ConfigurationProviderRule, AutomaticTe
             """,
             """
             class Foo: Hashable {
-                let bar: String = "Foo"
+              let bar: String = "Foo"
 
-                public var hashValue: String {
-                    return bar
-                }
+              public var hashValue: String {
+                return bar
+              }
             }
             """,
             """
             class Foo: Hashable {
-                let bar: String = "Foo"
+              let bar: String = "Foo"
 
-                public var hashValue: String {
-                    get { return bar }
-                    set { bar = newValue }
-                }
+              public var hashValue: String {
+                get { return bar }
+                set { bar = newValue }
+              }
             }
             """
         ],

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -15,47 +15,47 @@ public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule, Automat
             """
             switch myvar {
             case 1:
-                var a = 1
-                fallthrough
+              var a = 1
+              fallthrough
             case 2:
-                var a = 2
+              var a = 2
             }
             """,
             """
             switch myvar {
             case "a":
-                var one = 1
-                var two = 2
-                fallthrough
+              var one = 1
+              var two = 2
+              fallthrough
             case "b": /* comment */
-                var three = 3
+              var three = 3
             }
             """,
             """
             switch myvar {
             case 1:
-               let one = 1
+              let one = 1
             case 2:
-               // comment
-               var two = 2
+              // comment
+              var two = 2
             }
             """,
             """
             switch myvar {
             case MyFunc(x: [1, 2, YourFunc(a: 23)], y: 2):
-                var three = 3
-                fallthrough
+              var three = 3
+              fallthrough
             default:
-                var three = 4
+              var three = 4
             }
             """,
             """
             switch myvar {
             case .alpha:
-                var one = 1
+              var one = 1
             case .beta:
-                var three = 3
-                fallthrough
+              var three = 3
+              fallthrough
             default:
                 var four = 4
             }
@@ -64,21 +64,21 @@ public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule, Automat
             let aPoint = (1, -1)
             switch aPoint {
             case let (x, y) where x == y:
-                let A = "A"
+              let A = "A"
             case let (x, y) where x == -y:
-                let B = "B"
-                fallthrough
+              let B = "B"
+              fallthrough
             default:
-                let C = "C"
+              let C = "C"
             }
             """,
             """
             switch myvar {
             case MyFun(with: { $1 }):
-                let one = 1
-                fallthrough
+              let one = 1
+              fallthrough
             case "abc":
-                let two = 2
+              let two = 2
             }
             """
         ],
@@ -86,53 +86,53 @@ public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule, Automat
             """
             switch myvar {
             case 1:
-                ↓fallthrough
+              ↓fallthrough
             case 2:
-                var a = 1
+              var a = 1
             }
             """,
             """
             switch myvar {
             case 1:
-                var a = 2
+              var a = 2
             case 2:
-                ↓fallthrough
+              ↓fallthrough
             case 3:
-                var a = 3
+              var a = 3
             }
             """,
             """
             switch myvar {
             case 1: // comment
-                ↓fallthrough
+              ↓fallthrough
             }
             """,
             """
             switch myvar {
             case 1: /* multi
-                line
-                comment */
-                ↓fallthrough
+              line
+              comment */
+              ↓fallthrough
             case 2:
-                var a = 2
+              var a = 2
             }
             """,
             """
             switch myvar {
             case MyFunc(x: [1, 2, YourFunc(a: 23)], y: 2):
-                ↓fallthrough
+              ↓fallthrough
             default:
-                var three = 4
+              var three = 4
             }
             """,
             """
             switch myvar {
             case .alpha:
-                var one = 1
+              var one = 1
             case .beta:
-                ↓fallthrough
+              ↓fallthrough
             case .gamma:
-                var three = 3
+              var three = 3
             default:
               var four = 4
             }
@@ -141,19 +141,19 @@ public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule, Automat
             let aPoint = (1, -1)
             switch aPoint {
             case let (x, y) where x == y:
-                let A = "A"
+              let A = "A"
             case let (x, y) where x == -y:
-                ↓fallthrough
+              ↓fallthrough
             default:
-                let B = "B"
+              let B = "B"
             }
             """,
             """
             switch myvar {
             case MyFun(with: { $1 }):
-                ↓fallthrough
+              ↓fallthrough
             case "abc":
-                let two = 2
+              let two = 2
             }
             """
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -17,14 +17,36 @@ public struct PrivateOverFilePrivateRule: Rule, ConfigurationProviderRule, Corre
             "public \n enum MyEnum {}",
             "open extension \n String {}",
             "internal extension String {}",
-            "extension String {\nfileprivate func Something(){}\n}",
-            "class MyClass {\nfileprivate let myInt = 4\n}",
-            "class MyClass {\nfileprivate(set) var myInt = 4\n}",
-            "struct Outter {\nstruct Inter {\nfileprivate struct Inner {}\n}\n}"
+            """
+            extension String {
+              fileprivate func Something(){}
+            }
+            """,
+            """
+            class MyClass {
+              fileprivate let myInt = 4
+            }
+            """,
+            """
+            class MyClass {
+              fileprivate(set) var myInt = 4
+            }
+            """,
+            """
+            struct Outter {
+              struct Inter {
+                fileprivate struct Inner {}
+              }
+            }
+            """
         ],
         triggeringExamples: [
             "↓fileprivate enum MyEnum {}",
-            "↓fileprivate class MyClass {\nfileprivate(set) var myInt = 4\n}"
+            """
+            ↓fileprivate class MyClass {
+              fileprivate(set) var myInt = 4
+            }
+            """
         ],
         corrections: [
             "↓fileprivate enum MyEnum {}": "private enum MyEnum {}",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -60,9 +60,9 @@ public struct RedundantObjcAttributeRule: ASTRule, ConfigurationProviderRule, Au
             """
             @IBDesignable
             extension Foo {
-               @objc
-               var bar: Int { return 0 }
-               var fooBar: Int { return 1 }
+              @objc
+              var bar: Int { return 0 }
+              var fooBar: Int { return 1 }
             }
             """,
             """

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -21,20 +21,33 @@ public struct RedundantOptionalInitializationRule: ASTRule, CorrectableRule, Con
             "let myVar: Optional<Int> = nil\n",
             "var myVar: Optional<Int> = 0\n",
             // properties with body should be ignored
-            "var foo: Int? {\n" +
-            "   if bar != nil { }\n" +
-            "   return 0\n" +
-            "}\n",
+            """
+            var foo: Int? {
+              if bar != nil { }
+              return 0
+            }
+            """
+            ,
             // properties with a closure call
-            "var foo: Int? = {\n" +
-            "   if bar != nil { }\n" +
-            "   return 0\n" +
-            "}()\n",
+            """
+            var foo: Int? = {
+              if bar != nil { }
+              return 0
+            }()
+            """,
             // lazy variables need to be initialized
             "lazy var test: Int? = nil",
             // local variables
-            "func funcName() {\n    var myVar: String?\n}",
-            "func funcName() {\n    let myVar: String? = nil\n}"
+            """
+            func funcName() {
+              var myVar: String?
+            }
+            """,
+            """
+            func funcName() {
+              let myVar: String? = nil
+            }
+            """
         ],
         triggeringExamples: triggeringExamples,
         corrections: corrections

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -19,7 +19,7 @@ public struct RedundantSetAccessControlRule: ASTRule, ConfigurationProviderRule,
             "var foo: Int",
             """
             private final class A {
-                private(set) var value: Int
+              private(set) var value: Int
             }
             """
         ],
@@ -30,17 +30,17 @@ public struct RedundantSetAccessControlRule: ASTRule, ConfigurationProviderRule,
             "↓public(set) public var foo: Int",
             """
             open class Foo {
-                ↓open(set) open var bar: Int
+              ↓open(set) open var bar: Int
             }
             """,
             """
             class A {
-                ↓internal(set) var value: Int
+              ↓internal(set) var value: Int
             }
             """,
             """
             fileprivate class A {
-                ↓fileprivate(set) var value: Int
+              ↓fileprivate(set) var value: Int
             }
             """
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -61,6 +61,11 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
             """,
             """
             enum Numbers: String {
+              case one = ↓"one", two = ↓"two"
+            }
+            """,
+            """
+            enum Numbers: String {
               case one, two = ↓"two"
             }
             """

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -22,16 +22,48 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
         description: "String enum values can be omitted when they are equal to the enumcase name.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "enum Numbers: String {\n case one\n case two\n}\n",
-            "enum Numbers: Int {\n case one = 1\n case two = 2\n}\n",
-            "enum Numbers: String {\n case one = \"ONE\"\n case two = \"TWO\"\n}\n",
-            "enum Numbers: String {\n case one = \"ONE\"\n case two = \"two\"\n}\n",
-            "enum Numbers: String {\n case one, two\n}\n"
+            """
+            enum Numbers: String {
+              case one
+              case two
+            }
+            """,
+            """
+            enum Numbers: Int {
+              case one = 1
+              case two = 2
+            }
+            """,
+            """
+            enum Numbers: String {
+              case one = "ONE"
+              case two = "TWO"
+            }
+            """,
+            """
+            enum Numbers: String {
+              case one = "ONE"
+              case two = "two"
+            }
+            """,
+            """
+            enum Numbers: String {
+              case one, two
+            }
+            """
         ],
         triggeringExamples: [
-            "enum Numbers: String {\n case one = ↓\"one\"\n case two = ↓\"two\"\n}\n",
-            "enum Numbers: String {\n case one = ↓\"one\", two = ↓\"two\"\n}\n",
-            "enum Numbers: String {\n case one, two = ↓\"two\"\n}\n"
+            """
+            enum Numbers: String {
+              case one = ↓"one"
+              case two = ↓"two"
+            }
+            """,
+            """
+            enum Numbers: String {
+              case one, two = ↓"two"
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -25,9 +25,9 @@ public struct RedundantTypeAnnotationRule: Rule, OptInRule, CorrectableRule,
             "let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics",
             """
             class ViewController: UIViewController {
-                func someMethod() {
-                    let myVar↓: Int = Int(5)
-                }
+              func someMethod() {
+                let myVar↓: Int = Int(5)
+              }
             }
             """
         ],
@@ -38,16 +38,16 @@ public struct RedundantTypeAnnotationRule: Rule, OptInRule, CorrectableRule,
                 "let alphanumerics = CharacterSet.alphanumerics",
             """
             class ViewController: UIViewController {
-                func someMethod() {
-                    let myVar↓: Int = Int(5)
-                }
+              func someMethod() {
+                let myVar↓: Int = Int(5)
+              }
             }
             """:
             """
             class ViewController: UIViewController {
-                func someMethod() {
-                    let myVar = Int(5)
-                }
+              func someMethod() {
+                let myVar = Int(5)
+              }
             }
             """
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -26,9 +26,17 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
         ],
         triggeringExamples: [
             "func foo()↓ -> Void {}\n",
-            "protocol Foo {\n func foo()↓ -> Void\n}\n",
+            """
+            protocol Foo {
+              func foo()↓ -> Void
+            }
+            """,
             "func foo()↓ -> () {}\n",
-            "protocol Foo {\n func foo()↓ -> ()\n}\n"
+            """
+            protocol Foo {
+              func foo()↓ -> ()
+            }
+            """
         ],
         corrections: [
             "func foo()↓ -> Void {}\n": "func foo() {}\n",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
@@ -14,9 +14,9 @@ public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, OptInRule,
         nonTriggeringExamples: [
             """
             class A: Equatable {
-                static func == (lhs: A, rhs: A) -> Bool {
-                    return false
-                }
+              static func == (lhs: A, rhs: A) -> Bool {
+                return false
+              }
             """,
             """
             class A<T>: Equatable {
@@ -26,54 +26,54 @@ public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, OptInRule,
             """,
             """
             public extension Array where Element == Rule {
-                static func == (lhs: Array, rhs: Array) -> Bool {
-                    if lhs.count != rhs.count { return false }
-                    return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
-                }
+              static func == (lhs: Array, rhs: Array) -> Bool {
+                if lhs.count != rhs.count { return false }
+                return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
+              }
             }
             """,
             """
             private extension Optional where Wrapped: Comparable {
-                static func < (lhs: Optional, rhs: Optional) -> Bool {
-                    switch (lhs, rhs) {
-                    case let (lhs?, rhs?):
-                        return lhs < rhs
-                    case (nil, _?):
-                        return true
-                    default:
-                        return false
-                    }
+              static func < (lhs: Optional, rhs: Optional) -> Bool {
+                switch (lhs, rhs) {
+                case let (lhs?, rhs?):
+                  return lhs < rhs
+                case (nil, _?):
+                  return true
+                default:
+                  return false
                 }
+              }
             }
             """
         ],
         triggeringExamples: [
             """
             ↓func == (lhs: A, rhs: A) -> Bool {
-                return false
+              return false
             }
             """,
             """
             ↓func == <T>(lhs: A<T>, rhs: A<T>) -> Bool {
-                return false
+              return false
             }
             """,
             """
             ↓func == (lhs: [Rule], rhs: [Rule]) -> Bool {
-                if lhs.count != rhs.count { return false }
-                return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
+              if lhs.count != rhs.count { return false }
+              return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
             }
             """,
             """
             private ↓func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-                switch (lhs, rhs) {
-                case let (lhs?, rhs?):
-                    return lhs < rhs
-                case (nil, _?):
-                    return true
-                default:
-                    return false
-                }
+              switch (lhs, rhs) {
+              case let (lhs?, rhs?):
+                return lhs < rhs
+              case (nil, _?):
+                return true
+              default:
+                return false
+              }
             }
             """
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -14,18 +14,48 @@ public struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, Autom
         nonTriggeringExamples: [
             "extension String {}",
             "private extension String {}",
-            "public \n extension String {}",
-            "open extension \n String {}",
+            """
+            public
+            extension String {}
+            """,
+            """
+            open extension
+              String {}
+            """,
             "internal extension String {}"
         ],
         triggeringExamples: [
             "↓fileprivate extension String {}",
-            "↓fileprivate \n extension String {}",
-            "↓fileprivate extension \n String {}",
-            "extension String {\n↓fileprivate func Something(){}\n}",
-            "class MyClass {\n↓fileprivate let myInt = 4\n}",
-            "class MyClass {\n↓fileprivate(set) var myInt = 4\n}",
-            "struct Outter {\nstruct Inter {\n↓fileprivate struct Inner {}\n}\n}"
+            """
+            ↓fileprivate
+              extension String {}
+            """,
+            """
+            ↓fileprivate extension
+              String {}
+            """,
+            """
+            extension String {
+              ↓fileprivate func Something(){}
+            }
+            """,
+            """
+            class MyClass {
+              ↓fileprivate let myInt = 4
+            }
+            """,
+            """
+            class MyClass {
+              ↓fileprivate(set) var myInt = 4
+            }
+            """,
+            """
+            struct Outter {
+              struct Inter {
+                ↓fileprivate struct Inner {}
+              }
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -17,8 +17,16 @@ public struct SyntacticSugarRule: ConfigurationProviderRule, AutomaticTestableRu
             "let x: Int?",
             "func x(a: [Int], b: Int) -> [Int: Any]",
             "let x: Int!",
-            "extension Array { \n func x() { } \n }",
-            "extension Dictionary { \n func x() { } \n }",
+            """
+            extension Array {
+              func x() { }
+            }
+            """,
+            """
+            extension Dictionary {
+              func x() { }
+            }
+            """,
             "let x: CustomArray<String>",
             "var currentIndex: Array<OnboardingPage>.Index?",
             "func x(a: [Int], b: Int) -> Array<Int>.Index",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRuleExamples.swift
@@ -12,8 +12,16 @@ internal struct TypeNameRuleExamples {
         let typeAliasAndAssociatedTypeExamples = [
             "typealias Foo = Void",
             "private typealias Foo = Void",
-            "protocol Foo {\n associatedtype Bar\n }",
-            "protocol Foo {\n associatedtype Bar: Equatable\n }"
+            """
+            protocol Foo {
+              associatedtype Bar
+            }
+            """,
+            """
+            protocol Foo {
+              associatedtype Bar: Equatable
+            }
+            """
         ]
 
         return typeExamples + typeAliasAndAssociatedTypeExamples + ["enum MyType {\ncase value\n}"]
@@ -34,9 +42,21 @@ internal struct TypeNameRuleExamples {
             "private typealias ↓Foo_Bar = Void",
             "private typealias ↓foo = Void",
             "typealias ↓\(repeatElement("A", count: 41).joined()) = Void",
-            "protocol Foo {\n associatedtype ↓X\n }",
-            "protocol Foo {\n associatedtype ↓Foo_Bar: Equatable\n }",
-            "protocol Foo {\n associatedtype ↓\(repeatElement("A", count: 41).joined())\n }"
+            """
+            protocol Foo {
+              associatedtype ↓X
+            }
+            """,
+            """
+            protocol Foo {
+              associatedtype ↓Foo_Bar: Equatable
+            }
+            """,
+            """
+            protocol Foo {
+              associatedtype ↓\(repeatElement("A", count: 41).joined())
+            }
+            """
         ]
 
         return typeExamples + typeAliasAndAssociatedTypeExamples

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -15,39 +15,39 @@ public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptIn
         nonTriggeringExamples: [
             """
             class ViewController: UIViewController {
-                @available(*, unavailable)
-                public required init?(coder aDecoder: NSCoder) {
-                    fatalError("init(coder:) has not been implemented")
-                }
+              @available(*, unavailable)
+              public required init?(coder aDecoder: NSCoder) {
+                fatalError("init(coder:) has not been implemented")
+              }
             }
             """,
             """
             func jsonValue(_ jsonString: String) -> NSObject {
-                let data = jsonString.data(using: .utf8)!
-                let result = try! JSONSerialization.jsonObject(with: data, options: [])
-                if let dict = (result as? [String: Any])?.bridge() {
-                    return dict
-                } else if let array = (result as? [Any])?.bridge() {
-                    return array
-                }
-                fatalError()
+               let data = jsonString.data(using: .utf8)!
+               let result = try! JSONSerialization.jsonObject(with: data, options: [])
+               if let dict = (result as? [String: Any])?.bridge() {
+                return dict
+               } else if let array = (result as? [Any])?.bridge() {
+                return array
+               }
+               fatalError()
             }
             """
         ],
         triggeringExamples: [
             """
             class ViewController: UIViewController {
-                public required ↓init?(coder aDecoder: NSCoder) {
-                    fatalError("init(coder:) has not been implemented")
-                }
+              public required ↓init?(coder aDecoder: NSCoder) {
+                fatalError("init(coder:) has not been implemented")
+              }
             }
             """,
             """
             class ViewController: UIViewController {
-                public required ↓init?(coder aDecoder: NSCoder) {
-                    let reason = "init(coder:) has not been implemented"
-                    fatalError(reason)
-                }
+              public required ↓init?(coder aDecoder: NSCoder) {
+                let reason = "init(coder:) has not been implemented"
+                fatalError(reason)
+              }
             }
             """
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -35,19 +35,66 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, Aut
         description: "Catch statements should not declare error variables without type casting.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "do {\n    try foo() \n} catch {}",
-            "do {\n    try foo() \n} catch Error.invalidOperation {\n} catch {}",
-            "do {\n    try foo() \n} catch let error as MyError {\n} catch {}",
-            "do {\n    try foo() \n} catch var error as MyError {\n} catch {}"
+            """
+            do {
+              try foo()
+            } catch {}
+            """,
+            """
+            do {
+              try foo()
+            } catch Error.invalidOperation {
+            } catch {}
+            """,
+            """
+            do {
+              try foo()
+            } catch let error as MyError {
+            } catch {}
+            """,
+            """
+            do {
+              try foo()
+            } catch var error as MyError {
+            } catch {}
+            """
         ],
         triggeringExamples: [
-            "do {\n    try foo() \n} ↓catch var error {}",
-            "do {\n    try foo() \n} ↓catch let error {}",
-            "do {\n    try foo() \n} ↓catch let someError {}",
-            "do {\n    try foo() \n} ↓catch var someError {}",
-            "do {\n    try foo() \n} ↓catch let e {}",
-            "do {\n    try foo() \n} ↓catch(let error) {}",
-            "do {\n    try foo() \n} ↓catch (let error) {}"
+            """
+            do {
+              try foo()
+            } ↓catch var error {}
+            """,
+            """
+            do {
+              try foo()
+            } ↓catch let error {}
+            """,
+            """
+            do {
+              try foo()
+            } ↓catch let someError {}
+            """,
+            """
+            do {
+              try foo()
+            } ↓catch var someError {}
+            """,
+            """
+            do {
+              try foo()
+            } ↓catch let e {}
+            """,
+            """
+            do {
+              try foo()
+            } ↓catch(let error) {}
+            """,
+            """
+            do {
+              try foo()
+            } ↓catch (let error) {}
+            """
         ],
         corrections: [
             "do {\n    try foo() \n} ↓catch let error {}": "do {\n    try foo() \n} catch {}",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -11,20 +11,28 @@ public struct XCTFailMessageRule: ASTRule, ConfigurationProviderRule, AutomaticT
         description: "An XCTFail call should include a description of the assertion.",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "func testFoo() {\n" +
-            "    XCTFail(\"bar\")\n" +
-            "}",
-            "func testFoo() {\n" +
-            "    XCTFail(bar)\n" +
-            "}"
+            """
+            func testFoo() {
+              XCTFail("bar")
+            }
+            """,
+            """
+            func testFoo() {
+              XCTFail(bar)
+            }
+            """
         ],
         triggeringExamples: [
-            "func testFoo() {\n" +
-            "    ↓XCTFail()\n" +
-            "}",
-            "func testFoo() {\n" +
-            "    ↓XCTFail(\"\")\n" +
-            "}"
+            """
+            func testFoo() {
+              ↓XCTFail()
+            }
+            """,
+            """
+            func testFoo() {
+              ↓XCTFail("")
+            }
+            """
         ]
     )
 


### PR DESCRIPTION
I still need to convert some rules triggers
But here is the first approach as you described [here](https://github.com/realm/SwiftLint/pull/2505#issuecomment-444961761) @jpsim 