### PR TITLE
Introduce " - " delimiter to allow rules to be commented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 #### Enhancements
 
+
+* Add `" - "` delimiter to allow commenting SwiftLint commands without triggering
+`superfluous_disable_command`.
+  [Kevin Randrup](https://github.com/kevinrandrup)
+  [#2720](https://github.com/realm/SwiftLint/pull/2720)
+
 * Make `testSimulateHomebrewTest()` test opt-in because it may fail on unknown
   condition. Set `SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST` 
   environment variable to test like:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@
 
 
 * Add `" - "` delimiter to allow commenting SwiftLint commands without triggering
-`superfluous_disable_command`.
+`superfluous_disable_command`.  
   [Kevin Randrup](https://github.com/kevinrandrup)
-  [#2720](https://github.com/realm/SwiftLint/pull/2720)
 
 * Make `testSimulateHomebrewTest()` test opt-in because it may fail on unknown
   condition. Set `SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST` 

--- a/Rules.md
+++ b/Rules.md
@@ -18259,7 +18259,7 @@ Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Mi
 --- | --- | --- | --- | --- | ---
 `superfluous_disable_command` | Enabled | No | lint | No | 3.0.0 
 
-SwiftLint 'disable' commands are superfluous when the disabled rule would not have triggered a violation in the disabled region.
+SwiftLint 'disable' commands are superfluous when the disabled rule would not have triggered a violation in the disabled region. Use " - " if you wish to document a command.
 
 
 

--- a/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
@@ -9,7 +9,7 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule {
         identifier: "superfluous_disable_command",
         name: "Superfluous Disable Command",
         description: "SwiftLint 'disable' commands are superfluous when the disabled rule would not have " +
-                     "triggered a violation in the disabled region.",
+                     "triggered a violation in the disabled region. Use \" - \" if you wish to document a command.",
         kind: .lint
     )
 


### PR DESCRIPTION
Introduce "-" delimiter to allow rules to be commented

Ex. swiftlint:disable:next force_try - Explanation here