### PR TITLE
Fix false positive in UnusedCaptureListRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@
   [Frederick Pietschmann](https://github.com/fredpi)
   [#2670](https://github.com/realm/SwiftLint/issues/2670)
 
+* Fix false positives on `unused_capture_list` which resulted in an array
+  literal being mistaken for a capture list.  
+  [Dalton Claybrook](https://github.com/daltonclaybrook)
+  [#2726](https://github.com/realm/SwiftLint/issues/2726)
+
 ## 0.31.0: Busy Laundromat
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,11 +95,6 @@
   [Frederick Pietschmann](https://github.com/fredpi)
   [#2670](https://github.com/realm/SwiftLint/issues/2670)
 
-* Fix false positives on `unused_capture_list` which resulted in an array
-  literal being mistaken for a capture list.  
-  [Dalton Claybrook](https://github.com/daltonclaybrook)
-  [#2726](https://github.com/realm/SwiftLint/issues/2726)
-
 ## 0.31.0: Busy Laundromat
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -23057,7 +23057,15 @@ numbers.forEach({
 ```
 
 ```swift
-{ [foo] in foo.bar() }()
+withEnvironment(apiService: MockService(fetchProjectResponse: project)) {
+    [Device.phone4_7inch, Device.phone5_8inch, Device.pad].forEach { device in
+        device.handle()
+    }
+}
+```
+
+```swift
+{ [foo] _ in foo.bar() }()
 ```
 
 ```swift
@@ -23091,6 +23099,14 @@ numbers.forEach({
     [weak handler] in
     print($0)
 })
+```
+
+```swift
+withEnvironment(apiService: MockService(fetchProjectResponse: project)) { [↓foo] in
+    [Device.phone4_7inch, Device.phone5_8inch, Device.pad].forEach { device in
+        device.handle()
+    }
+}
 ```
 
 ```swift


### PR DESCRIPTION
Fixes concern raised by @jpsim [here](https://github.com/realm/SwiftLint/pull/2719#issuecomment-485172561).

An array literal was being mistaken for a capture list in some cases.