### PR TITLE
Add NSLocalizedStringRequireBundleRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   [Cihat Gündüz](https://github.com/Dschee)
   [#2294](https://github.com/realm/SwiftLint/issues/2294)
 
+* Add `nslocalizedstring_require_bundle` rule to ensure calls to
+  `NSLocalizedString` specify the bundle where the strings file is located.  
+  [Matthew Healy](https://github.com/matthew-healy)
+  [#2595](https://github.com/realm/SwiftLint/2595)
+
 #### Bug Fixes
 
 * `colon` rule now catches violations when declaring generic types with

--- a/Rules.md
+++ b/Rules.md
@@ -95,6 +95,7 @@
 * [No Grouping Extension](#no-grouping-extension)
 * [Notification Center Detachment](#notification-center-detachment)
 * [NSLocalizedString Key](#nslocalizedstring-key)
+* [NSLocalizedString Require Bundle](#nslocalizedstring-require-bundle)
 * [NSObject Prefer isEqual](#nsobject-prefer-isequal)
 * [Number Separator](#number-separator)
 * [Object Literal](#object-literal)
@@ -13543,6 +13544,60 @@ NSLocalizedString(↓method(), comment: nil)
 
 ```swift
 NSLocalizedString(↓"key_\(param)", comment: nil)
+```
+
+</details>
+
+
+
+## NSLocalizedString Require Bundle
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`nslocalizedstring_require_bundle` | Disabled | No | lint | No | 3.0.0 
+
+Calls to NSLocalisedString should specify the bundle which contains the strings file.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+NSLocalizedString("someKey", bundle: .main, comment: "test")
+```
+
+```swift
+NSLocalizedString("someKey", tableName: "a",
+                  bundle: Bundle(for: A.self),
+                  comment: "test")
+```
+
+```swift
+NSLocalizedString("someKey", tableName: "xyz",
+                  bundle: someBundle, value: "test"
+                  comment: "test")
+```
+
+```swift
+arbitraryFunctionCall("something")
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+↓NSLocalizedString("someKey", comment: "test")
+```
+
+```swift
+↓NSLocalizedString("someKey", tableName: "a", comment: "test")
+```
+
+```swift
+↓NSLocalizedString("someKey", tableName: "xyz",
+                  value: "test", comment: "test")
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -90,6 +90,7 @@ public let masterRuleList = RuleList(rules: [
     MultilineParametersRule.self,
     MultipleClosuresWithTrailingClosureRule.self,
     NSLocalizedStringKeyRule.self,
+    NSLocalizedStringRequireBundleRule.self,
     NSObjectPreferIsEqualRule.self,
     NestingRule.self,
     NimbleOperatorRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct NSLocalizedStringRequireBundleRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
@@ -46,6 +45,18 @@ public struct NSLocalizedStringRequireBundleRule: ASTRule, OptInRule, Configurat
     public func validate(file: File,
                          kind: SwiftExpressionKind,
                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        return []
+        let isBundleArgument: ([String: SourceKitRepresentable]) -> Bool = { $0.name == "bundle" }
+        guard kind == .call,
+            dictionary.name == "NSLocalizedString",
+            let offset = dictionary.offset,
+            !dictionary.enclosedArguments.contains(where: isBundleArgument) else {
+            return []
+        }
+
+        return [
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: offset))
+        ]
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SourceKittenFramework
+
+public struct NSLocalizedStringRequireBundleRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "nslocalizedstring_require_bundle",
+        name: "NSLocalizedString Require Bundle",
+        description: "Calls to NSLocalisedString should specify the bundle which contains the strings file.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            """
+            NSLocalizedString("someKey", bundle: .main, comment: "test")
+            """,
+            """
+            NSLocalizedString("someKey", tableName: "a",
+                              bundle: Bundle(for: A.self),
+                              comment: "test")
+            """,
+            """
+            NSLocalizedString("someKey", tableName: "xyz",
+                              bundle: someBundle, value: "test"
+                              comment: "test")
+            """,
+            """
+            arbitraryFunctionCall("something")
+            """
+        ],
+        triggeringExamples: [
+            """
+            ↓NSLocalizedString("someKey", comment: "test")
+            """,
+            """
+            ↓NSLocalizedString("someKey", tableName: "a", comment: "test")
+            """,
+            """
+            ↓NSLocalizedString("someKey", tableName: "xyz",
+                              value: "test", comment: "test")
+            """
+        ]
+    )
+
+    public func validate(file: File,
+                         kind: SwiftExpressionKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        return []
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
 		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
 		24E17F721B14BB3F008195BE /* File+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* File+Cache.swift */; };
+		287F8B642230843000BDC504 /* NSLocalizedStringRequireBundleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F8B62223083ED00BDC504 /* NSLocalizedStringRequireBundleRule.swift */; };
 		2882895F222975D00037CF5F /* NSObjectPreferIsEqualRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */; };
 		288289602229776C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */; };
 		29AD4C661F6EA1D5009B66E1 /* ContainsOverFirstNotNilRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AD4C641F6EA16C009B66E1 /* ContainsOverFirstNotNilRule.swift */; };
@@ -500,6 +501,7 @@
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
 		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* File+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "File+Cache.swift"; sourceTree = "<group>"; };
+		287F8B62223083ED00BDC504 /* NSLocalizedStringRequireBundleRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLocalizedStringRequireBundleRule.swift; sourceTree = "<group>"; };
 		2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectPreferIsEqualRule.swift; sourceTree = "<group>"; };
 		2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectPreferIsEqualRuleExamples.swift; sourceTree = "<group>"; };
 		29AD4C641F6EA16C009B66E1 /* ContainsOverFirstNotNilRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFirstNotNilRule.swift; sourceTree = "<group>"; };
@@ -1083,6 +1085,7 @@
 				D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */,
 				D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */,
 				D41985E621F85014003BE2B7 /* NSLocalizedStringKeyRule.swift */,
+				287F8B62223083ED00BDC504 /* NSLocalizedStringRequireBundleRule.swift */,
 				2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */,
 				2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */,
 				78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */,
@@ -1939,6 +1942,7 @@
 				D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */,
 				D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */,
 				623675B01F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift in Sources */,
+				287F8B642230843000BDC504 /* NSLocalizedStringRequireBundleRule.swift in Sources */,
 				D47079AD1DFE2FA700027086 /* EmptyParametersRule.swift in Sources */,
 				E87E4A091BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift in Sources */,
 				3B0B14541C505D6300BE82F7 /* SeverityConfiguration.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -826,6 +826,12 @@ extension NSLocalizedStringKeyRuleTests {
     ]
 }
 
+extension NSLocalizedStringRequireBundleRuleTests {
+    static var allTests: [(String, (NSLocalizedStringRequireBundleRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension NSObjectPreferIsEqualRuleTests {
     static var allTests: [(String, (NSObjectPreferIsEqualRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1590,6 +1596,7 @@ XCTMain([
     testCase(MultilineParametersRuleTests.allTests),
     testCase(MultipleClosuresWithTrailingClosureRuleTests.allTests),
     testCase(NSLocalizedStringKeyRuleTests.allTests),
+    testCase(NSLocalizedStringRequireBundleRuleTests.allTests),
     testCase(NSObjectPreferIsEqualRuleTests.allTests),
     testCase(NestingRuleTests.allTests),
     testCase(NimbleOperatorRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -384,6 +384,12 @@ class NSLocalizedStringKeyRuleTests: XCTestCase {
     }
 }
 
+class NSLocalizedStringRequireBundleRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NSLocalizedStringRequireBundleRule.description)
+    }
+}
+
 class NSObjectPreferIsEqualRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NSObjectPreferIsEqualRule.description)


### PR DESCRIPTION
Fixes #2595, by adding `NSLocalizedStringRequireBundleRule`. This is an opt-in rule that triggers when calls to `NSLocalizedString` do not contain a `bundle` argument. 