### PR TITLE
#2737 - Fix unused_imports false positive when only operators from the module are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
   [JP Simard](https://github.com/jpsim)
   [#2787](https://github.com/realm/SwiftLint/issues/2787)
 
+* Fix `unused_import` rule false positive when only operators from the module
+  are used.  
+  [Timofey Solonin](https://github.com/biboran)
+  [#2737](https://github.com/realm/SwiftLint/issues/2737)
+
 ## 0.34.0: Anti-Static Wool Dryer Balls
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -23808,6 +23808,13 @@ import UnknownModule
 func foo(error: Swift.Error) {}
 ```
 
+```swift
+import Foundation
+import ObjectiveC
+let 👨‍👩‍👧‍👦 = #selector(NSArray.contains(_:))
+👨‍👩‍👧‍👦 == 👨‍👩‍👧‍👦
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -75,6 +75,11 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
         return elements.compactMap { $0 as? [String: SourceKitRepresentable] }
     }
 
+    var entities: [[String: SourceKitRepresentable]] {
+        let entities = self["key.entities"] as? [SourceKitRepresentable] ?? []
+        return entities.compactMap { $0 as? [String: SourceKitRepresentable] }
+    }
+
     var enclosedVarParameters: [[String: SourceKitRepresentable]] {
         return substructure.flatMap { subDict -> [[String: SourceKitRepresentable]] in
             guard let kindString = subDict.kind else {


### PR DESCRIPTION
As was discussed #2737, I utilized the `indexsource` request to look up the operators and fetch the cursorInfo per operator. In the implementation I refrained from using `usr` to look up the operator because SourceKit [doesn't support](https://github.com/apple/swift/blob/5add16804272b4df917da15c46eb6f28d826d656/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp#L1799) fetching cursorInfo by `usr` when it comes from C (but it can still be fetched by offset).

I also made [an alternative implementation](https://github.com/realm/SwiftLint/compare/master...biboran:fix-unused-imports-for-operators-alternative) which uses the `indexsource` request instead of the `editor.open`. It seems to work with the unit tests but I am not 100% sure it doesn't introduce a regression since there is no oss-check for analyzer rules.

I also updated [the example](https://github.com/biboran/synthax-bug-example) to better reflect the original issue in case you want to test the changes manually  