### PR TITLE
Use binary search when searching for lines indexes in LetVarWhiteSpacesRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2874](https://github.com/realm/SwiftLint/issues/2874)
 
+* Speedup `LetVarWhiteSpacesRule`.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)
+  [#2901](https://github.com/realm/SwiftLint/issues/2901)  
+
 #### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -229,28 +229,16 @@ private extension File {
         return lineFast(byteOffset: byteOffset, startFrom: startFrom)
     }
 
-    // Zero-based line number for the given a byte offset
-    func lineSlow(byteOffset: Int, startFrom: Int = 0) -> Int {
-        for index in startFrom..<lines.count {
-            let line = lines[index]
-
-            if line.byteRange.location + line.byteRange.length > byteOffset {
-                return index
-            }
-        }
-        return -1
-    }
-
     // Zero-based line number for the given a byte offset,
     // Using binary search
     func lineFast(byteOffset: Int, startFrom: Int = 0) -> Int {
-        let n = lines.count - startFrom
+        let maxIndex = lines.count - startFrom
 
-        // The idxe, which definitely beyound byteOffset
+        // The index, which definitely beyond byteOffset
         var bad = -1
 
         // The index which is definitely after byteOffset
-        var good = n
+        var good = maxIndex
         var mid = (bad + good) / 2
 
         // 0 0 0 0 0 1 1 1 1 1
@@ -271,7 +259,7 @@ private extension File {
         }
 
         // Corner case, we' re out of bound, no good items in array
-        if mid == n {
+        if mid == maxIndex {
             return -1
         }
         return startFrom + good

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -118,8 +118,8 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
               let length = statement.length else {
             return nil
         }
-        let startLine = file.line(byteOffset: offset, startFrom: 0)
-        let endLine = file.line(byteOffset: offset + length, startFrom: max(startLine, 0))
+        let startLine = file.line(byteOffset: offset)
+        let endLine = file.line(byteOffset: offset + length)
 
         return (startLine, endLine)
     }
@@ -155,8 +155,8 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
                 // Exclude the body where the accessors are
                 if let bodyOffset = statement.bodyOffset,
                    let bodyLength = statement.bodyLength {
-                    let bodyStart = file.line(byteOffset: bodyOffset, startFrom: startLine) + 1
-                    let bodyEnd = file.line(byteOffset: bodyOffset + bodyLength, startFrom: bodyStart) - 1
+                    let bodyStart = file.line(byteOffset: bodyOffset) + 1
+                    let bodyEnd = file.line(byteOffset: bodyOffset + bodyLength) - 1
 
                     if bodyStart <= bodyEnd {
                         lines.subtract(Set(bodyStart...bodyEnd))
@@ -183,8 +183,8 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
 
         for token in syntaxMap.tokens where token.type == SyntaxKind.comment.rawValue ||
                                             token.type == SyntaxKind.docComment.rawValue {
-            let startLine = file.line(byteOffset: token.offset, startFrom: 0)
-            let endLine = file.line(byteOffset: token.offset + token.length, startFrom: startLine)
+            let startLine = file.line(byteOffset: token.offset)
+            let endLine = file.line(byteOffset: token.offset + token.length)
 
             if startLine <= endLine {
                 result.formUnion(Set(startLine...endLine))
@@ -225,43 +225,9 @@ private extension SwiftDeclarationKind {
 }
 
 private extension File {
-    func line(byteOffset: Int, startFrom: Int = 0) -> Int {
-        return lineFast(byteOffset: byteOffset, startFrom: startFrom)
-    }
-
-    // Zero-based line number for the given a byte offset,
-    // Using binary search
-    func lineFast(byteOffset: Int, startFrom: Int = 0) -> Int {
-        let maxIndex = lines.count - startFrom
-
-        // The index, which definitely beyond byteOffset
-        var bad = -1
-
-        // The index which is definitely after byteOffset
-        var good = maxIndex
-        var mid = (bad + good) / 2
-
-        // 0 0 0 0 0 1 1 1 1 1
-        //           ^
-        // The idea is to get _first_ *good* index, where byteOffset > line.byteRange.location + line.byteRange.length
-        func isGoodLine(at index: Int) -> Bool {
-            let line = lines[index]
-            return line.byteRange.location + line.byteRange.length > byteOffset
-        }
-
-        while bad + 1 < good {
-            if isGoodLine(at: startFrom + mid) {
-                good = mid
-            } else {
-                bad = mid
-            }
-            mid = (bad + good) / 2
-        }
-
-        // Corner case, we' re out of bound, no good items in array
-        if mid == maxIndex {
-            return -1
-        }
-        return startFrom + good
+    // Zero based line number for specified byte offset
+    func line(byteOffset: Int) -> Int {
+        guard let line = contents.bridge().lineAndCharacter(forByteOffset: byteOffset)?.line else { return -1 }
+        return line - 1
     }
 }


### PR DESCRIPTION
A bit faster searching for an line that starts specified offset for `LetVarWhitespaceRule`
While it doesn't seems a big deal, on big files, this gives a big boost in performance