### PR TITLE
Add NSObjectPreferIsEqualRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 #### Enhancements
 
-* None.
+* Add `nsobject_prefer_isequal` rule to warn against implementing `==` on an
+  `NSObject` subclass as calling `isEqual` (i.e. when using the class from
+  Objective-C) will will not use the defined `==` method.  
+  [Matthew Healy](https://github.com/matthew-healy)
+  [#2663](https://github.com/realm/SwiftLint/pull/2663)
 
 #### Bug Fixes
 
@@ -27,7 +31,6 @@
 * None.
 
 #### Enhancements
-
 * Add `deployment_target` rule to validate that `@availability` attributes and
   `#available` conditions are not using a version that is satisfied by the
   deployment target. Since SwiftLint can't read an Xcode project, you need to

--- a/Rules.md
+++ b/Rules.md
@@ -94,6 +94,7 @@
 * [No Grouping Extension](#no-grouping-extension)
 * [Notification Center Detachment](#notification-center-detachment)
 * [NSLocalizedString Key](#nslocalizedstring-key)
+* [NSObject Prefer isEqual](#nsobject-prefer-isequal)
 * [Number Separator](#number-separator)
 * [Object Literal](#object-literal)
 * [Opening Brace Spacing](#opening-brace-spacing)
@@ -13268,6 +13269,131 @@ NSLocalizedString(↓method(), comment: nil)
 
 ```swift
 NSLocalizedString(↓"key_\(param)", comment: nil)
+```
+
+</details>
+
+
+
+## NSObject Prefer isEqual
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`nsobject_prefer_isequal` | Enabled | No | lint | No | 3.0.0 
+
+NSObject subclasses should implement isEqual instead of ==.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+class AClass: NSObject {
+}
+```
+
+```swift
+@objc class AClass: SomeNSObjectSubclass {
+}
+```
+
+```swift
+class AClass: Equatable {
+    static func ==(lhs: AClass, rhs: AClass) -> Bool {
+        return true
+    }
+```
+
+```swift
+class AClass: NSObject {
+    override func isEqual(_ object: Any?) -> Bool {
+        return true
+    }
+}
+```
+
+```swift
+@objc class AClass: SomeNSObjectSubclass {
+    override func isEqual(_ object: Any?) -> Bool {
+        return false
+    }
+}
+```
+
+```swift
+class AClass: NSObject {
+    func ==(lhs: AClass, rhs: AClass) -> Bool {
+        return true
+    }
+}
+```
+
+```swift
+class AClass: NSObject {
+    static func ==(lhs: AClass, rhs: BClass) -> Bool {
+        return true
+    }
+}
+```
+
+```swift
+struct AStruct: Equatable {
+    static func ==(lhs: AStruct, rhs: AStruct) -> Bool {
+        return false
+    }
+}
+```
+
+```swift
+enum AnEnum: Equatable {
+    static func ==(lhs: AnEnum, rhs: AnEnum) -> Bool {
+        return true
+    }
+}
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+class AClass: NSObject {
+    ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+        return false
+    }
+}
+```
+
+```swift
+@objc class AClass: SomeOtherNSObjectSubclass {
+    ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+        return true
+    }
+}
+```
+
+```swift
+class AClass: NSObject, Equatable {
+    ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+        return false
+    }
+}
+```
+
+```swift
+class AClass: NSObject {
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? AClass else {
+            return false
+        }
+        return true
+    }
+
+    ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+        return false
+    }
+}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -89,7 +89,7 @@ public let masterRuleList = RuleList(rules: [
     MultilineParametersRule.self,
     MultipleClosuresWithTrailingClosureRule.self,
     NSLocalizedStringKeyRule.self,
-    NSObjectEqualsRule.self,
+    NSObjectPreferIsEqualRule.self,
     NestingRule.self,
     NimbleOperatorRule.self,
     NoExtensionAccessModifierRule.self,

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -89,6 +89,7 @@ public let masterRuleList = RuleList(rules: [
     MultilineParametersRule.self,
     MultipleClosuresWithTrailingClosureRule.self,
     NSLocalizedStringKeyRule.self,
+    NSObjectEqualsRule.self,
     NestingRule.self,
     NimbleOperatorRule.self,
     NoExtensionAccessModifierRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -1,0 +1,20 @@
+import SourceKittenFramework
+
+public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "nsobject_prefer_isequal",
+        name: "NSObject Prefer isEqual",
+        description: "NSObject subclasses should implement isEqual instead of ==.",
+        kind: .lint,
+        nonTriggeringExamples: NSObjectPreferIsEqualRuleExamples.nonTriggeringExamples,
+        triggeringExamples: NSObjectPreferIsEqualRuleExamples.triggeringExamples
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        return []
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRuleExamples.swift
@@ -1,0 +1,111 @@
+internal struct NSObjectPreferIsEqualRuleExamples {
+    static let nonTriggeringExamples: [String] = [
+        // NSObject subclass without ==
+        """
+        class AClass: NSObject {
+        }
+        """,
+        // @objc class without ==
+        """
+        @objc class AClass: SomeNSObjectSubclass {
+        }
+        """,
+        // Class with == which does not subclass NSObject
+        """
+        class AClass: Equatable {
+            static func ==(lhs: AClass, rhs: AClass) -> Bool {
+                return true
+            }
+        """,
+        // NSObject subclass implementing isEqual
+        """
+        class AClass: NSObject {
+            override func isEqual(_ object: Any?) -> Bool {
+                return true
+            }
+        }
+        """,
+        // @objc class implementing isEqual
+        """
+        @objc class AClass: SomeNSObjectSubclass {
+            override func isEqual(_ object: Any?) -> Bool {
+                return false
+            }
+        }
+        """,
+        // NSObject subclass with non-static ==
+        """
+        class AClass: NSObject {
+            func ==(lhs: AClass, rhs: AClass) -> Bool {
+                return true
+            }
+        }
+        """,
+        // NSObject subclass implementing == with different signature
+        """
+        class AClass: NSObject {
+            static func ==(lhs: AClass, rhs: BClass) -> Bool {
+                return true
+            }
+        }
+        """,
+        // Equatable struct
+        """
+        struct AStruct: Equatable {
+            static func ==(lhs: AStruct, rhs: AStruct) -> Bool {
+                return false
+            }
+        }
+        """,
+        // Equatable enum
+        """
+        enum AnEnum: Equatable {
+            static func ==(lhs: AnEnum, rhs: AnEnum) -> Bool {
+                return true
+            }
+        }
+        """
+    ]
+
+    static let triggeringExamples: [String] = [
+        // NSObject subclass implementing ==
+        """
+        class AClass: NSObject {
+            ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+                return false
+            }
+        }
+        """,
+        // @objc class implementing ==
+        """
+        @objc class AClass: SomeOtherNSObjectSubclass {
+            ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+                return true
+            }
+        }
+        """,
+        // Equatable NSObject subclass implementing ==
+        """
+        class AClass: NSObject, Equatable {
+            ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+                return false
+            }
+        }
+        """,
+        // NSObject subclass overriding isEqual and implementing ==
+        """
+        class AClass: NSObject {
+            override func isEqual(_ object: Any?) -> Bool {
+                guard let other = object as? AClass else {
+                    return false
+                }
+                return true
+            }
+
+            ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+                return false
+            }
+        }
+        """
+    ]
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
 		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
+		2882895F222975D00037CF5F /* NSObjectPreferIsEqualRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */; };
+		288289602229776C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */; };
 		29AD4C661F6EA1D5009B66E1 /* ContainsOverFirstNotNilRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AD4C641F6EA16C009B66E1 /* ContainsOverFirstNotNilRule.swift */; };
 		29FC197921382C07006D208C /* DuplicateImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC197721382C06006D208C /* DuplicateImportsRule.swift */; };
 		29FC197A21382C07006D208C /* DuplicateImportsRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC197821382C07006D208C /* DuplicateImportsRuleExamples.swift */; };
@@ -486,6 +488,8 @@
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
 		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
+		2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectPreferIsEqualRule.swift; sourceTree = "<group>"; };
+		2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectPreferIsEqualRuleExamples.swift; sourceTree = "<group>"; };
 		29AD4C641F6EA16C009B66E1 /* ContainsOverFirstNotNilRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFirstNotNilRule.swift; sourceTree = "<group>"; };
 		29FC197721382C06006D208C /* DuplicateImportsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuplicateImportsRule.swift; sourceTree = "<group>"; };
 		29FC197821382C07006D208C /* DuplicateImportsRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuplicateImportsRuleExamples.swift; sourceTree = "<group>"; };
@@ -1052,6 +1056,8 @@
 				D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */,
 				D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */,
 				D41985E621F85014003BE2B7 /* NSLocalizedStringKeyRule.swift */,
+				2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */,
+				2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */,
 				78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */,
 				D40FE89C1F867BFF006433E2 /* OverrideInExtensionRule.swift */,
 				62DEA1651FB21A9E00BCCCC6 /* PrivateActionRule.swift */,
@@ -1877,6 +1883,7 @@
 				181D9E172038343D001F6887 /* UntypedErrorInCatchRule.swift in Sources */,
 				47FF3BE11E7C75B600187E6D /* ImplicitlyUnwrappedOptionalRule.swift in Sources */,
 				623E36F01F3DB1B1002E5B71 /* QuickDiscouragedCallRule.swift in Sources */,
+				288289602229776C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift in Sources */,
 				BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */,
 				3B034B6E1E0BE549005D49A9 /* LineLengthConfiguration.swift in Sources */,
 				B25DCD0C1F7E9FA20028A199 /* MultilineArgumentsRule.swift in Sources */,
@@ -2026,6 +2033,7 @@
 				D93DA3D11E699E6300809827 /* NestingConfiguration.swift in Sources */,
 				CC26ED07204DEB510013BBBC /* RuleIdentifier.swift in Sources */,
 				C328A2F71E6759AE00A9E4D7 /* ExplicitTypeInterfaceRule.swift in Sources */,
+				2882895F222975D00037CF5F /* NSObjectPreferIsEqualRule.swift in Sources */,
 				18B90B6B21ADD99800B60749 /* RedundantObjcAttributeRule.swift in Sources */,
 				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift in Sources */,
 				D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -818,6 +818,12 @@ extension NSLocalizedStringKeyRuleTests {
     ]
 }
 
+extension NSObjectEqualsRuleTests {
+    static var allTests: [(String, (NSObjectEqualsRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension NestingRuleTests {
     static var allTests: [(String, (NestingRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -858,7 +864,8 @@ extension NumberSeparatorRuleTests {
     static var allTests: [(String, (NumberSeparatorRuleTests) -> () throws -> Void)] = [
         ("testNumberSeparatorWithDefaultConfiguration", testNumberSeparatorWithDefaultConfiguration),
         ("testNumberSeparatorWithMinimumLength", testNumberSeparatorWithMinimumLength),
-        ("testNumberSeparatorWithMinimumFractionLength", testNumberSeparatorWithMinimumFractionLength)
+        ("testNumberSeparatorWithMinimumFractionLength", testNumberSeparatorWithMinimumFractionLength),
+        ("testNumberSeparatorWithExcludeRanges", testNumberSeparatorWithExcludeRanges)
     ]
 }
 
@@ -1560,6 +1567,7 @@ XCTMain([
     testCase(MultilineParametersRuleTests.allTests),
     testCase(MultipleClosuresWithTrailingClosureRuleTests.allTests),
     testCase(NSLocalizedStringKeyRuleTests.allTests),
+    testCase(NSObjectEqualsRuleTests.allTests),
     testCase(NestingRuleTests.allTests),
     testCase(NimbleOperatorRuleTests.allTests),
     testCase(NoExtensionAccessModifierRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -818,8 +818,8 @@ extension NSLocalizedStringKeyRuleTests {
     ]
 }
 
-extension NSObjectEqualsRuleTests {
-    static var allTests: [(String, (NSObjectEqualsRuleTests) -> () throws -> Void)] = [
+extension NSObjectPreferIsEqualRuleTests {
+    static var allTests: [(String, (NSObjectPreferIsEqualRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]
 }
@@ -1567,7 +1567,7 @@ XCTMain([
     testCase(MultilineParametersRuleTests.allTests),
     testCase(MultipleClosuresWithTrailingClosureRuleTests.allTests),
     testCase(NSLocalizedStringKeyRuleTests.allTests),
-    testCase(NSObjectEqualsRuleTests.allTests),
+    testCase(NSObjectPreferIsEqualRuleTests.allTests),
     testCase(NestingRuleTests.allTests),
     testCase(NimbleOperatorRuleTests.allTests),
     testCase(NoExtensionAccessModifierRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -384,6 +384,12 @@ class NSLocalizedStringKeyRuleTests: XCTestCase {
     }
 }
 
+class NSObjectEqualsRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NSObjectEqualsRule.description)
+    }
+}
+
 class NestingRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NestingRule.description)

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -384,9 +384,9 @@ class NSLocalizedStringKeyRuleTests: XCTestCase {
     }
 }
 
-class NSObjectEqualsRuleTests: XCTestCase {
+class NSObjectPreferIsEqualRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
-        verifyRule(NSObjectEqualsRule.description)
+        verifyRule(NSObjectPreferIsEqualRule.description)
     }
 }
 


### PR DESCRIPTION
After accidentally mis-implementing `==` on an `NSObject` subclass one too many times, I decided to implement this rule. I also filled out the Rule Request info below, to explain why I think it's necessary.

### Rule Request
> 1. Why should this rule be added? 

When subclassing `NSObject` in Swift, properly implementing `Equatable` can be a little tricky. Whereas with most Swift types the correct thing to do is implement `==`, `NSObject` already exposes an implementation of `==` that calls out to `isEqual`. Adding a new implementation of `==` to an `NSObject` subclass can lead to odd situations where `a == b` is `true`, but `(a as NSObject) == b` (or, equivalently `a.isEqual(b)`) is `false`.

This rule is triggered whenever an `@objc` class or a direct `NSObject` subclass implements a `static` `==` function with exactly 2 arguments, both of which are of the same type as the class itself.

> 2. Provide several examples of what _would_ and _wouldn't_ trigger violations.

See the triggering & non-triggering examples in `NSObjectPreferIsEqualRuleExamples`.

> 3. Should the rule be configurable, if so what parameters should be configurable?

I included a `SeverityConfiguration`, because it seemed reasonable that folk might want to be aware of this violation without fixing it immediately.

> 4. Should the rule be opt-in or enabled by default? Why?

I'm not entirely sure. I implemented it as an `OptInRule` because it seemed safer, but I also can't think of a particularly good reason why you wouldn't want this to run, given the relative risks of differing notions of equality existing on the same type depending on the context. Happy to either leave as-is or enable by default depending on what others think.