### PR TITLE
Improve compilation time

### DIFF
--- a/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRuleExamples.swift
@@ -37,45 +37,57 @@ private func trailingClosure(_ violationSymbol: String = "",
                              codeLinesCount: Int,
                              commentLinesCount: Int,
                              emptyLinesCount: Int) -> String {
-    return "foo.bar \(violationSymbol){ toto in\n" +
-        repeatElement("\tlet a = 0\n", count: codeLinesCount).joined() +
-        repeatElement("\t// toto\n", count: commentLinesCount).joined() +
-        repeatElement("\t\n", count: emptyLinesCount).joined() +
-    "}"
+    return """
+        foo.bar \(violationSymbol){ toto in
+        \(repeatElement("\tlet a = 0\n", count: codeLinesCount).joined())\
+        \(repeatElement("\t// toto\n", count: commentLinesCount).joined())\
+        \(repeatElement("\t\n", count: emptyLinesCount).joined())\
+        }
+        """
 }
 
 private func argumentClosure(_ violationSymbol: String = "", codeLinesCount: Int) -> String {
-    return "foo.bar(\(violationSymbol){ toto in\n" +
-        repeatElement("\tlet a = 0\n", count: codeLinesCount).joined() +
-    "})"
+    return """
+        foo.bar(\(violationSymbol){ toto in
+        \(repeatElement("\tlet a = 0\n", count: codeLinesCount).joined())\
+        })
+        """
 }
 
 private func labeledArgumentClosure(_ violationSymbol: String = "", codeLinesCount: Int) -> String {
-    return "foo.bar(label: \(violationSymbol){ toto in\n" +
-        repeatElement("\tlet a = 0\n", count: codeLinesCount).joined() +
-    "})"
+    return """
+        foo.bar(label: \(violationSymbol){ toto in
+        \(repeatElement("\tlet a = 0\n", count: codeLinesCount).joined())\
+        })
+        """
 }
 
 private func multiLabeledArgumentClosures(_ violationSymbol: String = "", codeLinesCount: Int) -> String {
-    return "foo.bar(label: \(violationSymbol){ toto in\n" +
-        repeatElement("\tlet a = 0\n", count: codeLinesCount).joined() +
-        "}, anotherLabel: \(violationSymbol){ toto in\n" +
-        repeatElement("\tlet a = 0\n", count: codeLinesCount).joined() +
-    "})"
+    return """
+        foo.bar(label: \(violationSymbol){ toto in
+        \(repeatElement("\tlet a = 0\n", count: codeLinesCount).joined())\
+        }, anotherLabel: \(violationSymbol){ toto in
+        \(repeatElement("\tlet a = 0\n", count: codeLinesCount).joined())\
+        })
+        """
 }
 
 private func labeledAndTrailingClosures(_ violationSymbol: String = "", codeLinesCount: Int) -> String {
-    return "foo.bar(label: \(violationSymbol){ toto in\n" +
-        repeatElement("\tlet a = 0\n", count: codeLinesCount).joined() +
-        "}) \(violationSymbol){ toto in\n" +
-        repeatElement("\tlet a = 0\n", count: codeLinesCount).joined() +
-    "}"
+    return """
+        foo.bar(label: \(violationSymbol){ toto in
+        \(repeatElement("\tlet a = 0\n", count: codeLinesCount).joined())\
+        }) \(violationSymbol){ toto in
+        \(repeatElement("\tlet a = 0\n", count: codeLinesCount).joined())\
+        }
+        """
 }
 
 private func lazyInitialization(_ violationSymbol: String = "", codeLinesCount: Int) -> String {
-    return "let foo: Bar = \(violationSymbol){ toto in\n" +
-        "\tlet bar = Bar()\n" +
-        repeatElement("\tlet a = 0\n", count: codeLinesCount).joined() +
-        "\treturn bar\n" +
-    "}()"
+    return """
+        let foo: Bar = \(violationSymbol){ toto in
+        \tlet bar = Bar()
+        \(repeatElement("\tlet a = 0\n", count: codeLinesCount).joined())\
+        \treturn bar
+        }()
+        """
 }

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -110,9 +110,9 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
 
     private func isDecimal(number: String) -> Bool {
         let lowercased = number.lowercased()
-        let prefixes = ["0x", "0o", "0b"].flatMap { [$0, "-" + $0, "+" + $0] }
+        let prefixes = ["0x", "0o", "0b"].flatMap { [$0, "-\($0)", "+\($0)"] }
 
-        return !prefixes.contains { lowercased.hasPrefix($0) }
+        return !prefixes.contains(where: lowercased.hasPrefix)
     }
 
     private func isInValidRanges(number: String) -> Bool {

--- a/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
@@ -23,3 +23,17 @@ class CompilerProtocolInitRuleTests: XCTestCase {
         )
     }
 }
+
+#if compiler(<5.1)
+private enum UnwrapError: Error {
+    case missingValue
+}
+
+private func XCTUnwrap<T>(_ expression: @autoclosure () rethrows -> T?) throws -> T {
+    if let value = try expression() {
+        return value
+    } else {
+        throw UnwrapError.missingValue
+    }
+}
+#endif

--- a/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
@@ -29,7 +29,8 @@ private enum UnwrapError: Error {
     case missingValue
 }
 
-private func XCTUnwrap<T>(_ expression: @autoclosure () rethrows -> T?) throws -> T {
+private func XCTUnwrap<T>(_ expression: @autoclosure () rethrows -> T?,
+                          _ message: @autoclosure () -> String = "") throws -> T {
     if let value = try expression() {
         return value
     } else {

--- a/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
@@ -24,7 +24,8 @@ class CompilerProtocolInitRuleTests: XCTestCase {
     }
 }
 
-#if compiler(<5.1)
+// https://bugs.swift.org/browse/SR-11501
+#if compiler(<5.1) || (SWIFT_PACKAGE && os(macOS))
 private enum UnwrapError: Error {
     case missingValue
 }

--- a/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
@@ -8,22 +8,18 @@ class CompilerProtocolInitRuleTests: XCTestCase {
         verifyRule(CompilerProtocolInitRule.description)
     }
 
-    func testViolationMessageForExpressibleByIntegerLiteral() {
-        guard let config = makeConfig(nil, ruleID) else {
-            XCTFail("Failed to create configuration")
-            return
-        }
+    func testViolationMessageForExpressibleByIntegerLiteral() throws {
+        let config = try XCTUnwrap(makeConfig(nil, ruleID))
         let allViolations = violations("let a = NSNumber(integerLiteral: 1)", config: config)
 
         let compilerProtocolInitViolation = allViolations.first { $0.ruleDescription.identifier == ruleID }
-        if let violation = compilerProtocolInitViolation {
-            XCTAssertEqual(
-                violation.reason,
-                "The initializers declared in compiler protocol ExpressibleByIntegerLiteral " +
-                "shouldn't be called directly."
-            )
-        } else {
-            XCTFail("A compiler protocol init violation should have been triggered!")
-        }
+        let violation = try XCTUnwrap(
+            compilerProtocolInitViolation,
+            "A compiler protocol init violation should have been triggered!"
+        )
+        XCTAssertEqual(
+            violation.reason,
+            "The initializers declared in compiler protocol ExpressibleByIntegerLiteral shouldn't be called directly."
+        )
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
@@ -29,7 +29,7 @@ private enum UnwrapError: Error {
     case missingValue
 }
 
-private func XCTUnwrap<T>(_ expression: @autoclosure () rethrows -> T?,
+private func XCTUnwrap<T>(_ expression: @autoclosure () throws -> T?,
                           _ message: @autoclosure () -> String = "") throws -> T {
     if let value = try expression() {
         return value

--- a/script/oss-check
+++ b/script/oss-check
@@ -260,8 +260,6 @@ end
 def set_globals
   @effective_master_commitish = `git merge-base origin/master #{@options[:branch]}`.chomp
   @changed_swift_files = `git diff --diff-filter=d #{@effective_master_commitish} --name-only | grep "\.swift$" || true`.split("\n")
-  # True iff the only Swift files that were changed are SwiftLint rules, and that number is one or greater
-  @only_rules_changed = !@changed_swift_files.empty? && @changed_swift_files.all? { |file| file.start_with? 'Source/SwiftLintFramework/Rules/' }
   @changed_rule_files = @changed_swift_files.select do |file|
     file.start_with? 'Source/SwiftLintFramework/Rules/'
   end
@@ -272,6 +270,8 @@ def set_globals
       nil
     end
   end.compact.sort
+  # True iff the only Swift files that were changed are SwiftLint rules, and that number is one or greater
+  @only_rules_changed = !@rules_changed.empty? && @changed_swift_files.count == @rules_changed.count
 end
 
 def print_rules_changed


### PR DESCRIPTION
Before this change, `trailingClosure` took 8.6s to type check. After this change, it takes 31ms.

Found by running `make display_compilation_time`.