### PR TITLE
Cache Structure Dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 #### Breaking
 
-* None.
+* Use SourceKittenDictionary wrapper over dictionaries  
+  returned from SourceKitten  
+  [PaulTaykalo](https://github.com/PaulTaykalo)
+  [#2922](https://github.com/realm/SwiftLint/issues/2922)
 
 #### Experimental
 

--- a/Rules.md
+++ b/Rules.md
@@ -24981,13 +24981,13 @@ Function parameters should be aligned vertically if they're in multiple lines in
 
 ```swift
 func validateFunction(_ file: File, kind: SwiftDeclarationKind,
-                      dictionary: [String: SourceKitRepresentable]) { }
+                      dictionary: SourceKittenDictionary) { }
 
 ```
 
 ```swift
 func validateFunction(_ file: File, kind: SwiftDeclarationKind,
-                      dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]
+                      dictionary: SourceKittenDictionary) -> [StyleViolation]
 
 ```
 
@@ -25003,7 +25003,7 @@ func foo(bar: Int) -> String
 
 ```swift
 func validateFunction(_ file: File, kind: SwiftDeclarationKind,
-                      dictionary: [String: SourceKitRepresentable])
+                      dictionary: SourceKittenDictionary)
                       -> [StyleViolation]
 
 ```
@@ -25011,14 +25011,14 @@ func validateFunction(_ file: File, kind: SwiftDeclarationKind,
 ```swift
 func validateFunction(
    _ file: File, kind: SwiftDeclarationKind,
-   dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]
+   dictionary: SourceKittenDictionary) -> [StyleViolation]
 
 ```
 
 ```swift
 func validateFunction(
    _ file: File, kind: SwiftDeclarationKind,
-   dictionary: [String: SourceKitRepresentable]
+   dictionary: SourceKittenDictionary
 ) -> [StyleViolation]
 
 ```
@@ -25054,20 +25054,20 @@ func foo(data: Data,
 
 ```swift
 func validateFunction(_ file: File, kind: SwiftDeclarationKind,
-                  ↓dictionary: [String: SourceKitRepresentable]) { }
+                  ↓dictionary: SourceKittenDictionary) { }
 
 ```
 
 ```swift
 func validateFunction(_ file: File, kind: SwiftDeclarationKind,
-                       ↓dictionary: [String: SourceKitRepresentable]) { }
+                       ↓dictionary: SourceKittenDictionary) { }
 
 ```
 
 ```swift
 func validateFunction(_ file: File,
                   ↓kind: SwiftDeclarationKind,
-                  ↓dictionary: [String: SourceKitRepresentable]) { }
+                  ↓dictionary: SourceKittenDictionary) { }
 
 ```
 

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -2,12 +2,13 @@ import SourceKittenFramework
 
 public struct SourceKittenDictionary {
     public let value: [String: SourceKitRepresentable]
-    private let _substructure: [SourceKittenDictionary]
+    public let substructure: [SourceKittenDictionary]
+
     init(_ value: [String: SourceKitRepresentable]) {
         self.value = value
 
         let substructure = value["key.substructure"] as? [SourceKitRepresentable] ?? []
-        _substructure = substructure.compactMap { $0 as? [String: SourceKitRepresentable] }
+        self.substructure = substructure.compactMap { $0 as? [String: SourceKitRepresentable] }
             .map(SourceKittenDictionary.init)
     }
 
@@ -81,22 +82,15 @@ public struct SourceKittenDictionary {
 
     var swiftAttributes: [SourceKittenDictionary] {
         let array = value["key.attributes"] as? [SourceKitRepresentable] ?? []
-        let dictionaries = array.compactMap { ($0 as? SourceKittenDictionary) }
+        let dictionaries = array.compactMap { $0 as? [String: SourceKitRepresentable] }
+            .map(SourceKittenDictionary.init)
         return dictionaries
-    }
-
-    var substructure: [SourceKittenDictionary] {
-        return _substructure
     }
 
     var elements: [SourceKittenDictionary] {
         let elements = value["key.elements"] as? [SourceKitRepresentable] ?? []
-        return elements.compactMap { $0 as? SourceKittenDictionary }
-    }
-
-    var entities: [SourceKittenDictionary] {
-        let entities = value["key.entities"] as? [SourceKitRepresentable] ?? []
-        return entities.compactMap { $0 as? SourceKittenDictionary }
+        return elements.compactMap { $0 as? [String: SourceKitRepresentable] }
+        .map(SourceKittenDictionary.init)
     }
 
     var enclosedVarParameters: [SourceKittenDictionary] {

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -93,6 +93,12 @@ public struct SourceKittenDictionary {
         .map(SourceKittenDictionary.init)
     }
 
+    var entities: [SourceKittenDictionary] {
+        let entities = value["key.entities"] as? [SourceKitRepresentable] ?? []
+        return entities.compactMap { $0 as? [String: SourceKitRepresentable] }
+            .map(SourceKittenDictionary.init)
+    }
+
     var enclosedVarParameters: [SourceKittenDictionary] {
         return substructure.flatMap { subDict -> [SourceKittenDictionary] in
             guard let kindString = subDict.kind else {

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -18,6 +18,9 @@ private var structureCache = Cache({ file -> Structure? in
     }
     return nil
 })
+
+private var structureDictionaryCache = Cache({ file in structureCache.get(file).map { SourceKittenDictionary($0.dictionary) } })
+
 private var syntaxMapCache = Cache({ file in responseCache.get(file).map(SyntaxMap.init) })
 private var syntaxKindsByLinesCache = Cache({ file in file.syntaxKindsByLine() })
 private var syntaxTokensByLinesCache = Cache({ file in file.syntaxTokensByLine() })
@@ -128,6 +131,17 @@ extension File {
         return structure
     }
 
+    internal var structureDictionary: SourceKittenDictionary {
+        guard let structureDictionary = structureDictionaryCache.get(self) else {
+            if let handler = assertHandler {
+                handler()
+                return SourceKittenDictionary([:])
+            }
+            queuedFatalError("Never call this for file that sourcekitd fails.")
+        }
+        return structureDictionary
+    }
+
     internal var syntaxMap: SyntaxMap {
         guard let syntaxMap = syntaxMapCache.get(self) else {
             if let handler = assertHandler {
@@ -165,6 +179,7 @@ extension File {
         responseCache.invalidate(self)
         assertHandlerCache.invalidate(self)
         structureCache.invalidate(self)
+        structureDictionaryCache.invalidate(self)
         syntaxMapCache.invalidate(self)
         syntaxTokensByLinesCache.invalidate(self)
         syntaxKindsByLinesCache.invalidate(self)
@@ -175,6 +190,7 @@ extension File {
         responseCache.clear()
         assertHandlerCache.clear()
         structureCache.clear()
+        structureDictionaryCache.clear()
         syntaxMapCache.clear()
         syntaxTokensByLinesCache.clear()
         syntaxKindsByLinesCache.clear()

--- a/Source/SwiftLintFramework/Extensions/File+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/File+Cache.swift
@@ -19,7 +19,9 @@ private var structureCache = Cache({ file -> Structure? in
     return nil
 })
 
-private var structureDictionaryCache = Cache({ file in structureCache.get(file).map { SourceKittenDictionary($0.dictionary) } })
+private var structureDictionaryCache = Cache({ file in
+    return structureCache.get(file).map { SourceKittenDictionary($0.dictionary) }
+})
 
 private var syntaxMapCache = Cache({ file in responseCache.get(file).map(SyntaxMap.init) })
 private var syntaxKindsByLinesCache = Cache({ file in file.syntaxKindsByLine() })

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -131,7 +131,7 @@ extension File {
         }
         var results = [[SwiftDeclarationKind]](repeating: [], count: lines.count + 1)
         var lineIterator = lines.makeIterator()
-        var structureIterator = structure.kinds().makeIterator()
+        var structureIterator = structure.kinds(in: structureDictionary).makeIterator()
         var maybeLine = lineIterator.next()
         var maybeStructure = structureIterator.next()
         while let line = maybeLine, let structure = maybeStructure {

--- a/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/File+SwiftLint.swift
@@ -131,7 +131,7 @@ extension File {
         }
         var results = [[SwiftDeclarationKind]](repeating: [], count: lines.count + 1)
         var lineIterator = lines.makeIterator()
-        var structureIterator = structure.kinds(in: structureDictionary).makeIterator()
+        var structureIterator = structureDictionary.kinds().makeIterator()
         var maybeLine = lineIterator.next()
         var maybeStructure = structureIterator.next()
         while let line = maybeLine, let structure = maybeStructure {

--- a/Source/SwiftLintFramework/Extensions/SourceKittenDictionary+Swiftlint.swift
+++ b/Source/SwiftLintFramework/Extensions/SourceKittenDictionary+Swiftlint.swift
@@ -1,12 +1,11 @@
 import Foundation
-import SourceKittenFramework
 
-extension Structure {
+extension SourceKittenDictionary {
     /// Returns array of tuples containing "key.kind" and "byteRange" from Structure
     /// that contains the byte offset. Returns all kinds if no parameter specified.
     ///
     /// - Parameter byteOffset: Int?
-    internal func kinds(forByteOffset byteOffset: Int? = nil, in dictionary: SourceKittenDictionary)
+    internal func kinds(forByteOffset byteOffset: Int? = nil)
         -> [(kind: String, byteRange: NSRange)] {
         var results = [(kind: String, byteRange: NSRange)]()
 
@@ -23,12 +22,11 @@ extension Structure {
             }
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary)
+        parse(self)
         return results
     }
 
-    internal func structures(forByteOffset byteOffset: Int, in dictionary: SourceKittenDictionary)
-        -> [SourceKittenDictionary] {
+    internal func structures(forByteOffset byteOffset: Int) -> [SourceKittenDictionary] {
         var results = [SourceKittenDictionary]()
 
         func parse(_ dictionary: SourceKittenDictionary) {
@@ -41,7 +39,7 @@ extension Structure {
             results.append(dictionary)
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary)
+        parse(self)
         return results
     }
 }

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -22,7 +22,7 @@ extension String {
         return self == lowercased()
     }
 
-    internal func nameStrippingLeadingUnderscoreIfPrivate(_ dict: [String: SourceKitRepresentable]) -> String {
+    internal func nameStrippingLeadingUnderscoreIfPrivate(_ dict: SourceKittenDictionary) -> String {
         if let aclString = dict.accessibility,
            let acl = AccessControlLevel(identifier: aclString),
             acl.isPrivate && first == "_" {

--- a/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
@@ -9,7 +9,7 @@ extension Structure {
     internal func kinds(forByteOffset byteOffset: Int? = nil) -> [(kind: String, byteRange: NSRange)] {
         var results = [(kind: String, byteRange: NSRange)]()
 
-        func parse(_ dictionary: [String: SourceKitRepresentable]) {
+        func parse(_ dictionary: SourceKittenDictionary) {
             guard let offset = dictionary.offset,
                 let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }) else {
                     return
@@ -22,14 +22,14 @@ extension Structure {
             }
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary)
+        parse(SourceKittenDictionary(value: dictionary))
         return results
     }
 
-    internal func structures(forByteOffset byteOffset: Int) -> [[String: SourceKitRepresentable]] {
-        var results = [[String: SourceKitRepresentable]]()
+    internal func structures(forByteOffset byteOffset: Int) -> [SourceKittenDictionary] {
+        var results = [SourceKittenDictionary]()
 
-        func parse(_ dictionary: [String: SourceKitRepresentable]) {
+        func parse(_ dictionary: SourceKittenDictionary) {
             guard let offset = dictionary.offset,
                 let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }),
                 NSLocationInRange(byteOffset, byteRange) else {
@@ -39,7 +39,7 @@ extension Structure {
             results.append(dictionary)
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary)
+        parse(SourceKittenDictionary(value: dictionary))
         return results
     }
 }

--- a/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
@@ -6,7 +6,7 @@ extension Structure {
     /// that contains the byte offset. Returns all kinds if no parameter specified.
     ///
     /// - Parameter byteOffset: Int?
-    internal func kinds(forByteOffset byteOffset: Int? = nil) -> [(kind: String, byteRange: NSRange)] {
+    internal func kinds(forByteOffset byteOffset: Int? = nil, in dictionary: SourceKittenDictionary) -> [(kind: String, byteRange: NSRange)] {
         var results = [(kind: String, byteRange: NSRange)]()
 
         func parse(_ dictionary: SourceKittenDictionary) {
@@ -22,11 +22,11 @@ extension Structure {
             }
             dictionary.substructure.forEach(parse)
         }
-        parse(SourceKittenDictionary(value: dictionary))
+        parse(dictionary)
         return results
     }
 
-    internal func structures(forByteOffset byteOffset: Int) -> [SourceKittenDictionary] {
+    internal func structures(forByteOffset byteOffset: Int, in dictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         var results = [SourceKittenDictionary]()
 
         func parse(_ dictionary: SourceKittenDictionary) {
@@ -39,7 +39,7 @@ extension Structure {
             results.append(dictionary)
             dictionary.substructure.forEach(parse)
         }
-        parse(SourceKittenDictionary(value: dictionary))
+        parse(dictionary)
         return results
     }
 }

--- a/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Structure+SwiftLint.swift
@@ -6,7 +6,8 @@ extension Structure {
     /// that contains the byte offset. Returns all kinds if no parameter specified.
     ///
     /// - Parameter byteOffset: Int?
-    internal func kinds(forByteOffset byteOffset: Int? = nil, in dictionary: SourceKittenDictionary) -> [(kind: String, byteRange: NSRange)] {
+    internal func kinds(forByteOffset byteOffset: Int? = nil, in dictionary: SourceKittenDictionary)
+        -> [(kind: String, byteRange: NSRange)] {
         var results = [(kind: String, byteRange: NSRange)]()
 
         func parse(_ dictionary: SourceKittenDictionary) {
@@ -26,7 +27,8 @@ extension Structure {
         return results
     }
 
-    internal func structures(forByteOffset byteOffset: Int, in dictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
+    internal func structures(forByteOffset byteOffset: Int, in dictionary: SourceKittenDictionary)
+        -> [SourceKittenDictionary] {
         var results = [SourceKittenDictionary]()
 
         func parse(_ dictionary: SourceKittenDictionary) {

--- a/Source/SwiftLintFramework/Helpers/NamespaceCollector.swift
+++ b/Source/SwiftLintFramework/Helpers/NamespaceCollector.swift
@@ -5,9 +5,9 @@ struct NamespaceCollector {
         let name: String
         let kind: SwiftDeclarationKind
         let offset: Int
-        let dictionary: [String: SourceKitRepresentable]
+        let dictionary: SourceKittenDictionary
 
-        init?(dictionary: [String: SourceKitRepresentable], namespace: [String]) {
+        init?(dictionary: SourceKittenDictionary, namespace: [String]) {
             guard let name = dictionary.name,
                 let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
                 let offset = dictionary.offset else {
@@ -21,9 +21,9 @@ struct NamespaceCollector {
         }
     }
 
-    private let dictionary: [String: SourceKitRepresentable]
+    private let dictionary: SourceKittenDictionary
 
-    init(dictionary: [String: SourceKitRepresentable]) {
+    init(dictionary: SourceKittenDictionary) {
         self.dictionary = dictionary
     }
 
@@ -32,7 +32,7 @@ struct NamespaceCollector {
         return findAllElements(in: dictionary, of: types, namespace: namespace)
     }
 
-    private func findAllElements(in dictionary: [String: SourceKitRepresentable],
+    private func findAllElements(in dictionary: SourceKittenDictionary,
                                  of types: Set<SwiftDeclarationKind>,
                                  namespace: [String] = []) -> [Element] {
         return dictionary.substructure.flatMap { subDict -> [Element] in

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -104,7 +104,7 @@ public extension SwiftVersion {
             return token.type == SyntaxKind.string.rawValue
         }
         if !Request.disableSourceKit,
-            let decl = file.structure.kinds().first(where: { $0.kind == SwiftDeclarationKind.varGlobal.rawValue }),
+            let decl = file.structure.kinds(in: file.structureDictionary).first(where: { $0.kind == SwiftDeclarationKind.varGlobal.rawValue }),
             let token = file.syntaxMap.tokens(inByteRange: decl.byteRange).first(where: isString ) {
             return .init(rawValue: file.contents.substring(from: token.offset + 1, length: token.length - 2))
         }

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -104,7 +104,7 @@ public extension SwiftVersion {
             return token.type == SyntaxKind.string.rawValue
         }
         if !Request.disableSourceKit,
-            let decl = file.structure.kinds(in: file.structureDictionary)
+            let decl = file.structureDictionary.kinds()
                 .first(where: { $0.kind == SwiftDeclarationKind.varGlobal.rawValue }),
             let token = file.syntaxMap.tokens(inByteRange: decl.byteRange).first(where: isString ) {
             return .init(rawValue: file.contents.substring(from: token.offset + 1, length: token.length - 2))

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -104,7 +104,8 @@ public extension SwiftVersion {
             return token.type == SyntaxKind.string.rawValue
         }
         if !Request.disableSourceKit,
-            let decl = file.structure.kinds(in: file.structureDictionary).first(where: { $0.kind == SwiftDeclarationKind.varGlobal.rawValue }),
+            let decl = file.structure.kinds(in: file.structureDictionary)
+                .first(where: { $0.kind == SwiftDeclarationKind.varGlobal.rawValue }),
             let token = file.syntaxMap.tokens(inByteRange: decl.byteRange).first(where: isString ) {
             return .init(rawValue: file.contents.substring(from: token.offset + 1, length: token.length - 2))
         }

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -2,15 +2,15 @@ import SourceKittenFramework
 
 public protocol ASTRule: Rule {
     associatedtype KindType: RawRepresentable
-    func validate(file: File, kind: KindType, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]
+    func validate(file: File, kind: KindType, dictionary: SourceKittenDictionary) -> [StyleViolation]
 }
 
 public extension ASTRule where KindType.RawValue == String {
     func validate(file: File) -> [StyleViolation] {
-        return validate(file: file, dictionary: file.structure.dictionary)
+        return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
     }
 
-    func validate(file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+    func validate(file: File, dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict)
 

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -7,7 +7,7 @@ public protocol ASTRule: Rule {
 
 public extension ASTRule where KindType.RawValue == String {
     func validate(file: File) -> [StyleViolation] {
-        return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+        return validate(file: file, dictionary: file.structureDictionary)
     }
 
     func validate(file: File, dictionary: SourceKittenDictionary) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Protocols/CallPairRule.swift
+++ b/Source/SwiftLintFramework/Protocols/CallPairRule.swift
@@ -32,10 +32,11 @@ extension CallPairRule {
                            callNameSuffix: String,
                            severity: ViolationSeverity,
                            reason: String? = nil,
-                           predicate: ([String: SourceKitRepresentable]) -> Bool = { _ in true }) -> [StyleViolation] {
+                           predicate: (SourceKittenDictionary) -> Bool = { _ in true }) -> [StyleViolation] {
         let firstRanges = file.match(pattern: pattern, with: patternSyntaxKinds)
         let contents = file.contents.bridge()
         let structure = file.structure
+        let dictionary = SourceKittenDictionary(value: structure.dictionary)
 
         let violatingLocations: [Int] = firstRanges.compactMap { range in
             guard let bodyByteRange = contents.NSRangeToByteRange(start: range.location,
@@ -48,7 +49,7 @@ extension CallPairRule {
 
             return methodCall(forByteOffset: bodyByteRange.location - 1,
                               excludingOffset: firstByteRange.location,
-                              dictionary: structure.dictionary,
+                              dictionary: dictionary,
                               predicate: { dictionary in
                 guard let name = dictionary.name else {
                     return false
@@ -67,8 +68,8 @@ extension CallPairRule {
     }
 
     private func methodCall(forByteOffset byteOffset: Int, excludingOffset: Int,
-                            dictionary: [String: SourceKitRepresentable],
-                            predicate: ([String: SourceKitRepresentable]) -> Bool) -> Int? {
+                            dictionary: SourceKittenDictionary,
+                            predicate: (SourceKittenDictionary) -> Bool) -> Int? {
         if let kindString = dictionary.kind,
             SwiftExpressionKind(rawValue: kindString) == .call,
             let bodyOffset = dictionary.offset,

--- a/Source/SwiftLintFramework/Protocols/CallPairRule.swift
+++ b/Source/SwiftLintFramework/Protocols/CallPairRule.swift
@@ -35,8 +35,7 @@ extension CallPairRule {
                            predicate: (SourceKittenDictionary) -> Bool = { _ in true }) -> [StyleViolation] {
         let firstRanges = file.match(pattern: pattern, with: patternSyntaxKinds)
         let contents = file.contents.bridge()
-        let structure = file.structure
-        let dictionary = SourceKittenDictionary(value: structure.dictionary)
+        let dictionary = file.structureDictionary
 
         let violatingLocations: [Int] = firstRanges.compactMap { range in
             guard let bodyByteRange = contents.NSRangeToByteRange(start: range.location,

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -95,16 +95,16 @@ public extension SubstitutionCorrectableRule {
 
 public protocol SubstitutionCorrectableASTRule: SubstitutionCorrectableRule, ASTRule {
     func violationRanges(in file: File, kind: KindType,
-                         dictionary: [String: SourceKitRepresentable]) -> [NSRange]
+                         dictionary: SourceKittenDictionary) -> [NSRange]
 }
 
 extension SubstitutionCorrectableASTRule where KindType.RawValue == String {
     public func violationRanges(in file: File) -> [NSRange] {
-        return violationRanges(in: file, dictionary: file.structure.dictionary)
+        return violationRanges(in: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
     }
 
     private func violationRanges(in file: File,
-                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                 dictionary: SourceKittenDictionary) -> [NSRange] {
         let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
 

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -100,7 +100,7 @@ public protocol SubstitutionCorrectableASTRule: SubstitutionCorrectableRule, AST
 
 extension SubstitutionCorrectableASTRule where KindType.RawValue == String {
     public func violationRanges(in file: File) -> [NSRange] {
-        return violationRanges(in: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+        return violationRanges(in: file, dictionary: file.structureDictionary)
     }
 
     private func violationRanges(in file: File,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -38,7 +38,7 @@ public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule, AutomaticTe
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftVersion.current >= .four, kind == .functionMethodInstance,
             dictionary.enclosedSwiftAttributes.contains(.override),
             dictionary.name == "observeValue(forKeyPath:of:change:context:)",
@@ -67,7 +67,7 @@ public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule, AutomaticTe
     }
 }
 
-private extension Array where Element == [String: SourceKitRepresentable] {
+private extension Array where Element == SourceKittenDictionary {
     var parameterTypes: [String] {
         return compactMap { element in
             guard element.kind.flatMap(SwiftDeclarationKind.init) == .varParameter else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -58,7 +58,7 @@ public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let offset = dictionary.offset,
             [.class, .struct].contains(kind),
             dictionary.inheritedTypes.isEmpty,
@@ -94,7 +94,7 @@ public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule
         ]
     }
 
-    private func isFunctionUnavailable(file: File, dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isFunctionUnavailable(file: File, dictionary: SourceKittenDictionary) -> Bool {
         return dictionary.swiftAttributes.contains { dict -> Bool in
             guard dict.attribute.flatMap(SwiftDeclarationAttributeKind.init(rawValue:)) == .available,
                 let offset = dict.offset, let length = dict.length,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -26,7 +26,7 @@ public struct DiscouragedObjectLiteralRule: ASTRule, OptInRule, ConfigurationPro
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let offset = dictionary.offset, kind == .objectLiteral else { return [] }
 
         if !configuration.imageLiteral && dictionary.name == "imageLiteral" {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
@@ -17,7 +17,7 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
 
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let offsets = variableViolations(file: file, kind: kind, dictionary: dictionary) +
             functionViolations(file: file, kind: kind, dictionary: dictionary)
 
@@ -32,7 +32,7 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
 
     private func variableViolations(file: File,
                                     kind: SwiftDeclarationKind,
-                                    dictionary: [String: SourceKitRepresentable]) -> [Int] {
+                                    dictionary: SourceKittenDictionary) -> [Int] {
         guard
             SwiftDeclarationKind.variableKinds.contains(kind),
             let offset = dictionary.offset,
@@ -43,7 +43,7 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
 
     private func functionViolations(file: File,
                                     kind: SwiftDeclarationKind,
-                                    dictionary: [String: SourceKitRepresentable]) -> [Int] {
+                                    dictionary: SourceKittenDictionary) -> [Int] {
         guard
             SwiftDeclarationKind.functionKinds.contains(kind),
             let nameOffset = dictionary.nameOffset,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-private typealias SourceKittenElement = [String: SourceKitRepresentable]
+private typealias SourceKittenElement = SourceKittenDictionary
 
 public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
@@ -91,7 +91,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
     }
 
     public func validate(file: File) -> [StyleViolation] {
-        let implicitAndExplicitInternalElements = internalTypeElements(in: file.structure.dictionary)
+        let implicitAndExplicitInternalElements = internalTypeElements(in: SourceKittenDictionary(value: file.structure.dictionary) )
 
         guard !implicitAndExplicitInternalElements.isEmpty else {
             return []

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -91,7 +91,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
     }
 
     public func validate(file: File) -> [StyleViolation] {
-        let implicitAndExplicitInternalElements = internalTypeElements(in: SourceKittenDictionary(value: file.structure.dictionary) )
+        let implicitAndExplicitInternalElements = internalTypeElements(in: file.structureDictionary )
 
         guard !implicitAndExplicitInternalElements.isEmpty else {
             return []

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -73,7 +73,7 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .enum else {
             return []
         }
@@ -100,7 +100,7 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
         }
     }
 
-    private func violatingOffsetsForEnum(dictionary: [String: SourceKitRepresentable]) -> [Int] {
+    private func violatingOffsetsForEnum(dictionary: SourceKittenDictionary) -> [Int] {
         let locs = substructureElements(of: dictionary, matching: .enumcase)
             .compactMap { substructureElements(of: $0, matching: .enumelement) }
             .flatMap(enumElementsMissingInitExpr)
@@ -109,14 +109,14 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
         return locs
     }
 
-    private func substructureElements(of dict: [String: SourceKitRepresentable],
-                                      matching kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
+    private func substructureElements(of dict: SourceKittenDictionary,
+                                      matching kind: SwiftDeclarationKind) -> [SourceKittenDictionary] {
         return dict.substructure
             .filter { $0.kind.flatMap(SwiftDeclarationKind.init) == kind }
     }
 
     private func enumElementsMissingInitExpr(
-        _ enumElements: [[String: SourceKitRepresentable]]) -> [[String: SourceKitRepresentable]] {
+        _ enumElements: [SourceKittenDictionary]) -> [SourceKittenDictionary] {
         return enumElements
             .filter { !$0.elements.contains { $0.kind == "source.lang.swift.structure.elem.init_expr" } }
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -53,7 +53,7 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -64,7 +64,7 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
     private let initializerWithType = regex("^[A-Z][^(]*\\.init$")
 
     public func violationRanges(in file: File, kind: SwiftExpressionKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         func isExpected(_ name: String) -> Bool {
             let range = NSRange(location: 0, length: name.utf16.count)
             return !["super.init", "self.init"].contains(name)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -36,7 +36,8 @@ public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, Aut
                                                          .extensionProtocol, .extensionStruct]
 
         // find all top-level types marked as internal (either explictly or implictly)
-        let internalTypesOffsets = file.structure.dictionary.substructure.compactMap { element -> Int? in
+        let dictionary = SourceKittenDictionary(value: file.structure.dictionary)
+        let internalTypesOffsets = dictionary.substructure.compactMap { element -> Int? in
             // ignore extensions
             guard let kind = element.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
                 !extensionKinds.contains(kind) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -36,7 +36,7 @@ public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, Aut
                                                          .extensionProtocol, .extensionStruct]
 
         // find all top-level types marked as internal (either explictly or implictly)
-        let dictionary = SourceKittenDictionary(value: file.structure.dictionary)
+        let dictionary = file.structureDictionary
         let internalTypesOffsets = dictionary.substructure.compactMap { element -> Int? in
             // ignore extensions
             guard let kind = element.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -68,11 +68,11 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        return validate(file: file, dictionary: file.structure.dictionary, parentStructure: nil)
+        return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary), parentStructure: nil)
     }
 
-    private func validate(file: File, dictionary: [String: SourceKitRepresentable],
-                          parentStructure: [String: SourceKitRepresentable]?) -> [StyleViolation] {
+    private func validate(file: File, dictionary: SourceKittenDictionary,
+                          parentStructure: SourceKittenDictionary?) -> [StyleViolation] {
         return dictionary.substructure.flatMap({ subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict, parentStructure: dictionary)
 
@@ -87,8 +87,8 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
 
     private func validate(file: File,
                           kind: SwiftDeclarationKind,
-                          dictionary: [String: SourceKitRepresentable],
-                          parentStructure: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                          dictionary: SourceKittenDictionary,
+                          parentStructure: SourceKittenDictionary) -> [StyleViolation] {
         guard configuration.allowedKinds.contains(kind),
             let offset = dictionary.offset,
             !dictionary.containsType,
@@ -110,7 +110,8 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
     }
 }
 
-private extension Dictionary where Key == String, Value == SourceKitRepresentable {
+private extension SourceKittenDictionary {
+    
     var containsType: Bool {
         return typeName != nil
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -68,7 +68,7 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary), parentStructure: nil)
+        return validate(file: file, dictionary: file.structureDictionary, parentStructure: nil)
     }
 
     private func validate(file: File, dictionary: SourceKittenDictionary,
@@ -111,7 +111,6 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
 }
 
 private extension SourceKittenDictionary {
-    
     var containsType: Bool {
         return typeName != nil
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -77,7 +77,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .extension, let offset = dictionary.offset,
             dictionary.inheritedTypes.isEmpty else {
                 return []
@@ -116,7 +116,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
 
     private func declarationsViolations(file: File, acl: AccessControlLevel,
                                         declarationOffsets: [Int],
-                                        dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                                        dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let offset = dictionary.offset, let length = dictionary.length,
             case let contents = file.contents.bridge(),
             let range = contents.byteRangeToNSRange(start: offset, length: length) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -37,7 +37,7 @@ public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRu
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .call,
             let offset = dictionary.offset,
             dictionary.name == "fatalError",
@@ -52,7 +52,7 @@ public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRu
         ]
     }
 
-    private func hasEmptyBody(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func hasEmptyBody(dictionary: SourceKittenDictionary, file: File) -> Bool {
         guard let bodyOffset = dictionary.bodyOffset,
             let bodyLength = dictionary.bodyLength else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private let typeAndExtensionKinds = SwiftDeclarationKind.typeKinds + [.extension, .protocol]
 
-private extension Dictionary where Key: ExpressibleByStringLiteral {
+private extension SourceKittenDictionary {
     func recursiveDeclaredTypeNames() -> [String] {
         let subNames = substructure.flatMap { $0.recursiveDeclaredTypeNames() }
         if let kind = kind.flatMap(SwiftDeclarationKind.init),
@@ -57,7 +57,8 @@ public struct FileNameRule: ConfigurationProviderRule, OptInRule {
         }
 
         // Process nested type separator
-        let allDeclaredTypeNames = file.structure.dictionary.recursiveDeclaredTypeNames().map {
+        let dictionary = SourceKittenDictionary(value: file.structure.dictionary)
+        let allDeclaredTypeNames = dictionary.recursiveDeclaredTypeNames().map {
             $0.replacingOccurrences(of: ".", with: configuration.nestedTypeSeparator)
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -57,7 +57,7 @@ public struct FileNameRule: ConfigurationProviderRule, OptInRule {
         }
 
         // Process nested type separator
-        let dictionary = SourceKittenDictionary(value: file.structure.dictionary)
+        let dictionary = file.structureDictionary
         let allDeclaredTypeNames = dictionary.recursiveDeclaredTypeNames().map {
             $0.replacingOccurrences(of: ".", with: configuration.nestedTypeSeparator)
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -88,7 +88,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
     private static let commentKinds = SyntaxKind.commentAndStringKinds
 
     public func validate(file: File, kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .forEach,
             let subDictionary = forBody(dictionary: dictionary),
             subDictionary.substructure.count == 1,
@@ -108,13 +108,13 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
         ]
     }
 
-    private func forBody(dictionary: [String: SourceKitRepresentable]) -> [String: SourceKitRepresentable]? {
+    private func forBody(dictionary: SourceKittenDictionary) -> SourceKittenDictionary? {
         return dictionary.substructure.first(where: { subDict -> Bool in
             subDict.kind.flatMap(StatementKind.init) == .brace
         })
     }
 
-    private func isOnlyOneIf(dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isOnlyOneIf(dictionary: SourceKittenDictionary) -> Bool {
         let substructure = dictionary.substructure
         guard substructure.count == 1 else {
             return false
@@ -123,8 +123,8 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
         return dictionary.substructure.first?.kind.flatMap(StatementKind.init) == .brace
     }
 
-    private func isOnlyIfInsideFor(forDictionary: [String: SourceKitRepresentable],
-                                   ifDictionary: [String: SourceKitRepresentable],
+    private func isOnlyIfInsideFor(forDictionary: SourceKittenDictionary,
+                                   ifDictionary: SourceKittenDictionary,
                                    file: File) -> Bool {
         guard let offset = forDictionary.offset,
             let length = forDictionary.length,
@@ -146,7 +146,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
         return doesntContainComments
     }
 
-    private func isComplexCondition(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func isComplexCondition(dictionary: SourceKittenDictionary, file: File) -> Bool {
         let kind = "source.lang.swift.structure.elem.condition_expr"
         let contents = file.contents.bridge()
         return dictionary.elements.contains { element in

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -172,7 +172,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
 
     // check deepest kind matching range in structure is a typeAnnotation
     private func isTypeAnnotation(in file: File, contents: NSString, byteRange: NSRange) -> Bool {
-        let kinds = file.structure.kinds(forByteOffset: byteRange.location)
+        let kinds = file.structure.kinds(forByteOffset: byteRange.location, in: file.structureDictionary)
         guard let lastItem = kinds.last,
             let lastKind = SwiftDeclarationKind(rawValue: lastItem.kind),
             SwiftDeclarationKind.variableKinds.contains(lastKind) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -172,7 +172,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
 
     // check deepest kind matching range in structure is a typeAnnotation
     private func isTypeAnnotation(in file: File, contents: NSString, byteRange: NSRange) -> Bool {
-        let kinds = file.structure.kinds(forByteOffset: byteRange.location, in: file.structureDictionary)
+        let kinds = file.structureDictionary.kinds(forByteOffset: byteRange.location)
         guard let lastItem = kinds.last,
             let lastKind = SwiftDeclarationKind(rawValue: lastItem.kind),
             SwiftDeclarationKind.variableKinds.contains(lastKind) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -38,7 +38,7 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds.contains(kind),
             let offset = dictionary.offset,
             let bodyOffset = dictionary.bodyOffset,
@@ -48,7 +48,7 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
 
         let isNotClosure = { !self.isClosureParameter(dictionary: $0) }
         let params = dictionary.substructure
-            .flatMap { subDict -> [[String: SourceKitRepresentable]] in
+            .flatMap { subDict -> [SourceKittenDictionary] in
                 guard subDict.kind.flatMap(SwiftDeclarationKind.init) == .varParameter else {
                     return []
                 }
@@ -88,7 +88,7 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
         ]
     }
 
-    private func isClosureParameter(dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isClosureParameter(dictionary: SourceKittenDictionary) -> Bool {
         guard let typeName = dictionary.typeName else {
             return false
         }
@@ -96,7 +96,7 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
         return typeName.contains("->") || typeName.contains("@escaping")
     }
 
-    private func isDefaultParameter(file: File, dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isDefaultParameter(file: File, dictionary: SourceKittenDictionary) -> Bool {
         let contents = file.contents.bridge()
         guard let offset = dictionary.offset, let length = dictionary.length,
             let range = contents.byteRangeToNSRange(start: offset, length: length) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -54,15 +54,15 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         if shouldUseLegacyImplementation {
-            return validate(file: file, dictionary: file.structure.dictionary) +
+            return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary)) +
                 validateGenericTypeAliases(in: file)
         } else {
-            return validate(file: file, dictionary: file.structure.dictionary)
+            return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
         }
     }
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         if shouldUseLegacyImplementation {
             let types = genericTypesForType(in: file, kind: kind, dictionary: dictionary) +
                 genericTypesForFunction(in: file, kind: kind, dictionary: dictionary)
@@ -136,7 +136,7 @@ extension GenericTypeNameRule {
     }
 
     private func genericTypesForType(in file: File, kind: SwiftDeclarationKind,
-                                     dictionary: [String: SourceKitRepresentable]) -> [(String, Int)] {
+                                     dictionary: SourceKittenDictionary) -> [(String, Int)] {
         guard SwiftDeclarationKind.typeKinds.contains(kind),
             let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength,
@@ -155,7 +155,7 @@ extension GenericTypeNameRule {
     }
 
     private func genericTypesForFunction(in file: File, kind: SwiftDeclarationKind,
-                                         dictionary: [String: SourceKitRepresentable]) -> [(String, Int)] {
+                                         dictionary: SourceKittenDictionary) -> [(String, Int)] {
         guard SwiftDeclarationKind.functionKinds.contains(kind),
             let offset = dictionary.nameOffset,
             let length = dictionary.nameLength,
@@ -171,7 +171,7 @@ extension GenericTypeNameRule {
         return extractTypes(fromGenericConstraint: genericConstraint, offset: match.location, file: file)
     }
 
-    private func minParameterOffset(parameters: [[String: SourceKitRepresentable]], file: File) -> Int {
+    private func minParameterOffset(parameters: [SourceKittenDictionary], file: File) -> Int {
         let offsets = parameters.compactMap { param -> Int? in
             return param.offset.flatMap {
                 file.contents.bridge().byteRangeToNSRange(start: $0, length: 0)?.location

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -54,10 +54,10 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         if shouldUseLegacyImplementation {
-            return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary)) +
+            return validate(file: file, dictionary: file.structureDictionary) +
                 validateGenericTypeAliases(in: file)
         } else {
-            return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+            return validate(file: file, dictionary: file.structureDictionary)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -40,7 +40,7 @@ public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRul
     }
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.variableKinds.contains(kind) else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -43,7 +43,7 @@ public struct JoinedDefaultParameterRule: SubstitutionCorrectableASTRule, Config
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -59,7 +59,7 @@ public struct JoinedDefaultParameterRule: SubstitutionCorrectableASTRule, Config
 
     public func violationRanges(in file: File,
                                 kind: SwiftExpressionKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard
             // is it calling a method '.joined' and passing a single argument?
             kind == .call,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -126,7 +126,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
                                                        "UIOffsetMake": "UIOffset"]
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard containsViolation(kind: kind, dictionary: dictionary),
             let offset = dictionary.offset else {
                 return []
@@ -140,7 +140,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
     }
 
     private func violations(in file: File, kind: SwiftExpressionKind,
-                            dictionary: [String: SourceKitRepresentable]) -> [[String: SourceKitRepresentable]] {
+                            dictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         guard containsViolation(kind: kind, dictionary: dictionary) else {
             return []
         }
@@ -149,7 +149,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
     }
 
     private func containsViolation(kind: SwiftExpressionKind,
-                                   dictionary: [String: SourceKitRepresentable]) -> Bool {
+                                   dictionary: SourceKittenDictionary) -> Bool {
         guard kind == .call,
             let name = dictionary.name,
             dictionary.offset != nil,
@@ -162,8 +162,8 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
     }
 
     private func violations(in file: File,
-                            dictionary: [String: SourceKitRepresentable]) -> [[String: SourceKitRepresentable]] {
-        return dictionary.substructure.flatMap { subDict -> [[String: SourceKitRepresentable]] in
+                            dictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
+        return dictionary.substructure.flatMap { subDict -> [SourceKittenDictionary] in
             var dictionaries = violations(in: file, dictionary: subDict)
             if let kind = subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) {
                 dictionaries += violations(in: file, kind: kind, dictionary: subDict)
@@ -173,8 +173,8 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
         }
     }
 
-    private func violations(in file: File) -> [[String: SourceKitRepresentable]] {
-        return violations(in: file, dictionary: file.structure.dictionary).sorted { lhs, rhs in
+    private func violations(in file: File) -> [SourceKittenDictionary] {
+        return violations(in: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary)).sorted { lhs, rhs in
             (lhs.offset ?? 0) < (rhs.offset ?? 0)
         }
     }
@@ -214,7 +214,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
         return corrections
     }
 
-    private func argumentsContents(file: File, arguments: [[String: SourceKitRepresentable]]) -> [String] {
+    private func argumentsContents(file: File, arguments: [SourceKittenDictionary]) -> [String] {
         let contents = file.contents.bridge()
         return arguments.compactMap { argument -> String? in
             guard argument.name == nil,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -174,7 +174,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
     }
 
     private func violations(in file: File) -> [SourceKittenDictionary] {
-        return violations(in: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary)).sorted { lhs, rhs in
+        return violations(in: file, dictionary: file.structureDictionary).sorted { lhs, rhs in
             (lhs.offset ?? 0) < (rhs.offset ?? 0)
         }
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
@@ -80,7 +80,7 @@ public struct LegacyHashingRule: ASTRule, ConfigurationProviderRule, AutomaticTe
 
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .varInstance,
             dictionary.setterAccessibility == nil,
             dictionary.typeName == "Int",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
@@ -32,7 +32,7 @@ public struct LegacyRandomRule: ASTRule, OptInRule, ConfigurationProviderRule, A
     public func validate(
         file: File,
         kind: SwiftExpressionKind,
-        dictionary: [String: SourceKitRepresentable]
+        dictionary: SourceKittenDictionary
     ) -> [StyleViolation] {
         guard containsViolation(kind: kind, dictionary: dictionary),
         let offset = dictionary.offset else {
@@ -47,7 +47,7 @@ public struct LegacyRandomRule: ASTRule, OptInRule, ConfigurationProviderRule, A
         ]
     }
 
-    private func containsViolation(kind: SwiftExpressionKind, dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func containsViolation(kind: SwiftExpressionKind, dictionary: SourceKittenDictionary) -> Bool {
         guard kind == .call,
             let name = dictionary.name,
             legacyRandomFunctions.contains(name) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -125,7 +125,8 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
                     return false
                 }
 
-                let containsCall = file.structure.structures(forByteOffset: byteRange.upperBound - 1, in: file.structureDictionary)
+                let containsCall = file.structure.structures(forByteOffset: byteRange.upperBound - 1,
+                                                             in: file.structureDictionary)
                     .contains(where: { dict -> Bool in
                         return dict.kind.flatMap(SwiftExpressionKind.init) == .call &&
                             (dict.name ?? "").starts(with: "expect")

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -125,8 +125,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
                     return false
                 }
 
-                let containsCall = file.structure.structures(forByteOffset: byteRange.upperBound - 1,
-                                                             in: file.structureDictionary)
+                let containsCall = file.structureDictionary.structures(forByteOffset: byteRange.upperBound - 1)
                     .contains(where: { dict -> Bool in
                         return dict.kind.flatMap(SwiftExpressionKind.init) == .call &&
                             (dict.name ?? "").starts(with: "expect")

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -125,7 +125,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
                     return false
                 }
 
-                let containsCall = file.structure.structures(forByteOffset: byteRange.upperBound - 1)
+                let containsCall = file.structure.structures(forByteOffset: byteRange.upperBound - 1, in: file.structureDictionary)
                     .contains(where: { dict -> Bool in
                         return dict.kind.flatMap(SwiftExpressionKind.init) == .call &&
                             (dict.name ?? "").starts(with: "expect")

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -24,7 +24,7 @@ public struct NoExtensionAccessModifierRule: ASTRule, OptInRule, ConfigurationPr
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .extension, let offset = dictionary.offset else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -17,7 +17,7 @@ public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule, Automat
 
     public func validate(file: File,
                          kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .case,
             let length = dictionary.length,
             let offset = dictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -24,7 +24,7 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let collector = NamespaceCollector(dictionary: file.structure.dictionary)
+        let collector = NamespaceCollector(dictionary: SourceKittenDictionary(value: file.structure.dictionary))
         let elements = collector.findAllElements(of: [.class, .enum, .struct, .extension])
 
         let susceptibleNames = Set(elements.compactMap { $0.kind != .extension ? $0.name : nil })
@@ -44,7 +44,7 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
         }
     }
 
-    private func hasWhereClause(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func hasWhereClause(dictionary: SourceKittenDictionary, file: File) -> Bool {
         let contents = file.contents.bridge()
 
         guard let nameOffset = dictionary.nameOffset,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -24,7 +24,7 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let collector = NamespaceCollector(dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+        let collector = NamespaceCollector(dictionary: file.structureDictionary)
         let elements = collector.findAllElements(of: [.class, .enum, .struct, .extension])
 
         let susceptibleNames = Set(elements.compactMap { $0.kind != .extension ? $0.name : nil })

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -34,7 +34,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .call,
             let offset = dictionary.offset,
             (configuration.imageLiteral && isImageNamedInit(dictionary: dictionary, file: file)) ||
@@ -49,7 +49,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         ]
     }
 
-    private func isImageNamedInit(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func isImageNamedInit(dictionary: SourceKittenDictionary, file: File) -> Bool {
         guard let name = dictionary.name,
             inits(forClasses: ["UIImage", "NSImage"]).contains(name),
             case let arguments = dictionary.enclosedArguments,
@@ -63,7 +63,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         return true
     }
 
-    private func isColorInit(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func isColorInit(dictionary: SourceKittenDictionary, file: File) -> Bool {
         guard let name = dictionary.name,
             inits(forClasses: ["UIColor", "NSColor"]).contains(name),
             case let arguments = dictionary.enclosedArguments,
@@ -85,7 +85,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         }
     }
 
-    private func validateColorKinds(arguments: [[String: SourceKitRepresentable]], file: File) -> Bool {
+    private func validateColorKinds(arguments: [SourceKittenDictionary], file: File) -> Bool {
         for dictionary in arguments where kinds(forArgument: dictionary, file: file) != [.number] {
             return false
         }
@@ -93,7 +93,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         return true
     }
 
-    private func kinds(forArgument argument: [String: SourceKitRepresentable], file: File) -> Set<SyntaxKind> {
+    private func kinds(forArgument argument: SourceKittenDictionary, file: File) -> Set<SyntaxKind> {
         guard let offset = argument.bodyOffset, let length = argument.bodyLength else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -35,7 +35,7 @@ public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, O
     )
 
     public func validate(file: File, kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .case else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -67,7 +67,8 @@ public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, Substitutio
         let syntaxTokens = file.syntaxMap.tokens
         let contents = file.contents.bridge()
 
-        return file.structure.dictionary.substructure.compactMap { dictionary -> NSRange? in
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        return dict.substructure.compactMap { dictionary -> NSRange? in
             guard let offset = dictionary.offset else {
                 return nil
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -67,7 +67,7 @@ public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, Substitutio
         let syntaxTokens = file.syntaxMap.tokens
         let contents = file.contents.bridge()
 
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         return dict.substructure.compactMap { dictionary -> NSRange? in
             guard let offset = dictionary.offset else {
                 return nil

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -29,11 +29,11 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
     }
 
     public func violationRanges(in file: File) -> [NSRange] {
-        return violationRanges(file: file, dictionary: file.structure.dictionary, parentStructure: nil)
+        return violationRanges(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary), parentStructure: nil)
     }
 
-    private func violationRanges(file: File, dictionary: [String: SourceKitRepresentable],
-                                 parentStructure: [String: SourceKitRepresentable]?) -> [NSRange] {
+    private func violationRanges(file: File, dictionary: SourceKittenDictionary,
+                                 parentStructure: SourceKittenDictionary?) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
             var violations = violationRanges(file: file, dictionary: subDict, parentStructure: dictionary)
 
@@ -48,8 +48,8 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
 
     private func violationRanges(file: File,
                                  kind: SwiftDeclarationKind,
-                                 dictionary: [String: SourceKitRepresentable],
-                                 parentStructure: [String: SourceKitRepresentable]?) -> [NSRange] {
+                                 dictionary: SourceKittenDictionary,
+                                 parentStructure: SourceKittenDictionary?) -> [NSRange] {
         let objcAttribute = dictionary.swiftAttributes
                                       .first(where: { $0.attribute == SwiftDeclarationAttributeKind.objc.rawValue })
         guard let objcOffset = objcAttribute?.offset,
@@ -89,7 +89,7 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
     }
 }
 
-private extension Dictionary where Key == String, Value == SourceKitRepresentable {
+private extension SourceKittenDictionary{
     var isObjcAndIBDesignableDeclaredExtension: Bool {
         guard let kind = kind, let declaration = SwiftDeclarationKind(rawValue: kind) else {
             return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -29,7 +29,7 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
     }
 
     public func violationRanges(in file: File) -> [NSRange] {
-        return violationRanges(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary), parentStructure: nil)
+        return violationRanges(file: file, dictionary: file.structureDictionary, parentStructure: nil)
     }
 
     private func violationRanges(file: File, dictionary: SourceKittenDictionary,
@@ -89,7 +89,7 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
     }
 }
 
-private extension SourceKittenDictionary{
+private extension SourceKittenDictionary {
     var isObjcAndIBDesignableDeclaredExtension: Bool {
         guard let kind = kind, let declaration = SwiftDeclarationKind(rawValue: kind) else {
             return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -91,7 +91,7 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
     private let pattern = "\\s*=\\s*nil\\b"
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -104,7 +104,7 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
     }
 
     public func violationRanges(in file: File, kind: SwiftDeclarationKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard SwiftDeclarationKind.variableKinds.contains(kind),
             let type = dictionary.typeName,
             typeIsOptional(type),
@@ -119,7 +119,7 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
         return [match]
     }
 
-    private func range(for dictionary: [String: SourceKitRepresentable], file: File) -> NSRange? {
+    private func range(for dictionary: SourceKittenDictionary, file: File) -> NSRange? {
         guard let offset = dictionary.offset,
             let length = dictionary.length else {
                 return nil
@@ -138,7 +138,7 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
     }
 }
 
-extension Dictionary where Key == String, Value == SourceKitRepresentable {
+extension SourceKittenDictionary {
     fileprivate func isMutableVariable(file: File) -> Bool {
         return setterAccessibility != nil || (isLocal && isVariable(file: file))
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -47,11 +47,11 @@ public struct RedundantSetAccessControlRule: ConfigurationProviderRule, Automati
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        return validate(file: file, dictionary: file.structure.dictionary, parentDictionary: nil)
+        return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary), parentDictionary: nil)
     }
 
-    private func validate(file: File, dictionary: [String: SourceKitRepresentable],
-                          parentDictionary: [String: SourceKitRepresentable]?) -> [StyleViolation] {
+    private func validate(file: File, dictionary: SourceKittenDictionary,
+                          parentDictionary: SourceKittenDictionary?) -> [StyleViolation] {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict, parentDictionary: dictionary)
 
@@ -65,8 +65,8 @@ public struct RedundantSetAccessControlRule: ConfigurationProviderRule, Automati
     }
 
     private func validate(file: File, kind: SwiftDeclarationKind,
-                          dictionary: [String: SourceKitRepresentable],
-                          parentDictionary: [String: SourceKitRepresentable]?) -> [StyleViolation] {
+                          dictionary: SourceKittenDictionary,
+                          parentDictionary: SourceKittenDictionary?) -> [StyleViolation] {
         let aclAttributes: Set<SwiftDeclarationAttributeKind> = [.private, .fileprivate, .internal, .public, .open]
         let explicitACL = dictionary.swiftAttributes.compactMap { dict -> SwiftDeclarationAttributeKind? in
             guard let attribute = dict.attribute.flatMap(SwiftDeclarationAttributeKind.init),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -47,7 +47,7 @@ public struct RedundantSetAccessControlRule: ConfigurationProviderRule, Automati
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        return validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary), parentDictionary: nil)
+        return validate(file: file, dictionary: file.structureDictionary, parentDictionary: nil)
     }
 
     private func validate(file: File, dictionary: SourceKittenDictionary,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 
-private func children(of dict: [String: SourceKitRepresentable],
-                      matching kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
+private func children(of dict: SourceKittenDictionary,
+                      matching kind: SwiftDeclarationKind) -> [SourceKittenDictionary] {
     return dict.substructure.compactMap { subDict in
         if let kindString = subDict.kind,
             SwiftDeclarationKind(rawValue: kindString) == kind {
@@ -73,7 +73,7 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .enum else {
             return []
         }
@@ -91,7 +91,7 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
         }
     }
 
-    private func violatingOffsetsForEnum(dictionary: [String: SourceKitRepresentable], file: File) -> [Int] {
+    private func violatingOffsetsForEnum(dictionary: SourceKittenDictionary, file: File) -> [Int] {
         var caseCount = 0
         var violations = [Int]()
 
@@ -107,13 +107,13 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
         return violations
     }
 
-    private func enumElementsCount(dictionary: [String: SourceKitRepresentable]) -> Int {
+    private func enumElementsCount(dictionary: SourceKittenDictionary) -> Int {
         return children(of: dictionary, matching: .enumelement).filter({ element in
             return !filterEnumInits(dictionary: element).isEmpty
         }).count
     }
 
-    private func violatingOffsetsForEnumCase(dictionary: [String: SourceKitRepresentable], file: File) -> [Int] {
+    private func violatingOffsetsForEnumCase(dictionary: SourceKittenDictionary, file: File) -> [Int] {
         return children(of: dictionary, matching: .enumelement).flatMap { element -> [Int] in
             guard let name = element.name else {
                 return []
@@ -122,7 +122,7 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
         }
     }
 
-    private func violatingOffsetsForEnumElement(dictionary: [String: SourceKitRepresentable], name: String,
+    private func violatingOffsetsForEnumElement(dictionary: SourceKittenDictionary, name: String,
                                                 file: File) -> [Int] {
         let enumInits = filterEnumInits(dictionary: dictionary)
 
@@ -143,7 +143,7 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
         }
     }
 
-    private func filterEnumInits(dictionary: [String: SourceKitRepresentable]) -> [[String: SourceKitRepresentable]] {
+    private func filterEnumInits(dictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         return dictionary.elements.filter {
             $0.kind == "source.lang.swift.structure.elem.init_expr"
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -99,7 +99,7 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
 
     private func isIBInspectable(range: NSRange, file: File) -> Bool {
         guard let byteRange = file.contents.bridge().NSRangeToByteRange(start: range.location, length: range.length),
-            let dict = file.structure.structures(forByteOffset: byteRange.location, in: file.structureDictionary).last,
+            let dict = file.structureDictionary.structures(forByteOffset: byteRange.location).last,
             let kind = dict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
             SwiftDeclarationKind.variableKinds.contains(kind) else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -99,7 +99,7 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
 
     private func isIBInspectable(range: NSRange, file: File) -> Bool {
         guard let byteRange = file.contents.bridge().NSRangeToByteRange(start: range.location, length: range.length),
-            let dict = file.structure.structures(forByteOffset: byteRange.location).last,
+            let dict = file.structure.structures(forByteOffset: byteRange.location, in: file.structureDictionary).last,
             let kind = dict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
             SwiftDeclarationKind.variableKinds.contains(kind) else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -62,7 +62,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
     private let functionKinds = SwiftDeclarationKind.functionKinds.subtracting([.functionSubscript])
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -71,7 +71,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
     }
 
     public func violationRanges(in file: File, kind: SwiftDeclarationKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard functionKinds.contains(kind),
             !shouldReturnEarlyBasedOnTypeName(dictionary: dictionary),
             let nameOffset = dictionary.nameOffset,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -94,7 +94,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
         return (violationRange, "")
     }
 
-    private func shouldReturnEarlyBasedOnTypeName(dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func shouldReturnEarlyBasedOnTypeName(dictionary: SourceKittenDictionary) -> Bool {
         guard SwiftVersion.current >= .fourDotOne else {
             return false
         }
@@ -102,7 +102,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
         return !containsVoidReturnTypeBasedOnTypeName(dictionary: dictionary)
     }
 
-    private func containsVoidReturnTypeBasedOnTypeName(dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func containsVoidReturnTypeBasedOnTypeName(dictionary: SourceKittenDictionary) -> Bool {
         guard let typeName = dictionary.typeName else {
             return false
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
@@ -80,7 +80,7 @@ public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, OptInRule,
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .functionFree,
             let offset = dictionary.offset,
             let name = dictionary.name?.split(separator: "(").first.flatMap(String.init) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -158,7 +158,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
                 return false
             }
 
-            let kinds = file.structure.kinds(forByteOffset: byteOffset, in: file.structureDictionary)
+            let kinds = file.structureDictionary.kinds(forByteOffset: byteOffset)
                 .compactMap { SwiftExpressionKind(rawValue: $0.kind) }
             guard kinds.contains(.call) else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -158,7 +158,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
                 return false
             }
 
-            let kinds = file.structure.kinds(forByteOffset: byteOffset)
+            let kinds = file.structure.kinds(forByteOffset: byteOffset, in: file.structureDictionary)
                 .compactMap { SwiftExpressionKind(rawValue: $0.kind) }
             guard kinds.contains(.call) else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -23,11 +23,11 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         return validateTypeAliasesAndAssociatedTypes(in: file) +
-            validate(file: file, dictionary: file.structure.dictionary)
+            validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
     }
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard typeKinds.contains(kind),
             let name = dictionary.name,
             let offset = dictionary.nameOffset else {
@@ -62,7 +62,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         }
     }
 
-    private func validate(name: String, dictionary: [String: SourceKitRepresentable] = [:], file: File,
+    private func validate(name: String, dictionary: SourceKittenDictionary = SourceKittenDictionary(value: [:]), file: File,
                           offset: Int) -> [StyleViolation] {
         guard !configuration.excluded.contains(name) else {
             return []
@@ -96,7 +96,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
 }
 
 private extension String {
-    func nameStrippingTrailingSwiftUIPreviewProvider(_ dictionary: [String: SourceKitRepresentable]) -> String {
+    func nameStrippingTrailingSwiftUIPreviewProvider(_ dictionary: SourceKittenDictionary) -> String {
         guard dictionary.inheritedTypes.contains("PreviewProvider"),
             hasSuffix("_Previews"),
             let lastPreviewsIndex = lastIndex(of: "_Previews")

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -23,7 +23,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         return validateTypeAliasesAndAssociatedTypes(in: file) +
-            validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+            validate(file: file, dictionary: file.structureDictionary)
     }
 
     public func validate(file: File, kind: SwiftDeclarationKind,
@@ -62,7 +62,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         }
     }
 
-    private func validate(name: String, dictionary: SourceKittenDictionary = SourceKittenDictionary(value: [:]), file: File,
+    private func validate(name: String, dictionary: SourceKittenDictionary = SourceKittenDictionary([:]), file: File,
                           offset: Int) -> [StyleViolation] {
         guard !configuration.excluded.contains(name) else {
             return []

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -54,7 +54,7 @@ public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptIn
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds.contains(kind) else {
             return []
         }
@@ -78,7 +78,7 @@ public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptIn
         ]
     }
 
-    private func isFunctionUnavailable(file: File, dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isFunctionUnavailable(file: File, dictionary: SourceKittenDictionary) -> Bool {
         return dictionary.swiftAttributes.contains { dict -> Bool in
             guard dict.attribute.flatMap(SwiftDeclarationAttributeKind.init(rawValue:)) == .available,
                 let offset = dict.offset, let length = dict.length,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -73,7 +73,7 @@ public struct UnneededBreakInSwitchRule: ConfigurationProviderRule, AutomaticTes
         }
     }
 
-    private func patternEnd(dictionary: [String: SourceKitRepresentable]) -> Int? {
+    private func patternEnd(dictionary: SourceKittenDictionary) -> Int? {
         let patternEnds = dictionary.elements.compactMap { subDictionary -> Int? in
             guard subDictionary.kind == "source.lang.swift.structure.elem.pattern",
                 let offset = subDictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -36,7 +36,8 @@ public struct UnneededBreakInSwitchRule: ConfigurationProviderRule, AutomaticTes
         return file.match(pattern: "break", with: [.keyword]).compactMap { range in
             let contents = file.contents.bridge()
             guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length),
-                let innerStructure = file.structure.structures(forByteOffset: byteRange.location, in: file.structureDictionary).last,
+                let innerStructure = file.structure.structures(forByteOffset: byteRange.location,
+                                                               in: file.structureDictionary).last,
                 innerStructure.kind.flatMap(StatementKind.init) == .case,
                 let caseOffset = innerStructure.offset,
                 let caseLength = innerStructure.length,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -36,7 +36,7 @@ public struct UnneededBreakInSwitchRule: ConfigurationProviderRule, AutomaticTes
         return file.match(pattern: "break", with: [.keyword]).compactMap { range in
             let contents = file.contents.bridge()
             guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length),
-                let innerStructure = file.structure.structures(forByteOffset: byteRange.location).last,
+                let innerStructure = file.structure.structures(forByteOffset: byteRange.location, in: file.structureDictionary).last,
                 innerStructure.kind.flatMap(StatementKind.init) == .case,
                 let caseOffset = innerStructure.offset,
                 let caseLength = innerStructure.length,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -36,8 +36,7 @@ public struct UnneededBreakInSwitchRule: ConfigurationProviderRule, AutomaticTes
         return file.match(pattern: "break", with: [.keyword]).compactMap { range in
             let contents = file.contents.bridge()
             guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length),
-                let innerStructure = file.structure.structures(forByteOffset: byteRange.location,
-                                                               in: file.structureDictionary).last,
+                let innerStructure = file.structureDictionary.structures(forByteOffset: byteRange.location).last,
                 innerStructure.kind.flatMap(StatementKind.init) == .case,
                 let caseOffset = innerStructure.offset,
                 let caseLength = innerStructure.length,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -31,7 +31,7 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule, Automati
     )
 
     public func validate(file: File, kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .forEach,
             isEnumeratedCall(dictionary: dictionary),
             let byteRange = byteRangeForVariables(dictionary: dictionary),
@@ -68,7 +68,7 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule, Automati
             isUnderscore(file: file, token: token)
     }
 
-    private func isEnumeratedCall(dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isEnumeratedCall(dictionary: SourceKittenDictionary) -> Bool {
         for subDict in dictionary.substructure {
             guard let kindString = subDict.kind,
                 SwiftExpressionKind(rawValue: kindString) == .call,
@@ -84,7 +84,7 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule, Automati
         return false
     }
 
-    private func byteRangeForVariables(dictionary: [String: SourceKitRepresentable]) -> NSRange? {
+    private func byteRangeForVariables(dictionary: SourceKittenDictionary) -> NSRange? {
         let expectedKind = "source.lang.swift.structure.elem.id"
         for subDict in dictionary.elements where subDict.kind == expectedKind {
             guard let offset = subDict.offset,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -38,7 +38,7 @@ public struct XCTFailMessageRule: ASTRule, ConfigurationProviderRule, AutomaticT
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             let offset = dictionary.offset,
@@ -53,7 +53,7 @@ public struct XCTFailMessageRule: ASTRule, ConfigurationProviderRule, AutomaticT
                                location: Location(file: file, byteOffset: offset))]
     }
 
-    private func hasEmptyMessage(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func hasEmptyMessage(dictionary: SourceKittenDictionary, file: File) -> Bool {
         guard
             let bodyOffset = dictionary.bodyOffset,
             let bodyLength = dictionary.bodyLength else { return false }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -18,7 +18,7 @@ public struct XCTSpecificMatcherRule: ASTRule, OptInRule, ConfigurationProviderR
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             let offset = dictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
@@ -40,7 +40,7 @@ public struct AnyObjectProtocolRule: SubstitutionCorrectableASTRule, OptInRule,
 
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -56,7 +56,7 @@ public struct AnyObjectProtocolRule: SubstitutionCorrectableASTRule, OptInRule,
 
     public func violationRanges(in file: File,
                                 kind: SwiftDeclarationKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard kind == .protocol else { return [] }
 
         return dictionary.elements.compactMap { subDict -> NSRange? in

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -45,7 +45,7 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .call, let name = dictionary.name, name.hasSuffix(".map"),
             let bodyOffset = dictionary.bodyOffset,
             let bodyLength = dictionary.bodyLength,
@@ -173,7 +173,7 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
         }
     }
 
-    private func isParameterStyleViolation(file: File, dictionary: [String: SourceKitRepresentable],
+    private func isParameterStyleViolation(file: File, dictionary: SourceKittenDictionary,
                                            tokens: [SyntaxToken]) -> Bool {
         let parameters = dictionary.enclosedVarParameters
         guard parameters.count == 1,

--- a/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -31,7 +31,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule, Aut
     private let referenceTypeProtocols: Set = ["AnyObject", "NSObjectProtocol", "class"]
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .protocol else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
@@ -30,7 +30,7 @@ public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
     }
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             let (violation, range) = $0
             return StyleViolation(
@@ -43,7 +43,7 @@ public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func violationRanges(in file: File, kind: SwiftExpressionKind,
-                                 dictionary: [String: SourceKitRepresentable]) -> [(ExpressibleByCompiler, NSRange)] {
+                                 dictionary: SourceKittenDictionary) -> [(ExpressibleByCompiler, NSRange)] {
         guard kind == .call, let name = dictionary.name else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
@@ -40,7 +40,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        var violations = validateAttributes(file: file, dictionary: file.structure.dictionary)
+        var violations = validateAttributes(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
         violations += validateConditions(file: file)
         violations.sort(by: { $0.location < $1.location })
 
@@ -64,7 +64,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
         }
     }
 
-    private func validateAttributes(file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+    private func validateAttributes(file: File, dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validateAttributes(file: file, dictionary: subDict)
 
@@ -79,7 +79,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
 
     private func validateAttributes(file: File,
                                     kind: SwiftDeclarationKind,
-                                    dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                                    dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let attributes = dictionary.swiftAttributes.filter {
             $0.attribute.flatMap(SwiftDeclarationAttributeKind.init) == .available
         }

--- a/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
@@ -40,7 +40,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        var violations = validateAttributes(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+        var violations = validateAttributes(file: file, dictionary: file.structureDictionary)
         violations += validateConditions(file: file)
         violations.sort(by: { $0.location < $1.location })
 

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -39,7 +39,7 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationOffsets(in: file, dictionary: dictionary, kind: kind).map { location in
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -47,7 +47,7 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
         }
     }
 
-    private func violationOffsets(in file: File, dictionary: [String: SourceKitRepresentable],
+    private func violationOffsets(in file: File, dictionary: SourceKittenDictionary,
                                   kind: SwiftExpressionKind) -> [Int] {
         guard kind == .call,
             let name = dictionary.name,
@@ -83,10 +83,10 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
 }
 
 private extension Structure {
-    func functions(forByteOffset byteOffset: Int) -> [[String: SourceKitRepresentable]] {
-        var results = [[String: SourceKitRepresentable]]()
+    func functions(forByteOffset byteOffset: Int) -> [SourceKittenDictionary] {
+        var results = [SourceKittenDictionary]()
 
-        func parse(_ dictionary: [String: SourceKitRepresentable]) {
+        func parse(_ dictionary: SourceKittenDictionary) {
             guard let offset = dictionary.offset,
                 let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }),
                 NSLocationInRange(byteOffset, byteRange) else {
@@ -99,7 +99,7 @@ private extension Structure {
             }
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary)
+        parse(SourceKittenDictionary(value: dictionary))
         return results
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -82,7 +82,8 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
     }
 }
 
-private func functions(forByteOffset byteOffset: Int, in dictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
+private func functions(forByteOffset byteOffset: Int, in dictionary: SourceKittenDictionary)
+    -> [SourceKittenDictionary] {
     var results = [SourceKittenDictionary]()
 
     func parse(_ dictionary: SourceKittenDictionary) {

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -73,7 +73,7 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
 
         if let lastMatch = file.match(pattern: "\\breturn\\s+", with: [.keyword], range: range).last,
             lastMatch.location == range.length - lastMatch.length,
-            let lastFunction = functions(forByteOffset: offset, in: file.structureDictionary).last,
+            let lastFunction = file.structureDictionary.functions(forByteOffset: offset).last,
             !lastFunction.enclosedSwiftAttributes.contains(.discardableResult) {
             return []
         }
@@ -82,23 +82,24 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
     }
 }
 
-private func functions(forByteOffset byteOffset: Int, in dictionary: SourceKittenDictionary)
-    -> [SourceKittenDictionary] {
-    var results = [SourceKittenDictionary]()
+private extension SourceKittenDictionary {
+    func functions(forByteOffset byteOffset: Int) -> [SourceKittenDictionary] {
+        var results = [SourceKittenDictionary]()
 
-    func parse(_ dictionary: SourceKittenDictionary) {
-        guard let offset = dictionary.offset,
-            let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }),
-            NSLocationInRange(byteOffset, byteRange) else {
-                return
-        }
+        func parse(_ dictionary: SourceKittenDictionary) {
+            guard let offset = dictionary.offset,
+                let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }),
+                NSLocationInRange(byteOffset, byteRange) else {
+                    return
+            }
 
-        if let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
-            SwiftDeclarationKind.functionKinds.contains(kind) {
-            results.append(dictionary)
+            if let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
+                SwiftDeclarationKind.functionKinds.contains(kind) {
+                results.append(dictionary)
+            }
+            dictionary.substructure.forEach(parse)
         }
-        dictionary.substructure.forEach(parse)
+        parse(self)
+        return results
     }
-    parse(dictionary)
-    return results
 }

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -34,7 +34,7 @@ public struct DiscouragedDirectInitRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             let offset = dictionary.nameOffset,

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -38,7 +38,7 @@ public struct DuplicateEnumCasesRule: ConfigurationProviderRule, ASTRule, Automa
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .enum else {
             return []
         }
@@ -67,8 +67,8 @@ public struct DuplicateEnumCasesRule: ConfigurationProviderRule, ASTRule, Automa
             }
     }
 
-    private func substructureElements(of dict: [String: SourceKitRepresentable],
-                                      matching kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
+    private func substructureElements(of dict: SourceKittenDictionary,
+                                      matching kind: SwiftDeclarationKind) -> [SourceKittenDictionary] {
         return dict.substructure
             .filter { $0.kind.flatMap(SwiftDeclarationKind.init) == kind }
     }

--- a/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
@@ -26,7 +26,7 @@ public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule, AutomaticTe
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         // Look for functions with both "inline" and "dynamic". For each of these, we can get offset
         // of the "func" keyword. We can assume that the nearest "@inline" before this offset is
         // the attribute we are interested in.

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -20,8 +20,9 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule,
 
     // MARK: - Private
 
-    private func testClasses(in file: File) -> [[String: SourceKitRepresentable]] {
-        return file.structure.dictionary.substructure.filter { dictionary in
+    private func testClasses(in file: File) -> [SourceKittenDictionary] {
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        return dict.substructure.filter { dictionary in
             guard
                 let kind = dictionary.kind,
                 SwiftDeclarationKind(rawValue: kind) == .class else { return false }
@@ -30,7 +31,7 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule,
     }
 
     private func violations(in file: File,
-                            for dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                            for dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return dictionary.substructure.compactMap { subDictionary -> StyleViolation? in
             guard
                 let kind = subDictionary.kind.flatMap(SwiftDeclarationKind.init),

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -21,7 +21,7 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule,
     // MARK: - Private
 
     private func testClasses(in file: File) -> [SourceKittenDictionary] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         return dict.substructure.filter { dictionary in
             guard
                 let kind = dictionary.kind,

--- a/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
@@ -57,7 +57,8 @@ public struct InertDeferRule: ConfigurationProviderRule, AutomaticTestableRule {
         return defers.compactMap { range -> StyleViolation? in
             let contents = file.contents.bridge()
             guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length),
-                case let kinds = file.structure.kinds(forByteOffset: byteRange.upperBound, in: file.structureDictionary),
+                case let kinds = file.structure.kinds(forByteOffset: byteRange.upperBound,
+                                                      in: file.structureDictionary),
                 let brace = kinds.enumerated().lazy.reversed().first(where: isBrace),
                 brace.offset > kinds.startIndex,
                 case let outerKindIndex = kinds.index(before: brace.offset),

--- a/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
@@ -57,8 +57,7 @@ public struct InertDeferRule: ConfigurationProviderRule, AutomaticTestableRule {
         return defers.compactMap { range -> StyleViolation? in
             let contents = file.contents.bridge()
             guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length),
-                case let kinds = file.structure.kinds(forByteOffset: byteRange.upperBound,
-                                                      in: file.structureDictionary),
+                case let kinds = file.structureDictionary.kinds(forByteOffset: byteRange.upperBound),
                 let brace = kinds.enumerated().lazy.reversed().first(where: isBrace),
                 brace.offset > kinds.startIndex,
                 case let outerKindIndex = kinds.index(before: brace.offset),

--- a/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
@@ -57,7 +57,7 @@ public struct InertDeferRule: ConfigurationProviderRule, AutomaticTestableRule {
         return defers.compactMap { range -> StyleViolation? in
             let contents = file.contents.bridge()
             guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length),
-                case let kinds = file.structure.kinds(forByteOffset: byteRange.upperBound),
+                case let kinds = file.structure.kinds(forByteOffset: byteRange.upperBound, in: file.structureDictionary),
                 let brace = kinds.enumerated().lazy.reversed().first(where: isBrace),
                 brace.offset > kinds.startIndex,
                 case let outerKindIndex = kinds.index(before: brace.offset),

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -33,7 +33,7 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        return validateACL(isHigherThan: .open, in: file.structure.dictionary).map {
+        return validateACL(isHigherThan: .open, in: SourceKittenDictionary(value: file.structure.dictionary)).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
@@ -41,7 +41,7 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
     }
 
     private func validateACL(isHigherThan parentAccessibility: AccessControlLevel,
-                             in substructure: [String: SourceKitRepresentable]) -> [Int] {
+                             in substructure: SourceKittenDictionary) -> [Int] {
         return substructure.substructure.flatMap { element -> [Int] in
             guard let elementKind = element.kind.flatMap(SwiftDeclarationKind.init),
                 elementKind.isRelevantDeclaration else {

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -33,7 +33,7 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        return validateACL(isHigherThan: .open, in: SourceKittenDictionary(value: file.structure.dictionary)).map {
+        return validateACL(isHigherThan: .open, in: file.structureDictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 
 private extension File {
-    func missingDocOffsets(in dictionary: [String: SourceKitRepresentable],
+    func missingDocOffsets(in dictionary: SourceKittenDictionary,
                            acls: [AccessControlLevel]) -> [(Int, AccessControlLevel)] {
         if dictionary.enclosedSwiftAttributes.contains(.override) ||
             !dictionary.inheritedTypes.isEmpty {
@@ -77,7 +77,8 @@ public struct MissingDocsRule: OptInRule, ConfigurationProviderRule, AutomaticTe
 
     public func validate(file: File) -> [StyleViolation] {
         let acls = configuration.parameters.map { $0.value }
-        return file.missingDocOffsets(in: file.structure.dictionary,
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        return file.missingDocOffsets(in: dict,
                                       acls: acls).map { (offset: Int, acl: AccessControlLevel) in
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.parameters.first { $0.value == acl }?.severity ?? .warning,

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -77,7 +77,7 @@ public struct MissingDocsRule: OptInRule, ConfigurationProviderRule, AutomaticTe
 
     public func validate(file: File) -> [StyleViolation] {
         let acls = configuration.parameters.map { $0.value }
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         return file.missingDocOffsets(in: dict,
                                       acls: acls).map { (offset: Int, acl: AccessControlLevel) in
             StyleViolation(ruleDescription: type(of: self).description,

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringKeyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringKeyRule.swift
@@ -23,7 +23,7 @@ public struct NSLocalizedStringKeyRule: ASTRule, OptInRule, ConfigurationProvide
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .call,
             dictionary.name == "NSLocalizedString",
             let firstArgument = dictionary.enclosedArguments.first,

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -44,8 +44,8 @@ public struct NSLocalizedStringRequireBundleRule: ASTRule, OptInRule, Configurat
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
-        let isBundleArgument: ([String: SourceKitRepresentable]) -> Bool = { $0.name == "bundle" }
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        let isBundleArgument: (SourceKittenDictionary) -> Bool = { $0.name == "bundle" }
         guard kind == .call,
             dictionary.name == "NSLocalizedString",
             let offset = dictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -20,8 +20,10 @@ public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, Automa
 
     // MARK: - Private
 
-    private func objcVisibleClasses(in file: File) -> [[String: SourceKitRepresentable]] {
-        return file.structure.dictionary.substructure.filter { dictionary in
+    private func objcVisibleClasses(in file: File) -> [SourceKittenDictionary] {
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+
+        return dict.substructure.filter { dictionary in
             guard
                 let kind = dictionary.kind,
                 SwiftDeclarationKind(rawValue: kind) == .class
@@ -33,7 +35,7 @@ public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, Automa
     }
 
     private func violations(in file: File,
-                            for dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                            for dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let typeName = dictionary.name else { return [] }
         return dictionary.substructure.compactMap { subDictionary -> StyleViolation? in
             guard
@@ -46,7 +48,7 @@ public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, Automa
         }
     }
 
-    private func isDoubleEqualsMethod(_ method: [String: SourceKitRepresentable],
+    private func isDoubleEqualsMethod(_ method: SourceKittenDictionary,
                                       onType typeName: String) -> Bool {
         guard
             let kind = method.kind.flatMap(SwiftDeclarationKind.init),
@@ -58,7 +60,7 @@ public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, Automa
         return true
     }
 
-    private func areAllArguments(toMethod method: [String: SourceKitRepresentable],
+    private func areAllArguments(toMethod method: SourceKittenDictionary,
                                  ofType typeName: String) -> Bool {
         return method.enclosedVarParameters.allSatisfy { param in
             param.typeName == typeName

--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -21,7 +21,7 @@ public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, Automa
     // MARK: - Private
 
     private func objcVisibleClasses(in file: File) -> [SourceKittenDictionary] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
 
         return dict.substructure.filter { dictionary in
             guard

--- a/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
@@ -16,7 +16,7 @@ public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRu
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .class else {
             return []
         }
@@ -29,7 +29,7 @@ public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRu
     }
 
     private func violationOffsets(file: File,
-                                  dictionary: [String: SourceKitRepresentable]) -> [Int] {
+                                  dictionary: SourceKittenDictionary) -> [Int] {
         return dictionary.substructure.flatMap { subDict -> [Int] in
             // complete detachment is allowed on `deinit`
             if subDict.kind.flatMap(SwiftDeclarationKind.init) == .functionMethodInstance,
@@ -50,7 +50,7 @@ public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRu
 
     private var methodName = "NotificationCenter.default.removeObserver"
 
-    private func parameterIsSelf(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func parameterIsSelf(dictionary: SourceKittenDictionary, file: File) -> Bool {
         guard let bodyOffset = dictionary.bodyOffset,
             let bodyLength = dictionary.bodyLength else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
@@ -61,7 +61,7 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let offset = dictionary.bodyOffset,
             let name = dictionary.name,
             kind == .functionMethodInstance,

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -32,7 +32,7 @@ public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, Aut
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let collector = NamespaceCollector(dictionary: file.structure.dictionary)
+        let collector = NamespaceCollector(dictionary: SourceKittenDictionary(value: file.structure.dictionary))
         let elements = collector.findAllElements(of: [.class, .struct, .enum, .extension])
 
         let susceptibleNames = Set(elements.compactMap { $0.kind == .class ? $0.name : nil })

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -32,7 +32,7 @@ public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, Aut
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let collector = NamespaceCollector(dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+        let collector = NamespaceCollector(dictionary: file.structureDictionary)
         let elements = collector.findAllElements(of: [.class, .struct, .enum, .extension])
 
         let susceptibleNames = Set(elements.compactMap { $0.kind == .class ? $0.name : nil })

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
@@ -35,7 +35,7 @@ public struct PrivateActionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
 
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             let offset = dictionary.offset,
             kind == .functionMethodInstance,

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -24,7 +24,7 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .varInstance else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
@@ -2,14 +2,14 @@ import Foundation
 import SourceKittenFramework
 
 private extension AccessControlLevel {
-    init?(_ dictionary: [String: SourceKitRepresentable]) {
+    init?(_ dictionary: SourceKittenDictionary) {
         guard let accessibility = dictionary.accessibility,
             let acl = AccessControlLevel(rawValue: accessibility) else { return nil }
         self = acl
     }
 }
 
-private extension Dictionary where Key: ExpressibleByStringLiteral {
+private extension SourceKittenDictionary {
     var superclass: String? {
         guard let kindString = self.kind,
             let kind = SwiftDeclarationKind(rawValue: kindString), kind == .class,
@@ -17,7 +17,7 @@ private extension Dictionary where Key: ExpressibleByStringLiteral {
         return className
     }
 
-    var parameters: [[String: SourceKitRepresentable]] {
+    var parameters: [SourceKittenDictionary] {
         return substructure.filter { dict in
             guard let kind = dict.kind.flatMap(SwiftDeclarationKind.init) else {
                 return false
@@ -113,7 +113,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDesc
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .class && isTestClass(dictionary) else { return [] }
 
         /* It's not strictly necessary to check for `private` on classes because a
@@ -134,7 +134,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDesc
         }
     }
 
-    private func isTestClass(_ dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isTestClass(_ dictionary: SourceKittenDictionary) -> Bool {
         guard let regex = configuration.regex, let superclass = dictionary.superclass else {
             return false
         }
@@ -143,7 +143,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDesc
     }
 
     private func validateFunction(file: File,
-                                  dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
             kind == .functionMethodInstance,
             let name = dictionary.name, name.hasPrefix("test"),
@@ -154,7 +154,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDesc
     }
 
     private func validateAccessControlLevel(file: File,
-                                            dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                                            dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let acl = AccessControlLevel(dictionary), acl.isPrivate,
             !dictionary.enclosedSwiftAttributes.contains(.objc)
             else { return [] }

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -21,7 +21,7 @@ public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, ASTRule
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let offset = dictionary.offset else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
@@ -73,7 +73,7 @@ public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let offset = dictionary.bodyOffset,
             let name = dictionary.name,
             kind == .functionMethodInstance,

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -15,7 +15,7 @@ public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule, Au
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.contains("QuickSpec") &&
                 $0.kind.flatMap(SwiftDeclarationKind.init) == .class

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -15,7 +15,8 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let testClasses = file.structure.dictionary.substructure.filter {
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.contains("QuickSpec") &&
                 $0.kind.flatMap(SwiftDeclarationKind.init) == .class
         }
@@ -33,7 +34,7 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
         }
     }
 
-    private func validate(file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+    private func validate(file: File, dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict)
 
@@ -48,7 +49,7 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
 
     private func validate(file: File,
                           kind: SwiftExpressionKind,
-                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             let name = dictionary.name,

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -15,7 +15,7 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.contains("QuickSpec") &&
                 $0.kind.flatMap(SwiftDeclarationKind.init) == .class

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -15,7 +15,8 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let testClasses = file.structure.dictionary.substructure.filter {
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.contains("QuickSpec") &&
                 $0.kind.flatMap(SwiftDeclarationKind.init) == .class
         }
@@ -33,7 +34,7 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
         }
     }
 
-    private func validate(file: File, dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+    private func validate(file: File, dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict)
 
@@ -48,7 +49,7 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
 
     private func validate(file: File,
                           kind: SwiftExpressionKind,
-                          dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             let name = dictionary.name,

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -15,7 +15,7 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.contains("QuickSpec") &&
                 $0.kind.flatMap(SwiftDeclarationKind.init) == .class

--- a/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -85,7 +85,7 @@ AutomaticTestableRule {
 
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .enum else { return [] }
 
         let codableTypesSet = Set(["Codable", "Decodable", "Encodable"])
@@ -104,7 +104,7 @@ AutomaticTestableRule {
         }
     }
 
-    private func violatingOffsetsForEnum(dictionary: [String: SourceKitRepresentable]) -> [Int] {
+    private func violatingOffsetsForEnum(dictionary: SourceKittenDictionary) -> [Int] {
         let locs = substructureElements(of: dictionary, matching: .enumcase)
             .compactMap { substructureElements(of: $0, matching: .enumelement) }
             .flatMap(camelCasedEnumCasesMissingRawValue)
@@ -113,13 +113,13 @@ AutomaticTestableRule {
         return locs
     }
 
-    private func substructureElements(of dict: [String: SourceKitRepresentable],
-                                      matching kind: SwiftDeclarationKind) -> [[String: SourceKitRepresentable]] {
+    private func substructureElements(of dict: SourceKittenDictionary,
+                                      matching kind: SwiftDeclarationKind) -> [SourceKittenDictionary] {
         return dict.substructure.filter { $0.kind.flatMap(SwiftDeclarationKind.init) == kind }
     }
 
     private func camelCasedEnumCasesMissingRawValue(
-        _ enumElements: [[String: SourceKitRepresentable]]) -> [[String: SourceKitRepresentable]] {
+        _ enumElements: [SourceKittenDictionary]) -> [SourceKittenDictionary] {
         return enumElements
             .filter { substructure in
                 guard let name = substructure.name, !name.isLowercase() else { return false }

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredDeinitRule.swift
@@ -70,7 +70,7 @@ public struct RequiredDeinitRule: ASTRule, OptInRule, ConfigurationProviderRule,
 
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .class,
             let offset = dictionary.offset else {
                 return []

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -76,7 +76,7 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
         let inheritedTypes: [String]
         let cases: [String]
 
-        init(from dictionary: [String: SourceKitRepresentable], in file: File) {
+        init(from dictionary: SourceKittenDictionary, in file: File) {
             location = Enum.location(from: dictionary, in: file)
             inheritedTypes = dictionary.inheritedTypes
             cases = Enum.cases(from: dictionary)
@@ -88,7 +88,7 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
         ///   - dictionary: Parsed source for the enum.
         ///   - file: File that contains the enum.
         /// - Returns: Location of where the enum declaration starts.
-        static func location(from dictionary: [String: SourceKitRepresentable], in file: File) -> Location {
+        static func location(from dictionary: SourceKittenDictionary, in file: File) -> Location {
             return Location(file: file, characterOffset: dictionary.offset ?? 0)
         }
 
@@ -96,7 +96,7 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
         ///
         /// - Parameter dictionary: Parsed source for the enum.
         /// - Returns: Names of cases found in the enum.
-        static func cases(from dictionary: [String: SourceKitRepresentable]) -> [String] {
+        static func cases(from dictionary: SourceKittenDictionary) -> [String] {
             let caseSubstructures = dictionary.substructure.filter { dict in
                 return dict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) == .enumcase
             }.flatMap { $0.substructure }
@@ -160,7 +160,7 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .enum else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
@@ -22,7 +22,7 @@ public struct StrongIBOutletRule: ConfigurationProviderRule, ASTRule, OptInRule,
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .varInstance,
             case let attributes = dictionary.enclosedSwiftAttributes,
             attributes.contains(.iboutlet),

--- a/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -28,7 +28,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .closure, let bodyOffset = dictionary.bodyOffset, let bodyLength = dictionary.bodyLength,
             case let contents = file.contents.bridge(),
             let closureRange = contents.byteRangeToNSRange(start: bodyOffset, length: bodyLength),
@@ -60,10 +60,10 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
     }
 
     private func localVariableDeclarations(inByteRange byteRange: NSRange,
-                                           structure: Structure) -> [[String: SourceKitRepresentable]] {
-        var results = [[String: SourceKitRepresentable]]()
+                                           structure: Structure) -> [SourceKittenDictionary] {
+        var results = [SourceKittenDictionary]()
 
-        func parse(dictionary: [String: SourceKitRepresentable]) {
+        func parse(dictionary: SourceKittenDictionary) {
             if let kindString = (dictionary.kind),
                 SwiftDeclarationKind(rawValue: kindString) == .varLocal,
                 let offset = dictionary.offset,
@@ -76,7 +76,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
             }
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary: structure.dictionary)
+        parse(dictionary: SourceKittenDictionary(value: structure.dictionary))
         return results
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -40,7 +40,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
 
         let length = inTokenByteRange.location - bodyOffset
         let variables = localVariableDeclarations(inByteRange: NSRange(location: bodyOffset, length: length),
-                                                  structure: file.structure)
+                                                  structureDictionary: file.structureDictionary)
         let unownedVariableOffsets = variables.compactMap { dictionary in
             return dictionary.swiftAttributes.first { attributeDict in
                 guard attributeDict.attribute.flatMap(SwiftDeclarationAttributeKind.init) == .weak,
@@ -60,7 +60,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
     }
 
     private func localVariableDeclarations(inByteRange byteRange: NSRange,
-                                           structure: Structure) -> [SourceKittenDictionary] {
+                                           structureDictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         var results = [SourceKittenDictionary]()
 
         func parse(dictionary: SourceKittenDictionary) {
@@ -76,7 +76,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
             }
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary: SourceKittenDictionary(value: structure.dictionary))
+        parse(dictionary: structureDictionary)
         return results
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
@@ -75,7 +75,7 @@ public struct UnusedCaptureListRule: ASTRule, ConfigurationProviderRule, Automat
     private let captureListRegex = regex("^\\{\\s*\\[([^\\]]+)\\]")
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let contents = file.contents.bridge()
         guard kind == .closure,
             let offset = dictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -99,7 +99,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, dictionary: dictionary, kind: kind).map { range, name in
             let reason = "Unused parameter \"\(name)\" in a closure should be replaced with _."
             return StyleViolation(ruleDescription: type(of: self).description,
@@ -110,7 +110,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
     }
 
     public func violationRanges(in file: File, kind: SwiftExpressionKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         return violationRanges(in: file, dictionary: dictionary, kind: kind).map { $0.range }
     }
 
@@ -118,7 +118,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
         return (violationRange, "_")
     }
 
-    private func violationRanges(in file: File, dictionary: [String: SourceKitRepresentable],
+    private func violationRanges(in file: File, dictionary: SourceKittenDictionary,
                                  kind: SwiftExpressionKind) -> [(range: NSRange, name: String)] {
         guard kind == .call,
             !isClosure(dictionary: dictionary),
@@ -178,7 +178,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
         }
     }
 
-    private func isClosure(dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isClosure(dictionary: SourceKittenDictionary) -> Bool {
         return dictionary.name.flatMap { name -> Bool in
             let length = name.bridge().length
             let range = NSRange(location: 0, length: length)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -90,7 +90,7 @@ public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, Config
     private static let kinds: Set<StatementKind> = [.if, .for, .forEach, .while, .repeatWhile, .switch]
 
     public func validate(file: File, kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return self.violationRanges(in: file, kind: kind, dictionary: dictionary).map { range in
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -112,7 +112,7 @@ public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, Config
     }
 
     public func violationRanges(in file: File, kind: StatementKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard type(of: self).kinds.contains(kind),
             let offset = dictionary.offset, let length = dictionary.length,
             case let byteRange = NSRange(location: offset, length: length),

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -252,6 +252,15 @@ private extension File {
     }
 }
 
+private extension Dictionary where Value == SourceKitRepresentable, Key == String {
+
+    var name: String? {
+        return self["key.name"] as? String
+    }
+
+}
+
+
 // Skip initializers, deinit, enum cases and subscripts since we can't reliably detect if they're used.
 private let declarationKindsToSkip: Set<SwiftDeclarationKind> = [
     .functionConstructor,

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -253,13 +253,10 @@ private extension File {
 }
 
 private extension Dictionary where Value == SourceKitRepresentable, Key == String {
-
     var name: String? {
         return self["key.name"] as? String
     }
-
 }
-
 
 // Skip initializers, deinit, enum cases and subscripts since we can't reliably detect if they're used.
 private let declarationKindsToSkip: Set<SwiftDeclarationKind> = [

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -126,82 +126,86 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
 // MARK: - File Extensions
 
 private extension File {
-    func allCursorInfo(compilerArguments: [String]) -> [[String: SourceKitRepresentable]] {
-        guard let path = path, let editorOpen = try? Request.editorOpen(file: self).sendIfNotDisabled() else {
+    func allCursorInfo(compilerArguments: [String]) -> [SourceKittenDictionary] {
+        guard let path = path,
+            let editorOpen = (try? Request.editorOpen(file: self).sendIfNotDisabled())
+                .map(SourceKittenDictionary.init) else {
             return []
         }
 
-        return syntaxMap.tokens.compactMap { token in
-            guard let kind = SyntaxKind(rawValue: token.type), !syntaxKindsToSkip.contains(kind) else {
-                return nil
-            }
+        return syntaxMap.tokens
+            .compactMap { token in
+                guard let kind = SyntaxKind(rawValue: token.type), !syntaxKindsToSkip.contains(kind) else {
+                    return nil
+                }
 
-            let offset = Int64(token.offset)
-            let request = Request.cursorInfo(file: path, offset: offset, arguments: compilerArguments)
-            guard var cursorInfo = try? request.sendIfNotDisabled() else {
-                return nil
-            }
+                let offset = Int64(token.offset)
+                let request = Request.cursorInfo(file: path, offset: offset, arguments: compilerArguments)
+                guard var cursorInfo = try? request.sendIfNotDisabled() else {
+                    return nil
+                }
 
-            if let acl = File.aclAtOffset(offset, substructureElement: editorOpen) {
-                cursorInfo["key.accessibility"] = acl
+                if let acl = File.aclAtOffset(offset, substructureElement: editorOpen) {
+                    cursorInfo["key.accessibility"] = acl
+                }
+                cursorInfo["swiftlint.offset"] = offset
+                return cursorInfo
             }
-            cursorInfo["swiftlint.offset"] = offset
-            return cursorInfo
-        }
+            .map(SourceKittenDictionary.init)
     }
 
-    static func declaredUSRs(allCursorInfo: [[String: SourceKitRepresentable]], includePublicAndOpen: Bool)
+    static func declaredUSRs(allCursorInfo: [SourceKittenDictionary], includePublicAndOpen: Bool)
         -> [(usr: String, nameOffset: Int)] {
         return allCursorInfo.compactMap { cursorInfo in
             return declaredUSRAndOffset(cursorInfo: cursorInfo, includePublicAndOpen: includePublicAndOpen)
         }
     }
 
-    static func referencedUSRs(allCursorInfo: [[String: SourceKitRepresentable]]) -> [String] {
+    static func referencedUSRs(allCursorInfo: [SourceKittenDictionary]) -> [String] {
         return allCursorInfo.compactMap(referencedUSR)
     }
 
-    static func testCaseUSRs(allCursorInfo: [[String: SourceKitRepresentable]]) -> Set<String> {
+    static func testCaseUSRs(allCursorInfo: [SourceKittenDictionary]) -> Set<String> {
         return Set(allCursorInfo.compactMap(testCaseUSR))
     }
 
-    private static func declaredUSRAndOffset(cursorInfo: [String: SourceKitRepresentable], includePublicAndOpen: Bool)
+    private static func declaredUSRAndOffset(cursorInfo: SourceKittenDictionary, includePublicAndOpen: Bool)
         -> (usr: String, nameOffset: Int)? {
-        if let offset = cursorInfo["swiftlint.offset"] as? Int64,
-            let usr = cursorInfo["key.usr"] as? String,
-            let kind = (cursorInfo["key.kind"] as? String).flatMap(SwiftDeclarationKind.init(rawValue:)),
+        if let offset = cursorInfo.swiftlintOffset,
+            let usr = cursorInfo.usr,
+            let kind = cursorInfo.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
             !declarationKindsToSkip.contains(kind),
-            let acl = (cursorInfo["key.accessibility"] as? String).flatMap(AccessControlLevel.init(rawValue:)),
+            let acl = cursorInfo.accessibility.flatMap(AccessControlLevel.init(rawValue:)),
             includePublicAndOpen || [.internal, .private, .fileprivate].contains(acl) {
             // Skip declarations marked as @IBOutlet, @IBAction or @objc
             // since those might not be referenced in code, but only dynamically (e.g. Interface Builder)
-            if let annotatedDecl = cursorInfo["key.annotated_decl"] as? String,
+            if let annotatedDecl = cursorInfo.annotatedDeclaration,
                 ["@IBOutlet", "@IBAction", "@objc", "@IBInspectable"].contains(where: annotatedDecl.contains) {
                 return nil
             }
 
             // Classes marked as @UIApplicationMain are used by the operating system as the entry point into the app.
-            if let annotatedDecl = cursorInfo["key.annotated_decl"] as? String,
+            if let annotatedDecl = cursorInfo.annotatedDeclaration,
                 annotatedDecl.contains("@UIApplicationMain") {
                 return nil
             }
 
             // Skip declarations that override another. This works for both subclass overrides &
             // protocol extension overrides.
-            if cursorInfo["key.overrides"] != nil {
+            if cursorInfo.value["key.overrides"] != nil {
                 return nil
             }
 
             // Sometimes default protocol implementations don't have `key.overrides` set but they do have
             // `key.related_decls`.
-            if cursorInfo["key.related_decls"] != nil {
+            if cursorInfo.value["key.related_decls"] != nil {
                 return nil
             }
 
             // Skip CodingKeys as they are used
             if kind == .enum,
                 cursorInfo.name == "CodingKeys",
-                let annotatedDecl = cursorInfo["key.annotated_decl"] as? String,
+                let annotatedDecl = cursorInfo.annotatedDeclaration,
                 annotatedDecl.contains("usr=\"s:s9CodingKeyP\">CodingKey<") {
                 return nil
             }
@@ -212,9 +216,9 @@ private extension File {
         return nil
     }
 
-    private static func referencedUSR(cursorInfo: [String: SourceKitRepresentable]) -> String? {
-        if let usr = cursorInfo["key.usr"] as? String,
-            let kind = cursorInfo["key.kind"] as? String,
+    private static func referencedUSR(cursorInfo: SourceKittenDictionary) -> String? {
+        if let usr = cursorInfo.usr,
+            let kind = cursorInfo.kind,
             kind.contains("source.lang.swift.ref") {
             return usr
         }
@@ -222,39 +226,44 @@ private extension File {
         return nil
     }
 
-    private static func testCaseUSR(cursorInfo: [String: SourceKitRepresentable]) -> String? {
-        if let kind = (cursorInfo["key.kind"] as? String).flatMap(SwiftDeclarationKind.init(rawValue:)),
+    private static func testCaseUSR(cursorInfo: SourceKittenDictionary) -> String? {
+        if let kind = (cursorInfo.kind).flatMap(SwiftDeclarationKind.init(rawValue:)),
             kind == .class,
-            let annotatedDecl = cursorInfo["key.annotated_decl"] as? String,
+            let annotatedDecl = cursorInfo.annotatedDeclaration,
             annotatedDecl.contains("<Type usr=\"c:objc(cs)XCTestCase\">XCTestCase</Type>"),
-            let usr = cursorInfo["key.usr"] as? String {
+            let usr = cursorInfo.usr {
             return usr
         }
 
         return nil
     }
 
-    private static func aclAtOffset(_ offset: Int64, substructureElement: [String: SourceKitRepresentable]) -> String? {
-        if let nameOffset = substructureElement["key.nameoffset"] as? Int64,
+    private static func aclAtOffset(_ offset: Int64, substructureElement: SourceKittenDictionary) -> String? {
+        if let nameOffset = substructureElement.nameOffset,
             nameOffset == offset,
-            let acl = substructureElement["key.accessibility"] as? String {
+            let acl = substructureElement.accessibility {
             return acl
         }
-        if let substructure = substructureElement[SwiftDocKey.substructure.rawValue] as? [SourceKitRepresentable] {
-            let nestedSubstructure = substructure.compactMap({ $0 as? [String: SourceKitRepresentable] })
-            for child in nestedSubstructure {
-                if let acl = File.aclAtOffset(offset, substructureElement: child) {
-                    return acl
-                }
+        for child in substructureElement.substructure {
+            if let acl = File.aclAtOffset(offset, substructureElement: child) {
+                return acl
             }
         }
         return nil
     }
 }
 
-private extension Dictionary where Value == SourceKitRepresentable, Key == String {
-    var name: String? {
-        return self["key.name"] as? String
+private extension SourceKittenDictionary {
+    var swiftlintOffset: Int64? {
+        return value["swiftlint.offset"] as? Int64
+    }
+
+    var usr: String? {
+        return value["key.usr"] as? String
+    }
+
+    var annotatedDeclaration: String? {
+        return value["key.annotated_decl"] as? String
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -329,6 +329,35 @@ private extension File {
     }
 }
 
+private extension Dictionary where Value == SourceKitRepresentable, Key == String {
+
+    var entities: [[String: SourceKitRepresentable]] {
+        let entities = self["key.entities"] as? [SourceKitRepresentable] ?? []
+        return entities.compactMap { $0 as? [String: SourceKitRepresentable] }
+    }
+
+    var enclosedSwiftAttributes: [SwiftDeclarationAttributeKind] {
+        return swiftAttributes.compactMap { $0.attribute }
+                              .compactMap(SwiftDeclarationAttributeKind.init(rawValue:))
+    }
+
+    var swiftAttributes: [[String: SourceKitRepresentable]] {
+        let array = self["key.attributes"] as? [SourceKitRepresentable] ?? []
+        let dictionaries = array.compactMap { ($0 as? [String: SourceKitRepresentable]) }
+        return dictionaries
+    }
+
+    var attribute: String? {
+        return self["key.attribute"] as? String
+    }
+
+    var substructure: [[String: SourceKitRepresentable]] {
+        let substructure = self["key.substructure"] as? [SourceKitRepresentable] ?? []
+        return substructure.compactMap { $0 as? [String: SourceKitRepresentable] }
+    }
+
+}
+
 private let syntaxKindsToSkip: Set<SyntaxKind> = [
     .attributeBuiltin,
     .keyword,
@@ -350,3 +379,5 @@ private let attributesRequiringFoundation: Set<SwiftDeclarationAttributeKind> = 
     .objcMembers,
     .objcNonLazyRealization
 ]
+
+

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -317,7 +317,7 @@ private extension File {
             return false
         }
 
-        func containsAttributesRequiringFoundation(dict: [String: SourceKitRepresentable]) -> Bool {
+        func containsAttributesRequiringFoundation(dict: SourceKittenDictionary) -> Bool {
             if !attributesRequiringFoundation.isDisjoint(with: dict.enclosedSwiftAttributes) {
                 return true
             } else {
@@ -325,12 +325,11 @@ private extension File {
             }
         }
 
-        return containsAttributesRequiringFoundation(dict: self.structure.dictionary)
+        return containsAttributesRequiringFoundation(dict: self.structureDictionary)
     }
 }
 
 private extension Dictionary where Value == SourceKitRepresentable, Key == String {
-
     var entities: [[String: SourceKitRepresentable]] {
         let entities = self["key.entities"] as? [SourceKitRepresentable] ?? []
         return entities.compactMap { $0 as? [String: SourceKitRepresentable] }
@@ -355,7 +354,6 @@ private extension Dictionary where Value == SourceKitRepresentable, Key == Strin
         let substructure = self["key.substructure"] as? [SourceKitRepresentable] ?? []
         return substructure.compactMap { $0 as? [String: SourceKitRepresentable] }
     }
-
 }
 
 private let syntaxKindsToSkip: Set<SyntaxKind> = [
@@ -379,5 +377,3 @@ private let attributesRequiringFoundation: Set<SwiftDeclarationAttributeKind> = 
     .objcMembers,
     .objcNonLazyRealization
 ]
-
-

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -334,26 +334,6 @@ private extension Dictionary where Value == SourceKitRepresentable, Key == Strin
         let entities = self["key.entities"] as? [SourceKitRepresentable] ?? []
         return entities.compactMap { $0 as? [String: SourceKitRepresentable] }
     }
-
-    var enclosedSwiftAttributes: [SwiftDeclarationAttributeKind] {
-        return swiftAttributes.compactMap { $0.attribute }
-                              .compactMap(SwiftDeclarationAttributeKind.init(rawValue:))
-    }
-
-    var swiftAttributes: [[String: SourceKitRepresentable]] {
-        let array = self["key.attributes"] as? [SourceKitRepresentable] ?? []
-        let dictionaries = array.compactMap { ($0 as? [String: SourceKitRepresentable]) }
-        return dictionaries
-    }
-
-    var attribute: String? {
-        return self["key.attribute"] as? String
-    }
-
-    var substructure: [[String: SourceKitRepresentable]] {
-        let substructure = self["key.substructure"] as? [SourceKitRepresentable] ?? []
-        return substructure.compactMap { $0 as? [String: SourceKitRepresentable] }
-    }
 }
 
 private let syntaxKindsToSkip: Set<SyntaxKind> = [

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -103,7 +103,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
 
         let violatingLocations = setTokens.compactMap { setToken -> Int? in
             // the last element is the deepest structure
-            guard let dict = declarations(forByteOffset: setToken.offset, structure: file.structure).last,
+            guard let dict = declarations(forByteOffset: setToken.offset, structureDictionary: file.structureDictionary).last,
                 let bodyOffset = dict.bodyOffset, let bodyLength = dict.bodyLength,
                 case let contents = file.contents.bridge(),
                 let propertyRange = contents.byteRangeToNSRange(start: bodyOffset, length: bodyLength),
@@ -162,7 +162,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
                 return nil
         }
 
-        let declaration = file.structure.structures(forByteOffset: firstToken.offset)
+        let declaration = file.structure.structures(forByteOffset: firstToken.offset, in: file.structureDictionary)
             .first(where: { $0.offset == firstToken.offset && $0.length == firstToken.length })
 
         guard let name = declaration?.name else {
@@ -177,7 +177,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
         let getTokens = file.rangesAndTokens(matching: "\\bget\\b", range: range).keywordTokens()
         return getTokens.first(where: { token -> Bool in
             // the last element is the deepest structure
-            guard let dict = declarations(forByteOffset: token.offset, structure: file.structure).last,
+            guard let dict = declarations(forByteOffset: token.offset, structureDictionary: file.structureDictionary).last,
                 propertyStructure.value.isEqualTo(dict.value) else {
                     return false
             }
@@ -187,7 +187,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
     }
 
     private func declarations(forByteOffset byteOffset: Int,
-                              structure: Structure) -> [SourceKittenDictionary] {
+                              structureDictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         var results = [SourceKittenDictionary]()
         let allowedKinds = SwiftDeclarationKind.variableKinds.subtracting([.varParameter])
 
@@ -212,7 +212,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
             }
         }
 
-        let dict = SourceKittenDictionary(value: structure.dictionary)
+        let dict = structureDictionary
 
         for dictionary in dict.substructure {
             parse(dictionary: dictionary, parentKind: nil)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -163,7 +163,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
                 return nil
         }
 
-        let declaration = file.structure.structures(forByteOffset: firstToken.offset, in: file.structureDictionary)
+        let declaration = file.structureDictionary.structures(forByteOffset: firstToken.offset)
             .first(where: { $0.offset == firstToken.offset && $0.length == firstToken.length })
 
         guard let name = declaration?.name else {

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -103,7 +103,8 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
 
         let violatingLocations = setTokens.compactMap { setToken -> Int? in
             // the last element is the deepest structure
-            guard let dict = declarations(forByteOffset: setToken.offset, structureDictionary: file.structureDictionary).last,
+            guard let dict = declarations(forByteOffset: setToken.offset,
+                                          structureDictionary: file.structureDictionary).last,
                 let bodyOffset = dict.bodyOffset, let bodyLength = dict.bodyLength,
                 case let contents = file.contents.bridge(),
                 let propertyRange = contents.byteRangeToNSRange(start: bodyOffset, length: bodyLength),
@@ -177,7 +178,8 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
         let getTokens = file.rangesAndTokens(matching: "\\bget\\b", range: range).keywordTokens()
         return getTokens.first(where: { token -> Bool in
             // the last element is the deepest structure
-            guard let dict = declarations(forByteOffset: token.offset, structureDictionary: file.structureDictionary).last,
+            guard let dict = declarations(forByteOffset: token.offset,
+                                          structureDictionary: file.structureDictionary).last,
                 propertyStructure.value.isEqualTo(dict.value) else {
                     return false
             }

--- a/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
@@ -36,7 +36,7 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule, Automa
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .varInstance else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -33,7 +33,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule, AutomaticTes
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .varInstance else {
             return []
         }
@@ -76,10 +76,10 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule, AutomaticTes
     }
 
     private func protocolDeclarations(forByteOffset byteOffset: Int,
-                                      structure: Structure) -> [[String: SourceKitRepresentable]] {
-        var results = [[String: SourceKitRepresentable]]()
+                                      structure: Structure) -> [SourceKittenDictionary] {
+        var results = [SourceKittenDictionary]()
 
-        func parse(dictionary: [String: SourceKitRepresentable]) {
+        func parse(dictionary: SourceKittenDictionary) {
             // Only accepts protocols declarations which contains a body and contains the
             // searched byteOffset
             if let kindString = (dictionary.kind),
@@ -94,7 +94,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule, AutomaticTes
             }
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary: structure.dictionary)
+        parse(dictionary: SourceKittenDictionary(value: structure.dictionary))
         return results
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -50,7 +50,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule, AutomaticTes
 
         // if the declaration is inside a protocol
         if let offset = dictionary.offset,
-            !protocolDeclarations(forByteOffset: offset, structure: file.structure).isEmpty {
+            !protocolDeclarations(forByteOffset: offset, structureDictionary: file.structureDictionary).isEmpty {
             return []
         }
 
@@ -76,7 +76,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule, AutomaticTes
     }
 
     private func protocolDeclarations(forByteOffset byteOffset: Int,
-                                      structure: Structure) -> [SourceKittenDictionary] {
+                                      structureDictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         var results = [SourceKittenDictionary]()
 
         func parse(dictionary: SourceKittenDictionary) {
@@ -94,7 +94,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule, AutomaticTes
             }
             dictionary.substructure.forEach(parse)
         }
-        parse(dictionary: SourceKittenDictionary(value: structure.dictionary))
+        parse(dictionary: structureDictionary)
         return results
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
@@ -60,7 +60,7 @@ public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
 
     public func validate(file: File,
                          kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard observedStatements.contains(kind),
               let offset = dictionary.offset,
               let length = dictionary.length

--- a/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -19,7 +19,7 @@ public struct ClosureBodyLengthRule: OptInRule, ASTRule, ConfigurationProviderRu
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .closure,
             let offset = dictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
@@ -32,7 +32,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds.contains(kind) else {
             return []
         }
@@ -52,7 +52,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
         return []
     }
 
-    private func measureComplexity(in file: File, dictionary: [String: SourceKitRepresentable]) -> Int {
+    private func measureComplexity(in file: File, dictionary: SourceKittenDictionary) -> Int {
         var hasSwitchStatements = false
 
         let complexity = dictionary.substructure.reduce(0) { complexity, subDict in
@@ -88,7 +88,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
     // Switch complexity is reduced by `fallthrough` cases
 
     private func reduceSwitchComplexity(initialComplexity complexity: Int, file: File,
-                                        dictionary: [String: SourceKitRepresentable]) -> Int {
+                                        dictionary: SourceKittenDictionary) -> Int {
         let bodyOffset = dictionary.bodyOffset ?? 0
         let bodyLength = dictionary.bodyLength ?? 0
 

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
@@ -13,7 +13,7 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds.contains(kind),
             let offset = dictionary.offset,
             let bodyOffset = dictionary.bodyOffset,

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
@@ -35,7 +35,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds.contains(kind) else {
             return []
         }
@@ -78,7 +78,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
         return []
     }
 
-    private func allFunctionParameterCount(structure: [[String: SourceKitRepresentable]],
+    private func allFunctionParameterCount(structure: [SourceKittenDictionary],
                                            offset: Int, length: Int) -> Int {
         var parameterCount = 0
         for subDict in structure {

--- a/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
@@ -55,7 +55,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule, AutomaticTesta
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let offsets = violationOffsetsForTypes(in: file, dictionary: dictionary, kind: kind) +
             violationOffsetsForFunctions(in: file, dictionary: dictionary, kind: kind)
 
@@ -72,7 +72,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule, AutomaticTesta
         }
     }
 
-    private func violationOffsetsForTypes(in file: File, dictionary: [String: SourceKitRepresentable],
+    private func violationOffsetsForTypes(in file: File, dictionary: SourceKittenDictionary,
                                           kind: SwiftDeclarationKind) -> [(offset: Int, size: Int)] {
         let kinds = SwiftDeclarationKind.variableKinds.subtracting([.varLocal])
         guard kinds.contains(kind),
@@ -85,7 +85,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule, AutomaticTesta
         return sizes.max().flatMap { [(offset: offset, size: $0)] } ?? []
     }
 
-    private func violationOffsetsForFunctions(in file: File, dictionary: [String: SourceKitRepresentable],
+    private func violationOffsetsForFunctions(in file: File, dictionary: SourceKittenDictionary,
                                               kind: SwiftDeclarationKind) -> [(offset: Int, size: Int)] {
         let contents = file.contents.bridge()
         guard SwiftDeclarationKind.functionKinds.contains(kind),
@@ -124,7 +124,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule, AutomaticTesta
         return offsets
     }
 
-    private func returnRangeForFunction(dictionary: [String: SourceKitRepresentable]) -> NSRange? {
+    private func returnRangeForFunction(dictionary: SourceKittenDictionary) -> NSRange? {
         guard let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength,
             let length = dictionary.length,

--- a/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
@@ -30,11 +30,11 @@ public struct NestingRule: ASTRule, ConfigurationProviderRule, AutomaticTestable
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return validate(file: file, kind: kind, dictionary: dictionary, level: 0)
     }
 
-    private func validate(file: File, kind: SwiftDeclarationKind, dictionary: [String: SourceKitRepresentable],
+    private func validate(file: File, kind: SwiftDeclarationKind, dictionary: SourceKittenDictionary,
                           level: Int) -> [StyleViolation] {
         var violations = [StyleViolation]()
         let typeKinds = SwiftDeclarationKind.typeKinds

--- a/Source/SwiftLintFramework/Rules/Metrics/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/TypeBodyLengthRule.swift
@@ -32,7 +32,7 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule, AutomaticT
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.typeKinds.contains(kind) else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
@@ -98,7 +98,7 @@ public struct ReduceIntoRule: ASTRule, ConfigurationProviderRule, OptInRule, Aut
     private let initExpression = regex("^(?:\\[.+:?.*\\]|(?:Array|Dictionary)<.+>)(?:\\.init\\(|\\().*\\)$")
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             let nameOffset = dictionary.nameOffset,
@@ -123,7 +123,7 @@ public struct ReduceIntoRule: ASTRule, ConfigurationProviderRule, OptInRule, Aut
         return [violation]
     }
 
-    private func argumentIsCopyOnWriteType(_ argument: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func argumentIsCopyOnWriteType(_ argument: SourceKittenDictionary, file: File) -> Bool {
         if let substructure = argument.substructure.first,
             let kind = substructure.kind {
             switch kind {

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -26,11 +26,11 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         return validateTestableImport(file: file) +
-            validate(file: file, dictionary: file.structure.dictionary)
+            validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
     }
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let attributeShouldBeOnSameLine: Bool?
         if SwiftDeclarationKind.variableKinds.contains(kind) {
             attributeShouldBeOnSameLine = true
@@ -71,7 +71,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
     private func validateKind(file: File,
                               attributeShouldBeOnSameLine: Bool,
-                              dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                              dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let attributes = parseAttributes(dictionary: dictionary)
 
         guard !attributes.isEmpty,
@@ -162,7 +162,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         })
     }
 
-    private func violation(dictionary: [String: SourceKitRepresentable],
+    private func violation(dictionary: SourceKittenDictionary,
                            file: File) -> [StyleViolation] {
         let location: Location
         if let offset = dictionary.offset {
@@ -288,7 +288,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         return false
     }
 
-    private func parseAttributes(dictionary: [String: SourceKitRepresentable]) -> [SwiftDeclarationAttributeKind] {
+    private func parseAttributes(dictionary: SourceKittenDictionary) -> [SwiftDeclarationAttributeKind] {
         let attributes = dictionary.enclosedSwiftAttributes
         let blacklist: Set<SwiftDeclarationAttributeKind> = [
             .mutating,

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -26,7 +26,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
 
     public func validate(file: File) -> [StyleViolation] {
         return validateTestableImport(file: file) +
-            validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+            validate(file: file, dictionary: file.structureDictionary)
     }
 
     public func validate(file: File, kind: SwiftDeclarationKind,

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -112,11 +112,11 @@ extension ClosureEndIndentationRule {
     }
 
     fileprivate func violations(in file: File) -> [Violation] {
-        return violations(in: file, dictionary: file.structure.dictionary)
+        return violations(in: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
     }
 
     private func violations(in file: File,
-                            dictionary: [String: SourceKitRepresentable]) -> [Violation] {
+                            dictionary: SourceKittenDictionary) -> [Violation] {
         return dictionary.substructure.flatMap { subDict -> [Violation] in
             var subViolations = violations(in: file, dictionary: subDict)
 
@@ -130,7 +130,7 @@ extension ClosureEndIndentationRule {
     }
 
     private func violations(in file: File, of kind: SwiftExpressionKind,
-                            dictionary: [String: SourceKitRepresentable]) -> [Violation] {
+                            dictionary: SourceKittenDictionary) -> [Violation] {
         guard kind == .call else {
             return []
         }
@@ -145,7 +145,7 @@ extension ClosureEndIndentationRule {
     }
 
     private func hasTrailingClosure(in file: File,
-                                    dictionary: [String: SourceKitRepresentable]) -> Bool {
+                                    dictionary: SourceKittenDictionary) -> Bool {
         guard
             let offset = dictionary.offset,
             let length = dictionary.length,
@@ -158,7 +158,7 @@ extension ClosureEndIndentationRule {
     }
 
     private func validateCall(in file: File,
-                              dictionary: [String: SourceKitRepresentable]) -> Violation? {
+                              dictionary: SourceKittenDictionary) -> Violation? {
         let contents = file.contents.bridge()
         guard let offset = dictionary.offset,
             let length = dictionary.length,
@@ -199,7 +199,7 @@ extension ClosureEndIndentationRule {
     }
 
     private func validateArguments(in file: File,
-                                   dictionary: [String: SourceKitRepresentable]) -> [Violation] {
+                                   dictionary: SourceKittenDictionary) -> [Violation] {
         guard isFirstArgumentOnNewline(dictionary, file: file) else {
             return []
         }
@@ -218,7 +218,7 @@ extension ClosureEndIndentationRule {
     }
 
     private func validateClosureArgument(in file: File,
-                                         dictionary: [String: SourceKitRepresentable]) -> Violation? {
+                                         dictionary: SourceKittenDictionary) -> Violation? {
         let contents = file.contents.bridge()
         guard let offset = dictionary.offset,
             let length = dictionary.length,
@@ -258,7 +258,7 @@ extension ClosureEndIndentationRule {
                          range: NSRange(location: offset, length: length))
     }
 
-    private func startOffset(forDictionary dictionary: [String: SourceKitRepresentable], file: File) -> Int? {
+    private func startOffset(forDictionary dictionary: SourceKittenDictionary, file: File) -> Int? {
         guard let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength else {
             return nil
@@ -277,7 +277,7 @@ extension ClosureEndIndentationRule {
         return methodByteRange.location
     }
 
-    private func isSingleLineClosure(dictionary: [String: SourceKitRepresentable],
+    private func isSingleLineClosure(dictionary: SourceKittenDictionary,
                                      endPosition: Int, file: File) -> Bool {
         let contents = file.contents.bridge()
 
@@ -290,7 +290,7 @@ extension ClosureEndIndentationRule {
         return startLine == endLine
     }
 
-    private func containsSingleLineClosure(dictionary: [String: SourceKitRepresentable],
+    private func containsSingleLineClosure(dictionary: SourceKittenDictionary,
                                            endPosition: Int, file: File) -> Bool {
         let contents = file.contents.bridge()
 
@@ -304,21 +304,21 @@ extension ClosureEndIndentationRule {
         return startLine == endLine
     }
 
-    private func trailingClosure(dictionary: [String: SourceKitRepresentable],
-                                 file: File) -> [String: SourceKitRepresentable]? {
+    private func trailingClosure(dictionary: SourceKittenDictionary,
+                                 file: File) -> SourceKittenDictionary? {
         let arguments = dictionary.enclosedArguments
         let closureArguments = filterClosureArguments(arguments, file: file)
 
         if closureArguments.count == 1,
-            closureArguments.last?.bridge() == arguments.last?.bridge() {
+            closureArguments.last?.value.bridge() == arguments.last?.value.bridge() {
             return closureArguments.last
         }
 
         return nil
     }
 
-    private func filterClosureArguments(_ arguments: [[String: SourceKitRepresentable]],
-                                        file: File) -> [[String: SourceKitRepresentable]] {
+    private func filterClosureArguments(_ arguments: [SourceKittenDictionary],
+                                        file: File) -> [SourceKittenDictionary] {
         return arguments.filter { argument in
             guard let offset = argument.bodyOffset,
                 let length = argument.bodyLength,
@@ -332,7 +332,7 @@ extension ClosureEndIndentationRule {
         }
     }
 
-    private func isFirstArgumentOnNewline(_ dictionary: [String: SourceKitRepresentable],
+    private func isFirstArgumentOnNewline(_ dictionary: SourceKittenDictionary,
                                           file: File) -> Bool {
         guard
             let nameOffset = dictionary.nameOffset,

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -112,7 +112,7 @@ extension ClosureEndIndentationRule {
     }
 
     fileprivate func violations(in file: File) -> [Violation] {
-        return violations(in: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+        return violations(in: file, dictionary: file.structureDictionary)
     }
 
     private func violations(in file: File,

--- a/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
@@ -44,7 +44,7 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule, 
     private static let openBraceRegex = regex("\\{")
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .call else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
@@ -15,7 +15,7 @@ public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule, OptIn
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .dictionary || kind == .array else { return [] }
 
         let keyLocations: [Location]
@@ -51,16 +51,16 @@ public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule, OptIn
         }
     }
 
-    private func arrayElementLocations(with file: File, dictionary: [String: SourceKitRepresentable]) -> [Location] {
+    private func arrayElementLocations(with file: File, dictionary: SourceKittenDictionary) -> [Location] {
         return dictionary.elements.compactMap { element -> Location? in
             element.offset.map { Location(file: file, byteOffset: $0) }
         }
     }
 
     private func dictionaryKeyLocations(with file: File,
-                                        dictionary: [String: SourceKitRepresentable]) -> [Location] {
-        var keys: [[String: SourceKitRepresentable]] = []
-        var values: [[String: SourceKitRepresentable]] = []
+                                        dictionary: SourceKittenDictionary) -> [Location] {
+        var keys: [SourceKittenDictionary] = []
+        var values: [SourceKittenDictionary] = []
         dictionary.elements.enumerated().forEach { index, element in
             // in a dictionary, the even elements are keys, and the odd elements are values
             if index % 2 == 0 {

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+Dictionary.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+Dictionary.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 extension ColonRule {
     internal func dictionaryColonViolationRanges(in file: File,
-                                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                                 dictionary: SourceKittenDictionary) -> [NSRange] {
         guard configuration.applyToDictionaries else {
             return []
         }
@@ -22,7 +22,7 @@ extension ColonRule {
     }
 
     internal func dictionaryColonViolationRanges(in file: File, kind: SwiftExpressionKind,
-                                                 dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                                 dictionary: SourceKittenDictionary) -> [NSRange] {
         guard kind == .dictionary,
             let ranges = dictionaryColonRanges(dictionary: dictionary) else {
                 return []
@@ -43,7 +43,7 @@ extension ColonRule {
         }
     }
 
-    private func dictionaryColonRanges(dictionary: [String: SourceKitRepresentable]) -> [NSRange]? {
+    private func dictionaryColonRanges(dictionary: SourceKittenDictionary) -> [NSRange]? {
         let elements = dictionary.elements
         guard elements.count % 2 == 0 else {
             return nil

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+FunctionCall.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+FunctionCall.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 extension ColonRule {
     internal func functionCallColonViolationRanges(in file: File,
-                                                   dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                                   dictionary: SourceKittenDictionary) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges: [NSRange] = []
             if let kindString = subDict.kind,
@@ -16,7 +16,7 @@ extension ColonRule {
     }
 
     internal func functionCallColonViolationRanges(in file: File, kind: SwiftExpressionKind,
-                                                   dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                                   dictionary: SourceKittenDictionary) -> [NSRange] {
         guard kind == .argument,
             let ranges = functionCallColonRanges(dictionary: dictionary) else {
                 return []
@@ -37,7 +37,7 @@ extension ColonRule {
         }
     }
 
-    private func functionCallColonRanges(dictionary: [String: SourceKitRepresentable]) -> [NSRange]? {
+    private func functionCallColonRanges(dictionary: SourceKittenDictionary) -> [NSRange]? {
         guard let nameOffset = dictionary.nameOffset,
             let nameLength = dictionary.nameLength, nameLength > 0,
             let bodyOffset = dictionary.bodyOffset,

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -32,7 +32,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
 
         let dictionaryViolations: [StyleViolation]
         if configuration.applyToDictionaries {
-            dictionaryViolations = validate(file: file, dictionary: file.structure.dictionary)
+            dictionaryViolations = validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
         } else {
             dictionaryViolations = []
         }
@@ -75,7 +75,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
         let violations: [RangeWithKind] = typeColonViolationRanges(in: file, matching: pattern).map {
             (range: $0, kind: ColonKind.type)
         }
-        let dictionary = file.structure.dictionary
+        let dictionary = SourceKittenDictionary(value: file.structure.dictionary)
         let contents = file.contents.bridge()
         let dictViolations: [RangeWithKind] = dictionaryColonViolationRanges(in: file,
                                                                              dictionary: dictionary).compactMap {
@@ -101,7 +101,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
 extension ColonRule: ASTRule {
     /// Only returns dictionary and function calls colon violations
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let ranges = dictionaryColonViolationRanges(in: file, kind: kind, dictionary: dictionary) +
             functionCallColonViolationRanges(in: file, kind: kind, dictionary: dictionary)
 

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -32,7 +32,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
 
         let dictionaryViolations: [StyleViolation]
         if configuration.applyToDictionaries {
-            dictionaryViolations = validate(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+            dictionaryViolations = validate(file: file, dictionary: file.structureDictionary)
         } else {
             dictionaryViolations = []
         }
@@ -75,7 +75,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
         let violations: [RangeWithKind] = typeColonViolationRanges(in: file, matching: pattern).map {
             (range: $0, kind: ColonKind.type)
         }
-        let dictionary = SourceKittenDictionary(value: file.structure.dictionary)
+        let dictionary = file.structureDictionary
         let contents = file.contents.bridge()
         let dictViolations: [RangeWithKind] = dictionaryColonViolationRanges(in: file,
                                                                              dictionary: dictionary).compactMap {

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -74,7 +74,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
                 .filter { match, _ -> Bool in
                     let contents = file.contents.bridge()
                     guard let byteOffset = contents.NSRangeToByteRange(start: match.location, length: 1)?.location,
-                        let outerKind = file.structure.kinds(forByteOffset: byteOffset).last else {
+                        let outerKind = file.structure.kinds(forByteOffset: byteOffset, in: file.structureDictionary).last else {
                             return true
                     }
 

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -74,7 +74,8 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
                 .filter { match, _ -> Bool in
                     let contents = file.contents.bridge()
                     guard let byteOffset = contents.NSRangeToByteRange(start: match.location, length: 1)?.location,
-                        let outerKind = file.structure.kinds(forByteOffset: byteOffset, in: file.structureDictionary).last else {
+                        let outerKind = file.structure.kinds(forByteOffset: byteOffset,
+                                                             in: file.structureDictionary).last else {
                             return true
                     }
 

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -74,8 +74,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
                 .filter { match, _ -> Bool in
                     let contents = file.contents.bridge()
                     guard let byteOffset = contents.NSRangeToByteRange(start: match.location, length: 1)?.location,
-                        let outerKind = file.structure.kinds(forByteOffset: byteOffset,
-                                                             in: file.structureDictionary).last else {
+                        let outerKind = file.structureDictionary.kinds(forByteOffset: byteOffset).last else {
                             return true
                     }
 

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -55,7 +55,7 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
     )
 
     public func validate(file: File, kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -68,7 +68,7 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
     }
 
     public func violationRanges(in file: File, kind: StatementKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard kind == .case else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -47,7 +47,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
     private static let emptyParenthesesRegex = regex("^\\s*\\(\\s*\\)")
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -60,7 +60,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
     }
 
     public func violationRanges(in file: File, kind: SwiftExpressionKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard kind == .call else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -88,7 +88,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
         in file: File,
         mainTypeSubstructure: SourceKittenDictionary
     ) -> [SourceKittenDictionary] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         return dict.substructure.filter { substructure in
             guard let kind = substructure.kind else { return false }
             return substructure.value.bridge() != mainTypeSubstructure.value.bridge() &&
@@ -103,7 +103,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
         var supportingTypeKinds = SwiftDeclarationKind.typeKinds
         supportingTypeKinds.insert(SwiftDeclarationKind.protocol)
 
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         return dict.substructure.filter { substructure in
             guard let kind = substructure.kind else { return false }
             guard let declarationKind = SwiftDeclarationKind(rawValue: kind) else { return false }
@@ -114,7 +114,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
     }
 
     private func mainTypeSubstructure(in file: File) -> SourceKittenDictionary? {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
 
         guard let filePath = file.path else {
             return self.mainTypeSubstructure(in: dict)
@@ -122,7 +122,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
 
         let fileName = URL(fileURLWithPath: filePath).lastPathComponent.replacingOccurrences(of: ".swift", with: "")
         guard let mainTypeSubstructure = dict.substructure.first(where: { $0.name == fileName }) else {
-            return self.mainTypeSubstructure(in: SourceKittenDictionary(value: file.structure.dictionary))
+            return self.mainTypeSubstructure(in: file.structureDictionary)
         }
 
         // specify type with name matching the files name as main type

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -24,7 +24,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard !dictionary.enclosedSwiftAttributes.contains(.override) else {
             return []
         }
@@ -79,7 +79,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         } ?? []
     }
 
-    private func validateName(dictionary: [String: SourceKitRepresentable],
+    private func validateName(dictionary: SourceKittenDictionary,
                               kind: SwiftDeclarationKind) -> (name: String, offset: Int)? {
         guard var name = dictionary.name,
             let offset = dictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
@@ -218,12 +218,12 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
     }
 
     private func declarations(forByteOffset byteOffset: Int,
-                              structure: Structure) -> [[String: SourceKitRepresentable]] {
-        var results = [[String: SourceKitRepresentable]]()
+                              structure: Structure) -> [SourceKittenDictionary] {
+        var results = [SourceKittenDictionary]()
         let allowedKinds = SwiftDeclarationKind.variableKinds.subtracting([.varParameter])
                                                              .union([.functionSubscript])
 
-        func parse(dictionary: [String: SourceKitRepresentable], parentKind: SwiftDeclarationKind?) {
+        func parse(dictionary: SourceKittenDictionary, parentKind: SwiftDeclarationKind?) {
             // Only accepts declarations which contains a body and contains the
             // searched byteOffset
             guard let kindString = dictionary.kind,
@@ -244,7 +244,8 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
             }
         }
 
-        for dictionary in structure.dictionary.substructure {
+        let dict = SourceKittenDictionary(value: structure.dictionary)
+        for dictionary in dict.substructure {
             parse(dictionary: dictionary, parentKind: nil)
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
@@ -191,7 +191,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
 
         let violatingLocations = getTokens.compactMap { token -> (Int, SwiftDeclarationKind?)? in
             // the last element is the deepest structure
-            guard let dict = declarations(forByteOffset: token.offset, structure: file.structure).last else {
+            guard let dict = declarations(forByteOffset: token.offset, structureDictionary: file.structureDictionary).last else {
                 return nil
             }
 
@@ -218,7 +218,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
     }
 
     private func declarations(forByteOffset byteOffset: Int,
-                              structure: Structure) -> [SourceKittenDictionary] {
+                              structureDictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         var results = [SourceKittenDictionary]()
         let allowedKinds = SwiftDeclarationKind.variableKinds.subtracting([.varParameter])
                                                              .union([.functionSubscript])
@@ -244,7 +244,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
             }
         }
 
-        let dict = SourceKittenDictionary(value: structure.dictionary)
+        let dict = structureDictionary
         for dictionary in dict.substructure {
             parse(dictionary: dictionary, parentKind: nil)
         }

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
@@ -191,7 +191,8 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
 
         let violatingLocations = getTokens.compactMap { token -> (Int, SwiftDeclarationKind?)? in
             // the last element is the deepest structure
-            guard let dict = declarations(forByteOffset: token.offset, structureDictionary: file.structureDictionary).last else {
+            guard let dict = declarations(forByteOffset: token.offset,
+                                          structureDictionary: file.structureDictionary).last else {
                 return nil
             }
 
@@ -216,12 +217,14 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
                                   reason: reason)
         }
     }
+}
 
-    private func declarations(forByteOffset byteOffset: Int,
-                              structureDictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
+private extension ImplicitGetterRule {
+    func declarations(forByteOffset byteOffset: Int,
+                      structureDictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         var results = [SourceKittenDictionary]()
         let allowedKinds = SwiftDeclarationKind.variableKinds.subtracting([.varParameter])
-                                                             .union([.functionSubscript])
+            .union([.functionSubscript])
 
         func parse(dictionary: SourceKittenDictionary, parentKind: SwiftDeclarationKind?) {
             // Only accepts declarations which contains a body and contains the

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -68,8 +68,7 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
             guard kinds == [.keyword, .keyword] || kinds == [.keyword],
                 let byteRange = contents.NSRangeToByteRange(start: range.location,
                                                             length: range.length),
-                let outerKindString = file.structure.kinds(forByteOffset: byteRange.location,
-                                                           in: file.structureDictionary).last?.kind,
+                let outerKindString = file.structureDictionary.kinds(forByteOffset: byteRange.location).last?.kind,
                 let outerKind = SwiftExpressionKind(rawValue: outerKindString),
                 [.call, .argument, .closure].contains(outerKind) else {
                     return nil

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -68,7 +68,7 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
             guard kinds == [.keyword, .keyword] || kinds == [.keyword],
                 let byteRange = contents.NSRangeToByteRange(start: range.location,
                                                             length: range.length),
-                let outerKindString = file.structure.kinds(forByteOffset: byteRange.location).last?.kind,
+                let outerKindString = file.structure.kinds(forByteOffset: byteRange.location, in: file.structureDictionary).last?.kind,
                 let outerKind = SwiftExpressionKind(rawValue: outerKindString),
                 [.call, .argument, .closure].contains(outerKind) else {
                     return nil

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -68,7 +68,8 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
             guard kinds == [.keyword, .keyword] || kinds == [.keyword],
                 let byteRange = contents.NSRangeToByteRange(start: range.location,
                                                             length: range.length),
-                let outerKindString = file.structure.kinds(forByteOffset: byteRange.location, in: file.structureDictionary).last?.kind,
+                let outerKindString = file.structure.kinds(forByteOffset: byteRange.location,
+                                                           in: file.structureDictionary).last?.kind,
                 let outerKind = SwiftExpressionKind(rawValue: outerKindString),
                 [.call, .argument, .closure].contains(outerKind) else {
                     return nil

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -40,9 +40,11 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
     )
 
     public func validate(file: File) -> [StyleViolation] {
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+
         var attributeLines = attributeLineNumbers(file: file)
         let varLines = varLetLineNumbers(file: file,
-                                         structure: file.structure.dictionary.substructure,
+                                         structure: dict.substructure,
                                          attributeLines: &attributeLines)
         let skippedLines = skippedLineNumbers(file: file)
         var violations = [StyleViolation]()
@@ -113,7 +115,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
                                          location: location))
     }
 
-    private func lineOffsets(file: File, statement: [String: SourceKitRepresentable]) -> (Int, Int)? {
+    private func lineOffsets(file: File, statement: SourceKittenDictionary) -> (Int, Int)? {
         guard let offset = statement.offset,
               let length = statement.length else {
             return nil
@@ -126,7 +128,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
 
     // Collects all the line numbers containing var or let declarations
     private func varLetLineNumbers(file: File,
-                                   structure: [[String: SourceKitRepresentable]],
+                                   structure: [SourceKittenDictionary],
                                    attributeLines: inout Set<Int>) -> Set<Int> {
         var result = Set<Int>()
 

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -40,7 +40,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
 
         var attributeLines = attributeLineNumbers(file: file)
         let varLines = varLetLineNumbers(file: file,

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -178,11 +178,11 @@ extension LiteralExpressionEndIdentationRule {
     }
 
     fileprivate func violations(in file: File) -> [Violation] {
-        return violations(in: file, dictionary: file.structure.dictionary)
+        return violations(in: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
     }
 
     private func violations(in file: File,
-                            dictionary: [String: SourceKitRepresentable]) -> [Violation] {
+                            dictionary: SourceKittenDictionary) -> [Violation] {
         return dictionary.substructure.flatMap { subDict -> [Violation] in
             var subViolations = violations(in: file, dictionary: subDict)
 
@@ -197,7 +197,7 @@ extension LiteralExpressionEndIdentationRule {
     }
 
     private func violation(in file: File, of kind: SwiftExpressionKind,
-                           dictionary: [String: SourceKitRepresentable]) -> Violation? {
+                           dictionary: SourceKittenDictionary) -> Violation? {
         guard kind == .dictionary || kind == .array else {
             return nil
         }

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -178,7 +178,7 @@ extension LiteralExpressionEndIdentationRule {
     }
 
     fileprivate func violations(in file: File) -> [Violation] {
-        return violations(in: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+        return violations(in: file, dictionary: file.structureDictionary)
     }
 
     private func violations(in file: File,

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -57,7 +57,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
     }
 
     public func correct(file: File) -> [Correction] {
-        return correct(file: file, dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+        return correct(file: file, dictionary: file.structureDictionary)
     }
 
     private func correct(file: File, dictionary: SourceKittenDictionary) -> [Correction] {
@@ -198,7 +198,7 @@ private extension SourceKittenDictionary {
                 return nil
         }
 
-        return SourceKittenDictionary(value: ["key.kind": kind, "key.offset": Int64(offset)])
+        return SourceKittenDictionary(["key.kind": kind, "key.offset": Int64(offset)])
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -77,7 +77,7 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             let bodyOffset = dictionary.bodyOffset,

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
@@ -17,7 +17,7 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             case let arguments = dictionary.enclosedArguments,
@@ -51,7 +51,7 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
     // MARK: - Violation Logic
 
     private func findViolations(in arguments: [Argument],
-                                dictionary: [String: SourceKitRepresentable],
+                                dictionary: SourceKittenDictionary,
                                 file: File) -> [Argument] {
         guard case let contents = file.contents.bridge(),
             let nameOffset = dictionary.nameOffset,
@@ -110,7 +110,7 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
 
     // MARK: - Syntax Helpers
 
-    private func isTrailingClosure(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func isTrailingClosure(dictionary: SourceKittenDictionary, file: File) -> Bool {
         guard let offset = dictionary.offset,
             let length = dictionary.length,
             case let start = min(offset, offset + length - 1),
@@ -145,7 +145,7 @@ private struct Argument {
     let bodyOffset: Int
     let bodyLength: Int
 
-    init?(dictionary: [String: SourceKitRepresentable], file: File, index: Int) {
+    init?(dictionary: SourceKittenDictionary, file: File, index: Int) {
         guard let offset = dictionary.offset,
             let (line, _) = file.contents.bridge().lineAndCharacter(forByteOffset: offset),
             let bodyOffset = dictionary.bodyOffset,

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -96,7 +96,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violatingOffsets(file: file, kind: kind, dictionary: dictionary).map { offset in
             return StyleViolation(ruleDescription: type(of: self).description,
                                   severity: configuration.severity,
@@ -106,7 +106,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
 
     private func violatingOffsets(file: File,
                                   kind: SwiftExpressionKind,
-                                  dictionary: [String: SourceKitRepresentable]) -> [Int] {
+                                  dictionary: SourceKittenDictionary) -> [Int] {
         let ranges = callRanges(file: file, kind: kind, dictionary: dictionary)
 
         let calls = ranges.compactMap { range -> (dotLine: Int, dotOffset: Int, range: NSRange)? in
@@ -158,7 +158,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
 
     private func callRanges(file: File,
                             kind: SwiftExpressionKind,
-                            dictionary: [String: SourceKitRepresentable],
+                            dictionary: SourceKittenDictionary,
                             parentCallName: String? = nil) -> [NSRange] {
         guard
             kind == .call,
@@ -186,7 +186,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
     }
 
     private func subcallRange(file: File,
-                              call: [String: SourceKitRepresentable],
+                              call: SourceKittenDictionary,
                               parentName: String,
                               parentNameOffset: Int) -> NSRange? {
         guard
@@ -210,9 +210,9 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
     }
 }
 
-fileprivate extension Dictionary where Key: ExpressibleByStringLiteral {
-    var subcalls: [[String: SourceKitRepresentable]] {
-        return substructure.compactMap { dictionary -> [String: SourceKitRepresentable]? in
+fileprivate extension SourceKittenDictionary {
+    var subcalls: [SourceKittenDictionary] {
+        return substructure.compactMap { dictionary -> SourceKittenDictionary? in
             guard dictionary.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call else {
                 return nil
             }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -210,7 +210,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
     }
 }
 
-fileprivate extension SourceKittenDictionary {
+private extension SourceKittenDictionary {
     var subcalls: [SourceKittenDictionary] {
         return substructure.compactMap { dictionary -> SourceKittenDictionary? in
             guard dictionary.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call else {

--- a/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -99,7 +99,7 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             [.array, .dictionary].contains(kind),
             let bodyOffset = dictionary.bodyOffset,

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -88,10 +88,10 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        return violations(in: file.structure.dictionary, file: file)
+        return violations(in: SourceKittenDictionary(value: file.structure.dictionary), file: file)
     }
 
-    private func violations(in substructure: [String: SourceKitRepresentable], file: File) -> [StyleViolation] {
+    private func violations(in substructure: SourceKittenDictionary, file: File) -> [StyleViolation] {
         var violations = [StyleViolation]()
 
         // find violations at current level
@@ -127,7 +127,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
         return violations
     }
 
-    private func openingBracketViolation(parameters: [[String: SourceKitRepresentable]],
+    private func openingBracketViolation(parameters: [SourceKittenDictionary],
                                          file: File) -> StyleViolation? {
         guard
             let firstParamByteOffset = parameters.first?.offset,
@@ -154,7 +154,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
         )
     }
 
-    private func closingBracketViolation(parameters: [[String: SourceKitRepresentable]],
+    private func closingBracketViolation(parameters: [SourceKittenDictionary],
                                          file: File) -> StyleViolation? {
         guard
             let lastParamByteOffset = parameters.last?.offset,

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -88,7 +88,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        return violations(in: SourceKittenDictionary(value: file.structure.dictionary), file: file)
+        return violations(in: file.structureDictionary, file: file)
     }
 
     private func violations(in substructure: SourceKittenDictionary, file: File) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
@@ -18,7 +18,7 @@ public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProvider
 
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             SwiftDeclarationKind.functionKinds.contains(kind),
             let offset = dictionary.nameOffset,

--- a/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -31,7 +31,7 @@ public struct MultipleClosuresWithTrailingClosureRule: ASTRule, ConfigurationPro
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .call,
             case let arguments = dictionary.enclosedArguments,
             arguments.count > 1,
@@ -50,8 +50,8 @@ public struct MultipleClosuresWithTrailingClosureRule: ASTRule, ConfigurationPro
         ]
     }
 
-    private func isTrailingClosure(argument: [String: SourceKitRepresentable],
-                                   call: [String: SourceKitRepresentable]) -> Bool {
+    private func isTrailingClosure(argument: SourceKittenDictionary,
+                                   call: SourceKittenDictionary) -> Bool {
         guard let callOffset = call.offset,
             let callLength = call.length,
             let argumentOffset = argument.offset,
@@ -63,8 +63,8 @@ public struct MultipleClosuresWithTrailingClosureRule: ASTRule, ConfigurationPro
     }
 }
 
-private extension Array where Element == [String: SourceKitRepresentable] {
-    func filterClosures(file: File) -> [[String: SourceKitRepresentable]] {
+private extension Array where Element == SourceKittenDictionary {
+    func filterClosures(file: File) -> [SourceKittenDictionary] {
         if SwiftVersion.current < .fourDotTwo {
             return filter { argument in
                 guard let offset = argument.bodyOffset,

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -44,7 +44,7 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
 
     public func validate(file: File,
                          kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severity,
@@ -60,7 +60,7 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
 
     public func violationRanges(in file: File,
                                 kind: SwiftExpressionKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard kind == .call,
             let bodyOffset = dictionary.bodyOffset,
             let nameOffset = dictionary.nameOffset,

--- a/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -52,7 +52,7 @@ public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationPro
 
     public func validate(file: File,
                          kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         if configuration.onlyPrivateMembers,
             let acl = dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:)), !acl.isPrivate {
             return []

--- a/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
@@ -49,13 +49,13 @@ public struct RedundantDiscardableLetRule: SubstitutionCorrectableRule, Configur
             }
 
             return !isInBooleanCondition(byteOffset: byteRange.location,
-                                         dictionary: file.structure.dictionary)
+                                         dictionary: SourceKittenDictionary(value: file.structure.dictionary))
                 && !hasExplicitType(utf16Range: range.location ..< range.location + range.length,
                                     fileContents: contents)
         }
     }
 
-    private func isInBooleanCondition(byteOffset: Int, dictionary: [String: SourceKitRepresentable]) -> Bool {
+    private func isInBooleanCondition(byteOffset: Int, dictionary: SourceKittenDictionary) -> Bool {
         guard let offset = dictionary.offset,
             let byteRange = dictionary.length.map({ NSRange(location: offset, length: $0) }),
             NSLocationInRange(byteOffset, byteRange) else {

--- a/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
@@ -49,7 +49,7 @@ public struct RedundantDiscardableLetRule: SubstitutionCorrectableRule, Configur
             }
 
             return !isInBooleanCondition(byteOffset: byteRange.location,
-                                         dictionary: SourceKittenDictionary(value: file.structure.dictionary))
+                                         dictionary: file.structureDictionary)
                 && !hasExplicitType(utf16Range: range.location ..< range.location + range.length,
                                     fileContents: contents)
         }

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -42,8 +42,9 @@ public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule, A
         }
     }
 
-    private func testClasses(in file: File) -> [[String: SourceKitRepresentable]] {
-        return file.structure.dictionary.substructure.filter { dictionary in
+    private func testClasses(in file: File) -> [SourceKittenDictionary] {
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        return dict.substructure.filter { dictionary in
             guard
                 let kind = dictionary.kind,
                 SwiftDeclarationKind(rawValue: kind) == .class

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -43,7 +43,7 @@ public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule, A
     }
 
     private func testClasses(in file: File) -> [SourceKittenDictionary] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         return dict.substructure.filter { dictionary in
             guard
                 let kind = dictionary.kind,

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -16,7 +16,7 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File, kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let contents = file.contents.bridge()
 
         guard kind == .switch,

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -50,7 +50,7 @@ public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptIn
     )
 
     public func validate(file: File, kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .case,
             let offset = dictionary.offset,
             let length = dictionary.length,

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -31,7 +31,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         return violationOffsets(for: dict, file: file).map {
             StyleViolation(ruleDescription: type(of: self).description,
                            severity: configuration.severityConfiguration.severity,

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -56,7 +56,7 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
     private static let commaRegex = regex(",", options: [.ignoreMetacharacters])
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         if let (index, reason) = violationIndexAndReason(in: file, kind: kind, dictionary: dictionary) {
             return violations(file: file, byteOffset: index, reason: reason.rawValue)
         } else {
@@ -65,7 +65,7 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
     }
 
     public func violationRanges(in file: File, kind: SwiftExpressionKind,
-                                dictionary: [String: SourceKitRepresentable]) -> [NSRange] {
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
         guard let (offset, reason) = violationIndexAndReason(in: file, kind: kind, dictionary: dictionary),
             case let length = reason == .extraTrailingCommaReason ? 1 : 0,
             let range = file.contents.bridge().byteRangeToNSRange(start: offset, length: length) else {
@@ -80,7 +80,7 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
     }
 
     private func violationIndexAndReason(in file: File, kind: SwiftExpressionKind,
-                                         dictionary: [String: SourceKitRepresentable]) -> CommaRuleViolation? {
+                                         dictionary: SourceKittenDictionary) -> CommaRuleViolation? {
         let allowedKinds: Set<SwiftExpressionKind> = [.array, .dictionary]
 
         guard let bodyOffset = dictionary.bodyOffset,

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -17,14 +17,15 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let substructures = file.structure.dictionary.substructure
+        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let substructures = dict.substructure
         return substructures.reduce(into: [StyleViolation]()) { violations, substructure in
             violations.append(contentsOf: validateTypeSubstructure(substructure, in: file))
         }
     }
 
     private func validateTypeSubstructure(
-        _ substructure: [String: SourceKitRepresentable],
+        _ substructure: SourceKittenDictionary,
         in file: File
     ) -> [StyleViolation] {
         let typeContentOffsets = self.typeContentOffsets(in: substructure)
@@ -68,7 +69,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
         return violations
     }
 
-    private func typeContentOffsets(in typeStructure: [String: SourceKitRepresentable]) -> [TypeContentOffset] {
+    private func typeContentOffsets(in typeStructure: SourceKittenDictionary) -> [TypeContentOffset] {
         return typeStructure.substructure.compactMap { typeContentStructure in
             guard let typeContent = self.typeContent(for: typeContentStructure) else { return nil }
             return (typeContent, typeContentStructure.offset!)
@@ -76,7 +77,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
-    private func typeContent(for typeContentStructure: [String: SourceKitRepresentable]) -> TypeContent? {
+    private func typeContent(for typeContentStructure: SourceKittenDictionary) -> TypeContent? {
         guard let typeContentKind = SwiftDeclarationKind(rawValue: typeContentStructure.kind!) else { return nil }
 
         switch typeContentKind {

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -17,7 +17,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
     )
 
     public func validate(file: File) -> [StyleViolation] {
-        let dict = SourceKittenDictionary(value: file.structure.dictionary)
+        let dict = file.structureDictionary
         let substructures = dict.substructure
         return substructures.reduce(into: [StyleViolation]()) { violations, substructure in
             violations.append(contentsOf: validateTypeSubstructure(substructure, in: file))

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -45,7 +45,7 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: File,
                          kind: StatementKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let conditionKind = "source.lang.swift.structure.elem.condition_expr"
         guard kind == .if || kind == .guard else {
             return []

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -74,7 +74,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
     )
 
     public func validate(file: File, kind: SwiftExpressionKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .call,
             case let arguments = dictionary.enclosedArguments,
             arguments.count > 1,
@@ -126,7 +126,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
         }
     }
 
-    private func isMultiline(argument: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func isMultiline(argument: SourceKittenDictionary, file: File) -> Bool {
         guard let offset = argument.bodyOffset,
             let length = argument.bodyLength,
             case let contents = file.contents.bridge(),
@@ -138,7 +138,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
         return endLine > startLine
     }
 
-    private func isTrailingClosure(dictionary: [String: SourceKitRepresentable], file: File) -> Bool {
+    private func isTrailingClosure(dictionary: SourceKittenDictionary, file: File) -> Bool {
         guard let offset = dictionary.offset,
             let length = dictionary.length,
             case let start = min(offset, offset + length - 1),

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -15,7 +15,7 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
     )
 
     public func validate(file: File, kind: SwiftDeclarationKind,
-                         dictionary: [String: SourceKitRepresentable]) -> [StyleViolation] {
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds.contains(kind),
             let startOffset = dictionary.nameOffset,
             let length = dictionary.nameLength,
@@ -33,7 +33,7 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
         }
 
         let contents = file.contents.bridge()
-        let calculateLocation = { (dict: [String: SourceKitRepresentable]) -> Location? in
+        let calculateLocation = { (dict: SourceKittenDictionary) -> Location? in
             guard let byteOffset = dict.offset,
                 let lineAndChar = contents.lineAndCharacter(forByteOffset: byteOffset) else {
                     return nil

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRuleExamples.swift
@@ -2,20 +2,20 @@ internal struct VerticalParameterAlignmentRuleExamples {
     static let nonTriggeringExamples: [String] = {
         let commonExamples = [
             "func validateFunction(_ file: File, kind: SwiftDeclarationKind,\n" +
-            "                      dictionary: [String: SourceKitRepresentable]) { }\n",
+            "                      dictionary: SourceKittenDictionary) { }\n",
             "func validateFunction(_ file: File, kind: SwiftDeclarationKind,\n" +
-            "                      dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]\n",
+            "                      dictionary: SourceKittenDictionary) -> [StyleViolation]\n",
             "func foo(bar: Int)\n",
             "func foo(bar: Int) -> String \n",
             "func validateFunction(_ file: File, kind: SwiftDeclarationKind,\n" +
-            "                      dictionary: [String: SourceKitRepresentable])\n" +
+            "                      dictionary: SourceKittenDictionary)\n" +
             "                      -> [StyleViolation]\n",
             "func validateFunction(\n" +
             "   _ file: File, kind: SwiftDeclarationKind,\n" +
-            "   dictionary: [String: SourceKitRepresentable]) -> [StyleViolation]\n",
+            "   dictionary: SourceKittenDictionary) -> [StyleViolation]\n",
             "func validateFunction(\n" +
             "   _ file: File, kind: SwiftDeclarationKind,\n" +
-            "   dictionary: [String: SourceKitRepresentable]\n" +
+            "   dictionary: SourceKittenDictionary\n" +
             ") -> [StyleViolation]\n",
             "func regex(_ pattern: String,\n" +
             "           options: NSRegularExpression.Options = [.anchorsMatchLines,\n" +
@@ -40,12 +40,12 @@ internal struct VerticalParameterAlignmentRuleExamples {
     static let triggeringExamples: [String] = {
         let commonExamples = [
             "func validateFunction(_ file: File, kind: SwiftDeclarationKind,\n" +
-            "                  ↓dictionary: [String: SourceKitRepresentable]) { }\n",
+            "                  ↓dictionary: SourceKittenDictionary) { }\n",
             "func validateFunction(_ file: File, kind: SwiftDeclarationKind,\n" +
-            "                       ↓dictionary: [String: SourceKitRepresentable]) { }\n",
+            "                       ↓dictionary: SourceKittenDictionary) { }\n",
             "func validateFunction(_ file: File,\n" +
             "                  ↓kind: SwiftDeclarationKind,\n" +
-            "                  ↓dictionary: [String: SourceKitRepresentable]) { }\n"
+            "                  ↓dictionary: SourceKittenDictionary) { }\n"
         ]
 
         guard SwiftVersion.current >= .fiveDotOne else {

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -134,7 +134,6 @@
 		6C15818F23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */; };
 		6C1D763221A4E69600DEF783 /* Request+DisableSourceKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */; };
 		6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */; };
-		6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */; };
 		6CB8A80C1D11A7E10052816E /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8BA7E101B07A3EC003E02D0 /* Commandant.framework */; };
 		6CB8A80D1D11A7E10052816E /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8BA7E121B07A3F3003E02D0 /* Result.framework */; };
 		6CC4259B1C77046200AEA885 /* SyntaxMap+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */; };
@@ -365,6 +364,7 @@
 		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
 		E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */; };
 		E4A6CF752363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */; };
+		E4A365D223653649003B4141 /* SourceKittenDictionary+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A365D123653648003B4141 /* SourceKittenDictionary+Swiftlint.swift */; };
 		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
 		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
 		E80746F61ECB722F00548D31 /* CacheDescriptionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80746F51ECB722F00548D31 /* CacheDescriptionProvider.swift */; };
@@ -624,7 +624,6 @@
 		6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+DisableSourceKit.swift"; sourceTree = "<group>"; };
 		6C27B5FC2079D33F00353E17 /* Mac-XCTest.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Mac-XCTest.xcconfig"; sourceTree = "<group>"; };
 		6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceKitCrashTests.swift; sourceTree = "<group>"; };
-		6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Structure+SwiftLint.swift"; sourceTree = "<group>"; };
 		6CC4259A1C77046200AEA885 /* SyntaxMap+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxMap+SwiftLint.swift"; sourceTree = "<group>"; };
 		725094881D0855760039B353 /* StatementModeConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementModeConfiguration.swift; sourceTree = "<group>"; };
 		72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitACLRule.swift; sourceTree = "<group>"; };
@@ -868,6 +867,7 @@
 		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
 		E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicInlineRule.swift; sourceTree = "<group>"; };
 		E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RandomAccessCollection+Swiftlint.swift"; sourceTree = "<group>"; };
+		E4A365D123653648003B4141 /* SourceKittenDictionary+Swiftlint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SourceKittenDictionary+Swiftlint.swift"; sourceTree = "<group>"; };
 		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
 		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
 		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
@@ -1658,9 +1658,9 @@
 				E81619521BFC162C00946723 /* QueuedPrint.swift */,
 				E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */,
 				6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */,
+				E4A365D123653648003B4141 /* SourceKittenDictionary+Swiftlint.swift */,
 				E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */,
 				B39353F28BCCA39247B316BD /* String+XML.swift */,
-				6CB514E81C760C6900FA02C4 /* Structure+SwiftLint.swift */,
 				E816194B1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift */,
 				1894D740207D57AD00BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift */,
 				D47079AA1DFDCF7A00027086 /* SwiftExpressionKind.swift */,
@@ -2095,7 +2095,6 @@
 				D47EF4841F69E3D60012C4CA /* ColonRule+Type.swift in Sources */,
 				3BCC04D11C4F56D3006073C3 /* SeverityLevelsConfiguration.swift in Sources */,
 				D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */,
-				6CB514E91C760C6900FA02C4 /* Structure+SwiftLint.swift in Sources */,
 				D4C0E46F1E3D973600C560F2 /* ForWhereRule.swift in Sources */,
 				7565E5F12262BA0900B0597C /* UnusedCaptureListRule.swift in Sources */,
 				D4EA77CA1F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift in Sources */,
@@ -2132,6 +2131,7 @@
 				621061BF1ED57E640082D51E /* MultilineParametersRuleExamples.swift in Sources */,
 				D41985EB21FAB63E003BE2B7 /* DeploymentTargetConfiguration.swift in Sources */,
 				D48AE2CC1DFB58C5001C6A4A /* AttributesRuleExamples.swift in Sources */,
+				E4A365D223653649003B4141 /* SourceKittenDictionary+Swiftlint.swift in Sources */,
 				D48EE14B231CD34200DBB779 /* NoSpaceInMethodCallRule.swift in Sources */,
 				C28B2B3D2106DF730009A0FE /* PrefixedConstantRuleConfiguration.swift in Sources */,
 				62A7127520F1178F00E604A6 /* AnyObjectProtocolRule.swift in Sources */,


### PR DESCRIPTION
## What
- Add wrapper over `[String: SourceKitRepresentable]` -> `SourceKittenDictionary`
- Cache `File.structure.dictionary`

## Why
- This is one of the most often called and time-consuming function after the regex matching
![image](https://user-images.githubusercontent.com/119268/67628362-df6b0500-f86c-11e9-8ac5-f903583103e6.png)
- Speed up mostly
- Swiftlint using readonly dictionaries from SourceKitten this allows to pre-cache all information used in Swiftlint
- Swiftlint accesses `substructure` key too often, and since it is a computed property, too many objects will be created and removed upon accessing it 
- Having own type instead of extensions over Dictionary will also speed up indexer and compiler a bit

# Note
This is more of a suggestion. I totally understand that this is a big change. 
Some minor stylistic improvements can be done( like namings and moving extensions in and out)
i.e. this one probably should be moved to `File.structurekinds`
https://github.com/realm/SwiftLint/pull/2922/files#diff-74fa1a3ab98dac161c19949597728f07R9

This solution calculates all substructures of the original dictionary. Technically, this can lead to regression in time in some cases, if `substructure` is not used in rules. 

This is also can lead to some code duplication, in places, where it is still easier to work with `[Strings: SourekitRepresentable]`

----

BTW in order to have backward compatible API, we should probably use duplicated methods which still works with `[String: SourceKitRepresentable]` and will wrap those under the hood.

----

Please see https://github.com/realm/SwiftLint/pull/2924 and  https://github.com/realm/SwiftLint/pull/2929 for the more improvements, based on this solution