### PR TITLE
Update build instructions for Xcode 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,18 @@ running it.
 
 ### Compiling from source:
 
-You can also build from source by cloning this project and running
-`git submodule update --init --recursive; make install` (Xcode 10.2 or later).
+You can also build from source by cloning this project and following the steps according to the Xcode version (10.2 or later)
+
+#### Xcode 10.2.x or 10.3.x
+
+- Run `git submodule update --init --recursive; make install`
+- Build SwiftLint to a Mac device from SwiftLint.xcworkspace
+
+#### Xcode 11
+
+- Run `swift package update; swift package generate-xcodeproj`
+	- Alternatively, make sure to open with Xcode the SwiftLint _folder_ (**not** the xcworkspace) and wait for the Swift Package Dependencies to finish loading.
+- Build SwiftLint to a Mac device (may need to manually select "My Mac" as the target device)
 
 ### Known Installation Issues On MacOS Before 10.14.4
 


### PR DESCRIPTION
It took me a couple minutes to figure out how to build it with Xcode 11 so I figured it could be helpful to have specific instructions for it.

**However this should not be merged until https://github.com/realm/SwiftLint/issues/2867 is closed** (might want to explicitly mention in the README for now that building with SPM is not yet supported?)

Note: this PR is intended for SwiftLint contributors or anyone wanting to build it from source. There's https://github.com/realm/SwiftLint/pull/2615 with instructions for end users that want to integrate SwiftLint to their projects using SPM.