### PR TITLE
Migrate LinterCache to use Codable models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,16 @@
 #### Enhancements
 
 * Significantly improve performance when running with a large number of cached
-  configurations.  
+  configurations or when running with many cached results.
+  This was done by splitting each configuration to have its own cache and by
+  encoding the cache as a binary property list instead of json.  
   [Colton Schlosser](https://github.com/cltnschlosser)
+  [JP Simard](https://github.com/jpsim)
+
+* Several public types in SwiftLintFramework have added `Codable` conformance:
+  Location, RuleDescription, RuleKind, StyleViolation, SwiftVersion,
+  ViolationSeverity.  
+  [JP Simard](https://github.com/jpsim)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 private enum LinterCacheError: Error {
-    case invalidFormat
     case noLocation
 }
 

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -122,6 +122,7 @@ public final class LinterCache {
         defer {
             readCacheLock.unlock()
         }
+
         if let fileCache = lazyReadCache[cacheDescription] {
             return fileCache
         }
@@ -130,10 +131,9 @@ public final class LinterCache {
             return .empty
         }
 
-        let decoder = Decoder()
         let file = location.appendingPathComponent(cacheDescription).appendingPathExtension(LinterCache.fileExtension)
         let data = try? Data(contentsOf: file)
-        let fileCache = data.flatMap { try? decoder.decode(FileCache.self, from: $0) } ?? .empty
+        let fileCache = data.flatMap { try? Decoder().decode(FileCache.self, from: $0) } ?? .empty
         lazyReadCache[cacheDescription] = fileCache
         return fileCache
     }

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -1,12 +1,23 @@
 import Foundation
 
-internal enum LinterCacheError: Error {
+private enum LinterCacheError: Error {
     case invalidFormat
     case noLocation
 }
 
+private struct FileCacheEntry: Codable {
+    let violations: [StyleViolation]
+    let lastModification: Date
+    let swiftVersion: SwiftVersion
+}
+
+private struct FileCache: Codable {
+    var entries: [String: FileCacheEntry]
+
+    static var empty: FileCache { return FileCache(entries: [:]) }
+}
+
 public final class LinterCache {
-    private typealias FileCache = [String: [String: Any]]
     private typealias Cache = [String: FileCache]
 
     private var lazyReadCache: Cache
@@ -17,36 +28,21 @@ public final class LinterCache {
     private let location: URL?
     private let swiftVersion: SwiftVersion
 
-    internal init(fileManager: LintableFileManager = FileManager.default,
-                  swiftVersion: SwiftVersion = .current) {
+    internal init(fileManager: LintableFileManager = FileManager.default, swiftVersion: SwiftVersion = .current) {
         location = nil
         self.fileManager = fileManager
-        self.lazyReadCache = [:]
+        self.lazyReadCache = Cache()
         self.swiftVersion = swiftVersion
     }
 
-    internal init(cache: Any, fileManager: LintableFileManager = FileManager.default,
-                  swiftVersion: SwiftVersion = .current) throws {
-        guard let dictionary = cache as? Cache else {
-            throw LinterCacheError.invalidFormat
-        }
-
-        self.lazyReadCache = dictionary
-        location = nil
-        self.fileManager = fileManager
-        self.swiftVersion = swiftVersion
-    }
-
-    public init(configuration: Configuration,
-                fileManager: LintableFileManager = FileManager.default) {
+    public init(configuration: Configuration, fileManager: LintableFileManager = FileManager.default) {
         location = configuration.cacheURL
-        lazyReadCache = [:]
+        lazyReadCache = Cache()
         self.fileManager = fileManager
         self.swiftVersion = .current
     }
 
-    private init(cache: Cache, location: URL?, fileManager: LintableFileManager,
-                 swiftVersion: SwiftVersion) {
+    private init(cache: Cache, location: URL?, fileManager: LintableFileManager, swiftVersion: SwiftVersion) {
         self.lazyReadCache = cache
         self.location = location
         self.fileManager = fileManager
@@ -61,45 +57,23 @@ public final class LinterCache {
         let configurationDescription = configuration.cacheDescription
 
         writeCacheLock.lock()
-        var filesCache = writeCache[configurationDescription] ?? [:]
-        filesCache[file] = [
-            Key.violations.rawValue: violations.map(dictionary(for:)),
-            Key.lastModification.rawValue: lastModification.timeIntervalSinceReferenceDate,
-            Key.swiftVersion.rawValue: swiftVersion.rawValue
-        ]
+        var filesCache = writeCache[configurationDescription] ?? .empty
+        filesCache.entries[file] = FileCacheEntry(violations: violations, lastModification: lastModification,
+                                                  swiftVersion: swiftVersion)
         writeCache[configurationDescription] = filesCache
         writeCacheLock.unlock()
     }
 
     internal func violations(forFile file: String, configuration: Configuration) -> [StyleViolation]? {
-        guard let lastModification = fileManager.modificationDate(forFileAtPath: file) else {
-            return nil
-        }
-
-        let configurationDescription = configuration.cacheDescription
-
-        func getCacheLastModification(dict: [String: Any]) -> TimeInterval? {
-            let value = dict[.lastModification]
-#if os(Linux)
-            if let cacheLastModificationInt = value as? Int {
-                return TimeInterval(cacheLastModificationInt)
-            }
-#endif
-            return value as? TimeInterval
-        }
-
-        let filesCache = fileCache(cacheDescription: configurationDescription)
-        guard let entry = filesCache[file],
-            let cacheLastModification = getCacheLastModification(dict: entry),
-            cacheLastModification == lastModification.timeIntervalSinceReferenceDate,
-            let swiftVersion = (entry[.swiftVersion] as? String).flatMap(SwiftVersion.init(rawValue:)),
-            swiftVersion == self.swiftVersion,
-            let violations = entry[.violations] as? [[String: Any]]
+        guard let lastModification = fileManager.modificationDate(forFileAtPath: file),
+            let entry = fileCache(cacheDescription: configuration.cacheDescription).entries[file],
+            entry.lastModification == lastModification,
+            entry.swiftVersion == swiftVersion
         else {
             return nil
         }
 
-        return violations.compactMap { StyleViolation.from(cache: $0, file: file) }
+        return entry.violations
     }
 
     public func save() throws {
@@ -118,17 +92,19 @@ public final class LinterCache {
         let readCache = lazyReadCache
         readCacheLock.unlock()
 
-        for (description, writeFileCache) in writeCache where !writeFileCache.isEmpty {
-            let fileCache = readCache[description]?.merging(writeFileCache) { _, write in write } ?? writeFileCache
-            let json = try fileCache.toJSON()
-            let file = url.appendingPathComponent(description).appendingPathExtension("json")
-            try json.write(to: file, options: .atomic)
+        let encoder = PropertyListEncoder()
+        for (description, writeFileCache) in writeCache where !writeFileCache.entries.isEmpty {
+            let fileCacheEntries = readCache[description]?.entries.merging(writeFileCache.entries) { _, write in write }
+            let fileCache = fileCacheEntries.map(FileCache.init) ?? writeFileCache
+            let plist = try encoder.encode(fileCache)
+            let file = url.appendingPathComponent(description).appendingPathExtension("plist")
+            try plist.write(to: file, options: .atomic)
         }
     }
 
     internal func flushed() -> LinterCache {
-        return LinterCache(cache: mergeCaches(), location: location,
-                           fileManager: fileManager, swiftVersion: swiftVersion)
+        return LinterCache(cache: mergeCaches(), location: location, fileManager: fileManager,
+                           swiftVersion: swiftVersion)
     }
 
     private func fileCache(cacheDescription: String) -> FileCache {
@@ -141,96 +117,26 @@ public final class LinterCache {
         }
 
         guard let location = location else {
-            return [:]
+            return .empty
         }
 
-        let file = location.appendingPathComponent(cacheDescription).appendingPathExtension("json")
-        if let data = try? Data(contentsOf: file),
-            let json = try? JSONSerialization.jsonObject(with: data),
-            let fileCache = json as? FileCache {
-            lazyReadCache[cacheDescription] = fileCache
-            return fileCache
-        } else {
-            lazyReadCache[cacheDescription] = [:]
-            return [:]
-        }
+        let decoder = PropertyListDecoder()
+        let file = location.appendingPathComponent(cacheDescription).appendingPathExtension("plist")
+        let data = try? Data(contentsOf: file)
+        let fileCache = data.flatMap { try? decoder.decode(FileCache.self, from: $0) } ?? .empty
+        lazyReadCache[cacheDescription] = fileCache
+        return fileCache
     }
 
     private func mergeCaches() -> Cache {
         readCacheLock.lock()
-        var cache = lazyReadCache
-        readCacheLock.unlock()
         writeCacheLock.lock()
-        for (key, value) in writeCache {
-            var filesCache = cache[key] ?? [:]
-            for (file, fileCache) in value {
-                filesCache[file] = fileCache
-            }
-            cache[key] = filesCache
+        defer {
+            readCacheLock.unlock()
+            writeCacheLock.unlock()
         }
-        writeCacheLock.unlock()
-
-        return cache
-    }
-
-    private func dictionary(for violation: StyleViolation) -> [String: Any] {
-        return [
-            Key.line.rawValue: violation.location.line ?? NSNull() as Any,
-            Key.character.rawValue: violation.location.character ?? NSNull() as Any,
-            Key.severity.rawValue: violation.severity.rawValue,
-            Key.type.rawValue: violation.ruleDescription.name,
-            Key.ruleID.rawValue: violation.ruleDescription.identifier,
-            Key.reason.rawValue: violation.reason,
-            Key.ruleKind.rawValue: violation.ruleDescription.kind.rawValue
-        ]
-    }
-}
-
-private extension LinterCache {
-    enum Key: String {
-        case character
-        case lastModification = "last_modification"
-        case line
-        case reason
-        case ruleID = "rule_id"
-        case severity
-        case type
-        case violations
-        case ruleKind = "rule_kind"
-        case swiftVersion = "swift_version"
-    }
-}
-
-private extension Dictionary where Key == String {
-    subscript(_ key: LinterCache.Key) -> Value? {
-        return self[key.rawValue]
-    }
-}
-
-private extension StyleViolation {
-    static func from(cache: [String: Any], file: String) -> StyleViolation? {
-        guard let severityString = cache[.severity] as? String,
-            let severity = ViolationSeverity(rawValue: severityString),
-            let name = cache[.type] as? String,
-            let ruleID = cache[.ruleID] as? String,
-            let reason = cache[.reason] as? String,
-            let ruleKind = (cache[.ruleKind] as? String).flatMap(RuleKind.init(rawValue:)) else {
-                return nil
+        return lazyReadCache.merging(writeCache) { read, write in
+            FileCache(entries: read.entries.merging(write.entries) { _, write in write })
         }
-
-        let line = cache[.line] as? Int
-        let character = cache[.character] as? Int
-        let description = RuleDescription(identifier: ruleID, name: name, description: reason, kind: ruleKind)
-        return StyleViolation(ruleDescription: description,
-                              severity: severity,
-                              location: Location(file: file, line: line, character: character),
-                              reason: reason)
-    }
-}
-
-internal extension Dictionary where Key == String {
-    func toJSON() throws -> Data {
-        // not using .sortedKeys to avoid crash
-        return try JSONSerialization.data(withJSONObject: self, options: .prettyPrinted)
     }
 }

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -18,7 +18,7 @@ private struct FileCache: Codable {
 }
 
 public final class LinterCache {
-#if canImport(Darwin)
+#if canImport(Darwin) || compiler(>=5.1.0)
     private typealias Encoder = PropertyListEncoder
     private typealias Decoder = PropertyListDecoder
     private static let fileExtension = "plist"

--- a/Source/SwiftLintFramework/Models/Location.swift
+++ b/Source/SwiftLintFramework/Models/Location.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct Location: CustomStringConvertible, Comparable {
+public struct Location: CustomStringConvertible, Comparable, Codable {
     public let file: String?
     public let line: Int?
     public let character: Int?

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -1,4 +1,4 @@
-public struct RuleDescription: Equatable {
+public struct RuleDescription: Equatable, Codable {
     public let identifier: String
     public let name: String
     public let description: String

--- a/Source/SwiftLintFramework/Models/RuleKind.swift
+++ b/Source/SwiftLintFramework/Models/RuleKind.swift
@@ -1,4 +1,4 @@
-public enum RuleKind: String {
+public enum RuleKind: String, Codable {
     case lint
     case idiomatic
     case style

--- a/Source/SwiftLintFramework/Models/StyleViolation.swift
+++ b/Source/SwiftLintFramework/Models/StyleViolation.swift
@@ -1,4 +1,4 @@
-public struct StyleViolation: CustomStringConvertible, Equatable {
+public struct StyleViolation: CustomStringConvertible, Equatable, Codable {
     public let ruleDescription: RuleDescription
     public let severity: ViolationSeverity
     public let location: Location

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct SwiftVersion: RawRepresentable {
+public struct SwiftVersion: RawRepresentable, Codable {
     public typealias RawValue = String
 
     public let rawValue: String

--- a/Source/SwiftLintFramework/Models/ViolationSeverity.swift
+++ b/Source/SwiftLintFramework/Models/ViolationSeverity.swift
@@ -1,4 +1,4 @@
-public enum ViolationSeverity: String, Comparable {
+public enum ViolationSeverity: String, Comparable, Codable {
     case warning
     case error
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -727,9 +727,6 @@ extension LineLengthRuleTests {
 
 extension LinterCacheTests {
     static var allTests: [(String, (LinterCacheTests) -> () throws -> Void)] = [
-        ("testInitThrowsWhenUsingInvalidCacheFormat", testInitThrowsWhenUsingInvalidCacheFormat),
-        ("testSaveThrowsWithNoLocation", testSaveThrowsWithNoLocation),
-        ("testInitSucceeds", testInitSucceeds),
         ("testUnchangedFilesReusesCache", testUnchangedFilesReusesCache),
         ("testConfigFileReorderedReusesCache", testConfigFileReorderedReusesCache),
         ("testConfigFileWhitespaceAndCommentsChangedOrAddedOrRemovedReusesCache", testConfigFileWhitespaceAndCommentsChangedOrAddedOrRemovedReusesCache),
@@ -743,8 +740,7 @@ extension LinterCacheTests {
         ("testWhitelistRulesChangedOrAddedOrRemovedCausesAllFilesToBeReLinted", testWhitelistRulesChangedOrAddedOrRemovedCausesAllFilesToBeReLinted),
         ("testRuleConfigurationChangedOrAddedOrRemovedCausesAllFilesToBeReLinted", testRuleConfigurationChangedOrAddedOrRemovedCausesAllFilesToBeReLinted),
         ("testSwiftVersionChangedRemovedCausesAllFilesToBeReLinted", testSwiftVersionChangedRemovedCausesAllFilesToBeReLinted),
-        ("testDetectSwiftVersion", testDetectSwiftVersion),
-        ("testCacheToJSONDoesntCrash", testCacheToJSONDoesntCrash)
+        ("testDetectSwiftVersion", testDetectSwiftVersion)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -104,26 +104,6 @@ class LinterCacheTests: XCTestCase {
         XCTAssertEqual(cache.violations(forFile: file2, configuration: initialConfig)!, [], file: file, line: line)
     }
 
-    // MARK: Cache Initialization
-
-    func testInitThrowsWhenUsingInvalidCacheFormat() {
-        let cache = [["version": "0.1.0"]]
-        checkError(LinterCacheError.invalidFormat) {
-            _ = try LinterCache(cache: cache)
-        }
-    }
-
-    func testSaveThrowsWithNoLocation() throws {
-        let cache = try LinterCache(cache: [:])
-        checkError(LinterCacheError.noLocation) {
-            try cache.save()
-        }
-    }
-
-    func testInitSucceeds() {
-        XCTAssertNotNil(try? LinterCache(cache: [:]))
-    }
-
     // MARK: Cache Reuse
 
     // Two subsequent lints with no changes reuses cache
@@ -360,19 +340,5 @@ class LinterCacheTests: XCTestCase {
             let version = "4.0.0" // Since we can't pass SWIFT_VERSION=3 to sourcekit, it returns 4.0.0
         #endif
         XCTAssertEqual(SwiftVersion.current.rawValue, version)
-    }
-
-    // MARK: JSON output
-
-    func testCacheToJSONDoesntCrash() {
-        // swiftlint:disable line_length
-        let key1 = "[\"/SwiftLint/source\",[[\"block_based_kvo\",\"warning\"],[\"class_delegate_protocol\",\"warning\"],[\"closing_brace\",\"warning\"],[\"closure_parameter_position\",\"warning\"],[\"colon\",\"warning, flexible_right_spacing: false, apply_to_dictionaries: true\"],[\"comma\",\"warning\"],[\"compiler_protocol_init\",\"warning\"],[\"control_statement\",\"warning\"],[\"custom_rules\",\"\"],[\"cyclomatic_complexity\",\"warning: 10, error: 20, ignores_case_statements: false\"],[\"discarded_notification_center_observer\",\"warning\"],[\"discouraged_direct_init\",\"warning, types: [\"Bundle\", \"Bundle.init\", \"UIDevice\", \"UIDevice.init\"]\"],[\"dynamic_inline\",\"error\"],[\"empty_enum_arguments\",\"warning\"],[\"empty_parameters\",\"warning\"]]]"
-
-        let key2 = "[\"/SwiftLint/Source\",[[\"block_based_kvo\",\"warning\"],[\"class_delegate_protocol\",\"warning\"],[\"closing_brace\",\"warning\"],[\"closure_parameter_position\",\"warning\"],[\"colon\",\"warning, flexible_right_spacing: false, apply_to_dictionaries: true\"],[\"comma\",\"warning\"],[\"compiler_protocol_init\",\"warning\"],[\"control_statement\",\"warning\"],[\"custom_rules\",\"\"],[\"cyclomatic_complexity\",\"warning: 10, error: 20, ignores_case_statements: false\"],[\"discarded_notification_center_observer\",\"warning\"],[\"discouraged_direct_init\",\"warning, types: [\"Bundle\", \"Bundle.init\", \"UIDevice\", \"UIDevice.init\"]\"],[\"dynamic_inline\",\"error\"],[\"empty_enum_arguments\",\"warning\"],[\"empty_parameters\",\"warning\"]]]"
-        // swiftlint:enable line_length
-
-        let dict = [key1: "test", key2: "test2"]
-
-        XCTAssertNoThrow(try dict.toJSON())
     }
 }


### PR DESCRIPTION
Improving performance and type safety. This changes the cache file format from JSON to binary plist when available, which also happens to reduce disk usage by around ~10% in my tests.

For a project with about 7k Swift files amounting to about ~500k lines of Swift code, here are the benchmarks for before and after:

```
$ hyperfine 'swiftlint-master lint --quiet' 'swiftlint-codable-cache lint --quiet'                    
Benchmark #1: swiftlint-master lint --quiet
  Time (mean ± σ):      3.500 s ±  0.037 s    [User: 5.208 s, System: 1.115 s]
  Range (min … max):    3.439 s …  3.573 s    10 runs
 
Benchmark #2: swiftlint-codable-cache lint --quiet
  Time (mean ± σ):      3.013 s ±  0.026 s    [User: 4.807 s, System: 1.117 s]
  Range (min … max):    2.966 s …  3.041 s    10 runs
 
Summary
  'swiftlint-codable-cache lint --quiet' ran
    1.16 ± 0.02 times faster than 'swiftlint-master lint --quiet'
```