### PR TITLE
Synthesize Equatable implementations where possible

### DIFF
--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -4,7 +4,7 @@ enum FileType: String {
     case `extension` = "extension"
 }
 
-public struct FileTypesOrderConfiguration: RuleConfiguration {
+public struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var order: [[FileType]] = [
         [.supportingType],
@@ -39,17 +39,5 @@ public struct FileTypesOrderConfiguration: RuleConfiguration {
         if !customOrder.isEmpty {
             self.order = customOrder
         }
-    }
-}
-
-extension FileTypesOrderConfiguration: Equatable {
-    public static func == (lhs: FileTypesOrderConfiguration, rhs: FileTypesOrderConfiguration) -> Bool {
-        guard lhs.order.count == rhs.order.count else { return false }
-
-        for (leftIndex, leftOrderEntry) in lhs.order.enumerated() {
-            guard rhs.order[leftIndex] == leftOrderEntry else { return false }
-        }
-
-        return lhs.severityConfiguration == rhs.severityConfiguration
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -15,7 +15,7 @@ enum TypeContent: String {
     case `subscript` = "subscript"
 }
 
-public struct TypeContentsOrderConfiguration: RuleConfiguration {
+public struct TypeContentsOrderConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var order: [[TypeContent]] = [
         [.case],
@@ -60,17 +60,5 @@ public struct TypeContentsOrderConfiguration: RuleConfiguration {
         if !customOrder.isEmpty {
             self.order = customOrder
         }
-    }
-}
-
-extension TypeContentsOrderConfiguration: Equatable {
-    public static func == (lhs: TypeContentsOrderConfiguration, rhs: TypeContentsOrderConfiguration) -> Bool {
-        guard lhs.order.count == rhs.order.count else { return false }
-
-        for (leftIndex, leftOrderEntry) in lhs.order.enumerated() {
-            guard rhs.order[leftIndex] == leftOrderEntry else { return false }
-        }
-
-        return lhs.severityConfiguration == rhs.severityConfiguration
     }
 }


### PR DESCRIPTION
This has been possible since Swift 4.1 and we now require Swift 4.2 to build SwiftLint.