### PR TITLE
Use firstIndex(where:) instead of index(where:)

### DIFF
--- a/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
@@ -11,7 +11,7 @@ extension SyntaxMap {
                 .intersects(byteRange)
         }
 
-        guard let startIndex = tokens.index(where: intersect) else {
+        guard let startIndex = tokens.firstIndex(where: intersect) else {
             return []
         }
         let tokensBeginningIntersect = tokens.lazy.suffix(from: startIndex)

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -103,7 +103,7 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
 
             return caseSubstructures.compactMap { $0.name }.map { name in
                 if SwiftVersion.current > .fourDotOne,
-                    let parenIndex = name.index(of: "("),
+                    let parenIndex = name.firstIndex(of: "("),
                     parenIndex > name.startIndex {
                     let index = name.index(before: parenIndex)
                     return String(name[...index])

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -90,7 +90,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
 
         if kind == .enumelement,
             SwiftVersion.current > .fourDotOne,
-            let parenIndex = name.index(of: "("),
+            let parenIndex = name.firstIndex(of: "("),
             parenIndex > name.startIndex {
             let index = name.index(before: parenIndex)
             name = String(name[...index])

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -79,7 +79,7 @@ private func parseCLIArguments(_ string: String) -> [String] {
  more flags to remove in `.1`.
  */
 private func partiallyFilter(arguments args: [String]) -> ([String], Bool) {
-    guard let indexOfFlagToRemove = args.index(of: "-output-file-map") else {
+    guard let indexOfFlagToRemove = args.firstIndex(of: "-output-file-map") else {
         return (args, false)
     }
     var args = args


### PR DESCRIPTION
to silence a Swift 5 warning. This is compatible with Swift 4.2.