### PR TITLE
Make `redundant_objc_attribute` rule autocorrectable. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
   `SwiftVersion.current`.  
   [JP Simard](https://github.com/jpsim)
 
+* Make `redundant_objc_attribute` rule autocorrectable.  
+    [Daniel Metzing](https://github.com/dirtydanee)
+
 #### Bug Fixes
 
 * Fix `explicit_type_interface` when used in statements.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   [JP Simard](https://github.com/jpsim)
 
 * Make `redundant_objc_attribute` rule autocorrectable.  
-    [Daniel Metzing](https://github.com/dirtydanee)
+  [Daniel Metzing](https://github.com/dirtydanee)
 
 #### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -15677,7 +15677,7 @@ var myVar: Int? = nil; myVar↓??nil
 
 Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
 --- | --- | --- | --- | --- | ---
-`redundant_objc_attribute` | Enabled | No | idiomatic | No | 4.1.0 
+`redundant_objc_attribute` | Enabled | Yes | idiomatic | No | 4.1.0 
 
 Objective-C attribute (@objc) is redundant in declaration.
 
@@ -15721,54 +15721,54 @@ private @GKInspectable var foo: String! {}
 ```swift
 @objcMembers
 class Foo {
-  var bar: Any?
-  @objc
-  class Bar {
+    var bar: Any?
     @objc
-    var foo: Any?
-  }
+    class Bar {
+        @objc
+        var foo: Any?
+    }
 }
 ```
 
 ```swift
 @objc
 extension Foo {
-  var bar: Int {
-    return 0
-  }
+    var bar: Int {
+        return 0
+    }
 }
 ```
 
 ```swift
 extension Foo {
-  @objc
-  var bar: Int { return 0 }
+    @objc
+    var bar: Int { return 0 }
 }
 ```
 
 ```swift
 @objc @IBDesignable
 extension Foo {
-  var bar: Int { return 0 }
+    var bar: Int { return 0 }
 }
 ```
 
 ```swift
 @IBDesignable
 extension Foo {
-  @objc
-  var bar: Int { return 0 }
-  var fooBar: Int { return 1 }
+    @objc
+    var bar: Int { return 0 }
+    var fooBar: Int { return 1 }
 }
 ```
 
 ```swift
 @objcMembers
 class Foo: NSObject {
-  @objc
-  private var bar: Int {
-    return 0
-  }
+    @objc
+    private var bar: Int {
+        return 0
+    }
 }
 ```
 
@@ -15793,78 +15793,78 @@ class Foo {
 <summary>Triggering Examples</summary>
 
 ```swift
-@objc @IBInspectable private ↓var foo: String? {}
+↓@objc @IBInspectable private var foo: String? {}
 ```
 
 ```swift
-@IBInspectable @objc private ↓var foo: String? {}
+@IBInspectable ↓@objc private var foo: String? {}
 ```
 
 ```swift
-@objc @IBAction private ↓func foo(_ sender: Any) {}
+↓@objc @IBAction private func foo(_ sender: Any) {}
 ```
 
 ```swift
-@IBAction @objc private ↓func foo(_ sender: Any) {}
+@IBAction ↓@objc private func foo(_ sender: Any) {}
 ```
 
 ```swift
-@objc @GKInspectable private ↓var foo: String! {}
+↓@objc @GKInspectable private var foo: String! {}
 ```
 
 ```swift
-@GKInspectable @objc private ↓var foo: String! {}
+@GKInspectable ↓@objc private var foo: String! {}
 ```
 
 ```swift
-@objc @NSManaged private ↓var foo: String!
+↓@objc @NSManaged private var foo: String!
 ```
 
 ```swift
-@NSManaged @objc private ↓var foo: String!
+@NSManaged ↓@objc private var foo: String!
 ```
 
 ```swift
-@objc @IBDesignable ↓class Foo {}
+↓@objc @IBDesignable class Foo {}
 ```
 
 ```swift
 @objcMembers
 class Foo {
-  @objc ↓var bar: Any?
+    ↓@objc var bar: Any?
 }
 ```
 
 ```swift
 @objcMembers
 class Foo {
-  @objc ↓var bar: Any?
-  @objc ↓var foo: Any?
-  @objc
-  class Bar {
+    ↓@objc var bar: Any?
+    ↓@objc var foo: Any?
     @objc
-    var foo: Any?
-  }
+    class Bar {
+        @objc
+        var foo: Any?
+    }
 }
 ```
 
 ```swift
 @objc
 extension Foo {
-  @objc
-  ↓var bar: Int {
-    return 0
-  }
+    ↓@objc
+    var bar: Int {
+        return 0
+    }
 }
 ```
 
 ```swift
 @objc @IBDesignable
 extension Foo {
-  @objc
-  ↓var bar: Int {
-    return 0
-  }
+    ↓@objc
+    var bar: Int {
+        return 0
+    }
 }
 ```
 
@@ -15873,7 +15873,7 @@ extension Foo {
 class Foo {
     @objcMembers
     class Bar: NSObject {
-        @objc ↓var foo: Any
+        ↓@objc var foo: Any
     }
 }
 ```
@@ -15881,8 +15881,8 @@ class Foo {
 ```swift
 @objc
 extension Foo {
-    @objc
-    private ↓var bar: Int {
+    ↓@objc
+    private var bar: Int {
         return 0
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -1,9 +1,10 @@
+import Foundation
 import SourceKittenFramework
 
 private let kindsImplyingObjc: Set<SwiftDeclarationAttributeKind> =
     [.ibaction, .iboutlet, .ibinspectable, .gkinspectable, .ibdesignable, .nsManaged]
 
-public struct RedundantObjcAttributeRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -14,169 +15,45 @@ public struct RedundantObjcAttributeRule: ConfigurationProviderRule, AutomaticTe
         description: "Objective-C attribute (@objc) is redundant in declaration.",
         kind: .idiomatic,
         minSwiftVersion: .fourDotOne,
-        nonTriggeringExamples: [
-            "@objc private var foo: String? {}",
-            "@IBInspectable private var foo: String? {}",
-            "@objc private func foo(_ sender: Any) {}",
-            "@IBAction private func foo(_ sender: Any) {}",
-            "@GKInspectable private var foo: String! {}",
-            "private @GKInspectable var foo: String! {}",
-            "@NSManaged var foo: String!",
-            "@objc @NSCopying var foo: String!",
-            """
-            @objcMembers
-            class Foo {
-              var bar: Any?
-              @objc
-              class Bar {
-                @objc
-                var foo: Any?
-              }
-            }
-            """,
-            """
-            @objc
-            extension Foo {
-              var bar: Int {
-                return 0
-              }
-            }
-            """,
-            """
-            extension Foo {
-              @objc
-              var bar: Int { return 0 }
-            }
-            """,
-            """
-            @objc @IBDesignable
-            extension Foo {
-              var bar: Int { return 0 }
-            }
-            """,
-            """
-            @IBDesignable
-            extension Foo {
-              @objc
-              var bar: Int { return 0 }
-              var fooBar: Int { return 1 }
-            }
-            """,
-            """
-            @objcMembers
-            class Foo: NSObject {
-              @objc
-              private var bar: Int {
-                return 0
-              }
-            }
-            """,
-            """
-            @objcMembers
-            class Foo {
-                class Bar: NSObject {
-                    @objc var foo: Any
-                }
-            }
-            """,
-            """
-            @objcMembers
-            class Foo {
-                @objc class Bar {}
-            }
-            """
-        ],
-        triggeringExamples: [
-            "@objc @IBInspectable private ↓var foo: String? {}",
-            "@IBInspectable @objc private ↓var foo: String? {}",
-            "@objc @IBAction private ↓func foo(_ sender: Any) {}",
-            "@IBAction @objc private ↓func foo(_ sender: Any) {}",
-            "@objc @GKInspectable private ↓var foo: String! {}",
-            "@GKInspectable @objc private ↓var foo: String! {}",
-            "@objc @NSManaged private ↓var foo: String!",
-            "@NSManaged @objc private ↓var foo: String!",
-            "@objc @IBDesignable ↓class Foo {}",
-            """
-            @objcMembers
-            class Foo {
-              @objc ↓var bar: Any?
-            }
-            """,
-            """
-            @objcMembers
-            class Foo {
-              @objc ↓var bar: Any?
-              @objc ↓var foo: Any?
-              @objc
-              class Bar {
-                @objc
-                var foo: Any?
-              }
-            }
-            """,
-            """
-            @objc
-            extension Foo {
-              @objc
-              ↓var bar: Int {
-                return 0
-              }
-            }
-            """,
-            """
-            @objc @IBDesignable
-            extension Foo {
-              @objc
-              ↓var bar: Int {
-                return 0
-              }
-            }
-            """,
-            """
-            @objcMembers
-            class Foo {
-                @objcMembers
-                class Bar: NSObject {
-                    @objc ↓var foo: Any
-                }
-            }
-            """,
-            """
-            @objc
-            extension Foo {
-                @objc
-                private ↓var bar: Int {
-                    return 0
-                }
-            }
-            """
-        ])
+        nonTriggeringExamples: RedundantObjcAttributeRuleExamples.nonTriggeringExamples,
+        triggeringExamples: RedundantObjcAttributeRuleExamples.triggeringExamples,
+        corrections: RedundantObjcAttributeRuleExamples.corrections)
 
     public func validate(file: File) -> [StyleViolation] {
-        return validate(file: file, dictionary: file.structure.dictionary, parentStructure: nil)
+        return violationRanges(in: file).map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
+        }
     }
 
-    private func validate(file: File, dictionary: [String: SourceKitRepresentable],
-                          parentStructure: [String: SourceKitRepresentable]?) -> [StyleViolation] {
-        return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
-            var violations = validate(file: file, dictionary: subDict, parentStructure: dictionary)
+    public func violationRanges(in file: File) -> [NSRange] {
+        return violationRanges(file: file, dictionary: file.structure.dictionary, parentStructure: nil)
+    }
+    
+    private func violationRanges(file: File, dictionary: [String: SourceKitRepresentable],
+                                 parentStructure: [String: SourceKitRepresentable]?) -> [NSRange] {
+        return dictionary.substructure.flatMap { subDict -> [NSRange] in
+            var violations = violationRanges(file: file, dictionary: subDict, parentStructure: dictionary)
 
             if let kindString = subDict.kind,
                 let kind = SwiftDeclarationKind(rawValue: kindString) {
-                violations += validate(file: file, kind: kind, dictionary: subDict, parentStructure: dictionary)
+                violations += violationRanges(file: file, kind: kind, dictionary: subDict, parentStructure: dictionary)
             }
 
             return violations
         }
     }
 
-    private func validate(file: File,
-                          kind: SwiftDeclarationKind,
-                          dictionary: [String: SourceKitRepresentable],
-                          parentStructure: [String: SourceKitRepresentable]?) -> [StyleViolation] {
-        let enclosedSwiftAttributes = Set(dictionary.enclosedSwiftAttributes)
-        guard let offset = dictionary.offset,
-              enclosedSwiftAttributes.contains(.objc),
+    private func violationRanges(file: File,
+                                 kind: SwiftDeclarationKind,
+                                 dictionary: [String: SourceKitRepresentable],
+                                 parentStructure: [String: SourceKitRepresentable]?) -> [NSRange] {
+        let objcAttribute = dictionary.swiftAttributes
+                                      .first(where: { $0.attribute == SwiftDeclarationAttributeKind.objc.rawValue })
+        guard let objcOffset = objcAttribute?.offset,
+              let objcLength = objcAttribute?.length,
+              let range = file.contents.bridge().byteRangeToNSRange(start: objcOffset, length: objcLength),
               !dictionary.isObjcAndIBDesignableDeclaredExtension else {
             return []
         }
@@ -201,12 +78,10 @@ public struct RedundantObjcAttributeRule: ConfigurationProviderRule, AutomaticTe
             return !SwiftDeclarationKind.typeKinds.contains(kind)
         }
 
-        let isUsedWithObjcAttribute = !enclosedSwiftAttributes.isDisjoint(with: kindsImplyingObjc)
+        let isUsedWithObjcAttribute = !Set(dictionary.enclosedSwiftAttributes).isDisjoint(with: kindsImplyingObjc)
 
         if isUsedWithObjcAttribute || isInObjcVisibleScope() {
-            return [StyleViolation(ruleDescription: type(of: self).description,
-                                   severity: configuration.severity,
-                                   location: Location(file: file, byteOffset: offset))]
+            return [range]
         }
 
         return []
@@ -220,5 +95,21 @@ private extension Dictionary where Key == String, Value == SourceKitRepresentabl
         }
         return [.extensionClass, .extension].contains(declaration)
             && Set(enclosedSwiftAttributes).isSuperset(of: [.ibdesignable, .objc])
+    }
+}
+
+public extension RedundantObjcAttributeRule {
+     func substitution(for violationRange: NSRange, in file: File) -> (NSRange, String) {
+        var whitespaceAndNewlineOffset = 0
+        let nsCharSet = CharacterSet.whitespacesAndNewlines.bridge()
+        let nsContent = file.contents.bridge()
+        while nsCharSet
+            .characterIsMember(nsContent.character(at: violationRange.upperBound + whitespaceAndNewlineOffset)) {
+                whitespaceAndNewlineOffset += 1
+        }
+
+        let withTrailingWhitespaceAndNewlineRange = NSRange(location: violationRange.location,
+                                                             length: violationRange.length + whitespaceAndNewlineOffset)
+        return (withTrailingWhitespaceAndNewlineRange, "")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -1,0 +1,275 @@
+struct RedundantObjcAttributeRuleExamples {
+    static let nonTriggeringExamples = [
+        "@objc private var foo: String? {}",
+        "@IBInspectable private var foo: String? {}",
+        "@objc private func foo(_ sender: Any) {}",
+        "@IBAction private func foo(_ sender: Any) {}",
+        "@GKInspectable private var foo: String! {}",
+        "private @GKInspectable var foo: String! {}",
+        "@NSManaged var foo: String!",
+        "@objc @NSCopying var foo: String!",
+        """
+        @objcMembers
+        class Foo {
+            var bar: Any?
+            @objc
+            class Bar {
+                @objc
+                var foo: Any?
+            }
+        }
+        """,
+        """
+        @objc
+        extension Foo {
+            var bar: Int {
+                return 0
+            }
+        }
+        """,
+        """
+        extension Foo {
+            @objc
+            var bar: Int { return 0 }
+        }
+        """,
+        """
+        @objc @IBDesignable
+        extension Foo {
+            var bar: Int { return 0 }
+        }
+        """,
+        """
+        @IBDesignable
+        extension Foo {
+            @objc
+            var bar: Int { return 0 }
+            var fooBar: Int { return 1 }
+        }
+        """,
+        """
+        @objcMembers
+        class Foo: NSObject {
+            @objc
+            private var bar: Int {
+                return 0
+            }
+        }
+        """,
+        """
+        @objcMembers
+        class Foo {
+            class Bar: NSObject {
+                @objc var foo: Any
+            }
+        }
+        """,
+        """
+        @objcMembers
+        class Foo {
+            @objc class Bar {}
+        }
+        """
+    ]
+
+    static let triggeringExamples = [
+        "↓@objc @IBInspectable private var foo: String? {}",
+        "@IBInspectable ↓@objc private var foo: String? {}",
+        "↓@objc @IBAction private func foo(_ sender: Any) {}",
+        "@IBAction ↓@objc private func foo(_ sender: Any) {}",
+        "↓@objc @GKInspectable private var foo: String! {}",
+        "@GKInspectable ↓@objc private var foo: String! {}",
+        "↓@objc @NSManaged private var foo: String!",
+        "@NSManaged ↓@objc private var foo: String!",
+        "↓@objc @IBDesignable class Foo {}",
+        """
+        @objcMembers
+        class Foo {
+            ↓@objc var bar: Any?
+        }
+        """,
+        """
+        @objcMembers
+        class Foo {
+            ↓@objc var bar: Any?
+            ↓@objc var foo: Any?
+            @objc
+            class Bar {
+                @objc
+                var foo: Any?
+            }
+        }
+        """,
+        """
+        @objc
+        extension Foo {
+            ↓@objc
+            var bar: Int {
+                return 0
+            }
+        }
+        """,
+        """
+        @objc @IBDesignable
+        extension Foo {
+            ↓@objc
+            var bar: Int {
+                return 0
+            }
+        }
+        """,
+        """
+        @objcMembers
+        class Foo {
+            @objcMembers
+            class Bar: NSObject {
+                ↓@objc var foo: Any
+            }
+        }
+        """,
+        """
+        @objc
+        extension Foo {
+            ↓@objc
+            private var bar: Int {
+                return 0
+            }
+        }
+        """
+    ]
+
+    static let corrections = [
+        "↓@objc @IBInspectable private var foo: String? {}": "@IBInspectable private var foo: String? {}",
+        "@IBInspectable ↓@objc private var foo: String? {}": "@IBInspectable private var foo: String? {}",
+        "@IBAction ↓@objc private func foo(_ sender: Any) {}": "@IBAction private func foo(_ sender: Any) {}",
+        "↓@objc @GKInspectable private var foo: String! {}": "@GKInspectable private var foo: String! {}",
+        "@GKInspectable ↓@objc private var foo: String! {}": "@GKInspectable private var foo: String! {}",
+        "↓@objc @NSManaged private var foo: String!": "@NSManaged private var foo: String!",
+        "@NSManaged ↓@objc private var foo: String!": "@NSManaged private var foo: String!",
+        "↓@objc @IBDesignable class Foo {}": "@IBDesignable class Foo {}",
+        """
+        @objcMembers
+        class Foo {
+            ↓@objc var bar: Any?
+        }
+        """:
+        """
+        @objcMembers
+        class Foo {
+            var bar: Any?
+        }
+        """,
+        """
+        @objcMembers
+        class Foo {
+            ↓@objc var bar: Any?
+            ↓@objc var foo: Any?
+            @objc
+            class Bar {
+                @objc
+                var foo2: Any?
+            }
+        }
+        """:
+        """
+        @objcMembers
+        class Foo {
+            var bar: Any?
+            var foo: Any?
+            @objc
+            class Bar {
+                @objc
+                var foo2: Any?
+            }
+        }
+        """,
+        """
+        @objc
+        extension Foo {
+            ↓@objc
+            var bar: Int {
+                return 0
+            }
+        }
+        """:
+        """
+        @objc
+        extension Foo {
+            var bar: Int {
+                return 0
+            }
+        }
+        """,
+        """
+        @objc @IBDesignable
+        extension Foo {
+            ↓@objc
+            var bar: Int {
+                return 0
+            }
+        }
+        """:
+        """
+        @objc @IBDesignable
+        extension Foo {
+            var bar: Int {
+                return 0
+            }
+        }
+        """,
+        """
+        @objcMembers
+        class Foo {
+            @objcMembers
+            class Bar: NSObject {
+                ↓@objc var foo: Any
+            }
+        }
+        """:
+        """
+        @objcMembers
+        class Foo {
+            @objcMembers
+            class Bar: NSObject {
+                var foo: Any
+            }
+        }
+        """,
+        """
+        @objc
+        extension Foo {
+            ↓@objc
+            private var bar: Int {
+                return 0
+            }
+        }
+        """:
+        """
+        @objc
+        extension Foo {
+            private var bar: Int {
+                return 0
+            }
+        }
+        """,
+        """
+        @objc
+        extension Foo {
+            ↓@objc
+
+
+            private var bar: Int {
+                return 0
+            }
+        }
+        """:
+        """
+        @objc
+        extension Foo {
+            private var bar: Int {
+                return 0
+            }
+        }
+        """
+    ]
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		125CE52F20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125CE52E20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift */; };
 		12E3D4DC2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E3D4DB2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift */; };
 		181D9E172038343D001F6887 /* UntypedErrorInCatchRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 181D9E162038343D001F6887 /* UntypedErrorInCatchRule.swift */; };
+		183B6B4921FF672B00425134 /* RedundantObjcAttributeRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183B6B4721FF66B700425134 /* RedundantObjcAttributeRuleExamples.swift */; };
 		187290721FC37CA50016BEA2 /* YodaConditionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */; };
 		188B3FF2207D61040073C2D6 /* ModifierOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188B3FF1207D61040073C2D6 /* ModifierOrderRule.swift */; };
 		188B3FF4207D61230073C2D6 /* ModifierOrderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */; };
@@ -469,6 +470,7 @@
 		125CE52E20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceConfigurationTests.swift; sourceTree = "<group>"; };
 		12E3D4DB2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRuleTests.swift; sourceTree = "<group>"; };
 		181D9E162038343D001F6887 /* UntypedErrorInCatchRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntypedErrorInCatchRule.swift; sourceTree = "<group>"; };
+		183B6B4721FF66B700425134 /* RedundantObjcAttributeRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantObjcAttributeRuleExamples.swift; sourceTree = "<group>"; };
 		1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YodaConditionRule.swift; sourceTree = "<group>"; };
 		188B3FF1207D61040073C2D6 /* ModifierOrderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrderRule.swift; sourceTree = "<group>"; };
 		188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrderConfiguration.swift; sourceTree = "<group>"; };
@@ -1198,6 +1200,7 @@
 				1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */,
 				24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */,
 				18B90B6A21ADD99800B60749 /* RedundantObjcAttributeRule.swift */,
+				183B6B4721FF66B700425134 /* RedundantObjcAttributeRuleExamples.swift */,
 				D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */,
 				D49896F02026B36C00814A83 /* RedundantSetAccessControlRule.swift */,
 				D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */,
@@ -1885,6 +1888,7 @@
 				1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */,
 				DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */,
 				188B3FF4207D61230073C2D6 /* ModifierOrderConfiguration.swift in Sources */,
+				183B6B4921FF672B00425134 /* RedundantObjcAttributeRuleExamples.swift in Sources */,
 				D4B022961E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift in Sources */,
 				2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */,
 				D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */,


### PR DESCRIPTION
Hey all! Thanks for the great efforts on keeping the project nice and sound! With this PR I am aiming to add autocorrection to an already existing rule.

Main changes:
* Moved the violation point from the variables offset to the `@objc` attribute startIndex. I think it kinda makes sense, since the violations warns against the redundant attribute, there is nothing to fix on the variable itself.
* Searching for ranges of violations initially, and converting later only to `StyleViolation`-s
* Making the rule conforming to `CorrectableRule`. Kinda straightforward, the only extra is that I am counting the attribute's trailing whitespace and newline characters and removing with the attribute. I am doing so since I would like to keep the format of the code.