### PR TITLE
[minor] Fix broken link in a comment in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ docker_test:
 docker_htop:
 	docker run -it --rm --pid=container:swiftlint terencewestphal/htop || reset
 
-# http://irace.me/swift-profiling/
+# https://irace.me/swift-profiling
 display_compilation_time:
 	$(BUILD_TOOL) $(XCODEFLAGS) OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build-for-testing | grep -E ^[1-9]{1}[0-9]*.[0-9]+ms | sort -n
 


### PR DESCRIPTION
There's a link in one of the comments in the `Makefile` that returns a 404. I believe the issue was caused by a jekyll update that removed the automatic appending of a trailing slash to permalinks. This caused the permalink for http://irace.me/swift-profiling/ to become http://irace.me/swift-profiling. Since the website redirects to the `https` equivalent, I've used that as well. The comment now links to https://irace.me/swift-profiling.