### PR TITLE
Stringify swiftlint_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@
 * Fix an error when pulling SwiftLint as a dependency using Carthage.  
   [JP Simard](https://github.com/jpsim)
 
+* Non-string values specified in `swiftlint_version` now fail the lint if
+  it doesn't match the version.  
+  [JP Simard](https://github.com/jpsim)
+  [#2518](https://github.com/realm/SwiftLint/issues/2518)
+
 ## 0.29.1: There’s Always More Laundry
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -85,6 +85,7 @@ extension Configuration {
             return nil
         }
 
+        let swiftlintVersion = dict[Key.swiftlintVersion.rawValue].map { ($0 as? String) ?? String(describing: $0) }
         self.init(disabledRules: disabledRules,
                   optInRules: optInRules,
                   enableAllRules: enableAllRules,
@@ -96,7 +97,7 @@ extension Configuration {
                   reporter: dict[Key.reporter.rawValue] as? String ?? XcodeReporter.identifier,
                   ruleList: ruleList,
                   configuredRules: configuredRules,
-                  swiftlintVersion: dict[Key.swiftlintVersion.rawValue] as? String,
+                  swiftlintVersion: swiftlintVersion,
                   cachePath: cachePath ?? dict[Key.cachePath.rawValue] as? String,
                   indentation: indentation)
     }


### PR DESCRIPTION
to treat any specified value that doesn't match the version string to fail the lint.

Previously if `swiftlint_version: 0.29` was specified in the configuration file, any SwiftLint version successfully ran because technically no string was specified as a yaml value.

Now SwiftLint will log "Currently running SwiftLint 0.29.1 but configuration specified version 0.29." and exit.

Fixes #2518.