### PR TITLE
Adds more fields to `custom_rules` including autocorrection capabilities

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -59,6 +59,9 @@ opt_in_rules:
   - xct_specific_matcher
   - yoda_condition
 
+disabled_rules:
+  - opening_brace
+
 identifier_name:
   excluded:
     - id
@@ -92,4 +95,11 @@ custom_rules:
     name: Rule Test Function
     message: Rule Test Function mustn't end with `rule`
     regex: func\s*test\w+(r|R)ule\(\)
+    severity: error
+  rule_test_brace:
+    name: Opening Brace Rule
+    message: Opening braces should be preceded by a single space and on the same line as the declaration.
+    regex: "(?:[^( ]|[\\s(][\\s]+)\\{"
+    exclude_kinds: comment_and_string_kinds
+    exclude_regex: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{"
     severity: error

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,3 +103,4 @@ custom_rules:
     exclude_kinds: comment_and_string_kinds
     exclude_regex: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{"
     severity: error
+    correction: "$1 {"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -59,9 +59,6 @@ opt_in_rules:
   - xct_specific_matcher
   - yoda_condition
 
-disabled_rules:
-  - opening_brace
-
 identifier_name:
   excluded:
     - id
@@ -96,11 +93,3 @@ custom_rules:
     message: Rule Test Function mustn't end with `rule`
     regex: func\s*test\w+(r|R)ule\(\)
     severity: error
-  rule_test_brace:
-    name: Opening Brace Rule
-    message: "[Custom] Opening braces should be preceded by a single space and on the same line as the declaration."
-    regex: "(?:[^( ]|[\\s(][\\s]+)\\{"
-    exclude_kinds: comment_and_string_kinds
-    exclude_regex: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{"
-    severity: error
-    correction: "$1 {"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -98,7 +98,7 @@ custom_rules:
     severity: error
   rule_test_brace:
     name: Opening Brace Rule
-    message: Opening braces should be preceded by a single space and on the same line as the declaration.
+    message: "[Custom] Opening braces should be preceded by a single space and on the same line as the declaration."
     regex: "(?:[^( ]|[\\s(][\\s]+)\\{"
     exclude_kinds: comment_and_string_kinds
     exclude_regex: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
   muted parameter.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
+* Adds more fields to `custom_rules` including autocorrection capabilities.  
+  [therealbnut](https://github.com/therealbnut)
+
 #### Bug Fixes
 
 * Fix false positives on `identical_operands` rule when the right side of the

--- a/Rules.md
+++ b/Rules.md
@@ -2802,7 +2802,7 @@ class DummyClass {}
 
 Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
 --- | --- | --- | --- | --- | ---
-`custom_rules` | Enabled | No | style | No | 3.0.0 
+`custom_rules` | Enabled | Yes | style | No | 3.0.0 
 
 Create custom rules by providing a regex string. Optionally specify what syntax kinds to match against, the severity level, and what message to display.
 

--- a/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxKind+SwiftLint.swift
@@ -20,3 +20,21 @@ extension SyntaxKind {
                                             .objectLiteral, .parameter, .placeholder, .string,
                                             .stringInterpolationAnchor, .typeidentifier]
 }
+
+extension Set where Element == SyntaxKind {
+    init(shortName: Swift.String) throws {
+        do {
+            self = try [SyntaxKind(shortName: shortName)]
+        } catch {
+            switch shortName {
+            case "comment_and_string_kinds":
+                self = SyntaxKind.commentAndStringKinds
+            case "comment_kinds":
+                self = SyntaxKind.commentKinds
+            case "all_kinds":
+                self = SyntaxKind.allKinds
+            default: throw error
+            }
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -9,8 +9,8 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
     public var excludeRegex: NSRegularExpression?
     public var included: NSRegularExpression?
     public var excluded: NSRegularExpression?
-    private var matchKinds = SyntaxKind.allKinds
-    private var excludeKinds = Set<SyntaxKind>()
+    internal var matchKinds = SyntaxKind.allKinds
+    internal var excludeKinds = Set<SyntaxKind>()
     public var correction: String?
 
     public var severityConfiguration = SeverityConfiguration(.warning)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -9,8 +9,9 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
     public var excludeRegex: NSRegularExpression?
     public var included: NSRegularExpression?
     public var excluded: NSRegularExpression?
-    public var matchKinds = SyntaxKind.allKinds
-    public var excludeKinds = Set<SyntaxKind>()
+    private var matchKinds = SyntaxKind.allKinds
+    private var excludeKinds = Set<SyntaxKind>()
+    public var correction: String?
 
     public var severityConfiguration = SeverityConfiguration(.warning)
 
@@ -84,6 +85,14 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
         if let severityString = configurationDict["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)
         }
+
+        if let correction = configurationDict["correction"] as? String {
+            self.correction = correction
+        }
+    }
+
+    public var syntaxKinds: Set<SyntaxKind> {
+        return self.matchKinds.subtracting(self.excludeKinds)
     }
 
     public func hash(into hasher: inout Hasher) {

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -131,11 +131,9 @@ public struct CustomRules: CorrectableRule, ConfigurationProviderRule, CacheDesc
 
         return corrections
     }
-
 }
 
 extension RegexConfiguration {
-
     func violatingRanges(inFile file: File) -> [NSRange] {
         let excludingSyntaxKinds = SyntaxKind.allKinds.subtracting(syntaxKinds)
         let pattern = regex.pattern
@@ -161,5 +159,4 @@ extension RegexConfiguration {
         }
         return !region.isRuleDisabled(customRuleIdentifier: identifier)
     }
-
 }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -10,16 +10,22 @@ class CustomRulesTests: XCTestCase {
                 "name": "MyCustomRule",
                 "message": "Message",
                 "regex": "regex",
-                "match_kinds": "comment",
-                "severity": "error"
+                "exclude_regex": "regex2",
+                "match_kinds": "comment_kinds",
+                "exclude_kinds": "all_kinds",
+                "severity": "error",
+                "correction": "abc"
             ]
         ]
         var comp = RegexConfiguration(identifier: "my_custom_rule")
         comp.name = "MyCustomRule"
         comp.message = "Message"
         comp.regex = regex("regex")
+        comp.excludeRegex = regex("regex2")
         comp.severityConfiguration = SeverityConfiguration(.error)
-        comp.matchKinds = Set([SyntaxKind.comment])
+        comp.matchKinds = SyntaxKind.commentKinds
+        comp.excludeKinds = SyntaxKind.allKinds
+        comp.correction = "abc"
         var compRules = CustomRulesConfiguration()
         compRules.customRuleConfigurations = [comp]
         do {


### PR DESCRIPTION
I wanted to be able to tweak something like "OpeningBraceRule" without forking SwiftLint, this lets me do that in many more cases:

```yaml
  rule_test_brace:
    name: Opening Brace Rule
    message: "[Custom] Opening braces should be preceded by a single space and on the same line as the declaration."
    regex: "(?:[^( ]|[\\s(][\\s]+)\\{"
    exclude_kinds: comment_and_string_kinds
    exclude_regex: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{"
    severity: error
    correction: "$1 {"
```