### PR TITLE
Don’t trigger colon inside object literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   return type is required.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
+* Don't trigger `colon` violations in object literals
+  (`#imageLiteral(name:"image")` for example).  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2740](https://github.com/realm/SwiftLint/issues/2740)
+
 ## 0.32.0: Wash-N-Fold-N-Reduce
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -2052,6 +2052,10 @@ class ABC { let def = ghi(jkl: mno) } }
 func foo() { let dict = [1: 1] }
 ```
 
+```swift
+#imageLiteral(resourceName:"grayArrowUp"))
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+FunctionCall.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+FunctionCall.swift
@@ -18,7 +18,7 @@ extension ColonRule {
     internal func functionCallColonViolationRanges(in file: File, kind: SwiftExpressionKind,
                                                    dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         guard kind == .argument,
-            let ranges = functionCallColonRanges(dictionary: dictionary) else {
+            let ranges = functionCallColonRanges(dictionary: dictionary, file: file) else {
                 return []
         }
 
@@ -37,12 +37,14 @@ extension ColonRule {
         }
     }
 
-    private func functionCallColonRanges(dictionary: [String: SourceKitRepresentable]) -> [NSRange]? {
+    private func functionCallColonRanges(dictionary: [String: SourceKitRepresentable], file: File) -> [NSRange]? {
         guard let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength, nameLength > 0,
             let bodyOffset = dictionary.bodyOffset,
             case let location = nameOffset + nameLength,
-            bodyOffset > location else {
+            bodyOffset > location,
+            case let nameRange = NSRange(location: nameOffset, length: nameLength),
+            file.syntaxMap.kinds(inByteRange: nameRange) != [.objectLiteral] else {
                 return nil
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/ColonRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRuleExamples.swift
@@ -37,7 +37,8 @@ internal struct ColonRuleExamples {
         "func abc() { def(ghi: jkl) }",
         "func abc(def: Void) { ghi(jkl: mno) }",
         "class ABC { let def = ghi(jkl: mno) } }",
-        "func foo() { let dict = [1: 1] }"
+        "func foo() { let dict = [1: 1] }",
+        "#imageLiteral(resourceName:\"grayArrowUp\"))"
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
Fixes #2740