### PR TITLE
fixed `vertical_whitespace_between_cases` rule containing strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@
 
 #### Bug Fixes
 
-* None.
+* Fixed `vertical_whitespace_between_cases` rule containing strings.
+  [Andrey Uryadov](https://github.com/a-25)
+  [#2760](https://github.com/realm/SwiftLint/issues/2760)
+
 
 ## 0.35.0: Secondary Lint Trap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 #### Bug Fixes
 
-* Fixed `vertical_whitespace_between_cases` rule containing strings.
+* Fixed `vertical_whitespace_between_cases` rule containing strings.  
   [Andrey Uryadov](https://github.com/a-25)
   [#2760](https://github.com/realm/SwiftLint/issues/2760)
 

--- a/Rules.md
+++ b/Rules.md
@@ -25112,6 +25112,19 @@ Include a single empty line between switch cases.
 <summary>Non Triggering Examples</summary>
 
 ```swift
+    switch string {
+    case "Idle":
+        self = .idle
+
+    case "Connecting":
+        self = .connecting
+
+    default:
+        return nil
+    }
+```
+
+```swift
     switch x {
     case .valid:
         print("multiple ...")
@@ -25192,6 +25205,18 @@ default:
 </details>
 <details>
 <summary>Triggering Examples</summary>
+
+```swift
+    switch string {
+    case "Idle":
+        self = .idle
+↓    case "Connecting":
+        self = .connecting
+
+    default:
+        return nil
+    }
+```
 
 ```swift
     switch x {

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private extension File {
     func violatingRanges(for pattern: String) -> [NSRange] {
-        return match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
+        return match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentKinds)
     }
 }
 
@@ -108,6 +108,28 @@ public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
             case .invalid:
                 print("multiple ...")
                 print("... lines")
+            }
+        """,
+        """
+            switch string {
+            case "Idle":
+                self = .idle
+        ↓    case "Connecting":
+                self = .connecting
+
+            default:
+                return nil
+            }
+        """: """
+            switch string {
+            case "Idle":
+                self = .idle
+
+            case "Connecting":
+                self = .connecting
+
+            default:
+                return nil
             }
         """
     ]

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -54,7 +54,19 @@ public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
         "    \n" +
         "default:    \n" +
         "    print(\"not one\")    \n" +
-        "}    "
+        "}    ",
+        """
+            switch string {
+            case "Idle":
+                self = .idle
+
+            case "Connecting":
+                self = .connecting
+
+            default:
+                return nil
+            }
+        """
     ]
 
     private static let violatingToValidExamples: [String: String] = [


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/2760