### PR TITLE
Identical operands rule using syntaxmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 #### Enhancements
 
-* None.
+* Speed up Identical Operands rule by using syntaxmap instead of
+  regular expressions.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)
+  [#2918](https://github.com/realm/SwiftLint/issues/2918)
 
 #### Bug Fixes
 

--- a/Rules.md
+++ b/Rules.md
@@ -9607,6 +9607,14 @@ func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError
 let array = Array<Array<Int>>()
 ```
 
+```swift
+guard Set(identifiers).count != identifiers.count else { return }
+```
+
+```swift
+expect("foo") == "foo"
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -9672,6 +9672,10 @@ expect("foo") == "foo"
 ```
 
 ```swift
+↓a?.b == a?.b
+```
+
+```swift
 ↓1 != 1
 ```
 
@@ -9689,6 +9693,10 @@ expect("foo") == "foo"
 
 ```swift
 ↓$0 != $0
+```
+
+```swift
+↓a?.b != a?.b
 ```
 
 ```swift
@@ -9712,6 +9720,10 @@ expect("foo") == "foo"
 ```
 
 ```swift
+↓a?.b === a?.b
+```
+
+```swift
 ↓1 !== 1
 ```
 
@@ -9729,6 +9741,10 @@ expect("foo") == "foo"
 
 ```swift
 ↓$0 !== $0
+```
+
+```swift
+↓a?.b !== a?.b
 ```
 
 ```swift
@@ -9752,6 +9768,10 @@ expect("foo") == "foo"
 ```
 
 ```swift
+↓a?.b > a?.b
+```
+
+```swift
 ↓1 >= 1
 ```
 
@@ -9769,6 +9789,10 @@ expect("foo") == "foo"
 
 ```swift
 ↓$0 >= $0
+```
+
+```swift
+↓a?.b >= a?.b
 ```
 
 ```swift
@@ -9792,6 +9816,10 @@ expect("foo") == "foo"
 ```
 
 ```swift
+↓a?.b < a?.b
+```
+
+```swift
 ↓1 <= 1
 ```
 
@@ -9809,6 +9837,10 @@ expect("foo") == "foo"
 
 ```swift
 ↓$0 <= $0
+```
+
+```swift
+↓a?.b <= a?.b
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -9201,6 +9201,10 @@ _ = num != nil && num == num?.byteSwapped
 ```
 
 ```swift
+num == num!.byteSwapped
+```
+
+```swift
 1 != 2
 ```
 
@@ -9255,6 +9259,10 @@ string != string.lowercased()
 ```swift
 let num: Int? = 0
 _ = num != nil && num != num?.byteSwapped
+```
+
+```swift
+num != num!.byteSwapped
 ```
 
 ```swift
@@ -9315,6 +9323,10 @@ _ = num != nil && num === num?.byteSwapped
 ```
 
 ```swift
+num === num!.byteSwapped
+```
+
+```swift
 1 !== 2
 ```
 
@@ -9369,6 +9381,10 @@ string !== string.lowercased()
 ```swift
 let num: Int? = 0
 _ = num != nil && num !== num?.byteSwapped
+```
+
+```swift
+num !== num!.byteSwapped
 ```
 
 ```swift
@@ -9429,6 +9445,10 @@ _ = num != nil && num > num?.byteSwapped
 ```
 
 ```swift
+num > num!.byteSwapped
+```
+
+```swift
 1 >= 2
 ```
 
@@ -9483,6 +9503,10 @@ string >= string.lowercased()
 ```swift
 let num: Int? = 0
 _ = num != nil && num >= num?.byteSwapped
+```
+
+```swift
+num >= num!.byteSwapped
 ```
 
 ```swift
@@ -9543,6 +9567,10 @@ _ = num != nil && num < num?.byteSwapped
 ```
 
 ```swift
+num < num!.byteSwapped
+```
+
+```swift
 1 <= 2
 ```
 
@@ -9597,6 +9625,10 @@ string <= string.lowercased()
 ```swift
 let num: Int? = 0
 _ = num != nil && num <= num?.byteSwapped
+```
+
+```swift
+num <= num!.byteSwapped
 ```
 
 ```swift

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -128,7 +128,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
             while currentIndex > 0 {
                 let prevToken = tokens[currentIndex - 1]
 
-                guard file.contents.isDotBetweenTokens(prevToken, leftMostToken) else { break }
+                guard file.contents.isDotOrOptionalChainingBetweenTokens(prevToken, leftMostToken) else { break }
 
                 leftTokens.insert(prevToken, at: 0)
                 currentIndex -= 1
@@ -142,7 +142,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
             while currentIndex < tokens.count - 1 {
                 let nextToken = tokens[currentIndex + 1]
 
-                guard file.contents.isDotBetweenTokens(rightMostToken, nextToken) else { break }
+                guard file.contents.isDotOrOptionalChainingBetweenTokens(rightMostToken, nextToken) else { break }
 
                 rightTokens.append(nextToken)
                 currentIndex += 1
@@ -164,8 +164,8 @@ private extension NSString {
                                       length: endToken.offset - startToken.offset - startToken.length)
     }
 
-    func isDotBetweenTokens(_ startToken: SyntaxToken, _ endToken: SyntaxToken) -> Bool {
-        return isRegexBetweenTokens(startToken, "\\.", endToken)
+    func isDotOrOptionalChainingBetweenTokens(_ startToken: SyntaxToken, _ endToken: SyntaxToken) -> Bool {
+        return isRegexBetweenTokens(startToken, "\\??\\.", endToken)
     }
 
     func isNilCoalecingOperatorBetweenTokens(_ startToken: SyntaxToken, _ endToken: SyntaxToken) -> Bool {

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -31,7 +31,8 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
                 """
                 let num: Int? = 0
                 _ = num != nil && num \(operation) num?.byteSwapped
-                """
+                """,
+                "num \(operation) num!.byteSwapped"
             ]
         } + [
             "func evaluate(_ mode: CommandMode) -> Result<AutoCorrectOptions, CommandantError<CommandantError<()>>>",
@@ -181,7 +182,7 @@ private extension NSString {
     }
 
     func isDotOrOptionalChainingBetweenTokens(_ startToken: SyntaxToken, _ endToken: SyntaxToken) -> Bool {
-        return isRegexBetweenTokens(startToken, "\\??\\.", endToken)
+        return isRegexBetweenTokens(startToken, "[\\?!]?\\.", endToken)
     }
 
     func isNilCoalecingOperatorBetweenTokens(_ startToken: SyntaxToken, _ endToken: SyntaxToken) -> Bool {

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -46,7 +46,8 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
                 "↓foo \(operation) foo",
                 "↓foo.aProperty \(operation) foo.aProperty",
                 "↓self.aProperty \(operation) self.aProperty",
-                "↓$0 \(operation) $0"
+                "↓$0 \(operation) $0",
+                "↓a?.b \(operation) a?.b"
             ]
         }
     )
@@ -103,14 +104,14 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
         }
 
         // Make sure both operands have same token types
-        guard zip(leftOperand.tokens, rightOperand.tokens).allSatisfy({ $0.0.type == $0.1.type }) else {
+        guard leftOperand.tokens.map({ $0.type }) == rightOperand.tokens.map({ $0.type }) else {
             return nil
         }
 
-        // Make sure that every part of the operand part is equal to previous on
-        guard zip(leftOperand.tokens, rightOperand.tokens).allSatisfy({
-            contents.subStringWithSyntaxToken($0.0) == contents.subStringWithSyntaxToken($0.1) }) else {
-                return nil
+        // Make sure that every part of the operand part is equal to previous one
+        guard leftOperand.tokens.map(contents.subStringWithSyntaxToken) ==
+            rightOperand.tokens.map(contents.subStringWithSyntaxToken) else {
+            return nil
         }
 
         guard let leftmostToken = leftOperand.tokens.first else {


### PR DESCRIPTION
Rewrite identical operands rule which using syntax map and tokens access instead of full Regex solution.

This solutions search for the operator first and then tries to find operands to the right and to the left of the operator. This is done by searching tokens which has dots between them.

````
|   asd    ?? |      self   .    a      ==    self   .    a
| [token]     |    [token]     [token]       [token]     [token]
| identifier  |    keyword    identifier     keyword    identifier
````

Operands are matching if the next is true:

- they have same tokens count
- they have tokens of the same type
- they have identical tokens strings
- if there's a token to the left of the left token, string between them doesn't have the nil-coalescing operator