### PR TITLE
Add SubstitutionCorrectableRule and SubstitutionCorrectableASTRule

### DIFF
--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SourceKittenFramework
 
 public protocol Rule {

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -61,7 +61,7 @@ public extension SubstitutionCorrectableRule {
         let description = type(of: self).description
         var corrections = [Correction]()
         var contents = file.contents
-        for range in violatingRanges {
+        for range in violatingRanges.sorted(by: { $0.location > $1.location }) {
             let contentsNSString = contents.bridge()
 
             let (rangeToRemove, substitution) = self.substitution(for: range, in: file)
@@ -82,9 +82,7 @@ public protocol SubstitutionCorrectableASTRule: SubstitutionCorrectableRule, AST
 
 extension SubstitutionCorrectableASTRule where KindType.RawValue == String {
     public func violationRanges(in file: File) -> [NSRange] {
-        return violationRanges(in: file, dictionary: file.structure.dictionary).sorted {
-            $0.location > $1.location
-        }
+        return violationRanges(in: file, dictionary: file.structure.dictionary)
     }
 
     private func violationRanges(in file: File,
@@ -92,7 +90,7 @@ extension SubstitutionCorrectableASTRule where KindType.RawValue == String {
         let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
 
-            if let kind = subDict.kind.flatMap(KindType.init(rawValue:)) {
+            if let kind = subDict.kind.flatMap(KindType.init) {
                 ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct PrivateOverFilePrivateRule: Rule, ConfigurationProviderRule, CorrectableRule {
+public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
     public var configuration = PrivateOverFilePrivateRuleConfiguration()
 
     public init() {}
@@ -63,7 +63,7 @@ public struct PrivateOverFilePrivateRule: Rule, ConfigurationProviderRule, Corre
         }
     }
 
-    private func violationRanges(in file: File) -> [NSRange] {
+    public func violationRanges(in file: File) -> [NSRange] {
         let syntaxTokens = file.syntaxMap.tokens
         let contents = file.contents.bridge()
 
@@ -90,23 +90,7 @@ public struct PrivateOverFilePrivateRule: Rule, ConfigurationProviderRule, Corre
         }
     }
 
-    public func correct(file: File) -> [Correction] {
-        let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
-        var correctedContents = file.contents
-        var adjustedLocations = [Int]()
-
-        for violatingRange in violatingRanges.reversed() {
-            if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
-                correctedContents = correctedContents.replacingCharacters(in: indexRange, with: "private")
-                adjustedLocations.insert(violatingRange.location, at: 0)
-            }
-        }
-
-        file.write(correctedContents)
-
-        return adjustedLocations.map {
-            Correction(ruleDescription: type(of: self).description,
-                       location: Location(file: file, characterOffset: $0))
-        }
+    public func substitution(for violationRange: NSRange, in file: File) -> (NSRange, String) {
+        return (violationRange, "private")
     }
 }


### PR DESCRIPTION
This adds two new protocols that rules can adopt `SubstitutionCorrectableRule` and `SubstitutionCorrectableASTRule`.

This should make implementing corrections easier in most cases while keeping the flexibility of implementing `CorrectableRule` directly if needed.

I've updated 3 rules that I think are representative of the typical use cases to implement the new protocols.