### PR TITLE
Update Mint installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git is discouraged.
 
 ### Using [Mint](https://github.com/yonaskolb/mint):
 ```
-$ mint run realm/SwiftLint
+$ mint install realm/SwiftLint
 ```
 
 ### Using a pre-built package:

--- a/README_KR.md
+++ b/README_KR.md
@@ -35,7 +35,7 @@ CocoaPods를 사용하면 최신 버전 외에도 SwiftLint의 특정 버전을 
 
 ### [Mint](https://github.com/yonaskolb/mint)를 사용하는 경우:
 ```
-$ mint run realm/SwiftLint
+$ mint install realm/SwiftLint
 ```
 
 ### 빌드된 패키지를 사용하는 경우:


### PR DESCRIPTION
Now that Mint links a global version on install, a better example of installation is to use `mint install` rather than `mint run`