### PR TITLE
#2749 Fix file_types_order in extension-only files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@
   [alvarhansen](https://github.com/alvarhansen)
   [#2746](https://github.com/realm/SwiftLint/issues/2746)
 
+* Don't trigger `file_types_order` violations in files only containing 
+  extensions.  
+  [Sam Rayner](https://github.com/samrayner)
+  [#2749](https://github.com/realm/SwiftLint/issues/2749)
+
 ## 0.32.0: Wash-N-Fold-N-Reduce
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -7812,6 +7812,13 @@ extension TestViewController: UITableViewDataSource {
 }
 ```
 
+```swift
+// Only extensions
+extension Foo {}
+extension Bar {
+}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -140,16 +140,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
             return (lhs.bodyLength ?? 0) > (rhs.bodyLength ?? 0)
         }
 
-        guard let mainTypeSubstructure = substructuresSortedByBodyLength.first else {
-            let substructuresSortedByBodyLength = dict.substructure.sorted { lhs, rhs in
-                return (lhs.bodyLength ?? 0) > (rhs.bodyLength ?? 0)
-            }
-
-            // specify substructure with longest body as main type if existent
-            return substructuresSortedByBodyLength.first
-        }
-
         // specify class, enum or struct with longest body as main type
-        return mainTypeSubstructure
+        return substructuresSortedByBodyLength.first
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
@@ -123,7 +123,15 @@ internal struct FileTypesOrderRuleExamples {
         """
     ]
 
-    static let nonTriggeringExamples = [FileTypesOrderRuleExamples.defaultOrderParts.joined(separator: "\n\n")]
+    static let nonTriggeringExamples = [
+        FileTypesOrderRuleExamples.defaultOrderParts.joined(separator: "\n\n"),
+        """
+        // Only extensions
+        extension Foo {}
+        extension Bar {
+        }
+        """
+    ]
 
     static let triggeringExamples = [
         """


### PR DESCRIPTION
Prevents extensions being flagged as in the wrong order when a file only contains extensions and nothing else (enums, classes, structs). In this case it's not intuitive that the longest extension be considered the "main" one so the file can be considered as having no "main" type.