### PR TITLE
Optimize `redundant_void_return`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 * Make `toggle_bool` rule substitution correctable.  
   [MaxHaertwig](https://github.com/maxhaertwig)
 
+* Optimize the performance of `redundant_void_return` rule.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 * Support building with Swift 5.1 on Linux.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2874](https://github.com/realm/SwiftLint/issues/2874)

--- a/Rules.md
+++ b/Rules.md
@@ -17879,6 +17879,10 @@ func foo()↓ -> () {}
 ```
 
 ```swift
+func foo()↓ -> ( ) {}
+```
+
+```swift
 protocol Foo {
   func foo()↓ -> ()
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -73,7 +73,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
     public func violationRanges(in file: File, kind: SwiftDeclarationKind,
                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
         guard functionKinds.contains(kind),
-            containsVoidReturnTypeBasedOnTypeName(dictionary: dictionary),
+            !shouldReturnEarlyBasedOnTypeName(dictionary: dictionary),
             let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength,
             let length = dictionary.length,
@@ -94,11 +94,15 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
         return (violationRange, "")
     }
 
-    private func containsVoidReturnTypeBasedOnTypeName(dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func shouldReturnEarlyBasedOnTypeName(dictionary: [String: SourceKitRepresentable]) -> Bool {
         guard SwiftVersion.current >= .fourDotOne else {
-            return true
+            return false
         }
 
+        return !containsVoidReturnTypeBasedOnTypeName(dictionary: dictionary)
+    }
+
+    private func containsVoidReturnTypeBasedOnTypeName(dictionary: [String: SourceKitRepresentable]) -> Bool {
         guard let typeName = dictionary.typeName else {
             return false
         }


### PR DESCRIPTION
This speed ups `redundant_void_return` from ~1.5s to 300-400ms on a mid size codebase. 