### PR TITLE
Use swift enums instead of raw values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 #### Enhancements
 
+* Speedup Swiftlint by using swift enums instead of raw values.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)
+  [#2924](https://github.com/realm/SwiftLint/issues/2924)
+
 * Speed up Identical Operands rule by using syntaxmap instead of
   regular expressions.  
   [PaulTaykalo](https://github.com/PaulTaykalo)

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -8,6 +8,8 @@ public struct SourceKittenDictionary {
     public let declarationKind: SwiftDeclarationKind?
     public let statementKind: StatementKind?
 
+    public let accessibility: AccessControlLevel?
+
     init(_ value: [String: SourceKitRepresentable]) {
         self.value = value
 
@@ -19,11 +21,8 @@ public struct SourceKittenDictionary {
         self.expressionKind = stringKind.flatMap(SwiftExpressionKind.init)
         self.declarationKind = stringKind.flatMap(SwiftDeclarationKind.init)
         self.statementKind = stringKind.flatMap(StatementKind.init)
-    }
 
-    /// Accessibility.
-    var accessibility: String? {
-        return value["key.accessibility"] as? String
+        self.accessibility = (value["key.accessibility"] as? String).flatMap(AccessControlLevel.init(identifier:))
     }
 
     /// Body length

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -23,8 +23,7 @@ extension String {
     }
 
     internal func nameStrippingLeadingUnderscoreIfPrivate(_ dict: SourceKittenDictionary) -> String {
-        if let aclString = dict.accessibility,
-           let acl = AccessControlLevel(identifier: aclString),
+        if let acl = dict.accessibility,
             acl.isPrivate && first == "_" {
             return String(self[index(after: startIndex)...])
         }

--- a/Source/SwiftLintFramework/Helpers/NamespaceCollector.swift
+++ b/Source/SwiftLintFramework/Helpers/NamespaceCollector.swift
@@ -9,7 +9,7 @@ struct NamespaceCollector {
 
         init?(dictionary: SourceKittenDictionary, namespace: [String]) {
             guard let name = dictionary.name,
-                let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
+                let kind = dictionary.declarationKind,
                 let offset = dictionary.offset else {
                     return nil
             }

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -3,9 +3,10 @@ import SourceKittenFramework
 public protocol ASTRule: Rule {
     associatedtype KindType: RawRepresentable
     func validate(file: File, kind: KindType, dictionary: SourceKittenDictionary) -> [StyleViolation]
+    func kind(from dictionary: SourceKittenDictionary) -> KindType?
 }
 
-public extension ASTRule where KindType.RawValue == String {
+public extension ASTRule {
     func validate(file: File) -> [StyleViolation] {
         return validate(file: file, dictionary: file.structureDictionary)
     }
@@ -14,12 +15,29 @@ public extension ASTRule where KindType.RawValue == String {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict)
 
-            if let kindString = subDict.kind,
-                let kind = KindType(rawValue: kindString) {
+            if let kind = self.kind(from: subDict) {
                 violations += validate(file: file, kind: kind, dictionary: subDict)
             }
 
             return violations
         }
+    }
+}
+
+public extension ASTRule where KindType == SwiftDeclarationKind {
+    func kind(from dictionary: SourceKittenDictionary) -> KindType? {
+        return dictionary.declarationKind
+    }
+}
+
+public extension ASTRule where KindType == SwiftExpressionKind {
+    func kind(from dictionary: SourceKittenDictionary) -> KindType? {
+        return dictionary.expressionKind
+    }
+}
+
+public extension ASTRule where KindType == StatementKind {
+    func kind(from dictionary: SourceKittenDictionary) -> KindType? {
+        return dictionary.statementKind
     }
 }

--- a/Source/SwiftLintFramework/Protocols/CallPairRule.swift
+++ b/Source/SwiftLintFramework/Protocols/CallPairRule.swift
@@ -69,8 +69,7 @@ extension CallPairRule {
     private func methodCall(forByteOffset byteOffset: Int, excludingOffset: Int,
                             dictionary: SourceKittenDictionary,
                             predicate: (SourceKittenDictionary) -> Bool) -> Int? {
-        if let kindString = dictionary.kind,
-            SwiftExpressionKind(rawValue: kindString) == .call,
+        if dictionary.expressionKind == .call,
             let bodyOffset = dictionary.offset,
             let bodyLength = dictionary.length,
             let offset = dictionary.offset {

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -108,7 +108,7 @@ extension SubstitutionCorrectableASTRule where KindType.RawValue == String {
         let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges = violationRanges(in: file, dictionary: subDict)
 
-            if let kind = subDict.kind.flatMap(KindType.init) {
+            if let kind = self.kind(from: subDict) {
                 ranges += violationRanges(in: file, kind: kind, dictionary: subDict)
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -70,7 +70,7 @@ public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule, AutomaticTe
 private extension Array where Element == SourceKittenDictionary {
     var parameterTypes: [String] {
         return compactMap { element in
-            guard element.kind.flatMap(SwiftDeclarationKind.init) == .varParameter else {
+            guard element.declarationKind == .varParameter else {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -67,7 +67,7 @@ public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule
         }
 
         let containsInstanceDeclarations = dictionary.substructure.contains { dict in
-            guard let kind = dict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) else {
+            guard let kind = dict.declarationKind else {
                 return false
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -70,7 +70,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
                 return nil
             }
 
-            guard let kind = element.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
+            guard let kind = element.declarationKind,
                 !extensionKinds.contains(kind) else {
                     return nil
             }
@@ -116,7 +116,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
 
     private func internalTypeElements(in element: SourceKittenElement) -> [SourceKittenElement] {
         return element.substructure.flatMap { element -> [SourceKittenElement] in
-            guard let elementKind = element.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) else {
+            guard let elementKind = element.declarationKind else {
                 return []
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -125,11 +125,11 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
                 return []
             }
 
-            let isPrivate = element.accessibility.flatMap(AccessControlLevel.init(rawValue:))?.isPrivate ?? false
+            let isPrivate = element.accessibility?.isPrivate ?? false
             let internalTypeElementsInSubstructure = elementKind.childsAreExemptFromACL || isPrivate ? [] :
                 internalTypeElements(in: element)
 
-            if element.accessibility.flatMap(AccessControlLevel.init(identifier:)) == .internal {
+            if element.accessibility == .internal {
                 return internalTypeElementsInSubstructure + [element]
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -112,7 +112,7 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
     private func substructureElements(of dict: SourceKittenDictionary,
                                       matching kind: SwiftDeclarationKind) -> [SourceKittenDictionary] {
         return dict.substructure
-            .filter { $0.kind.flatMap(SwiftDeclarationKind.init) == kind }
+            .filter { $0.declarationKind == kind }
     }
 
     private func enumElementsMissingInitExpr(

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -39,7 +39,7 @@ public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, Aut
         let dictionary = file.structureDictionary
         let internalTypesOffsets = dictionary.substructure.compactMap { element -> Int? in
             // ignore extensions
-            guard let kind = element.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
+            guard let kind = element.declarationKind,
                 !extensionKinds.contains(kind) else {
                     return nil
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -44,7 +44,7 @@ public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, Aut
                     return nil
             }
 
-            if element.accessibility.flatMap(AccessControlLevel.init(identifier:)) == .internal {
+            if element.accessibility == .internal {
                 return element.offset
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -76,8 +76,7 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
         return dictionary.substructure.flatMap({ subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict, parentStructure: dictionary)
 
-            if let kindString = subDict.kind,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
+            if let kind = subDict.declarationKind {
                 violations += validate(file: file, kind: kind, dictionary: subDict, parentStructure: dictionary)
             }
 
@@ -157,9 +156,8 @@ private extension SourceKittenDictionary {
     }
 
     func contains(_ statements: Set<StatementKind>) -> Bool {
-        guard let kind = kind,
-              let statement = StatementKind(rawValue: kind) else {
-                return false
+        guard let statement = statementKind else {
+            return false
         }
         return statements.contains(statement)
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -84,7 +84,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
         }
 
         let declarations = dictionary.substructure.compactMap { entry -> (acl: AccessControlLevel, offset: Int)? in
-            guard entry.kind.flatMap(SwiftDeclarationKind.init) != nil,
+            guard entry.declarationKind != nil,
                 let acl = entry.accessibility.flatMap(AccessControlLevel.init(identifier:)),
                 let offset = entry.offset else {
                 return nil

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -85,7 +85,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
 
         let declarations = dictionary.substructure.compactMap { entry -> (acl: AccessControlLevel, offset: Int)? in
             guard entry.declarationKind != nil,
-                let acl = entry.accessibility.flatMap(AccessControlLevel.init(identifier:)),
+                let acl = entry.accessibility,
                 let offset = entry.offset else {
                 return nil
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -6,7 +6,7 @@ private let typeAndExtensionKinds = SwiftDeclarationKind.typeKinds + [.extension
 private extension SourceKittenDictionary {
     func recursiveDeclaredTypeNames() -> [String] {
         let subNames = substructure.flatMap { $0.recursiveDeclaredTypeNames() }
-        if let kind = kind.flatMap(SwiftDeclarationKind.init),
+        if let kind = declarationKind,
             typeAndExtensionKinds.contains(kind), let name = name {
             return [name] + subNames
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -93,7 +93,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
             let subDictionary = forBody(dictionary: dictionary),
             subDictionary.substructure.count == 1,
             let bodyDictionary = subDictionary.substructure.first,
-            bodyDictionary.kind.flatMap(StatementKind.init) == .if,
+            bodyDictionary.statementKind == .if,
             isOnlyOneIf(dictionary: bodyDictionary),
             isOnlyIfInsideFor(forDictionary: subDictionary, ifDictionary: bodyDictionary, file: file),
             !isComplexCondition(dictionary: bodyDictionary, file: file),
@@ -110,7 +110,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
 
     private func forBody(dictionary: SourceKittenDictionary) -> SourceKittenDictionary? {
         return dictionary.substructure.first(where: { subDict -> Bool in
-            subDict.kind.flatMap(StatementKind.init) == .brace
+            subDict.statementKind == .brace
         })
     }
 
@@ -120,7 +120,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
             return false
         }
 
-        return dictionary.substructure.first?.kind.flatMap(StatementKind.init) == .brace
+        return dictionary.substructure.first?.statementKind == .brace
     }
 
     private func isOnlyIfInsideFor(forDictionary: SourceKittenDictionary,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -49,7 +49,7 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
         let isNotClosure = { !self.isClosureParameter(dictionary: $0) }
         let params = dictionary.substructure
             .flatMap { subDict -> [SourceKittenDictionary] in
-                guard subDict.kind.flatMap(SwiftDeclarationKind.init) == .varParameter else {
+                guard subDict.declarationKind == .varParameter else {
                     return []
                 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -165,7 +165,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
                             dictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
         return dictionary.substructure.flatMap { subDict -> [SourceKittenDictionary] in
             var dictionaries = violations(in: file, dictionary: subDict)
-            if let kind = subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) {
+            if let kind = subDict.expressionKind {
                 dictionaries += violations(in: file, kind: kind, dictionary: subDict)
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -127,8 +127,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
 
                 let containsCall = file.structureDictionary.structures(forByteOffset: byteRange.upperBound - 1)
                     .contains(where: { dict -> Bool in
-                        return dict.kind.flatMap(SwiftExpressionKind.init) == .call &&
-                            (dict.name ?? "").starts(with: "expect")
+                        return dict.expressionKind == .call && (dict.name ?? "").starts(with: "expect")
                     })
 
                 return containsCall

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -74,7 +74,7 @@ public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, Substitutio
             }
 
             if !configuration.validateExtensions &&
-                dictionary.kind.flatMap(SwiftDeclarationKind.init) == .extension {
+                dictionary.declarationKind == .extension {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -37,8 +37,7 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
             var violations = violationRanges(file: file, dictionary: subDict, parentStructure: dictionary)
 
-            if let kindString = subDict.kind,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
+            if let kind = subDict.declarationKind {
                 violations += violationRanges(file: file, kind: kind, dictionary: subDict, parentStructure: dictionary)
             }
 
@@ -61,8 +60,8 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
 
         let isInObjcVisibleScope = { () -> Bool in
             guard let parentStructure = parentStructure,
-                let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
-                let parentKind = parentStructure.kind.flatMap(SwiftDeclarationKind.init),
+                let kind = dictionary.declarationKind,
+                let parentKind = parentStructure.declarationKind,
                 let acl = dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:)) else {
                     return false
             }
@@ -91,7 +90,7 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
 
 private extension SourceKittenDictionary {
     var isObjcAndIBDesignableDeclaredExtension: Bool {
-        guard let kind = kind, let declaration = SwiftDeclarationKind(rawValue: kind) else {
+        guard let declaration = declarationKind else {
             return false
         }
         return [.extensionClass, .extension].contains(declaration)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -62,7 +62,7 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
             guard let parentStructure = parentStructure,
                 let kind = dictionary.declarationKind,
                 let parentKind = parentStructure.declarationKind,
-                let acl = dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:)) else {
+                let acl = dictionary.accessibility else {
                     return false
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -55,8 +55,7 @@ public struct RedundantSetAccessControlRule: ConfigurationProviderRule, Automati
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict, parentDictionary: dictionary)
 
-            if let kindString = subDict.kind,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
+            if let kind = subDict.declarationKind {
                 violations += validate(file: file, kind: kind, dictionary: subDict, parentDictionary: dictionary)
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -76,9 +76,9 @@ public struct RedundantSetAccessControlRule: ConfigurationProviderRule, Automati
             return attribute
         }.first
 
-        let acl = dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:))
+        let acl = dictionary.accessibility
         let resolvedAccessibility: AccessControlLevel? = explicitACL?.acl ?? {
-            let parentACL = parentDictionary?.accessibility.flatMap(AccessControlLevel.init(identifier:))
+            let parentACL = parentDictionary?.accessibility
 
             if acl == .internal, let parentACL = parentACL, parentACL == .fileprivate {
                 return .fileprivate
@@ -101,7 +101,7 @@ public struct RedundantSetAccessControlRule: ConfigurationProviderRule, Automati
         }
 
         // if it's an inferred `private`, it means the variable is actually inside a fileprivate structure
-        if dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:)) == .private,
+        if dictionary.accessibility == .private,
             explicitACL == nil,
             dictionary.setterAccessibility.flatMap(AccessControlLevel.init(identifier:)) == .private {
                 return []

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -3,8 +3,7 @@ import SourceKittenFramework
 private func children(of dict: SourceKittenDictionary,
                       matching kind: SwiftDeclarationKind) -> [SourceKittenDictionary] {
     return dict.substructure.compactMap { subDict in
-        if let kindString = subDict.kind,
-            SwiftDeclarationKind(rawValue: kindString) == kind {
+        if subDict.declarationKind == kind {
             return subDict
         }
         return nil

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -100,7 +100,7 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
     private func isIBInspectable(range: NSRange, file: File) -> Bool {
         guard let byteRange = file.contents.bridge().NSRangeToByteRange(start: range.location, length: range.length),
             let dict = file.structureDictionary.structures(forByteOffset: byteRange.location).last,
-            let kind = dict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
+            let kind = dict.declarationKind,
             SwiftDeclarationKind.variableKinds.contains(kind) else {
                 return false
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -60,7 +60,7 @@ public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptIn
         }
 
         let containsFatalError = dictionary.substructure.contains { dict -> Bool in
-            return dict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call && dict.name == "fatalError"
+            return dict.expressionKind == .call && dict.name == "fatalError"
         }
 
         guard let offset = dictionary.offset, containsFatalError,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -37,7 +37,7 @@ public struct UnneededBreakInSwitchRule: ConfigurationProviderRule, AutomaticTes
             let contents = file.contents.bridge()
             guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length),
                 let innerStructure = file.structureDictionary.structures(forByteOffset: byteRange.location).last,
-                innerStructure.kind.flatMap(StatementKind.init) == .case,
+                innerStructure.statementKind == .case,
                 let caseOffset = innerStructure.offset,
                 let caseLength = innerStructure.length,
                 let lastPatternEnd = patternEnd(dictionary: innerStructure) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -70,8 +70,7 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule, Automati
 
     private func isEnumeratedCall(dictionary: SourceKittenDictionary) -> Bool {
         for subDict in dictionary.substructure {
-            guard let kindString = subDict.kind,
-                SwiftExpressionKind(rawValue: kindString) == .call,
+            guard subDict.expressionKind == .call,
                 let name = subDict.name else {
                     continue
             }

--- a/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
@@ -68,8 +68,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validateAttributes(file: file, dictionary: subDict)
 
-            if let kindString = subDict.kind,
-                let kind = SwiftDeclarationKind(rawValue: kindString) {
+            if let kind = subDict.declarationKind {
                 violations += validateAttributes(file: file, kind: kind, dictionary: subDict)
             }
 

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -93,11 +93,10 @@ private extension SourceKittenDictionary {
                     return
             }
 
-            if let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
+            if let kind = dictionary.declarationKind,
                 SwiftDeclarationKind.functionKinds.contains(kind) {
                 results.append(dictionary)
             }
-            dictionary.substructure.forEach(parse)
         }
         parse(self)
         return results

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -97,6 +97,7 @@ private extension SourceKittenDictionary {
                 SwiftDeclarationKind.functionKinds.contains(kind) {
                 results.append(dictionary)
             }
+            dictionary.substructure.forEach(parse)
         }
         parse(self)
         return results

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -70,6 +70,6 @@ public struct DuplicateEnumCasesRule: ConfigurationProviderRule, ASTRule, Automa
     private func substructureElements(of dict: SourceKittenDictionary,
                                       matching kind: SwiftDeclarationKind) -> [SourceKittenDictionary] {
         return dict.substructure
-            .filter { $0.kind.flatMap(SwiftDeclarationKind.init) == kind }
+            .filter { $0.declarationKind == kind }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -23,9 +23,7 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule,
     private func testClasses(in file: File) -> [SourceKittenDictionary] {
         let dict = file.structureDictionary
         return dict.substructure.filter { dictionary in
-            guard
-                let kind = dictionary.kind,
-                SwiftDeclarationKind(rawValue: kind) == .class else { return false }
+            guard dictionary.declarationKind == .class else { return false }
             return dictionary.inheritedTypes.contains("XCTestCase")
         }
     }
@@ -34,7 +32,7 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule,
                             for dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return dictionary.substructure.compactMap { subDictionary -> StyleViolation? in
             guard
-                let kind = subDictionary.kind.flatMap(SwiftDeclarationKind.init),
+                let kind = subDictionary.declarationKind,
                 SwiftDeclarationKind.functionKinds.contains(kind),
                 let name = subDictionary.name, isXCTestMethod(name),
                 let offset = subDictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -43,7 +43,7 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
     private func validateACL(isHigherThan parentAccessibility: AccessControlLevel,
                              in substructure: SourceKittenDictionary) -> [Int] {
         return substructure.substructure.flatMap { element -> [Int] in
-            guard let elementKind = element.kind.flatMap(SwiftDeclarationKind.init),
+            guard let elementKind = element.declarationKind,
                 elementKind.isRelevantDeclaration else {
                 return []
             }

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -49,7 +49,7 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
             }
 
             var violationOffset: Int?
-            let accessibility = element.accessibility.flatMap(AccessControlLevel.init(identifier:)) ?? .internal
+            let accessibility = element.accessibility ?? .internal
             // Swift 5 infers members of private types with no explicit ACL attribute to be `internal`.
             let isInferredACL = accessibility == .internal && !element.enclosedSwiftAttributes.contains(.internal)
             if !isInferredACL, accessibility.priority > parentAccessibility.priority {

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -12,7 +12,7 @@ private extension File {
         }
         let extensionKinds: Set<SwiftDeclarationKind> = [.extension, .extensionEnum, .extensionClass,
                                                          .extensionStruct, .extensionProtocol]
-        guard let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
+        guard let kind = dictionary.declarationKind,
             !extensionKinds.contains(kind),
             case let isDeinit = kind == .functionMethodInstance && dictionary.name == "deinit",
             !isDeinit,

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -17,8 +17,7 @@ private extension File {
             case let isDeinit = kind == .functionMethodInstance && dictionary.name == "deinit",
             !isDeinit,
             let offset = dictionary.offset,
-            let accessibility = dictionary.accessibility,
-            let acl = AccessControlLevel(identifier: accessibility),
+            let acl = dictionary.accessibility,
             acls.contains(acl) else {
                 return substructureOffsets
         }

--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -24,9 +24,7 @@ public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, Automa
         let dict = file.structureDictionary
 
         return dict.substructure.filter { dictionary in
-            guard
-                let kind = dictionary.kind,
-                SwiftDeclarationKind(rawValue: kind) == .class
+            guard dictionary.declarationKind == .class
             else { return false }
             let isDirectNSObjectSubclass = dictionary.inheritedTypes.contains("NSObject")
             let isMarkedObjc = dictionary.enclosedSwiftAttributes.contains(.objc)
@@ -51,7 +49,7 @@ public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, Automa
     private func isDoubleEqualsMethod(_ method: SourceKittenDictionary,
                                       onType typeName: String) -> Bool {
         guard
-            let kind = method.kind.flatMap(SwiftDeclarationKind.init),
+            let kind = method.declarationKind,
             let name = method.name,
             kind == .functionMethodStatic,
             name == "==(_:_:)",

--- a/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
@@ -32,12 +32,12 @@ public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRu
                                   dictionary: SourceKittenDictionary) -> [Int] {
         return dictionary.substructure.flatMap { subDict -> [Int] in
             // complete detachment is allowed on `deinit`
-            if subDict.kind.flatMap(SwiftDeclarationKind.init) == .functionMethodInstance,
+            if subDict.declarationKind == .functionMethodInstance,
                 subDict.name == "deinit" {
                 return []
             }
 
-            if subDict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call,
+            if subDict.expressionKind == .call,
                 subDict.name == methodName,
                 parameterIsSelf(dictionary: subDict, file: file),
                 let offset = subDict.offset {

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -41,7 +41,7 @@ public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, Aut
             .filter { $0.kind == .extension && !susceptibleNames.contains($0.name) }
             .flatMap { element in
                 return element.dictionary.substructure.compactMap { element -> Int? in
-                    guard element.kind.flatMap(SwiftDeclarationKind.init) != nil,
+                    guard element.declarationKind != nil,
                         element.enclosedSwiftAttributes.contains(.override),
                         let offset = element.offset else {
                             return nil

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
@@ -40,7 +40,7 @@ public struct PrivateActionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
             let offset = dictionary.offset,
             kind == .functionMethodInstance,
             dictionary.enclosedSwiftAttributes.contains(.ibaction),
-            let controlLevel = dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:)),
+            let controlLevel = dictionary.accessibility,
             controlLevel.isPrivate == false
             else {
                 return []

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -34,7 +34,7 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
         guard isOutlet else { return [] }
 
         // Check if private
-        let isPrivate = isPrivateLevel(identifier: dictionary.accessibility)
+        let isPrivate = dictionary.accessibility?.isPrivate ?? false
         let isPrivateSet = isPrivateLevel(identifier: dictionary.setterAccessibility)
 
         if isPrivate || (configuration.allowPrivateSet && isPrivateSet) {

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
@@ -11,15 +11,14 @@ private extension AccessControlLevel {
 
 private extension SourceKittenDictionary {
     var superclass: String? {
-        guard let kindString = self.kind,
-            let kind = SwiftDeclarationKind(rawValue: kindString), kind == .class,
+        guard declarationKind == .class,
             let className = inheritedTypes.first else { return nil }
         return className
     }
 
     var parameters: [SourceKittenDictionary] {
         return substructure.filter { dict in
-            guard let kind = dict.kind.flatMap(SwiftDeclarationKind.init) else {
+            guard let kind = dict.declarationKind else {
                 return false
             }
 
@@ -144,7 +143,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDesc
 
     private func validateFunction(file: File,
                                   dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        guard let kind = dictionary.kind.flatMap(SwiftDeclarationKind.init),
+        guard let kind = dictionary.declarationKind,
             kind == .functionMethodInstance,
             let name = dictionary.name, name.hasPrefix("test"),
             dictionary.parameters.isEmpty else {

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
@@ -1,14 +1,6 @@
 import Foundation
 import SourceKittenFramework
 
-private extension AccessControlLevel {
-    init?(_ dictionary: SourceKittenDictionary) {
-        guard let accessibility = dictionary.accessibility,
-            let acl = AccessControlLevel(rawValue: accessibility) else { return nil }
-        self = acl
-    }
-}
-
 private extension SourceKittenDictionary {
     var superclass: String? {
         guard declarationKind == .class,
@@ -154,7 +146,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDesc
 
     private func validateAccessControlLevel(file: File,
                                             dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        guard let acl = AccessControlLevel(dictionary), acl.isPrivate,
+        guard let acl = dictionary.accessibility, acl.isPrivate,
             !dictionary.enclosedSwiftAttributes.contains(.objc)
             else { return [] }
         let offset = dictionary.offset ?? 0

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -18,13 +18,13 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
         let dict = file.structureDictionary
         let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.contains("QuickSpec") &&
-                $0.kind.flatMap(SwiftDeclarationKind.init) == .class
+                $0.declarationKind == .class
         }
 
         let specDeclarations = testClasses.flatMap { classDict in
             return classDict.substructure.filter {
                 return $0.name == "spec()" && $0.enclosedVarParameters.isEmpty &&
-                    $0.kind.flatMap(SwiftDeclarationKind.init) == .functionMethodInstance &&
+                    $0.declarationKind == .functionMethodInstance &&
                     $0.enclosedSwiftAttributes.contains(.override)
             }
         }
@@ -38,8 +38,7 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict)
 
-            if let kindString = subDict.kind,
-                let kind = SwiftExpressionKind(rawValue: kindString) {
+            if let kind = subDict.expressionKind {
                 violations += validate(file: file, kind: kind, dictionary: subDict)
             }
 

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -18,13 +18,13 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
         let dict = file.structureDictionary
         let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.contains("QuickSpec") &&
-                $0.kind.flatMap(SwiftDeclarationKind.init) == .class
+                $0.declarationKind == .class
         }
 
         let specDeclarations = testClasses.flatMap { classDict in
             return classDict.substructure.filter {
                 return $0.name == "spec()" && $0.enclosedVarParameters.isEmpty &&
-                    $0.kind.flatMap(SwiftDeclarationKind.init) == .functionMethodInstance &&
+                    $0.declarationKind == .functionMethodInstance &&
                     $0.enclosedSwiftAttributes.contains(.override)
             }
         }
@@ -38,8 +38,7 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
         return dictionary.substructure.flatMap { subDict -> [StyleViolation] in
             var violations = validate(file: file, dictionary: subDict)
 
-            if let kindString = subDict.kind,
-                let kind = SwiftExpressionKind(rawValue: kindString) {
+            if let kind = subDict.expressionKind {
                 violations += validate(file: file, kind: kind, dictionary: subDict)
             }
 

--- a/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -115,7 +115,7 @@ AutomaticTestableRule {
 
     private func substructureElements(of dict: SourceKittenDictionary,
                                       matching kind: SwiftDeclarationKind) -> [SourceKittenDictionary] {
-        return dict.substructure.filter { $0.kind.flatMap(SwiftDeclarationKind.init) == kind }
+        return dict.substructure.filter { $0.declarationKind == kind }
     }
 
     private func camelCasedEnumCasesMissingRawValue(

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -98,7 +98,7 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
         /// - Returns: Names of cases found in the enum.
         static func cases(from dictionary: SourceKittenDictionary) -> [String] {
             let caseSubstructures = dictionary.substructure.filter { dict in
-                return dict.kind.flatMap(SwiftDeclarationKind.init(rawValue:)) == .enumcase
+                return dict.declarationKind == .enumcase
             }.flatMap { $0.substructure }
 
             return caseSubstructures.compactMap { $0.name }.map { name in

--- a/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -64,8 +64,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
         var results = [SourceKittenDictionary]()
 
         func parse(dictionary: SourceKittenDictionary) {
-            if let kindString = (dictionary.kind),
-                SwiftDeclarationKind(rawValue: kindString) == .varLocal,
+            if dictionary.declarationKind == .varLocal,
                 let offset = dictionary.offset,
                 let length = dictionary.length {
                 let variableByteRange = NSRange(location: offset, length: length)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -173,7 +173,7 @@ private extension File {
         -> (usr: String, nameOffset: Int)? {
         if let offset = cursorInfo.swiftlintOffset,
             let usr = cursorInfo.usr,
-            let kind = cursorInfo.kind.flatMap(SwiftDeclarationKind.init(rawValue:)),
+            let kind = cursorInfo.declarationKind,
             !declarationKindsToSkip.contains(kind),
             let acl = cursorInfo.accessibility.flatMap(AccessControlLevel.init(rawValue:)),
             includePublicAndOpen || [.internal, .private, .fileprivate].contains(acl) {
@@ -227,7 +227,7 @@ private extension File {
     }
 
     private static func testCaseUSR(cursorInfo: SourceKittenDictionary) -> String? {
-        if let kind = (cursorInfo.kind).flatMap(SwiftDeclarationKind.init(rawValue:)),
+        if let kind = cursorInfo.declarationKind,
             kind == .class,
             let annotatedDecl = cursorInfo.annotatedDeclaration,
             annotatedDecl.contains("<Type usr=\"c:objc(cs)XCTestCase\">XCTestCase</Type>"),

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -196,8 +196,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
         func parse(dictionary: SourceKittenDictionary, parentKind: SwiftDeclarationKind?) {
             // Only accepts declarations which contains a body and contains the
             // searched byteOffset
-            guard let kindString = dictionary.kind,
-                let kind = SwiftDeclarationKind(rawValue: kindString),
+            guard let kind = dictionary.declarationKind,
                 let bodyOffset = dictionary.bodyOffset,
                 let bodyLength = dictionary.bodyLength,
                 case let byteRange = NSRange(location: bodyOffset, length: bodyLength),

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -82,8 +82,7 @@ public struct WeakDelegateRule: ASTRule, ConfigurationProviderRule, AutomaticTes
         func parse(dictionary: SourceKittenDictionary) {
             // Only accepts protocols declarations which contains a body and contains the
             // searched byteOffset
-            if let kindString = (dictionary.kind),
-                SwiftDeclarationKind(rawValue: kindString) == .protocol,
+            if dictionary.declarationKind == .protocol,
                 let offset = dictionary.bodyOffset,
                 let length = dictionary.bodyLength {
                 let byteRange = NSRange(location: offset, length: length)

--- a/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
@@ -56,16 +56,16 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
         var hasSwitchStatements = false
 
         let complexity = dictionary.substructure.reduce(0) { complexity, subDict in
-            guard let kind = subDict.kind else {
+            guard subDict.kind != nil else {
                 return complexity
             }
 
-            if let declarationKind = SwiftDeclarationKind(rawValue: kind),
+            if let declarationKind = subDict.declarationKind,
                 SwiftDeclarationKind.functionKinds.contains(declarationKind) {
                 return complexity
             }
 
-            guard let statementKind = StatementKind(rawValue: kind) else {
+            guard let statementKind = subDict.statementKind else {
                 return complexity + measureComplexity(in: file, dictionary: subDict)
             }
 

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
@@ -82,7 +82,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
                                            offset: Int, length: Int) -> Int {
         var parameterCount = 0
         for subDict in structure {
-            guard let key = subDict.kind,
+            guard subDict.kind != nil,
                 let parameterOffset = subDict.offset else {
                     continue
             }
@@ -91,7 +91,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
                 return parameterCount
             }
 
-            if SwiftDeclarationKind(rawValue: key) == .varParameter {
+            if subDict.declarationKind == .varParameter {
                 parameterCount += 1
             }
         }

--- a/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
@@ -52,7 +52,7 @@ public struct NestingRule: ASTRule, ConfigurationProviderRule, AutomaticTestable
             }
         }
         violations.append(contentsOf: dictionary.substructure.compactMap { subDict in
-            if let kind = (subDict.kind).flatMap(SwiftDeclarationKind.init) {
+            if let kind = subDict.declarationKind {
                 return (kind, subDict)
             }
             return nil

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -41,7 +41,7 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
         ) { dictionary in
             if
                 !dictionary.substructure.isEmpty &&
-                dictionary.substructure.last?.kind.flatMap(SwiftExpressionKind.init) != .argument &&
+                dictionary.substructure.last?.expressionKind != .argument &&
                 dictionary.substructure.last?.name != "NSPredicate"
             {
                 return true // has a substructure, like a closure

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
@@ -125,13 +125,9 @@ public struct ReduceIntoRule: ASTRule, ConfigurationProviderRule, OptInRule, Aut
 
     private func argumentIsCopyOnWriteType(_ argument: SourceKittenDictionary, file: File) -> Bool {
         if let substructure = argument.substructure.first,
-            let kind = substructure.kind {
-            switch kind {
-            case SwiftExpressionKind.array.rawValue,
-                 SwiftExpressionKind.dictionary.rawValue:
+            let kind = substructure.expressionKind {
+            if kind == .array || kind == .dictionary {
                 return true
-            default:
-                break
             }
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -120,8 +120,7 @@ extension ClosureEndIndentationRule {
         return dictionary.substructure.flatMap { subDict -> [Violation] in
             var subViolations = violations(in: file, dictionary: subDict)
 
-            if let kindString = subDict.kind,
-                let kind = SwiftExpressionKind(rawValue: kindString) {
+            if let kind = subDict.expressionKind {
                 subViolations += violations(in: file, of: kind, dictionary: subDict)
             }
 

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+Dictionary.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+Dictionary.swift
@@ -10,7 +10,7 @@ extension ColonRule {
 
         let ranges = dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges: [NSRange] = []
-            if let kind = subDict.kind.flatMap(KindType.init(rawValue:)) {
+            if let kind = subDict.expressionKind {
                 ranges += dictionaryColonViolationRanges(in: file, kind: kind, dictionary: subDict)
             }
             ranges += dictionaryColonViolationRanges(in: file, dictionary: subDict)

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+FunctionCall.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+FunctionCall.swift
@@ -6,9 +6,8 @@ extension ColonRule {
                                                    dictionary: SourceKittenDictionary) -> [NSRange] {
         return dictionary.substructure.flatMap { subDict -> [NSRange] in
             var ranges: [NSRange] = []
-            if let kindString = subDict.kind,
-                let kind = KindType(rawValue: kindString) {
-                    ranges += functionCallColonViolationRanges(in: file, kind: kind, dictionary: subDict)
+            if let kind = subDict.expressionKind {
+                ranges += functionCallColonViolationRanges(in: file, kind: kind, dictionary: subDict)
             }
             ranges += functionCallColonViolationRanges(in: file, dictionary: subDict)
             return ranges

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -76,7 +76,7 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
         let contents = file.contents.bridge()
 
         let callsRanges = dictionary.substructure.compactMap { dict -> NSRange? in
-            guard dict.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call,
+            guard dict.expressionKind == .call,
                 let offset = dict.offset,
                 let length = dict.length,
                 let range = contents.byteRangeToNSRange(start: offset, length: length) else {

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -76,7 +76,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
 
         // avoid the more expensive regex match if there's no trailing closure in the substructure
         if SwiftVersion.current >= .fourDotTwo,
-            dictionary.substructure.last?.kind.flatMap(SwiftExpressionKind.init(rawValue:)) != .closure {
+            dictionary.substructure.last?.expressionKind != .closure {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -105,8 +105,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
 
         let dict = file.structureDictionary
         return dict.substructure.filter { substructure in
-            guard let kind = substructure.kind else { return false }
-            guard let declarationKind = SwiftDeclarationKind(rawValue: kind) else { return false }
+            guard let declarationKind = substructure.declarationKind else { return false }
 
             return substructure.value.bridge() != mainTypeSubstructure.value.bridge() &&
                 supportingTypeKinds.contains(declarationKind)
@@ -131,11 +130,10 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
 
     private func mainTypeSubstructure(in dict: SourceKittenDictionary) -> SourceKittenDictionary? {
         let priorityKinds: [SwiftDeclarationKind] = [.class, .enum, .struct]
-        let priorityKindRawValues = priorityKinds.map { $0.rawValue }
 
         let priorityKindSubstructures = dict.substructure.filter { substructure in
-            guard let kind = substructure.kind else { return false }
-            return priorityKindRawValues.contains(kind)
+            guard let kind = substructure.declarationKind else { return false }
+            return priorityKinds.contains(kind)
         }
 
         let substructuresSortedByBodyLength = priorityKindSubstructures.sorted { lhs, rhs in

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
@@ -201,7 +201,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
                 return nil
             }
 
-            let kind = dict.kind.flatMap(SwiftDeclarationKind.init(rawValue:))
+            let kind = dict.declarationKind
             return (token.offset, kind)
         }
 
@@ -229,8 +229,7 @@ private extension ImplicitGetterRule {
         func parse(dictionary: SourceKittenDictionary, parentKind: SwiftDeclarationKind?) {
             // Only accepts declarations which contains a body and contains the
             // searched byteOffset
-            guard let kindString = dictionary.kind,
-                let kind = SwiftDeclarationKind(rawValue: kindString),
+            guard let kind = dictionary.declarationKind,
                 let bodyOffset = dictionary.bodyOffset,
                 let bodyLength = dictionary.bodyLength,
                 case let byteRange = NSRange(location: bodyOffset, length: bodyLength),

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -186,8 +186,7 @@ extension LiteralExpressionEndIdentationRule {
         return dictionary.substructure.flatMap { subDict -> [Violation] in
             var subViolations = violations(in: file, dictionary: subDict)
 
-            if let kindString = subDict.kind,
-                let kind = SwiftExpressionKind(rawValue: kindString),
+            if let kind = subDict.expressionKind,
                 let violation = violation(in: file, of: kind, dictionary: subDict) {
                 subViolations.append(violation)
             }

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -64,8 +64,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         return dictionary.substructure.flatMap { subDict -> [Correction] in
             var corrections = correct(file: file, dictionary: subDict)
 
-            if let kindString = subDict.kind,
-                let kind = KindType(rawValue: kindString) {
+            if let kind = subDict.declarationKind {
                 corrections += correct(file: file, kind: kind, dictionary: subDict)
             }
 
@@ -192,13 +191,13 @@ private extension SourceKittenDictionary {
     }
 
     private func kindsAndOffsets(in declarationKinds: [SwiftDeclarationKind]) -> SourceKittenDictionary? {
-        guard let kind = kind, let offset = offset,
-            let declarationKind = SwiftDeclarationKind(rawValue: kind),
+        guard let offset = offset,
+            let declarationKind = declarationKind,
             declarationKinds.contains(declarationKind) else {
                 return nil
         }
 
-        return SourceKittenDictionary(["key.kind": kind, "key.offset": Int64(offset)])
+        return SourceKittenDictionary(["key.kind": declarationKind.rawValue, "key.offset": Int64(offset)])
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -213,7 +213,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
 private extension SourceKittenDictionary {
     var subcalls: [SourceKittenDictionary] {
         return substructure.compactMap { dictionary -> SourceKittenDictionary? in
-            guard dictionary.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call else {
+            guard dictionary.expressionKind == .call else {
                 return nil
             }
             return dictionary

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -95,7 +95,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
         var violations = [StyleViolation]()
 
         // find violations at current level
-        if let kindString = substructure.kind, let kind = SwiftDeclarationKind(rawValue: kindString),
+        if let kind = substructure.declarationKind,
             SwiftDeclarationKind.functionKinds.contains(kind) {
             guard
                 let nameOffset = substructure.nameOffset,
@@ -107,7 +107,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
 
             let isMultiline = functionName.contains("\n")
 
-            let parameters = substructure.substructure.filter { $0.kind == SwiftDeclarationKind.varParameter.rawValue }
+            let parameters = substructure.substructure.filter { $0.declarationKind == .varParameter }
             if isMultiline && !parameters.isEmpty {
                 if let openingBracketViolation = openingBracketViolation(parameters: parameters, file: file) {
                     violations.append(openingBracketViolation)

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
@@ -31,7 +31,7 @@ public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProvider
             guard
                 let offset = subStructure.offset,
                 let length = subStructure.length,
-                let kind = subStructure.kind, SwiftDeclarationKind(rawValue: kind) == .varParameter
+                subStructure.declarationKind == .varParameter
                 else {
                     return nil
             }

--- a/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -80,7 +80,7 @@ private extension Array where Element == SourceKittenDictionary {
         } else {
             return filter { argument in
                 return argument.substructure.contains(where: { dictionary in
-                    dictionary.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .closure
+                    dictionary.expressionKind == .closure
                 })
             }
         }

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -76,7 +76,7 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
 
         // Don't trigger if it's a single parameter trailing closure without parens
         if let subDict = dictionary.substructure.last,
-            subDict.kind.flatMap(SwiftExpressionKind.init) == .closure,
+            subDict.expressionKind == .closure,
             let closureBodyOffset = subDict.bodyOffset,
             closureBodyOffset == bodyOffset {
             return []

--- a/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -54,7 +54,7 @@ public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationPro
                          kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         if configuration.onlyPrivateMembers,
-            let acl = dictionary.accessibility.flatMap(AccessControlLevel.init(identifier:)), !acl.isPrivate {
+            let acl = dictionary.accessibility, !acl.isPrivate {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
@@ -63,7 +63,7 @@ public struct RedundantDiscardableLetRule: SubstitutionCorrectableRule, Configur
         }
 
         let kinds: Set<StatementKind> = [.if, .guard, .while]
-        if let kind = dictionary.kind.flatMap(StatementKind.init), kinds.contains(kind) {
+        if let kind = dictionary.statementKind, kinds.contains(kind) {
             let conditionKind = "source.lang.swift.structure.elem.condition_expr"
             for element in dictionary.elements where element.kind == conditionKind {
                 guard let elementOffset = element.offset,

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -45,11 +45,7 @@ public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule, A
     private func testClasses(in file: File) -> [SourceKittenDictionary] {
         let dict = file.structureDictionary
         return dict.substructure.filter { dictionary in
-            guard
-                let kind = dictionary.kind,
-                SwiftDeclarationKind(rawValue: kind) == .class
-                else { return false }
-
+            guard dictionary.declarationKind == .class else { return false }
             return !testClasses.isDisjoint(with: dictionary.inheritedTypes)
         }
     }

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -27,7 +27,7 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
 
         let caseStatements = dictionary.substructure.filter { subDict in
             // includes both `case` and `default` statements
-            return subDict.kind.flatMap(StatementKind.init) == .case
+            return subDict.statementKind == .case
         }
 
         if caseStatements.isEmpty {

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -42,16 +42,16 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
     private func violationOffsets(for dictionary: SourceKittenDictionary, file: File) -> [Int] {
         var results = [Int]()
 
-        if dictionary.kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .call,
+        if dictionary.expressionKind == .call,
             shouldBeTrailingClosure(dictionary: dictionary, file: file),
             let offset = dictionary.offset {
             results = [offset]
         }
 
-        if let kind = dictionary.kind.flatMap(StatementKind.init), kind != .brace {
+        if let kind = dictionary.statementKind, kind != .brace {
             // trailing closures are not allowed in `if`, `guard`, etc
             results += dictionary.substructure.flatMap { subDict -> [Int] in
-                guard subDict.kind.flatMap(StatementKind.init) == .brace else {
+                guard subDict.statementKind == .brace else {
                     return []
                 }
 

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -78,7 +78,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func typeContent(for typeContentStructure: SourceKittenDictionary) -> TypeContent? {
-        guard let typeContentKind = SwiftDeclarationKind(rawValue: typeContentStructure.kind!) else { return nil }
+        guard let typeContentKind = typeContentStructure.declarationKind else { return nil }
 
         switch typeContentKind {
         case .enumcase, .enumelement:

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -24,7 +24,7 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
         }
 
         let params = dictionary.substructure.filter { subDict in
-            return subDict.kind.flatMap(SwiftDeclarationKind.init) == .varParameter &&
+            return subDict.declarationKind == .varParameter &&
                 (subDict.offset ?? .max) < endOffset
         }
 


### PR DESCRIPTION
Since we have own dictionary, no need to have calculated properties for some parameters in dictionaries.
A lot of time was spent on conversion from `stringKind` of elements to some specific enum (i.e. `SwiftDeclarationKind`, `StatementKind`, `SwiftExpressionKind`)
![image](https://user-images.githubusercontent.com/119268/67629643-717d0880-f881-11e9-84ca-469105058638.png)

These were pre-cached in the dictionary, which allowed to 
1) Write a bit more type-safe code
2) Have a bit faster code (there's no need to converts Strings to enums all the time)
3) Some dictionary subscript unneeded access removed as well.

## Note
- Some parts of code still using `kind` as a string because there are no enums or enum cases that represent those strings
- If we're about to continue to use props caching in `SourceKittenDictionary`, we need to be careful, because if properties will take too much place in memory, `SourceKittenDictionary` will start behaving like a `class` and will be put on the heap.