### PR TITLE
Add `todo_attribution` opt-in rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2901](https://github.com/realm/SwiftLint/issues/2901)  
 
+* Add `todo_attribution` opt-in rule to enforce TODOs and FIXMEs attribution.
+  [Hèctor Marquès](https://github.com/hectr)
+  [#2871](https://github.com/realm/SwiftLint/issues/2871)
+
 #### Bug Fixes
 
 * Fix running analyzer rules on the output of builds performed with

--- a/Rules.md
+++ b/Rules.md
@@ -151,6 +151,7 @@
 * [Switch Case on Newline](#switch-case-on-newline)
 * [Syntactic Sugar](#syntactic-sugar)
 * [Todo](#todo)
+* [Todo Attribution](#todo-attribution)
 * [Toggle Bool](#toggle-bool)
 * [Trailing Closure](#trailing-closure)
 * [Trailing Comma](#trailing-comma)
@@ -19610,6 +19611,87 @@ TODOs and FIXMEs should be resolved.
 
 ```swift
 /** ↓TODO: */
+
+```
+
+</details>
+
+
+
+## Todo Attribution
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`todo_attribution` | Disabled | No | lint | No | 3.0.0 
+
+TODOs and FIXMEs should be attributed to an owner or related issue
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+// TODO: @gituser 
+```
+
+```swift
+// FIXME: @GitUser this assumes 64 bit words
+```
+
+```swift
+// TODO: #4 Implement
+```
+
+```swift
+// FIXME: #134
+```
+
+```swift
+// TODO: @gituser #27 make async
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+// ↓TODO:  @gituser
+
+```
+
+```swift
+// ↓FIXME:  #2871
+
+```
+
+```swift
+// ↓TODO(#2871)
+
+```
+
+```swift
+// ↓FIXME(@gituser)
+
+```
+
+```swift
+/* ↓fixme: @gituser*/
+
+```
+
+```swift
+/* ↓todo: */
+
+```
+
+```swift
+/** ↓FIX_ME: */
+
+```
+
+```swift
+/** ↓TO-DO: */
 
 ```
 

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -151,6 +151,7 @@ public let masterRuleList = RuleList(rules: [
     SwitchCaseAlignmentRule.self,
     SwitchCaseOnNewlineRule.self,
     SyntacticSugarRule.self,
+    TodoAttributionRule.self,
     TodoRule.self,
     ToggleBoolRule.self,
     TrailingClosureRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/TodoAttributionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TodoAttributionRule.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SourceKittenFramework
+
+public struct TodoAttributionRule: OptInRule, ConfigurationProviderRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    private let todoPattern = "[tT][oO][-_]{0,1}[dD][oO]"
+    private let fixmePattern = "[fF][iI][xX][-_]{0,1}[mM][eE]"
+    private let ownerPattern = "@[:alnum:]+"
+    private let issuePattern = "#[:alnum:]+"
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "todo_attribution",
+        name: "Todo Attribution",
+        description: "TODOs and FIXMEs should be attributed to an owner or related issue",
+        kind: .lint,
+        nonTriggeringExamples: [
+            "// TODO: @gituser ",
+            "// FIXME: @GitUser this assumes 64 bit words",
+            "// TODO: #4 Implement",
+            "// FIXME: #134",
+            "// TODO: @gituser #27 make async"
+        ],
+        triggeringExamples: [
+            "// ↓TODO:  @gituser\n",
+            "// ↓FIXME:  #2871\n",
+            "// ↓TODO(#2871)\n",
+            "// ↓FIXME(@gituser)\n",
+            "/* ↓fixme: @gituser*/\n",
+            "/* ↓todo: */\n",
+            "/** ↓FIX_ME: */\n",
+            "/** ↓TO-DO: */\n"
+        ]
+    )
+
+    private func areThereMatches(of pattern: String, in string: String) -> Bool {
+        let range = NSRange(location: 0, length: string.count)
+        let regularExpression = regex(pattern)
+        let matchRange = regularExpression.rangeOfFirstMatch(in: string, options: [], range: range)
+        return matchRange.location != NSNotFound
+    }
+
+    private func customMessage(file: File, range: NSRange) -> String {
+        var reason = type(of: self).description.description
+        let offset = NSMaxRange(range)
+
+        guard let (lineNumber, _) = file.contents.bridge().lineAndCharacter(forCharacterOffset: offset) else {
+            return type(of: self).description.description
+        }
+
+        let line = file.lines[lineNumber - 1]
+        let lineContent = line.content
+        let kind = areThereMatches(of: todoPattern, in: lineContent) ? "TODO" : "FIXME"
+        let hasOwner = areThereMatches(of: "\(ownerPattern)\\b", in: lineContent)
+        let hasIssue = areThereMatches(of: "\(issuePattern)\\b", in: lineContent)
+
+        switch (hasOwner, hasIssue) {
+        case (false, false):
+            let ownerExample = "(e.g. '\(kind): @gituser')"
+            let issueExample = "(e.g. '\(kind): #2871')"
+            reason = "\(kind)s should be attributed to their owner \(ownerExample) or related issue \(issueExample)."
+        case (false, true):
+            reason = "Expected \(kind) format is: '\(kind): #issue_identifier'."
+        case (true, false):
+            reason = "Expected \(kind) format is: '\(kind): @owner_handle'."
+        case (true, true):
+            reason = "Expected \(kind) format is: '\(kind): @owner_handle #issue_identifier'."
+        }
+
+        return reason
+    }
+
+    public func validate(file: File) -> [StyleViolation] {
+        let validTodoPattern = "\\b(?:TODO|FIXME): (?:\(ownerPattern)|\(issuePattern))\\b"
+        let rulePattern = "(?!\(validTodoPattern))\\b(?:(?:\(todoPattern))|(?:\(fixmePattern)))\\b"
+        return file.match(pattern: rulePattern).compactMap { range, syntaxKinds in
+            if syntaxKinds.contains(where: { !$0.isCommentLike }) {
+                return nil
+            }
+            let reason = customMessage(file: file, range: range)
+
+            return StyleViolation(ruleDescription: type(of: self).description,
+                                  severity: configuration.severity,
+                                  location: Location(file: file, characterOffset: range.location),
+                                  reason: reason)
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		C3D23F1D21E3A33700E9BD1B /* UnusedControlFlowLabelRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D7320C21E15ED4001C07D9 /* UnusedControlFlowLabelRule.swift */; };
 		C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */; };
 		C3EF547821B5A4000009262F /* LegacyHashingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EF547521B5A2190009262F /* LegacyHashingRule.swift */; };
+		C4126E492334A38C00C1C8DC /* TodoAttributionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4126E482334A38B00C1C8DC /* TodoAttributionRule.swift */; };
+		C4126E4E2335366C00C1C8DC /* TodoAttributionRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4126E4C233535FF00C1C8DC /* TodoAttributionRuleTests.swift */; };
 		C946FECB1EAE67EE007DD778 /* LetVarWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */; };
 		C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */; };
 		CC26ED07204DEB510013BBBC /* RuleIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */; };
@@ -708,6 +710,8 @@
 		C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRule.swift; sourceTree = "<group>"; };
 		C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FatalErrorMessageRule.swift; sourceTree = "<group>"; };
 		C3EF547521B5A2190009262F /* LegacyHashingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHashingRule.swift; sourceTree = "<group>"; };
+		C4126E482334A38B00C1C8DC /* TodoAttributionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoAttributionRule.swift; sourceTree = "<group>"; };
+		C4126E4C233535FF00C1C8DC /* TodoAttributionRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoAttributionRuleTests.swift; sourceTree = "<group>"; };
 		C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LetVarWhitespaceRule.swift; sourceTree = "<group>"; };
 		C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
 		CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleIdentifier.swift; sourceTree = "<group>"; };
@@ -1144,6 +1148,7 @@
 				B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */,
 				D450D1D021EC4A6900E60010 /* StrongIBOutletRule.swift */,
 				D40E041B1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift */,
+				C4126E482334A38B00C1C8DC /* TodoAttributionRule.swift */,
 				E88DEA811B0990A700A66CB0 /* TodoRule.swift */,
 				7565E5F02262BA0900B0597C /* UnusedCaptureListRule.swift */,
 				D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */,
@@ -1449,6 +1454,7 @@
 			isa = PBXGroup;
 			children = (
 				D4998DE61DF191380006E05D /* AttributesRuleTests.swift */,
+				C4126E4C233535FF00C1C8DC /* TodoAttributionRuleTests.swift */,
 				D4EAB3A320E9948D0051C09A /* AutomaticRuleTests.generated.swift */,
 				260F669F225C5B6D00407CF5 /* CollectingRuleTests.swift */,
 				7578C915214173BE0080FEC9 /* CollectionAlignmentRuleTests.swift */,
@@ -2223,6 +2229,7 @@
 				D4DABFD71E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift in Sources */,
 				3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */,
 				D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */,
+				C4126E492334A38C00C1C8DC /* TodoAttributionRule.swift in Sources */,
 				C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */,
 				A3184D56215BCEFF00621EA2 /* LegacyRandomRule.swift in Sources */,
 				626C16E21F948EBC00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift in Sources */,
@@ -2293,6 +2300,7 @@
 				821F70B7210720C700E2C84F /* FileTypesOrderRuleTests.swift in Sources */,
 				3B3A9A331EA3DFD90075B121 /* IdentifierNameRuleTests.swift in Sources */,
 				62329C2B1F30B2310035737E /* DiscouragedDirectInitRuleTests.swift in Sources */,
+				C4126E4E2335366C00C1C8DC /* TodoAttributionRuleTests.swift in Sources */,
 				C25EBBE221078D5F00E27603 /* GlobTests.swift in Sources */,
 				E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */,
 				BCB68283216213130078E4C3 /* CompilerProtocolInitRuleTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1312,6 +1312,17 @@ extension SyntacticSugarRuleTests {
     ]
 }
 
+extension TodoAttributionRuleTests {
+    static var allTests: [(String, (TodoAttributionRuleTests) -> () throws -> Void)] = [
+        ("testTodoAttribution", testTodoAttribution),
+        ("testTodoMessage", testTodoMessage),
+        ("testFixmeMessage", testFixmeMessage),
+        ("testOwnerExpectedFormatMessage", testOwnerExpectedFormatMessage),
+        ("testIssueExpectedFormatMessage", testIssueExpectedFormatMessage),
+        ("testIssueAndOwnerExpectedFormatMessage", testIssueAndOwnerExpectedFormatMessage)
+    ]
+}
+
 extension TodoRuleTests {
     static var allTests: [(String, (TodoRuleTests) -> () throws -> Void)] = [
         ("testTodo", testTodo),
@@ -1741,6 +1752,7 @@ XCTMain([
     testCase(SwitchCaseAlignmentRuleTests.allTests),
     testCase(SwitchCaseOnNewlineRuleTests.allTests),
     testCase(SyntacticSugarRuleTests.allTests),
+    testCase(TodoAttributionRuleTests.allTests),
     testCase(TodoRuleTests.allTests),
     testCase(ToggleBoolRuleTests.allTests),
     testCase(TrailingClosureConfigurationTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/TodoAttributionRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoAttributionRuleTests.swift
@@ -1,0 +1,57 @@
+import SwiftLintFramework
+import XCTest
+
+class TodoAttributionRuleTests: XCTestCase {
+    func testTodoAttribution() {
+        verifyRule(TodoAttributionRule.description, commentDoesntViolate: false)
+    }
+
+    func testTodoMessage() {
+        let string = "fatalError() // TODO: Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        let expected = "TODOs should be attributed to "
+            + "their owner (e.g. 'TODO: @gituser') "
+            + "or related issue (e.g. 'TODO: #2871')."
+        XCTAssertEqual(violations.first!.reason, expected)
+    }
+
+    func testFixmeMessage() {
+        let string = "fatalError() // FIXME: Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        let expected = "FIXMEs should be attributed to "
+        + "their owner (e.g. 'FIXME: @gituser') "
+        + "or related issue (e.g. 'FIXME: #2871')."
+        XCTAssertEqual(violations.first!.reason, expected)
+    }
+
+    func testOwnerExpectedFormatMessage() {
+        let string = "fatalError() // FIXME: Implement @gituser"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        let expected = "Expected FIXME format is: 'FIXME: @owner_handle'."
+        XCTAssertEqual(violations.first!.reason, expected)
+    }
+
+    func testIssueExpectedFormatMessage() {
+        let string = "fatalError() // TO-DO: #2871 Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        let expected = "Expected TODO format is: 'TODO: #issue_identifier'."
+        XCTAssertEqual(violations.first!.reason, expected)
+    }
+
+    func testIssueAndOwnerExpectedFormatMessage() {
+        let string = "fatalError() // fixme: @gituser #2871 Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        let expected = "Expected FIXME format is: 'FIXME: @owner_handle #issue_identifier'."
+        XCTAssertEqual(violations.first!.reason, expected)
+    }
+
+    private func violations(_ string: String) -> [StyleViolation] {
+        let config = makeConfig(nil, TodoAttributionRule.description.identifier)!
+        return SwiftLintFrameworkTests.violations(string, config: config)
+    }
+}


### PR DESCRIPTION
This rule enforces TODO and FIXME comments to be attributed to their owner or to a related issue from the issue tracker.

As I saw in another pull request, I have filled out the *New rule request* info below.

# New rule request

> 1. Why should this rule be added? Share links to existing discussion about what the community thinks about this.

TODO and FIXME comments are prone to overuse. That made them very unpopular (e.g. [Todo Comments Considered Harmful](http://wiki.c2.com/?TodoCommentsConsideredHarmful), [The case against TODO](http://wordaligned.org/articles/todo)).

Even SwiftLint complains about them: `"TODOs and FIXMEs should be resolved"`.

But it should be noted that, in quite a few development teams it is a common practice to split a feature into several small pull requests that are easier to code review. This technique may lead to a situation where you need to leave a TODO comment in the code of one PR, that will be resolved in the next.

There may also be situations where you only want to mark (and possibly explain) a non-fatal defect in the code (e.g. a performance issue). This could be the case if the fix required is beyond the scope of the task you are committed to at that particular time.

So, given that a handful of developers and teams will continue to use them, IMO `todo_attribution` rule should be added to ensure that it is easy to keep track of TODOs and FIXMEs. The alternative is risking for them to be lost and forgotten and never resolved.

Best `todo_attribution` selling points are that:

- as it enforces the format, it becomes easier to find TODOs and FIXMEs with a simple text search;
- as it makes mandatory to relate the comment with a developer or a tracked issue, it points you to a source of information about the signaled problem.

> 2. Provide several examples of what would and wouldn't trigger violations.

**Non-triggering examples:**

- `TODO: @hectr do something`
- `TODO: #2871`
- `TODO: @hectr #2871 implement`
- `FIXME: @hectr`
- `FIXME: #2871 fix`

**Triggering examples:**

- `TODO: #`
- `ToDo: @hectr`
- `To-Do`
- `TO-DO: #2871`
- `todo`
- `to-do do something`
- `FIXME: ` ` @hectr assumes valid input`
- `FixMe ...`
- `Fix-Me`
- `FIX-ME`
- `fixme#2871`
- `fix-me`

> 3. Should the rule be configurable, if so what parameters should be configurable?

It seems reasonable to use `SeverityConfiguration` because you may want to be aware of this violation without fixing it immediately.

> 4. Should the rule be opt-in or enabled by default? Why? See README.md for guidelines on when to mark a rule as opt-in.

This rule fits well in the "*A rule that is not general consensus or is only useful in some cases*" category for 2 reasons:

- it enforces a very specific format for TODO and FIXME comments;
- TODOs and FIXMEs are not allowed by `todo` rule, which is enabled by default.