### PR TITLE
Split cache into one file per configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 #### Enhancements
 
-* Split cache into one file per configuration.  
+* Significantly improve performance when running with a large number of cached
+  configurations.  
   [Colton Schlosser](https://github.com/cltnschlosser)
-  [#2796](https://github.com/realm/SwiftLint/pull/2796)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* Split cache into one file per configuration.  
+  [Colton Schlosser](https://github.com/cltnschlosser)
+  [#2796](https://github.com/realm/SwiftLint/pull/2796)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -87,6 +87,6 @@ extension Configuration {
             queuedPrintError("Error while creating cache: " + error.localizedDescription)
         }
 
-        return folder.appendingPathComponent("cache.json")
+        return folder
     }
 }

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -118,11 +118,7 @@ public final class LinterCache {
         let readCache = lazyReadCache
         readCacheLock.unlock()
 
-        for (description, writeFileCache) in writeCache {
-            guard !writeFileCache.isEmpty else {
-                continue
-            }
-
+        for (description, writeFileCache) in writeCache where !writeFileCache.isEmpty {
             let fileCache = readCache[description]?.merging(writeFileCache) { _, write in write } ?? writeFileCache
             let json = try fileCache.toJSON()
             let file = url.appendingPathComponent(description).appendingPathExtension("json")

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -126,7 +126,7 @@ public final class LinterCache {
             let fileCache = readCache[description]?.merging(writeFileCache) { _, write in write } ?? writeFileCache
             let json = try fileCache.toJSON()
             let file = url.appendingPathComponent(description).appendingPathExtension("json")
-            try json.write(to: file, atomically: true, encoding: .utf8)
+            try json.write(to: file, options: .atomic)
         }
     }
 
@@ -233,13 +233,8 @@ private extension StyleViolation {
 }
 
 internal extension Dictionary where Key == String {
-    func toJSON() throws -> String {
+    func toJSON() throws -> Data {
         // not using .sortedKeys to avoid crash
-        let prettyJSONData = try JSONSerialization.data(withJSONObject: self, options: .prettyPrinted)
-        if let jsonString = String(data: prettyJSONData, encoding: .utf8) {
-            return jsonString
-        } else {
-            throw LinterCacheError.invalidFormat
-        }
+        return try JSONSerialization.data(withJSONObject: self, options: .prettyPrinted)
     }
 }


### PR DESCRIPTION
This improves cache deserialization performance. I discovered this potential bottleneck after accidentally running swiftlint over a large amount of generated files. This caused my cache to balloon in size.

Here are some rough performance numbers from a large app, with many private pods. Times collected using `time` utility averaged over several runs and rounded. This isn't the most accurate way to benchmark, but I was looking for big noticeable changes.
Also I found I could improve the script we were using for running swiftlint over the whole project. You'll see this referenced as `old script` and `new script`.
`old script` was implemented by running `swiftlint` once for each private pod path.
`new script` batches all the paths together and runs `swiftlint` once by providing it multiple paths.

```
0.33.0:
Old script:
- Without cache: 37
- With bloated cache: 3:08
- After minimal cache: 32

New script:
- Without cache: 35
- With bloated cache: 5.6
- With minimal cache: 2.8

cs_splitCache:
Old script:
- Without cache: 38
- With empty cache: 39
- With cache: 5.9

New script:
- Without cache: 34
- With empty cache: 34
- With cache: 2.8
```

`Without cache` tests were run with `--no-cache`.
`With empty cache` tests were run after deleting the caches directory. This was to confirm that saving to the cache didn't have large impact to performance.

Key take aways here:
- Old script was harshly punished by bloated and long cache load times. This is because the cache had to be loaded multiple times.
- Splitting the cache helps reduce cache bloat. This is especially useful for people who use swiftlint on multiple large projects.

Other things tested:
- Using read/write locks or DispatchQueues instead of NSLock. This didn't have a measurable effect in my testing, so I left the NSLocks because they are more simple.

Concerns:
- Possible regression for projects with lots of `.swiftlint.yml` configuration files. If anyone has a project I can test, or wants to help make an example worst case project, let me know. Considering all the fileIO swiftlint already does, I wouldn't expect this to be a bottleneck, but I consider it an area where there could be a performance regression.