### PR TITLE
Use a bit faster comparison in 'file_types_order' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 * Add GitHub Actions Logging reporter (`github-actions-logging`).  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Use faster comparison in 'file_types_order' rule.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)
+  [#2949](https://github.com/realm/SwiftLint/issues/2949)
+
 #### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -91,7 +91,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
         let dict = file.structureDictionary
         return dict.substructure.filter { substructure in
             guard let kind = substructure.kind else { return false }
-            return substructure.value.bridge() != mainTypeSubstructure.value.bridge() &&
+            return substructure.offset != mainTypeSubstructure.offset &&
                 kind.contains(SwiftDeclarationKind.extension.rawValue)
         }
     }
@@ -107,7 +107,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
         return dict.substructure.filter { substructure in
             guard let declarationKind = substructure.declarationKind else { return false }
 
-            return substructure.value.bridge() != mainTypeSubstructure.value.bridge() &&
+            return substructure.offset != mainTypeSubstructure.offset &&
                 supportingTypeKinds.contains(declarationKind)
         }
     }


### PR DESCRIPTION
In order to check whether the main structure is not of the substructures in the file, we don't need to make a deep diff. Instead, simple offset checking can be enough.