### PR TITLE
Fix UnusedDeclaration false positive - captured variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * Release memory created for sourcekitd requests.  
   [Colton Schlosser](https://github.com/cltnschlosser)
   [#2812](https://github.com/realm/SwiftLint/issues/2812)
+* Fix UnusedDeclaration false positive - captured variable.  
+  [Colton Schlosser](https://github.com/cltnschlosser)
 
 ## 0.34.0: Anti-Static Wool Dryer Balls
 

--- a/Rules.md
+++ b/Rules.md
@@ -23651,6 +23651,13 @@ class ResponseModel {
 _ = ResponseModel()
 ```
 
+```swift
+private let limit = 5
+[].forEach { [limit] in
+    print(limit)
+}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>
@@ -23674,6 +23681,12 @@ struct ↓ResponseModel: Codable {
 class ↓ResponseModel {
     func ↓foo() {
     }
+}
+```
+
+```swift
+private let limit = 5
+[].forEach { [limit] in
 }
 ```
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -169,7 +169,7 @@ private extension File {
     }
 
     static func referencedUSRs(allCursorInfo: [[String: SourceKitRepresentable]]) -> [String] {
-        return allCursorInfo.flatMap(referencedUSR)
+        return allCursorInfo.flatMap { $0.referencedUSRs }
     }
 
     static func testCaseUSRs(allCursorInfo: [[String: SourceKitRepresentable]]) -> Set<String> {
@@ -221,20 +221,6 @@ private extension File {
         }
 
         return nil
-    }
-
-    private static func referencedUSR(cursorInfo: [String: SourceKitRepresentable]) -> [String] {
-        if let usr = cursorInfo["key.usr"] as? String,
-            let kind = cursorInfo["key.kind"] as? String,
-            kind.contains("source.lang.swift.ref") {
-            if let relatedDecls = cursorInfo["key.related_decls"] as? [[String: SourceKitRepresentable]] {
-                return [usr] + relatedDecls.compactMap { ($0["key.annotated_decl"] as? String)?.usrFromXml }
-            } else {
-                return [usr]
-            }
-        }
-
-        return []
     }
 
     private static func testCaseUSR(cursorInfo: [String: SourceKitRepresentable]) -> String? {
@@ -291,14 +277,3 @@ private let syntaxKindsToSkip: Set<SyntaxKind> = [
     .string,
     .stringInterpolationAnchor
 ]
-
-private extension String {
-    var usrFromXml: String? {
-        guard let usrIndex = lastIndex(of: "usr=\""),
-            let end = lastIndex(of: "\">") else {
-                return nil
-        }
-        let start = usrIndex + 5
-        return substring(from: start, length: end - start)
-    }
-}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import SwiftLintFramework


### PR DESCRIPTION
The non-triggering example was triggering before.

Here is the `allCursorInfo`, may help with understanding my approach:
```
(lldb) po allCursorInfo
▿ 5 elements
  ▿ 0 : 12 elements
    ▿ 0 : 2 elements
      - key : "key.typename"
      - value : "Int"
    ▿ 1 : 2 elements
      - key : "key.annotated_decl"
      - value : "<Declaration>private let limit: <Type usr=\"s:Si\">Int</Type></Declaration>"
    ▿ 2 : 2 elements
      - key : "key.length"
      - value : 5
    ▿ 3 : 2 elements
      - key : "key.name"
      - value : "limit"
    ▿ 4 : 2 elements
      - key : "swiftlint.offset"
      - value : 12
    ▿ 5 : 2 elements
      - key : "key.offset"
      - value : 12
    ▿ 6 : 2 elements
      - key : "key.kind"
      - value : "source.lang.swift.decl.var.global"
    ▿ 7 : 2 elements
      - key : "key.typeusr"
      - value : "$sSiD"
    ▿ 8 : 2 elements
      - key : "key.usr"
      - value : "s:4main5limit33_BF49849BA67C991867DA082EF03F5F16LLSivp"
    ▿ 9 : 2 elements
      - key : "key.accessibility"
      - value : "source.lang.swift.accessibility.private"
    ▿ 10 : 2 elements
      - key : "key.fully_annotated_decl"
      - value : "<decl.var.global><syntaxtype.keyword>private</syntaxtype.keyword> <syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>limit</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.global>"
    ▿ 11 : 2 elements
      - key : "key.filepath"
      - value : "/private/var/folders/pt/lbjvlskx26n1dg8dllcjfzrw0000gq/T/FDB8FF8A-0459-49D5-AEA1-A6CB5231E80C.swift"
  ▿ 1 : 13 elements
    ▿ 0 : 2 elements
      - key : "key.typename"
      - value : "<Self where Self : Sequence> (Self) -> ((Self.Element) throws -> ()) throws -> ()"
    ▿ 1 : 2 elements
      - key : "swiftlint.offset"
      - value : 25
    ▿ 2 : 2 elements
      - key : "key.containertypeusr"
      - value : "$sSayytGD"
    ▿ 3 : 2 elements
      - key : "key.typeusr"
      - value : "$syyy7ElementQzKXEKcD"
    ▿ 4 : 2 elements
      - key : "key.kind"
      - value : "source.lang.swift.ref.function.method.instance"
    ▿ 5 : 2 elements
      - key : "key.name"
      - value : "forEach(_:)"
    ▿ 6 : 2 elements
      - key : "key.groupname"
      - value : "Collection/Array"
    ▿ 7 : 2 elements
      - key : "key.fully_annotated_decl"
      - value : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>forEach</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>body</decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><tuple>()</tuple></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>throws</syntaxtype.keyword> -&gt; <decl.function.returntype><ref.typealias usr=\"s:s4Voida\">Void</ref.typealias></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>rethrows</syntaxtype.keyword></decl.function.method.instance>"
    ▿ 8 : 2 elements
      - key : "key.is_system"
      - value : true
    ▿ 9 : 2 elements
      - key : "key.usr"
      - value : "s:STsE7forEachyyy7ElementQzKXEKF::SYNTHESIZED::s:Sa"
    ▿ 10 : 2 elements
      - key : "key.doc.full_as_xml"
      - value : "<Function><Name>forEach(_:)</Name><USR>s:STsE7forEachyyy7ElementQzKXEKF</USR><Declaration>@inlinable func forEach(_ body: (Self.Element) throws -&gt; Void) rethrows</Declaration><CommentParts><Abstract><Para>Calls the given closure on each element in the sequence in the same order as a <codeVoice>for</codeVoice>-<codeVoice>in</codeVoice> loop.</Para></Abstract><Parameters><Parameter><Name>body</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A closure that takes an element of the sequence as a parameter.</Para></Discussion></Parameter></Parameters><Discussion><Para>The two loops in the following example produce the same output:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let numberWords = [\"one\", \"two\", \"three\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[for word in numberWords {]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(word)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"one\"]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"two\"]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"three\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[numberWords.forEach { word in]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(word)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Same as above]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing><Para>Using the <codeVoice>forEach</codeVoice> method is distinct from a <codeVoice>for</codeVoice>-<codeVoice>in</codeVoice> loop in two important ways:</Para><List-Number><Item><Para>You cannot use a <codeVoice>break</codeVoice> or <codeVoice>continue</codeVoice> statement to exit the current call of the <codeVoice>body</codeVoice> closure or skip subsequent calls.</Para></Item><Item><Para>Using the <codeVoice>return</codeVoice> statement in the <codeVoice>body</codeVoice> closure will exit only from the current call to <codeVoice>body</codeVoice>, not from any outer scope, and won’t skip subsequent calls.</Para></Item></List-Number></Discussion></CommentParts></Function>"
    ▿ 11 : 2 elements
      - key : "key.modulename"
      - value : "Swift"
    ▿ 12 : 2 elements
      - key : "key.annotated_decl"
      - value : "<Declaration>@inlinable func forEach(_ body: (()) throws -&gt; <Type usr=\"s:s4Voida\">Void</Type>) rethrows</Declaration>"
  ▿ 2 : 12 elements
    ▿ 0 : 2 elements
      - key : "key.annotated_decl"
      - value : "<Declaration>let limit: <Type usr=\"s:Si\">Int</Type></Declaration>"
    ▿ 1 : 2 elements
      - key : "key.filepath"
      - value : "/private/var/folders/pt/lbjvlskx26n1dg8dllcjfzrw0000gq/T/FDB8FF8A-0459-49D5-AEA1-A6CB5231E80C.swift"
    ▿ 2 : 2 elements
      - key : "key.usr"
      - value : "s:4main5limitL_Sivp"
    ▿ 3 : 2 elements
      - key : "key.length"
      - value : 5
    ▿ 4 : 2 elements
      - key : "key.kind"
      - value : "source.lang.swift.decl.var.local"
    ▿ 5 : 2 elements
      - key : "key.offset"
      - value : 36
    ▿ 6 : 2 elements
      - key : "key.typename"
      - value : "Int"
    ▿ 7 : 2 elements
      - key : "key.typeusr"
      - value : "$sSiD"
    ▿ 8 : 2 elements
      - key : "key.fully_annotated_decl"
      - value : "<decl.var.local><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>limit</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.local>"
    ▿ 9 : 2 elements
      - key : "key.related_decls"
      ▿ value : 1 element
        ▿ 0 : 1 element
          ▿ 0 : 2 elements
            - key : "key.annotated_decl"
            - value : "<RelatedName usr=\"s:4main5limit33_BF49849BA67C991867DA082EF03F5F16LLSivp\">limit</RelatedName>"
    ▿ 10 : 2 elements
      - key : "key.name"
      - value : "limit"
    ▿ 11 : 2 elements
      - key : "swiftlint.offset"
      - value : 36
  ▿ 3 : 13 elements
    ▿ 0 : 2 elements
      - key : "key.usr"
      - value : "s:s5print_9separator10terminatoryypd_S2StF"
    ▿ 1 : 2 elements
      - key : "key.typename"
      - value : "(Any..., String, String) -> ()"
    ▿ 2 : 2 elements
      - key : "key.annotated_decl"
      - value : "<Declaration>func print(_ items: Any..., separator: <Type usr=\"s:SS\">String</Type> = &quot; &quot;, terminator: <Type usr=\"s:SS\">String</Type> = &quot;\\n&quot;)</Declaration>"
    ▿ 3 : 2 elements
      - key : "key.is_system"
      - value : true
    ▿ 4 : 2 elements
      - key : "key.kind"
      - value : "source.lang.swift.ref.function.free"
    ▿ 5 : 2 elements
      - key : "key.doc.full_as_xml"
      - value : "<Function><Name>print(_:separator:terminator:)</Name><USR>s:s5print_9separator10terminatoryypd_S2StF</USR><Declaration>func print(_ items: Any..., separator: String = &quot; &quot;, terminator: String = &quot;\\n&quot;)</Declaration><CommentParts><Abstract><Para>Writes the textual representations of the given items into the standard output.</Para></Abstract><Parameters><Parameter><Name>items</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Zero or more items to print.</Para></Discussion></Parameter><Parameter><Name>separator</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A string to print between each item. The default is a single space (<codeVoice>&quot; &quot;</codeVoice>).</Para></Discussion></Parameter><Parameter><Name>terminator</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The string to print after all items have been printed. The default is a newline (<codeVoice>&quot;\\n&quot;</codeVoice>).</Para></Discussion></Parameter></Parameters><Discussion><Para>You can pass zero or more items to the <codeVoice>print(_:separator:terminator:)</codeVoice> function. The textual representation for each item is the same as that obtained by calling <codeVoice>String(item)</codeVoice>. The following example prints a string, a closed range of integers, and a group of floating-point values to standard output:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(\"One two three four five\")]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"One two three four five\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(1...5)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"1...5\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(1.0, 2.0, 3.0, 4.0, 5.0)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"1.0 2.0 3.0 4.0 5.0\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing><Para>To print the items separated by something other than a space, pass a string as <codeVoice>separator</codeVoice>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(1.0, 2.0, 3.0, 4.0, 5.0, separator: \" ... \")]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"1.0 ... 2.0 ... 3.0 ... 4.0 ... 5.0\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing><Para>The output from each call to <codeVoice>print(_:separator:terminator:)</codeVoice> includes a newline by default. To print the items without a trailing newline, pass an empty string as <codeVoice>terminator</codeVoice>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[for n in 1...5 {]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(n, terminator: \"\")]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"12345\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>"
    ▿ 6 : 2 elements
      - key : "key.fully_annotated_decl"
      - value : "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>print</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>items</decl.var.parameter.name>: <decl.var.parameter.type>Any</decl.var.parameter.type>...</decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>separator</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String</ref.struct></decl.var.parameter.type> = &quot; &quot;</decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>terminator</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String</ref.struct></decl.var.parameter.type> = &quot;\\n&quot;</decl.var.parameter>)</decl.function.free>"
    ▿ 7 : 2 elements
      - key : "swiftlint.offset"
      - value : 50
    ▿ 8 : 2 elements
      - key : "key.name"
      - value : "print(_:separator:terminator:)"
    ▿ 9 : 2 elements
      - key : "key.typeusr"
      - value : "$s_9separator10terminatoryypd_S2StcD"
    ▿ 10 : 2 elements
      - key : "key.modulename"
      - value : "Swift"
    ▿ 11 : 2 elements
      - key : "key.groupname"
      - value : "Misc"
    ▿ 12 : 2 elements
      - key : "key.related_decls"
      ▿ value : 1 element
        ▿ 0 : 1 element
          ▿ 0 : 2 elements
            - key : "key.annotated_decl"
            - value : "<RelatedName usr=\"s:s5print_9separator10terminator2toyypd_S2Sxzts16TextOutputStreamRzlF\">print(_:separator:terminator:to:)</RelatedName>"
  ▿ 4 : 12 elements
    ▿ 0 : 2 elements
      - key : "key.filepath"
      - value : "/private/var/folders/pt/lbjvlskx26n1dg8dllcjfzrw0000gq/T/FDB8FF8A-0459-49D5-AEA1-A6CB5231E80C.swift"
    ▿ 1 : 2 elements
      - key : "key.usr"
      - value : "s:4main5limitL_Sivp"
    ▿ 2 : 2 elements
      - key : "key.related_decls"
      ▿ value : 1 element
        ▿ 0 : 1 element
          ▿ 0 : 2 elements
            - key : "key.annotated_decl"
            - value : "<RelatedName usr=\"s:4main5limit33_BF49849BA67C991867DA082EF03F5F16LLSivp\">limit</RelatedName>"
    ▿ 3 : 2 elements
      - key : "key.fully_annotated_decl"
      - value : "<decl.var.local><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>limit</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.local>"
    ▿ 4 : 2 elements
      - key : "key.name"
      - value : "limit"
    ▿ 5 : 2 elements
      - key : "key.typename"
      - value : "Int"
    ▿ 6 : 2 elements
      - key : "key.offset"
      - value : 36
    ▿ 7 : 2 elements
      - key : "key.annotated_decl"
      - value : "<Declaration>let limit: <Type usr=\"s:Si\">Int</Type></Declaration>"
    ▿ 8 : 2 elements
      - key : "key.length"
      - value : 5
    ▿ 9 : 2 elements
      - key : "swiftlint.offset"
      - value : 56
    ▿ 10 : 2 elements
      - key : "key.typeusr"
      - value : "$sSiD"
    ▿ 11 : 2 elements
      - key : "key.kind"
      - value : "source.lang.swift.ref.var.local"
```