### PR TITLE
[Makefile] Avoid using `-Xswiftc -static-stdlib` if toolchain does not have `usr/lib/swift_static` directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ XCODEFLAGS=-workspace 'SwiftLint.xcworkspace' \
 SWIFT_BUILD_FLAGS=--configuration release
 UNAME=$(shell uname)
 ifeq ($(UNAME), Darwin)
+USE_SWIFT_STATIC_STDLIB:=$(shell test -d $$(dirname $$(xcrun --find swift))/../lib/swift_static/macosx && echo yes)
+ifeq ($(USE_SWIFT_STATIC_STDLIB), yes)
 SWIFT_BUILD_FLAGS+= -Xswiftc -static-stdlib
+endif
 endif
 
 SWIFTLINT_EXECUTABLE=$(shell swift build $(SWIFT_BUILD_FLAGS) --show-bin-path)/swiftlint


### PR DESCRIPTION
This is required on building with Xcode 10.2, because Xcode 10.2’s toolchain does not have `usr/lib/swift_static` directory.