### PR TITLE
Migrate CorrectableRules to use new protocols

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, OptInRule, CorrectableRule,
+public struct JoinedDefaultParameterRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, OptInRule,
                                           AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -51,50 +51,15 @@ public struct JoinedDefaultParameterRule: ASTRule, ConfigurationProviderRule, Op
         }
     }
 
-    // MARK: - CorrectableRule
+    // MARK: - SubstitutionCorrectableASTRule
 
-    public func correct(file: File) -> [Correction] {
-        let matches = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
-        var correctedContents = file.contents
-        var adjustedLocations: [Int] = []
-
-        for violatingRange in matches.reversed() {
-            if let range = file.contents.nsrangeToIndexRange(violatingRange) {
-                correctedContents = correctedContents.replacingCharacters(in: range, with: "")
-                adjustedLocations.insert(violatingRange.location, at: 0)
-            }
-        }
-
-        file.write(correctedContents)
-
-        return adjustedLocations.map {
-            Correction(ruleDescription: type(of: self).description, location: Location(file: file, characterOffset: $0))
-        }
+    public func substitution(for violationRange: NSRange, in file: File) -> (NSRange, String) {
+        return (violationRange, "")
     }
 
-    // MARK: - Private
-
-    private func violationRanges(in file: File) -> [NSRange] {
-        return violationRanges(in: file, dictionary: file.structure.dictionary).sorted { $0.location < $1.location }
-    }
-
-    private func violationRanges(in file: File,
-                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
-            var ranges = violationRanges(in: file, dictionary: subDict)
-            if let kind = subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) {
-                ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
-            }
-
-            return ranges
-        }
-
-        return ranges.unique
-    }
-
-    private func violationRanges(in file: File,
-                                 kind: SwiftExpressionKind,
-                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+    public func violationRanges(in file: File,
+                                kind: SwiftExpressionKind,
+                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         guard
             // is it calling a method '.joined' and passing a single argument?
             kind == .call,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, CorrectableRule, AutomaticTestableRule {
+public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableASTRule,
+                                       AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -49,6 +50,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
     )
 
     private let pattern = "\\s*->\\s*(?:Void\\b|\\(\\s*\\))(?![?!])"
+    private let excludingKinds = SyntaxKind.allKinds.subtracting([.typeidentifier])
 
     public func validate(file: File, kind: SwiftDeclarationKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
@@ -59,8 +61,8 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
         }
     }
 
-    private func violationRanges(in file: File, kind: SwiftDeclarationKind,
-                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+    public func violationRanges(in file: File, kind: SwiftDeclarationKind,
+                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         guard SwiftDeclarationKind.functionKinds.contains(kind),
             let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength,
@@ -78,44 +80,7 @@ public struct RedundantVoidReturnRule: ASTRule, ConfigurationProviderRule, Corre
         return [match]
     }
 
-    private let excludingKinds = SyntaxKind.allKinds.subtracting([.typeidentifier])
-
-    private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
-            var ranges = violationRanges(in: file, dictionary: subDict)
-            if let kind = subDict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) {
-                ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
-            }
-
-            return ranges
-        }
-
-        return ranges.unique
-    }
-
-    private func violationRanges(in file: File) -> [NSRange] {
-        return violationRanges(in: file, dictionary: file.structure.dictionary).sorted { lhs, rhs in
-            lhs.location < rhs.location
-        }
-    }
-
-    public func correct(file: File) -> [Correction] {
-        let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
-        var correctedContents = file.contents
-        var adjustedLocations = [Int]()
-
-        for violatingRange in violatingRanges.reversed() {
-            if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
-                correctedContents = correctedContents.replacingCharacters(in: indexRange, with: "")
-                adjustedLocations.insert(violatingRange.location, at: 0)
-            }
-        }
-
-        file.write(correctedContents)
-
-        return adjustedLocations.map {
-            Correction(ruleDescription: type(of: self).description,
-                       location: Location(file: file, characterOffset: $0))
-        }
+    public func substitution(for violationRange: NSRange, in file: File) -> (NSRange, String) {
+        return (violationRange, "")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedControlFlowLabelRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule, CorrectableRule {
+public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule,
+                                          AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -97,41 +98,29 @@ public struct UnusedControlFlowLabelRule: ASTRule, ConfigurationProviderRule, Au
         }
     }
 
-    public func correct(file: File) -> [Correction] {
-        let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
-        guard !violatingRanges.isEmpty else { return [] }
-
-        let description = type(of: self).description
-        var corrections = [Correction]()
-        var contents = file.contents
-        for range in violatingRanges {
-            var rangeToRemove = range
-            let contentsNSString = contents.bridge()
-            if let byteRange = contentsNSString.NSRangeToByteRange(start: range.location, length: range.length),
-                let nextToken = file.syntaxMap.tokens.first(where: { $0.offset > byteRange.location }),
-                let nextTokenLocation = contentsNSString.byteRangeToNSRange(start: nextToken.offset, length: 0) {
-                rangeToRemove.length = nextTokenLocation.location - range.location
-            }
-
-            contents = contentsNSString.replacingCharacters(in: rangeToRemove, with: "")
-            let location = Location(file: file, characterOffset: range.location)
-            corrections.append(Correction(ruleDescription: description, location: location))
+    public func substitution(for violationRange: NSRange, in file: File) -> (NSRange, String) {
+        var rangeToRemove = violationRange
+        let contentsNSString = file.contents.bridge()
+        if let byteRange = contentsNSString.NSRangeToByteRange(start: violationRange.location,
+                                                               length: violationRange.length),
+            let nextToken = file.syntaxMap.tokens.first(where: { $0.offset > byteRange.location }),
+            let nextTokenLocation = contentsNSString.byteRangeToNSRange(start: nextToken.offset, length: 0) {
+            rangeToRemove.length = nextTokenLocation.location - violationRange.location
         }
 
-        file.write(contents)
-        return corrections
+        return (rangeToRemove, "")
     }
 
-    private func violationRanges(in file: File, kind: StatementKind,
-                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+    public func violationRanges(in file: File, kind: StatementKind,
+                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         guard type(of: self).kinds.contains(kind),
             let offset = dictionary.offset, let length = dictionary.length,
             case let byteRange = NSRange(location: offset, length: length),
             case let tokens = file.syntaxMap.tokens(inByteRange: byteRange),
             let firstToken = tokens.first,
             SyntaxKind(rawValue: firstToken.type) == .identifier,
+            let tokenContent = file.contents(for: firstToken),
             case let contents = file.contents.bridge(),
-            let tokenContent = contents.substring(with: firstToken),
             let range = contents.byteRangeToNSRange(start: offset, length: length) else {
                 return []
         }
@@ -144,30 +133,5 @@ public struct UnusedControlFlowLabelRule: ASTRule, ConfigurationProviderRule, Au
         }
 
         return [violationRange]
-    }
-
-    private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
-        let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
-            var ranges = violationRanges(in: file, dictionary: subDict)
-            if let kind = subDict.kind.flatMap(StatementKind.init(rawValue:)) {
-                ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
-            }
-
-            return ranges
-        }
-
-        return ranges.unique
-    }
-
-    private func violationRanges(in file: File) -> [NSRange] {
-        return violationRanges(in: file, dictionary: file.structure.dictionary).sorted { lhs, rhs in
-            lhs.location > rhs.location
-        }
-    }
-}
-
-private extension NSString {
-    func substring(with token: SyntaxToken) -> String? {
-        return substringWithByteRange(start: token.offset, length: token.length)
     }
 }


### PR DESCRIPTION
Uses #2598 to remove the boilerplate when implementing `CorrectableRule`

I *think* I've migrated all rules that were straight-forward to do so.