### PR TITLE
Add allowed_symbols to type_name example

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ type_name:
     warning: 40
     error: 50
   excluded: iPhone # excluded via string
+  allowed_symbols: ["_"] # these are allowed in type names
 identifier_name:
   min_length: # only min_length
     error: 4 # only error


### PR DESCRIPTION
This extends the example by `allowed_symbols` for the `type_name` rule. There was an issue which is hard to find though. This way it is more discoverable.