### PR TITLE
Check the type of swiftlint_version input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   [Daniel Metzing](https://github.com/dirtydanee)
   [#2499](https://github.com/realm/SwiftLint/issues/2499)
 
+* Verify correct type of the `swiftlint_version` configuration value.  
+  [skagedal](https://github.com/skagedal)
+  [#2518](https://github.com/realm/SwiftLint/issues/2518)
+  
 ## 0.29.1: There’s Always More Laundry
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -85,6 +85,18 @@ extension Configuration {
             return nil
         }
 
+        let swiftlintVersion: String?
+        if let version = dict[Key.swiftlintVersion.rawValue] {
+            if let version = version as? String {
+                swiftlintVersion = version
+            } else {
+                queuedPrintError("Incorrect type for \(Key.swiftlintVersion.rawValue) – expected string, got \(type(of: version)). Ignoring.")
+                swiftlintVersion = nil
+            }
+        } else {
+            swiftlintVersion = nil
+        }
+        
         self.init(disabledRules: disabledRules,
                   optInRules: optInRules,
                   enableAllRules: enableAllRules,
@@ -96,7 +108,7 @@ extension Configuration {
                   reporter: dict[Key.reporter.rawValue] as? String ?? XcodeReporter.identifier,
                   ruleList: ruleList,
                   configuredRules: configuredRules,
-                  swiftlintVersion: dict[Key.swiftlintVersion.rawValue] as? String,
+                  swiftlintVersion: swiftlintVersion,
                   cachePath: cachePath ?? dict[Key.cachePath.rawValue] as? String,
                   indentation: indentation)
     }


### PR DESCRIPTION
See issue #2518. This fixes the problem by checking the type of input.

If the wrong type is found, it prints an error message and continues. This is consistent with some other similar parsing in the file, like the check for invalid keys. I personally think it would make sense to exit with error. I tried to instead return nil from the initializer, but then SwiftLint crashed. 

Not the prettiest code, I could try clean it up if you think the general approach is right. 