### PR TITLE
#2441 - Fix inaccessible custom rules in nested configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
   [Ben Staveley-Taylor](https://github.com/BenStaveleyTaylor)
   [#2538](https://github.com/realm/SwiftLint/issues/2538)
 
+* Fix unaccessible custom rules in nested configurations.  
+  [Timofey Solonin](https://github.com/biboran)
+  [#2441](https://github.com/realm/SwiftLint/issues/2441)
+
 ## 0.29.2: Washateria
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix unaccessible custom rules in nested configurations.  
+  [Timofey Solonin](https://github.com/biboran)
+  [#2441](https://github.com/realm/SwiftLint/issues/2441)
 
 ## 0.29.3: Entangled Agitator
 
@@ -70,10 +72,6 @@
   line is present but it contains trailing whitespace.  
   [Ben Staveley-Taylor](https://github.com/BenStaveleyTaylor)
   [#2538](https://github.com/realm/SwiftLint/issues/2538)
-
-* Fix unaccessible custom rules in nested configurations.  
-  [Timofey Solonin](https://github.com/biboran)
-  [#2441](https://github.com/realm/SwiftLint/issues/2441)
 
 ## 0.29.2: Washateria
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
 
 #### Bug Fixes
 
-* Fix unaccessible custom rules in nested configurations.  
+* Fix inaccessible custom rules in nested configurations.  
   [Timofey Solonin](https://github.com/biboran)
+  [#1815](https://github.com/realm/SwiftLint/issues/1815)
   [#2441](https://github.com/realm/SwiftLint/issues/2441)
 
 ## 0.29.3: Entangled Agitator

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -74,16 +74,43 @@ extension Configuration {
         }
     }
 
+    private func mergingCustomRules(mergedRules: [Rule], configuration: Configuration) -> [Rule] {
+        guard
+            let thisCustomRules = rules.first(where: { $0 is CustomRules }) as? CustomRules,
+            let otherCustomRules = configuration.rules.first(where: { $0 is CustomRules }) as? CustomRules else {
+            return mergedRules
+        }
+        let customRulesFilter: (RegexConfiguration) -> (Bool)
+        switch configuration.rulesMode {
+        case .allEnabled:
+            customRulesFilter = { _ in true }
+        case let .whitelisted(whitelistedRules):
+            customRulesFilter = { whitelistedRules.contains($0.identifier) }
+        case let .default(disabledRules, _):
+            customRulesFilter = { !disabledRules.contains($0.identifier) }
+        }
+        var customRules = CustomRules()
+        var configuration = CustomRulesConfiguration()
+        configuration.customRuleConfigurations = Set(
+            thisCustomRules.configuration.customRuleConfigurations
+        ).union(
+            Set(otherCustomRules.configuration.customRuleConfigurations)
+        ).filter(customRulesFilter)
+        customRules.configuration = configuration
+        return mergedRules.filter { !($0 is CustomRules) } + [customRules]
+    }
+
     private func mergingRules(with configuration: Configuration) -> [Rule] {
+        let regularMergedRules: [Rule]
         switch configuration.rulesMode {
         case .allEnabled:
             // Technically not possible yet as it's not configurable in a .swiftlint.yml file,
             // but implemented for completeness
-            return configuration.rules
+            regularMergedRules = configuration.rules
         case .whitelisted(let whitelistedRules):
             // Use an intermediate set to filter out duplicate rules when merging configurations
             // (always use the nested rule first if it exists)
-            return Set(configuration.rules.map(HashableRule.init))
+            regularMergedRules = Set(configuration.rules.map(HashableRule.init))
                 .union(rules.map(HashableRule.init))
                 .map { $0.rule }
                 .filter { rule in
@@ -91,7 +118,7 @@ extension Configuration {
                 }
         case let .default(disabled, optIn):
             // Same here
-            return Set(
+            regularMergedRules = Set(
                 configuration.rules
                     // Enable rules that are opt-in by the nested configuration
                     .filter { rule in
@@ -107,6 +134,7 @@ extension Configuration {
                 )
                 .map { $0.rule }
         }
+        return mergingCustomRules(mergedRules: regularMergedRules, configuration: configuration)
     }
 
     internal func merge(with configuration: Configuration) -> Configuration {

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -21,8 +21,16 @@ extension Configuration {
         if configurationSearchPath != configurationPath &&
             FileManager.default.fileExists(atPath: configurationSearchPath) {
             let fullPath = pathNSString.absolutePathRepresentation()
+            let customRuleIdentifiers = (rules.first(where: { $0 is CustomRules }) as? CustomRules)?
+                .configuration.customRuleConfigurations.map { $0.identifier }
             let config = Configuration.getCached(atPath: fullPath) ??
-                Configuration(path: configurationSearchPath, rootPath: fullPath, optional: false, quiet: true)
+                Configuration(
+                    path: configurationSearchPath,
+                    rootPath: fullPath,
+                    optional: false,
+                    quiet: true,
+                    customRulesIdentifiers: customRuleIdentifiers ?? []
+                )
             return merge(with: config)
         }
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -74,7 +74,7 @@ extension Configuration {
         }
     }
 
-    private func mergingCustomRules(mergedRules: [Rule], configuration: Configuration) -> [Rule] {
+    private func mergeCustomRules(mergedRules: [Rule], configuration: Configuration) -> [Rule] {
         guard
             let thisCustomRules = rules.first(where: { $0 is CustomRules }) as? CustomRules,
             let otherCustomRules = configuration.rules.first(where: { $0 is CustomRules }) as? CustomRules else {
@@ -134,7 +134,7 @@ extension Configuration {
                 )
                 .map { $0.rule }
         }
-        return mergingCustomRules(mergedRules: regularMergedRules, configuration: configuration)
+        return mergeCustomRules(mergedRules: regularMergedRules, configuration: configuration)
     }
 
     internal func merge(with configuration: Configuration) -> Configuration {

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -47,7 +47,7 @@ extension Configuration {
     }
 
     public init?(dict: [String: Any], ruleList: RuleList = masterRuleList, enableAllRules: Bool = false,
-                 cachePath: String? = nil) {
+                 cachePath: String? = nil, customRulesIdentifiers: [String] = []) {
         func defaultStringArray(_ object: Any?) -> [String] {
             return [String].array(of: object) ?? []
         }
@@ -99,7 +99,8 @@ extension Configuration {
                   configuredRules: configuredRules,
                   swiftlintVersion: swiftlintVersion,
                   cachePath: cachePath ?? dict[Key.cachePath.rawValue] as? String,
-                  indentation: indentation)
+                  indentation: indentation,
+                  customRulesIdentifiers: customRulesIdentifiers)
     }
 
     private init?(disabledRules: [String],
@@ -115,7 +116,8 @@ extension Configuration {
                   configuredRules: [Rule]?,
                   swiftlintVersion: String?,
                   cachePath: String?,
-                  indentation: IndentationStyle) {
+                  indentation: IndentationStyle,
+                  customRulesIdentifiers: [String]) {
         let rulesMode: RulesMode
         if enableAllRules {
             rulesMode = .allEnabled
@@ -140,7 +142,8 @@ extension Configuration {
                   configuredRules: configuredRules,
                   swiftlintVersion: swiftlintVersion,
                   cachePath: cachePath,
-                  indentation: indentation)
+                  indentation: indentation,
+                  customRulesIdentifiers: customRulesIdentifiers)
     }
 
     private static func warnAboutDeprecations(configurationDictionary dict: [String: Any],

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -46,6 +46,7 @@ extension Configuration {
         return .default
     }
 
+    // swiftlint:disable:next function_body_length
     public init?(dict: [String: Any], ruleList: RuleList = masterRuleList, enableAllRules: Bool = false,
                  cachePath: String? = nil, customRulesIdentifiers: [String] = []) {
         func defaultStringArray(_ object: Any?) -> [String] {

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -46,23 +46,12 @@ extension Configuration {
         return .default
     }
 
-    // swiftlint:disable:next function_body_length
     public init?(dict: [String: Any], ruleList: RuleList = masterRuleList, enableAllRules: Bool = false,
                  cachePath: String? = nil, customRulesIdentifiers: [String] = []) {
-        func defaultStringArray(_ object: Any?) -> [String] {
-            return [String].array(of: object) ?? []
-        }
-
         // Use either new 'opt_in_rules' or deprecated 'enabled_rules' for now.
-        let optInRules = defaultStringArray(
-            dict[Key.optInRules.rawValue] ?? dict[Key.enabledRules.rawValue]
-        )
+        let optInRules = defaultStringArray(dict[Key.optInRules.rawValue] ?? dict[Key.enabledRules.rawValue])
 
-        // Log an error when supplying invalid keys in the configuration dictionary
-        let invalidKeys = Set(dict.keys).subtracting(Configuration.validKeys(ruleList: ruleList))
-        if !invalidKeys.isEmpty {
-            queuedPrintError("Configuration contains invalid keys:\n\(invalidKeys)")
-        }
+        Configuration.warnAboutInvalidKeys(configurationDictionary: dict, ruleList: ruleList)
 
         let disabledRules = defaultStringArray(dict[Key.disabledRules.rawValue])
         let whitelistRules = defaultStringArray(dict[Key.whitelistRules.rawValue])
@@ -181,4 +170,16 @@ extension Configuration {
                 "completely removed in a future release.")
         }
     }
+
+    private static func warnAboutInvalidKeys(configurationDictionary dict: [String: Any], ruleList: RuleList) {
+        // Log an error when supplying invalid keys in the configuration dictionary
+        let invalidKeys = Set(dict.keys).subtracting(self.validKeys(ruleList: ruleList))
+        if !invalidKeys.isEmpty {
+            queuedPrintError("Configuration contains invalid keys:\n\(invalidKeys)")
+        }
+    }
+}
+
+private func defaultStringArray(_ object: Any?) -> [String] {
+    return [String].array(of: object) ?? []
 }

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -56,7 +56,8 @@ public struct Configuration: Hashable {
                  configuredRules: [Rule]? = nil,
                  swiftlintVersion: String? = nil,
                  cachePath: String? = nil,
-                 indentation: IndentationStyle = .default) {
+                 indentation: IndentationStyle = .default,
+                 customRulesIdentifiers: [String] = []) {
         if let pinnedVersion = swiftlintVersion, pinnedVersion != Version.current.value {
             queuedPrintError("Currently running SwiftLint \(Version.current.value) but " +
                 "configuration specified version \(pinnedVersion).")
@@ -71,7 +72,8 @@ public struct Configuration: Hashable {
 
         guard let rules = enabledRules(from: configuredRules,
                                        with: rulesMode,
-                                       aliasResolver: handleAliasWithRuleList) else {
+                                       aliasResolver: handleAliasWithRuleList,
+                                       customRulesIdentifiers: customRulesIdentifiers) else {
             return nil
         }
 
@@ -120,7 +122,8 @@ public struct Configuration: Hashable {
     }
 
     public init(path: String = Configuration.fileName, rootPath: String? = nil,
-                optional: Bool = true, quiet: Bool = false, enableAllRules: Bool = false, cachePath: String? = nil) {
+                optional: Bool = true, quiet: Bool = false, enableAllRules: Bool = false,
+                cachePath: String? = nil, customRulesIdentifiers: [String] = []) {
         let fullPath: String
         if let rootPath = rootPath, rootPath.isDirectory() {
             fullPath = path.bridge().absolutePathRepresentation(rootDirectory: rootPath)
@@ -141,7 +144,7 @@ public struct Configuration: Hashable {
         let rulesMode: RulesMode = enableAllRules ? .allEnabled : .default(disabled: [], optIn: [])
         if path.isEmpty || !FileManager.default.fileExists(atPath: fullPath) {
             if !optional { fail("File not found.") }
-            self.init(rulesMode: rulesMode, cachePath: cachePath)!
+            self.init(rulesMode: rulesMode, cachePath: cachePath, customRulesIdentifiers: customRulesIdentifiers)!
             self.rootPath = rootPath
             return
         }
@@ -151,7 +154,7 @@ public struct Configuration: Hashable {
             if !quiet {
                 queuedPrintError("Loading configuration from '\(path)'")
             }
-            self.init(dict: dict, enableAllRules: enableAllRules, cachePath: cachePath)!
+            self.init(dict: dict, enableAllRules: enableAllRules, cachePath: cachePath, customRulesIdentifiers: customRulesIdentifiers)!
             configurationPath = fullPath
             self.rootPath = rootPath
             setCached(atPath: fullPath)
@@ -161,7 +164,7 @@ public struct Configuration: Hashable {
         } catch {
             fail("\(error)")
         }
-        self.init(rulesMode: rulesMode, cachePath: cachePath)!
+        self.init(rulesMode: rulesMode, cachePath: cachePath, customRulesIdentifiers: customRulesIdentifiers)!
         setCached(atPath: fullPath)
     }
 
@@ -213,8 +216,12 @@ private func containsDuplicateIdentifiers(_ identifiers: [String]) -> Bool {
 
 private func enabledRules(from configuredRules: [Rule],
                           with mode: Configuration.RulesMode,
-                          aliasResolver: (String) -> String) -> [Rule]? {
-    let validRuleIdentifiers = configuredRules.map { type(of: $0).description.identifier }
+                          aliasResolver: (String) -> String,
+                          customRulesIdentifiers: [String]) -> [Rule]? {
+    let regularRuleIdentifiers = configuredRules.map { type(of: $0).description.identifier }
+    let configurationCustomRulesIdentifiers = (configuredRules.first(where: { $0 is CustomRules }) as? CustomRules)?
+        .configuration.customRuleConfigurations.map { $0.identifier } ?? []
+    let validRuleIdentifiers = regularRuleIdentifiers + configurationCustomRulesIdentifiers + customRulesIdentifiers
 
     switch mode {
     case .allEnabled:

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -154,7 +154,8 @@ public struct Configuration: Hashable {
             if !quiet {
                 queuedPrintError("Loading configuration from '\(path)'")
             }
-            self.init(dict: dict, enableAllRules: enableAllRules, cachePath: cachePath, customRulesIdentifiers: customRulesIdentifiers)!
+            self.init(dict: dict, enableAllRules: enableAllRules,
+                      cachePath: cachePath, customRulesIdentifiers: customRulesIdentifiers)!
             configurationPath = fullPath
             self.rootPath = rootPath
             setCached(atPath: fullPath)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RegexConfiguration: RuleConfiguration, Equatable, CacheDescriptionProvider {
+public struct RegexConfiguration: RuleConfiguration, Equatable, Hashable, CacheDescriptionProvider {
     public let identifier: String
     public var name: String?
     public var message = "Regex matched."
@@ -74,5 +74,9 @@ public struct RegexConfiguration: RuleConfiguration, Equatable, CacheDescription
         if let severityString = configurationDict["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)
         }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RegexConfiguration: RuleConfiguration, Equatable, Hashable, CacheDescriptionProvider {
+public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionProvider {
     public let identifier: String
     public var name: String?
     public var message = "Regex matched."

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
@@ -1,5 +1,5 @@
 public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
-    struct RequiredCase: Equatable, Hashable {
+    struct RequiredCase: Hashable {
         var name: String
         var severity: ViolationSeverity
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -175,7 +175,9 @@ extension ConfigurationTests {
         ("testLevel3", testLevel3),
         ("testNestedConfigurationWithCustomRootPath", testNestedConfigurationWithCustomRootPath),
         ("testMergedWarningThreshold", testMergedWarningThreshold),
-        ("testNestedWhitelistedRules", testNestedWhitelistedRules)
+        ("testNestedWhitelistedRules", testNestedWhitelistedRules),
+        ("testNestedConfigurationsWithCustomRulesMerge", testNestedConfigurationsWithCustomRulesMerge),
+        ("testNestedConfigurationAllowsDisablingParentsCustomRules", testNestedConfigurationAllowsDisablingParentsCustomRules)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -85,4 +85,32 @@ extension ConfigurationTests {
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceCastRule.self))
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceTryRule.self))
     }
+
+    func testNestedConfigurationsWithCustomRulesMerge() {
+        let mergedConfiguration = projectMockConfig0CustomRules.merge(with: projectMockConfig2CustomRules)
+        guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
+            else {
+            return XCTFail("Custom rule are expected to be present")
+        }
+        XCTAssertTrue(
+            mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abc" })
+        )
+        XCTAssertTrue(
+            mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abcd" })
+        )
+    }
+
+    func testNestedConfigurationAllowsDisablingParentsCustomRules() {
+        let mergedConfiguration = projectMockConfig0CustomRules.merge(with: projectMockConfig2CustomRulesDisabled)
+        guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
+            else {
+            return XCTFail("Custom rule are expected to be present")
+        }
+        XCTAssertFalse(
+            mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abc" })
+        )
+        XCTAssertTrue(
+            mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abcd" })
+        )
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+ProjectMock.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+ProjectMock.swift
@@ -26,8 +26,20 @@ extension ConfigurationTests {
         return projectMockPathLevel0.stringByAppendingPathComponent("custom.yml")
     }
 
+    var projectMockYAML0CustomRules: String {
+        return projectMockPathLevel0.stringByAppendingPathComponent("custom_rules.yml")
+    }
+
     var projectMockYAML2: String {
         return projectMockPathLevel2.stringByAppendingPathComponent(Configuration.fileName)
+    }
+
+    var projectMockYAML2CustomRules: String {
+        return projectMockPathLevel2.stringByAppendingPathComponent("custom_rules.yml")
+    }
+
+    var projectMockYAML2CustomRulesDisabled: String {
+        return projectMockPathLevel2.stringByAppendingPathComponent("custom_rules_disabled.yml")
     }
 
     var projectMockSwift0: String {
@@ -56,8 +68,23 @@ extension ConfigurationTests {
                              optional: false, quiet: true)
     }
 
+    var projectMockConfig0CustomRules: Configuration {
+        return Configuration(path: projectMockYAML0CustomRules, rootPath: projectMockPathLevel0,
+                             optional: false, quiet: true)
+    }
+
     var projectMockConfig2: Configuration {
         return Configuration(path: projectMockYAML2, optional: false, quiet: true)
+    }
+
+    var projectMockConfig2CustomRules: Configuration {
+        return Configuration(path: projectMockYAML2CustomRules, rootPath: projectMockPathLevel0,
+                             optional: false, quiet: true)
+    }
+
+    var projectMockConfig2CustomRulesDisabled: Configuration {
+        return Configuration(path: projectMockYAML2CustomRulesDisabled, rootPath: projectMockPathLevel0,
+                             optional: false, quiet: true)
     }
 
     var projectMockConfig3: Configuration {

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules.yml
@@ -1,0 +1,4 @@
+custom_rules:
+  no_abcd:
+    name: "Don't use abcd"
+    regex: 'abcd'

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules_disabled.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules_disabled.yml
@@ -1,0 +1,6 @@
+custom_rules:
+  no_abcd:
+    name: "Don't use abcd"
+    regex: 'abcd'
+disabled_rules:
+  - no_abc

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/custom_rules.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/custom_rules.yml
@@ -1,0 +1,4 @@
+custom_rules:
+  no_abc:
+    name: "Don't use abc"
+    regex: 'abc'


### PR DESCRIPTION
Continued from #2532, all credit to @biboran I just made a few small modifications

> This PR addresses 2 issues:
> * As per #2441 a nested configuration wasn't able properly initialize due to temporal coupling with `enabledRules` routine that was called before the nested configuration merge. To remedy this issue I just passed the `customRulesIdentifiers` to the `enabledRules` thus making it aware of the parent's custom rules. I guess it is not an elegant solution but it works.
> * Another issue I found was that nested configuration wasn't able to define its own custom rules because they wouldn't be merged (#1815). The parent's `CustomRules` instance would always be the one left by the `union` in `Configuration+Merging.swift`. This was also the reason why disabling custom rules in the nested configuration was impossible. I just added a special method that merges custom rules separately.
