### PR TITLE
Remove unmeaning comment in colon rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1927,7 +1927,6 @@ func abc(def: Void, ghi: Void) {}
 ```
 
 ```swift
-// 周斌佳年周斌佳
 let abc: String = "abc:"
 ```
 

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -29,7 +29,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
             "let abc: Enum=Enum.Value\n",
             "func abc(def: Void) {}\n",
             "func abc(def: Void, ghi: Void) {}\n",
-            "// 周斌佳年周斌佳\nlet abc: String = \"abc:\"",
+            "let abc: String = \"abc:\"",
             "let abc = [Void: Void]()\n",
             "let abc = [1: [3: 2], 3: 4]\n",
             "let abc = [\"string\": \"string\"]\n",


### PR DESCRIPTION
Thanks for this great repo, I use `SwiftLint` in my company and I want to generate document via `swiftlint generate-docs`. Howerver, I found `// 周斌佳年周斌佳` in the markdown file, that is unmeaning even in chinese.

So, is it right for remove that comment?