### PR TITLE
Remove unnecessary environment variable operations from `execute(_:in:input:)`

### DIFF
--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -171,12 +171,6 @@ private func execute(_ args: [String],
     if let directory = directory {
         process.currentDirectoryPath = directory.path
     }
-    var environment = ProcessInfo.processInfo.environment
-    environment["DISCORD_TOKEN"] = nil
-    environment["DYNO"] = nil
-    environment["PORT"] = nil
-    environment["TIMEOUT"] = nil
-    process.environment = environment
     let stdoutPipe = Pipe(), stderrPipe = Pipe()
     process.standardOutput = stdoutPipe
     process.standardError = stderrPipe


### PR DESCRIPTION
Those environment variables are not required on SwiftLint.
Sorry, I forgot to remove them on copying the `execute(_:in:input:)` from my other project. :bowing_man: