### PR TITLE
Add no_space_in_method_call rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   [atfelix](https://github.com/atfelix)
   [#2791](https://github.com/realm/SwiftLint/issues/2791)
 
+* Add `no_space_in_method_call` rule to validate that there're no spaces
+  between the method name and parentheses in a method call.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 * Add `contains_over_filter_count` opt-in rule to warn against using
   expressions like `filter(where:).count > 0` instead of `contains(where:)`.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/Rules.md
+++ b/Rules.md
@@ -14017,6 +14017,10 @@ object.foo { print($0 }
 list.sorted { $0.0 < $1.0 }.map { $0.value }
 ```
 
+```swift
+self.init(rgb: (Int) (colorInt))
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -98,6 +98,7 @@
 * [No Extension Access Modifier](#no-extension-access-modifier)
 * [No Fallthrough Only](#no-fallthrough-only)
 * [No Grouping Extension](#no-grouping-extension)
+* [No Space in Method Call](#no-space-in-method-call)
 * [Notification Center Detachment](#notification-center-detachment)
 * [NSLocalizedString Key](#nslocalizedstring-key)
 * [NSLocalizedString Require Bundle](#nslocalizedstring-require-bundle)
@@ -13973,6 +13974,75 @@ class Ham { class Spam {}}
 extension External { struct Gotcha {}}
 ↓extension External.Gotcha {}
 
+```
+
+</details>
+
+
+
+## No Space in Method Call
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`no_space_in_method_call` | Enabled | Yes | style | No | 4.2.0 
+
+Don't add a space between the method name and the parentheses.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+foo()
+```
+
+```swift
+object.foo()
+```
+
+```swift
+object.foo(1)
+```
+
+```swift
+object.foo(value: 1)
+```
+
+```swift
+object.foo { print($0 }
+```
+
+```swift
+list.sorted { $0.0 < $1.0 }.map { $0.value }
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+foo↓ ()
+```
+
+```swift
+object.foo↓ ()
+```
+
+```swift
+object.foo↓ (1)
+```
+
+```swift
+object.foo↓ (value: 1)
+```
+
+```swift
+object.foo↓ () {}
+```
+
+```swift
+object.foo↓     ()
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.16.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.16.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 public let masterRuleList = RuleList(rules: [
@@ -102,6 +102,7 @@ public let masterRuleList = RuleList(rules: [
     NoExtensionAccessModifierRule.self,
     NoFallthroughOnlyRule.self,
     NoGroupingExtensionRule.self,
+    NoSpaceInMethodCallRule.self,
     NotificationCenterDetachmentRule.self,
     NumberSeparatorRule.self,
     ObjectLiteralRule.self,

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -19,7 +19,8 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
             "object.foo(1)",
             "object.foo(value: 1)",
             "object.foo { print($0 }",
-            "list.sorted { $0.0 < $1.0 }.map { $0.value }"
+            "list.sorted { $0.0 < $1.0 }.map { $0.value }",
+            "self.init(rgb: (Int) (colorInt))"
         ],
         triggeringExamples: [
             "foo↓ ()",
@@ -78,6 +79,11 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
             subDict.kind.flatMap(SwiftExpressionKind.init) == .closure,
             let closureBodyOffset = subDict.bodyOffset,
             closureBodyOffset == bodyOffset {
+            return []
+        }
+
+        // Don't trigger if it's a typecast
+        if let name = dictionary.name, name.hasPrefix("("), name.hasSuffix(")") {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SourceKittenFramework
+
+public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule,
+                                       AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "no_space_in_method_call",
+        name: "No Space in Method Call",
+        description: "Don't add a space between the method name and the parentheses.",
+        kind: .style,
+        minSwiftVersion: .fourDotTwo,
+        nonTriggeringExamples: [
+            "foo()",
+            "object.foo()",
+            "object.foo(1)",
+            "object.foo(value: 1)",
+            "object.foo { print($0 }",
+            "list.sorted { $0.0 < $1.0 }.map { $0.value }"
+        ],
+        triggeringExamples: [
+            "foo↓ ()",
+            "object.foo↓ ()",
+            "object.foo↓ (1)",
+            "object.foo↓ (value: 1)",
+            "object.foo↓ () {}",
+            "object.foo↓     ()"
+        ],
+        corrections: [
+            "foo↓ ()": "foo()",
+            "object.foo↓ ()": "object.foo()",
+            "object.foo↓ (1)": "object.foo(1)",
+            "object.foo↓ (value: 1)": "object.foo(value: 1)",
+            "object.foo↓ () {}": "object.foo() {}",
+            "object.foo↓     ()": "object.foo()"
+        ]
+    )
+
+    // MARK: - ASTRule
+
+    public func validate(file: File,
+                         kind: SwiftExpressionKind,
+                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+        return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+
+    // MARK: - SubstitutionCorrectableASTRule
+
+    public func substitution(for violationRange: NSRange, in file: File) -> (NSRange, String) {
+        return (violationRange, "")
+    }
+
+    public func violationRanges(in file: File,
+                                kind: SwiftExpressionKind,
+                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+        guard kind == .call,
+            let bodyOffset = dictionary.bodyOffset,
+            let nameOffset = dictionary.nameOffset,
+            let nameLength = dictionary.nameLength,
+            nameLength > 0,
+            case let nameEndPosition = nameOffset + nameLength,
+            bodyOffset != nameEndPosition + 1,
+            case let contents = file.contents.bridge(),
+            let range = contents.byteRangeToNSRange(start: nameEndPosition,
+                                                    length: bodyOffset - nameEndPosition - 1) else {
+                return []
+        }
+
+        // Don't trigger if it's a single parameter trailing closure without parens
+        if let subDict = dictionary.substructure.last,
+            subDict.kind.flatMap(SwiftExpressionKind.init) == .closure,
+            let closureBodyOffset = subDict.bodyOffset,
+            closureBodyOffset == bodyOffset {
+            return []
+        }
+
+        return [range]
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -300,6 +300,7 @@
 		D48AE2CC1DFB58C5001C6A4A /* AttributesRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48AE2CB1DFB58C5001C6A4A /* AttributesRuleExamples.swift */; };
 		D48B51211F4F5DEF0068AB98 /* RuleList+Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48B51201F4F5DEF0068AB98 /* RuleList+Documentation.swift */; };
 		D48B51231F4F5E4B0068AB98 /* DocumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48B51221F4F5E4B0068AB98 /* DocumentationTests.swift */; };
+		D48EE14B231CD34200DBB779 /* NoSpaceInMethodCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48EE14A231CD34200DBB779 /* NoSpaceInMethodCallRule.swift */; };
 		D495B1A221165DAA00E2CD7B /* FileNameRuleFixtures in Resources */ = {isa = PBXBuildFile; fileRef = D495B1A021165DAA00E2CD7B /* FileNameRuleFixtures */; };
 		D495B1A321165DAA00E2CD7B /* FileHeaderRuleFixtures in Resources */ = {isa = PBXBuildFile; fileRef = D495B1A121165DAA00E2CD7B /* FileHeaderRuleFixtures */; };
 		D49896F12026B36C00814A83 /* RedundantSetAccessControlRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49896F02026B36C00814A83 /* RedundantSetAccessControlRule.swift */; };
@@ -796,6 +797,7 @@
 		D48AE2CB1DFB58C5001C6A4A /* AttributesRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRuleExamples.swift; sourceTree = "<group>"; };
 		D48B51201F4F5DEF0068AB98 /* RuleList+Documentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RuleList+Documentation.swift"; sourceTree = "<group>"; };
 		D48B51221F4F5E4B0068AB98 /* DocumentationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentationTests.swift; sourceTree = "<group>"; };
+		D48EE14A231CD34200DBB779 /* NoSpaceInMethodCallRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSpaceInMethodCallRule.swift; sourceTree = "<group>"; };
 		D495B1A021165DAA00E2CD7B /* FileNameRuleFixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FileNameRuleFixtures; sourceTree = "<group>"; };
 		D495B1A121165DAA00E2CD7B /* FileHeaderRuleFixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FileHeaderRuleFixtures; sourceTree = "<group>"; };
 		D49896F02026B36C00814A83 /* RedundantSetAccessControlRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantSetAccessControlRule.swift; sourceTree = "<group>"; };
@@ -1195,6 +1197,7 @@
 				6238AE411ED4D734006C3601 /* MultilineParametersRule.swift */,
 				621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */,
 				BB00B4E71F5216070079869F /* MultipleClosuresWithTrailingClosureRule.swift */,
+				D48EE14A231CD34200DBB779 /* NoSpaceInMethodCallRule.swift */,
 				D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */,
 				D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */,
 				692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */,
@@ -2113,6 +2116,7 @@
 				621061BF1ED57E640082D51E /* MultilineParametersRuleExamples.swift in Sources */,
 				D41985EB21FAB63E003BE2B7 /* DeploymentTargetConfiguration.swift in Sources */,
 				D48AE2CC1DFB58C5001C6A4A /* AttributesRuleExamples.swift in Sources */,
+				D48EE14B231CD34200DBB779 /* NoSpaceInMethodCallRule.swift in Sources */,
 				C28B2B3D2106DF730009A0FE /* PrefixedConstantRuleConfiguration.swift in Sources */,
 				62A7127520F1178F00E604A6 /* AnyObjectProtocolRule.swift in Sources */,
 				D4D0B8F42211428D0053A116 /* ColonRuleExamples.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -910,6 +910,12 @@ extension NoGroupingExtensionRuleTests {
     ]
 }
 
+extension NoSpaceInMethodCallRuleTests {
+    static var allTests: [(String, (NoSpaceInMethodCallRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension NotificationCenterDetachmentRuleTests {
     static var allTests: [(String, (NotificationCenterDetachmentRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1663,6 +1669,7 @@ XCTMain([
     testCase(NoExtensionAccessModifierRuleTests.allTests),
     testCase(NoFallthroughOnlyRuleTests.allTests),
     testCase(NoGroupingExtensionRuleTests.allTests),
+    testCase(NoSpaceInMethodCallRuleTests.allTests),
     testCase(NotificationCenterDetachmentRuleTests.allTests),
     testCase(NumberSeparatorRuleTests.allTests),
     testCase(ObjectLiteralRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -450,6 +450,12 @@ class NoGroupingExtensionRuleTests: XCTestCase {
     }
 }
 
+class NoSpaceInMethodCallRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NoSpaceInMethodCallRule.description)
+    }
+}
+
 class NotificationCenterDetachmentRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NotificationCenterDetachmentRule.description)


### PR DESCRIPTION
Adding this as a default rule because I don't expect it to happen too much in the wild.

I'm open to suggestions for the name rule/description!