### PR TITLE
Add new indentation_width rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,11 @@
   expressions.  
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2918](https://github.com/realm/SwiftLint/issues/2918)
+  
+* Add new indentation opt-in-rule checking for
+  basic additive indentation pattern.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 * Speed up syntax token lookups, which can improve performance when
   linting large files.  
@@ -215,11 +220,6 @@
 
 * Make `contains_over_first_not_nil` rule also match `first(where:) == nil`.  
   [Colton Schlosser](https://github.com/cltnschlosser)
-  
-* Add new indentation opt-in-rule checking for
-  super-basic additive indentation pattern.  
-  [Frederick Pietschmann](https://github.com/fredpi)
-  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 * Add two new cases to the Mark rule to detect a Mark using three slashes.  
   [nvanfleet](https://github.com/nvanfleet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,11 +172,6 @@
   expressions.  
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2918](https://github.com/realm/SwiftLint/issues/2918)
-  
-* Add new indentation opt-in-rule checking for
-  basic additive indentation pattern.  
-  [Frederick Pietschmann](https://github.com/fredpi)
-  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 * Speed up syntax token lookups, which can improve performance when
   linting large files.  
@@ -1618,7 +1613,10 @@ The next release will require Swift 4.0 or higher to build.
 
 #### Enhancements
 
-* None.
+* Add new indentation opt-in-rule checking for
+  basic additive indentation pattern.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,11 @@ This is the last release to support building with Swift 4.2.x.
   in closures when using Swift 5.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2097](https://github.com/realm/SwiftLint/issues/2097)
+  
+* Add new indentation opt-in-rule checking for
+  super-basic additive indentation pattern.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 * Don't trigger a `no_fallthrough_only` violation if next case is an
   `@unknown default`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   to any declarations.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2989](https://github.com/realm/SwiftLint/issues/2989)
+  
+* Add new indentation opt-in rule (`indentation_width`) checking for
+  super-basic additive indentation pattern.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 #### Bug Fixes
 
@@ -1055,11 +1060,6 @@ This is the last release to support building with Swift 4.0 and Swift 4.1.
 #### Enhancements
 
 * None.
-  
-* Add new indentation opt-in-rule checking for
-  super-basic additive indentation pattern.  
-  [Frederick Pietschmann](https://github.com/fredpi)
-  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 #### Bug Fixes
 
@@ -1613,10 +1613,7 @@ The next release will require Swift 4.0 or higher to build.
 
 #### Enhancements
 
-* Add new indentation opt-in-rule checking for
-  basic additive indentation pattern.  
-  [Frederick Pietschmann](https://github.com/fredpi)
-  [#227](https://github.com/realm/SwiftLint/issues/227)
+* None.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,11 +444,6 @@ This is the last release to support building with Swift 4.2.x.
   in closures when using Swift 5.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2097](https://github.com/realm/SwiftLint/issues/2097)
-  
-* Add new indentation opt-in-rule checking for
-  super-basic additive indentation pattern.  
-  [Frederick Pietschmann](https://github.com/fredpi)
-  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 * Don't trigger a `no_fallthrough_only` violation if next case is an
   `@unknown default`.  
@@ -1060,6 +1055,11 @@ This is the last release to support building with Swift 4.0 and Swift 4.1.
 #### Enhancements
 
 * None.
+  
+* Add new indentation opt-in-rule checking for
+  super-basic additive indentation pattern.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,11 @@
 
 * Make `contains_over_first_not_nil` rule also match `first(where:) == nil`.  
   [Colton Schlosser](https://github.com/cltnschlosser)
+  
+* Add new indentation opt-in-rule checking for
+  super-basic additive indentation pattern.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 * Add two new cases to the Mark rule to detect a Mark using three slashes.  
   [nvanfleet](https://github.com/nvanfleet)
@@ -288,11 +293,6 @@ This is the last release to support building with Swift 4.2.x.
   comparison to `[]` or `[:]`.  
   [Colton Schlosser](https://github.com/cltnschlosser)
   [#2807](https://github.com/realm/SwiftLint/issues/2807)
-  
-* Add new indentation opt-in-rule checking for
-  super-basic additive indentation pattern.  
-  [Frederick Pietschmann](https://github.com/fredpi)
-  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,11 @@ This is the last release to support building with Swift 4.2.x.
   comparison to `[]` or `[:]`.  
   [Colton Schlosser](https://github.com/cltnschlosser)
   [#2807](https://github.com/realm/SwiftLint/issues/2807)
+  
+* Add new indentation opt-in-rule checking for
+  super-basic additive indentation pattern.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#227](https://github.com/realm/SwiftLint/issues/227)
 
 #### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -71,6 +71,7 @@
 * [Implicit Getter](#implicit-getter)
 * [Implicit Return](#implicit-return)
 * [Implicitly Unwrapped Optional](#implicitly-unwrapped-optional)
+* [Indentation Width](#indentation-width)
 * [Inert Defer](#inert-defer)
 * [Is Disjoint](#is-disjoint)
 * [Joined Default Parameter](#joined-default-parameter)
@@ -10632,6 +10633,106 @@ let collection: AnyCollection<Int!>
 
 ```swift
 func foo(int: Int!) {}
+```
+
+</details>
+
+
+
+## Indentation Width
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`indentation_width` | Disabled | No | style | No | 3.0.0 
+
+Indent code using either one tab or the configured amount of spaces, unindent to match previous indentations. Don't indent the first line.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+firstLine
+secondLine
+```
+
+```swift
+firstLine
+    secondLine
+```
+
+```swift
+firstLine
+	secondLine
+```
+
+```swift
+firstLine
+	secondLine
+		thirdLine
+
+		fourthLine
+```
+
+```swift
+firstLine
+	secondLine
+		thirdLine
+ 
+		fourthLine
+```
+
+```swift
+firstLine
+	secondLine
+		thirdLine
+//test
+		fourthLine
+```
+
+```swift
+firstLine
+    secondLine
+        thirdLine
+fourthLine
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+firstLine
+	    secondLine
+```
+
+```swift
+    firstLine
+```
+
+```swift
+firstLine
+        secondLine
+```
+
+```swift
+firstLine
+		secondLine
+```
+
+```swift
+firstLine
+	secondLine
+
+			fourthLine
+```
+
+```swift
+firstLine
+    secondLine
+        thirdLine
+ fourthLine
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -10665,21 +10665,8 @@ firstLine
 ```swift
 firstLine
 	secondLine
-```
-
-```swift
-firstLine
-	secondLine
 		thirdLine
 
-		fourthLine
-```
-
-```swift
-firstLine
-	secondLine
-		thirdLine
- 
 		fourthLine
 ```
 
@@ -10703,22 +10690,12 @@ fourthLine
 <summary>Triggering Examples</summary>
 
 ```swift
-firstLine
-	    secondLine
-```
-
-```swift
     firstLine
 ```
 
 ```swift
 firstLine
         secondLine
-```
-
-```swift
-firstLine
-		secondLine
 ```
 
 ```swift

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -72,6 +72,7 @@ public let masterRuleList = RuleList(rules: [
     ImplicitGetterRule.self,
     ImplicitReturnRule.self,
     ImplicitlyUnwrappedOptionalRule.self,
+    IndentationWidthRule.self,
     InertDeferRule.self,
     IsDisjointRule.self,
     JoinedDefaultParameterRule.self,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -1,17 +1,22 @@
 public struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription), " + "indentation_width: \(indentationWidth)"
+        return "severity: \(severityConfiguration.consoleDescription), "
+            + "indentation_width: \(indentationWidth)"
+            + "include_comments: \(includeComments)"
     }
 
     private(set) public var severityConfiguration: SeverityConfiguration
     private(set) public var indentationWidth: Int
+    private(set) public var includeComments: Bool
 
     public init(
         severity: ViolationSeverity,
-        indentationWidth: Int
+        indentationWidth: Int,
+        includeComments: Bool
     ) {
         self.severityConfiguration = SeverityConfiguration(severity)
         self.indentationWidth = indentationWidth
+        self.includeComments = includeComments
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -25,6 +30,10 @@ public struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
 
         if let indentationWidth = configurationDict["indentation_width"] as? Int, indentationWidth >= 1 {
             self.indentationWidth = indentationWidth
+        }
+
+        if let includeComments = configurationDict["include_comments"] as? Bool {
+            self.includeComments = includeComments
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -5,9 +5,9 @@ public struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
             + "include_comments: \(includeComments)"
     }
 
-    private(set) public var severityConfiguration: SeverityConfiguration
-    private(set) public var indentationWidth: Int
-    private(set) public var includeComments: Bool
+    public private(set) var severityConfiguration: SeverityConfiguration
+    public private(set) var indentationWidth: Int
+    public private(set) var includeComments: Bool
 
     public init(
         severity: ViolationSeverity,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -1,0 +1,30 @@
+public struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
+    public var consoleDescription: String {
+        return "severity: \(severityConfiguration.consoleDescription), " + "indentation_width: \(indentationWidth)"
+    }
+
+    private(set) public var severityConfiguration: SeverityConfiguration
+    private(set) public var indentationWidth: Int
+
+    public init(
+        severity: ViolationSeverity,
+        indentationWidth: Int
+    ) {
+        self.severityConfiguration = SeverityConfiguration(severity)
+        self.indentationWidth = indentationWidth
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configurationDict = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let config = configurationDict["severity"] {
+            try severityConfiguration.apply(configuration: config)
+        }
+
+        if let indentationWidth = configurationDict["indentation_width"] as? Int, indentationWidth >= 1 {
+            self.indentationWidth = indentationWidth
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -1,0 +1,159 @@
+import Foundation
+import SourceKittenFramework
+
+public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
+    // MARK: - Subtypes
+    private enum Indentation: Equatable {
+        case tabs(Int)
+        case spaces(Int)
+
+        func spacesEquivalent(indentationWidth: Int) -> Int {
+            switch self {
+            case let .tabs(tabs): return tabs & indentationWidth
+            case let .spaces(spaces): return spaces
+            }
+        }
+    }
+
+    // MARK: - Properties
+    public var configuration = IndentationWidthConfiguration(severity: .warning, indentationWidth: 4)
+    public static let description = RuleDescription(
+        identifier: "indentation_width",
+        name: "Indentation Width",
+        description: "Indent code using either one tab or the configured amount of spaces, " +
+            "unindent to match previous indentations. Don't indent the first line.",
+        kind: .style,
+        nonTriggeringExamples: [
+            "firstLine\nsecondLine", // It's okay to keep the same indentation
+            "firstLine\n    secondLine", // It's okay to indent using the specified indentationWidth
+            "firstLine\n\tsecondLine", // It's okay to indent using a tab
+            "firstLine\n\tsecondLine\n\t\tthirdLine\n\n\t\tfourthLine", // It's okay to have empty lines between
+            "firstLine\n\tsecondLine\n\t\tthirdLine\n \n\t\tfourthLine", // It's okay to have empty lines between
+            "firstLine\n\tsecondLine\n\t\tthirdLine\n//test\n\t\tfourthLine", // It's okay to have comment lines between
+            "firstLine\n    secondLine\n        thirdLine\nfourthLine"
+            // It's okay to unindent indentationWidth * (1, 2, 3, ...)
+        ],
+        triggeringExamples: [
+            "firstLine\n\t    secondLine", // It's not okay to indent using both tabs and spaces in one line
+            "    firstLine", // It's not okay to have the first line indented
+            "firstLine\n        secondLine", // It's not okay to indent using neither one tab or indentationWidth spaces
+            "firstLine\n\t\tsecondLine", // It's not okay to indent using multiple tabs
+            "firstLine\n\tsecondLine\n\n\t\t\tfourthLine",
+            // It's okay to have empty lines between, but then, the following indentation must obey the rules
+            "firstLine\n    secondLine\n        thirdLine\n fourthLine"
+            // It's not okay to unindent indentationWidth * (1, 2, 3, ...) - 3
+        ]
+    )
+
+    // MARK: - Initializers
+    public init() {}
+
+    // MARK: - Methods: Validation
+    public func validate(file: File) -> [StyleViolation] { // swiftlint:disable:this function_body_length
+        var violations: [StyleViolation] = []
+        var previousLineIndentation: Indentation?
+
+        for line in file.lines {
+            let indentationCharacterCount = line.content.countOfLeadingCharacters(in: CharacterSet(charactersIn: " \t"))
+
+            // Skip line if it's a whitespace or comment line
+            if line.content.count == indentationCharacterCount || line.content.prefix(2) == "//" { continue }
+
+            // Get space and tab count in prefix
+            let prefix = String(line.content.prefix(indentationCharacterCount))
+            let tabCount = prefix.filter { $0 == "\t" }.count
+            let spaceCount = prefix.filter { $0 == " " }.count
+
+            // Catch mixed indentation
+            if tabCount != 0 && spaceCount != 0 {
+                violations.append(
+                    StyleViolation(
+                        ruleDescription: IndentationWidthRule.description,
+                        severity: .warning,
+                        location: Location(file: file, characterOffset: line.range.location),
+                        reason: "Code should be indented with tabs or " +
+                        "\(configuration.indentationWidth) spaces, but not both in the same line."
+                    )
+                )
+
+                // Break as next line cannot be parsed without knowing this line's exact indentation
+                break
+            }
+
+            // Catch indented first line
+            let indentation: Indentation = tabCount != 0 ? .tabs(tabCount) : .spaces(spaceCount)
+            guard let lastIndentation = previousLineIndentation else {
+                previousLineIndentation = indentation
+
+                if indentation != .spaces(0) {
+                    // There's an indentation although this is the first line!
+                    violations.append(
+                        StyleViolation(
+                            ruleDescription: IndentationWidthRule.description,
+                            severity: .warning,
+                            location: Location(file: file, characterOffset: line.range.location),
+                            reason: "The first line shall not be indented."
+                        )
+                    )
+                }
+
+                continue
+            }
+
+            // Catch wrong indentation or wrong unindentation
+            if !validate(indentation: indentation, comparingTo: lastIndentation) {
+                let isIndentation = indentation.spacesEquivalent(indentationWidth: configuration.indentationWidth) >=
+                    lastIndentation.spacesEquivalent(indentationWidth: configuration.indentationWidth)
+
+                let indentWidth = configuration.indentationWidth
+                violations.append(
+                    StyleViolation(
+                        ruleDescription: IndentationWidthRule.description,
+                        severity: .warning,
+                        location: Location(file: file, characterOffset: line.range.location),
+                        reason: isIndentation ?
+                            "Code should be indented using one tab or \(indentWidth) spaces." :
+                            "Code should be unindented by multiples of one tab or multiples of \(indentWidth) spaces."
+                    )
+                )
+            } else {
+                // Only store if validation went well, avoids a duplicate warning in consequential lines
+                previousLineIndentation = indentation
+            }
+        }
+
+        return violations
+    }
+
+    /// Validates whether the indentation of a specific line is valid
+    /// based on the indentation of the previous line.
+    ///
+    /// Returns a Bool determining the validity of the indentation.
+    private func validate(indentation: Indentation, comparingTo lastIndentation: Indentation) -> Bool {
+        switch indentation {
+        case let .spaces(currentSpaceCount):
+            let previousSpacesCount = lastIndentation.spacesEquivalent(indentationWidth: configuration.indentationWidth)
+            guard
+                currentSpaceCount == previousSpacesCount + configuration.indentationWidth ||
+                (
+                    (previousSpacesCount - currentSpaceCount) >= 0 &&
+                    (previousSpacesCount - currentSpaceCount) % configuration.indentationWidth == 0
+                )
+            else { return false }
+
+        case let .tabs(currentTabCount):
+            switch lastIndentation {
+            case let .spaces(previousSpacesCount):
+                guard
+                    currentTabCount * configuration.indentationWidth - previousSpacesCount
+                        <= configuration.indentationWidth
+                else { return false }
+
+            case let .tabs(previousTabCount):
+                guard currentTabCount - previousTabCount <= 1 else { return false }
+            }
+        }
+
+        return true
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -28,24 +28,17 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
             "unindent to match previous indentations. Don't indent the first line.",
         kind: .style,
         nonTriggeringExamples: [
-            "firstLine\nsecondLine", // It's okay to keep the same indentation
-            "firstLine\n    secondLine", // It's okay to indent using the specified indentationWidth
-            "firstLine\n\tsecondLine", // It's okay to indent using a tab
-            "firstLine\n\tsecondLine\n\t\tthirdLine\n\n\t\tfourthLine", // It's okay to have empty lines between
-            "firstLine\n\tsecondLine\n\t\tthirdLine\n \n\t\tfourthLine", // It's okay to have empty lines between
-            "firstLine\n\tsecondLine\n\t\tthirdLine\n//test\n\t\tfourthLine", // It's okay to have comment lines between
+            "firstLine\nsecondLine",
+            "firstLine\n    secondLine",
+            "firstLine\n\tsecondLine\n\t\tthirdLine\n\n\t\tfourthLine",
+            "firstLine\n\tsecondLine\n\t\tthirdLine\n//test\n\t\tfourthLine",
             "firstLine\n    secondLine\n        thirdLine\nfourthLine"
-            // It's okay to unindent indentationWidth * (1, 2, 3, ...)
         ],
         triggeringExamples: [
-            "firstLine\n\t    secondLine", // It's not okay to indent using both tabs and spaces in one line
-            "    firstLine", // It's not okay to have the first line indented
-            "firstLine\n        secondLine", // It's not okay to indent using neither one tab or indentationWidth spaces
-            "firstLine\n\t\tsecondLine", // It's not okay to indent using multiple tabs
+            "    firstLine",
+            "firstLine\n        secondLine",
             "firstLine\n\tsecondLine\n\n\t\t\tfourthLine",
-            // It's okay to have empty lines between, but then, the following indentation must obey the rules
             "firstLine\n    secondLine\n        thirdLine\n fourthLine"
-            // It's not okay to unindent indentationWidth * (1, 2, 3, ...) - 3
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -46,7 +46,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
     public init() {}
 
     // MARK: - Methods: Validation
-    public func validate(file: File) -> [StyleViolation] { // swiftlint:disable:this function_body_length
+    public func validate(file: SwiftLintFile) -> [StyleViolation] { // swiftlint:disable:this function_body_length
         var violations: [StyleViolation] = []
         var previousLineIndentations: [Indentation] = []
 

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -51,15 +51,14 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
         var previousLineIndentations: [Indentation] = []
 
         for line in file.lines {
+            // Skip line if it's a whitespace-only line
             let indentationCharacterCount = line.content.countOfLeadingCharacters(in: CharacterSet(charactersIn: " \t"))
+            if line.content.count == indentationCharacterCount { continue }
 
-            if configuration.includeComments {
-                // Skip line if it's a whitespace-only line
-                if line.content.count == indentationCharacterCount { continue }
-            } else {
-                // Skip line if it only has whitespaces or is a part of a comment
+            if !configuration.includeComments {
+                // Skip line if it's part of a comment
                 let syntaxKindsInLine = Set(file.syntaxMap.tokens(inByteRange: line.byteRange).kinds)
-                if SyntaxKind.commentKinds.isSuperset(of: syntaxKindsInLine) { continue }
+                if !syntaxKindsInLine.isEmpty && SyntaxKind.commentKinds.isSuperset(of: syntaxKindsInLine) { continue }
             }
 
             // Get space and tab count in prefix

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -243,6 +243,9 @@
 		C946FECB1EAE67EE007DD778 /* LetVarWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */; };
 		C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */; };
 		CC26ED07204DEB510013BBBC /* RuleIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */; };
+		CC6D28592292F0380052B682 /* IndentationWidthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6D28572292EF460052B682 /* IndentationWidthRule.swift */; };
+		CC6D285B2292F0600052B682 /* IndentationWidthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6D285A2292F0600052B682 /* IndentationWidthConfiguration.swift */; };
+		CC8C6D2322935F5200A55D1A /* IndentationWidthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8C6D2122935F4E00A55D1A /* IndentationWidthRuleTests.swift */; };
 		CCD8B87920559D1E00B75847 /* DisableAllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD8B87720559C4A00B75847 /* DisableAllTests.swift */; };
 		CE8178ED1EAC039D0063186E /* UnusedOptionalBindingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -742,6 +745,9 @@
 		C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LetVarWhitespaceRule.swift; sourceTree = "<group>"; };
 		C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
 		CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleIdentifier.swift; sourceTree = "<group>"; };
+		CC6D28572292EF460052B682 /* IndentationWidthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationWidthRule.swift; sourceTree = "<group>"; usesTabs = 0; };
+		CC6D285A2292F0600052B682 /* IndentationWidthConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationWidthConfiguration.swift; sourceTree = "<group>"; };
+		CC8C6D2122935F4E00A55D1A /* IndentationWidthRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationWidthRuleTests.swift; sourceTree = "<group>"; };
 		CCD8B87720559C4A00B75847 /* DisableAllTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableAllTests.swift; sourceTree = "<group>"; };
 		CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingConfiguration.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -1052,6 +1058,7 @@
 				8B01E4FB20A4183C00C9233E /* FunctionParameterCountConfiguration.swift */,
 				47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */,
 				B1FD3AB8238877F200CE121E /* ImplicitReturnConfiguration.swift */,
+				CC6D285A2292F0600052B682 /* IndentationWidthConfiguration.swift */,
 				3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */,
 				F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */,
 				188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */,
@@ -1215,10 +1222,10 @@
 				1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */,
 				756B585C2138ECD300D1A4E9 /* CollectionAlignmentRule.swift */,
 				E88DEA831B0990F500A66CB0 /* ColonRule.swift */,
-				D4D0B8F32211428D0053A116 /* ColonRuleExamples.swift */,
 				D47EF4811F69E34D0012C4CA /* ColonRule+Dictionary.swift */,
 				D47EF47F1F69E3100012C4CA /* ColonRule+FunctionCall.swift */,
 				D47EF4831F69E3D60012C4CA /* ColonRule+Type.swift */,
+				D4D0B8F32211428D0053A116 /* ColonRuleExamples.swift */,
 				695BE9CE1BDFD92B0071E985 /* CommaRule.swift */,
 				93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */,
 				65454F451B14D73800319A6C /* ControlStatementRule.swift */,
@@ -1235,6 +1242,7 @@
 				D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */,
 				D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */,
 				B1FD3ABE238BC6D400CE121E /* ImplicitReturnRuleExamples.swift */,
+				CC6D28572292EF460052B682 /* IndentationWidthRule.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */,
 				D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */,
@@ -1537,6 +1545,7 @@
 				47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */,
 				B1FD3ABA238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift */,
 				B1FD3ABC238BC5FB00CE121E /* ImplicitReturnRuleTests.swift */,
+				CC8C6D2122935F4E00A55D1A /* IndentationWidthRuleTests.swift */,
 				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
 				3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */,
 				3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */,
@@ -2103,6 +2112,7 @@
 				D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */,
 				D4EA77C81F817FD200C315FB /* UnneededBreakInSwitchRule.swift in Sources */,
 				D4D383852145F550000235BD /* StaticOperatorRule.swift in Sources */,
+				CC6D285B2292F0600052B682 /* IndentationWidthConfiguration.swift in Sources */,
 				006204DC1E1E492F00FFFBE1 /* VerticalWhitespaceConfiguration.swift in Sources */,
 				E88198441BEA93D200333A11 /* ColonRule.swift in Sources */,
 				623675B21F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift in Sources */,
@@ -2296,6 +2306,7 @@
 				D4DABFD71E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift in Sources */,
 				3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */,
 				D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */,
+				CC6D28592292F0380052B682 /* IndentationWidthRule.swift in Sources */,
 				C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */,
 				A3184D56215BCEFF00621EA2 /* LegacyRandomRule.swift in Sources */,
 				626C16E21F948EBC00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift in Sources */,
@@ -2338,6 +2349,7 @@
 				E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */,
 				D4C27C001E12DFF500DF713E /* LinterCacheTests.swift in Sources */,
 				D45255C81F0932F8003C9B56 /* RuleDescription+Examples.swift in Sources */,
+				CC8C6D2322935F5200A55D1A /* IndentationWidthRuleTests.swift in Sources */,
 				E81ADD721ED5ED9D000CD451 /* RegionTests.swift in Sources */,
 				D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */,
 				750BBD0B214180AF007EC437 /* CollectionAlignmentRuleTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -692,7 +692,8 @@ extension ImplicitlyUnwrappedOptionalRuleTests {
 
 extension IndentationWidthRuleTests {
     static var allTests: [(String, (IndentationWidthRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testTriggeringExamples", testTriggeringExamples),
+        ("testNonTriggeringExamples", testNonTriggeringExamples)
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -244,7 +244,8 @@ extension CustomRulesTests {
         ("testLocalDisableCustomRuleWithMultipleRules", testLocalDisableCustomRuleWithMultipleRules),
         ("testCustomRulesIncludedDefault", testCustomRulesIncludedDefault),
         ("testCustomRulesIncludedExcludesFile", testCustomRulesIncludedExcludesFile),
-        ("testCustomRulesExcludedExcludesFile", testCustomRulesExcludedExcludesFile)
+        ("testCustomRulesExcludedExcludesFile", testCustomRulesExcludedExcludesFile),
+        ("testCustomRulesCaptureGroup", testCustomRulesCaptureGroup)
     ]
 }
 
@@ -699,6 +700,7 @@ extension IndentationWidthRuleTests {
         ("testIndentationLength", testIndentationLength),
         ("testUnindentation", testUnindentation),
         ("testEmptyLinesBetween", testEmptyLinesBetween),
+        ("testsBrackets", testsBrackets),
         ("testCommentLines", testCommentLines),
         ("testDuplicateWarningAvoidanceMechanism", testDuplicateWarningAvoidanceMechanism)
     ]

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -690,6 +690,12 @@ extension ImplicitlyUnwrappedOptionalRuleTests {
     ]
 }
 
+extension IndentationWidthRuleTests {
+    static var allTests: [(String, (IndentationWidthRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension InertDeferRuleTests {
     static var allTests: [(String, (InertDeferRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1711,6 +1717,7 @@ XCTMain([
     testCase(ImplicitReturnRuleTests.allTests),
     testCase(ImplicitlyUnwrappedOptionalConfigurationTests.allTests),
     testCase(ImplicitlyUnwrappedOptionalRuleTests.allTests),
+    testCase(IndentationWidthRuleTests.allTests),
     testCase(InertDeferRuleTests.allTests),
     testCase(IntegrationTests.allTests),
     testCase(IsDisjointRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -692,8 +692,14 @@ extension ImplicitlyUnwrappedOptionalRuleTests {
 
 extension IndentationWidthRuleTests {
     static var allTests: [(String, (IndentationWidthRuleTests) -> () throws -> Void)] = [
-        ("testTriggeringExamples", testTriggeringExamples),
-        ("testNonTriggeringExamples", testNonTriggeringExamples)
+        ("testFirstLineIndentation", testFirstLineIndentation),
+        ("testMixedTabSpaceIndentation", testMixedTabSpaceIndentation),
+        ("testKeepingIndentation", testKeepingIndentation),
+        ("testIndentationLength", testIndentationLength),
+        ("testUnindentation", testUnindentation),
+        ("testEmptyLinesBetween", testEmptyLinesBetween),
+        ("testCommentLines", testCommentLines),
+        ("testDuplicateWarningAvoidanceMechanism", testDuplicateWarningAvoidanceMechanism)
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -694,6 +694,7 @@ extension IndentationWidthRuleTests {
     static var allTests: [(String, (IndentationWidthRuleTests) -> () throws -> Void)] = [
         ("testFirstLineIndentation", testFirstLineIndentation),
         ("testMixedTabSpaceIndentation", testMixedTabSpaceIndentation),
+        ("testMixedTabsAndSpacesIndentation", testMixedTabsAndSpacesIndentation),
         ("testKeepingIndentation", testKeepingIndentation),
         ("testIndentationLength", testIndentationLength),
         ("testUnindentation", testUnindentation),

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -21,6 +21,13 @@ class IndentationWidthRuleTests: XCTestCase {
         assertViolations(in: "firstLine\n    \tsecondLine", equals: 2)
     }
 
+    /// It's okay to indent using either tabs or spaces in different lines.
+    func testMixedTabsAndSpacesIndentation() {
+        assertNoViolation(in: "firstLine\n\tsecondLine\n        thirdLine")
+        assertNoViolation(in: "firstLine\n    secondLine\n\t\tthirdLine")
+        assertNoViolation(in: "firstLine\n\tsecondLine\n        thirdLine\n\t\t\tfourthLine")
+    }
+
     /// It's okay to keep the same indentation.
     func testKeepingIndentation() {
         assertNoViolation(in: "firstLine\nsecondLine")

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -16,8 +16,9 @@ class IndentationWidthRuleTests: XCTestCase {
 
     /// It's not okay to indent using both tabs and spaces in one line.
     func testMixedTabSpaceIndentation() {
-        assert1Violation(in: "firstLine\n\t    secondLine")
-        assert1Violation(in: "firstLine\n    \tsecondLine")
+        // Expect 2 violations as secondLine is also indented by 8 spaces (which isn't valid)
+        assertViolations(in: "firstLine\n\t    secondLine", equals: 2)
+        assertViolations(in: "firstLine\n    \tsecondLine", equals: 2)
     }
 
     /// It's okay to keep the same indentation.

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import SwiftLintFramework
+import XCTest
+
+class IndentationWidthRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        // Don't do crazy testing as this triggers invalid warnings
+        verifyRule(
+            IndentationWidthRule.description,
+            skipCommentTests: true,
+            skipDisableCommandTests: true,
+            testMultiByteOffsets: false,
+            testShebang: false
+        )
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 class IndentationWidthRuleTests: XCTestCase {
-    // MARK: Triggering Examples
+    // MARK: Examples
     /// It's not okay to have the first line indented.
     func testFirstLineIndentation() {
         assert1Violation(in: "    firstLine")
@@ -85,6 +85,28 @@ class IndentationWidthRuleTests: XCTestCase {
         assert1Violation(in: "firstLine\n\tsecondLine\n\n            fourthLine")
         assert1Violation(in: "firstLine\n\tsecondLine\n \n            fourthLine")
         assert1Violation(in: "firstLine\n\tsecondLine\n           \n            fourthLine")
+    }
+
+    func testsBrackets() {
+        assertNoViolation(
+            in: "firstLine\n    [\n        .thirdLine\n    ]\nfifthLine",
+            includeComments: true
+        )
+
+        assertNoViolation(
+            in: "firstLine\n    [\n        .thirdLine\n    ]\nfifthLine",
+            includeComments: false
+        )
+
+        assertNoViolation(
+            in: "firstLine\n    (\n        .thirdLine\n    )\nfifthLine",
+            includeComments: true
+        )
+
+        assertNoViolation(
+            in: "firstLine\n    (\n        .thirdLine\n    )\nfifthLine",
+            includeComments: false
+        )
     }
 
     /// It's okay to have comments not following the indentation pattern iff the configuration allows this.

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 @testable import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -3,10 +3,43 @@ import Foundation
 import XCTest
 
 class IndentationWidthRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
+    func testTriggeringExamples() {
+        let triggeringExamples = [
+            "firstLine\n\t    secondLine", // It's not okay to indent using both tabs and spaces in one line
+            "    firstLine", // It's not okay to have the first line indented
+            "firstLine\n        secondLine", // It's not okay to indent using neither one tab or indentationWidth spaces
+            "firstLine\n\t\tsecondLine", // It's not okay to indent using multiple tabs
+            "firstLine\n\tsecondLine\n\n\t\t\tfourthLine",
+            // It's okay to have empty lines between, but then, the following indentation must obey the rules
+            "firstLine\n    secondLine\n        thirdLine\n fourthLine"
+            // It's not okay to unindent indentationWidth * (1, 2, 3, ...) - 3
+        ]
+
         // Don't do crazy testing as this triggers invalid warnings
         verifyRule(
-            IndentationWidthRule.description,
+            IndentationWidthRule.description.with(nonTriggeringExamples: [], triggeringExamples: triggeringExamples),
+            skipCommentTests: true,
+            skipDisableCommandTests: true,
+            testMultiByteOffsets: false,
+            testShebang: false
+        )
+    }
+
+    func testNonTriggeringExamples() {
+        let nonTriggeringExamples = [
+            "firstLine\nsecondLine", // It's okay to keep the same indentation
+            "firstLine\n    secondLine", // It's okay to indent using the specified indentationWidth
+            "firstLine\n\tsecondLine", // It's okay to indent using a tab
+            "firstLine\n\tsecondLine\n\t\tthirdLine\n\n\t\tfourthLine", // It's okay to have empty lines between
+            "firstLine\n\tsecondLine\n\t\tthirdLine\n \n\t\tfourthLine", // It's okay to have empty lines between
+            // "firstLine\n\tsecondLine\n\t\tthirdLine\n//test\n\t\tfourthLine", // It's okay to have comment lines between
+            "firstLine\n    secondLine\n        thirdLine\nfourthLine"
+            // It's okay to unindent indentationWidth * (1, 2, 3, ...)
+        ]
+
+        // Don't do crazy testing as this triggers invalid warnings
+        verifyRule(
+            IndentationWidthRule.description.with(nonTriggeringExamples: nonTriggeringExamples, triggeringExamples: []),
             skipCommentTests: true,
             skipDisableCommandTests: true,
             testMultiByteOffsets: false,


### PR DESCRIPTION
It's been a while since https://github.com/realm/SwiftLint/issues/227 has last been discussed and it seems that an advanced indentation rule is somehow also pending some clarification on Xcode's side. However, since this issue has been open for such a long time, I thought about adding a basic additive indentation rule that only does the following things:

- Check whether the next line is on the same level as the previous line or one tab or `n` spaces indented (where `n` can be configured via `indentation_width`) or unindented keeping the grid.
- Check whether the first line is not indented.
- Check whether spaces and tabs aren't mixed up in one line's indentation.

This PR implements such a basic rule. I tested it with a large project we have in our company and found out that it matches the indentation style we already pursued before:

```
let testStruct = TestStruct(
    name: "Test",
    indentation: "Cool"
)
```

However, this rule won't be compatible with other indentation styles like the one Xcode does by default and that is enforced by the `vertical_parameter_alignment_on_call` opt-in-rule:

```
let testStruct = TestStruct(name: "Test",
                            indentation: "Cool")
```

That's why this is an opt-in rule. As such, it won't do harm to those following another indentation style, yet enable built-in indentation linting for those who follow this basic additive pattern. Previously, we had implemented such a rule using multiple regexes that checked for indentation but didn't always work properly, so having this built-in is definitely a plus.

I want to mention that, according to this rule, unindentation can not only be done by one step (~ `indentation_width` spaces), but also by multiples of one step. This is to allow for the following indentation which I consider valid:

```
if
    let myLet = someBool ?
        myLet1 :
        myLet2
{
    // Do something with myLet
} 
```