### PR TITLE
Fix false positive in identical_operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 
 #### Bug Fixes
 
-* None.
+* Fix false positives on `identical_operands` rule when the right side of the
+  operand has a chained optional.  
+  [JP Simard](https://github.com/jpsim)
+  [#2564](https://github.com/realm/SwiftLint/issues/2564)
 
 ## 0.29.4: In-Unit Operands
 

--- a/Rules.md
+++ b/Rules.md
@@ -8016,11 +8016,16 @@ $0 == 0
 ```
 
 ```swift
-keyValues?.count ?? 0  == 0
+keyValues?.count ?? 0 == 0
 ```
 
 ```swift
 string == string.lowercased()
+```
+
+```swift
+let num: Int? = 0
+_ = num != nil && num == num?.byteSwapped
 ```
 
 ```swift
@@ -8068,11 +8073,16 @@ $0 != 0
 ```
 
 ```swift
-keyValues?.count ?? 0  != 0
+keyValues?.count ?? 0 != 0
 ```
 
 ```swift
 string != string.lowercased()
+```
+
+```swift
+let num: Int? = 0
+_ = num != nil && num != num?.byteSwapped
 ```
 
 ```swift
@@ -8120,11 +8130,16 @@ $0 === 0
 ```
 
 ```swift
-keyValues?.count ?? 0  === 0
+keyValues?.count ?? 0 === 0
 ```
 
 ```swift
 string === string.lowercased()
+```
+
+```swift
+let num: Int? = 0
+_ = num != nil && num === num?.byteSwapped
 ```
 
 ```swift
@@ -8172,11 +8187,16 @@ $0 !== 0
 ```
 
 ```swift
-keyValues?.count ?? 0  !== 0
+keyValues?.count ?? 0 !== 0
 ```
 
 ```swift
 string !== string.lowercased()
+```
+
+```swift
+let num: Int? = 0
+_ = num != nil && num !== num?.byteSwapped
 ```
 
 ```swift
@@ -8224,11 +8244,16 @@ $0 > 0
 ```
 
 ```swift
-keyValues?.count ?? 0  > 0
+keyValues?.count ?? 0 > 0
 ```
 
 ```swift
 string > string.lowercased()
+```
+
+```swift
+let num: Int? = 0
+_ = num != nil && num > num?.byteSwapped
 ```
 
 ```swift
@@ -8276,11 +8301,16 @@ $0 >= 0
 ```
 
 ```swift
-keyValues?.count ?? 0  >= 0
+keyValues?.count ?? 0 >= 0
 ```
 
 ```swift
 string >= string.lowercased()
+```
+
+```swift
+let num: Int? = 0
+_ = num != nil && num >= num?.byteSwapped
 ```
 
 ```swift
@@ -8328,11 +8358,16 @@ $0 < 0
 ```
 
 ```swift
-keyValues?.count ?? 0  < 0
+keyValues?.count ?? 0 < 0
 ```
 
 ```swift
 string < string.lowercased()
+```
+
+```swift
+let num: Int? = 0
+_ = num != nil && num < num?.byteSwapped
 ```
 
 ```swift
@@ -8380,11 +8415,16 @@ $0 <= 0
 ```
 
 ```swift
-keyValues?.count ?? 0  <= 0
+keyValues?.count ?? 0 <= 0
 ```
 
 ```swift
 string <= string.lowercased()
+```
+
+```swift
+let num: Int? = 0
+_ = num != nil && num <= num?.byteSwapped
 ```
 
 ```swift

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -26,8 +26,12 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
                 "lhs.identifier \(operation) rhs.identifier",
                 "i \(operation) index",
                 "$0 \(operation) 0",
-                "keyValues?.count ?? 0  \(operation) 0",
-                "string \(operation) string.lowercased()"
+                "keyValues?.count ?? 0 \(operation) 0",
+                "string \(operation) string.lowercased()",
+                """
+                let num: Int? = 0
+                _ = num != nil && num \(operation) num?.byteSwapped
+                """
             ]
         } + [
             "func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>>",
@@ -47,7 +51,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
     public func validate(file: File) -> [StyleViolation] {
         let operators = type(of: self).operators.joined(separator: "|")
         let pattern = """
-        (?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*(\(operators))\\s*\\1\\b(?!\\s*(\\.|\\>|\\<))
+        (?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*(\(operators))\\s*\\1\\b(?!\\s*(\\.|\\>|\\<|\\?))
         """
         let syntaxKinds = SyntaxKind.commentKinds
         let excludingPattern = "\\?\\?\\s*" + pattern


### PR DESCRIPTION
Fix false positives on `identical_operands` rule when the right side of the operand has a chained optional. Fixes #2564.