### PR TITLE
Fixed false positive in `colon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 #### Bug Fixes
 
+* Fixed false positive in `colon` rule inside guard and ternary operator.
+  [Andrey Uryadov](https://github.com/a-25)
+  [#2806](https://github.com/realm/SwiftLint/issues/2806)
+
 * Release memory created for sourcekitd requests.  
   [Colton Schlosser](https://github.com/cltnschlosser)
   [#2812](https://github.com/realm/SwiftLint/issues/2812)

--- a/Rules.md
+++ b/Rules.md
@@ -2054,6 +2054,13 @@ class ABC { let def = ghi(jkl: mno) } }
 func foo() { let dict = [1: 1] }
 ```
 
+```swift
+let aaa = Self.bbb ? Self.ccc : Self.ddd else {
+return nil
+}
+
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Style/ColonRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRuleExamples.swift
@@ -37,7 +37,10 @@ internal struct ColonRuleExamples {
         "func abc() { def(ghi: jkl) }",
         "func abc(def: Void) { ghi(jkl: mno) }",
         "class ABC { let def = ghi(jkl: mno) } }",
-        "func foo() { let dict = [1: 1] }"
+        "func foo() { let dict = [1: 1] }",
+        "let aaa = Self.bbb ? Self.ccc : Self.ddd else {\n" +
+            "return nil\n" +
+        "}\n"
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
Fixes #2806

File to trigger the bug on previous version: [test.swift.zip](https://github.com/realm/SwiftLint/files/3501671/test.swift.zip)
