### PR TITLE
Refactor `Configuration.groupFiles(...)` for style and performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
 
 #### Bug Fixes
 
+* Fix bug where SwiftLint ignores excluded files list in a nested configuration
+  file.  
+  [Dylan Bruschi](https://github.com/Bruschidy54)
+  [#2447](https://github.com/realm/SwiftLint/issues/2447)
+
 * `colon` rule now catches violations when declaring generic types with
   inheritance or protocol conformance.  
   [Marcelo Fabri](https://github.com/marcelofabri)
@@ -120,10 +125,6 @@
   [#2637](https://github.com/realm/SwiftLint/issues/2637)
 
 #### Bug Fixes
-
-* Fix bug where SwiftLint ignores excluded files list in a nested configuration file.  
-  [Dylan Bruschi](https://github.com/Bruschidy54)
-  [#2447](https://github.com/realm/SwiftLint/issues/2447)
 
 * Fix false positives on `no_grouping_extension` rule when using `where`
   clause.  

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -66,20 +66,16 @@ extension Configuration {
         for file in files {
             // Files whose configuration specifies they should be excluded will be skipped
             let fileConfiguration = configuration(for: file)
-            let excludedPaths = fileConfiguration.excluded
-                .map { (fileConfiguration.rootPath ?? "").bridge().appendingPathComponent($0) }
-
-            let shouldSkip: Bool = excludedPaths.contains {
-                file.path?.bridge().pathComponents.starts(with: $0.bridge().pathComponents) ?? false
+            let fileConfigurationRootPath = (fileConfiguration.rootPath ?? "").bridge()
+            let shouldSkip = fileConfiguration.excluded.contains { excludedRelativePath in
+                let excludedPath = fileConfigurationRootPath.appendingPathComponent(excludedRelativePath)
+                let filePathComponents = file.path?.bridge().pathComponents ?? []
+                let excludedPathComponents = excludedPath.bridge().pathComponents
+                return filePathComponents.starts(with: excludedPathComponents)
             }
 
             if !shouldSkip {
-                if var configuredFiles = groupedFiles[fileConfiguration] {
-                    configuredFiles.append(file)
-                    groupedFiles[fileConfiguration] = configuredFiles
-                } else {
-                    groupedFiles[fileConfiguration] = [file]
-                }
+                groupedFiles[fileConfiguration, default: []].append(file)
             }
         }
 


### PR DESCRIPTION
This is a small followup from #2648. Also fixes the changelog entry's location to put it under the right version section.