### PR TITLE
Update documentation regarding `exclude` definition in nested `.swiftlint.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,8 +444,7 @@ the linting process.
 * Each file will be linted using the configuration file that is in its
   directory or at the deepest level of its parent directories. Otherwise the
   root configuration will be used.
-* `excluded` and `included` are ignored for nested
-  configurations.
+* `included` is ignored for nested configurations.
 
 ### Auto-correct
 


### PR DESCRIPTION
#2648 added support for using `exclude` in nested `.swiftlint.yml` configurations.

This PR updates the documentation (README) to reflect the changes of named PR. Since I speak neither Chinese nor Korean I only changed the english `README.md` 😅 