### PR TITLE
Use the best run when deciding which branch is performing better

### DIFF
--- a/script/oss-check
+++ b/script/oss-check
@@ -15,7 +15,7 @@ require 'erb'
 
 @options = {
   branch: 'HEAD',
-  iterations: 5,
+  iterations: 8,
   skip_clean: false,
   verbose: false
 }

--- a/script/oss-check
+++ b/script/oss-check
@@ -174,11 +174,11 @@ def generate_reports(branch)
         durations << Time.now - start
       end
       puts ''
-      average_duration = (durations.reduce(:+) / iterations).round(2)
+      best_duration = durations.min.round(2)
       if branch == 'branch'
-        repo.branch_duration = average_duration
+        repo.branch_duration = best_duration
       else
-        repo.master_duration = average_duration
+        repo.master_duration = best_duration
       end
     end
   end


### PR DESCRIPTION
If we're about to compare two solutions on which one is faster we need to take the fastest run of all
This can be due a lot of levels of caching on file level etc

i.e. this is how it's done in Python
https://docs.python.org/2/library/timeit.html
> It’s tempting to calculate mean and standard deviation from the result vector and report these. However, this is not very useful. In a typical case, the lowest value gives a lower bound for how fast your machine can run the given code snippet; higher values in the result vector are typically not caused by variability in Python’s speed, but by other processes interfering with your timing accuracy. So the min() of the result is probably the only number you should be interested in. After that, you should look at the entire vector and apply common sense rather than statistics.