### PR TITLE
Fix identical operands rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@
   [Ben Staveley-Taylor](https://github.com/BenStaveleyTaylor)
   [#2538](https://github.com/realm/SwiftLint/issues/2538)
 
+* Fix false positives on `identical_operands` rule when the right side of the
+  operand does not terminate.
+  [Xavier Lowmiller](https://github.com/xavierLowmiller)
+  [#2467](https://github.com/realm/SwiftLint/issues/2467)
+
 ## 0.29.2: Washateria
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -8019,6 +8019,10 @@ keyValues?.count ?? 0  == 0
 ```
 
 ```swift
+string == string.lowercased()
+```
+
+```swift
 1 != 2
 ```
 
@@ -8064,6 +8068,10 @@ $0 != 0
 
 ```swift
 keyValues?.count ?? 0  != 0
+```
+
+```swift
+string != string.lowercased()
 ```
 
 ```swift
@@ -8115,6 +8123,10 @@ keyValues?.count ?? 0  === 0
 ```
 
 ```swift
+string === string.lowercased()
+```
+
+```swift
 1 !== 2
 ```
 
@@ -8160,6 +8172,10 @@ $0 !== 0
 
 ```swift
 keyValues?.count ?? 0  !== 0
+```
+
+```swift
+string !== string.lowercased()
 ```
 
 ```swift
@@ -8211,6 +8227,10 @@ keyValues?.count ?? 0  > 0
 ```
 
 ```swift
+string > string.lowercased()
+```
+
+```swift
 1 >= 2
 ```
 
@@ -8256,6 +8276,10 @@ $0 >= 0
 
 ```swift
 keyValues?.count ?? 0  >= 0
+```
+
+```swift
+string >= string.lowercased()
 ```
 
 ```swift
@@ -8307,6 +8331,10 @@ keyValues?.count ?? 0  < 0
 ```
 
 ```swift
+string < string.lowercased()
+```
+
+```swift
 1 <= 2
 ```
 
@@ -8355,7 +8383,15 @@ keyValues?.count ?? 0  <= 0
 ```
 
 ```swift
+string <= string.lowercased()
+```
+
+```swift
 func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>>
+```
+
+```swift
+let array = Array<Array<Int>>()
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -46,7 +46,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
 
     public func validate(file: File) -> [StyleViolation] {
         let operators = type(of: self).operators.joined(separator: "|")
-        let pattern = "(?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*(\(operators))\\s*\\1\\b"
+        let pattern = "(?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*(\(operators))\\s*\\1$"
         let syntaxKinds = SyntaxKind.commentKinds
         let excludingPattern = "\\?\\?\\s*" + pattern
 

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -26,10 +26,12 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
                 "lhs.identifier \(operation) rhs.identifier",
                 "i \(operation) index",
                 "$0 \(operation) 0",
-                "keyValues?.count ?? 0  \(operation) 0"
+                "keyValues?.count ?? 0  \(operation) 0",
+                "string \(operation) string.lowercased()"
             ]
         } + [
-            "func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>>"
+            "func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>>",
+            "let array = Array<Array<Int>>()"
         ],
         triggeringExamples: operators.flatMap { operation in
             [

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -46,8 +46,9 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
 
     public func validate(file: File) -> [StyleViolation] {
         let operators = type(of: self).operators.joined(separator: "|")
-        let pattern = "(?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*" +
-            operators + "\\s*\\1\\b(?!\\s*(?:\\.|\\>|\\<))"
+        let pattern = """
+        (?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*(\(operators))\\s*\\1\\b(?!\\s*(\\.|\\>|\\<))
+        """
         let syntaxKinds = SyntaxKind.commentKinds
         let excludingPattern = "\\?\\?\\s*" + pattern
 

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -46,7 +46,8 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
 
     public func validate(file: File) -> [StyleViolation] {
         let operators = type(of: self).operators.joined(separator: "|")
-        let pattern = "(?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*(\(operators))\\s*\\1$"
+        let pattern = "(?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*" +
+            operators + "\\s*\\1\\b(?!\\s*(?:\\.|\\>|\\<))"
         let syntaxKinds = SyntaxKind.commentKinds
         let excludingPattern = "\\?\\?\\s*" + pattern
 


### PR DESCRIPTION
(Fixes #2467)

This PR changes the regex to terminate with a `$` instead of `\b`, since `\b` does not account for the false positives in #2467.

Characters like `<` and `.` are valid word boundaries.