### PR TITLE
Remove unnecessary backticks

### DIFF
--- a/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftDeclarationKind+SwiftLint.swift
@@ -28,10 +28,10 @@ extension SwiftDeclarationKind {
     ]
 
     internal static let typeKinds: Set<SwiftDeclarationKind> = [
-        .`class`,
-        .`struct`,
-        .`typealias`,
-        .`associatedtype`,
-        .`enum`
+        .class,
+        .struct,
+        .typealias,
+        .associatedtype,
+        .enum
     ]
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -130,17 +130,17 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
 private extension SwiftDeclarationKind {
     var childsAreExemptFromACL: Bool {
         switch self {
-        case .`associatedtype`, .enumcase, .enumelement, .functionAccessorAddress,
+        case .associatedtype, .enumcase, .enumelement, .functionAccessorAddress,
              .functionAccessorDidset, .functionAccessorGetter, .functionAccessorMutableaddress,
              .functionAccessorSetter, .functionAccessorWillset, .genericTypeParam, .module,
              .precedenceGroup, .varLocal, .varParameter, .varClass,
-             .varGlobal, .varInstance, .varStatic, .`typealias`, .functionConstructor, .functionDestructor,
+             .varGlobal, .varInstance, .varStatic, .typealias, .functionConstructor, .functionDestructor,
              .functionFree, .functionMethodClass, .functionMethodInstance, .functionMethodStatic,
              .functionOperator, .functionOperatorInfix, .functionOperatorPostfix, .functionOperatorPrefix,
-             .functionSubscript, .`protocol`:
+             .functionSubscript, .protocol:
             return true
-        case .`class`, .`enum`, .`extension`, .`extensionClass`, .`extensionEnum`,
-             .extensionProtocol, .extensionStruct, .`struct`:
+        case .class, .enum, .extension, .extensionClass, .extensionEnum,
+             .extensionProtocol, .extensionStruct, .struct:
             return false
         }
     }

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -41,14 +41,14 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
     private func validateACL(isHigherThan parentAccessibility: AccessControlLevel,
                              in substructure: [String: SourceKitRepresentable]) -> [Int] {
         return substructure.substructure.flatMap { element -> [Int] in
-            guard let elementKind = element.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
+            guard let elementKind = element.kind.flatMap(SwiftDeclarationKind.init),
                 elementKind.isRelevantDeclaration else {
                 return []
             }
 
             var violationOffset: Int?
             let accessibility = element.accessibility.flatMap(AccessControlLevel.init(identifier:))
-                ?? .`internal`
+                ?? .internal
             if accessibility.priority > parentAccessibility.priority {
                 violationOffset = element.offset
             }
@@ -61,15 +61,15 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
 private extension SwiftDeclarationKind {
     var isRelevantDeclaration: Bool {
         switch self {
-        case .`associatedtype`, .enumcase, .enumelement, .`extension`, .`extensionClass`, .`extensionEnum`,
+        case .associatedtype, .enumcase, .enumelement, .extension, .extensionClass, .extensionEnum,
              .extensionProtocol, .extensionStruct, .functionAccessorAddress, .functionAccessorDidset,
              .functionAccessorGetter, .functionAccessorMutableaddress, .functionAccessorSetter,
              .functionAccessorWillset, .functionDestructor, .genericTypeParam, .module, .precedenceGroup, .varLocal,
              .varParameter:
             return false
-        case .`class`, .`enum`, .functionConstructor, .functionFree, .functionMethodClass, .functionMethodInstance,
+        case .class, .enum, .functionConstructor, .functionFree, .functionMethodClass, .functionMethodInstance,
              .functionMethodStatic, .functionOperator, .functionOperatorInfix, .functionOperatorPostfix,
-             .functionOperatorPrefix, .functionSubscript, .`protocol`, .`struct`, .`typealias`, .varClass, .varGlobal,
+             .functionOperatorPrefix, .functionSubscript, .protocol, .struct, .typealias, .varClass, .varGlobal,
              .varInstance, .varStatic:
             return true
         }


### PR DESCRIPTION
These were once required but now that we only support Swift 4.2 or later, they're unnecessary.