### PR TITLE
Include functions and getters in rule `implicit_return` and make it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
   [Dan Loman](https://github.com/namolnad)
   [#727](https://github.com/realm/SwiftLint/issues/727)
 
+* Add option to configure which kinds of `return` statements should omit their
+  `return` keyword by introducting an `included` configuration for the
+  `implicit_return` rule.  
+  [Sven Münnich](https://github.com/svenmuennich)
+  [#2870](https://github.com/realm/SwiftLint/issues/2870)
+
 #### Bug Fixes
 
 * Fix false positive for LetVarWhitespaceRule.  

--- a/Rules.md
+++ b/Rules.md
@@ -10358,12 +10358,18 @@ Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Mi
 --- | --- | --- | --- | --- | ---
 `implicit_return` | Disabled | Yes | style | No | 3.0.0 
 
-Prefer implicit returns in closures.
+Prefer implicit returns in closures, functions and getters.
 
 ### Examples
 
 <details>
 <summary>Non Triggering Examples</summary>
+
+```swift
+if foo {
+  return 0
+}
+```
 
 ```swift
 foo.map { $0 + 1 }
@@ -10378,19 +10384,43 @@ foo.map { value in value + 1 }
 ```
 
 ```swift
+[1, 2].first(where: {
+    true
+})
+```
+
+```swift
 func foo() -> Int {
-  return 0
+    0
 }
 ```
 
 ```swift
-if foo {
-  return 0
+class Foo {
+    func foo() -> Int { 0 }
 }
 ```
 
 ```swift
-var foo: Bool { return true }
+var foo: Bool { true }
+```
+
+```swift
+class Foo {
+    var bar: Int {
+        get {
+            0
+        }
+    }
+}
+```
+
+```swift
+class Foo {
+    static var bar: Int {
+        0
+    }
+}
 ```
 
 </details>
@@ -10399,24 +10429,58 @@ var foo: Bool { return true }
 
 ```swift
 foo.map { value in
-  ↓return value + 1
+    return value + 1
 }
 ```
 
 ```swift
 foo.map {
-  ↓return $0 + 1
+    return $0 + 1
 }
 ```
 
 ```swift
-foo.map({ ↓return $0 + 1})
+foo.map({ return $0 + 1})
 ```
 
 ```swift
 [1, 2].first(where: {
-    ↓return true
+    return true
 })
+```
+
+```swift
+func foo() -> Int {
+    return 0
+}
+```
+
+```swift
+class Foo {
+    func foo() -> Int { return 0 }
+}
+```
+
+```swift
+var foo: Bool { return true }
+```
+
+```swift
+class Foo {
+    var bar: Int {
+        get {
+            return 0
+        }
+    }
+}
+```
+
+```swift
+class Foo {
+    static var bar: Int {
+        return 0
+    }
+}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -1,0 +1,44 @@
+public struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
+    public enum ReturnKind: String, CaseIterable {
+        case closure
+        case function
+        case getter
+    }
+
+    public static let defaultIncludedKinds = Set(ReturnKind.allCases)
+
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var includedKinds = Self.defaultIncludedKinds
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription + ", included: \(Self.defaultIncludedKinds)"
+    }
+
+    public init(includedKinds: Set<ReturnKind> = Self.defaultIncludedKinds) {
+        self.includedKinds = includedKinds
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let includedKinds = configuration["included"] as? [String] {
+            self.includedKinds = try Set(includedKinds.map {
+                guard let kind = ReturnKind(rawValue: $0) else {
+                    throw ConfigurationError.unknownConfiguration
+                }
+
+                return kind
+            })
+        }
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+    }
+
+    public func isKindIncluded(_ kind: ReturnKind) -> Bool {
+        return self.includedKinds.contains(kind)
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -8,13 +8,14 @@ public struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
     public static let defaultIncludedKinds = Set(ReturnKind.allCases)
 
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
-    private(set) var includedKinds = Self.defaultIncludedKinds
+    private(set) var includedKinds = ImplicitReturnConfiguration.defaultIncludedKinds
 
     public var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", included: \(Self.defaultIncludedKinds)"
+        return severityConfiguration.consoleDescription +
+            ", included: \(ImplicitReturnConfiguration.defaultIncludedKinds)"
     }
 
-    public init(includedKinds: Set<ReturnKind> = Self.defaultIncludedKinds) {
+    public init(includedKinds: Set<ReturnKind> = ImplicitReturnConfiguration.defaultIncludedKinds) {
         self.includedKinds = includedKinds
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -1,56 +1,25 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule, OptInRule,
-                                  AutomaticTestableRule {
-    public var configuration = SeverityConfiguration(.warning)
+public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule, OptInRule {
+    public var configuration = ImplicitReturnConfiguration()
 
     public init() {}
 
     public static let description = RuleDescription(
         identifier: "implicit_return",
         name: "Implicit Return",
-        description: "Prefer implicit returns in closures.",
+        description: "Prefer implicit returns in closures, functions and getters.",
         kind: .style,
-        nonTriggeringExamples: [
-            "foo.map { $0 + 1 }",
-            "foo.map({ $0 + 1 })",
-            "foo.map { value in value + 1 }",
-            "func foo() -> Int {\n  return 0\n}",
-            "if foo {\n  return 0\n}",
-            "var foo: Bool { return true }"
-        ],
-        triggeringExamples: [
-            "foo.map { value in\n  ↓return value + 1\n}",
-            "foo.map {\n  ↓return $0 + 1\n}",
-            "foo.map({ ↓return $0 + 1})",
-            """
-            [1, 2].first(where: {
-                ↓return true
-            })
-            """
-        ],
-        corrections: [
-            "foo.map { value in\n  ↓return value + 1\n}": "foo.map { value in\n  value + 1\n}",
-            "foo.map {\n  ↓return $0 + 1\n}": "foo.map {\n  $0 + 1\n}",
-            "foo.map({ ↓return $0 + 1})": "foo.map({ $0 + 1})",
-            """
-            [1, 2].first(where: {
-                ↓return true
-            })
-            """:
-            """
-            [1, 2].first(where: {
-                true
-            })
-            """
-        ]
+        nonTriggeringExamples: ImplicitReturnRuleExamples.nonTriggeringExamples,
+        triggeringExamples: ImplicitReturnRuleExamples.triggeringExamples,
+        corrections: ImplicitReturnRuleExamples.corrections
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).compactMap {
             StyleViolation(ruleDescription: type(of: self).description,
-                           severity: configuration.severity,
+                           severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
     }
@@ -68,13 +37,25 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
             guard kinds == [.keyword, .keyword] || kinds == [.keyword],
                 let byteRange = contents.NSRangeToByteRange(start: range.location,
                                                             length: range.length),
-                let outerKindString = file.structureDictionary.kinds(forByteOffset: byteRange.location).last?.kind,
-                let outerKind = SwiftExpressionKind(rawValue: outerKindString),
-                [.call, .argument, .closure].contains(outerKind) else {
+                let outerKindString = file.structureDictionary.kinds(forByteOffset: byteRange.location).last?.kind
+                else {
                     return nil
             }
 
-            return result.range(at: 1)
+            if let outerKind = SwiftExpressionKind(rawValue: outerKindString),
+                self.configuration.isKindIncluded(.closure),
+                [.call, .argument, .closure].contains(outerKind) {
+                    return result.range(at: 1)
+            }
+
+            if let outerKind = SwiftDeclarationKind(rawValue: outerKindString),
+                // swiftlint:disable:next line_length
+                (self.configuration.isKindIncluded(.function) && SwiftDeclarationKind.functionKinds.contains(outerKind)) ||
+                (self.configuration.isKindIncluded(.getter) && SwiftDeclarationKind.variableKinds.contains(outerKind)) {
+                    return result.range(at: 1)
+            }
+
+            return nil
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRuleExamples.swift
@@ -1,0 +1,149 @@
+internal struct ImplicitReturnRuleExamples {
+    internal struct GenericExamples {
+        static let nonTriggeringExamples = ["if foo {\n  return 0\n}"]
+    }
+
+    internal struct ClosureExamples {
+        static let nonTriggeringExamples = [
+            "foo.map { $0 + 1 }",
+            "foo.map({ $0 + 1 })",
+            "foo.map { value in value + 1 }",
+            """
+            [1, 2].first(where: {
+                true
+            })
+            """
+        ]
+
+        static let triggeringExamples = [
+            """
+            foo.map { value in
+                return value + 1
+            }
+            """,
+            """
+            foo.map {
+                return $0 + 1
+            }
+            """,
+            "foo.map({ return $0 + 1})",
+            """
+            [1, 2].first(where: {
+                return true
+            })
+            """
+        ]
+
+        static let corrections = [
+            "foo.map { value in\n  return value + 1\n}": "foo.map { value in\n  value + 1\n}",
+            "foo.map {\n  return $0 + 1\n}": "foo.map {\n  $0 + 1\n}",
+            "foo.map({ return $0 + 1})": "foo.map({ $0 + 1})",
+            "[1, 2].first(where: {\n  return true })": "[1, 2].first(where: {\n  true })"
+        ]
+    }
+
+    internal struct FunctionExamples {
+        static let nonTriggeringExamples = [
+            """
+            func foo() -> Int {
+                0
+            }
+            """,
+            """
+            class Foo {
+                func foo() -> Int { 0 }
+            }
+            """
+        ]
+
+        static let triggeringExamples = [
+            """
+            func foo() -> Int {
+                return 0
+            }
+            """,
+            """
+            class Foo {
+                func foo() -> Int { return 0 }
+            }
+            """
+        ]
+
+        static let corrections = [
+            "func foo() -> Int {\n  return 0\n}": "func foo() -> Int {\n  0\n}",
+            // swiftlint:disable:next line_length
+            "class Foo {\n  func foo() -> Int {\n    return 0\n  }\n}": "class Foo {\n  func foo() -> Int {\n    0\n  }\n}"
+        ]
+    }
+
+    internal struct GetterExamples {
+        static let nonTriggeringExamples = [
+            "var foo: Bool { true }",
+            """
+            class Foo {
+                var bar: Int {
+                    get {
+                        0
+                    }
+                }
+            }
+            """,
+            """
+            class Foo {
+                static var bar: Int {
+                    0
+                }
+            }
+            """
+        ]
+
+        static let triggeringExamples = [
+            "var foo: Bool { return true }",
+            """
+            class Foo {
+                var bar: Int {
+                    get {
+                        return 0
+                    }
+                }
+            }
+            """,
+            """
+            class Foo {
+                static var bar: Int {
+                    return 0
+                }
+            }
+            """
+        ]
+
+        static let corrections = [
+            "var foo: Bool { return true }": "var foo: Bool { true }",
+            // swiftlint:disable:next line_length
+            "class Foo {\n  var bar: Int {\n    get {\n      return 0\n    }\n  }\n}": "class Foo {\n  var bar: Int {\n    get {\n      0\n    }\n  }\n}"
+        ]
+    }
+
+    static let nonTriggeringExamples = GenericExamples.nonTriggeringExamples +
+        ClosureExamples.nonTriggeringExamples +
+        FunctionExamples.nonTriggeringExamples +
+        GetterExamples.nonTriggeringExamples
+
+    static let triggeringExamples = ClosureExamples.triggeringExamples +
+        FunctionExamples.triggeringExamples +
+        GetterExamples.triggeringExamples
+
+    static var corrections: [String: String] {
+        let corrections: [[String: String]] = [
+            ClosureExamples.corrections,
+            FunctionExamples.corrections,
+            GetterExamples.corrections
+        ]
+
+        return corrections.reduce(into: [:]) { result, element in
+            result.merge(element) { _, _ in
+                preconditionFailure("Duplicate correction in implicit return rule examples.")
+            }
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -198,6 +198,10 @@
 		A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */; };
 		A3184D56215BCEFF00621EA2 /* LegacyRandomRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3184D55215BCEFF00621EA2 /* LegacyRandomRule.swift */; };
 		A73469421FB121BA009B57C7 /* CallPairRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73469401FB12149009B57C7 /* CallPairRule.swift */; };
+		B1FD3AB9238877F200CE121E /* ImplicitReturnConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD3AB8238877F200CE121E /* ImplicitReturnConfiguration.swift */; };
+		B1FD3ABB238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD3ABA238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift */; };
+		B1FD3ABD238BC5FB00CE121E /* ImplicitReturnRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD3ABC238BC5FB00CE121E /* ImplicitReturnRuleTests.swift */; };
+		B1FD3ABF238BC6D400CE121E /* ImplicitReturnRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD3ABE238BC6D400CE121E /* ImplicitReturnRuleExamples.swift */; };
 		B25DCD0B1F7E9F9E0028A199 /* MultilineArgumentsRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */; };
 		B25DCD0C1F7E9FA20028A199 /* MultilineArgumentsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */; };
 		B25DCD0E1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD0D1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift */; };
@@ -685,6 +689,10 @@
 		A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralConfiguration.swift; sourceTree = "<group>"; };
 		A3184D55215BCEFF00621EA2 /* LegacyRandomRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyRandomRule.swift; sourceTree = "<group>"; };
 		A73469401FB12149009B57C7 /* CallPairRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallPairRule.swift; sourceTree = "<group>"; };
+		B1FD3AB8238877F200CE121E /* ImplicitReturnConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitReturnConfiguration.swift; sourceTree = "<group>"; };
+		B1FD3ABA238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitReturnConfigurationTests.swift; sourceTree = "<group>"; };
+		B1FD3ABC238BC5FB00CE121E /* ImplicitReturnRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitReturnRuleTests.swift; sourceTree = "<group>"; };
+		B1FD3ABE238BC6D400CE121E /* ImplicitReturnRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitReturnRuleExamples.swift; sourceTree = "<group>"; };
 		B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRule.swift; sourceTree = "<group>"; };
 		B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRuleExamples.swift; sourceTree = "<group>"; };
 		B25DCD0D1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsConfiguration.swift; sourceTree = "<group>"; };
@@ -1024,6 +1032,7 @@
 				82DB55FD21008F3E001C62FF /* FileTypesOrderConfiguration.swift */,
 				8B01E4FB20A4183C00C9233E /* FunctionParameterCountConfiguration.swift */,
 				47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */,
+				B1FD3AB8238877F200CE121E /* ImplicitReturnConfiguration.swift */,
 				3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */,
 				F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */,
 				188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */,
@@ -1203,6 +1212,7 @@
 				D4130D961E16183F00242361 /* IdentifierNameRuleExamples.swift */,
 				D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */,
 				D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */,
+				B1FD3ABE238BC6D400CE121E /* ImplicitReturnRuleExamples.swift */,
 				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
 				C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */,
 				D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */,
@@ -1498,6 +1508,8 @@
 				3B3A9A321EA3DFD90075B121 /* IdentifierNameRuleTests.swift */,
 				47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */,
 				47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */,
+				B1FD3ABA238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift */,
+				B1FD3ABC238BC5FB00CE121E /* ImplicitReturnRuleTests.swift */,
 				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
 				3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */,
 				3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */,
@@ -1964,6 +1976,7 @@
 				D44037972132730000FDA77B /* ProhibitedInterfaceBuilderRule.swift in Sources */,
 				78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */,
 				D47079A71DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift in Sources */,
+				B1FD3AB9238877F200CE121E /* ImplicitReturnConfiguration.swift in Sources */,
 				E881985E1BEA982100333A11 /* TypeBodyLengthRule.swift in Sources */,
 				69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */,
 				C26330382073DAC500D7B4FD /* LowerACLThanParentRule.swift in Sources */,
@@ -2081,6 +2094,7 @@
 				D42B45D91F0AF5E30086B683 /* StrictFilePrivateRule.swift in Sources */,
 				E48F715F23789824003E1775 /* SwiftLintSyntaxToken.swift in Sources */,
 				1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */,
+				B1FD3ABF238BC6D400CE121E /* ImplicitReturnRuleExamples.swift in Sources */,
 				F90DBD7F2092E669002CC310 /* MissingDocsRuleConfiguration.swift in Sources */,
 				67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */,
 				57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */,
@@ -2279,6 +2293,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				825F19D11EEFF19700969EF1 /* ObjectLiteralRuleTests.swift in Sources */,
+				B1FD3ABB238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift in Sources */,
 				D4F5851520E99A8A0085C6D8 /* TrailingWhitespaceTests.swift in Sources */,
 				D450D1E021F19AB300E60010 /* TrailingClosureRuleTests.swift in Sources */,
 				3B12C9C31C320A53000B423F /* YamlSwiftLintTests.swift in Sources */,
@@ -2342,6 +2357,7 @@
 				C2B3C1612106F78C00088928 /* ConfigurationAliasesTests.swift in Sources */,
 				D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */,
 				787CDE3B208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift in Sources */,
+				B1FD3ABD238BC5FB00CE121E /* ImplicitReturnRuleTests.swift in Sources */,
 				F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */,
 				B89F3BCE1FD5EE0200931E59 /* RequiredEnumCaseRuleTestCase.swift in Sources */,
 				C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -641,9 +641,19 @@ extension ImplicitGetterRuleTests {
     ]
 }
 
+extension ImplicitReturnConfigurationTests {
+    static var allTests: [(String, (ImplicitReturnConfigurationTests) -> () throws -> Void)] = [
+        ("testImplicitReturnConfigurationFromDictionary", testImplicitReturnConfigurationFromDictionary),
+        ("testImplicitReturnConfigurationThrowsOnUnrecognizedModifierGroup", testImplicitReturnConfigurationThrowsOnUnrecognizedModifierGroup)
+    ]
+}
+
 extension ImplicitReturnRuleTests {
     static var allTests: [(String, (ImplicitReturnRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration),
+        ("testOnlyClosureKindIncluded", testOnlyClosureKindIncluded),
+        ("testOnlyFunctionKindIncluded", testOnlyFunctionKindIncluded),
+        ("testOnlyGetterKindIncluded", testOnlyGetterKindIncluded)
     ]
 }
 
@@ -1664,6 +1674,7 @@ XCTMain([
     testCase(IdenticalOperandsRuleTests.allTests),
     testCase(IdentifierNameRuleTests.allTests),
     testCase(ImplicitGetterRuleTests.allTests),
+    testCase(ImplicitReturnConfigurationTests.allTests),
     testCase(ImplicitReturnRuleTests.allTests),
     testCase(ImplicitlyUnwrappedOptionalConfigurationTests.allTests),
     testCase(ImplicitlyUnwrappedOptionalRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -276,12 +276,6 @@ class ImplicitGetterRuleTests: XCTestCase {
     }
 }
 
-class ImplicitReturnRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(ImplicitReturnRule.description)
-    }
-}
-
 class InertDeferRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(InertDeferRule.description)

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
@@ -1,0 +1,34 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class ImplicitReturnConfigurationTests: XCTestCase {
+    func testImplicitReturnConfigurationFromDictionary() throws {
+        var configuration = ImplicitReturnConfiguration(includedKinds: Set<ImplicitReturnConfiguration.ReturnKind>())
+        let config: [String: Any] = [
+            "severity": "error",
+            "included": [
+                "closure",
+                "function",
+                "getter"
+            ]
+        ]
+
+        try configuration.apply(configuration: config)
+        let expectedKinds: Set<ImplicitReturnConfiguration.ReturnKind> = Set([
+            .closure,
+            .function,
+            .getter
+        ])
+        XCTAssert(configuration.severityConfiguration.severity == .error)
+        XCTAssertTrue(configuration.includedKinds == expectedKinds)
+    }
+
+    func testImplicitReturnConfigurationThrowsOnUnrecognizedModifierGroup() {
+        var configuration = ImplicitReturnConfiguration()
+        let config = ["included": ["foreach"]] as [String: Any]
+
+        checkError(ConfigurationError.unknownConfiguration) {
+            try configuration.apply(configuration: config)
+        }
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnRuleTests.swift
@@ -1,0 +1,66 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class ImplicitReturnRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(ImplicitReturnRule.description)
+    }
+
+    func testOnlyClosureKindIncluded() {
+        let nonTriggeringExamples = ImplicitReturnRuleExamples.GenericExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.ClosureExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.FunctionExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.FunctionExamples.triggeringExamples +
+            ImplicitReturnRuleExamples.GetterExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.GetterExamples.triggeringExamples
+        let triggeringExamples = ImplicitReturnRuleExamples.ClosureExamples.triggeringExamples
+        let corrections = ImplicitReturnRuleExamples.ClosureExamples.corrections
+
+        let description = ImplicitReturnRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: corrections)
+
+        self.verifyRule(description, returnKind: .closure)
+    }
+
+    func testOnlyFunctionKindIncluded() {
+        let nonTriggeringExamples = ImplicitReturnRuleExamples.GenericExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.ClosureExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.ClosureExamples.triggeringExamples +
+            ImplicitReturnRuleExamples.FunctionExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.GetterExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.GetterExamples.triggeringExamples
+        let triggeringExamples = ImplicitReturnRuleExamples.FunctionExamples.triggeringExamples
+        let corrections = ImplicitReturnRuleExamples.FunctionExamples.corrections
+
+        let description = ImplicitReturnRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: corrections)
+
+        self.verifyRule(description, returnKind: .function)
+    }
+
+    func testOnlyGetterKindIncluded() {
+        let nonTriggeringExamples = ImplicitReturnRuleExamples.GenericExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.ClosureExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.ClosureExamples.triggeringExamples +
+            ImplicitReturnRuleExamples.FunctionExamples.nonTriggeringExamples +
+            ImplicitReturnRuleExamples.FunctionExamples.triggeringExamples +
+            ImplicitReturnRuleExamples.GetterExamples.nonTriggeringExamples
+        let triggeringExamples = ImplicitReturnRuleExamples.GetterExamples.triggeringExamples
+        let corrections = ImplicitReturnRuleExamples.GetterExamples.corrections
+
+        let description = ImplicitReturnRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: corrections)
+
+        self.verifyRule(description, returnKind: .getter)
+    }
+
+    private func verifyRule(_ ruleDescription: RuleDescription, returnKind: ImplicitReturnConfiguration.ReturnKind) {
+        self.verifyRule(ruleDescription, ruleConfiguration: ["included": [returnKind.rawValue]])
+    }
+}


### PR DESCRIPTION
Currently the rule `implicit_return` only lints closures, which was the only context in which implicit returns could occur up until Swift 5.0. However, since Swift 5.1 it is possible to drop the `return` keyword from all closures, functions and getters if they contain only a single expression ([SE-0255](https://github.com/apple/swift-evolution/blob/cbb73367484a24a15e59f1d96885f637f4207b5d/proposals/0255-omit-return.md)).

This PR updates the rule to lint all `return`s that can be omitted in closures, functions and getters. It also adds a custom configuration that allows to finely tune which of these context should use implicit `return`s:
```yaml
implicit_return:
  included:
    - closure
    - function
    - getter
```

By default all kinds are linted, which is a **breaking change for existing configurations**.

---
Fixes #2870