### PR TITLE
RFC: Spellchecking rule.

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -130,6 +130,7 @@
 * [Single Test Class](#single-test-class)
 * [Min or Max over Sorted First or Last](#min-or-max-over-sorted-first-or-last)
 * [Sorted Imports](#sorted-imports)
+* [SpellCheck Rule](#spellcheck-rule)
 * [Statement Position](#statement-position)
 * [Static Operator](#static-operator)
 * [Strict fileprivate](#strict-fileprivate)
@@ -17398,6 +17399,56 @@ import ↓CCC
 #endif
 import AAA
 import BBB
+```
+
+</details>
+
+
+
+## SpellCheck Rule
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`spell_check` | Enabled | No | style | No | 3.0.0 
+
+Identifiers should have correct spelling.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+let number = 5
+```
+
+```swift
+let camelCaseNumber = 4
+```
+
+```swift
+let snake_case_number = 3
+```
+
+```swift
+func testRule_withUnderscore_shouldSpellCheck(label argument: Int) {
+}
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+let nuber = 5
+```
+
+```swift
+let camelCasenumber = 4
+```
+
+```swift
+let snake_casenumber = 3
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
@@ -131,6 +131,7 @@ public let masterRuleList = RuleList(rules: [
     SingleTestClassRule.self,
     SortedFirstLastRule.self,
     SortedImportsRule.self,
+    SpellingRule.self,
     StatementPositionRule.self,
     StaticOperatorRule.self,
     StrictFilePrivateRule.self,

--- a/Source/SwiftLintFramework/Rules/Style/SpellingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SpellingRule.swift
@@ -1,0 +1,159 @@
+import Foundation
+import SourceKittenFramework
+
+public struct SpellingRule: ASTRule, ConfigurationProviderRule {
+    public var configuration = SpellingConfiguration(allowedExtraWords: [])
+
+    let words: Set<String>
+
+    public init() {
+        let manager = FileManager.default
+        let path = "/usr/share/dict/words"
+
+        guard manager.fileExists(atPath: path) else {
+            queuedFatalError("test")
+        }
+        guard let validHandle = FileHandle(forReadingAtPath: path) else {
+            queuedFatalError("test")
+        }
+        let fileData = validHandle.readDataToEndOfFile()
+        let fileString = String(data: fileData, encoding: .utf8)!
+
+        words = Set(fileString.components(separatedBy: .newlines).map { $0.lowercased() })
+    }
+
+    public static let description = RuleDescription(
+        identifier: "spell_check",
+        name: "SpellCheck Rule",
+        description: "Identifiers should have correct spelling.",
+        kind: .style,
+        nonTriggeringExamples: [
+            "let number = 5",
+            "let camelCaseNumber = 4",
+            "let snake_case_number = 3"
+        ],
+        triggeringExamples: [
+            "let nuber = 5",
+            "let camelCasenumber = 4",
+            "let snake_casenumber = 3"
+        ],
+        deprecatedAliases: []
+    )
+
+    public func validate(file: File, kind: SwiftDeclarationKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        guard !dictionary.enclosedSwiftAttributes.contains(.override) else {
+            return []
+        }
+
+        return validateName(dictionary: dictionary, kind: kind).map { name, offset in
+            guard !configuration.allowedExtraWords.contains(name) else {
+                return []
+            }
+
+            let description = Swift.type(of: self).description
+
+            let type = self.type(for: kind)
+
+            let components = name.splitBefore { $0.isUpperCase }
+            for component in components {
+                if !words.contains(component.lowercased()) {
+                    let reason = "\(type) name should be spelled correctly: '\(name)': '\(component.lowercased())'"
+                    return [
+                        StyleViolation(ruleDescription: description,
+                                       severity: .error,
+                                       location: Location(file: file, byteOffset: offset),
+                                       reason: reason)
+                    ]
+                }
+            }
+
+            return []
+        } ?? []
+    }
+
+    private func validateName(dictionary: [String: SourceKitRepresentable],
+                              kind: SwiftDeclarationKind) -> (name: String, offset: Int)? {
+        guard var name = dictionary.name,
+            let offset = dictionary.offset,
+            kinds.contains(kind),
+            !name.hasPrefix("$") else {
+                return nil
+        }
+
+        if kind == .enumelement,
+            SwiftVersion.current > .fourDotOne,
+            let parenIndex = name.index(of: "("),
+            parenIndex > name.startIndex {
+            let index = name.index(before: parenIndex)
+            name = String(name[...index])
+        }
+
+        return (name.nameStrippingLeadingUnderscoreIfPrivate(dictionary), offset)
+    }
+
+    private let kinds: Set<SwiftDeclarationKind> = {
+        return SwiftDeclarationKind.variableKinds
+            .union(SwiftDeclarationKind.functionKinds)
+            .union([.enumelement])
+    }()
+
+    private func type(for kind: SwiftDeclarationKind) -> String {
+        if SwiftDeclarationKind.functionKinds.contains(kind) {
+            return "Function"
+        } else if kind == .enumelement {
+            return "Enum element"
+        } else {
+            return "Variable"
+        }
+    }
+}
+
+private extension String {
+    func splitBefore(separator isSeparator: (Character) throws -> Bool) rethrows -> [String] {
+        var result: [String] = []
+        var subSequence: String = ""
+
+        var iterator = self.makeIterator()
+        while let element = iterator.next() {
+            if try isSeparator(element) {
+                if !subSequence.isEmpty {
+                    result.append(subSequence)
+                }
+                subSequence = String(element)
+            } else {
+                subSequence.append(element)
+            }
+        }
+        result.append(subSequence)
+        return result
+    }
+}
+
+private extension Character {
+    var isUpperCase: Bool {
+        return String(self) == String(self).uppercased()
+    }
+}
+
+public struct SpellingConfiguration: RuleConfiguration, Equatable {
+    public var consoleDescription: String {
+        return ""
+    }
+
+    public var allowedExtraWords: Set<String>
+
+    public init(allowedExtraWords: [String]) {
+        self.allowedExtraWords = Set(allowedExtraWords)
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configurationDict = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let allowedExtraWords = [String].array(of: configurationDict["allowed_extra_words"]) {
+            self.allowedExtraWords = Set(allowedExtraWords)
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856651A61D6B395F005E6B29 /* MarkRule.swift */; };
 		8B01E4FD20A41C8700C9233E /* FunctionParameterCountConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B01E4FB20A4183C00C9233E /* FunctionParameterCountConfiguration.swift */; };
 		8B01E50220A4349100C9233E /* FunctionParameterCountRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B01E4FF20A4340A00C9233E /* FunctionParameterCountRuleTests.swift */; };
+		8E890281D4A50AE56AF2BF51 /* SpellingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E890F16A211D5CB98788C3C /* SpellingRule.swift */; };
 		8F2CC1CB20A6A070006ED34F /* FileNameConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2CC1CA20A6A070006ED34F /* FileNameConfiguration.swift */; };
 		8F2CC1CD20A6A189006ED34F /* FileNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2CC1CC20A6A189006ED34F /* FileNameRuleTests.swift */; };
 		8F6AA75B211905B8009BA28A /* LintableFilesVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA75A211905B8009BA28A /* LintableFilesVisitor.swift */; };
@@ -617,6 +618,7 @@
 		856651A61D6B395F005E6B29 /* MarkRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
 		8B01E4FB20A4183C00C9233E /* FunctionParameterCountConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountConfiguration.swift; sourceTree = "<group>"; };
 		8B01E4FF20A4340A00C9233E /* FunctionParameterCountRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRuleTests.swift; sourceTree = "<group>"; };
+		8E890F16A211D5CB98788C3C /* SpellingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpellingRule.swift; sourceTree = "<group>"; };
 		8F2CC1CA20A6A070006ED34F /* FileNameConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameConfiguration.swift; sourceTree = "<group>"; };
 		8F2CC1CC20A6A189006ED34F /* FileNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileNameRuleTests.swift; sourceTree = "<group>"; };
 		8F6AA75A211905B8009BA28A /* LintableFilesVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LintableFilesVisitor.swift; sourceTree = "<group>"; };
@@ -1165,6 +1167,7 @@
 				82FE253E20F604AD00295958 /* VerticalWhitespaceOpeningBracesRule.swift */,
 				1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */,
 				D47079AE1DFE520000027086 /* VoidReturnRule.swift */,
+				8E890F16A211D5CB98788C3C /* SpellingRule.swift */,
 			);
 			path = Style;
 			sourceTree = "<group>";
@@ -2147,6 +2150,7 @@
 				D47079AF1DFE520000027086 /* VoidReturnRule.swift in Sources */,
 				B3935EE74B1E8E14FBD65E7F /* String+XML.swift in Sources */,
 				BC87573B2195CF2A00CA7A74 /* ModifierOrderRuleExamples.swift in Sources */,
+				8E890281D4A50AE56AF2BF51 /* SpellingRule.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -1181,6 +1181,12 @@ extension SourceKitCrashTests {
     ]
 }
 
+extension SpellingRuleTests {
+    static var allTests: [(String, (SpellingRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension StatementPositionRuleTests {
     static var allTests: [(String, (StatementPositionRuleTests) -> () throws -> Void)] = [
         ("testStatementPosition", testStatementPosition),
@@ -1621,6 +1627,7 @@ XCTMain([
     testCase(SortedFirstLastRuleTests.allTests),
     testCase(SortedImportsRuleTests.allTests),
     testCase(SourceKitCrashTests.allTests),
+    testCase(SpellingRuleTests.allTests),
     testCase(StatementPositionRuleTests.allTests),
     testCase(StaticOperatorRuleTests.allTests),
     testCase(StrictFilePrivateRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import SwiftLintFramework
@@ -597,6 +597,12 @@ class SortedFirstLastRuleTests: XCTestCase {
 class SortedImportsRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SortedImportsRule.description)
+    }
+}
+
+class SpellingRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(SpellingRule.description)
     }
 }
 


### PR DESCRIPTION
I'm curious what the view on spellchecking as a feature in SwiftLint is. I made a small proof of concept implementation of what spellchecking could look like. Using `/usr/share/dict/words` as the default dictionary. However this did not work too well because `/usr/share/dict/words` is missing a lot of words and grammatical conjugations of words. 

There are a couple of different solutions to this problem.

1. `AppKit` has `NSSpellChecker`. Although this would introduce another dependency.
2. Bundle a default dictionary with a fitting license. 
3. Have no default dictionary and let the user download and use whatever dictionary they choose.

So what do you guys think? Is spellchecking something that should be a part of SwiftLint? If so what is the preferred solution?