### PR TITLE
Make WeakDelegateRule not trigger on immediately initialized properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2433](https://github.com/realm/SwiftLint/issues/2433)
 
+* Make `weak_delegate` not trigger on properties that are immediately assigned.  
+  [skagedal](https://github.com/skagedal)
+  
 #### Bug Fixes
 
 * Fix inaccessible custom rules in nested configurations.  

--- a/Rules.md
+++ b/Rules.md
@@ -23017,6 +23017,13 @@ class Foo {
 }
 ```
 
+```swift
+class Foo {
+ var immediatelyInitializedDelegate = SomeClass()
+ }
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>


### PR DESCRIPTION
> Any such fooDelegate would be something the object holds on to and is a delegate for something else.

It can sometimes be convenient to use a helper class that only has the job of being a delegate for another class. It may make sense to call that class `FooDelegate` and holding on to it in a private property called `fooDelegate`. But this isn't something that acts as a delegate for something, thus should not be weak and should not be affected by this rule. 