### PR TITLE
Add tests that fail with Swift 5

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -11007,24 +11007,32 @@ private struct Foo { fileprivate func bar() {} }
 private func foo(id: String) {}
 ```
 
+```swift
+private class Foo { func bar() {} }
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
 
 ```swift
-struct Foo { public func bar() {} }
+struct Foo { public ↓func bar() {} }
 ```
 
 ```swift
-enum Foo { public func bar() {} }
+enum Foo { public ↓func bar() {} }
 ```
 
 ```swift
-public class Foo { open func bar() }
+public class Foo { open ↓func bar() }
 ```
 
 ```swift
-class Foo { public private(set) var bar: String? }
+class Foo { public private(set) ↓var bar: String? }
+```
+
+```swift
+private class Foo { internal ↓func bar() {} }
 ```
 
 </details>
@@ -22876,6 +22884,11 @@ foo(param1: 1, param2: [
 ], param3: 0)
 ```
 
+```swift
+myFunc(foo: 0,
+       bar: baz == 0)
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -22911,6 +22924,11 @@ foo(param1: 1,
 ```swift
 foo(param1: 1, param2: { _ in },
        ↓param3: false, param4: true)
+```
+
+```swift
+myFunc(foo: 0,
+        ↓bar: baz == 0)
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -20,13 +20,15 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
             "private struct Foo { private func bar(id: String) }",
             "extension Foo { public func bar() {} }",
             "private struct Foo { fileprivate func bar() {} }",
-            "private func foo(id: String) {}"
+            "private func foo(id: String) {}",
+            "private class Foo { func bar() {} }"
         ],
         triggeringExamples: [
-            "struct Foo { public func bar() {} }",
-            "enum Foo { public func bar() {} }",
-            "public class Foo { open func bar() }",
-            "class Foo { public private(set) var bar: String? }"
+            "struct Foo { public ↓func bar() {} }",
+            "enum Foo { public ↓func bar() {} }",
+            "public class Foo { open ↓func bar() }",
+            "class Foo { public private(set) ↓var bar: String? }",
+            "private class Foo { internal ↓func bar() {} }"
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -44,7 +44,11 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             "foo(param1: 1, param2: [\n" +
             "   0,\n" +
             "   1\n" +
-            "], param3: 0)"
+            "], param3: 0)",
+            """
+            myFunc(foo: 0,
+                   bar: baz == 0)
+            """
         ],
         triggeringExamples: [
             "foo(param1: 1, param2: bar\n" +
@@ -61,7 +65,11 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
             "}, param3: 2,\n" +
             " ↓param4: 0)",
             "foo(param1: 1, param2: { _ in },\n" +
-            "       ↓param3: false, param4: true)"
+            "       ↓param3: false, param4: true)",
+            """
+            myFunc(foo: 0,
+                    ↓bar: baz == 0)
+            """
         ]
     )
 


### PR DESCRIPTION
These are tests that pass with Swift 4.2.x but fail with Swift 5.0 from Xcode 10.2 beta 1.