### PR TITLE
Fix false positives on `redundant_objc_attribute` rule when using nested types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2533](https://github.com/realm/SwiftLint/issues/2533)
 
+* Fix false positives on `redundant_objc_attribute` rule when using nested
+  types.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2539](https://github.com/realm/SwiftLint/issues/2539)
+
 ## 0.29.2: Washateria
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -15320,16 +15320,6 @@ class Foo: NSObject {
 ```
 
 ```swift
-@objc
-extension Foo {
-  @objc
-  private var bar: Int {
-    return 0
-  }
-}
-```
-
-```swift
 @objcMembers
 class Foo {
     class Bar: NSObject {
@@ -15431,6 +15421,16 @@ class Foo {
     @objcMembers
     class Bar: NSObject {
         @objc ↓var foo: Any
+    }
+}
+```
+
+```swift
+@objc
+extension Foo {
+    @objc
+    private var bar: Int {
+        return 0
     }
 }
 ```

--- a/Rules.md
+++ b/Rules.md
@@ -15429,7 +15429,7 @@ class Foo {
 @objc
 extension Foo {
     @objc
-    private var bar: Int {
+    private ↓var bar: Int {
         return 0
     }
 }

--- a/Rules.md
+++ b/Rules.md
@@ -15319,6 +15319,32 @@ class Foo: NSObject {
 }
 ```
 
+```swift
+@objc
+extension Foo {
+  @objc
+  private var bar: Int {
+    return 0
+  }
+}
+```
+
+```swift
+@objcMembers
+class Foo {
+    class Bar: NSObject {
+        @objc var foo: Any
+    }
+}
+```
+
+```swift
+@objcMembers
+class Foo {
+    @objc class Bar {}
+}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -15400,12 +15426,12 @@ extension Foo {
 ```
 
 ```swift
-@objc
-extension Foo {
-  @objc
-  private ↓var bar: Int {
-    return 0
-  }
+@objcMembers
+class Foo {
+    @objcMembers
+    class Bar: NSObject {
+        @objc ↓var foo: Any
+    }
 }
 ```
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -3,8 +3,6 @@ import SourceKittenFramework
 private let kindsImplyingObjc: Set<SwiftDeclarationAttributeKind> =
     [.ibaction, .iboutlet, .ibinspectable, .gkinspectable, .ibdesignable, .nsManaged]
 
-private let privateACL: Set<SwiftDeclarationAttributeKind> = [.private, .fileprivate]
-
 public struct RedundantObjcAttributeRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -74,15 +74,6 @@ public struct RedundantObjcAttributeRule: ConfigurationProviderRule, AutomaticTe
             }
             """,
             """
-            @objc
-            extension Foo {
-              @objc
-              private var bar: Int {
-                return 0
-              }
-            }
-            """,
-            """
             @objcMembers
             class Foo {
                 class Bar: NSObject {
@@ -151,6 +142,15 @@ public struct RedundantObjcAttributeRule: ConfigurationProviderRule, AutomaticTe
                     @objc ↓var foo: Any
                 }
             }
+            """,
+            """
+            @objc
+            extension Foo {
+                @objc
+                private var bar: Int {
+                    return 0
+                }
+            }
             """
         ])
 
@@ -187,14 +187,14 @@ public struct RedundantObjcAttributeRule: ConfigurationProviderRule, AutomaticTe
             guard let parentStructure = parentStructure,
                 let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
                 let parentKind = parentStructure.kind.flatMap(SwiftDeclarationKind.init),
-                enclosedSwiftAttributes.isDisjoint(with: privateACL) else {
+                let acl = dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:)) else {
                     return false
             }
 
             let isInObjCExtension = [.extensionClass, .extension].contains(parentKind) &&
                 parentStructure.enclosedSwiftAttributes.contains(.objc)
 
-            let isInObjcMembers = parentStructure.enclosedSwiftAttributes.contains(.objcMembers)
+            let isInObjcMembers = parentStructure.enclosedSwiftAttributes.contains(.objcMembers) && !acl.isPrivate
 
             guard isInObjCExtension || isInObjcMembers else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -147,7 +147,7 @@ public struct RedundantObjcAttributeRule: ConfigurationProviderRule, AutomaticTe
             @objc
             extension Foo {
                 @objc
-                private var bar: Int {
+                private ↓var bar: Int {
                     return 0
                 }
             }


### PR DESCRIPTION
Fixes #2539

