### PR TITLE
Run CI on Xcode 11.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.26.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
-    ] + (addCryptoSwift ? [.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.0.0")] : []),
+    ] + (addCryptoSwift ? [.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.0.0"))] : []),
     targets: [
         .target(
             name: "swiftlint",

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -299,8 +299,11 @@ class LinterCacheTests: XCTestCase {
         XCTAssertNil(cache.violations(forFile: file, configuration: helper.configuration))
     }
 
+    // swiftlint:disable:next function_body_length
     func testDetectSwiftVersion() {
-        #if compiler(>=5.1.0)
+        #if compiler(>=5.1.1)
+            let version = "5.1.1"
+        #elseif compiler(>=5.1.0)
             let version = "5.1.0"
         #elseif compiler(>=5.0.0)
             let version = "5.0.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,8 @@ jobs:
         DEVELOPER_DIR: /Applications/Xcode_10.2.app
       xcode103:
         DEVELOPER_DIR: /Applications/Xcode_10.3.app
-      xcode110:
-        DEVELOPER_DIR: /Applications/Xcode_11.app
+      xcode111:
+        DEVELOPER_DIR: /Applications/Xcode_11.1.app
   steps:
     - script: git submodule update --init --recursive
       displayName: Update git submodules
@@ -57,8 +57,8 @@ jobs:
         DEVELOPER_DIR: /Applications/Xcode_10.2.app
       xcode103:
         DEVELOPER_DIR: /Applications/Xcode_10.3.app
-      xcode110:
-        DEVELOPER_DIR: /Applications/Xcode_11.app
+      xcode111:
+        DEVELOPER_DIR: /Applications/Xcode_11.1.app
   steps:
     - script: |
         sw_vers
@@ -73,7 +73,7 @@ jobs:
   pool:
     vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_11.app
+    DEVELOPER_DIR: /Applications/Xcode_11.1.app
   steps:
     - script: bundle install --path vendor/bundle
       displayName: bundle install
@@ -86,7 +86,7 @@ jobs:
   pool:
     vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_11.app
+    DEVELOPER_DIR: /Applications/Xcode_11.1.app
   steps:
     - script: bundle install --path vendor/bundle
       displayName: bundle install
@@ -99,7 +99,7 @@ jobs:
   pool:
     vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_11.app
+    DEVELOPER_DIR: /Applications/Xcode_11.1.app
   steps:
     - script: make analyze
       displayName: Run SwiftLint Analyze
@@ -108,7 +108,7 @@ jobs:
   pool:
     vmImage: 'macOS 10.14'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_11.app
+    DEVELOPER_DIR: /Applications/Xcode_11.1.app
   steps:
     - script: swift run --sanitize=thread swiftlint lint --lenient
       displayName: Pre-cache SwiftLint Run


### PR DESCRIPTION
There shouldn't be any relevant Swift differences between Xcode 11.0 and 11.1, so I think we can run only on Xcode 11.1.