### PR TITLE
Don't trigger `explicit_type_interface` on if case statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@
 
 #### Bug Fixes
 
-* None.
+
+* Don't trigger `explicit_type_interface` on `if case let` statements.  
+  [Carlos Millani](https://github.com/cmillani)
 
 ## 0.35.0: Secondary Lint Trap
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -95,6 +95,7 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
             (!configuration.allowRedundancy ||
                 (!dictionary.isInitCall(file: file) && !dictionary.isTypeReferenceAssignment(file: file))
             ),
+            !dictionary.isIfCaseCall(file: file, parentStructure: parentStructure),
             !parentStructure.contains([.forEach, .guard]),
             !parentStructure.caseStatementPatternRanges.contains(offset),
             !parentStructure.caseExpressionRanges.contains(offset),
@@ -113,6 +114,20 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
 private extension Dictionary where Key == String, Value == SourceKitRepresentable {
     var containsType: Bool {
         return typeName != nil
+    }
+
+    func isIfCaseCall(file: File, parentStructure: [String: SourceKitRepresentable]) -> Bool {
+        guard parentStructure.kind == SwiftExpressionKind.call.rawValue,
+            let parentOffset = parentStructure.offset,
+            case let contents = file.contents.bridge(),
+            let beforeParentRange = contents.byteRangeToNSRange(start: parentOffset, length: 0) else {
+            return false
+        }
+
+        let fileUpToParent = contents.substring(to: beforeParentRange.location)
+        let isCaseRegex = regex("if\\s+case\\s+(let|var)?\\s*$")
+
+        return isCaseRegex.firstMatch(in: fileUpToParent, options: [], range: fileUpToParent.fullNSRange) != nil
     }
 
     func isInitCall(file: File) -> Bool {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -443,6 +443,7 @@ extension ExplicitTypeInterfaceRuleTests {
         ("testAllowRedundancy", testAllowRedundancy),
         ("testEmbededInStatements", testEmbededInStatements),
         ("testCaptureGroup", testCaptureGroup),
+        ("testTryCatchDeclarations", testTryCatchDeclarations),
         ("testFastEnumerationDeclaration", testFastEnumerationDeclaration),
         ("testSwitchCaseDeclarations", testSwitchCaseDeclarations)
     ]

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -178,6 +178,17 @@ class ExplicitTypeInterfaceRuleTests: XCTestCase {
                 case var (x, y): break
                 }
             }
+            """,
+            """
+            enum Foo {
+              case caseOne(propOne: Int)
+            }
+
+            let testA: Foo = .caseOne(propOne: 2)
+
+            if case let Foo.caseOne(propOne) = testA { }
+
+            if case Foo.caseOne(let propOne) = testA { }
             """
         ]
 

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -184,11 +184,22 @@ class ExplicitTypeInterfaceRuleTests: XCTestCase {
               case caseOne(propOne: Int)
             }
 
+            enum Bar: Error {
+              case testError
+              case multiVariable(foo: Int, bar: String)
+            }
+
             let testA: Foo = .caseOne(propOne: 2)
 
             if case let Foo.caseOne(propOne) = testA { }
 
             if case Foo.caseOne(let propOne) = testA { }
+
+            if 5 > 2, case Foo.caseOne(let propOne) = testA { }
+
+            let multiVariable: Error = Bar.multiVariable(foo: 10, bar: "")
+
+            if case Bar.multiVariable(let foo, _) = multiVariable { }
             """
         ]
 

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -1,6 +1,7 @@
 import SwiftLintFramework
 import XCTest
 
+//swiftlint:disable type_body_length
 class ExplicitTypeInterfaceRuleTests: XCTestCase {
     func testExplicitTypeInterface() {
         verifyRule(ExplicitTypeInterfaceRule.description)
@@ -123,6 +124,27 @@ class ExplicitTypeInterfaceRuleTests: XCTestCase {
             .with(triggeringExamples: triggeringExamples)
             .with(nonTriggeringExamples: nonTriggeringExamples)
 
+        verifyRule(description)
+    }
+
+    func testTryCatchDeclarations() {
+        let nonTriggeringExaples = [
+            """
+            enum FooError: Error {
+                case errorWithValue(value: Int)
+            }
+            do {
+                throw FooError.errorWithValue(value: 2)
+            } catch FooError.errorWithValue(let value) {
+                print(value)
+            }
+            """
+        ]
+
+        let triggeringExamples = ExplicitTypeInterfaceRule.description.triggeringExamples
+        let description = ExplicitTypeInterfaceRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExaples)
         verifyRule(description)
     }
 


### PR DESCRIPTION
The `explicit_type_interface` is being triggered on `if case let` statements with enum with types.

For exemple, this code will trigger a warning:

```swift
enum Foo {
  case caseOne(propOne: Int)
}

let testA: Foo = .caseOne(propOne: 2)

if case let Foo.caseOne(propOne) = testA { }
```

while this one will not:

```swift
enum Foo {
  case caseOne(propOne: Int)
}

let testA: Foo = .caseOne(propOne: 2)

switch testA {
  case let .caseOne(propOne): break
}
```

On `if case Enum.case(variable) = enum` the parent of the variable structure is of `call` type, because of this the current validation for `switch` and `cases` are not working

I was in doubt if a better solution would be:
* Verify if the parent of the variable declaration is a call, and this caracterizes a `if case let`
* Verify if the words before call are `if case`

I think the first one seems to follow better the pattern I saw on the code, but I am not comfortable assuming every combination of "Parent: Call, child: Var" is indeed a `if case let` situation. With this one, checking if the grandparent of the var is an if statement should also be good, what makes it even more complicated.

The second one seems a little bit inefficient, but is clear when reading and seems more assertive to me.