### PR TITLE
Add triggering examples with parentheses to the number separator rule tests

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -14010,6 +14010,42 @@ let foo = ↓1_000_000.000000_1
 let foo = ↓1000000.000000_1
 ```
 
+```swift
+let foo: Double = ↓-(100000)
+```
+
+```swift
+let foo: Double = ↓-(10.000000_1)
+```
+
+```swift
+let foo: Double = ↓-(123456 / ↓447.214214)
+```
+
+```swift
+let foo: Double = +(↓100000)
+```
+
+```swift
+let foo: Double = +(↓10.000000_1)
+```
+
+```swift
+let foo: Double = +(↓123456 / ↓447.214214)
+```
+
+```swift
+let foo: Double = (↓100000)
+```
+
+```swift
+let foo: Double = (↓10.000000_1)
+```
+
+```swift
+let foo: Double = (↓123456 / ↓447.214214)
+```
+
 </details>
 
 

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
@@ -20,7 +20,8 @@ internal struct NumberSeparatorRuleExamples {
         }
     }()
 
-    static let triggeringExamples = makeTriggeringExamples(signs: ["↓-", "+↓", "↓"])
+    static let triggeringExamples = makeTriggeringExamples(signs: ["↓-", "+↓", "↓"]) +
+        makeTriggeringExamplesWithParentheses()
 
     static let corrections = makeCorrections(signs: [("↓-", "-"), ("+↓", "+"), ("↓", "")])
 
@@ -35,6 +36,17 @@ internal struct NumberSeparatorRuleExamples {
                 "let foo = \(sign)1.0001",
                 "let foo = \(sign)1_000_000.000000_1",
                 "let foo = \(sign)1000000.000000_1"
+            ]
+        }
+    }
+
+    private static func makeTriggeringExamplesWithParentheses() -> [String] {
+        let signsWithParenthesisAndViolation = ["↓-(", "+(↓", "(↓"]
+        return signsWithParenthesisAndViolation.flatMap { (sign: String) -> [String] in
+            [
+                "let foo: Double = \(sign)100000)",
+                "let foo: Double = \(sign)10.000000_1)",
+                "let foo: Double = \(sign)123456 / ↓447.214214)"
             ]
         }
     }


### PR DESCRIPTION
Further improves #2683 

I did not create a new changelog entry for this PR because it should have been implemented as part of #2687, but I'll be happy to add one anyway if necessary.

Due to how the number is parsed, the violation can occur either inside or outside the opening parenthesis depending on the sign, so I could not simply append new values inside the existing `makeTriggeringExamples` function. Let me know if you think this should be handled differently.