### PR TITLE
Avoid false positives in contains_over_filter_count

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2549,6 +2549,11 @@ let result = myList.filter { $0 % 2 == 0 }.count > 1
 ```
 
 ```swift
+let result = myList.filter(where: { $0 % 2 == 0 }).count > 01
+
+```
+
+```swift
 let result = myList.filter(where: { $0 % 2 == 0 }).count == 1
 
 ```
@@ -2559,12 +2564,22 @@ let result = myList.filter { $0 % 2 == 0 }.count == 1
 ```
 
 ```swift
+let result = myList.filter(where: { $0 % 2 == 0 }).count == 01
+
+```
+
+```swift
 let result = myList.filter(where: { $0 % 2 == 0 }).count != 1
 
 ```
 
 ```swift
 let result = myList.filter { $0 % 2 == 0 }.count != 1
+
+```
+
+```swift
+let result = myList.filter(where: { $0 % 2 == 0 }).count != 01
 
 ```
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -13,7 +13,8 @@ public struct ContainsOverFilterCountRule: CallPairRule, OptInRule, Configuratio
         nonTriggeringExamples: [">", "==", "!="].flatMap { operation in
             return [
                 "let result = myList.filter(where: { $0 % 2 == 0 }).count \(operation) 1\n",
-                "let result = myList.filter { $0 % 2 == 0 }.count \(operation) 1\n"
+                "let result = myList.filter { $0 % 2 == 0 }.count \(operation) 1\n",
+                "let result = myList.filter(where: { $0 % 2 == 0 }).count \(operation) 01\n"
             ]
         } +  [
             "let result = myList.contains(where: { $0 % 2 == 0 })\n",
@@ -30,7 +31,7 @@ public struct ContainsOverFilterCountRule: CallPairRule, OptInRule, Configuratio
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let pattern = "[\\}\\)]\\s*\\.count\\s*(?:!=|==|>)\\s*0"
+        let pattern = "[\\}\\)]\\s*\\.count\\s*(?:!=|==|>)\\s*0\\b"
         return validate(file: file, pattern: pattern, patternSyntaxKinds: [.identifier, .number],
                         callNameSuffix: ".filter", severity: configuration.severity)
     }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import SwiftLintFramework


### PR DESCRIPTION
Missed this in #2841. Not adding a CHANGELOG entry because this rule hasn't been released yet.