### PR TITLE
added regex_ignore parameter to custom rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 #### Enhancements
 
+* added `regex_ignore` parameter to custom rules.  
+  [Igor Chertenkov](https://github.com/dieworld)
+  [#2724](https://github.com/realm/SwiftLint/issues/2724)
+
 * Add `reduce_boolean` rule to prefer simpler constructs over `reduce(Boolean)`.  
   [Xavier Lowmiller](https://github.com/xavierLowmiller)
   [#2675](https://github.com/realm/SwiftLint/issues/2675)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -6,6 +6,7 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
     public var name: String?
     public var message = "Regex matched."
     public var regex: NSRegularExpression!
+    public var regexIgnore: NSRegularExpression?
     public var included: NSRegularExpression?
     public var excluded: NSRegularExpression?
     public var matchKinds = SyntaxKind.allKinds
@@ -25,6 +26,7 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
             name ?? "",
             message,
             regex.pattern,
+            regexIgnore?.pattern ?? "",
             included?.pattern ?? "",
             excluded?.pattern ?? "",
             matchKinds.map({ $0.rawValue }).sorted(by: <).joined(separator: ","),
@@ -53,6 +55,10 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
         }
 
         regex = try .cached(pattern: regexString)
+
+        if let regexIgnoreString = configurationDict["regex_ignore"] as? String {
+            regexIgnore = try .cached(pattern: regexIgnoreString)
+        }
 
         if let includedString = configurationDict["included"] as? String {
             included = try .cached(pattern: includedString)

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -89,7 +89,16 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
         return configurations.flatMap { configuration -> [StyleViolation] in
             let pattern = configuration.regex.pattern
             let excludingKinds = SyntaxKind.allKinds.subtracting(configuration.matchKinds)
-            return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map({
+
+            var match: [NSRange] = []
+            if let ignorePattern = configuration.regexIgnore?.pattern {
+                match = file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds,
+                                   excludingPattern: ignorePattern)
+            } else {
+                match = file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds)
+            }
+
+            return match.map({
                 StyleViolation(ruleDescription: configuration.description,
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location),


### PR DESCRIPTION
I wanted to add some tweaks to existing rules without forking swiftlint.

Example: I want to forbid force casting for all classes except view controllers. In this case I add regex for searching "as!" pattern, but also add another regex to ignore all matches which force cast to any class ending with ...ViewController.