### PR TITLE
Faster tokens resolving in syntaxmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2901](https://github.com/realm/SwiftLint/issues/2901)  
 
+* Faster tokens resolving in syntaxmap.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)  
+  [#2916](https://github.com/realm/SwiftLint/issues/2916)  
+
 #### Bug Fixes
 
 * Fix running analyzer rules on the output of builds performed with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2918](https://github.com/realm/SwiftLint/issues/2918)
 
+* Speed up syntax token lookups, which can improve performance when linting
+  large files.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)  
+  [#2916](https://github.com/realm/SwiftLint/issues/2916)  
+
 * Add GitHub Actions Logging reporter (`github-actions-logging`).  
   [Norio Nomura](https://github.com/norio-nomura)
 
@@ -73,10 +78,6 @@
 * Speedup `LetVarWhiteSpacesRule`.  
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2901](https://github.com/realm/SwiftLint/issues/2901)  
-
-* Faster tokens resolving in syntaxmap.  
-  [PaulTaykalo](https://github.com/PaulTaykalo)  
-  [#2916](https://github.com/realm/SwiftLint/issues/2916)  
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/RandomAccessCollection+Swiftlint.swift
+++ b/Source/SwiftLintFramework/Extensions/RandomAccessCollection+Swiftlint.swift
@@ -1,0 +1,57 @@
+internal extension RandomAccessCollection where Index == Int {
+    /// Returns the first index in which an element of the collection satisfies
+    /// the given predicate. The collection assumed to be sorted. If collection is not have sorted values
+    /// the result is undefined
+    ///
+    /// The idea  is to get first index of a function where predicate starting to return true values.
+    ///
+    ///       let values = [1,2,3,4,5]
+    ///       let idx = values.firstIndexAssumingSorted(where: { $0 > 3 })
+    ///
+    ///       // false, false, false, true, true
+    ///       //                      ^
+    ///       // therefore idx == 3
+    ///
+    /// - Parameter predicate: A closure that takes an element as its argument
+    ///   and returns a Boolean value that indicates whether the passed element
+    ///   represents a match.
+    /// - Returns: The index of the first element for which `predicate` returns
+    ///   `true`. If no elements in the collection satisfy the given predicate,
+    ///   returns `nil`.
+    ///
+    /// - Complexity: O(log(*n*)), where *n* is the length of the collection.
+    @inlinable
+    func firstIndexAssumingSorted(where predicate: (Self.Element) throws -> Bool) rethrows -> Int? {
+        // Predicate should divide a collection to two pars of vaues
+        // "bad" values for which predicate returns `false``
+        // "good" values for which predicate return `true`
+
+        // false false false false false true true true
+        //                               ^
+        // The idea is to get _first_ index which for which predicate returns `true`
+
+        let lastIndex = count
+
+        // The index that represetns where bad values starts.
+        var badIndex = -1
+
+        // The index that represetns where good values starts
+        var goodIndex = lastIndex
+        var midIndex = (badIndex + goodIndex) / 2
+
+        while badIndex + 1 < goodIndex {
+            if try predicate(self[midIndex]) {
+                goodIndex = midIndex
+            } else {
+                badIndex = midIndex
+            }
+            midIndex = (badIndex + goodIndex) / 2
+        }
+
+        // Corner case, we' re out of bound, no good items in array
+        if midIndex == lastIndex {
+            return nil
+        }
+        return goodIndex
+    }
+}

--- a/Source/SwiftLintFramework/Extensions/RandomAccessCollection+Swiftlint.swift
+++ b/Source/SwiftLintFramework/Extensions/RandomAccessCollection+Swiftlint.swift
@@ -1,9 +1,8 @@
-internal extension RandomAccessCollection where Index == Int {
-    /// Returns the first index in which an element of the collection satisfies
-    /// the given predicate. The collection assumed to be sorted. If collection is not have sorted values
-    /// the result is undefined
+extension RandomAccessCollection where Index == Int {
+    /// Returns the first index in which an element of the collection satisfies the given predicate.
+    /// The collection assumed to be sorted. If collection is not have sorted values the result is undefined.
     ///
-    /// The idea  is to get first index of a function where predicate starting to return true values.
+    /// The idea is to get first index of a function for which the given predicate evaluates to true.
     ///
     ///       let values = [1,2,3,4,5]
     ///       let idx = values.firstIndexAssumingSorted(where: { $0 > 3 })
@@ -15,6 +14,7 @@ internal extension RandomAccessCollection where Index == Int {
     /// - Parameter predicate: A closure that takes an element as its argument
     ///   and returns a Boolean value that indicates whether the passed element
     ///   represents a match.
+    ///
     /// - Returns: The index of the first element for which `predicate` returns
     ///   `true`. If no elements in the collection satisfy the given predicate,
     ///   returns `nil`.
@@ -22,20 +22,20 @@ internal extension RandomAccessCollection where Index == Int {
     /// - Complexity: O(log(*n*)), where *n* is the length of the collection.
     @inlinable
     func firstIndexAssumingSorted(where predicate: (Self.Element) throws -> Bool) rethrows -> Int? {
-        // Predicate should divide a collection to two pars of vaues
+        // Predicate should divide a collection to two pairs of values
         // "bad" values for which predicate returns `false``
         // "good" values for which predicate return `true`
 
         // false false false false false true true true
         //                               ^
-        // The idea is to get _first_ index which for which predicate returns `true`
+        // The idea is to get _first_ index which for which the predicate returns `true`
 
         let lastIndex = count
 
-        // The index that represetns where bad values starts.
+        // The index that represents where bad values start
         var badIndex = -1
 
-        // The index that represetns where good values starts
+        // The index that represents where good values start
         var goodIndex = lastIndex
         var midIndex = (badIndex + goodIndex) / 2
 
@@ -48,7 +48,7 @@ internal extension RandomAccessCollection where Index == Int {
             midIndex = (badIndex + goodIndex) / 2
         }
 
-        // Corner case, we' re out of bound, no good items in array
+        // We're out of bounds, no good items in array
         if midIndex == lastIndex {
             return nil
         }

--- a/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
@@ -11,57 +11,21 @@ extension SyntaxMap {
                 .intersects(byteRange)
         }
 
-        guard let startIndex = firstIntersectingTokenIndex(inByteRange: byteRange) else {
-            return []
+        func intersectsOrAfter(_ token: SyntaxToken) -> Bool {
+            return token.offset + token.length > byteRange.location
         }
 
-        func isAfterByteRange(_ token: SyntaxToken) -> Bool {
-            return token.offset < byteRange.upperBound
+        guard let startIndex = tokens.firstIndexAssumingSorted(where: intersectsOrAfter) else {
+            return []
         }
 
         let tokensAfterFirstIntersection = tokens
             .lazy
             .suffix(from: startIndex)
-            .prefix(while: isAfterByteRange)
+            .prefix(while: { $0.offset < byteRange.upperBound })
             .filter(intersect)
 
         return Array(tokensAfterFirstIntersection)
-    }
-
-    // Index of first token which intersects byterange
-    // Using binary search
-    func firstIntersectingTokenIndex(inByteRange byteRange: NSRange) -> Int? {
-        let lastIndex = tokens.count
-
-        // The idx, which definitely beyound byteOffset
-        var bad = -1
-
-        // The index which is definitely after byteOffset
-        var good = lastIndex
-        var mid = (bad + good) / 2
-
-        // 0 0 0 0 0 1 1 1 1 1
-        //           ^
-        // The idea is to get _first_ token index which intesects the byteRange
-        func intersectsOrAfter(at index: Int) -> Bool {
-            let token = tokens[index]
-            return token.offset + token.length > byteRange.location
-        }
-
-        while bad + 1 < good {
-            if intersectsOrAfter(at: mid) {
-                good = mid
-            } else {
-                bad = mid
-            }
-            mid = (bad + good) / 2
-        }
-
-        // Corner case, we' re out of bound, no good items in array
-        if mid == lastIndex {
-            return nil
-        }
-        return good
     }
 
     internal func kinds(inByteRange byteRange: NSRange) -> [SyntaxKind] {

--- a/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxMap+SwiftLint.swift
@@ -15,11 +15,17 @@ extension SyntaxMap {
             return []
         }
 
-        let intersectingTokens = tokens
+        func isAfterByteRange(_ token: SyntaxToken) -> Bool {
+            return token.offset < byteRange.upperBound
+        }
+
+        let tokensAfterFirstIntersection = tokens
             .lazy
             .suffix(from: startIndex)
-            .prefix(while: intersect)
-        return Array(intersectingTokens)
+            .prefix(while: isAfterByteRange)
+            .filter(intersect)
+
+        return Array(tokensAfterFirstIntersection)
     }
 
     // Index of first token which intersects byterange

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -364,6 +364,7 @@
 		D93DA3D11E699E6300809827 /* NestingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */; };
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
 		E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */; };
+		E4A6CF752363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
 		E80746F61ECB722F00548D31 /* CacheDescriptionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80746F51ECB722F00548D31 /* CacheDescriptionProvider.swift */; };
@@ -866,6 +867,7 @@
 		D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestingConfiguration.swift; sourceTree = "<group>"; };
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
 		E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicInlineRule.swift; sourceTree = "<group>"; };
+		E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RandomAccessCollection+Swiftlint.swift"; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
 		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
@@ -1654,6 +1656,7 @@
 				3BA79C9A1C4767910057E705 /* NSRange+SwiftLint.swift */,
 				3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */,
 				E81619521BFC162C00946723 /* QueuedPrint.swift */,
+				E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */,
 				6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */,
 				E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */,
 				B39353F28BCCA39247B316BD /* String+XML.swift */,
@@ -2216,6 +2219,7 @@
 				6C15818D237026AC00F582A2 /* GitHubActionsLoggingReporter.swift in Sources */,
 				62FE5D32200CABDD00F68793 /* DiscouragedOptionalCollectionExamples.swift in Sources */,
 				D49896F12026B36C00814A83 /* RedundantSetAccessControlRule.swift in Sources */,
+				E4A6CF752363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift in Sources */,
 				29FFC37A1F15764D007E4825 /* FileLengthRuleConfiguration.swift in Sources */,
 				ED641C3820AA07B400212C62 /* NoFallthroughOnlyRule.swift in Sources */,
 				D4B31ADC22A0581B000300F1 /* DuplicateEnumCasesRule.swift in Sources */,


### PR DESCRIPTION
When the request is asked which tokens are have in an intersection, the previous solution was searching for first Index (linearly) and then filtered everything that was coming after that index using `intersect function`

The updated solution  will search for the first token index using`binary search`

# Speedup

While this is only one function was updated, the next options were considered:

- [**lin+filter**] old solution 
- [**lin+prefix**] old solution with `prefix:wihle` instead of filtering
- [**bin+filter**] binary search with filter 
- [**bin+prefix**] binary search with `prefix:wihle` instead of filtering

The speedup highly depends on the file sizes. The bigger/longer files the bigger win is

# Benchmark

## Kickstarter

|lin+filter|lin+prefix|bin+filter|bin+prefix|speedup|
|-|-|-|-|-|
|0.494|0.243|0.390|\***0.117\***|  ~4x |

## Swift

|lin+filter|lin+prefix|bin+filter|bin+prefix|speedup|
|-|-|-|-|-|
|1.739|0.740|1.273|\***0.103**\*| ~16x |

## WordPress
|lin+filter|lin+prefix|bin+filter|bin+prefix|speedup|
|-|-|-|-|-|
|1.270|0.526|0.918|0.148| ~8x |

# Testing code

This code was tested with these parts of code (in Release build)
```
fileprivate var counter = 0
fileprivate var times: [String: Double] = [:]
fileprivate let timesQueue = DispatchQueue.init(label: "benchmarks")

fileprivate func timeLog<T>(_ name: String, block: () -> T) -> T {
    let start = DispatchTime.now()
    let result = block()
    let end = DispatchTime.now()
    timesQueue.async {
        let oldValue = times[name, default:0.0]
        let diff = TimeInterval(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
        let newValue = oldValue + diff
        times[name] = newValue
        counter += 1
        if counter % 1000 * times.count == 0 {
            print("!!!!: \(times)")
        }
    }
    return result
}

    internal func tokens(inByteRange byteRange: NSRange) -> [SyntaxToken] {
        let new = timeLog("new") { tokensFast(inByteRange: byteRange) }
        let new2 = timeLog("old") { tokensOld(inByteRange: byteRange) }
        return arc4random() % 2 == 1 ? new : new2
    }

```