### PR TITLE
Remove @ mark to fix invalid link in Rules.md

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -116,7 +116,7 @@
 * [Quick Discouraged Pending Test](#quick-discouraged-pending-test)
 * [Redundant Discardable Let](#redundant-discardable-let)
 * [Redundant Nil Coalescing](#redundant-nil-coalescing)
-* [Redundant @objc Attribute](#redundant-@objc-attribute)
+* [Redundant @objc Attribute](#redundant-objc-attribute)
 * [Redundant Optional Initialization](#redundant-optional-initialization)
 * [Redundant Set Access Control Rule](#redundant-set-access-control-rule)
 * [Redundant String Enum Value](#redundant-string-enum-value)


### PR DESCRIPTION
Just made the internal link for `Redundant @objc Attribute` valid.