### PR TITLE
Update Discarded Notification Center Observer Violation false positive trigger on array append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
   [#2628](https://github.com/realm/SwiftLint/issues/2628)
 
 * `discarded_notification_center_observer` rule now checks if the observer is
-  appended to an array before triggering the violation.
+  appended to an array before triggering the violation.  
   [jsloop42](https://github.com/jsloop42)
   [#2684](https://github.com/realm/SwiftLint/issues/2684)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
   [#2628](https://github.com/realm/SwiftLint/issues/2628)
 
 * `discarded_notification_center_observer` rule now checks if the observer is
-  appended to an array before triggering the violation.  
+  added to any collection or passed to a function before triggering the violation.  
   [jsloop42](https://github.com/jsloop42)
   [#2684](https://github.com/realm/SwiftLint/issues/2684)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2628](https://github.com/realm/SwiftLint/issues/2628)
 
+* `discarded_notification_center_observer` rule now checks if the observer is
+  appended to an array before triggering the violation.
+  [jsloop42](https://github.com/jsloop42)
+  [#2684](https://github.com/realm/SwiftLint/issues/2684)
+
 ## 0.31.0: Busy Laundromat
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -3085,13 +3085,22 @@ obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queu
 ```
 
 ```swift
+var obs: [String: Any?] = []
+obs["foo"] = nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { })
+
+```
+
+```swift
 var obs: [Any?] = []
 obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))
 
 ```
 
 ```swift
-func foo(_ notif: Any) {   obs.append(notif)}foo(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))
+func foo(_ notif: Any) {
+   obs.append(notif)
+}
+foo(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))
 
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -3084,6 +3084,17 @@ obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queu
 
 ```
 
+```swift
+var obs: [Any?] = []
+obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))
+
+```
+
+```swift
+func foo(_ notif: Any) {   obs.append(notif)}foo(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -3078,6 +3078,12 @@ func foo() -> Any {
 
 ```
 
+```swift
+var obs: [Any?] = []
+obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -17,7 +17,9 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
             "let foo = nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { })\n",
             "func foo() -> Any {\n" +
             "   return nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { })\n" +
-            "}\n"
+            "}\n",
+            "var obs: [Any?] = []\n" +
+            "obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n"
         ],
         triggeringExamples: [
             "↓nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil) { }\n",
@@ -49,6 +51,11 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
             let offset = dictionary.offset,
             let range = file.contents.bridge().byteRangeToNSRange(start: 0, length: offset) else {
                 return []
+        }
+
+        if let lastMatch = regex("append\\(").matches(in: file.contents, options: [], range: range).last?.range,
+            lastMatch.location == range.length - lastMatch.length {
+            return []
         }
 
         if let lastMatch = regex("\\s?=\\s*").matches(in: file.contents, options: [], range: range).last?.range,

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -19,7 +19,13 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
             "   return nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { })\n" +
             "}\n",
             "var obs: [Any?] = []\n" +
-            "obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n"
+            "obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n",
+            "var obs: [Any?] = []\n" +
+            "obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n",
+            "func foo(_ notif: Any) {" +
+                "   obs.append(notif)" +
+                "}" +
+            "foo(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n"
         ],
         triggeringExamples: [
             "↓nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil) { }\n",
@@ -53,8 +59,8 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
                 return []
         }
 
-        if let lastMatch = regex("append\\(").matches(in: file.contents, options: [], range: range).last?.range,
-            lastMatch.location == range.length - lastMatch.length {
+        if let lastMatch = regex("\\b[^\\(]+").matches(in: file.contents, options: [], range: range).last?.range,
+            lastMatch.location == range.length - lastMatch.length - 1 {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -20,11 +20,13 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
             "}\n",
             "var obs: [Any?] = []\n" +
             "obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n",
+            "var obs: [String: Any?] = []\n" +
+            "obs[\"foo\"] = nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { })\n",
             "var obs: [Any?] = []\n" +
             "obs.append(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n",
-            "func foo(_ notif: Any) {" +
-                "   obs.append(notif)" +
-                "}" +
+            "func foo(_ notif: Any) {\n" +
+            "   obs.append(notif)\n" +
+            "}\n" +
             "foo(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n"
         ],
         triggeringExamples: [


### PR DESCRIPTION
- This fixes an issue where the notification center observer is appended to an array, which triggers the violation. Fixes https://github.com/realm/SwiftLint/issues/2684.