### PR TITLE
Fix bug where nested configuration excluded files are ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@
 #### Bug Fixes
 
 * Fix bug where SwiftLint ignores excluded files list in a nested configuration file.  
-[Dylan Bruschi](https://github.com/Bruschidy54)
-[#2447](https://github.com/realm/SwiftLint/issues/2447)
+  [Dylan Bruschi](https://github.com/Bruschidy54)
+  [#2447](https://github.com/realm/SwiftLint/issues/2447)
 
 * Fix false positives on `no_grouping_extension` rule when using `where`
   clause.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
 
 #### Bug Fixes
 
+* Fix bug where SwiftLint ignores excluded files list in a nested configuration file.  
+[Dylan Bruschi](https://github.com/Bruschidy54)
+[#2447](https://github.com/realm/SwiftLint/issues/2447)
+
 * Fix false positives on `no_grouping_extension` rule when using `where`
   clause.  
   [Almaz Ibragimov](https://github.com/almazrafi)

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -69,8 +69,8 @@ extension Configuration {
             let excludedPaths = fileConfiguration.excluded
                 .map { (fileConfiguration.rootPath ?? "").bridge().appendingPathComponent($0) }
 
-            let shouldSkip: Bool = excludedPaths.contains
-            { file.path?.bridge().pathComponents.starts(with: $0.bridge().pathComponents) ?? false }
+            let shouldSkip: Bool = excludedPaths.contains { file.path?.bridge().pathComponents
+                .starts(with: $0.bridge().pathComponents) ?? false }
 
             if !shouldSkip {
                 if var configuredFiles = groupedFiles[fileConfiguration] {

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -69,7 +69,6 @@ extension Configuration {
             let excludedPaths = fileConfiguration.excluded
                 .compactMap { fileConfiguration.rootPath?.bridge().appendingPathComponent($0) }
 
-
             var shouldSkip = false
             for excludedPath in excludedPaths {
                 if file.path?.bridge().pathComponents.starts(with: excludedPath.bridge().pathComponents) ?? false {

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -69,8 +69,9 @@ extension Configuration {
             let excludedPaths = fileConfiguration.excluded
                 .map { (fileConfiguration.rootPath ?? "").bridge().appendingPathComponent($0) }
 
-            let shouldSkip: Bool = excludedPaths.contains { file.path?.bridge().pathComponents
-                .starts(with: $0.bridge().pathComponents) ?? false }
+            let shouldSkip: Bool = excludedPaths.contains {
+                file.path?.bridge().pathComponents.starts(with: $0.bridge().pathComponents) ?? false
+            }
 
             if !shouldSkip {
                 if var configuredFiles = groupedFiles[fileConfiguration] {

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -67,15 +67,10 @@ extension Configuration {
             // Files whose configuration specifies they should be excluded will be skipped
             let fileConfiguration = configuration(for: file)
             let excludedPaths = fileConfiguration.excluded
-                .compactMap { fileConfiguration.rootPath?.bridge().appendingPathComponent($0) }
+                .map { (fileConfiguration.rootPath ?? "").bridge().appendingPathComponent($0) }
 
-            var shouldSkip = false
-            for excludedPath in excludedPaths {
-                if file.path?.bridge().pathComponents.starts(with: excludedPath.bridge().pathComponents) ?? false {
-                    shouldSkip = true
-                    break
-                }
-            }
+            let shouldSkip: Bool = excludedPaths.contains
+            { file.path?.bridge().pathComponents.starts(with: $0.bridge().pathComponents) ?? false }
 
             if !shouldSkip {
                 if var configuredFiles = groupedFiles[fileConfiguration] {


### PR DESCRIPTION
Fixes #2447

When SwiftLint is linting files in `visitLintableFiles` in `Configuration+CommandLine`, it:

1. Gathers all lintable files in `getFiles`. This is where the exclusion of files occurs based on the parent configuration's exclusion list.
2. These files are grouped by their specific configuration in `groupFiles`. This is where configurations for each available file are determined (and if nested configurations exist, merged). After these configurations are determined and the files are grouped accordingly, no more files are excluded from the lintable files list. Even though a file's configuration thinks it should be excluded, these files are not removed from the list of lintable files, generating the bug.
3. Finally, each file is visited by the linter.

My solution is to skip files whose merged configurations specify they should be excluded in step 2 or `groupFiles`. Therefore, they will not be visited in step 3.