### PR TITLE
Add more configuration options to OpeningBrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 #### Enhancements
 
+* Add more configuration options to `opening_brace`. It's now possible to
+  configure the excluded keywords for multiline statements, previously
+  hardcoded to `if` `guard` and `while`.
+  [Vojta Stavik](https://github.com/VojtaStavik)
+  [#2635](https://github.com/realm/SwiftLint/issues/2635)
+
 * Add `deployment_target` rule to validate that `@availability` attributes and
   `#available` conditions are not using a version that is satisfied by the
   deployment target. Since SwiftLint can't read an Xcode project, you need to

--- a/Rules.md
+++ b/Rules.md
@@ -13735,6 +13735,13 @@ func abc()
 ```
 
 ```swift
+func abc(
+	a: Int,
+	b: Int)
+↓{ }
+```
+
+```swift
 [].map()↓{ $0 }
 ```
 
@@ -13759,6 +13766,13 @@ if
 	let a = b,
 	let c = d
 	where a == c↓{ }
+```
+
+```swift
+if let a = b,
+   let c = d
+   where a == c
+↓{ }
 ```
 
 ```swift

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OpeningBraceRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OpeningBraceRuleConfiguration.swift
@@ -1,0 +1,32 @@
+public struct OpeningBraceRuleConfiguration: RuleConfiguration, Equatable {
+    private(set) var severityConfiguration: SeverityConfiguration
+
+    /// If this regex matches the first line of a statement, the potential rule
+    /// violations are ignored for the given statement.
+    private(set) var firstLineExcludingRegex: String
+
+    init(severity: ViolationSeverity, firstLineExcludingRegex: String) {
+        self.severityConfiguration = SeverityConfiguration(severity)
+        self.firstLineExcludingRegex = firstLineExcludingRegex
+    }
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription +
+        ", first_line_excluding_regex: \(firstLineExcludingRegex)"
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        let configurationDict = configuration as? [String: Any]
+
+        let severityString = configuration as? String
+            ?? configurationDict?["severity"] as? String
+
+        if let severityString = severityString {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        if let excludingRegex = configurationDict?["first_line_excluding_regex"] as? String {
+            firstLineExcludingRegex = excludingRegex
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -14,7 +14,7 @@ private extension File {
     }
 }
 
-public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = OpeningBraceRuleConfiguration(severity: .warning,
                                                              firstLineExcludingRegex: "if|guard|while")
 
@@ -42,12 +42,14 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule, Auto
         triggeringExamples: [
             "func abc()↓{\n}",
             "func abc()\n\t↓{ }",
+            "func abc(\n\ta: Int,\n\tb: Int)\n↓{ }",
             "[].map()↓{ $0 }",
             "[].map( ↓{ } )",
             "if let a = b↓{ }",
             "while a == b↓{ }",
             "guard let a = b else↓{ }",
             "if\n\tlet a = b,\n\tlet c = d\n\twhere a == c↓{ }",
+            "if let a = b,\n   let c = d\n   where a == c\n↓{ }",
             "while\n\tlet a = b,\n\tlet c = d\n\twhere a == c↓{ }",
             "guard\n\tlet a = b,\n\tlet c = d\n\twhere a == c else↓{ }",
             "struct Rule↓{}\n",

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1894D746207D585400BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1894D740207D57AD00BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift */; };
 		18B90B6B21ADD99800B60749 /* RedundantObjcAttributeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B90B6A21ADD99800B60749 /* RedundantObjcAttributeRule.swift */; };
 		1B37EAAB221308E60009ED7C /* OpeningBraceRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B37EAAA221308E60009ED7C /* OpeningBraceRuleConfiguration.swift */; };
+		1B37EAAD2213197D0009ED7C /* OpeningBraceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B37EAAC2213197D0009ED7C /* OpeningBraceRuleTests.swift */; };
 		1E18574B1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */; };
 		1E3C2D711EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */; };
 		1E82D5591D7775C7009553D7 /* ClosureSpacingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */; };
@@ -479,6 +480,7 @@
 		1894D740207D57AD00BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftDeclarationAttributeKind+Swiftlint.swift"; sourceTree = "<group>"; };
 		18B90B6A21ADD99800B60749 /* RedundantObjcAttributeRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantObjcAttributeRule.swift; sourceTree = "<group>"; };
 		1B37EAAA221308E60009ED7C /* OpeningBraceRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningBraceRuleConfiguration.swift; sourceTree = "<group>"; };
+		1B37EAAC2213197D0009ED7C /* OpeningBraceRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningBraceRuleTests.swift; sourceTree = "<group>"; };
 		1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoExtensionAccessModifierRule.swift; sourceTree = "<group>"; };
 		1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRule.swift; sourceTree = "<group>"; };
 		1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureSpacingRule.swift; sourceTree = "<group>"; };
@@ -1408,6 +1410,7 @@
 				B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */,
 				D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */,
 				825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */,
+				1B37EAAC2213197D0009ED7C /* OpeningBraceRuleTests.swift */,
 				C25EBBDD210787B200E27603 /* PrefixedTopLevelConstantRuleTests.swift */,
 				D4F5851820E99B5A0085C6D8 /* PrivateOutletRuleTests.swift */,
 				D4246D6E1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift */,
@@ -2173,6 +2176,7 @@
 				D4246D6F1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift in Sources */,
 				B25DCD101F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift in Sources */,
 				3BB47D871C51DE6E00AE6A10 /* CustomRulesTests.swift in Sources */,
+				1B37EAAD2213197D0009ED7C /* OpeningBraceRuleTests.swift in Sources */,
 				E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */,
 				D414D6AC21D0B77F00960935 /* DiscouragedObjectLiteralRuleTests.swift in Sources */,
 				3B20CD0C1EB699C20069EF2E /* TypeNameRuleTests.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		188B3FF4207D61230073C2D6 /* ModifierOrderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */; };
 		1894D746207D585400BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1894D740207D57AD00BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift */; };
 		18B90B6B21ADD99800B60749 /* RedundantObjcAttributeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B90B6A21ADD99800B60749 /* RedundantObjcAttributeRule.swift */; };
+		1B37EAAB221308E60009ED7C /* OpeningBraceRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B37EAAA221308E60009ED7C /* OpeningBraceRuleConfiguration.swift */; };
 		1E18574B1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */; };
 		1E3C2D711EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */; };
 		1E82D5591D7775C7009553D7 /* ClosureSpacingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */; };
@@ -477,6 +478,7 @@
 		188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrderConfiguration.swift; sourceTree = "<group>"; };
 		1894D740207D57AD00BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftDeclarationAttributeKind+Swiftlint.swift"; sourceTree = "<group>"; };
 		18B90B6A21ADD99800B60749 /* RedundantObjcAttributeRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantObjcAttributeRule.swift; sourceTree = "<group>"; };
+		1B37EAAA221308E60009ED7C /* OpeningBraceRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningBraceRuleConfiguration.swift; sourceTree = "<group>"; };
 		1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoExtensionAccessModifierRule.swift; sourceTree = "<group>"; };
 		1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRule.swift; sourceTree = "<group>"; };
 		1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureSpacingRule.swift; sourceTree = "<group>"; };
@@ -960,6 +962,7 @@
 				D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */,
 				A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */,
 				78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */,
+				1B37EAAA221308E60009ED7C /* OpeningBraceRuleConfiguration.swift */,
 				C28B2B3B2106DF210009A0FE /* PrefixedConstantRuleConfiguration.swift */,
 				DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */,
 				D4246D6C1F30D8620097E658 /* PrivateOverFilePrivateRuleConfiguration.swift */,
@@ -1871,6 +1874,7 @@
 				8F6B3154213CDCD100858E44 /* UnusedPrivateDeclarationRule.swift in Sources */,
 				1894D746207D585400BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift in Sources */,
 				D4E92D1F2137B4C9002EDD48 /* IdenticalOperandsRule.swift in Sources */,
+				1B37EAAB221308E60009ED7C /* OpeningBraceRuleConfiguration.swift in Sources */,
 				6250D32A1ED4DFEB00735129 /* MultilineParametersRule.swift in Sources */,
 				009E092A1DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift in Sources */,
 				341FDB2021AD69970022E8E9 /* MarkdownReporter.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -873,7 +873,9 @@ extension ObjectLiteralRuleTests {
 
 extension OpeningBraceRuleTests {
     static var allTests: [(String, (OpeningBraceRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testOpeningBraceRule", testOpeningBraceRule),
+        ("testMultilineFuncWhenAddedToExcluded", testMultilineFuncWhenAddedToExcluded),
+        ("testMultilineIfWhenRemovedFromExcluded", testMultilineIfWhenRemovedFromExcluded)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -420,12 +420,6 @@ class NotificationCenterDetachmentRuleTests: XCTestCase {
     }
 }
 
-class OpeningBraceRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(OpeningBraceRule.description)
-    }
-}
-
 class OperatorFunctionWhitespaceRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OperatorFunctionWhitespaceRule.description)

--- a/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
@@ -1,0 +1,55 @@
+import SwiftLintFramework
+import XCTest
+
+class OpeningBraceRuleTests: XCTestCase {
+    func testOpeningBraceRule() {
+        verifyRule(OpeningBraceRule.description)
+    }
+
+    func testMultilineFuncWhenAddedToExcluded() {
+        let baseDescription = OpeningBraceRule.description
+
+        let triggeringExamplesToRemove = [
+            "func abc(\n\ta: Int,\n\tb: Int)\n↓{ }"
+        ]
+
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples +
+            triggeringExamplesToRemove.map { $0.replacingOccurrences(of: "↓", with: "") }
+
+        let triggeringExamples = baseDescription.triggeringExamples
+            .filter { !triggeringExamplesToRemove.contains($0) }
+
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+
+        verifyRule(description, ruleConfiguration:
+            ["first_line_excluding_regex": "if|guard|while|func \\w+\\("]
+        )
+    }
+
+    func testMultilineIfWhenRemovedFromExcluded() {
+        let baseDescription = OpeningBraceRule.description
+
+        let nonTriggeringExamplesToRemove = [
+            "if\n\tlet a = b,\n\tlet c = d\n\twhere a == c\n{ }"
+        ]
+
+        let newTriggeringExamples = [
+            "if\n\tlet a = b,\n\tlet c = d\n\twhere a == c\n↓{ }"
+        ]
+
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples
+            .filter { !nonTriggeringExamplesToRemove.contains($0) }
+
+        let triggeringExamples = baseDescription.triggeringExamples
+            + newTriggeringExamples
+
+        let description = baseDescription
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+
+        verifyRule(description, ruleConfiguration:
+            ["first_line_excluding_regex": "guard|while"]
+        )
+    }
+}


### PR DESCRIPTION
### This PR adds more configuration options to `opening_brace`

Changes:

- `OpeningBraceRule` now uses `OpeningBraceRuleConfiguration`. Using `first_line_excluding_regex `, we can configure the keywords which should be excluded when in a multiline statement. 

#### Example 1

In the default configuration, the following code triggers a violation:
```swift
func abc(
   a: Int,
   b: Int
) -> Int
↓{ … }
```

When we add `func` into the `first_line_excluding_regex` configuration, the violation is gone:
```swift
["first_line_excluding_regex": "if|guard|while|func \\w+\\("]
/ ... /

func abc(
   a: Int,
   b: Int
) -> Int
{ … }
```

#### Example 2

The default configuration allows multiline `if` statements:
```swift
if
   let a = b
   let c = d
   where a == c
{ … }
```

If we remove `if` from `first_line_excluding_regex`, the same code now triggers a violation:
```swift
["first_line_excluding_regex": "guard|while"]
/ ... /

if
   let a = b
   let c = d
   where a == c
↓{ … }
```

---

[Closes #2635]