### PR TITLE
Update group Array extension to faster implementation

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -35,12 +35,7 @@ extension Array {
     }
 
     func group<U: Hashable>(by transform: (Element) -> U) -> [U: [Element]] {
-        return reduce([:]) { dictionary, element in
-            var dictionary = dictionary
-            let key = transform(element)
-            dictionary[key] = (dictionary[key] ?? []) + [element]
-            return dictionary
-        }
+        return Dictionary(grouping: self, by: { transform($0) })
     }
 
     func partitioned(by belongsInSecondPartition: (Element) throws -> Bool) rethrows ->


### PR DESCRIPTION
This should be slightly faster than using reduce

![image](https://user-images.githubusercontent.com/119268/53133694-b62b0400-357c-11e9-91bf-db4581aa14ba.png)
