### PR TITLE
Add parameter max_declarations to pattern_matching_keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 #### Enhancements
 
-* None.
+* Add `max_declarations` configuration on `pattern_matching_keywords` rule
+  to specify number of declarations allowed inside tuples in a `switch`.  
+  [Marcin Podeszwa](https://github.com/mpodeszwa)
+  [#2821](https://github.com/realm/SwiftLint/pull/2821)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PatternMatchingKeywordsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PatternMatchingKeywordsRuleConfiguration.swift
@@ -1,0 +1,24 @@
+public struct PatternMatchingKeywordsRuleConfiguration: RuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.warning)
+    var maxDeclarations = 1
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription + ", max_declarations: \(maxDeclarations)"
+    }
+
+    public init(maxDeclarations: Int) {
+        self.maxDeclarations = maxDeclarations
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        maxDeclarations = configuration["max_declarations"] as? Int ?? 1
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */; };
 		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
 		429644B61FB0A9B400D75128 /* SortedFirstLastRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429644B41FB0A99E00D75128 /* SortedFirstLastRule.swift */; };
+		4671A29B22E61689008E2BC7 /* PatternMatchingKeywordsRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4671A29722E61612008E2BC7 /* PatternMatchingKeywordsRuleConfiguration.swift */; };
+		4671A29D22E61A97008E2BC7 /* PatternMatchingKeywordsRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4671A29C22E61A97008E2BC7 /* PatternMatchingKeywordsRuleTests.swift */; };
 		47ACC8981E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */; };
 		47ACC89A1E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */; };
 		47ACC89C1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */; };
@@ -557,6 +559,8 @@
 		3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlParser.swift; sourceTree = "<group>"; };
 		3BDB224A1C345B4900473680 /* ProjectMock */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ProjectMock; sourceTree = "<group>"; };
 		429644B41FB0A99E00D75128 /* SortedFirstLastRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortedFirstLastRule.swift; sourceTree = "<group>"; };
+		4671A29722E61612008E2BC7 /* PatternMatchingKeywordsRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternMatchingKeywordsRuleConfiguration.swift; sourceTree = "<group>"; };
+		4671A29C22E61A97008E2BC7 /* PatternMatchingKeywordsRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternMatchingKeywordsRuleTests.swift; sourceTree = "<group>"; };
 		47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalConfiguration.swift; sourceTree = "<group>"; };
 		47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalConfigurationTests.swift; sourceTree = "<group>"; };
 		47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalRuleTests.swift; sourceTree = "<group>"; };
@@ -1009,6 +1013,7 @@
 				D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */,
 				A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */,
 				78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */,
+				4671A29722E61612008E2BC7 /* PatternMatchingKeywordsRuleConfiguration.swift */,
 				C28B2B3B2106DF210009A0FE /* PrefixedConstantRuleConfiguration.swift */,
 				DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */,
 				D4246D6C1F30D8620097E658 /* PrivateOverFilePrivateRuleConfiguration.swift */,
@@ -1475,6 +1480,7 @@
 				B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */,
 				D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */,
 				825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */,
+				4671A29C22E61A97008E2BC7 /* PatternMatchingKeywordsRuleTests.swift */,
 				C25EBBDD210787B200E27603 /* PrefixedTopLevelConstantRuleTests.swift */,
 				D4F5851820E99B5A0085C6D8 /* PrivateOutletRuleTests.swift */,
 				D4246D6E1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift */,
@@ -2015,6 +2021,7 @@
 				D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */,
 				82EB7885215BAE790042E0FD /* FileTypesOrderRuleExamples.swift in Sources */,
 				E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */,
+				4671A29B22E61689008E2BC7 /* PatternMatchingKeywordsRuleConfiguration.swift in Sources */,
 				125AAC78203AA82D0004BCE0 /* ExplicitTypeInterfaceConfiguration.swift in Sources */,
 				1E18574B1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift in Sources */,
 				D42D2B381E09CC0D00CD7A2E /* FirstWhereRule.swift in Sources */,
@@ -2269,6 +2276,7 @@
 				CCD8B87920559D1E00B75847 /* DisableAllTests.swift in Sources */,
 				821F70B7210720C700E2C84F /* FileTypesOrderRuleTests.swift in Sources */,
 				3B3A9A331EA3DFD90075B121 /* IdentifierNameRuleTests.swift in Sources */,
+				4671A29D22E61A97008E2BC7 /* PatternMatchingKeywordsRuleTests.swift in Sources */,
 				62329C2B1F30B2310035737E /* DiscouragedDirectInitRuleTests.swift in Sources */,
 				C25EBBE221078D5F00E27603 /* GlobTests.swift in Sources */,
 				E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -948,7 +948,8 @@ extension OverrideInExtensionRuleTests {
 
 extension PatternMatchingKeywordsRuleTests {
     static var allTests: [(String, (PatternMatchingKeywordsRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration),
+        ("testWithZeroMaxDeclarations", testWithZeroMaxDeclarations)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import SwiftLintFramework
@@ -465,12 +465,6 @@ class OverriddenSuperCallRuleTests: XCTestCase {
 class OverrideInExtensionRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OverrideInExtensionRule.description)
-    }
-}
-
-class PatternMatchingKeywordsRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(PatternMatchingKeywordsRule.description)
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/PatternMatchingKeywordsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/PatternMatchingKeywordsRuleTests.swift
@@ -1,0 +1,47 @@
+import SwiftLintFramework
+import XCTest
+
+class PatternMatchingKeywordsRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PatternMatchingKeywordsRule.description)
+    }
+
+    func testWithZeroMaxDeclarations() {
+        let nonTriggeringExamples = [
+            "default",
+            "case 1",
+            "case bar",
+            "case let (x)",
+            "case let (x, y)",
+            "case let .foo(x, y)",
+            "case .foo(let x, var y)",
+            "case var (x, y)",
+            "case var .foo(x, y)"
+        ].map(wrapInSwitch)
+        let triggeringExamples = [
+            "case .foo(↓let x)",
+            "case .foo(↓let x), .bar(↓let x)",
+            "case .foo(↓let x), let .bar(x)",
+            "case .foo(↓var x)",
+            "case .foo(↓let x, (↓let y, ↓let z))",
+            "case .foo(↓let x, ↓let (y, z))",
+            "case (↓let x,  ↓let y)",
+            "case .foo(↓let x, ↓let y)",
+            "case (.yamlParsing(↓let x), .yamlParsing(↓let y))",
+            "case (↓var x,  ↓var y)",
+            "case .foo(↓var x, ↓var y)",
+            "case (.yamlParsing(↓var x), .yamlParsing(↓var y))"
+        ].map(wrapInSwitch)
+
+        let description = PatternMatchingKeywordsRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["max_declarations": 0])
+    }
+}
+
+private func wrapInSwitch(_ str: String) -> String {
+    return  "switch foo {\n" +
+            "    \(str): break\n" +
+            "}"
+}


### PR DESCRIPTION
This change adds additional configuration for `pattern_matching_keyword` rule (purely for styling).

Consider following enum:

```
enum Foo {
    case single(Int)
    case double(Int, Int)
    case triple(Int, Int, Int)

    var sum: Int {
        switch self {
        case .single(let x):
            return x
        case .double(let x, let y):
            return x + y
        case .triple(let x, let y, let z):
            return x + y + z
        }
    }
}
```

Enabling `pattern_matching_keyword` would enforce following code:

```
enum Foo {
    case single(Int)
    case double(Int, Int)
    case triple(Int, Int, Int)

    var sum: Int {
        switch self {
        case .single(let x):
            return x
        case let .double(x, y):
            return x + y
        case let .triple(x, y, z):
            return x + y + z
        }
    }
}
```

However, in this case `let`s are not in the same place. `let` is either before or after identifier depending on number of parameters. 

This PR allows you to specify in `.swiftlint.yml`:

```
pattern_matching_keyword:
  max_declarations: 0
```

and then example code will look like this:

```
enum Foo {
    case single(Int)
    case double(Int, Int)
    case triple(Int, Int, Int)

    var sum: Int {
        switch self {
        case let .single(x):
            return x
        case let .double(x, y):
            return x + y
        case let .triple(x, y, z):
            return x + y + z
        }
    }
}
```
