### PR TITLE
Don't trigger `missing_docs` on `deinit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   [JP Simard](https://github.com/jpsim)
   [#2787](https://github.com/realm/SwiftLint/issues/2787)
 
+* Don't trigger `missing_docs` violations when implementing `deinit`.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2690](https://github.com/realm/SwiftLint/issues/2690)
+
 * Fix `unused_import` rule false positive when only operators from the module
   are used.  
   [Timofey Solonin](https://github.com/biboran)

--- a/Rules.md
+++ b/Rules.md
@@ -11717,6 +11717,13 @@ override public var description: String { fatalError() } }
 
 ```
 
+```swift
+/// docs
+public class A {
+    deinit {}
+}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>


### PR DESCRIPTION
Fixes #2690