### PR TITLE
Speedup Swiftlint a little

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2874](https://github.com/realm/SwiftLint/issues/2874)
   
-  * Speedup Swiftlint a little.  
+* Speedup Swiftlint a little.  
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2898](https://github.com/realm/SwiftLint/issues/2898)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 * Support building with Swift 5.1 on Linux.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2874](https://github.com/realm/SwiftLint/issues/2874)
+  
+  * Speedup Swiftlint a little.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)
+  [#2898](https://github.com/realm/SwiftLint/issues/2898)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -256,15 +256,19 @@ extension File {
     }
 
     internal func ruleEnabled(violatingRanges: [NSRange], for rule: Rule) -> [NSRange] {
+        return ruleEnabled(violatingItems: violatingRanges, selector: { $0 }, for: rule)
+    }
+
+    internal func ruleEnabled<T>(violatingItems: [T], selector: (T) -> NSRange, for rule: Rule) -> [T] {
         let fileRegions = regions()
-        if fileRegions.isEmpty { return violatingRanges }
-        let violatingRanges = violatingRanges.filter { range in
+        if fileRegions.isEmpty { return violatingItems }
+        let violatingItems = violatingItems.filter { range in
             let region = fileRegions.first {
-                $0.contains(Location(file: self, characterOffset: range.location))
+                $0.contains(Location(file: self, characterOffset: selector(range).location))
             }
             return region?.isRuleEnabled(rule) ?? true
         }
-        return violatingRanges
+        return violatingItems
     }
 
     internal func ruleEnabled(violatingRange: NSRange, for rule: Rule) -> NSRange? {

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -15,8 +15,9 @@ private extension Rule {
             return []
         }
 
+        let rule = self.init()
         let regionsDisablingCurrentRule = regions.filter { region in
-            return region.isRuleDisabled(self.init())
+            return region.isRuleDisabled(rule)
         }
         let regionsDisablingSuperfluousDisableRule = regions.filter { region in
             return region.isRuleDisabled(superfluousDisableCommandRule)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -26,7 +26,6 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
         let contents = file.contents.bridge()
 
         let ranges = file.syntaxMap.tokens
-            .lazy
             .filter { SyntaxKind(rawValue: $0.type) == .buildconfigKeyword }
             .map { NSRange(location: $0.offset, length: $0.length) }
             .filter { range in

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -26,6 +26,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
         let contents = file.contents.bridge()
 
         let ranges = file.syntaxMap.tokens
+            .lazy
             .filter { SyntaxKind(rawValue: $0.type) == .buildconfigKeyword }
             .map { NSRange(location: $0.offset, length: $0.length) }
             .filter { range in
@@ -49,6 +50,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
         // attributes(optional) import import-kind(optional) import-path
         let regex = "^(\\w\\s)?import(\\s(\(importKinds)))?\\s+[a-zA-Z0-9._]+$"
         let importRanges = file.match(pattern: regex)
+            .lazy
             .filter { $0.1.allSatisfy { [.keyword, .identifier].contains($0) } }
             .compactMap { contents.NSRangeToByteRange(start: $0.0.location, length: $0.0.length) }
             .filter { importRange -> Bool in

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -48,6 +48,7 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
 
         let isNotClosure = { !self.isClosureParameter(dictionary: $0) }
         let params = dictionary.substructure
+            .lazy
             .flatMap { subDict -> [[String: SourceKitRepresentable]] in
                 guard subDict.kind.flatMap(SwiftDeclarationKind.init) == .varParameter else {
                     return []

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
@@ -26,6 +26,7 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule, Au
         let pattern = "\\b" + LegacyConstantRule.legacyConstants.joined(separator: "|")
 
         return file.match(pattern: pattern, range: nil)
+            .lazy
             .filter { Set($0.1).isSubset(of: [.identifier]) }
             .map { $0.0 }
             .map {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -200,11 +200,11 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
                 let joinedArguments = zip(expectedArguments, arguments).map { "\($0): \($1)" }.joined(separator: ", ")
                 let replacement = correctedName + "(" + joinedArguments + ")"
                 correctedContents = correctedContents.replacingCharacters(in: indexRange, with: replacement)
-                adjustedLocations.insert(range.location, at: 0)
+                adjustedLocations.append(range.location)
             }
         }
 
-        let corrections = adjustedLocations.map {
+        let corrections = adjustedLocations.reversed().map {
             Correction(ruleDescription: type(of: self).description,
                        location: Location(file: file, characterOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -137,8 +137,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
     }
 
     public func correct(file: File) -> [Correction] {
-        let matches = violationMatchesRanges(in: file)
-            .filter { !file.ruleEnabled(violatingRanges: [$0], for: self).isEmpty }
+        let matches = file.ruleEnabled(violatingRanges: violationMatchesRanges(in: file), for: self)
         guard !matches.isEmpty else { return [] }
 
         let description = type(of: self).description

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -116,6 +116,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
         let excludingKinds = SyntaxKind.commentKinds
 
         return file.match(pattern: pattern)
+            .lazy
             .filter { _, kinds in
                 excludingKinds.isDisjoint(with: kinds) && kinds.first == .identifier
             }.map { $0.0 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -157,13 +157,13 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
                 contents = correctedString
                 let correction = Correction(ruleDescription: description,
                                             location: Location(file: file, characterOffset: range.location))
-                corrections.insert(correction, at: 0)
+                corrections.append(correction)
                 break
             }
         }
 
         file.write(contents)
-        return corrections
+        return corrections.reversed()
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -184,7 +184,7 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
         }
 
         let parameterEnd = offset + length
-        let tokens = Array(tokens.filter { $0.offset >= parameterEnd }.drop { token in
+        let tokens = Array(tokens.lazy.filter { $0.offset >= parameterEnd }.drop { token in
             let isKeyword = SyntaxKind(rawValue: token.type) == .keyword
             return !isKeyword || file.contents(for: token) != "in"
         })

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -61,6 +61,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
                                                               range: range).map { $0.range }
 
         return file.matchesAndTokens(matching: pattern)
+            .lazy
             .filter { result, _ in
                 let range = result.range(at: 1)
                 return !range.intersects(exclusionRanges)

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -38,6 +38,7 @@ public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, Aut
         let susceptibleNames = Set(elements.compactMap { $0.kind == .class ? $0.name : nil })
 
         return elements
+            .lazy   
             .filter { $0.kind == .extension && !susceptibleNames.contains($0.name) }
             .flatMap { element in
                 return element.dictionary.substructure.compactMap { element -> Int? in

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -38,7 +38,7 @@ public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, Aut
         let susceptibleNames = Set(elements.compactMap { $0.kind == .class ? $0.name : nil })
 
         return elements
-            .lazy   
+            .lazy
             .filter { $0.kind == .extension && !susceptibleNames.contains($0.name) }
             .flatMap { element in
                 return element.dictionary.substructure.compactMap { element -> Int? in

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -109,6 +109,7 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
         // 3. minus all XCTestCase subclasses
         // 4. minus all XCTest test functions
         let unusedDeclarations = declaredUSRs
+            .lazy
             .filter { !allReferencedUSRs.contains($0.usr) }
             .filter { !allTestCaseUSRs.contains($0.usr) }
             .filter { declaredUSR in

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -38,9 +38,9 @@ public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderR
 
 extension ClosureEndIndentationRule: CorrectableRule {
     public func correct(file: File) -> [Correction] {
-        let allViolations = violations(in: file).reversed().filter {
-            !file.ruleEnabled(violatingRanges: [$0.range], for: self).isEmpty
-        }
+        let allViolations = file.ruleEnabled(violatingItems: violations(in: file).reversed(),
+                                             selector: { $0.range },
+                                             for: self)
 
         guard !allViolations.isEmpty else {
             return []

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -149,9 +149,9 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
     }
 
     public func correct(file: File) -> [Correction] {
-        var matches = removeNested(findViolations(file: file)).filter {
-            !file.ruleEnabled(violatingRanges: [$0], for: self).isEmpty
-        }
+        let violatingRanges = removeNested(findViolations(file: file))
+        var matches = file.ruleEnabled(violatingRanges: violatingRanges, for: self)
+
         guard !matches.isEmpty else { return [] }
 
         // `matches` should be sorted by location from `findViolations`.

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+Type.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+Type.swift
@@ -24,7 +24,7 @@ internal extension ColonRule {
 
     func typeColonViolationRanges(in file: File, matching pattern: String) -> [NSRange] {
         let nsstring = file.contents.bridge()
-        return file.matchesAndTokens(matching: pattern).filter { match, syntaxTokens in
+        return file.matchesAndTokens(matching: pattern).lazy.filter { match, syntaxTokens in
             if match.range(at: 2).length > 0 && syntaxTokens.count > 2 { // captured a generic definition
                 let tokens = [syntaxTokens.first, syntaxTokens.last].compactMap { $0 }
                 return isValidMatch(syntaxTokens: tokens, file: file)

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+Type.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+Type.swift
@@ -27,10 +27,10 @@ internal extension ColonRule {
         return file.matchesAndTokens(matching: pattern).lazy.filter { match, syntaxTokens in
             if match.range(at: 2).length > 0 && syntaxTokens.count > 2 { // captured a generic definition
                 let tokens = [syntaxTokens.first, syntaxTokens.last].compactMap { $0 }
-                return isValidMatch(syntaxTokens: tokens, file: file)
+                return self.isValidMatch(syntaxTokens: tokens, file: file)
             }
 
-            return isValidMatch(syntaxTokens: syntaxTokens, file: file)
+            return self.isValidMatch(syntaxTokens: syntaxTokens, file: file)
         }.compactMap { match, syntaxTokens in
             let identifierRange = nsstring
                 .byteRangeToNSRange(start: syntaxTokens[0].offset, length: 0)

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -41,10 +41,9 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
     }
 
     public func correct(file: File) -> [Correction] {
-        let violations = correctionRanges(in: file)
-        let matches = violations.filter {
-            !file.ruleEnabled(violatingRanges: [$0.range], for: self).isEmpty
-        }
+        let matches = file.ruleEnabled(violatingItems: correctionRanges(in: file),
+                                       selector: { $0.range },
+                                       for: self)
 
         guard !matches.isEmpty else { return [] }
         let regularExpression = regex(pattern)

--- a/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -32,7 +32,7 @@ public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, Rule, 
     public func validate(file: File) -> [StyleViolation] {
         let pattern = configuration.ifOnly ? "(if)[^\n]*return" : "(guard|if)[^\n]*return"
 
-        return file.rangesAndTokens(matching: pattern).filter { _, tokens in
+        return file.rangesAndTokens(matching: pattern).lazy.filter { _, tokens in
             guard let firstToken = tokens.first, let lastToken = tokens.last,
                 SyntaxKind(rawValue: firstToken.type) == .keyword &&
                     SyntaxKind(rawValue: lastToken.type) == .keyword else {

--- a/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -39,9 +39,9 @@ public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, Rule, 
                         return false
             }
 
-            let searchTokens = configuration.ifOnly ? ["if"] : ["if", "guard"]
-            return searchTokens.contains(content(for: firstToken, file: file)) &&
-                content(for: lastToken, file: file) == "return"
+            let searchTokens = self.configuration.ifOnly ? ["if"] : ["if", "guard"]
+            return searchTokens.contains(self.content(for: firstToken, file: file)) &&
+                self.content(for: lastToken, file: file) == "return"
         }.map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severityConfiguration.severity,

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -70,7 +70,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
                 .lazy
                 .filter { match, syntaxKinds -> Bool in
                     let matchString = file.contents.substring(from: match.location, length: match.length)
-                    return !isFalsePositive(matchString, syntaxKind: syntaxKinds.first)
+                    return !self.isFalsePositive(matchString, syntaxKind: syntaxKinds.first)
                 }
                 .filter { match, _ -> Bool in
                     let contents = file.contents.bridge()

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -67,6 +67,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
         }
         return statementPatterns.flatMap { pattern -> [StyleViolation] in
             return file.match(pattern: pattern)
+                .lazy
                 .filter { match, syntaxKinds -> Bool in
                     let matchString = file.contents.substring(from: match.location, length: match.length)
                     return !isFalsePositive(matchString, syntaxKind: syntaxKinds.first)

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -89,13 +89,14 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
         return configurations.flatMap { configuration -> [StyleViolation] in
             let pattern = configuration.regex.pattern
             let excludingKinds = SyntaxKind.allKinds.subtracting(configuration.matchKinds)
+            let fileRegions = file.regions()
             return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map({
                 StyleViolation(ruleDescription: configuration.description,
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location),
                                reason: configuration.message)
             }).filter { violation in
-                guard let region = file.regions().first(where: { $0.contains(violation.location) }) else {
+                guard let region = fileRegions.first(where: { $0.contains(violation.location) }) else {
                     return true
                 }
 

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -192,7 +192,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
         }
 
         let directives: Set = ["#if", "#elseif", "#else", "#endif", "#!", "#warning", "#error"]
-        let directiveLines = file.lines.filter {
+        let directiveLines = file.lines.lazy.filter {
             let trimmed = $0.content.trimmingCharacters(in: .whitespaces)
             return directives.contains(where: trimmed.hasPrefix)
         }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -107,14 +107,18 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
 
             let isMultiline = functionName.contains("\n")
 
-            let parameters = substructure.substructure.filter { $0.kind == SwiftDeclarationKind.varParameter.rawValue }
-            if isMultiline && !parameters.isEmpty {
-                if let openingBracketViolation = openingBracketViolation(parameters: parameters, file: file) {
-                    violations.append(openingBracketViolation)
+            if isMultiline {
+                let parameters = substructure.substructure.filter {
+                    $0.kind == SwiftDeclarationKind.varParameter.rawValue
                 }
+                if !parameters.isEmpty {
+                    if let openingBracketViolation = openingBracketViolation(parameters: parameters, file: file) {
+                        violations.append(openingBracketViolation)
+                    }
 
-                if let closingBracketViolation = closingBracketViolation(parameters: parameters, file: file) {
-                    violations.append(closingBracketViolation)
+                    if let closingBracketViolation = closingBracketViolation(parameters: parameters, file: file) {
+                        violations.append(closingBracketViolation)
+                    }
                 }
             }
         }

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -96,13 +96,13 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
         for (violatingRange, correction) in violatingRanges.reversed() {
             if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
                 correctedContents = correctedContents.replacingCharacters(in: indexRange, with: correction)
-                adjustedLocations.insert(violatingRange.location, at: 0)
+                adjustedLocations.append(violatingRange.location)
             }
         }
 
         file.write(correctedContents)
 
-        return adjustedLocations.map {
+        return adjustedLocations.reversed().map {
             Correction(ruleDescription: type(of: self).description,
                        location: Location(file: file, characterOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -84,12 +84,12 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule, Auto
 
         for (violatingRange, location) in violatingRanges.reversed() {
             correctedContents = correct(contents: correctedContents, violatingRange: violatingRange)
-            adjustedLocations.insert(Location(file: file, characterOffset: location), at: 0)
+            adjustedLocations.append(Location(file: file, characterOffset: location))
         }
 
         file.write(correctedContents)
 
-        return adjustedLocations.map {
+        return adjustedLocations.reversed().map {
             Correction(ruleDescription: type(of: self).description,
                        location: $0)
         }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -152,9 +152,9 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
     }
 
     public func correct(file: File) -> [Correction] {
-        let violatingRanges = violationRanges(file: file).filter { range, _ in
-            return !file.ruleEnabled(violatingRanges: [range], for: self).isEmpty
-        }
+        let violatingRanges = file.ruleEnabled(violatingItems: self.violationRanges(file: file),
+                                               selector: { $0.0 },
+                                               for: self)
 
         var correctedContents = file.contents
         var adjustedLocations = [Int]()

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -163,13 +163,13 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
                 correctedContents = correctedContents
                     .replacingCharacters(in: indexRange, with: correction)
-                adjustedLocations.insert(violatingRange.location, at: 0)
+                adjustedLocations.append(violatingRange.location)
             }
         }
 
         file.write(correctedContents)
 
-        return adjustedLocations.map {
+        return adjustedLocations.reversed().map {
             Correction(ruleDescription: type(of: self).description,
                        location: Location(file: file, characterOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -99,7 +99,7 @@ private extension StatementPositionRule {
     }
 
     func defaultViolationRanges(in file: File, matching pattern: String) -> [NSRange] {
-        return file.match(pattern: pattern).filter { _, syntaxKinds in
+        return file.match(pattern: pattern).lazy.filter { _, syntaxKinds in
             return syntaxKinds.starts(with: [.keyword])
         }.compactMap { $0.0 }
     }

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -192,8 +192,9 @@ private extension StatementPositionRule {
         let validator = type(of: self).uncuddledMatchValidator(contents: contents)
         let filterRanges = type(of: self).uncuddledMatchFilter(contents: contents, syntaxMap: syntaxMap)
 
-        let validMatches = matches.compactMap(validator).filter(filterRanges)
-                  .filter { !file.ruleEnabled(violatingRanges: [$0.range], for: self).isEmpty }
+        let validMatches = file.ruleEnabled(violatingItems: matches.compactMap(validator).filter(filterRanges),
+                                            selector: { $0.range },
+                                            for: self)
         if validMatches.isEmpty { return [] }
         let description = type(of: self).uncuddledDescription
         var corrections = [Correction]()

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -55,6 +55,7 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
         let indentation = configuration.indentedCases ? firstCaseCharacter - switchCharacter : 0
 
         return caseLocations
+            .lazy
             .filter { $0.character != switchCharacter + indentation }
             .map(locationToViolation)
     }

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -47,7 +47,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 }
             }
 
-            let violatingIndexes = potentialViolatingIndexes.filter { $0 < lastMatchingIndex }
+            let violatingIndexes = potentialViolatingIndexes.lazy.filter { $0 < lastMatchingIndex }
             violatingIndexes.forEach { index in
                 let typeContentOffset = orderedTypeContentOffsets[index]
 

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -116,13 +116,13 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
                 let updatedArguments = correctedContents[updatedRange]
                 correctedContents = correctedContents.replacingCharacters(in: indexRange,
                                                                           with: String(updatedArguments))
-                adjustedLocations.insert(violatingRange.location, at: 0)
+                adjustedLocations.append(violatingRange.location)
             }
         }
 
         file.write(correctedContents)
 
-        return adjustedLocations.map {
+        return adjustedLocations.reversed().map {
             Correction(ruleDescription: type(of: self).description,
                        location: Location(file: file, characterOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -79,7 +79,7 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
         return matches
             .lazy
             .filter { kinds.isDisjoint(with: $0.1) }
-            .filter { kind != .guard || !containsOptionalTry(at: $0.0.range, of: file) }
+            .filter { kind != .guard || !self.containsOptionalTry(at: $0.0.range, of: file) }
             .map { $0.0.range(at: 1) }
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -77,6 +77,7 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
         let matches = file.matchesAndSyntaxKinds(matching: letUnderscore, range: range)
 
         return matches
+            .lazy
             .filter { kinds.isDisjoint(with: $0.1) }
             .filter { kind != .guard || !containsOptionalTry(at: $0.0.range, of: file) }
             .map { $0.0.range(at: 1) }


### PR DESCRIPTION
## What
A little speedup of a Swiftlint by

- Using lazy collections which prevents temporary structures creation
- changing insert at 0 -> append && reverse after cycle


## Why
Hacktoberfest

![image](https://user-images.githubusercontent.com/119268/66682981-0d522600-ec7f-11e9-8e2d-e7017fbab336.png)
