### PR TITLE
Add strong_iboutlet opt-in rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 #### Enhancements
 
-* None.
+* Add `strong_iboutlet` opt-in rule to enforce that `@IBOutlet`s are not
+  declared as `weak`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2433](https://github.com/realm/SwiftLint/issues/2433)
 
 #### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -127,6 +127,7 @@
 * [Statement Position](#statement-position)
 * [Static Operator](#static-operator)
 * [Strict fileprivate](#strict-fileprivate)
+* [Strong IBOutlet](#strong-iboutlet)
 * [Superfluous Disable Command](#superfluous-disable-command)
 * [Switch and Case Statement Alignment](#switch-and-case-statement-alignment)
 * [Switch Case on Newline](#switch-case-on-newline)
@@ -16837,6 +16838,57 @@ struct Outter {
   struct Inter {
     ↓fileprivate struct Inner {}
   }
+}
+```
+
+</details>
+
+
+
+## Strong IBOutlet
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`strong_iboutlet` | Disabled | No | lint | No | 3.0.0 
+
+@IBOutlets shouldn't be declared as weak.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+class ViewController: UIViewController {
+    @IBOutlet var label: UILabel?
+}
+```
+
+```swift
+class ViewController: UIViewController {
+    weak var label: UILabel?
+}
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+class ViewController: UIViewController {
+    @IBOutlet weak ↓var label: UILabel?
+}
+```
+
+```swift
+class ViewController: UIViewController {
+    @IBOutlet unowned ↓var label: UILabel!
+}
+```
+
+```swift
+class ViewController: UIViewController {
+    @IBOutlet weak ↓var textField: UITextField?
 }
 ```
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -128,6 +128,7 @@ public let masterRuleList = RuleList(rules: [
     StatementPositionRule.self,
     StaticOperatorRule.self,
     StrictFilePrivateRule.self,
+    StrongIBOutletRule.self,
     SuperfluousDisableCommandRule.self,
     SwitchCaseAlignmentRule.self,
     SwitchCaseOnNewlineRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
@@ -1,0 +1,48 @@
+import SourceKittenFramework
+
+public struct StrongIBOutletRule: ConfigurationProviderRule, ASTRule, OptInRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "strong_iboutlet",
+        name: "Strong IBOutlet",
+        description: "@IBOutlets shouldn't be declared as weak.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            "@IBOutlet var label: UILabel?",
+            "weak var label: UILabel?"
+        ].map(wrapExample),
+        triggeringExamples: [
+            "@IBOutlet weak ↓var label: UILabel?",
+            "@IBOutlet unowned ↓var label: UILabel!",
+            "@IBOutlet weak ↓var textField: UITextField?"
+        ].map(wrapExample)
+    )
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard kind == .varInstance,
+            case let attributes = dictionary.enclosedSwiftAttributes,
+            attributes.contains(.iboutlet),
+            attributes.contains(.weak),
+            let offset = dictionary.offset else {
+                return []
+        }
+
+        return [
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: offset))
+        ]
+    }
+}
+
+private func wrapExample(_ text: String) -> String {
+    return """
+    class ViewController: UIViewController {
+        \(text)
+    }
+    """
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */; };
 		D4470D5D1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D5C1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift */; };
 		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
+		D450D1D121EC4A6900E60010 /* StrongIBOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D450D1D021EC4A6900E60010 /* StrongIBOutletRule.swift */; };
 		D45255C81F0932F8003C9B56 /* RuleDescription+Examples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45255C71F0932F8003C9B56 /* RuleDescription+Examples.swift */; };
 		D462021F1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */; };
 		D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */; };
@@ -701,6 +702,7 @@
 		D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRuleTests.swift; sourceTree = "<group>"; };
 		D4470D5C1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentOnCallRule.swift; sourceTree = "<group>"; };
 		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
+		D450D1D021EC4A6900E60010 /* StrongIBOutletRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrongIBOutletRule.swift; sourceTree = "<group>"; };
 		D45255C71F0932F8003C9B56 /* RuleDescription+Examples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RuleDescription+Examples.swift"; sourceTree = "<group>"; };
 		D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleExamples.swift; sourceTree = "<group>"; };
 		D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRule.swift; sourceTree = "<group>"; };
@@ -1032,6 +1034,7 @@
 				623675AF1F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift */,
 				623675B11F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift */,
 				B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */,
+				D450D1D021EC4A6900E60010 /* StrongIBOutletRule.swift */,
 				D40E041B1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift */,
 				E88DEA811B0990A700A66CB0 /* TodoRule.swift */,
 				D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */,
@@ -1976,6 +1979,7 @@
 				18B90B6B21ADD99800B60749 /* RedundantObjcAttributeRule.swift in Sources */,
 				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift in Sources */,
 				D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */,
+				D450D1D121EC4A6900E60010 /* StrongIBOutletRule.swift in Sources */,
 				824AB64D2105C39F004B5A8F /* ConditionalReturnsOnNewlineConfiguration.swift in Sources */,
 				62A6E7931F3317E3003A0479 /* JoinedDefaultParameterRule.swift in Sources */,
 				D4FD4C851F2A260A00DD8AA8 /* BlockBasedKVORule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1150,6 +1150,12 @@ extension StrictFilePrivateRuleTests {
     ]
 }
 
+extension StrongIBOutletRuleTests {
+    static var allTests: [(String, (StrongIBOutletRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension SwitchCaseAlignmentRuleTests {
     static var allTests: [(String, (SwitchCaseAlignmentRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration),
@@ -1541,6 +1547,7 @@ XCTMain([
     testCase(StatementPositionRuleTests.allTests),
     testCase(StaticOperatorRuleTests.allTests),
     testCase(StrictFilePrivateRuleTests.allTests),
+    testCase(StrongIBOutletRuleTests.allTests),
     testCase(SwitchCaseAlignmentRuleTests.allTests),
     testCase(SwitchCaseOnNewlineRuleTests.allTests),
     testCase(SyntacticSugarRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -582,6 +582,12 @@ class StrictFilePrivateRuleTests: XCTestCase {
     }
 }
 
+class StrongIBOutletRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(StrongIBOutletRule.description)
+    }
+}
+
 class SwitchCaseOnNewlineRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SwitchCaseOnNewlineRule.description)


### PR DESCRIPTION
Fixes #2433

Added this as an opt-in rule because even though Apple recommends using strong variables on WWDC videos, the Xcode default is to create a `weak` variable so I can see teams preferring sticking to it.