### PR TITLE
Support glob patterns without the star

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
   [Kim de Vos](https://github.com/kimdv)
   [#2282](https://github.com/realm/SwiftLint/issues/2282)
 
+* Support glob patterns without the star.  
+  [Maksym Grebenets](https://github.com/mgrebenets)
+
 #### Bug Fixes
 
 * Fix false positives in `redundant_objc_attribute` for private declarations

--- a/Source/SwiftLintFramework/Helpers/Glob.swift
+++ b/Source/SwiftLintFramework/Helpers/Glob.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 #if canImport(Darwin)
 import Darwin
 
@@ -12,7 +14,8 @@ private let globFunction = Glibc.glob
 
 struct Glob {
     static func resolveGlob(_ pattern: String) -> [String] {
-        guard pattern.contains("*") else {
+        let globCharset = CharacterSet(charactersIn: "*?[]")
+        guard pattern.rangeOfCharacter(from: globCharset) != nil else {
             return [pattern]
         }
 

--- a/Tests/SwiftLintFrameworkTests/GlobTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GlobTests.swift
@@ -23,6 +23,31 @@ final class GlobTests: XCTestCase {
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
+    func testMatchesSingleCharacter() {
+        let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level?.swift"))
+        XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
+    }
+
+    func testMatchesOneCharacterInBracket() {
+        let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[01].swift"))
+        XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
+    }
+
+    func testNoMatchOneCharacterInBracket() {
+        let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[ab].swift"))
+         XCTAssertTrue(files.isEmpty)
+    }
+
+    func testMatchesCharacterInRange() {
+        let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[0-9].swift"))
+        XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
+    }
+
+    func testNoMatchCharactersInRange() {
+        let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[a-z].swift"))
+        XCTAssertTrue(files.isEmpty)
+    }
+
     func testMatchesMultipleFiles() {
         let expectedFiles: Set = [
             mockPath.stringByAppendingPathComponent("Level0.swift"),
@@ -37,5 +62,16 @@ final class GlobTests: XCTestCase {
     func testMatchesNestedDirectory() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level1/*.swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level1/Level1.swift")])
+    }
+
+    func testNoGlobstarSupport() {
+        let expectedFiles: Set = [
+            mockPath.stringByAppendingPathComponent("Directory.swift/DirectoryLevel1.swift"),
+            mockPath.stringByAppendingPathComponent("Level1/Level1.swift")
+        ]
+
+        let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("**/*.swift"))
+        XCTAssertEqual(files.count, 2)
+        XCTAssertEqual(Set(files), expectedFiles)
     }
 }


### PR DESCRIPTION
Enables use of '[abc]', '?' and '[a-z]' glob syntax without the need to use '*' in the pattern.