### PR TITLE
Fix running analyze on Xcode 11 build outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix running analyzer rules on the output of builds performed with
+  Xcode 11 or later.  
+  [JP Simard](https://github.com/jpsim)
 
 ## 0.35.0: Secondary Lint Trap
 


### PR DESCRIPTION
Xcode 11 started using [response files](https://github.com/apple/swift/pull/16362) to avoid exceeding command line length limits. For SwiftLint's analyzer rules to find which compiler arguments are needed for a given file being analyzed, we first need to expand these response files to their contents.

This was ported over from https://github.com/jpsim/SourceKitten/pull/613