### PR TITLE
Fix ExplicitTypeInterfaceRule in groups and statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix `explicit_type_interface` when used in statements.  
+  [Daniel Metzing](https://github.com/dirtydanee)
+  [#2154](https://github.com/realm/SwiftLint/issues/2154)
   
 ## 0.30.1: Localized Stain Remover
 

--- a/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftExpressionKind.swift
@@ -5,4 +5,5 @@ public enum SwiftExpressionKind: String {
     case dictionary = "source.lang.swift.expr.dictionary"
     case objectLiteral = "source.lang.swift.expr.object_literal"
     case closure = "source.lang.swift.expr.closure"
+    case tuple = "source.lang.swift.expr.tuple"
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -381,7 +381,11 @@ extension ExplicitTypeInterfaceRuleTests {
         ("testExplicitTypeInterface", testExplicitTypeInterface),
         ("testExcludeLocalVars", testExcludeLocalVars),
         ("testExcludeClassVars", testExcludeClassVars),
-        ("testAllowRedundancy", testAllowRedundancy)
+        ("testAllowRedundancy", testAllowRedundancy),
+        ("testEmbededInStatements", testEmbededInStatements),
+        ("testCaptureGroup", testCaptureGroup),
+        ("testFastEnumerationDeclaration", testFastEnumerationDeclaration),
+        ("testSwitchCaseDeclarations", testSwitchCaseDeclarations)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -64,4 +64,153 @@ class ExplicitTypeInterfaceRuleTests: XCTestCase {
 
         verifyRule(description, ruleConfiguration: ["allow_redundancy": true])
     }
+
+    func testEmbededInStatements() {
+        let nonTriggeringExamples = [
+            """
+            func foo() {
+                var bar: String?
+                guard let strongBar = bar else {
+                    return
+                }
+            }
+            """,
+            """
+            struct SomeError: Error {}
+            var error: Error?
+            switch error {
+            case let error as SomeError: break
+            default: break
+            }
+            """
+        ]
+        let triggeringExamples = ExplicitTypeInterfaceRule.description.triggeringExamples
+        let description = ExplicitTypeInterfaceRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+
+        verifyRule(description)
+    }
+
+    func testCaptureGroup() {
+        let nonTriggeringExamples = [
+            """
+            var k: Int = 0
+            _ = { [weak k] in
+                print(k)
+            }
+            """,
+            """
+            var k: Int = 0
+            _ = { [unowned k] in
+                print(k)
+            }
+            """,
+            """
+            class Foo {
+                func bar() {
+                    var k: Int = 0
+                    _ = { [weak self, weak k] in
+                        guard let strongSelf = self else { return }
+                    }
+                }
+            }
+            """
+        ]
+        let triggeringExamples = ExplicitTypeInterfaceRule.description.triggeringExamples
+        let description = ExplicitTypeInterfaceRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+
+        verifyRule(description)
+    }
+
+    func testFastEnumerationDeclaration() {
+        let nonTriggeringExaples = [
+            """
+            func foo() {
+                let elements: [Int] = [1, 2]
+                for element in elements {}
+            }
+            """,
+            """
+            func foo() {
+                let elements: [Int] = [1, 2]
+                for (index, element) in elements.enumerated() {}
+            }
+            """
+        ]
+
+        let triggeringExamples = ExplicitTypeInterfaceRule.description.triggeringExamples
+        let description = ExplicitTypeInterfaceRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExaples)
+        verifyRule(description)
+    }
+
+    //swiftlint:disable function_body_length
+    func testSwitchCaseDeclarations() {
+        guard SwiftVersion.current >= .fourDotOne else {
+            return
+        }
+
+        let nonTriggeringExamples = [
+            """
+            enum Foo {
+                case failure(Any)
+                case success(Any)
+                }
+                func bar() {
+                    let foo: Foo = .success(1)
+                    switch foo {
+                    case .failure(let error): let bar: Int = 1
+                    case .success(let result): let bar: Int = 2
+                }
+            }
+            """,
+            """
+            enum Foo {
+                case failure(Any, Any)
+            }
+            func foo() {
+                switch foo {
+                case var (x, y): break
+                }
+            }
+            """
+        ]
+
+        let triggeringExamples = [
+            """
+            enum Foo {
+                case failure(Any)
+                case success(Any)
+            }
+            func bar() {
+                let foo: Foo = .success(1)
+                switch foo {
+                case .failure(let error): ↓let fooBar = 1
+                case .success(let result): ↓let fooBar = 1
+                }
+            }
+            """,
+            """
+            enum Foo {
+                case failure(Any, Any)
+            }
+            func foo() {
+                let foo: Foo = .failure(1, 1)
+                switch foo {
+                case var .failure(x, y): ↓let fooBar = 1
+                default: ↓let fooBar = 1
+                }
+            }
+            """
+        ]
+
+        let description = ExplicitTypeInterfaceRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+        verifyRule(description)
+    }
 }


### PR DESCRIPTION
First of all, thanks for all the efforts on the project! In this PR I am attempting to fix https://github.com/realm/SwiftLint/issues/2154

Main changes to the original rule's implementation:
* Added checks if a given declaration kind:
  * is not in a `for` or `forEach` statement
  * is not in a case statement
  * is not wrapped in a tuple
  * is not in a capture group - had to use regex, I could not find other way to figure it out from the parent structure
 
 * Moved functions to an extension on Dictionary
 * Added test cases covering the new implementation to `ExplicitTypeInterfaceRuleTests.swift`
