### PR TITLE
Remove OptInRule protocol

### DIFF
--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -245,7 +245,7 @@ private func enabledRules(from configuredRules: [Rule],
         return configuredRules.filter { rule in
             let id = type(of: rule).description.identifier
             if validDisabledRuleIdentifiers.contains(id) { return false }
-            return validOptInRuleIdentifiers.contains(id) || !(rule is OptInRule)
+            return validOptInRuleIdentifiers.contains(id) || !rule.isOptIn
         }
     }
 }

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -3,6 +3,7 @@ public struct RuleDescription: Equatable {
     public let name: String
     public let description: String
     public let kind: RuleKind
+    public let isOptIn: Bool
     public let nonTriggeringExamples: [String]
     public let triggeringExamples: [String]
     public let corrections: [String: String]
@@ -18,6 +19,7 @@ public struct RuleDescription: Equatable {
 
     public init(identifier: String, name: String, description: String, kind: RuleKind,
                 minSwiftVersion: SwiftVersion = .three,
+                isOptIn: Bool = false,
                 nonTriggeringExamples: [String] = [], triggeringExamples: [String] = [],
                 corrections: [String: String] = [:],
                 deprecatedAliases: Set<String> = [],
@@ -26,6 +28,7 @@ public struct RuleDescription: Equatable {
         self.name = name
         self.description = description
         self.kind = kind
+        self.isOptIn = isOptIn
         self.nonTriggeringExamples = nonTriggeringExamples
         self.triggeringExamples = triggeringExamples
         self.corrections = corrections

--- a/Source/SwiftLintFramework/Models/RuleList+Documentation.swift
+++ b/Source/SwiftLintFramework/Models/RuleList+Documentation.swift
@@ -64,7 +64,7 @@ extension RuleList {
         var content = columns.joined(separator: " | ") + "\n"
         content += columns.map { _ in "---" }.joined(separator: " | ") + "\n"
         let identifier = type(of: rule).description.identifier
-        let defaultStatus = rule is OptInRule ? "Disabled" : "Enabled"
+        let defaultStatus = rule.isOptIn ? "Disabled" : "Enabled"
         let correctable = rule is CorrectableRule ? "Yes" : "No"
         let kind = type(of: rule).description.kind
         let analyzer = rule is AnalyzerRule ? "Yes" : "No"

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -24,9 +24,11 @@ extension Rule {
     internal var cacheDescription: String {
         return (self as? CacheDescriptionProvider)?.cacheDescription ?? configurationDescription
     }
-}
 
-public protocol OptInRule: Rule {}
+    public var isOptIn: Bool {
+        return type(of: self).description.isOptIn
+    }
+}
 
 public protocol AutomaticTestableRule: Rule {}
 
@@ -49,7 +51,7 @@ public extension CorrectableRule {
 
 public protocol SourceKitFreeRule: Rule {}
 
-public protocol AnalyzerRule: OptInRule {}
+public protocol AnalyzerRule: Rule {}
 
 public extension AnalyzerRule {
     func validate(file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ConvenienceTypeRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -12,6 +12,7 @@ public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule
                      "to avoid instantiation.",
         kind: .idiomatic,
         minSwiftVersion: .fourDotOne,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             enum Math { // enum

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct DiscouragedObjectLiteralRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct DiscouragedObjectLiteralRule: ASTRule, ConfigurationProviderRule {
     public var configuration = ObjectLiteralConfiguration()
 
     public init() {}
@@ -10,6 +10,7 @@ public struct DiscouragedObjectLiteralRule: ASTRule, OptInRule, ConfigurationPro
         name: "Discouraged Object Literal",
         description: "Prefer initializers over object literals.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let image = UIImage(named: aVariable)",
             "let image = UIImage(named: \"interpolated \\(variable)\")",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DiscouragedOptionalBooleanRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRu
         name: "Discouraged Optional Boolean",
         description: "Prefer non-optional booleans over optional booleans.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: DiscouragedOptionalBooleanRuleExamples.nonTriggeringExamples,
         triggeringExamples: DiscouragedOptionalBooleanRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DiscouragedOptionalCollectionRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
         name: "Discouraged Optional Collection",
         description: "Prefer empty collection over optional collection.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: DiscouragedOptionalCollectionExamples.nonTriggeringExamples,
         triggeringExamples: DiscouragedOptionalCollectionExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private typealias SourceKittenElement = [String: SourceKitRepresentable]
 
-public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ExplicitACLRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -13,6 +13,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
         name: "Explicit ACL",
         description: "All declarations should specify Access Control Level keywords explicitly.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "internal enum A {}\n",
             "public final class B {}\n",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ExplicitEnumRawValueRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
         name: "Explicit Enum Raw Value",
         description: "Enums should be explicitly assigned their raw values.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             enum Numbers {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableRule, OptInRule, AutomaticTestableRule {
+public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ExplicitInitRule: ASTRule, ConfigurationProviderRule, CorrectableR
         name: "Explicit Init",
         description: "Explicitly calling .init() should be avoided.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "import Foundation; class C: NSObject { override init() { super.init() }}", // super
             "struct S { let n: Int }; extension S { init() { self.init(n: 1) } }",      // self

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ExplicitTopLevelACLRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, Aut
         name: "Explicit Top Level ACL",
         description: "Top-level declarations should specify Access Control Level keywords explicitly.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "internal enum A {}\n",
             "public final class B {}\n",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitTypeInterfaceRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct ExplicitTypeInterfaceRule: ASTRule, ConfigurationProviderRule {
     public var configuration = ExplicitTypeInterfaceConfiguration()
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ExplicitTypeInterfaceRule: ASTRule, OptInRule, ConfigurationProvid
         name: "Explicit Type Interface",
         description: "Properties should have a type interface",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             class Foo {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
         name: "Extension Access Modifier",
         description: "Prefer to use extension access modifiers",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             extension Foo: SomeProtocol {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FallthroughRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct FallthroughRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct FallthroughRule: ConfigurationProviderRule, OptInRule, AutomaticTe
         name: "Fallthrough",
         description: "Fallthrough should be avoided.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             switch foo {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRu
         name: "Fatal Error Message",
         description: "A fatalError call should have a message.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             func foo() {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -14,7 +14,7 @@ private extension Dictionary where Key: ExpressibleByStringLiteral {
     }
 }
 
-public struct FileNameRule: ConfigurationProviderRule, OptInRule {
+public struct FileNameRule: ConfigurationProviderRule {
     public var configuration = FileNameConfiguration(
         severity: .warning,
         excluded: ["main.swift", "LinuxMain.swift"],
@@ -28,7 +28,8 @@ public struct FileNameRule: ConfigurationProviderRule, OptInRule {
         identifier: "file_name",
         name: "File Name",
         description: "File name should match a type or extension declared in the file (if any).",
-        kind: .idiomatic
+        kind: .idiomatic,
+        isOptIn: true
     )
 
     public func validate(file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ForceUnwrappingRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
         name: "Force Unwrapping",
         description: "Force unwrapping should be avoided.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "if let url = NSURL(string: query)",
             "navigationController?.pushViewController(viewController, animated: true)",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
         name: "Function Default Parameter at End",
         description: "Prefer to locate parameters with defaults toward the end of the parameter list.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "func foo(baz: String, bar: Int = 0) {}",
             "func foo(x: String, y: Int = 0, z: CGFloat = 0) {}",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRule, OptInRule {
+public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRule {
     public var configuration = ImplicitlyUnwrappedOptionalConfiguration(mode: .allExceptIBOutlets,
                                                                         severity: SeverityConfiguration(.warning))
 
@@ -12,6 +12,7 @@ public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRul
         name: "Implicitly Unwrapped Optional",
         description: "Implicitly unwrapped optionals should be avoided when possible.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "@IBOutlet private var label: UILabel!",
             "@IBOutlet var label: UILabel!",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, OptInRule, CorrectableRule,
+public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, CorrectableRule,
                                           AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -12,6 +12,7 @@ public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, Op
         name: "Joined Default Parameter",
         description: "Discouraged explicit usage of the default separator.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let foo = bar.joined()",
             "let foo = bar.joined(separator: \",\")",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct LegacyRandomRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyRandomRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct LegacyRandomRule: ASTRule, OptInRule, ConfigurationProviderRule, A
         description: "Prefer using `type.random(in:)` over legacy functions.",
         kind: .idiomatic,
         minSwiftVersion: .fourDotTwo,
+        isOptIn: true,
         nonTriggeringExamples: [
             "Int.random(in: 0..<10)\n",
             "Double.random(in: 8.6...111.34)\n",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, CorrectableRule, AutomaticTestableRule {
+public struct NimbleOperatorRule: ConfigurationProviderRule, CorrectableRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
         name: "Nimble Operator",
         description: "Prefer Nimble operator overloads over free matcher functions.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "expect(seagull.squawk) != \"Hi!\"\n",
             "expect(\"Hi!\") == \"Hi!\"\n",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct NoExtensionAccessModifierRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NoExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct NoExtensionAccessModifierRule: ASTRule, OptInRule, ConfigurationPr
         name: "No Extension Access Modifier",
         description: "Prefer not to use extension access modifiers",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "extension String {}",
             "\n\n extension String {}"

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NoGroupingExtensionRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
         name: "No Grouping Extension",
         description: "Extensions shouldn't be used to group code within the same source file.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "protocol Food {}\nextension Food {}\n",
             "class Apples {}\nextension Oranges {}\n"

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
+public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule {
     public var configuration = ObjectLiteralConfiguration()
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         name: "Object Literal",
         description: "Prefer object literals over image and color inits.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let image = #imageLiteral(resourceName: \"image.jpg\")",
             "let color = #colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, O
         name: "Pattern Matching Keywords",
         description: "Combine multiple pattern matching bindings by moving keywords out of tuples.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "default",
             "case 1",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -8,7 +8,7 @@ private extension File {
     }
 }
 
-public struct RedundantNilCoalescingRule: OptInRule, CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct RedundantNilCoalescingRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -19,6 +19,7 @@ public struct RedundantNilCoalescingRule: OptInRule, CorrectableRule, Configurat
         description: "nil coalescing operator is only evaluated if the lhs is nil" +
             ", coalescing operator with nil as rhs is redundant",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "var myVar: Int?; myVar ?? 0\n"
         ],

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantTypeAnnotationRule: Rule, OptInRule, CorrectableRule,
+public struct RedundantTypeAnnotationRule: CorrectableRule,
                                            ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -12,6 +12,7 @@ public struct RedundantTypeAnnotationRule: Rule, OptInRule, CorrectableRule,
         name: "Redundant Type Annotation",
         description: "Variables should not have redundant type annotation",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "var url = URL()",
             "var url: CustomStringConvertible = URL()"

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, OptInRule,
         name: "Static Operator",
         description: "Operators should be declared as static functions, not free functions.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             class A: Equatable {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct StrictFilePrivateRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, Autom
         name: "Strict fileprivate",
         description: "`fileprivate` should be avoided.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             "extension String {}",
             "private extension String {}",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ToggleBoolRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ToggleBoolRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ToggleBoolRule: ConfigurationProviderRule, OptInRule, AutomaticTes
         description: "Prefer `someBool.toggle()` over `someBool = !someBool`.",
         kind: .idiomatic,
         minSwiftVersion: .fourDotTwo,
+        isOptIn: true,
         nonTriggeringExamples: [
             "isHidden.toggle()\n",
             "view.clipsToBounds.toggle()\n",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -12,6 +12,7 @@ public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptIn
         description: "Unimplemented functions should be marked as unavailable.",
         kind: .idiomatic,
         minSwiftVersion: .fourDotOne,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             class ViewController: UIViewController {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct UntypedErrorInCatchRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -34,6 +34,7 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, Aut
         name: "Untyped Error in Catch",
         description: "Catch statements should not declare error variables without type casting.",
         kind: .idiomatic,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             do {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct XCTSpecificMatcherRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct XCTSpecificMatcherRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -12,6 +12,7 @@ public struct XCTSpecificMatcherRule: ASTRule, OptInRule, ConfigurationProviderR
         description: "Prefer specific XCTest matchers over `XCTAssertEqual` and `XCTAssertNotEqual`",
         kind: .idiomatic,
         minSwiftVersion: .fourDotOne,
+        isOptIn: true,
         nonTriggeringExamples: XCTSpecificMatcherRuleExamples.nonTriggeringExamples,
         triggeringExamples: XCTSpecificMatcherRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct AnyObjectProtocolRule: ASTRule, OptInRule, CorrectableRule,
+public struct AnyObjectProtocolRule: ASTRule, CorrectableRule,
                                      ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -13,6 +13,7 @@ public struct AnyObjectProtocolRule: ASTRule, OptInRule, CorrectableRule,
         description: "Prefer using `AnyObject` over `class` for class-only protocols.",
         kind: .lint,
         minSwiftVersion: .fourDotOne,
+        isOptIn: true,
         nonTriggeringExamples: [
             "protocol SomeProtocol {}\n",
             "protocol SomeClassOnlyProtocol: AnyObject {}\n",

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
         name: "Array Init",
         description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "Array(foo)\n",
             "foo.map { $0.0 }\n",

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct EmptyXCTestMethodRule: Rule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule,
         name: "Empty XCTest Method",
         description: "Empty XCTest method should be avoided.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: EmptyXCTestMethodRuleExamples.nonTriggeringExamples,
         triggeringExamples: EmptyXCTestMethodRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct IdenticalOperandsRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -13,6 +13,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
         name: "Identical Operands",
         description: "Comparing two identical operands is likely a mistake.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: operators.flatMap { operation in
             [
                 "1 \(operation) 2",

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LowerACLThanParentRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
         name: "Lower ACL than parent",
         description: "Ensure definitions have a lower access control level than their enclosing parent",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "public struct Foo { public func bar() {} }",
             "internal struct Foo { func bar() {} }",

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -24,7 +24,7 @@ private extension File {
     }
 }
 
-public struct MissingDocsRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MissingDocsRule: ConfigurationProviderRule, AutomaticTestableRule {
     public init() {
         configuration = MissingDocsRuleConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
@@ -40,6 +40,7 @@ public struct MissingDocsRule: OptInRule, ConfigurationProviderRule, AutomaticTe
         description: "Declarations should be documented.",
         kind: .lint,
         minSwiftVersion: .fourDotOne,
+        isOptIn: true,
         nonTriggeringExamples: [
             // locally-defined superclass member is documented, but subclass member is not
             "/// docs\npublic class A {\n/// docs\npublic func b() {}\n}\n" +

--- a/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptInRule, AutomaticTestableRule {
+public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, AutomaticTestableRule {
     public var configuration = OverridenSuperCallConfiguration()
 
     public init() {}
@@ -10,6 +10,7 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
         name: "Overridden methods call super",
         description: "Some overridden methods should always call super",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "class VC: UIViewController {\n" +
                 "\toverride func viewWillAppear(_ animated: Bool) {\n" +

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct OverrideInExtensionRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, Aut
         name: "Override in Extension",
         description: "Extensions shouldn't override declarations.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "extension Person {\n  var age: Int { return 42 }\n}\n",
             "extension Person {\n  func celebrateBirthday() {}\n}\n",

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct PrivateActionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct PrivateActionRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct PrivateActionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         name: "Private Actions",
         description: "IBActions should be private.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "class Foo {\n\t@IBAction private func barButtonTapped(_ sender: UIButton) {}\n}\n",
             "struct Foo {\n\t@IBAction private func barButtonTapped(_ sender: UIButton) {}\n}\n",

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct PrivateOutletRule: ASTRule, ConfigurationProviderRule {
     public var configuration = PrivateOutletRuleConfiguration(allowPrivateSet: false)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
         name: "Private Outlets",
         description: "IBOutlets should be private to avoid leaking UIKit to higher layers.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "class Foo {\n  @IBOutlet private var label: UILabel?\n}\n",
             "class Foo {\n  @IBOutlet private var label: UILabel!\n}\n",

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, ASTRule, OptInRule, AutomaticTestableRule {
+public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, ASTRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, ASTRule
         name: "Prohibited Interface Builder",
         description: "Creating views using Interface Builder should be avoided.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "var label: UILabel!",
             "@objc func buttonTapped(_ sender: UIButton) {}"

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule, AutomaticTestableRule {
+public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, AutomaticTestableRule {
     public var configuration = ProhibitedSuperConfiguration()
 
     public init() {}
@@ -10,6 +10,7 @@ public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule
         name: "Prohibited calls to super",
         description: "Some methods should not call super",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             class VC: UIViewController {

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct QuickDiscouragedCallRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule, Au
         name: "Quick Discouraged Call",
         description: "Discouraged call inside 'describe' and/or 'context' block.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: QuickDiscouragedCallRuleExamples.nonTriggeringExamples,
         triggeringExamples: QuickDiscouragedCallRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct QuickDiscouragedFocusedTestRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
         name: "Quick Discouraged Focused Test",
         description: "Discouraged focused test. Other tests won't run while this one is focused.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: QuickDiscouragedFocusedTestRuleExamples.nonTriggeringExamples,
         triggeringExamples: QuickDiscouragedFocusedTestRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct QuickDiscouragedPendingTestRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
         name: "Quick Discouraged Pending Test",
         description: "Discouraged pending test. This test won't run while it's marked as pending.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: QuickDiscouragedPendingTestRuleExamples.nonTriggeringExamples,
         triggeringExamples: QuickDiscouragedPendingTestRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -67,7 +67,7 @@ import SourceKittenFramework
 ///     case accountCreated
 /// }
 /// ````
-public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct RequiredEnumCaseRule: ASTRule, ConfigurationProviderRule {
     private typealias RequiredCase = RequiredEnumCaseRuleConfiguration.RequiredCase
 
     /// Simple representation of parsed information from the SourceKitRepresentable dictionary.
@@ -123,6 +123,7 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
         name: "Required Enum Case",
         description: "Enums conforming to a specified protocol must implement a specific case(s).",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "enum MyNetworkResponse: String, NetworkResponsable {\n" +
             "    case success, error, notConnected \n" +

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -11,6 +11,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
         name: "Unused Import",
         description: "All imported modules should be required to make the file compile.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             import Dispatch

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedPrivateDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedPrivateDeclarationRule.swift
@@ -11,6 +11,7 @@ public struct UnusedPrivateDeclarationRule: AutomaticTestableRule, Configuration
         name: "Unused Private Declaration",
         description: "Private declarations should be referenced in that file.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             private let kConstant = 0

--- a/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct YodaConditionRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -37,6 +37,7 @@ public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         name: "Yoda condition rule",
         description: "The variable should be placed on the left, the constant on the right of a comparison operator.",
         kind: .lint,
+        isOptIn: true,
         nonTriggeringExamples: [
             "if foo == 42 {}\n",
             "if foo <= 42.42 {}\n",

--- a/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ClosureBodyLengthRule: OptInRule, ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ClosureBodyLengthRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityLevelsConfiguration(warning: 20, error: 100)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ClosureBodyLengthRule: OptInRule, ASTRule, ConfigurationProviderRu
         description: "Closure bodies should not span too many lines.",
         kind: .metrics,
         minSwiftVersion: .fourDotTwo,
+        isOptIn: true,
         nonTriggeringExamples: ClosureBodyLengthRuleExamples.nonTriggeringExamples,
         triggeringExamples: ClosureBodyLengthRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ContainsOverFirstNotNilRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ContainsOverFirstNotNilRule: CallPairRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct ContainsOverFirstNotNilRule: CallPairRule, OptInRule, Configuratio
         name: "Contains over first not nil",
         description: "Prefer `contains` over `first(where:) != nil`",
         kind: .performance,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let first = myList.first(where: { $0 % 2 == 0 })\n",
             "let first = myList.first { $0 % 2 == 0 }\n"

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct EmptyCountRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct EmptyCountRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule, AutomaticTes
         name: "Empty Count",
         description: "Prefer checking `isEmpty` over comparing `count` to zero.",
         kind: .performance,
+        isOptIn: true,
         nonTriggeringExamples: [
             "var count = 0\n",
             "[Int]().isEmpty\n",

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct EmptyStringRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct EmptyStringRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct EmptyStringRule: ConfigurationProviderRule, OptInRule, AutomaticTe
         name: "Empty String",
         description: "Prefer checking `isEmpty` over comparing `string` to an empty string literal.",
         kind: .performance,
+        isOptIn: true,
         nonTriggeringExamples: [
             "myString.isEmpty",
             "!myString.isEmpy"

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct FirstWhereRule: CallPairRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
         name: "First Where",
         description: "Prefer using `.first(where:)` over `.filter { }.first` in collections.",
         kind: .performance,
+        isOptIn: true,
         nonTriggeringExamples: [
             "kinds.filter(excludingKinds.contains).isEmpty && kinds.first == .identifier\n",
             "myList.first(where: { $0 % 2 == 0 })\n",

--- a/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LastWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LastWhereRule: CallPairRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -12,6 +12,7 @@ public struct LastWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule,
         description: "Prefer using `.last(where:)` over `.filter { }.last` in collections.",
         kind: .performance,
         minSwiftVersion: .fourDotTwo,
+        isOptIn: true,
         nonTriggeringExamples: [
             "kinds.filter(excludingKinds.contains).isEmpty && kinds.last == .identifier\n",
             "myList.last(where: { $0 % 2 == 0 })\n",

--- a/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct SortedFirstLastRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct SortedFirstLastRule: CallPairRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -10,6 +10,7 @@ public struct SortedFirstLastRule: CallPairRule, OptInRule, ConfigurationProvide
         name: "Min or Max over Sorted First or Last",
         description: "Prefer using `min()` or `max()` over `sorted().first` or `sorted().last`",
         kind: .performance,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let min = myList.min()\n",
             "let min = myList.min(by: { $0 < $1 })\n",

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -6,7 +6,7 @@ private enum AttributesRuleError: Error {
     case moreThanOneAttributeInSameLine
 }
 
-public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct AttributesRule: ASTRule, ConfigurationProviderRule {
     public var configuration = AttributesConfiguration()
 
     private static let parametersPattern = "^\\s*\\(.+\\)"
@@ -20,6 +20,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         description: "Attributes should be on their own lines in functions and types, " +
                      "but on the same line as variables and imports.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,
         triggeringExamples: AttributesRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ClosureEndIndentationRule: Rule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderR
         name: "Closure End Indentation",
         description: "Closure end should have the same indentation as the line that started it.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: ClosureEndIndentationRuleExamples.nonTriggeringExamples,
         triggeringExamples: ClosureEndIndentationRuleExamples.triggeringExamples,
         corrections: ClosureEndIndentationRuleExamples.corrections

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -16,7 +16,7 @@ extension NSRange {
     }
 }
 
-public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -26,6 +26,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
         name: "Closure Spacing",
         description: "Closure expressions should have a single space inside each brace.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "[].map ({ $0.description })",
             "[].filter { $0.contains(location) }",

--- a/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule, OptInRule {
+public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule {
     public var configuration = CollectionAlignmentConfiguration()
 
     public init() {}
@@ -10,6 +10,7 @@ public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule, OptIn
         name: "Collection Element Alignment",
         description: "All elements in a collection literal should be vertically aligned",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: Examples(alignColons: false).nonTriggeringExamples,
         triggeringExamples: Examples(alignColons: false).triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, Rule, OptInRule {
+public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule {
     public var configuration = ConditionalReturnsOnNewlineConfiguration()
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, Rule, 
         name: "Conditional Returns on Newline",
         description: "Conditional statements should always return on the next line",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "guard true else {\n return true\n}",
             "guard true,\n let x = true else {\n return true\n}",

--- a/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
@@ -11,6 +11,7 @@ public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, Anal
         name: "Explicit Self",
         description: "Instance variables and functions should be explicitly accessed with 'self.'.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             struct A {

--- a/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
+public struct FileHeaderRule: ConfigurationProviderRule {
     public var configuration = FileHeaderConfiguration()
 
     public init() {}
@@ -13,6 +13,7 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
             "The SWIFTLINT_CURRENT_FILENAME placeholder can optionally be used in the " +
             "required and forbidden patterns. It will be replaced by the real file name.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let foo = \"Copyright\"",
             "let foo = 2 // Copyright",

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ImplicitReturnRule: ConfigurationProviderRule, CorrectableRule, OptInRule, AutomaticTestableRule {
+public struct ImplicitReturnRule: ConfigurationProviderRule, CorrectableRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, CorrectableRule, Op
         name: "Implicit Return",
         description: "Prefer implicit returns in closures.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "foo.map { $0 + 1 }",
             "foo.map({ $0 + 1 })",

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct LetVarWhitespaceRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
         name: "Variable Declaration Whitespace",
         description: "Let and var should be separated from other statements by a blank line.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let a = 0\nvar x = 1\n\nx = 2\n",
             "a = 5\n\nvar x = 1\n",

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
         name: "Literal Expression End Indentation",
         description: "Array and dictionary literal end should have the same indentation as the line that started it.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "[1, 2, 3]",
             "[1,\n" +

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, CorrectableRule {
+public struct ModifierOrderRule: ASTRule, ConfigurationProviderRule, CorrectableRule {
     public var configuration = ModifierOrderConfiguration(
         preferredModifierOrder: [
             .override,
@@ -26,6 +26,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         description: "Modifier order should be consistent.",
         kind: .style,
         minSwiftVersion: .fourDotOne ,
+        isOptIn: true,
         nonTriggeringExamples: ModifierOrderRuleExamples.nonTriggeringExamples,
         triggeringExamples: ModifierOrderRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineArgumentsBracketsRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
         name: "Multiline Arguments Brackets",
         description: "Multiline arguments should have their surrounding brackets in a new line.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             foo(param1: "Param1", param2: "Param2", param3: "Param3")

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct MultilineArgumentsRule: ASTRule, ConfigurationProviderRule {
     public var configuration = MultilineArgumentsConfiguration()
 
     public init() {}
@@ -11,6 +11,7 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
         name: "Multiline Arguments",
         description: "Arguments should be either on the same line, or one per line.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: MultilineArgumentsRuleExamples.nonTriggeringExamples,
         triggeringExamples: MultilineArgumentsRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineFunctionChainsRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
         name: "Multiline Function Chains",
         description: "Chained function calls should be either on the same line, or one per line.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let evenSquaresSum = [20, 17, 35, 4].filter { $0 % 2 == 0 }.map { $0 * $0 }.reduce(0, +)",
             """

--- a/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineLiteralBracketsRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
         name: "Multiline Literal Brackets",
         description: "Multiline literals should have their surrounding brackets in a new line.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             let trio = ["harry", "ronald", "hermione"]

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineParametersBracketsRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
         name: "Multiline Parameters Brackets",
         description: "Multiline parameters should have their surrounding brackets in a new line.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             """
             func foo(param1: String, param2: String, param3: String)

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineParametersRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     private typealias ParameterRange = (offset: Int, length: Int)
@@ -12,6 +12,7 @@ public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProvider
         name: "Multiline Parameters",
         description: "Functions and methods parameters should be either on the same line, or one per line.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: MultilineParametersRuleExamples.nonTriggeringExamples,
         triggeringExamples: MultilineParametersRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProviderRule {
+public struct NumberSeparatorRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = NumberSeparatorConfiguration(minimumLength: 0, minimumFractionLength: nil)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
         name: "Number Separator",
         description: "Underscores should be used as thousand separator in large decimal numbers.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: NumberSeparatorRuleExamples.nonTriggeringExamples,
         triggeringExamples: NumberSeparatorRuleExamples.triggeringExamples,
         corrections: NumberSeparatorRuleExamples.corrections

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, ConfigurationProviderRule,
+public struct OperatorUsageWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
                                            AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -13,6 +13,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         description: "Operators should be surrounded by a single whitespace " +
                      "when they are being used.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let foo = 1 + 2\n",
             "let foo = 1 > 2\n",

--- a/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct PrefixedTopLevelConstantRule: ASTRule, ConfigurationProviderRule {
     public var configuration = PrefixedConstantRuleConfiguration(onlyPrivateMembers: false)
 
     private let topLevelPrefix = "k"
@@ -12,6 +12,7 @@ public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationPro
         name: "Prefixed Top-Level Constant",
         description: "Top-level constants should be prefixed by `k`.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "private let kFoo = 20.0",
             "public let kFoo = false",

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct SingleTestClassRule: Rule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public static let description = RuleDescription(
@@ -8,6 +8,7 @@ public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule, A
         name: "Single Test Class",
         description: "Test files should contain a single QuickSpec or XCTestCase class.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "class FooTests {  }\n",
             "class FooTests: QuickSpec {  }\n",

--- a/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
@@ -46,7 +46,7 @@ private extension Sequence where Element == Line {
     }
 }
 
-public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -56,6 +56,7 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
         name: "Sorted Imports",
         description: "Imports should be sorted.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "import AAA\nimport BBB\nimport CCC\nimport DDD",
             "import Alamofire\nimport API",

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -5,7 +5,7 @@ private func wrapInSwitch(_ str: String) -> String {
     return "switch foo {\n  \(str)\n}\n"
 }
 
-public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -15,6 +15,7 @@ public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptIn
         name: "Switch Case on Newline",
         description: "Cases inside a switch should always be on a newline",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "/*case 1: */return true",
             "//case 1:\n return true",

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct TrailingClosureRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,6 +11,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule, Automat
         name: "Trailing Closure",
         description: "Trailing closure syntax should be used whenever possible.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "foo.map { $0 + 1 }\n",
             "foo.bar()\n",

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, CorrectableRule, OptInRule,
+public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, CorrectableRule,
                                                         AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -12,6 +12,7 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
         name: "Unneeded Parentheses in Closure Argument",
         description: "Parentheses are not needed when declaring closure arguments.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "let foo = { (bar: Int) in }\n",
             "let foo = { bar, _  in }\n",

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule,
+public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule,
                                                     AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -11,6 +11,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
         name: "Vertical Parameter Alignment On Call",
         description: "Function parameters should be aligned vertically if they're in multiple lines in a method call.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: [
             "foo(param1: 1, param2: bar\n" +
             "    param3: false, param4: true)",

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -106,12 +106,13 @@ public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
     private let pattern = "([^\\n{][ \\t]*\\n)([ \\t]*(?:case[^\\n]+|default):[ \\t]*\\n)"
 }
 
-extension VerticalWhitespaceBetweenCasesRule: OptInRule, AutomaticTestableRule {
+extension VerticalWhitespaceBetweenCasesRule: AutomaticTestableRule {
     public static let description = RuleDescription(
         identifier: "vertical_whitespace_between_cases",
         name: "Vertical Whitespace Between Cases",
         description: "Include a single empty line between switch cases.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: (violatingToValidExamples.values + nonTriggeringExamples).sorted(),
         triggeringExamples: Array(violatingToValidExamples.keys).sorted(),
         corrections: violatingToValidExamples.removingViolationMarkers()

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -39,7 +39,7 @@ public struct VerticalWhitespaceClosingBracesRule: ConfigurationProviderRule {
     private let pattern = "((?:\\n[ \\t]*)+)(\\n[ \\t]*[)}\\]])"
 }
 
-extension VerticalWhitespaceClosingBracesRule: OptInRule, AutomaticTestableRule {
+extension VerticalWhitespaceClosingBracesRule: AutomaticTestableRule {
     public var configurationDescription: String { return "N/A" }
 
     public init(configuration: Any) throws {}
@@ -49,6 +49,7 @@ extension VerticalWhitespaceClosingBracesRule: OptInRule, AutomaticTestableRule 
         name: "Vertical Whitespace before Closing Braces",
         description: "Don't include vertical whitespace (empty line) before closing braces.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: (violatingToValidExamples.values + nonTriggeringExamples).sorted(),
         triggeringExamples: Array(violatingToValidExamples.keys).sorted(),
         corrections: violatingToValidExamples.removingViolationMarkers()

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -60,7 +60,7 @@ public struct VerticalWhitespaceOpeningBracesRule: ConfigurationProviderRule {
     private let pattern = "([{(\\[][ \\t]*(?:[^\\n{]+ in[ \\t]*$)?)((?:\\n[ \\t]*)+)(\\n)"
 }
 
-extension VerticalWhitespaceOpeningBracesRule: OptInRule, AutomaticTestableRule {
+extension VerticalWhitespaceOpeningBracesRule: AutomaticTestableRule {
     public var configurationDescription: String { return "N/A" }
 
     public init(configuration: Any) throws {}
@@ -70,6 +70,7 @@ extension VerticalWhitespaceOpeningBracesRule: OptInRule, AutomaticTestableRule 
         name: "Vertical Whitespace after Opening Braces",
         description: "Don't include vertical whitespace (empty line) after opening braces.",
         kind: .style,
+        isOptIn: true,
         nonTriggeringExamples: (violatingToValidExamples.values + nonTriggeringExamples).sorted(),
         triggeringExamples: Array(violatingToValidExamples.keys).sorted(),
         corrections: violatingToValidExamples.removingViolationMarkers()

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -146,7 +146,7 @@ extension TextTable {
             }
             addRow(values: [
                 ruleID,
-                (rule is OptInRule) ? "yes" : "no",
+                rule.isOptIn ? "yes" : "no",
                 (rule is CorrectableRule) ? "yes" : "no",
                 configuredRule != nil ? "yes" : "no",
                 ruleType.description.kind.rawValue,

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -3,13 +3,13 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-private let optInRules = masterRuleList.list.filter({ $0.1.init() is OptInRule }).map({ $0.0 })
+private let optInRules = masterRuleList.list.filter({ $0.1.description.isOptIn }).map({ $0.0 })
 
 private extension Configuration {
     var disabledRules: [String] {
         let configuredRuleIDs = rules.map({ type(of: $0).description.identifier })
         let defaultRuleIDs = Set(masterRuleList.list.values.filter({
-            !($0.init() is OptInRule)
+            !$0.description.isOptIn
         }).map({ $0.description.identifier }))
         return defaultRuleIDs.subtracting(configuredRuleIDs).sorted(by: <)
     }


### PR DESCRIPTION
This PR removes the `OptInRule` protocol in favor of a property in `RuleDescription`.

It allows [plugins to expose opt-in rules](https://github.com/realm/SwiftLint/issues/2529#issuecomment-450695614) without much effort.

The downside IMO is that for we don't get "being opt-in" for free in `AnalyzerRule` anymore.