### PR TITLE
Fix `lower_acl_than_parent` when linting with Swift 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 * Fix `explicit_type_interface` when used in statements.  
   [Daniel Metzing](https://github.com/dirtydanee)
   [#2154](https://github.com/realm/SwiftLint/issues/2154)
+
+* Fix `lower_acl_than_parent` when linting with Swift 5.  
+  [JP Simard](https://github.com/jpsim)
+  [#2607](https://github.com/realm/SwiftLint/issues/2607)
   
 ## 0.30.1: Localized Stain Remover
 

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -49,9 +49,10 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
             }
 
             var violationOffset: Int?
-            let accessibility = element.accessibility.flatMap(AccessControlLevel.init(identifier:))
-                ?? .internal
-            if accessibility.priority > parentAccessibility.priority {
+            let accessibility = element.accessibility.flatMap(AccessControlLevel.init(identifier:)) ?? .internal
+            // Swift 5 infers members of private types with no explicit ACL attribute to be `internal`.
+            let isInferredACL = accessibility == .internal && !element.enclosedSwiftAttributes.contains(.internal)
+            if !isInferredACL, accessibility.priority > parentAccessibility.priority {
                 violationOffset = element.offset
             }
 


### PR DESCRIPTION
Fixes #2607