### PR TITLE
Speedup identical operands rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2901](https://github.com/realm/SwiftLint/issues/2901)  
 
+* Speedup identical operands rule.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)  
+  [#2903](https://github.com/realm/SwiftLint/issues/2903)  
+
 #### Bug Fixes
 
 * Fix running analyzer rules on the output of builds performed with

--- a/Rules.md
+++ b/Rules.md
@@ -9632,6 +9632,10 @@ let array = Array<Array<Int>>()
 ```
 
 ```swift
+XCTAssertTrue(↓s1 == s2)
+```
+
+```swift
 ↓1 != 1
 ```
 
@@ -9649,6 +9653,10 @@ let array = Array<Array<Int>>()
 
 ```swift
 ↓$0 != $0
+```
+
+```swift
+XCTAssertTrue(↓s1 != s2)
 ```
 
 ```swift
@@ -9672,6 +9680,10 @@ let array = Array<Array<Int>>()
 ```
 
 ```swift
+XCTAssertTrue(↓s1 === s2)
+```
+
+```swift
 ↓1 !== 1
 ```
 
@@ -9689,6 +9701,10 @@ let array = Array<Array<Int>>()
 
 ```swift
 ↓$0 !== $0
+```
+
+```swift
+XCTAssertTrue(↓s1 !== s2)
 ```
 
 ```swift
@@ -9712,6 +9728,10 @@ let array = Array<Array<Int>>()
 ```
 
 ```swift
+XCTAssertTrue(↓s1 > s2)
+```
+
+```swift
 ↓1 >= 1
 ```
 
@@ -9729,6 +9749,10 @@ let array = Array<Array<Int>>()
 
 ```swift
 ↓$0 >= $0
+```
+
+```swift
+XCTAssertTrue(↓s1 >= s2)
 ```
 
 ```swift
@@ -9752,6 +9776,10 @@ let array = Array<Array<Int>>()
 ```
 
 ```swift
+XCTAssertTrue(↓s1 < s2)
+```
+
+```swift
 ↓1 <= 1
 ```
 
@@ -9769,6 +9797,10 @@ let array = Array<Array<Int>>()
 
 ```swift
 ↓$0 <= $0
+```
+
+```swift
+XCTAssertTrue(↓s1 <= s2)
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -9632,7 +9632,7 @@ let array = Array<Array<Int>>()
 ```
 
 ```swift
-XCTAssertTrue(↓s1 == s2)
+XCTAssertTrue(↓s1 == s1)
 ```
 
 ```swift
@@ -9656,7 +9656,7 @@ XCTAssertTrue(↓s1 == s2)
 ```
 
 ```swift
-XCTAssertTrue(↓s1 != s2)
+XCTAssertTrue(↓s1 != s1)
 ```
 
 ```swift
@@ -9680,7 +9680,7 @@ XCTAssertTrue(↓s1 != s2)
 ```
 
 ```swift
-XCTAssertTrue(↓s1 === s2)
+XCTAssertTrue(↓s1 === s1)
 ```
 
 ```swift
@@ -9704,7 +9704,7 @@ XCTAssertTrue(↓s1 === s2)
 ```
 
 ```swift
-XCTAssertTrue(↓s1 !== s2)
+XCTAssertTrue(↓s1 !== s1)
 ```
 
 ```swift
@@ -9728,7 +9728,7 @@ XCTAssertTrue(↓s1 !== s2)
 ```
 
 ```swift
-XCTAssertTrue(↓s1 > s2)
+XCTAssertTrue(↓s1 > s1)
 ```
 
 ```swift
@@ -9752,7 +9752,7 @@ XCTAssertTrue(↓s1 > s2)
 ```
 
 ```swift
-XCTAssertTrue(↓s1 >= s2)
+XCTAssertTrue(↓s1 >= s1)
 ```
 
 ```swift
@@ -9776,7 +9776,7 @@ XCTAssertTrue(↓s1 >= s2)
 ```
 
 ```swift
-XCTAssertTrue(↓s1 < s2)
+XCTAssertTrue(↓s1 < s1)
 ```
 
 ```swift
@@ -9800,7 +9800,7 @@ XCTAssertTrue(↓s1 < s2)
 ```
 
 ```swift
-XCTAssertTrue(↓s1 <= s2)
+XCTAssertTrue(↓s1 <= s1)
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -50,9 +50,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
     )
 
     private struct OperandsMatch {
-        let leftOperandRange: NSRange
         let operatorRange: NSRange
-        let rightOperandRange: NSRange
         let fullRange: NSRange
     }
 
@@ -91,9 +89,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
                 let fullMatchRange = NSRange(location: leftOperandLocation, length: operandLength + result.range.length)
 
                 let identicalMatch = OperandsMatch(
-                    leftOperandRange: leftOperandRange,
                     operatorRange: result.range(at: 1),
-                    rightOperandRange: rightOperandRange,
                     fullRange: fullMatchRange
                 )
                 return (identicalMatch, tokens)

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -44,7 +44,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
                 "↓foo.aProperty \(operation) foo.aProperty",
                 "↓self.aProperty \(operation) self.aProperty",
                 "↓$0 \(operation) $0",
-                "XCTAssertTrue(↓s1 \(operation) s2)"
+                "XCTAssertTrue(↓s1 \(operation) s1)"
             ]
         }
     )

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -43,62 +43,97 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
                 "↓foo \(operation) foo",
                 "↓foo.aProperty \(operation) foo.aProperty",
                 "↓self.aProperty \(operation) self.aProperty",
-                "↓$0 \(operation) $0"
+                "↓$0 \(operation) $0",
+                "XCTAssertTrue(↓s1 \(operation) s2)"
             ]
         }
     )
 
     public func validate(file: File) -> [StyleViolation] {
         let operators = type(of: self).operators.joined(separator: "|")
-        let pattern = """
-        (?<!\\.|\\$)(?:\\s|\\b|\\A)([\\$A-Za-z0-9_\\.]+)\\s*(\(operators))\\s*\\1\\b(?!\\s*(\\.|\\>|\\<|\\?))
+
+        let findOperators = """
+        (?:\\s*)(\(operators))\\s*([\\$A-Za-z0-9_\\.]+)(?!\\s*(\\.|\\>|\\<|\\?))
         """
-        let syntaxKinds = SyntaxKind.commentKinds
-        let excludingPattern = "\\?\\?\\s*" + pattern
 
-        let range = NSRange(location: 0, length: file.contents.utf16.count)
-        let exclusionRanges = regex(excludingPattern).matches(in: file.contents, options: [],
-                                                              range: range).map { $0.range }
+        struct IdenticalMatch {
+            let firstIdentifierRange: NSRange
+            let operatorRange: NSRange
+            let secondIndentifierRange: NSRange
+            let fullRange: NSRange
+        }
 
-        return file.matchesAndTokens(matching: pattern)
-            .filter { result, _ in
-                let range = result.range(at: 1)
-                return !range.intersects(exclusionRanges)
-            }
-            .filter { result, tokens in
-                let contents = file.contents.bridge()
-                let range = result.range(at: 1)
-                guard let byteRange = contents.NSRangeToByteRange(start: range.location,
-                                                                  length: range.length) else {
-                    return false
-                }
+        return file.matchesAndTokens(matching: findOperators)
+            .compactMap { result, tokens -> (IdenticalMatch, [SyntaxToken])? in
+                let secondIdentifierRange = result.range(at: 2)
+                let identifierLength = secondIdentifierRange.length
+                guard let secondIdentifier = file.contents.validSubstring(range: secondIdentifierRange) else { return nil }
 
-                let kinds = tokens
-                    .filter { $0.offset >= byteRange.location }
-                    .kinds
-                return syntaxKinds.isDisjoint(with: kinds)
-            }
-            .compactMap { result, tokens in
-                return (result, tokens.kinds)
-            }
-            .compactMap { result, syntaxKinds -> StyleViolation? in
-                guard Set(syntaxKinds) != [.typeidentifier] else {
+                // Check what was before
+                let firstIdentifierLocation = result.range.location - identifierLength
+                guard firstIdentifierLocation >= 0 else {
+                    // Not enough place to match firs Identifier
                     return nil
                 }
 
-                let range = result.range(at: 1)
-                let operatorRange = result.range(at: 2)
-                let contents = file.contents.bridge()
+                // Skip if we cannot convert range to nstrange
+                let firstIdentifierRange = NSRange(location: firstIdentifierLocation, length: identifierLength)
+                guard let firstIdentifier = file.contents.validSubstring(range: firstIdentifierRange) else { return nil }
 
-                guard let byteRange = contents.NSRangeToByteRange(start: operatorRange.location,
-                                                                  length: operatorRange.length),
-                    file.syntaxMap.kinds(inByteRange: byteRange).isEmpty else {
-                        return nil
+                guard firstIdentifier == secondIdentifier else { return nil }
+
+                // make sure that previous one is a word boundary
+                if firstIdentifierLocation != 0 {
+                    guard let previousCharacter = file.contents.validSubstring(from: firstIdentifierLocation - 1, length: 1) else { return nil }
+                    guard [" ", "\n", "\t", "\r", "(", "{", "[" ].contains(previousCharacter) else { return nil }
                 }
 
+                // Make sure that we doesn't have ??
+                // We'll skip multiple whitespaces before ?? for now and let's see how it performs
+                if firstIdentifierLocation > 3 {
+                    guard let previousCharacters = file.contents.validSubstring(from: firstIdentifierLocation - 3, length: 2) else { return nil }
+                    guard previousCharacters != "??" else { return nil }
+                }
+                let fullMatchRange = NSRange(location: firstIdentifierLocation, length: identifierLength + result.range.length)
+
+                let identicalMatch = IdenticalMatch(
+                    firstIdentifierRange: firstIdentifierRange,
+                    operatorRange: result.range(at: 1),
+                    secondIndentifierRange: secondIdentifierRange,
+                    fullRange: fullMatchRange
+                )
+                return (identicalMatch, tokens)
+            }
+
+            // Skip comments
+            .filter { result, _ in
+                let contents = file.contents.bridge()
+                guard let byteRange = contents.NSRangeToByteRange(start: result.operatorRange.location,
+                                                                  length: result.operatorRange.length),
+                    file.syntaxMap.kinds(inByteRange: byteRange).isEmpty else {
+                        return false
+                }
+                return true
+            }
+
+             .compactMap { result, syntaxKinds -> StyleViolation? in
+                guard Set(syntaxKinds.kinds) != [.typeidentifier] else {
+                    return nil
+                }
                 return StyleViolation(ruleDescription: type(of: self).description,
                                       severity: configuration.severity,
-                                      location: Location(file: file, characterOffset: range.location))
-            }
+                                      location: Location(file: file, characterOffset: result.fullRange.location))
+             }
+    }
+}
+
+private extension String {
+    internal func validSubstring(from: Int, length: Int) -> String? {
+        return validSubstring(range: NSRange(location: from, length: length))
+    }
+
+    internal func validSubstring(range: NSRange) -> String? {
+        guard let indexRange = nsrangeToIndexRange(range) else { return nil }
+        return String(self[indexRange])
     }
 }


### PR DESCRIPTION
Due to a bit ineffective Regular expression, identical operands rule was taking about 1/3 of time spent on regex matching in `Swift` repository
![image](https://user-images.githubusercontent.com/119268/66734971-bfe7db80-ee6d-11e9-86fc-3ec61e34bb50.png)

With a bit updated logic, new implementation should be a bit faster