### PR TITLE
Add support for compilation databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#2953](https://github.com/realm/SwiftLint/issues/2953)
 
+* Support compilation databases for `swiftlint analayze`.  
+  [kastiglione](https://github.com/kastiglione)
+  [#2962](https://github.com/realm/SwiftLint/issues/2962)
+
 ## 0.37.0: Double Load
 
 #### Breaking

--- a/Source/SwiftLintFramework/Models/YamlParser.swift
+++ b/Source/SwiftLintFramework/Models/YamlParser.swift
@@ -19,6 +19,16 @@ public struct YamlParser {
             throw YamlParserError.yamlParsing("\(error)")
         }
     }
+
+    public static func parseArray(_ yaml: String,
+                             env: [String: String] = ProcessInfo.processInfo.environment) throws -> [[String: Any]] {
+        do {
+            return try Yams.load(yaml: yaml, .default,
+                                 .swiftlintContructor(env: env)) as? [[String: Any]] ?? []
+        } catch {
+            throw YamlParserError.yamlParsing("\(error)")
+        }
+    }
 }
 
 private extension Constructor {

--- a/Source/SwiftLintFramework/Models/YamlParser.swift
+++ b/Source/SwiftLintFramework/Models/YamlParser.swift
@@ -19,16 +19,6 @@ public struct YamlParser {
             throw YamlParserError.yamlParsing("\(error)")
         }
     }
-
-    public static func parseArray(_ yaml: String,
-                             env: [String: String] = ProcessInfo.processInfo.environment) throws -> [[String: Any]] {
-        do {
-            return try Yams.load(yaml: yaml, .default,
-                                 .swiftlintContructor(env: env)) as? [[String: Any]] ?? []
-        } catch {
-            throw YamlParserError.yamlParsing("\(error)")
-        }
-    }
 }
 
 private extension Constructor {

--- a/Source/swiftlint/Commands/AnalyzeCommand.swift
+++ b/Source/swiftlint/Commands/AnalyzeCommand.swift
@@ -48,19 +48,20 @@ struct AnalyzeOptions: OptionsProtocol {
     let enableAllRules: Bool
     let autocorrect: Bool
     let compilerLogPath: String
+    let compileCommands: String
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ paths: [String]) -> AnalyzeOptions {
-        return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { paths in
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ paths: [String]) -> AnalyzeOptions {
+        return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
             } else {
                 allPaths = paths
             }
-            return self.init(paths: allPaths, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, enableAllRules: enableAllRules, autocorrect: autocorrect, compilerLogPath: compilerLogPath)
+            return self.init(paths: allPaths, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, enableAllRules: enableAllRules, autocorrect: autocorrect, compilerLogPath: compilerLogPath, compileCommands: compileCommands)
             // swiftlint:enable line_length
-        }}}}}}}}}}}}
+        }}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AnalyzeOptions, CommandantError<CommandantError<()>>> {
@@ -86,6 +87,8 @@ struct AnalyzeOptions: OptionsProtocol {
                                usage: "correct violations whenever possible")
             <*> mode <| Option(key: "compiler-log-path", defaultValue: "",
                                usage: "the path of the full xcodebuild log to use when linting AnalyzerRules")
+            <*> mode <| Option(key: "compile-commands", defaultValue: "",
+                               usage: "the path of a compilation database to use when linting AnalyzerRules")
             // This should go last to avoid eating other args
             <*> mode <| pathsArgument(action: "analyze")
     }

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -142,6 +142,7 @@ struct LintOrAnalyzeOptions {
     let enableAllRules: Bool
     let autocorrect: Bool
     let compilerLogPath: String
+    let compileCommands: String
 
     init(_ options: LintOptions) {
         mode = .lint
@@ -160,6 +161,7 @@ struct LintOrAnalyzeOptions {
         enableAllRules = options.enableAllRules
         autocorrect = false
         compilerLogPath = ""
+        compileCommands = ""
     }
 
     init(_ options: AnalyzeOptions) {
@@ -179,6 +181,7 @@ struct LintOrAnalyzeOptions {
         enableAllRules = options.enableAllRules
         autocorrect = options.autocorrect
         compilerLogPath = options.compilerLogPath
+        compileCommands = options.compileCommands
     }
 
     var verb: String {

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -161,7 +161,7 @@ struct LintableFilesVisitor {
         }
 
         // Convert compile_commands.json into a structure convenient for subscripting.
-        // Compile commands are and array of dictionaries. Each dict has a key for "file", and a key for "arguments".
+        // Compile commands are an array of dictionaries. Each dict has a key for "file", and a key for "arguments".
         // This `reduce` converts that structure into a [File: Arguments] argument lookup table.
         return database.reduce(into: [:]) { (commands: inout [File: Arguments], entry: [String: Any]) in
             if let file = entry["file"] as? String, let arguments = entry["arguments"] as? [String] {

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -166,6 +166,10 @@ struct LintableFilesVisitor {
         return database.reduce(into: [:]) { (commands: inout [File: Arguments], entry: [String: Any]) in
             if let file = entry["file"] as? String, let arguments = entry["arguments"] as? [String] {
                 commands[file] = arguments
+                if let directory = entry["directory"] as? String {
+                    let absolutePath = directory.bridge().appendingPathComponent(file)
+                    commands[absolutePath] = arguments
+                }
             }
         }
     }

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -77,10 +77,10 @@ struct LintableFilesVisitor {
             compilerInvocations = nil
         } else {
             switch loadCompilerInvocations(options) {
-                case let .success(invocations):
-                    compilerInvocations = invocations
-                case let .failure(error):
-                    return .failure(error)
+            case let .success(invocations):
+                compilerInvocations = invocations
+            case let .failure(error):
+                return .failure(error)
             }
         }
 
@@ -153,8 +153,7 @@ struct LintableFilesVisitor {
     private static func loadCompileCommands(_ path: String) -> [String: [String]]? {
         guard let jsonContents = FileManager.default.contents(atPath: path),
             let object = try? JSONSerialization.jsonObject(with: jsonContents),
-            let database = object as? [[String: Any]] else
-        {
+            let database = object as? [[String: Any]] else {
             return nil
         }
 

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -82,12 +82,16 @@ struct LintableFilesVisitor {
                 compilerInvocations = .buildLog(compilerInvocations: allCompilerInvocations)
             } else if !options.compileCommands.isEmpty {
                 do {
-                    let yamlContents = try String(contentsOfFile: options.compileCommands, encoding: .utf8)
-                    let compileCommands = try YamlParser.parseArray(yamlContents)
+                    let jsonContents = try Data(contentsOf: URL(fileURLWithPath: options.compileCommands))
+                    guard let compileCommands = try JSONSerialization.jsonObject(with: jsonContents) as? [[String: Any]] else {
+                        return .failure(
+                            .usageError(description: "Unexpected structure of compilation database  at path: '\(options.compileCommands)'")
+                        )
+                    }
                     compilerInvocations = .compilationDatabase(compileCommands: compileCommands)
                 } catch {
                     return .failure(
-                        .usageError(description: "Could not compilation database at path: '\(options.compileCommands)'")
+                        .usageError(description: "Could not read compilation database at path: '\(options.compileCommands)'")
                     )
                 }
             } else {

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -3,9 +3,12 @@ import Foundation
 import SourceKittenFramework
 import SwiftLintFramework
 
+typealias File = String
+typealias Arguments = [String]
+
 enum CompilerInvocations {
     case buildLog(compilerInvocations: [String])
-    case compilationDatabase(compileCommands: [String: [String]])
+    case compilationDatabase(compileCommands: [File: Arguments])
 
     func arguments(forFile path: String?) -> [String] {
         return path.flatMap { path in
@@ -157,7 +160,10 @@ struct LintableFilesVisitor {
             return nil
         }
 
-        return database.reduce(into: [:]) { (commands: inout [String: [String]], entry: [String: Any]) in
+        // Convert compile_commands.json into a structure convenient for subscripting.
+        // Compile commands are and array of dictionaries. Each dict has a key for "file", and a key for "arguments".
+        // This `reduce` converts that structure into a [File: Arguments] argument lookup table.
+        return database.reduce(into: [:]) { (commands: inout [File: Arguments], entry: [String: Any]) in
             if let file = entry["file"] as? String, let arguments = entry["arguments"] as? [String] {
                 commands[file] = arguments
             }

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -166,10 +166,6 @@ struct LintableFilesVisitor {
         return database.reduce(into: [:]) { (commands: inout [File: Arguments], entry: [String: Any]) in
             if let file = entry["file"] as? String, let arguments = entry["arguments"] as? [String] {
                 commands[file] = arguments
-                if let directory = entry["directory"] as? String {
-                    let absolutePath = directory.bridge().appendingPathComponent(file)
-                    commands[absolutePath] = arguments
-                }
             }
         }
     }

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -160,7 +160,7 @@ struct LintableFilesVisitor {
             return nil
         }
 
-        // Convert the compilation database into dictionary, with source paths as keys and compiler arguments as values.
+        // Convert the compilation database to a dictionary, with source files as keys and compiler arguments as values.
         //
         // Compilation databases are an array of dictionaries. Each dict has "file" and "arguments" keys.
         return compileDB.reduce(into: [:]) { (commands: inout [File: Arguments], entry: [String: Any]) in

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -165,7 +165,7 @@ struct LintableFilesVisitor {
         // This `reduce` converts that structure into a [File: Arguments] argument lookup table.
         return database.reduce(into: [:]) { (commands: inout [File: Arguments], entry: [String: Any]) in
             if let file = entry["file"] as? String, let arguments = entry["arguments"] as? [String] {
-                commands[file] = arguments
+                commands[file] = CompilerArgumentsExtractor.filterCompilerArguments(arguments)
             }
         }
     }

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -126,7 +126,7 @@ struct LintableFilesVisitor {
             }
 
             return .success(.buildLog(compilerInvocations: compilerInvocations))
-        } else if options.compileCommands.isEmpty {
+        } else if !options.compileCommands.isEmpty {
             let path = options.compileCommands
             guard let compileCommands = self.loadCompileCommands(path) else {
                 return .failure(


### PR DESCRIPTION
This is to add support for [compilation databases](https://clang.llvm.org/docs/JSONCompilationDatabase.html) (aka `compile_commands.json`) as an alternative to parsing compiler invocations from a build log.

A compilation database can be passed using the newly added `--compile-commands` flag. This new flag is mutually exclusive to `--compiler-log-path`.

TODO

- [ ] ~~Add tests~~
