### PR TITLE
Fix false positives on no_grouping_extension rule when using where clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
 
 #### Bug Fixes
 
+* Fix false positives on `no_grouping_extension` rule when using `where` clause.
+  [Almaz Ibragimov](https://github.com/almazrafi)
+
 * Fix `explicit_type_interface` when used in statements.  
   [Daniel Metzing](https://github.com/dirtydanee)
   [#2154](https://github.com/realm/SwiftLint/issues/2154)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@
 
 #### Bug Fixes
 
-* Fix false positives on `no_grouping_extension` rule when using `where` clause.
+* Fix false positives on `no_grouping_extension` rule when using `where`
+  clause.  
   [Almaz Ibragimov](https://github.com/almazrafi)
 
 * Fix `explicit_type_interface` when used in statements.  

--- a/Rules.md
+++ b/Rules.md
@@ -13143,6 +13143,12 @@ extension Oranges {}
 
 ```
 
+```swift
+class Box<T> {}
+extension Box where T: Vegetable {}
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -34,7 +34,7 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
                 return nil
             }
 
-            guard !hasWhereClause(element: element, file: file) else {
+            guard !hasWhereClause(dictionary: element.dictionary, file: file) else {
                 return nil
             }
 
@@ -44,12 +44,12 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
         }
     }
 
-    private func hasWhereClause(element: NamespaceCollector.Element, file: File) -> Bool {
+    private func hasWhereClause(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
         let contents = file.contents.bridge()
 
-        guard let nameOffset = element.dictionary.nameOffset,
-            let nameLength = element.dictionary.nameLength,
-            let bodyOffset = element.dictionary.bodyOffset else {
+        guard let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            let bodyOffset = dictionary.bodyOffset else {
             return false
         }
 
@@ -60,6 +60,6 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
             return false
         }
 
-        return (regex(" where ").firstMatch(in: file.contents, options: [], range: range) != nil)
+        return !file.match(pattern: "\\bwhere\\b", with: [.keyword], range: range).isEmpty
     }
 }


### PR DESCRIPTION
The `no_grouping_extension` rule diagnoses extensions with `where` clause as a violation. For example:

```
	class Box<T> {}

	extension Box where T: FloatingPoint {}
```

Since the rule prohibits the use of extensions to group code ([No Grouping Extension](https://github.com/realm/SwiftLint/blob/master/Rules.md#no-grouping-extension)), it must ignore the extensions with `where` cause.