### PR TITLE
Add ExpiringTodoRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 * Make `control_statement` rule correctable.  
   [MaxHaertwig](https://github.com/maxhaertwig)
+* Add `expiring_todo` opt-in rule to allow developers to mark their todos with an expiration date.  
+  [Dan Loman](https://github.com/namolnad)
+  [#727](https://github.com/realm/SwiftLint/issues/727)
 
 #### Bug Fixes
 
@@ -98,10 +101,6 @@
 * None.
 
 #### Enhancements
-
-* Add `expiring_todo` opt-in rule to allow developers to mark their todos with an expiration date.  
-  [Dan Loman](https://github.com/namolnad)
-  [#727](https://github.com/realm/SwiftLint/issues/727)
 
 * Add `contains_over_range_nil_comparison` opt-in rule to prefer
   using `contains` over comparison of `range(of:)` to `nil`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,10 @@
 
 #### Enhancements
 
+* Add `expiring_todo` opt-in rule to allow developers to mark their todos with an expiration date.
+  [Dan Loman](https://github.com/namolnad)
+  [#727](https://github.com/realm/SwiftLint/issues/727)
+
 * Add `contains_over_range_nil_comparison` opt-in rule to prefer
   using `contains` over comparison of `range(of:)` to `nil`.  
   [Colton Schlosser](https://github.com/cltnschlosser)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Make `control_statement` rule correctable.  
   [MaxHaertwig](https://github.com/maxhaertwig)
 * Add `expiring_todo` opt-in rule to allow developers to mark their todos with an expiration date.  
+* Add `expiring_todo` opt-in rule to allow developers to mark their
+  todos with an expiration date.  
   [Dan Loman](https://github.com/namolnad)
   [#727](https://github.com/realm/SwiftLint/issues/727)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@
 
 #### Enhancements
 
-* Add `expiring_todo` opt-in rule to allow developers to mark their todos with an expiration date.
+* Add `expiring_todo` opt-in rule to allow developers to mark their todos with an expiration date.  
   [Dan Loman](https://github.com/namolnad)
   [#727](https://github.com/realm/SwiftLint/issues/727)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Make `control_statement` rule correctable.  
   [MaxHaertwig](https://github.com/maxhaertwig)
-* Add `expiring_todo` opt-in rule to allow developers to mark their todos with an expiration date.  
+
 * Add `expiring_todo` opt-in rule to allow developers to mark their
   todos with an expiration date.  
   [Dan Loman](https://github.com/namolnad)

--- a/Rules.md
+++ b/Rules.md
@@ -40,6 +40,7 @@
 * [Empty Parentheses with Trailing Closure](#empty-parentheses-with-trailing-closure)
 * [Empty String](#empty-string)
 * [Empty XCTest Method](#empty-xctest-method)
+* [ExpiringTodo](#expiringtodo)
 * [Explicit ACL](#explicit-acl)
 * [Explicit Enum Raw Value](#explicit-enum-raw-value)
 * [Explicit Init](#explicit-init)
@@ -6133,6 +6134,82 @@ class FooTests: XCTestCase {
 class BarTests: XCTestCase {
     ↓func testFoo() {}
 }
+```
+
+</details>
+
+
+
+## ExpiringTodo
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`expiring_todo` | Disabled | No | lint | No | 3.0.0 
+
+TODOs and FIXMEs should be resolved prior to their expiry date.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+// notaTODO:
+
+```
+
+```swift
+// notaFIXME:
+
+```
+
+```swift
+// TODO: [12/31/9999]
+
+```
+
+```swift
+// TODO(note)
+
+```
+
+```swift
+// FIXME(note)
+
+```
+
+```swift
+/* FIXME: */
+
+```
+
+```swift
+/* TODO: */
+
+```
+
+```swift
+/** FIXME: */
+
+```
+
+```swift
+/** TODO: */
+
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+// TODO: [10/14/2019]
+
+```
+
+```swift
+// FIXME: [10/14/2019]
+
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -41,6 +41,7 @@ public let masterRuleList = RuleList(rules: [
     EmptyParenthesesWithTrailingClosureRule.self,
     EmptyStringRule.self,
     EmptyXCTestMethodRule.self,
+    ExpiringTodoRule.self,
     ExplicitACLRule.self,
     ExplicitEnumRawValueRule.self,
     ExplicitInitRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -46,9 +46,8 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
     public init() {}
 
     public func validate(file: File) -> [StyleViolation] {
-        // swiftlint:disable line_length
+        // swiftlint:disable:next line_length
         let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{2,4}\\\(configuration.dateSeparator)\\d{2}\\\(configuration.dateSeparator)\\d{2,4})\\\(configuration.dateDelimiters.closing)"
-        // swiftlint:enable line_length
 
         return file.matchesAndSyntaxKinds(matching: regex).compactMap { checkingResult, syntaxKinds in
             guard

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -42,7 +42,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
 
     public init() {}
 
-    public func validate(file: File) -> [StyleViolation] {
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
         // swiftlint:disable:next line_length
         let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{2,4}\\\(configuration.dateSeparator)\\d{2}\\\(configuration.dateSeparator)\\d{2,4})\\\(configuration.dateDelimiters.closing)"
 
@@ -66,7 +66,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
         }
     }
 
-    private func expiryDate(file: File, range: NSRange) -> Date? {
+    private func expiryDate(file: SwiftLintFile, range: NSRange) -> Date? {
         let expiryDateString = file.contents.bridge()
             .substring(with: range)
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SourceKittenFramework
 
 public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -1,0 +1,120 @@
+import SourceKittenFramework
+
+public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+    public static let description = RuleDescription(
+        identifier: "expiring_todo",
+        name: "ExpiringTodo",
+        description: "TODOs and FIXMEs should be resolved prior to their expiry date.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            "// notaTODO:\n",
+            "// notaFIXME:\n",
+            "// ↓TODO: [12/31/9999]\n",
+            "// ↓TODO(note)\n",
+            "// ↓FIXME(note)\n",
+            "/* ↓FIXME: */\n",
+            "/* ↓TODO: */\n",
+            "/** ↓FIXME: */\n",
+            "/** ↓TODO: */\n"
+        ],
+        triggeringExamples: [
+            "// ↓TODO: [10/14/2019]\n",
+            "// ↓FIXME: [10/14/2019]\n"
+        ]
+    )
+
+    public var configuration = ExpiringTodoConfiguration(
+        approachingExpirySeverity: .init(.warning),
+        expiredSeverity: .init(.error)
+    )
+
+    private var calendar: Calendar = .current
+
+    public init() {}
+
+    public func validate(file: File) -> [StyleViolation] {
+        // swiftlint:disable line_length
+        let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{2}\\\(configuration.dateSeparator)\\d{2}\\\(configuration.dateSeparator)\\d{4})\\\(configuration.dateDelimiters.closing)"
+        // swiftlint:enable line_length
+
+        return file.matchesAndSyntaxKinds(matching: regex).compactMap { checkingResult, syntaxKinds in
+            guard
+                syntaxKinds.allSatisfy({ $0.isCommentLike }),
+                checkingResult.numberOfRanges > 1,
+                case let range = checkingResult.range(at: 1),
+                let date = expiryDate(file: file, range: range),
+                let violationLevel = self.violationLevel(for: date),
+                let severity = self.severity(for: violationLevel) else {
+                return nil
+            }
+
+            return StyleViolation(
+                ruleDescription: type(of: self).description,
+                severity: severity,
+                location: Location(file: file, characterOffset: range.location),
+                reason: violationLevel.reason
+            )
+        }
+    }
+
+    private func expiryDate(file: File, range: NSRange) -> Date? {
+        // Get the date of expiry
+        let expiryDateString = file.contents.bridge()
+            .substring(with: range)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = configuration.dateFormat
+
+        return formatter.date(from: expiryDateString)
+    }
+
+    private func severity(for violationLevel: ViolationLevel) -> ViolationSeverity? {
+        switch violationLevel {
+        case .approaching:
+            return configuration.approachingExpirySeverity.severity
+        case .expired:
+            return configuration.expiredSeverity.severity
+        }
+    }
+
+    private func violationLevel(for date: Date) -> ViolationLevel? {
+        guard date.isEarlierThanToday else {
+            return .expired
+        }
+        guard let approachingDate = calendar.date(
+            byAdding: .day,
+            value: -configuration.approachingExpiryThreshold,
+            to: date) else {
+                return nil
+        }
+        return date.isDateInDaysBefore(otherDate: approachingDate) ?
+            nil :
+            .approaching
+    }
+}
+
+private enum ViolationLevel {
+    case approaching
+    case expired
+
+    var reason: String {
+        switch self {
+        case .approaching:
+            return "TODO/FIXME is approaching its expiry"
+        case .expired:
+            return "TODO/FIXME has expired and must be resolved"
+        }
+    }
+}
+
+private extension Date {
+    var isEarlierThanToday: Bool {
+        isDateInDaysBefore(otherDate: .init())
+    }
+
+    /// Returns `false` if date falls after (or in same day as) otherDate
+    func isDateInDaysBefore(otherDate: Date) -> Bool {
+        self < otherDate && !Calendar.current.isDate(self, inSameDayAs: otherDate)
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -34,7 +34,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule, AutomaticT
 
     public func validate(file: File) -> [StyleViolation] {
         // swiftlint:disable line_length
-        let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{2}\\\(configuration.dateSeparator)\\d{2}\\\(configuration.dateSeparator)\\d{4})\\\(configuration.dateDelimiters.closing)"
+        let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{2,4}\\\(configuration.dateSeparator)\\d{2}\\\(configuration.dateSeparator)\\d{2,4})\\\(configuration.dateDelimiters.closing)"
         // swiftlint:enable line_length
 
         return file.matchesAndSyntaxKinds(matching: regex).compactMap { checkingResult, syntaxKinds in

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -38,10 +38,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
         ]
     )
 
-    public var configuration = ExpiringTodoConfiguration(
-        approachingExpirySeverity: .init(.warning),
-        expiredSeverity: .init(.error)
-    )
+    public var configuration: ExpiringTodoConfiguration = .init()
 
     public init() {}
 

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -71,7 +71,6 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
     }
 
     private func expiryDate(file: File, range: NSRange) -> Date? {
-        // Get the date of expiry
         let expiryDateString = file.contents.bridge()
             .substring(with: range)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -110,6 +109,6 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
 
 private extension Date {
     var isAfterToday: Bool {
-        Calendar.current.compare(.init(), to: self, toGranularity: .day) == .orderedAscending
+        return Calendar.current.compare(.init(), to: self, toGranularity: .day) == .orderedAscending
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -15,9 +15,8 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
 
     private(set) var expiredSeverity: SeverityConfiguration
 
-    // swiftlint:disable todo
+    // swiftlint:disable:next todo
     /// The number of days prior to expiry before the TODO emits a violation
-    // swiftlint:enable todo
     private(set) var approachingExpiryThreshold: Int
     /// The opening/closing characters used to surround the expiry-date string
     private(set) var dateDelimiters: DelimiterConfiguration

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -4,6 +4,11 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
 
         fileprivate(set) var opening: String
         fileprivate(set) var closing: String
+
+        public init(opening: String, closing: String) {
+            self.opening = opening
+            self.closing = closing
+        }
     }
 
     public var consoleDescription: String {
@@ -26,8 +31,8 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
     private(set) var dateSeparator: String
 
     public init(
-        approachingExpirySeverity: SeverityConfiguration,
-        expiredSeverity: SeverityConfiguration,
+        approachingExpirySeverity: SeverityConfiguration = .init(.warning),
+        expiredSeverity: SeverityConfiguration = .init(.error),
         approachingExpiryThreshold: Int = 15,
         dateFormat: String = "MM/dd/yyyy",
         dateDelimiters: DelimiterConfiguration = .default,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -29,7 +29,7 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         approachingExpirySeverity: SeverityConfiguration,
         expiredSeverity: SeverityConfiguration,
         approachingExpiryThreshold: Int = 15,
-        dateFormat: String = "mm/DD/yyyy",
+        dateFormat: String = "MM/dd/yyyy",
         dateDelimiters: DelimiterConfiguration = .default,
         dateSeparator: Character = "/") {
         self.approachingExpirySeverity = approachingExpirySeverity

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -74,22 +74,4 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
             self.dateSeparator = dateSeparator
         }
     }
-
-    func severity(with config: SeverityLevelsConfiguration, for level: Int) -> ViolationSeverity? {
-        if let error = config.error, level > error {
-            return .error
-        } else if level > config.warning {
-            return .warning
-        }
-        return nil
-    }
-
-    func threshold(with config: SeverityLevelsConfiguration, for severity: ViolationSeverity) -> Int {
-        switch severity {
-        case .error:
-            return config.error ?? config.warning
-        case .warning:
-            return config.warning
-        }
-    }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -2,8 +2,8 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
     public struct DelimiterConfiguration: Equatable {
         public static let `default`: DelimiterConfiguration = .init(opening: "[", closing: "]")
 
-        let opening: Character
-        let closing: Character
+        fileprivate(set) var opening: String
+        fileprivate(set) var closing: String
     }
 
     public var consoleDescription: String {
@@ -11,19 +11,20 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         "(reached_or_passed_expiry_severity) \(expiredSeverity.consoleDescription)"
     }
 
-    var approachingExpirySeverity: SeverityConfiguration
-    var expiredSeverity: SeverityConfiguration
+    private(set) var approachingExpirySeverity: SeverityConfiguration
+
+    private(set) var expiredSeverity: SeverityConfiguration
 
     // swiftlint:disable todo
     /// The number of days prior to expiry before the TODO emits a violation
     // swiftlint:enable todo
-    let approachingExpiryThreshold: Int
+    private(set) var approachingExpiryThreshold: Int
     /// The opening/closing characters used to surround the expiry-date string
-    let dateDelimiters: DelimiterConfiguration
+    private(set) var dateDelimiters: DelimiterConfiguration
     /// The format which should be used to the expiry-date string into a `Date` object
-    let dateFormat: String
+    private(set) var dateFormat: String
     /// The separator used for regex detection of the expiry-date string
-    let dateSeparator: Character
+    private(set) var dateSeparator: String
 
     public init(
         approachingExpirySeverity: SeverityConfiguration,
@@ -31,7 +32,7 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         approachingExpiryThreshold: Int = 15,
         dateFormat: String = "MM/dd/yyyy",
         dateDelimiters: DelimiterConfiguration = .default,
-        dateSeparator: Character = "/") {
+        dateSeparator: String = "/") {
         self.approachingExpirySeverity = approachingExpirySeverity
         self.expiredSeverity = expiredSeverity
         self.approachingExpiryThreshold = approachingExpiryThreshold
@@ -50,6 +51,23 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         }
         if let expiredConfiguration = configurationDict["expired_severity"] {
             try expiredSeverity.apply(configuration: expiredConfiguration)
+        }
+        if let approachingExpiryThreshold = configurationDict["approaching_expiry_threshold"] as? Int {
+            self.approachingExpiryThreshold = approachingExpiryThreshold
+        }
+        if let dateFormat = configurationDict["date_format"] as? String {
+            self.dateFormat = dateFormat
+        }
+        if let dateDelimiters = configurationDict["date_delimiters"] as? [String: String] {
+            if let openingDelimiter = dateDelimiters["opening"] {
+                self.dateDelimiters.opening = openingDelimiter
+            }
+            if let closingDelimiter = dateDelimiters["closing"] {
+                self.dateDelimiters.closing = closingDelimiter
+            }
+        }
+        if let dateSeparator = configurationDict["date_separator"] as? String {
+            self.dateSeparator = dateSeparator
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -1,0 +1,73 @@
+public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
+    public struct DelimiterConfiguration: Equatable {
+        public static let `default`: DelimiterConfiguration = .init(opening: "[", closing: "]")
+
+        let opening: Character
+        let closing: Character
+    }
+
+    public var consoleDescription: String {
+        return "(approaching_expiry_severity) \(approachingExpirySeverity.consoleDescription), " +
+        "(reached_or_passed_expiry_severity) \(expiredSeverity.consoleDescription)"
+    }
+
+    var approachingExpirySeverity: SeverityConfiguration
+    var expiredSeverity: SeverityConfiguration
+
+    // swiftlint:disable todo
+    /// The number of days prior to expiry before the TODO emits a violation
+    // swiftlint:enable todo
+    let approachingExpiryThreshold: Int
+    /// The opening/closing characters used to surround the expiry-date string
+    let dateDelimiters: DelimiterConfiguration
+    /// The format which should be used to the expiry-date string into a `Date` object
+    let dateFormat: String
+    /// The separator used for regex detection of the expiry-date string
+    let dateSeparator: Character
+
+    public init(
+        approachingExpirySeverity: SeverityConfiguration,
+        expiredSeverity: SeverityConfiguration,
+        approachingExpiryThreshold: Int = 15,
+        dateFormat: String = "mm/DD/yyyy",
+        dateDelimiters: DelimiterConfiguration = .default,
+        dateSeparator: Character = "/") {
+        self.approachingExpirySeverity = approachingExpirySeverity
+        self.expiredSeverity = expiredSeverity
+        self.approachingExpiryThreshold = approachingExpiryThreshold
+        self.dateDelimiters = dateDelimiters
+        self.dateFormat = dateFormat
+        self.dateSeparator = dateSeparator
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configurationDict = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let approachingExpiryConfiguration = configurationDict["approaching_expiry_severity"] {
+            try approachingExpirySeverity.apply(configuration: approachingExpiryConfiguration)
+        }
+        if let expiredConfiguration = configurationDict["expired_severity"] {
+            try expiredSeverity.apply(configuration: expiredConfiguration)
+        }
+    }
+
+    func severity(with config: SeverityLevelsConfiguration, for level: Int) -> ViolationSeverity? {
+        if let error = config.error, level > error {
+            return .error
+        } else if level > config.warning {
+            return .warning
+        }
+        return nil
+    }
+
+    func threshold(with config: SeverityLevelsConfiguration, for severity: ViolationSeverity) -> Int {
+        switch severity {
+        case .error:
+            return config.error ?? config.warning
+        case .warning:
+            return config.warning
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */; };
 		1EF115921EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */; };
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
+		22A36FDF235673F50037B47D /* ExpiringTodoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */; };
+		22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */; };
 		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
 		24E17F721B14BB3F008195BE /* SwiftLintFile+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* SwiftLintFile+Cache.swift */; };
 		260F66A0225C5B6D00407CF5 /* CollectingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260F669F225C5B6D00407CF5 /* CollectingRuleTests.swift */; };
@@ -516,6 +518,8 @@
 		1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRule.swift; sourceTree = "<group>"; };
 		1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTopLevelACLRule.swift; sourceTree = "<group>"; };
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
+		22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRule.swift; sourceTree = "<group>"; };
+		22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoConfiguration.swift; sourceTree = "<group>"; };
 		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* SwiftLintFile+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftLintFile+Cache.swift"; sourceTree = "<group>"; };
 		260F669F225C5B6D00407CF5 /* CollectingRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectingRuleTests.swift; sourceTree = "<group>"; };
@@ -1040,6 +1044,7 @@
 				787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */,
 				D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */,
 				D450D1DA21F1992E00E60010 /* TrailingClosureConfiguration.swift */,
+				22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */,
 				BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */,
 				82DB55FF21008F54001C62FF /* TypeContentsOrderConfiguration.swift */,
 				CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */,
@@ -1160,6 +1165,7 @@
 				D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */,
 				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
 				1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */,
+				22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */,
 			);
 			path = Lint;
 			sourceTree = "<group>";
@@ -2016,6 +2022,7 @@
 				8F2CC1CB20A6A070006ED34F /* FileNameConfiguration.swift in Sources */,
 				D4CFC5D2209EC95A00668488 /* FunctionDefaultParameterAtEndRule.swift in Sources */,
 				E88198541BEA945100333A11 /* CommaRule.swift in Sources */,
+				22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */,
 				D4DA1DFE1E1A10DB0037413D /* NumberSeparatorConfiguration.swift in Sources */,
 				E88198601BEA98F000333A11 /* IdentifierNameRule.swift in Sources */,
 				E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */,
@@ -2158,6 +2165,7 @@
 				B25DCD0E1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift in Sources */,
 				827009FD20FE26B700ECA185 /* FileTypesOrderRule.swift in Sources */,
 				E4EA064C23688EB5002531D7 /* SwiftLintFile.swift in Sources */,
+				22A36FDF235673F50037B47D /* ExpiringTodoRule.swift in Sources */,
 				24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */,
 				D4130D971E16183F00242361 /* IdentifierNameRuleExamples.swift in Sources */,
 				7250948A1D0859260039B353 /* StatementModeConfiguration.swift in Sources */,

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */; };
 		1EF115921EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */; };
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
+		224E7F9D235A5E800051368B /* ExpiringTodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */; };
 		22A36FDF235673F50037B47D /* ExpiringTodoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */; };
 		22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */; };
 		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
@@ -518,6 +519,7 @@
 		1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRule.swift; sourceTree = "<group>"; };
 		1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTopLevelACLRule.swift; sourceTree = "<group>"; };
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
+		224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRuleTests.swift; sourceTree = "<group>"; };
 		22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRule.swift; sourceTree = "<group>"; };
 		22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoConfiguration.swift; sourceTree = "<group>"; };
 		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
@@ -1522,6 +1524,7 @@
 				787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */,
 				E81224991B04F85B001783D2 /* TestHelpers.swift */,
 				D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */,
+				224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */,
 				D450D1E121F19B1E00E60010 /* TrailingClosureConfigurationTests.swift */,
 				D450D1DE21F19A9400E60010 /* TrailingClosureRuleTests.swift */,
 				C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */,
@@ -2333,6 +2336,7 @@
 				D4F5851720E99B260085C6D8 /* StatementPositionRuleTests.swift in Sources */,
 				1EB7C8531F0C45C2004BAD22 /* ModifierOrderTests.swift in Sources */,
 				67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */,
+				224E7F9D235A5E800051368B /* ExpiringTodoRuleTests.swift in Sources */,
 				F90DBD812092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift in Sources */,
 				C25EBBDF2107884200E27603 /* PrefixedTopLevelConstantRuleTests.swift in Sources */,
 				C2B3C1612106F78C00088928 /* ConfigurationAliasesTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -394,6 +394,16 @@ extension EmptyXCTestMethodRuleTests {
     ]
 }
 
+extension ExpiringTodoRuleTests {
+    static var allTests: [(String, (ExpiringTodoRuleTests) -> () throws -> Void)] = [
+        ("testExpiringTodo", testExpiringTodo),
+        ("testExpiredTodo", testExpiredTodo),
+        ("testExpiredFixMe", testExpiredFixMe),
+        ("testApproachingExpiryTodo", testApproachingExpiryTodo),
+        ("testNonExpiredTodo", testNonExpiredTodo)
+    ]
+}
+
 extension ExplicitACLRuleTests {
     static var allTests: [(String, (ExplicitACLRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1621,6 +1631,7 @@ XCTMain([
     testCase(EmptyParenthesesWithTrailingClosureRuleTests.allTests),
     testCase(EmptyStringRuleTests.allTests),
     testCase(EmptyXCTestMethodRuleTests.allTests),
+    testCase(ExpiringTodoRuleTests.allTests),
     testCase(ExplicitACLRuleTests.allTests),
     testCase(ExplicitEnumRawValueRuleTests.allTests),
     testCase(ExplicitInitRuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -401,7 +401,9 @@ extension ExpiringTodoRuleTests {
         ("testExpiredFixMe", testExpiredFixMe),
         ("testApproachingExpiryTodo", testApproachingExpiryTodo),
         ("testNonExpiredTodo", testNonExpiredTodo),
-        ("testExpiredCustomDelimiters", testExpiredCustomDelimiters)
+        ("testExpiredCustomDelimiters", testExpiredCustomDelimiters),
+        ("testExpiredCustomSeparator", testExpiredCustomSeparator),
+        ("testExpiredCustomFormat", testExpiredCustomFormat)
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -400,7 +400,8 @@ extension ExpiringTodoRuleTests {
         ("testExpiredTodo", testExpiredTodo),
         ("testExpiredFixMe", testExpiredFixMe),
         ("testApproachingExpiryTodo", testApproachingExpiryTodo),
-        ("testNonExpiredTodo", testNonExpiredTodo)
+        ("testNonExpiredTodo", testNonExpiredTodo),
+        ("testExpiredCustomDelimiters", testExpiredCustomDelimiters)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -46,9 +46,8 @@ class ExpiringTodoRuleTests: XCTestCase {
     }
 
     private func date(for status: ExpiringTodoRule.ExpiryViolationLevel?) -> Date {
-        // swiftlint:disable force_cast
+        // swiftlint:disable:next force_cast
         let rule = config.rules.first(where: { $0 is ExpiringTodoRule }) as! ExpiringTodoRule
-        // swiftlint:enable force_cast
 
         let daysToAdvance: Int
 

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -1,0 +1,71 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class ExpiringTodoRuleTests: XCTestCase {
+    private let config = makeConfig(nil, ExpiringTodoRule.description.identifier)!
+
+    func testExpiringTodo() {
+        verifyRule(ExpiringTodoRule.description, commentDoesntViolate: false)
+    }
+
+    func testExpiredTodo() {
+        let string = "fatalError() // TODO: [\(dateString(for: .expired))] Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "TODO/FIXME has expired and must be resolved.")
+    }
+
+    func testExpiredFixMe() {
+        let string = "fatalError() // FIXME: [\(dateString(for: .expired))] Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "TODO/FIXME has expired and must be resolved.")
+    }
+
+    func testApproachingExpiryTodo() {
+        let string = "fatalError() // TODO: [\(dateString(for: .approachingExpiry))] Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "TODO/FIXME is approaching its expiry and should be resolved soon.")
+    }
+
+    func testNonExpiredTodo() {
+        let string = "fatalError() // TODO: [\(dateString(for: nil))] Implement"
+        XCTAssertEqual(violations(string).count, 0)
+    }
+
+    private func violations(_ string: String) -> [StyleViolation] {
+        return SwiftLintFrameworkTests.violations(string, config: config)
+    }
+
+    private func dateString(for status: ExpiringTodoRule.ExpiryViolationLevel?) -> String {
+        let formatter: DateFormatter = .init()
+        formatter.dateFormat = "MM/dd/yyyy"
+
+        return formatter.string(from: date(for: status))
+    }
+
+    private func date(for status: ExpiringTodoRule.ExpiryViolationLevel?) -> Date {
+        // swiftlint:disable force_cast
+        let rule = config.rules.first(where: { $0 is ExpiringTodoRule }) as! ExpiringTodoRule
+        // swiftlint:enable force_cast
+
+        let daysToAdvance: Int
+
+        switch status {
+        case nil:
+            daysToAdvance = rule.configuration.approachingExpiryThreshold + 1
+        case .approachingExpiry:
+            daysToAdvance = rule.configuration.approachingExpiryThreshold
+        case .expired:
+            daysToAdvance = 0
+        }
+
+        return Calendar.current
+            .date(
+                byAdding: .day,
+                value: daysToAdvance,
+                to: .init()
+            )!
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -2,7 +2,13 @@
 import XCTest
 
 class ExpiringTodoRuleTests: XCTestCase {
-    private let config = makeConfig(nil, ExpiringTodoRule.description.identifier)!
+    private lazy var config: Configuration = makeConfiguration()
+
+    override func setUp() {
+        super.setUp()
+
+        config = makeConfiguration()
+    }
 
     func testExpiringTodo() {
         verifyRule(ExpiringTodoRule.description, commentDoesntViolate: false)
@@ -34,30 +40,66 @@ class ExpiringTodoRuleTests: XCTestCase {
         XCTAssertEqual(violations(string).count, 0)
     }
 
+    func testExpiredCustomDelimiters() {
+        let ruleConfig: ExpiringTodoConfiguration = .init(
+            dateDelimiters: .init(opening: "<", closing: ">")
+        )
+        config = makeConfiguration(with: ruleConfig)
+
+        let string = "fatalError() // TODO: <\(dateString(for: .expired))> Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "TODO/FIXME has expired and must be resolved.")
+    }
+
+    func testExpiredCustomSeparator() {
+        let ruleConfig: ExpiringTodoConfiguration = .init(
+            dateFormat: "MM-dd-yyyy",
+            dateSeparator: "-"
+        )
+        config = makeConfiguration(with: ruleConfig)
+
+        let string = "fatalError() // TODO: [\(dateString(for: .expired))] Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "TODO/FIXME has expired and must be resolved.")
+    }
+
+    func testExpiredCustomFormat() {
+        let ruleConfig: ExpiringTodoConfiguration = .init(
+            dateFormat: "yyyy/MM/dd"
+        )
+        config = makeConfiguration(with: ruleConfig)
+
+        let string = "fatalError() // TODO: [\(dateString(for: .expired))] Implement"
+        let violations = self.violations(string)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "TODO/FIXME has expired and must be resolved.")
+    }
+
     private func violations(_ string: String) -> [StyleViolation] {
         return SwiftLintFrameworkTests.violations(string, config: config)
     }
 
     private func dateString(for status: ExpiringTodoRule.ExpiryViolationLevel?) -> String {
         let formatter: DateFormatter = .init()
-        formatter.dateFormat = "MM/dd/yyyy"
+        formatter.dateFormat = config.ruleConfiguration.dateFormat
 
         return formatter.string(from: date(for: status))
     }
 
     private func date(for status: ExpiringTodoRule.ExpiryViolationLevel?) -> Date {
-        // swiftlint:disable:next force_cast
-        let rule = config.rules.first(where: { $0 is ExpiringTodoRule }) as! ExpiringTodoRule
+        let ruleConfiguration = config.ruleConfiguration
 
         let daysToAdvance: Int
 
         switch status {
         case .approachingExpiry?:
-            daysToAdvance = rule.configuration.approachingExpiryThreshold
+            daysToAdvance = ruleConfiguration.approachingExpiryThreshold
         case .expired?:
             daysToAdvance = 0
         case nil:
-            daysToAdvance = rule.configuration.approachingExpiryThreshold + 1
+            daysToAdvance = ruleConfiguration.approachingExpiryThreshold + 1
         }
 
         return Calendar.current
@@ -66,5 +108,32 @@ class ExpiringTodoRuleTests: XCTestCase {
                 value: daysToAdvance,
                 to: .init()
             )!
+    }
+
+    private func makeConfiguration(with ruleConfiguration: ExpiringTodoConfiguration? = nil) -> Configuration {
+        var serializedConfig: [String: Any]?
+
+        if let config = ruleConfiguration {
+            serializedConfig = [
+                "expired_severity": config.expiredSeverity.severity.rawValue,
+                "approaching_expiry_severity": config.approachingExpirySeverity.severity.rawValue,
+                "approaching_expiry_threshold": config.approachingExpiryThreshold,
+                "date_format": config.dateFormat,
+                "date_delimiters": [
+                    "opening": config.dateDelimiters.opening,
+                    "closing": config.dateDelimiters.closing
+                ],
+                "date_separator": config.dateSeparator
+            ]
+        }
+
+        return makeConfig(serializedConfig, ExpiringTodoRule.description.identifier)!
+    }
+}
+
+fileprivate extension Configuration {
+    var ruleConfiguration: ExpiringTodoConfiguration {
+        // swiftlint:disable:next force_cast
+        return (rules.first(where: { $0 is ExpiringTodoRule }) as! ExpiringTodoRule).configuration
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -53,12 +53,12 @@ class ExpiringTodoRuleTests: XCTestCase {
         let daysToAdvance: Int
 
         switch status {
+        case .approachingExpiry?:
+            daysToAdvance = rule.configuration.approachingExpiryThreshold
+        case .expired?:
+            daysToAdvance = 0
         case nil:
             daysToAdvance = rule.configuration.approachingExpiryThreshold + 1
-        case .approachingExpiry:
-            daysToAdvance = rule.configuration.approachingExpiryThreshold
-        case .expired:
-            daysToAdvance = 0
         }
 
         return Calendar.current


### PR DESCRIPTION
This PR adds a new `expiring_todo` linter rule which enables developers to add an expiry date to their TODO comments. Example: `// TODO: [10/19/2019] Fix that thing`

By default the rule emits a warning when the todo expiry is within the next 15 days and an error if the expiry is at or past the current date.

Configurable parameters:
- `approaching_expiry_severity`
- `expired_severity`
- `approaching_expiry_threshold`
- `date_format`
- `date_delimiters` (`opening` and `closing`)
- `date_separator` (used to adjust the regex of the rule)

This should solve issue #727 