### PR TITLE
SubstitutionCorrectableRule return optional correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* Allow `SubstitutionCorrectableRule` to return `nil` instead of a correction
+  to indicate that a suitable correction couldn't be found for a specific case.  
+  [MaxHaertwig](https://github.com/maxhaertwig)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -69,7 +69,7 @@ public extension CorrectableRule {
 
 public protocol SubstitutionCorrectableRule: CorrectableRule {
     func violationRanges(in file: SwiftLintFile) -> [NSRange]
-    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)?
 }
 
 public extension SubstitutionCorrectableRule {
@@ -82,11 +82,11 @@ public extension SubstitutionCorrectableRule {
         var contents = file.contents
         for range in violatingRanges.sorted(by: { $0.location > $1.location }) {
             let contentsNSString = contents.bridge()
-
-            let (rangeToRemove, substitution) = self.substitution(for: range, in: file)
-            contents = contentsNSString.replacingCharacters(in: rangeToRemove, with: substitution)
-            let location = Location(file: file, characterOffset: range.location)
-            corrections.append(Correction(ruleDescription: description, location: location))
+            if let (rangeToRemove, substitution) = self.substitution(for: range, in: file) {
+                contents = contentsNSString.replacingCharacters(in: rangeToRemove, with: substitution)
+                let location = Location(file: file, characterOffset: range.location)
+                corrections.append(Correction(ruleDescription: description, location: location))
+            }
         }
 
         file.write(contents)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -83,7 +83,7 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
         return [range]
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -53,7 +53,7 @@ public struct JoinedDefaultParameterRule: SubstitutionCorrectableASTRule, Config
 
     // MARK: - SubstitutionCorrectableASTRule
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -91,7 +91,7 @@ public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, Substitutio
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "private")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -34,7 +34,7 @@ public struct RedundantNilCoalescingRule: OptInRule, SubstitutionCorrectableRule
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -89,7 +89,7 @@ private extension SourceKittenDictionary {
 }
 
 public extension RedundantObjcAttributeRule {
-     func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+     func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         var whitespaceAndNewlineOffset = 0
         let nsCharSet = CharacterSet.whitespacesAndNewlines.bridge()
         let nsContent = file.contents.bridge()

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -99,7 +99,7 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -64,7 +64,7 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -90,7 +90,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
         return [match]
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -82,7 +82,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
         return violationResults(in: file).map { $0.range }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         let contents = file.contents.bridge()
         let declaration = contents.substring(with: violationRange)
         let originalRange = NSRange(location: 0, length: declaration.count)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -46,7 +46,7 @@ public struct ToggleBoolRule: SubstitutionCorrectableRule, ConfigurationProvider
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds)
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         let violationString = file.contents.bridge().substring(with: violationRange)
         let identifier = violationString.components(separatedBy: .whitespaces).first { !$0.isEmpty }
         return (violationRange, identifier! + ".toggle()")

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -41,7 +41,7 @@ public struct TrailingSemicolonRule: SubstitutionCorrectableRule, ConfigurationP
                           excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
@@ -50,7 +50,7 @@ public struct AnyObjectProtocolRule: SubstitutionCorrectableASTRule, OptInRule,
 
     // MARK: - SubstitutionCorrectableASTRule
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "AnyObject")
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -114,7 +114,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
         return violationRanges(in: file, dictionary: dictionary, kind: kind).map { $0.range }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "_")
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -98,7 +98,7 @@ public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, Config
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         var rangeToRemove = violationRange
         let contentsNSString = file.contents.bridge()
         if let byteRange = contentsNSString.NSRangeToByteRange(start: violationRange.location,

--- a/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
@@ -37,7 +37,7 @@ public struct ClosingBraceRule: SubstitutionCorrectableRule, ConfigurationProvid
         return file.match(pattern: "(\\}[ \\t]+\\))", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "})")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -44,7 +44,7 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, ", ")
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -114,7 +114,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         var violationString = file.contents.bridge().substring(with: violationRange)
         if violationString.contains("(") && violationString.contains(")") {
             if let openingIndex = violationString.firstIndex(of: "(") {

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -63,7 +63,7 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
@@ -55,7 +55,7 @@ public struct EmptyParametersRule: ConfigurationProviderRule, SubstitutionCorrec
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "()")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -55,7 +55,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -55,7 +55,7 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -54,7 +54,7 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
 
     // MARK: - SubstitutionCorrectableASTRule
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -38,7 +38,7 @@ public struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, Sub
         return file.match(pattern: "\\bset\\s*get\\b", with: [.keyword, .keyword])
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "get set")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
@@ -37,7 +37,7 @@ public struct RedundantDiscardableLetRule: SubstitutionCorrectableRule, Configur
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "_")
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -75,7 +75,7 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
         return [range]
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, configuration.mandatoryComma ? "," : "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
@@ -62,7 +62,7 @@ public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectable
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String) {
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "Void")
     }
 }


### PR DESCRIPTION
This PR allows `SubstitutionCorrectableRule` to return `nil` instead of a correction to indicate that a suitable correction couldn't be found for a specific case.

This could be useful for providing corrections for certain rules that cannot offer corrections in all cases. E.g. `discouraged_direct_init` could provide corrections for the default cases (`UIDevice()` -> `UIDevice.current`), but wouldn't require users to provide corrections for their custom rule configuration.