### PR TITLE
Return false for isFile for empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@
   [Taiki Komaba](https://github.com/r-plus)
   [#2700](https://github.com/realm/SwiftLint/issues/2700)
 
+* Fix crash when running on Linux with Swift 5 without specifying a `--path`
+  value or specifying an empty string.  
+  [Keith Smiley](https://github.com/keith)
+  [#2703](https://github.com/realm/SwiftLint/issues/2703)
+
 ## 0.31.0: Busy Laundromat
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -80,6 +80,9 @@ extension String {
     }
 
     internal var isFile: Bool {
+        if self.isEmpty {
+            return false
+        }
         var isDirectoryObjC: ObjCBool = false
         if FileManager.default.fileExists(atPath: self, isDirectory: &isDirectoryObjC) {
             return !isDirectoryObjC.boolValue


### PR DESCRIPTION
As of Swift 5, corelibs-foundation crashes if you pass an empty string
to `fileExists` https://github.com/apple/swift-corelibs-foundation/blob/cae5eaca63cd57f64a93b4d5de87a4ffc04466d5/Foundation/FileManager.swift#L2033