### PR TITLE
#2353 - Make modifier_order rule autocorrectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 * Support glob patterns without the star.  
   [Maksym Grebenets](https://github.com/mgrebenets)
 
+* Make `modifier_order` rule autocorrectable.  
+  [Timofey Solonin](https://github.com/biboran)
+  [#2353](https://github.com/realm/SwiftLint/issues/2353)
+
 #### Bug Fixes
 
 * Fix false positives in `redundant_objc_attribute` for private declarations
@@ -92,10 +96,6 @@
   version defined as `swiftlint_version` in the configuration file.  
   [Kim de Vos](https://github.com/kimdv)
   [#2074](https://github.com/realm/SwiftLint/issues/2074)
-
-* Make `modifier_order` rule autocorrectable  
-  [Timofey Solonin](https://github.com/biboran)
-  [#2353](https://github.com/realm/SwiftLint/issues/2353)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@
   [Kim de Vos](https://github.com/kimdv)
   [#2074](https://github.com/realm/SwiftLint/issues/2074)
 
+* Make `modifier_order` rule autocorrectable  
+  [Timofey Solonin](https://github.com/biboran)
+  [#2353](https://github.com/realm/SwiftLint/issues/2353)
+
 #### Bug Fixes
 
 * Fix false positive in `nimble_operator` rule.  

--- a/Rules.md
+++ b/Rules.md
@@ -10751,7 +10751,7 @@ public let b: Int
 
 Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
 --- | --- | --- | --- | --- | ---
-`modifier_order` | Disabled | No | style | No | 4.1.0 
+`modifier_order` | Disabled | Yes | style | No | 4.1.0 
 
 Modifier order should be consistent.
 

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -267,6 +267,10 @@ extension File {
         return violatingRanges
     }
 
+    internal func ruleEnabled(violatingRange: NSRange, for rule: Rule) -> NSRange? {
+        return ruleEnabled(violatingRanges: [violatingRange], for: rule).first
+    }
+
     fileprivate func numberOfCommentAndWhitespaceOnlyLines(startLine: Int, endLine: Int) -> Int {
         let commentKinds = SyntaxKind.commentKinds
         return syntaxKindsByLines[startLine...endLine].filter { kinds in

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SourceKittenFramework
 
 public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, CorrectableRule {

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -36,18 +36,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule {
             return []
         }
 
-        let violatableModifiers = self.violatableModifiers(declaredModifiers: dictionary.modifierDescriptions)
-        let prioritizedModifiers = self.prioritizedModifiers(violatableModifiers: violatableModifiers)
-        let sortedByPriorityModifiers = prioritizedModifiers.sorted(
-            by: { lhs, rhs in lhs.priority < rhs.priority }
-        ).map { $0.modifier }
-
-        let violatingModifiers = zip(
-            sortedByPriorityModifiers,
-            violatableModifiers
-        ).filter { sortedModifier, unsortedModifier in
-            return sortedModifier != unsortedModifier
-        }
+        let violatingModifiers = self.violatingModifiers(dictionary: dictionary)
 
         if let first = violatingModifiers.first {
             let preferredModifier = first.0
@@ -85,6 +74,25 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule {
             }
             return prioritizedModifiers + [(priority: priority, modifier: modifier)]
         }
+    }
+
+    private func violatingModifiers(
+        dictionary: [String: SourceKitRepresentable]
+    ) -> [(preferredModifier: ModifierDescription, declaredModifier: ModifierDescription)] {
+        let violatableModifiers = self.violatableModifiers(declaredModifiers: dictionary.modifierDescriptions)
+        let prioritizedModifiers = self.prioritizedModifiers(violatableModifiers: violatableModifiers)
+        let sortedByPriorityModifiers = prioritizedModifiers.sorted(
+            by: { lhs, rhs in lhs.priority < rhs.priority }
+            ).map { $0.modifier }
+
+        let violatingModifiers = zip(
+            sortedByPriorityModifiers,
+            violatableModifiers
+        ).filter { sortedModifier, unsortedModifier in
+            sortedModifier != unsortedModifier
+        }
+
+        return violatingModifiers
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -148,18 +148,11 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
     ) -> [(preferredModifier: ModifierDescription, declaredModifier: ModifierDescription)] {
         let violatableModifiers = self.violatableModifiers(declaredModifiers: dictionary.modifierDescriptions)
         let prioritizedModifiers = self.prioritizedModifiers(violatableModifiers: violatableModifiers)
-        let sortedByPriorityModifiers = prioritizedModifiers.sorted(
-            by: { lhs, rhs in lhs.priority < rhs.priority }
-            ).map { $0.modifier }
+        let sortedByPriorityModifiers = prioritizedModifiers
+            .sorted { $0.priority < $1.priority }
+            .map { $0.modifier }
 
-        let violatingModifiers = zip(
-            sortedByPriorityModifiers,
-            violatableModifiers
-        ).filter { sortedModifier, unsortedModifier in
-            sortedModifier != unsortedModifier
-        }
-
-        return violatingModifiers
+        return zip(sortedByPriorityModifiers, violatableModifiers).filter { $0 != $1 }
     }
 }
 
@@ -210,8 +203,8 @@ private extension Dictionary where Key == String, Value == SourceKitRepresentabl
 }
 
 private extension String {
-    func lastComponentAfter(_ charachter: String) -> String {
-        return components(separatedBy: charachter).last ?? ""
+    func lastComponentAfter(_ character: String) -> String {
+        return components(separatedBy: character).last ?? ""
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -108,16 +108,23 @@ private extension Dictionary where Key == String, Value == SourceKitRepresentabl
                 return rhsOffset < lhsOffset
             }
             .compactMap {
+                guard let offset = $0.offset else { return nil }
                 if let attribute = $0.attribute,
-                   let modifierGroup = SwiftDeclarationAttributeKind.ModifierGroup(rawAttribute: attribute) {
+                   let modifierGroup = SwiftDeclarationAttributeKind.ModifierGroup(rawAttribute: attribute),
+                   let length = $0.length {
                     return ModifierDescription(
                         keyword: attribute.lastComponentAfter("."),
-                        group: modifierGroup
+                        group: modifierGroup,
+                        offset: offset,
+                        length: length
                     )
                 } else if let kind = $0.kind {
+                    let keyword = kind.lastComponentAfter(".")
                     return ModifierDescription(
-                        keyword: kind.lastComponentAfter("."),
-                        group: .typeMethods
+                        keyword: keyword,
+                        group: .typeMethods,
+                        offset: offset,
+                        length: keyword.count
                     )
                 }
                 return nil
@@ -144,4 +151,6 @@ private extension String {
 private struct ModifierDescription: Equatable {
     let keyword: String
     let group: SwiftDeclarationAttributeKind.ModifierGroup
+    let offset: Int
+    let length: Int
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -718,6 +718,9 @@ extension ModifierOrderTests {
         ("testRightOrderedModifierGroups", testRightOrderedModifierGroups),
         ("testAtPrefixedGroup", testAtPrefixedGroup),
         ("testNonSpecifiedModifiersDontInterfere", testNonSpecifiedModifiersDontInterfere),
+        ("testCorrectionsAreAppliedCorrectly", testCorrectionsAreAppliedCorrectly),
+        ("testCorrectionsAreNotAppliedToIrrelevantModifier", testCorrectionsAreNotAppliedToIrrelevantModifier),
+        ("testTypeMethodClassCorrection", testTypeMethodClassCorrection),
         ("testViolationMessage", testViolationMessage)
     ]
 }

--- a/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
@@ -371,10 +371,10 @@ class ModifierOrderTests: XCTestCase {
                 final private class Foo {}
                 """,
                 """
-                public protocol Foo: class {}
+                public protocol Foo: class {}\n
                 """:
                 """
-                public protocol Foo: class {}
+                public protocol Foo: class {}\n
                 """
             ]
         )

--- a/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
@@ -1,8 +1,7 @@
 @testable import SwiftLintFramework
 import XCTest
 
-// swiftlint:disable file_length
-// swiftlint:disable type_body_length
+// swiftlint:disable file_length type_body_length
 
 class ModifierOrderTests: XCTestCase {
     func testAttributeTypeMethod() {

--- a/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
@@ -1,6 +1,9 @@
 @testable import SwiftLintFramework
 import XCTest
 
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
+
 class ModifierOrderTests: XCTestCase {
     func testAttributeTypeMethod() {
         let descriptionOverride = RuleDescription(
@@ -199,6 +202,185 @@ class ModifierOrderTests: XCTestCase {
 
         verifyRule(descriptionOverride,
                    ruleConfiguration: ["preferred_modifier_order": ["final", "override", "acl"]])
+    }
+
+    func testCorrectionsAreAppliedCorrectly() {
+        let descriptionOverride = RuleDescription(
+            identifier: "modifier_order",
+            name: "Modifier Order",
+            description: "Modifier order should be consistent.",
+            kind: .style,
+            minSwiftVersion: .fourDotOne,
+            nonTriggeringExamples: [],
+            triggeringExamples: [],
+            corrections: [
+                """
+                class Foo {
+                    private final override var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    final override private var bar: UIView?
+                }
+                """,
+                """
+                class Foo {
+                    private final var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    final private var bar: UIView?
+                }
+                """,
+                """
+                class Foo {
+                    class private final var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    final private class var bar: UIView?
+                }
+                """,
+                """
+                class Foo {
+                    @objc
+                    private
+                    class
+                    final
+                    override
+                    var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    @objc
+                    final
+                    override
+                    private
+                    class
+                    var bar: UIView?
+                }
+                """,
+                """
+                private final class Foo {}
+                """:
+                """
+                final private class Foo {}
+                """
+            ]
+        )
+
+        verifyRule(descriptionOverride,
+                   ruleConfiguration: ["preferred_modifier_order": ["final", "override", "acl", "typeMethods"]])
+    }
+
+    func testCorrectionsAreNotAppliedToIrrelevantModifier() {
+        let descriptionOverride = RuleDescription(
+            identifier: "modifier_order",
+            name: "Modifier Order",
+            description: "Modifier order should be consistent.",
+            kind: .style,
+            minSwiftVersion: .fourDotOne,
+            nonTriggeringExamples: [],
+            triggeringExamples: [],
+            corrections: [
+                """
+                class Foo {
+                    weak class final var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    weak final class var bar: UIView?
+                }
+                """,
+                """
+                class Foo {
+                    static weak final var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    final weak static var bar: UIView?
+                }
+                """,
+                """
+                class Foo {
+                    class final weak var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    final class weak var bar: UIView?
+                }
+                """,
+                """
+                class Foo {
+                    @objc
+                    private
+                    private(set)
+                    class
+                    final
+                    var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    @objc
+                    final
+                    private(set)
+                    private
+                    class
+                    var bar: UIView?
+                }
+                """,
+                """
+                class Foo {
+                    var bar: UIView?
+                }
+                """:
+                """
+                class Foo {
+                    var bar: UIView?
+                }
+                """
+            ]
+        )
+
+        verifyRule(descriptionOverride,
+                   ruleConfiguration: ["preferred_modifier_order": ["final", "override", "acl", "typeMethods"]])
+    }
+
+    func testTypeMethodClassCorrection() {
+        let descriptionOverride = RuleDescription(
+            identifier: "modifier_order",
+            name: "Modifier Order",
+            description: "Modifier order should be consistent.",
+            kind: .style,
+            minSwiftVersion: .fourDotOne,
+            nonTriggeringExamples: [],
+            triggeringExamples: [],
+            corrections: [
+                """
+                private final class Foo {}
+                """:
+                """
+                final private class Foo {}
+                """,
+                """
+                public protocol Foo: class {}
+                """:
+                """
+                public protocol Foo: class {}
+                """
+            ]
+        )
+
+        verifyRule(descriptionOverride,
+                   ruleConfiguration: ["preferred_modifier_order": ["final", "typeMethods", "acl"]])
     }
 
     func testViolationMessage() {


### PR DESCRIPTION
As per #2353 
* Added `CorrectableRule` conformance to `ModifierOrderRule`
* Added relevant corrections tests