### PR TITLE
Don't trigger `missing_docs` on extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2842](https://github.com/realm/SwiftLint/issues/2842)
 
+* Don't trigger `missing_docs` violations on extensions.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#2851](https://github.com/realm/SwiftLint/issues/2851)
+
 ## 0.34.0: Anti-Static Wool Dryer Balls
 
 #### Breaking

--- a/Rules.md
+++ b/Rules.md
@@ -12008,6 +12008,10 @@ public class A {
 }
 ```
 
+```swift
+public extension A {}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -10,7 +10,10 @@ private extension File {
         let substructureOffsets = dictionary.substructure.flatMap {
             missingDocOffsets(in: $0, acls: acls)
         }
+        let extensionKinds: Set<SwiftDeclarationKind> = [.extension, .extensionEnum, .extensionClass,
+                                                         .extensionStruct, .extensionProtocol]
         guard let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
+            !extensionKinds.contains(kind),
             case let isDeinit = kind == .functionMethodInstance && dictionary.name == "deinit",
             !isDeinit,
             let offset = dictionary.offset,
@@ -54,6 +57,9 @@ public struct MissingDocsRule: OptInRule, ConfigurationProviderRule, AutomaticTe
             public class A {
                 deinit {}
             }
+            """,
+            """
+            public extension A {}
             """
         ],
         triggeringExamples: [


### PR DESCRIPTION
Fixes #2851