### PR TITLE
Add `npath_complexity` rule.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,6 +69,7 @@ opt_in_rules:
   - vertical_whitespace_opening_braces
   - xct_specific_matcher
   - yoda_condition
+  - npath_complexity
 
 identifier_name:
   excluded:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,10 @@ This is the last release to support building with Swift 4.2.x.
 * Add `contains_over_filter_is_empty` opt-in rule to warn against using
   expressions like `filter(where:).isEmpty` instead of `contains(where:)`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  
+  * Add `npath_complexity` opt-in rule to warn against overly complex functions.  
+  [Niil Öhlin](https://github.com/niilohlin)
+  [#1188](https://github.com/realm/SwiftLint/issues/1188)
 
 * Add `empty_collection_literal` opt-in rule to prefer using `isEmpty` to
   comparison to `[]` or `[:]`.  

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -101,6 +101,7 @@ public let masterRuleList = RuleList(rules: [
     MultilineParametersBracketsRule.self,
     MultilineParametersRule.self,
     MultipleClosuresWithTrailingClosureRule.self,
+    NPathComplexityRule.self,
     NSLocalizedStringKeyRule.self,
     NSLocalizedStringRequireBundleRule.self,
     NSObjectPreferIsEqualRule.self,

--- a/Source/SwiftLintFramework/Rules/Metrics/NPathComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NPathComplexityRule.swift
@@ -11,20 +11,68 @@ public struct NPathComplexityRule: ASTRule, ConfigurationProviderRule, OptInRule
         description: "The number of paths of function bodies should be limited.",
         kind: .metrics,
         nonTriggeringExamples: [
-            "func f1() {\nif true {\nfor _ in 1..5 { } }\nif false { }\n}",
-            "func f(code: Int) -> Int {\n" +
-                "switch code {\n case 0: fallthrough\n case 0: return 1\n case 0: return 1\n" +
-                " case 0: return 1\n case 0: return 1\n case 0: return 1\n case 0: return 1\n" +
-                " case 0: return 1\n case 0: return 1\n default: return 1\n }\n}",
-            "func f1() {" +
-                "if true {}; if true {}; if true {}; if true {}; if true {}; if true {}\n" +
-                "func f2() {\n" +
-                "if true {}; if true {}; if true {}; if true {}; if true {}\n" +
-            "}}"
+            """
+            // NPath Complexity: 6
+            func nonTriggering() {
+                if true {
+                    for _ in 1..5 {
+                        print("non triggering")
+                    }
+                }
+                if false {
+                    print("non triggering")
+                }
+            }
+            """,
+            """
+            // NPath Complexity: 11
+            func switchCase(code: Int) -> Int {
+                switch code {
+                case 0: fallthrough
+                case 1: return 1
+                case 2: return 2
+                case 3: return 3
+                case 4: return 4
+                case 5: return 5
+                case 6: return 6
+                case 7: return 7
+                case 8: return 8
+                case 9: return 9
+                default: return 0
+                }
+            }
+            """,
+            """
+            // NPath Complexity: 64
+            func nestedFunctions() {
+                if true {}
+                if true {}
+                if true {}
+                if true {}
+                if true {}
+                if true {}
+                // NPath Complexity: 4
+                func innerFunction() {
+                    if true {}
+                    if true {}
+                }
+            }
+            """
         ],
         triggeringExamples: [
-            "↓func f1() {\n if true {}\n if true {}\n if true {}\n if true {}\n if true {}\n if true {}\n" +
-                " if true {}\n if true {}\n}"
+            """
+            // NPath Complexity: 256
+            ↓func triggeringFunction() {
+                if true {}
+                if true {}
+                if true {}
+                if true {}
+                if true {}
+                if true {}
+                if true {}
+                if true {}
+            }
+            """
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Metrics/NPathComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NPathComplexityRule.swift
@@ -1,0 +1,98 @@
+import SourceKittenFramework
+
+public struct NPathComplexityRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    public var configuration = CyclomaticComplexityConfiguration(warning: 200, error: 1000)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "npath_complexity",
+        name: "NPath Complexity",
+        description: "The number of paths of function bodies should be limited.",
+        kind: .metrics,
+        nonTriggeringExamples: [
+            "func f1() {\nif true {\nfor _ in 1..5 { } }\nif false { }\n}",
+            "func f(code: Int) -> Int {\n" +
+                "switch code {\n case 0: fallthrough\n case 0: return 1\n case 0: return 1\n" +
+                " case 0: return 1\n case 0: return 1\n case 0: return 1\n case 0: return 1\n" +
+                " case 0: return 1\n case 0: return 1\n default: return 1\n }\n}",
+            "func f1() {" +
+                "if true {}; if true {}; if true {}; if true {}; if true {}; if true {}\n" +
+                "func f2() {\n" +
+                "if true {}; if true {}; if true {}; if true {}; if true {}\n" +
+            "}}"
+        ],
+        triggeringExamples: [
+            "↓func f1() {\n if true {}\n if true {}\n if true {}\n if true {}\n if true {}\n if true {}\n" +
+                " if true {}\n if true {}\n}"
+        ]
+    )
+
+    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        guard SwiftDeclarationKind.functionKinds.contains(kind) else {
+            return []
+        }
+
+        let complexity = measureComplexity(in: file, dictionary: dictionary).totalPaths
+
+        for parameter in configuration.params where complexity > parameter.value {
+            let offset = dictionary.offset ?? 0
+            let reason = "Function should have complexity \(configuration.length.warning) or less: " +
+            "currently complexity equals \(complexity)"
+            return [StyleViolation(ruleDescription: type(of: self).description,
+                                   severity: parameter.severity,
+                                   location: Location(file: file, byteOffset: offset),
+                                   reason: reason)]
+        }
+
+        return []
+    }
+
+    private func measureComplexity(in file: SwiftLintFile, dictionary: SourceKittenDictionary
+                                  ) -> (totalPaths: Int, currentPaths: Int) {
+        let complexity = dictionary.substructure.reduce((totalPaths: 1, currentPaths: 1)) { complexity, subDict in
+            guard let kind = subDict.kind else {
+                return complexity
+            }
+
+            if let declarationKind = SwiftDeclarationKind(rawValue: kind),
+                SwiftDeclarationKind.functionKinds.contains(declarationKind) {
+                return complexity
+            }
+
+            guard let statementKind = StatementKind(rawValue: kind) else {
+                let subComplexity = measureComplexity(in: file, dictionary: subDict)
+                return (totalPaths: complexity.totalPaths * subComplexity.totalPaths,
+                        currentPaths: subComplexity.currentPaths)
+            }
+
+            let score = configuration.complexityStatements.contains(statementKind) ? 1 : 0
+
+            // The complexity of everything inside the if/guard/switch
+            let subScore = measureComplexity(in: file, dictionary: subDict)
+
+            // subScore.totalPaths is always at least one.
+            let totalPaths = complexity.totalPaths + complexity.currentPaths * (score + subScore.totalPaths - 1)
+
+            // Guard always exits. Return the same current paths as input paths.
+            if statementKind == .guard {
+                return (totalPaths: totalPaths, currentPaths: complexity.currentPaths * score)
+            }
+
+            // Remove one path since a switch will always be entered.
+            if statementKind == .switch {
+                return (totalPaths: totalPaths - 1,
+                        currentPaths: complexity.currentPaths * (score + subScore.totalPaths) - 1)
+            }
+
+            if statementKind == .case {
+                return (totalPaths: totalPaths, currentPaths: complexity.currentPaths * score)
+            }
+
+            return (totalPaths: totalPaths, currentPaths: complexity.currentPaths * (score + subScore.totalPaths))
+        }
+
+        return complexity
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -241,6 +241,8 @@
 		C3D23F1D21E3A33700E9BD1B /* UnusedControlFlowLabelRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D7320C21E15ED4001C07D9 /* UnusedControlFlowLabelRule.swift */; };
 		C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */; };
 		C3EF547821B5A4000009262F /* LegacyHashingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EF547521B5A2190009262F /* LegacyHashingRule.swift */; };
+		C8BE297823155B0A00C1E917 /* NPathComplexityRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BE29762315580A00C1E917 /* NPathComplexityRule.swift */; };
+		C8BE297A23155D5D00C1E917 /* NPathComplexityRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BE297923155D5D00C1E917 /* NPathComplexityRuleTests.swift */; };
 		C946FECB1EAE67EE007DD778 /* LetVarWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */; };
 		C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */; };
 		CC26ED07204DEB510013BBBC /* RuleIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */; };
@@ -742,6 +744,8 @@
 		C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRule.swift; sourceTree = "<group>"; };
 		C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FatalErrorMessageRule.swift; sourceTree = "<group>"; };
 		C3EF547521B5A2190009262F /* LegacyHashingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHashingRule.swift; sourceTree = "<group>"; };
+		C8BE29762315580A00C1E917 /* NPathComplexityRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NPathComplexityRule.swift; sourceTree = "<group>"; };
+		C8BE297923155D5D00C1E917 /* NPathComplexityRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NPathComplexityRuleTests.swift; sourceTree = "<group>"; };
 		C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LetVarWhitespaceRule.swift; sourceTree = "<group>"; };
 		C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
 		CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleIdentifier.swift; sourceTree = "<group>"; };
@@ -1124,6 +1128,7 @@
 				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
 				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
 				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
+				C8BE29762315580A00C1E917 /* NPathComplexityRule.swift */,
 			);
 			path = Metrics;
 			sourceTree = "<group>";
@@ -1591,6 +1596,7 @@
 				627C7A312004F9290053C79D /* XCTSpecificMatcherRuleTests.swift */,
 				3B30C4A01C3785B300E04027 /* YamlParserTests.swift */,
 				3B12C9C21C320A53000B423F /* YamlSwiftLintTests.swift */,
+				C8BE297923155D5D00C1E917 /* NPathComplexityRuleTests.swift */,
 			);
 			name = SwiftLintFrameworkTests;
 			path = Tests/SwiftLintFrameworkTests;
@@ -2009,6 +2015,7 @@
 				4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */,
 				D4F10614229A2F5E00FDE319 /* NoFallthroughOnlyRuleExamples.swift in Sources */,
 				3ABE19CF20B7CE32009C2EC2 /* MultilineFunctionChainsRule.swift in Sources */,
+				C8BE297823155B0A00C1E917 /* NPathComplexityRule.swift in Sources */,
 				82FE253F20F604AD00295958 /* VerticalWhitespaceOpeningBracesRule.swift in Sources */,
 				827169B51F48D712003FB9AF /* NoGroupingExtensionRule.swift in Sources */,
 				D41B57781ED8CEE0007B0470 /* ExtensionAccessModifierRule.swift in Sources */,
@@ -2347,6 +2354,7 @@
 				B1FD3ABB238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift in Sources */,
 				D4F5851520E99A8A0085C6D8 /* TrailingWhitespaceTests.swift in Sources */,
 				D450D1E021F19AB300E60010 /* TrailingClosureRuleTests.swift in Sources */,
+				C8BE297A23155D5D00C1E917 /* NPathComplexityRuleTests.swift in Sources */,
 				3B12C9C31C320A53000B423F /* YamlSwiftLintTests.swift in Sources */,
 				D41985ED21FAD033003BE2B7 /* DeploymentTargetConfigurationTests.swift in Sources */,
 				D450D1E221F19B1E00E60010 /* TrailingClosureConfigurationTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -925,6 +925,24 @@ extension MultipleClosuresWithTrailingClosureRuleTests {
     ]
 }
 
+extension NPathComplexityRuleTests {
+    static var allTests: [(String, (NPathComplexityRuleTests) -> () throws -> Void)] = [
+        ("testNPathComplexityRule", testNPathComplexityRule),
+        ("testSimpleNPathComplexity", testSimpleNPathComplexity),
+        ("testSimpleNestedIfExample", testSimpleNestedIfExample),
+        ("testMoreComplexIfExample", testMoreComplexIfExample),
+        ("testGuardExample", testGuardExample),
+        ("testIfGuardExample", testIfGuardExample),
+        ("testGuardIfExample", testGuardIfExample),
+        ("testGuardWithInnerIfExample", testGuardWithInnerIfExample),
+        ("testSimpleCaseExample", testSimpleCaseExample),
+        ("testCaseExample", testCaseExample),
+        ("testCaseIfExample", testCaseIfExample),
+        ("testCaseNestedIfExample", testCaseNestedIfExample),
+        ("testForExample", testForExample)
+    ]
+}
+
 extension NSLocalizedStringKeyRuleTests {
     static var allTests: [(String, (NSLocalizedStringKeyRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1750,6 +1768,7 @@ XCTMain([
     testCase(MultilineParametersBracketsRuleTests.allTests),
     testCase(MultilineParametersRuleTests.allTests),
     testCase(MultipleClosuresWithTrailingClosureRuleTests.allTests),
+    testCase(NPathComplexityRuleTests.allTests),
     testCase(NSLocalizedStringKeyRuleTests.allTests),
     testCase(NSLocalizedStringRequireBundleRuleTests.allTests),
     testCase(NSObjectPreferIsEqualRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/NPathComplexityRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NPathComplexityRuleTests.swift
@@ -2,27 +2,26 @@ import SwiftLintFramework
 import XCTest
 
 class NPathComplexityRuleTests: XCTestCase {
-    // NPath complexity: 8
     private lazy var simpleIfExample: String = {
         return """
-        func ifsInALine() {
-            if true != false {
-                print("true")
-            }
-            if false != true {
-                print("false")
-            }
-            if 2 + 2 == 5 {
-                print("maybe")
-            }
-        }
-
-        """
+               // NPath complexity: 8
+               func ifsInALine() {
+                   if true != false {
+                       print("true")
+                   }
+                   if false != true {
+                       print("false")
+                   }
+                   if 2 + 2 == 5 {
+                       print("maybe")
+                   }
+               }
+               """
     }()
 
-    // NPath complexity: 4
     private lazy var simpleNestedIfExample: String = {
         return """
+               // NPath complexity: 4
                func nestedIfs() {
                    if true != false {
                        print("true")
@@ -37,30 +36,29 @@ class NPathComplexityRuleTests: XCTestCase {
                """
     }()
 
-    // NPath complexity: 8
     private lazy var nestedIfExample: String = {
         return """
-                func nestedIfs() {
-                    if true != false {
-                        print("true")
-                        if false != true {
-                            print("false")
-                            if 2 + 2 == 5 {
-                                print("maybe")
-                            }
-                        }
-                    }
-                    if Bool.random() {
-                        print("random")
-                    }
-                }
-
+               // NPath complexity: 8
+               func nestedIfs() {
+                   if true != false {
+                       print("true")
+                       if false != true {
+                           print("false")
+                           if 2 + 2 == 5 {
+                               print("maybe")
+                           }
+                       }
+                   }
+                   if Bool.random() {
+                       print("random")
+                   }
+               }
                """
     }()
 
-    // NPath complexity: 4
     private lazy var guardExample: String = {
         return """
+               // NPath complexity: 4
                func guardFunction() {
                    guard true != false else {
                        return
@@ -77,9 +75,9 @@ class NPathComplexityRuleTests: XCTestCase {
                """
     }()
 
-    // NPath complexity: 3
     private lazy var guardIfExample: String = {
         return """
+               // NPath complexity: 3
                func guardIfFunction() {
                    guard true != false else {
                        return
@@ -91,9 +89,9 @@ class NPathComplexityRuleTests: XCTestCase {
                """
     }()
 
-    // NPath complexity: 4
     private lazy var ifGuardExample: String = {
         return """
+               // NPath complexity: 4
                func ifGuardFunction() {
                    if false == true {
                        print("here")
@@ -105,9 +103,9 @@ class NPathComplexityRuleTests: XCTestCase {
                """
     }()
 
-    // NPath complexity: 4
     private lazy var guardWithInnerIf: String = {
         return """
+               // NPath complexity: 4
                func guardWithInnerIfFunction() {
                    guard true != false else {
                        if false == true {
@@ -122,9 +120,9 @@ class NPathComplexityRuleTests: XCTestCase {
                """
     }()
 
-    // NPath complexity: 2
     private lazy var simpleCaseExample: String = {
         return """
+               // NPath complexity: 2
                func simpleCaseFunction() {
                    switch true {
                    case false:
@@ -136,10 +134,10 @@ class NPathComplexityRuleTests: XCTestCase {
                """
     }()
 
-    // NPath complexity: 3
     // fallthrough does not affect NPath complexity
     private lazy var caseExample: String = {
         return """
+               // NPath complexity: 3
                func caseFunction() {
                    switch 3 {
                    case 0:
@@ -153,9 +151,9 @@ class NPathComplexityRuleTests: XCTestCase {
                """
     }()
 
-    // NPath complexity: 4
     private lazy var caseIfExample: String = {
         return """
+               // NPath complexity: 4
                 func caseIfFunction() {
                     switch true {
                     case false:
@@ -169,46 +167,30 @@ class NPathComplexityRuleTests: XCTestCase {
                """
     }()
 
-    // NPath complexity: 3
     private lazy var caseNestedIfExample: String = {
         return """
-                func caseNestedIfFunction() {
-                    switch true {
-                    case false:
-                        if true {}
-                        break
-                    case true:
-                        break
-                    }
-                }
-
+               // NPath complexity: 3
+               func caseNestedIfFunction() {
+                   switch true {
+                   case false:
+                       if true {}
+                       break
+                   case true:
+                       break
+                   }
+               }
                """
     }()
 
     private lazy var forExample: String = {
         return """
-            func forFunction() {
-                for _ in (0 ... 100) {
-                }
-            }
-            """
+               // NPath complexity: 2
+               func forFunction() {
+                   for _ in (0 ... 100) {
+                   }
+               }
+               """
     }()
-
-    private func verify(that example: String, hasComplexity complexity: Int) {
-        let baseDescription = NPathComplexityRule.description
-
-        let nonTriggeringDescription = baseDescription.with(nonTriggeringExamples: [example])
-            .with(triggeringExamples: [])
-
-        verifyRule(nonTriggeringDescription, ruleConfiguration: ["warning": complexity],
-                   commentDoesntViolate: true, stringDoesntViolate: true)
-
-        let triggeringDescription = baseDescription.with(nonTriggeringExamples: [])
-            .with(triggeringExamples: [example])
-
-        verifyRule(triggeringDescription, ruleConfiguration: ["warning": complexity - 1],
-                   commentDoesntViolate: true, stringDoesntViolate: true)
-    }
 
     func testNPathComplexityRule() {
         verifyRule(NPathComplexityRule.description, commentDoesntViolate: true, stringDoesntViolate: true)
@@ -260,5 +242,23 @@ class NPathComplexityRuleTests: XCTestCase {
 
     func testForExample() {
         verify(that: forExample, hasComplexity: 2)
+    }
+}
+
+private extension XCTestCase {
+    func verify(that example: String, hasComplexity complexity: Int) {
+        let baseDescription = NPathComplexityRule.description
+
+        let nonTriggeringDescription = baseDescription.with(nonTriggeringExamples: [example])
+            .with(triggeringExamples: [])
+
+        verifyRule(nonTriggeringDescription, ruleConfiguration: ["warning": complexity],
+                   commentDoesntViolate: true, stringDoesntViolate: true)
+
+        let triggeringDescription = baseDescription.with(nonTriggeringExamples: [])
+            .with(triggeringExamples: [example])
+
+        verifyRule(triggeringDescription, ruleConfiguration: ["warning": complexity - 1],
+                   commentDoesntViolate: true, stringDoesntViolate: true)
     }
 }

--- a/Tests/SwiftLintFrameworkTests/NPathComplexityRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NPathComplexityRuleTests.swift
@@ -1,0 +1,264 @@
+import SwiftLintFramework
+import XCTest
+
+class NPathComplexityRuleTests: XCTestCase {
+    // NPath complexity: 8
+    private lazy var simpleIfExample: String = {
+        return """
+        func ifsInALine() {
+            if true != false {
+                print("true")
+            }
+            if false != true {
+                print("false")
+            }
+            if 2 + 2 == 5 {
+                print("maybe")
+            }
+        }
+
+        """
+    }()
+
+    // NPath complexity: 4
+    private lazy var simpleNestedIfExample: String = {
+        return """
+               func nestedIfs() {
+                   if true != false {
+                       print("true")
+                       if false != true {
+                           print("false")
+                           if 2 + 2 == 5 {
+                               print("maybe")
+                           }
+                       }
+                   }
+               }
+               """
+    }()
+
+    // NPath complexity: 8
+    private lazy var nestedIfExample: String = {
+        return """
+                func nestedIfs() {
+                    if true != false {
+                        print("true")
+                        if false != true {
+                            print("false")
+                            if 2 + 2 == 5 {
+                                print("maybe")
+                            }
+                        }
+                    }
+                    if Bool.random() {
+                        print("random")
+                    }
+                }
+
+               """
+    }()
+
+    // NPath complexity: 4
+    private lazy var guardExample: String = {
+        return """
+               func guardFunction() {
+                   guard true != false else {
+                       return
+                   }
+
+                   guard false != true else {
+                       return
+                   }
+
+                   guard 5 < 4 else {
+                       return
+                   }
+               }
+               """
+    }()
+
+    // NPath complexity: 3
+    private lazy var guardIfExample: String = {
+        return """
+               func guardIfFunction() {
+                   guard true != false else {
+                       return
+                   }
+                   if false == true {
+                       print("here")
+                   }
+               }
+               """
+    }()
+
+    // NPath complexity: 4
+    private lazy var ifGuardExample: String = {
+        return """
+               func ifGuardFunction() {
+                   if false == true {
+                       print("here")
+                   }
+                   guard true != false else {
+                       return
+                   }
+               }
+               """
+    }()
+
+    // NPath complexity: 4
+    private lazy var guardWithInnerIf: String = {
+        return """
+               func guardWithInnerIfFunction() {
+                   guard true != false else {
+                       if false == true {
+                           print("here")
+                       }
+                       return
+                   }
+                   if true {
+                       print("there")
+                   }
+               }
+               """
+    }()
+
+    // NPath complexity: 2
+    private lazy var simpleCaseExample: String = {
+        return """
+               func simpleCaseFunction() {
+                   switch true {
+                   case false:
+                       break
+                   default:
+                       break
+                   }
+               }
+               """
+    }()
+
+    // NPath complexity: 3
+    // fallthrough does not affect NPath complexity
+    private lazy var caseExample: String = {
+        return """
+               func caseFunction() {
+                   switch 3 {
+                   case 0:
+                       fallthrough
+                   case 1:
+                       break
+                   default:
+                       break
+                   }
+               }
+               """
+    }()
+
+    // NPath complexity: 4
+    private lazy var caseIfExample: String = {
+        return """
+                func caseIfFunction() {
+                    switch true {
+                    case false:
+                        break
+                    case true:
+                        break
+                    }
+                    if true {}
+                }
+
+               """
+    }()
+
+    // NPath complexity: 3
+    private lazy var caseNestedIfExample: String = {
+        return """
+                func caseNestedIfFunction() {
+                    switch true {
+                    case false:
+                        if true {}
+                        break
+                    case true:
+                        break
+                    }
+                }
+
+               """
+    }()
+
+    private lazy var forExample: String = {
+        return """
+            func forFunction() {
+                for _ in (0 ... 100) {
+                }
+            }
+            """
+    }()
+
+    private func verify(that example: String, hasComplexity complexity: Int) {
+        let baseDescription = NPathComplexityRule.description
+
+        let nonTriggeringDescription = baseDescription.with(nonTriggeringExamples: [example])
+            .with(triggeringExamples: [])
+
+        verifyRule(nonTriggeringDescription, ruleConfiguration: ["warning": complexity],
+                   commentDoesntViolate: true, stringDoesntViolate: true)
+
+        let triggeringDescription = baseDescription.with(nonTriggeringExamples: [])
+            .with(triggeringExamples: [example])
+
+        verifyRule(triggeringDescription, ruleConfiguration: ["warning": complexity - 1],
+                   commentDoesntViolate: true, stringDoesntViolate: true)
+    }
+
+    func testNPathComplexityRule() {
+        verifyRule(NPathComplexityRule.description, commentDoesntViolate: true, stringDoesntViolate: true)
+    }
+
+    func testSimpleNPathComplexity() {
+        verify(that: simpleIfExample, hasComplexity: 8)
+    }
+
+    func testSimpleNestedIfExample() {
+        verify(that: simpleNestedIfExample, hasComplexity: 4)
+    }
+
+    func testMoreComplexIfExample() {
+        verify(that: nestedIfExample, hasComplexity: 8)
+    }
+
+    func testGuardExample() {
+        verify(that: guardExample, hasComplexity: 4)
+    }
+
+    func testIfGuardExample() {
+        verify(that: ifGuardExample, hasComplexity: 4)
+    }
+
+    func testGuardIfExample() {
+        verify(that: guardIfExample, hasComplexity: 3)
+    }
+
+    func testGuardWithInnerIfExample() {
+        verify(that: guardWithInnerIf, hasComplexity: 4)
+    }
+
+    func testSimpleCaseExample() {
+        verify(that: simpleCaseExample, hasComplexity: 2)
+    }
+
+    func testCaseExample() {
+        verify(that: caseExample, hasComplexity: 3)
+    }
+
+    func testCaseIfExample() {
+        verify(that: caseIfExample, hasComplexity: 4)
+    }
+
+    func testCaseNestedIfExample() {
+        verify(that: caseNestedIfExample, hasComplexity: 3)
+    }
+
+    func testForExample() {
+        verify(that: forExample, hasComplexity: 2)
+    }
+}


### PR DESCRIPTION
Solves https://github.com/realm/SwiftLint/issues/1188. 

NPath Complexity is related to Cyclomatic Complexity but instead of adding up the different possible branching statements it tries to calculate the possible number of code paths in a given function.

**Known limits:** This implementation does not take `try/catch`, `return` or multi-clause conditions (`||`, `&&`, and `,`) statements into consideration when calculating NPath complexity. Since it is not available in the AST.

The default values are inspired by [phpmd](https://phpmd.org/rules/codesize.html) and the test values are verified against phpmd.
