### PR TITLE
Skip module import if cursor info is missing module info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
   return type is required.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
+* Skip module import if cursor info is missing module info.  
+  [alvarhansen](https://github.com/alvarhansen)
+  [#2746](https://github.com/realm/SwiftLint/issues/2746)
+
 ## 0.32.0: Wash-N-Fold-N-Reduce
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -23574,6 +23574,11 @@ import Foundation
 class A {}
 ```
 
+```swift
+import UnknownModule
+func foo(error: Swift.Error) {}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -23605,6 +23610,12 @@ dispatchMain()
 ↓import Foundation
 // @objc
 class A {}
+```
+
+```swift
+↓import Foundation
+import UnknownModule
+func foo(error: Swift.Error) {}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -24,6 +24,10 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
             import Foundation
             @objc
             class A {}
+            """,
+            """
+            import UnknownModule
+            func foo(error: Swift.Error) {}
             """
         ],
         triggeringExamples: [
@@ -51,6 +55,11 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
             ↓import Foundation
             // @objc
             class A {}
+            """,
+            """
+            ↓import Foundation
+            import UnknownModule
+            func foo(error: Swift.Error) {}
             """
         ],
         corrections: [
@@ -181,9 +190,9 @@ private extension File {
                     imports.insert(importedModule)
                     nextIsModuleImport = false
                     continue
+                } else {
+                    nextIsModuleImport = false
                 }
-            } else {
-                nextIsModuleImport = false
             }
 
             if let usr = cursorInfo["key.modulename"] as? String {


### PR DESCRIPTION
I believe setting `nextIsModuleImport = false` in current code is accidental bug, as it makes no sense to set it false if it already is false. It makes more sense if it is in inner if statements else block.

At the moment it will lead to crash if you import module that SourceKit is unable to find info for.

With following code:

```swift
import UnknownModule
func foo(error: Swift.Error) {}
```

The execution goes like this:
1. `import` token is found and `nextIsModuleImport` is set to `true`
2. `identifier` token is found but if SourceKit returns empty dictionary the loop just continues
3. `Swift` token in `foo(error: Swift.Error) ` is visited and if it has `key.modulename` `source.lang.swift.ref.module` it is falsely considered as an import statement.
4. Its name is added to `unusedImports`
5. `contentsNSString.range(of: "import \(module)\n")` returns NSRange with location NSNotFound
...
6. `func correct(file: File, compilerArguments: [String]) -> [Correction]` will throw NSException when attempting to replace this range. 