### PR TITLE
Issue 2538: vertical_whitespace_between_cases gives false warning if blank line has whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@
   types.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2539](https://github.com/realm/SwiftLint/issues/2539)
+  
+* Fix false positives on `vertical_whitespace_between_cases` rule when a blank
+  line is present but it contains trailing whitespace.  
+  [Ben Staveley-Taylor](https://github.com/BenStaveleyTaylor)
+  [#2538](https://github.com/realm/SwiftLint/issues/2538)
 
 ## 0.29.2: Washateria
 

--- a/Rules.md
+++ b/Rules.md
@@ -22321,6 +22321,16 @@ default: print("x is invalid")
 }
 ```
 
+```swift
+switch x {    
+case 1:    
+    print("one")    
+    
+default:    
+    print("not one")    
+}    
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -46,6 +46,15 @@ public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
         default: print("x is invalid")
         }
         """
+        ,
+        // Testing handling of trailing spaces: do not convert to """ style
+        "switch x {    \n" +
+        "case 1:    \n" +
+        "    print(\"one\")    \n" +
+        "    \n" +
+        "default:    \n" +
+        "    print(\"not one\")    \n" +
+        "}    "
     ]
 
     private static let violatingToValidExamples: [String: String] = [
@@ -115,8 +124,7 @@ public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
         // Regex incorrectly flags blank lines that contain trailing whitespace (#2538)
         let patternRegex = regex(pattern)
         let substring = file.contents.substring(from: range.location, length: range.length)
-        let substringRange = NSRange(location: 0, length: substring.count)
-        guard let matchResult = patternRegex.firstMatch(in: substring, options: [], range: substringRange),
+        guard let matchResult = patternRegex.firstMatch(in: substring, options: [], range: substring.fullNSRange),
             matchResult.numberOfRanges > 1 else {
             return false
         }
@@ -143,8 +151,8 @@ extension VerticalWhitespaceBetweenCasesRule: OptInRule, AutomaticTestableRule {
         let patternRegex = regex(pattern)
         return violationRanges(in: file).compactMap { violationRange in
             let substring = file.contents.substring(from: violationRange.location, length: violationRange.length)
-            let substringRange = NSRange(location: 0, length: substring.count)
-            guard let matchResult = patternRegex.firstMatch(in: substring, options: [], range: substringRange) else {
+            guard let matchResult = patternRegex.firstMatch(in: substring, options: [],
+                                                            range: substring.fullNSRange) else {
                 return nil
             }
 


### PR DESCRIPTION
Here's a go at fixing issue 2538 in vertical_whitespace_between_cases.

It would be simpler if there was a regex pattern change that would correctly skip lines containing whitespace, but the only way I could think of was to use a negative look-behind assertion and NSRegularExpression does not support use of `*` or `+` in those (to look-behind for `\n\s+\n`). Maybe someone with greater skill in regexes has way?

So instead I introduced a filter to remove false positives in the violating range set, which I can see some other rules use too.

I tested the behaviour both when linting and autocorrecting.

I can't quite see what to do about adding a unit test for this case. Trailing white space in the `nonTriggeringExamples` literal array will be invisible to users and also causes a trailing_whitespace violation itself. Please advise me on what to do if I need to add a test somehow.