### PR TITLE
Print relative path for duplicate filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   ViolationSeverity.  
   [JP Simard](https://github.com/jpsim)
 
+* Print full relative path to file in log output when it matches the file name
+  of another path being linted.  
+  [Keith Smiley](https://github.com/keith)
+
 #### Bug Fixes
 
 * Don't trigger `vertical_parameter_alignment` violations when using parameters

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -89,11 +89,11 @@ extension Configuration {
         }
 
         var pathComponents = path.pathComponents
-        for component in root.pathComponents where !pathComponents.isEmpty && pathComponents[0] == component {
+        for component in root.pathComponents where pathComponents.first == component {
             pathComponents.removeFirst()
         }
 
-        return NSString.path(withComponents: pathComponents)
+        return pathComponents.joined(separator: "/")
     }
 
     private func visit(filesPerConfiguration: [Configuration: [File]],
@@ -104,7 +104,8 @@ extension Configuration {
         let visit = { (file: File, config: Configuration, duplicateFileNames: Set<String>) -> Void in
             let skipFile = visitor.shouldSkipFile(atPath: file.path)
             if !visitor.quiet, let filePath = file.path?.bridge() {
-                let outputFilename = self.outputFilename(for: filePath, in: root, duplicateFileNames: duplicateFileNames)
+                let outputFilename = self.outputFilename(for: filePath, in: root,
+                                                         duplicateFileNames: duplicateFileNames)
                 let increment = {
                     index += 1
                     if skipFile {


### PR DESCRIPTION
In projects with multiple Swift targets, it's possible to have multiple
Swift files with the same name. In this case you can't differentiate
from the log, which one SwiftLint is printing about. Now in this case it
prints the relative (to your pwd) path of the file.