### PR TITLE
Clean up CryptoSwift references

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "Carthage/Checkouts/Yams"]
 	path = Carthage/Checkouts/Yams
 	url = https://github.com/jpsim/Yams.git
-[submodule "Carthage/Checkouts/CryptoSwift"]
-	path = Carthage/Checkouts/CryptoSwift
-	url = https://github.com/krzyzanowskim/CryptoSwift.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
   [Daniel Metzing](https://github.com/dirtydanee)
   [#2499](https://github.com/realm/SwiftLint/issues/2499)
 
+* Fix an error when pulling SwiftLint as a dependency using Carthage.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.29.1: There’s Always More Laundry
 
 #### Breaking

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Carthage/Commandant" "0.15.0"
 github "antitypical/Result" "4.0.0"
-github "drmohundro/SWXMLHash" "4.7.5"
+github "drmohundro/SWXMLHash" "4.7.6"
 github "jpsim/SourceKitten" "0.22.0"
 github "jpsim/Yams" "1.0.1"
 github "jspahrsummers/xcconfigs" "0.12"

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct LegacyHashingRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -589,7 +589,6 @@
 		8F6B3153213CDCD100858E44 /* UnusedPrivateDeclarationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedPrivateDeclarationRule.swift; sourceTree = "<group>"; };
 		8F715B82213B528B00427BD9 /* UnusedImportRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedImportRule.swift; sourceTree = "<group>"; };
 		8F8050811FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+IndentationStyle.swift"; sourceTree = "<group>"; };
-		8FB2AE2E21A1F99200D380F3 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8FC8523A2117BDDE0015269B /* ExplicitSelfRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitSelfRule.swift; sourceTree = "<group>"; };
 		8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsDisjointRule.swift; sourceTree = "<group>"; };
 		8FD216CB205584AF008ED13F /* CharacterSet+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CharacterSet+SwiftLint.swift"; sourceTree = "<group>"; };
@@ -1169,14 +1168,6 @@
 				626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */,
 			);
 			path = Idiomatic;
-			sourceTree = "<group>";
-		};
-		8FB2AE2D21A1F99200D380F3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				8FB2AE2E21A1F99200D380F3 /* CryptoSwift.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		D0D1210F19E87861005E4BAA = {


### PR DESCRIPTION
We had a lingering reference to CryptoSwift in the `.gitmodules` file and the Xcode project.

This caused issues when pulling SwiftLint as a Carthage dependency:

> Parse error: expected submodule commit SHA in output of task (ls-tree -z 0.29.1 Carthage/Checkouts/CryptoSwift) but encountered:

Reported by @CedricSoubrie in https://github.com/realm/SwiftLint/commit/068d785ffd8a0b3a9100d473ddf3813703f1e63e#commitcomment-31748086