### PR TITLE
Add SPM instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ Note that this will add the SwiftLint binaries, its dependencies' binaries and t
 library distribution to the `Pods/` directory, so checking in this directory to SCM such as
 git is discouraged.
 
+### Using Swift Package Manager:
+
+Add the following line to your `Package.swift`:
+
+```swift
+dependencies: [
+    // ...
+    .package(url: "https://github.com/realm/SwiftLint.git"),
+],
+```
+
 ### Using [Mint](https://github.com/yonaskolb/mint):
 ```
 $ mint install realm/SwiftLint
@@ -90,6 +101,12 @@ Alternatively, if you've installed SwiftLint via CocoaPods the script should loo
 
 ```bash
 "${PODS_ROOT}/SwiftLint/swiftlint"
+```
+
+If you've installed via Swift Package Manager:
+
+```bash
+"${DWARF_DSYM_FOLDER_PATH}/swiftlint"
 ```
 
 #### Format on Save Xcode Plugin


### PR DESCRIPTION
Introduced the instructions needed to use SwiftLint with SPM. Note that this doesn't cover setting up the build phase in generated Xcode projects, so users will need to set it up manually. This is a problem that will be common in projects that use SPM, because it's common for projects that use SPM to not ship with an Xcode project due to how easy xcprojes are to generate.

Hopefully this problem will be resolved in a future proposal.