### PR TITLE
Update bundler version to v2.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,4 +112,4 @@ DEPENDENCIES
   danger
 
 BUNDLED WITH
-   1.16.6
+   2.0.1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,8 +67,6 @@ jobs:
   variables:
     DEVELOPER_DIR: /Applications/Xcode_10.1.app
   steps:
-    - script: bundle update --bundler
-      displayName: Update bundler
     - script: bundle install --path vendor/bundle
       displayName: bundle install
     - script: bundle exec pod lib lint --verbose SwiftLintFramework.podspec
@@ -80,8 +78,6 @@ jobs:
   variables:
     DEVELOPER_DIR: /Applications/Xcode_10.1.app
   steps:
-    - script: bundle update --bundler
-      displayName: Update bundler
     - script: bundle install --path vendor/bundle
       displayName: bundle install
     - script: bundle exec danger --verbose


### PR DESCRIPTION
Updated the bundler version to v2.0.1 which is the latest release: https://github.com/bundler/bundler/releases

Also, on Azure Pipelines, it'll use the version in `Gemfile.lock`.