### PR TITLE
Add optional support for Missing Import Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,7 +438,7 @@ This is the last release to support building with Swift 5.0.x.
   using `flatMap` over `map { ... }.reduce([], +)`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2883](https://github.com/realm/SwiftLint/issues/2883)
-  
+
 * Add autocorrection to `syntactic_sugar`.  
   [Ivan Vavilov](https://github.com/vani2)
 
@@ -452,14 +452,24 @@ This is the last release to support building with Swift 5.0.x.
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2874](https://github.com/realm/SwiftLint/issues/2874)
 
-* Add `raw_value_for_camel_cased_codable_enum` opt-in rule to enforce raw values 
+* Add `raw_value_for_camel_cased_codable_enum` opt-in rule to enforce raw values
   for camel cased Codable String enum cases.  
   [Marko Pejovic](https://github.com/00FA9A)
   [#2888](https://github.com/realm/SwiftLint/issues/2888)
 
 * Speedup `LetVarWhiteSpacesRule`.  
   [PaulTaykalo](https://github.com/PaulTaykalo)
-  [#2901](https://github.com/realm/SwiftLint/issues/2901)  
+  [#2901](https://github.com/realm/SwiftLint/issues/2901)
+
+* Add `missing_import_result` opt-in rule to warn when using a version of
+  [Result](https://github.com/antitypical/Result) that is not compatible with
+  Swift 5's `Result` type. If your code still depends on the `Result` (v4.0.1 and
+  earlier) framework, then you must import it or your code will either not
+  compile or silently compile with the intrinsic `Result` type.
+  Turn this rule on in a project that depends on this framework to avoid
+  missing this crucial import. NB: Version 5.0 of `Result` makes it compatible
+  with Swift 5's `Result` type.  
+  [Gus Verdun](https://github.com/ghv)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -93,6 +93,7 @@ public let masterRuleList = RuleList(rules: [
     LowerACLThanParentRule.self,
     MarkRule.self,
     MissingDocsRule.self,
+    MissingImportResultRule.self,
     ModifierOrderRule.self,
     MultilineArgumentsBracketsRule.self,
     MultilineArgumentsRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/MissingImportResultRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingImportResultRule.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SourceKittenFramework
+
+public struct MissingImportResultRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "missing_import_result",
+        name: "Missing Import Result",
+        description: "You must add `import Result` in order to use the correct `Result` type.",
+        kind: .lint,
+        minSwiftVersion: .four,
+        nonTriggeringExamples: [
+            """
+            @testable import Foo
+            import Foundation
+            import Result
+            func foo() -> Result<String, Error> { }
+            func foo(result: Result<String, Error>) ->  {
+                let r: Result<String> = result
+            }
+            func Result() {
+            }
+            """
+        ],
+        triggeringExamples: [
+            """
+            @testable import Foo
+            import Foundation
+            func foo() -> ↓Result<String, Error> { }
+            func foo(result: ↓Result<String, Error>) ->  {
+                let r: ↓Result<String> = result
+            }
+            func Result() {
+            }
+            """
+        ]
+    )
+
+    public func validate(file: File) -> [StyleViolation] {
+        return file.checkIfMissingImportResult().map {
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+}
+
+extension File {
+    func checkIfMissingImportResult() -> [NSRange] {
+        let kImport = "import"
+        let kResult = "Result"
+
+        let contentsNSString = contents.bridge()
+        func getTextFrom(_ token: SyntaxToken) -> String? {
+            return contentsNSString.substringWithByteRange(start: token.offset, length: token.length)
+        }
+
+        var nextTokenIsModuleName = false
+        var resultTypeOffsets: [NSRange] = []
+        let tokens = syntaxMap.tokens
+        for token in tokens {
+            guard let tokenKind = SyntaxKind(rawValue: token.type) else {
+                continue
+            }
+            if tokenKind == .keyword, let tokenText = getTextFrom(token), tokenText == kImport {
+                nextTokenIsModuleName = true
+                continue
+            }
+            if nextTokenIsModuleName {
+                nextTokenIsModuleName = false
+                if tokenKind == .identifier, let tokenText = getTextFrom(token), tokenText == kResult {
+                    return []
+                }
+            } else if tokenKind == .typeidentifier, let tokenText = getTextFrom(token), tokenText == kResult {
+                if let range = contentsNSString.byteRangeToNSRange(start: token.offset, length: token.length) {
+                    resultTypeOffsets.append(range)
+                }
+            }
+        }
+
+        return resultTypeOffsets
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		CC6D28592292F0380052B682 /* IndentationWidthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6D28572292EF460052B682 /* IndentationWidthRule.swift */; };
 		CC6D285B2292F0600052B682 /* IndentationWidthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6D285A2292F0600052B682 /* IndentationWidthConfiguration.swift */; };
 		CC8C6D2322935F5200A55D1A /* IndentationWidthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8C6D2122935F4E00A55D1A /* IndentationWidthRuleTests.swift */; };
+		CC7C3DC7231D461E00AE6C48 /* MissingImportResultRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7C3DC4231D42AA00AE6C48 /* MissingImportResultRule.swift */; };
 		CCD8B87920559D1E00B75847 /* DisableAllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD8B87720559C4A00B75847 /* DisableAllTests.swift */; };
 		CE8178ED1EAC039D0063186E /* UnusedOptionalBindingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -765,6 +766,7 @@
 		CC6D28572292EF460052B682 /* IndentationWidthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationWidthRule.swift; sourceTree = "<group>"; usesTabs = 0; };
 		CC6D285A2292F0600052B682 /* IndentationWidthConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationWidthConfiguration.swift; sourceTree = "<group>"; };
 		CC8C6D2122935F4E00A55D1A /* IndentationWidthRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationWidthRuleTests.swift; sourceTree = "<group>"; };
+		CC7C3DC4231D42AA00AE6C48 /* MissingImportResultRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissingImportResultRule.swift; sourceTree = "<group>"; };
 		CCD8B87720559C4A00B75847 /* DisableAllTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableAllTests.swift; sourceTree = "<group>"; };
 		CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingConfiguration.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -1187,6 +1189,7 @@
 				C26330352073DAA200D7B4FD /* LowerACLThanParentRule.swift */,
 				856651A61D6B395F005E6B29 /* MarkRule.swift */,
 				F9E691272091952E0085B53E /* MissingDocsRule.swift */,
+				CC7C3DC4231D42AA00AE6C48 /* MissingImportResultRule.swift */,
 				D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */,
 				D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */,
 				D4B31ADB22A0581B000300F1 /* DuplicateEnumCasesRule.swift */,
@@ -2107,6 +2110,7 @@
 				E816194E1BFBFEAB00946723 /* ForceTryRule.swift in Sources */,
 				8F2CC1CB20A6A070006ED34F /* FileNameConfiguration.swift in Sources */,
 				D4CFC5D2209EC95A00668488 /* FunctionDefaultParameterAtEndRule.swift in Sources */,
+				CC7C3DC7231D461E00AE6C48 /* MissingImportResultRule.swift in Sources */,
 				E88198541BEA945100333A11 /* CommaRule.swift in Sources */,
 				22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */,
 				D4DA1DFE1E1A10DB0037413D /* NumberSeparatorConfiguration.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -888,6 +888,12 @@ extension MissingDocsRuleTests {
     ]
 }
 
+extension MissingImportResultRuleTests {
+    static var allTests: [(String, (MissingImportResultRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension ModifierOrderTests {
     static var allTests: [(String, (ModifierOrderTests) -> () throws -> Void)] = [
         ("testAttributeTypeMethod", testAttributeTypeMethod),
@@ -1765,6 +1771,7 @@ XCTMain([
     testCase(LowerACLThanParentRuleTests.allTests),
     testCase(MissingDocsRuleConfigurationTests.allTests),
     testCase(MissingDocsRuleTests.allTests),
+    testCase(MissingImportResultRuleTests.allTests),
     testCase(ModifierOrderTests.allTests),
     testCase(MultilineArgumentsBracketsRuleTests.allTests),
     testCase(MultilineArgumentsRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -372,6 +372,12 @@ class MissingDocsRuleTests: XCTestCase {
     }
 }
 
+class MissingImportResultRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(MissingImportResultRule.description)
+    }
+}
+
 class MultilineArgumentsBracketsRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultilineArgumentsBracketsRule.description)


### PR DESCRIPTION
Swift 5 and 5.1 compiled code (including Swift 4, 4.1, 4.2 code compiled by Swift 5) all have access to the intrinsic Result type. If your code still depends on the `Result` (v4.0.1 and earlier) framework, then you must import it or your code will either not compile or silently compile with the intrinsic `Result` type. Turn this rule on in a project that depends on this framework to avoid missing this crucial import. NB: Version 5.0 of `Result` makes it compatible with Swift 5's `Result` type.