### PR TITLE
Make `testSimulateHomebrewTest()` test opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@
 
 #### Enhancements
 
-* None.
+* Make `testSimulateHomebrewTest()` test opt-in because it may fail on unknown
+  condition. Set `SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST` 
+  environment variable to test like:
+    ```terminal.sh-session
+    $ SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST=1 \
+    swift test --filter testSimulateHomebrewTest
+    ```  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 #### Bug Fixes
 

--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -43,6 +43,14 @@ class IntegrationTests: XCTestCase {
         // Since this test uses the `swiftlint` binary built while building `SwiftLintPackageTests`,
         // we run it only on macOS using SwiftPM.
 #if os(macOS) && SWIFT_PACKAGE
+        let keyName = "SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST"
+        guard ProcessInfo.processInfo.environment[keyName] != nil else {
+            print("""
+                Skipping the opt-in test `\(#function)`.
+                Set the `\(keyName)` environment variable to test `\(#function)`.
+            """)
+            return
+        }
         guard let swiftlintURL = swiftlintBuiltBySwiftPM(),
             let (testSwiftURL, seatbeltURL) = prepareSandbox() else {
             return


### PR DESCRIPTION
because it may fail on unknown condition.
Set `SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST` environment variable to test like following:
```terminal.sh-session
$ SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST=1 \
swift test --filter testSimulateHomebrewTest
```