### PR TITLE
Fix `swiftlint rules` output table formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [Colton Schlosser](https://github.com/cltnschlosser)
   [#2812](https://github.com/realm/SwiftLint/issues/2812)
 
+* Fix `swiftlinit rules` output table formatting.  
+  [JP Simard](https://github.com/jpsim)
+  [#2787](https://github.com/realm/SwiftLint/issues/2787)
+
 ## 0.34.0: Anti-Static Wool Dryer Balls
 
 #### Breaking

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -122,7 +122,7 @@ extension TextTable {
         func truncate(_ string: String) -> String {
             let stringWithNoNewlines = string.replacingOccurrences(of: "\n", with: "\\n")
             let minWidth = "configuration".count - "...".count
-            let configurationStartColumn = 112
+            let configurationStartColumn = 124
             let truncatedEndIndex = stringWithNoNewlines.index(
                 stringWithNoNewlines.startIndex,
                 offsetBy: max(minWidth, Terminal.currentWidth() - configurationStartColumn),


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/2787

Broken since https://github.com/realm/SwiftLint/pull/2379

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/474794/62014052-bdb88f80-b150-11e9-811f-41af9e060832.png)|![image](https://user-images.githubusercontent.com/474794/62014044-a1b4ee00-b150-11e9-9b9c-5bd370e72d37.png)|