### PR TITLE
Add capture_group option to custom_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   [Dan Loman](https://github.com/namolnad)
   [#727](https://github.com/realm/SwiftLint/issues/727)
 
+* Add `capture_group` option to `custom_rules` for more fine-grained placement
+  of the location marker for violating code.  
+  [pyrtsa](https://github.com/pyrtsa)
+  [#2982](https://github.com/realm/SwiftLint/pull/2982)
+
 #### Bug Fixes
 
 * Fix false positive for LetVarWhitespaceRule.  

--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ custom_rules:
     excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Pirates Beat Ninjas" # rule name. optional.
     regex: "([n,N]inja)" # matching pattern
+    capture_group: 0 # number of regex capture group to highlight the rule violation at. optional.
     match_kinds: # SyntaxKinds to match. optional.
       - comment
       - identifier

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
@@ -119,9 +119,9 @@ extension SwiftLintFile {
         return matchesAndTokens(matching: pattern, range: range).map { ($0.0.range, $0.1) }
     }
 
-    internal func match(pattern: String, range: NSRange? = nil) -> [(NSRange, [SyntaxKind])] {
+    internal func match(pattern: String, range: NSRange? = nil, captureGroup: Int = 0) -> [(NSRange, [SyntaxKind])] {
         return matchesAndSyntaxKinds(matching: pattern, range: range).map { textCheckingResult, syntaxKinds in
-            (textCheckingResult.range, syntaxKinds)
+            (textCheckingResult.range(at: captureGroup), syntaxKinds)
         }
     }
 
@@ -200,8 +200,9 @@ extension SwiftLintFile {
      */
     internal func match(pattern: String,
                         excludingSyntaxKinds syntaxKinds: Set<SyntaxKind>,
-                        range: NSRange? = nil) -> [NSRange] {
-        return match(pattern: pattern, range: range)
+                        range: NSRange? = nil,
+                        captureGroup: Int = 0) -> [NSRange] {
+        return match(pattern: pattern, range: range, captureGroup: captureGroup)
             .filter { syntaxKinds.isDisjoint(with: $0.1) }
             .map { $0.0 }
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -10,6 +10,7 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
     public var excluded: NSRegularExpression?
     public var matchKinds = SyntaxKind.allKinds
     public var severityConfiguration = SeverityConfiguration(.warning)
+    public var captureGroup: Int = 0
 
     public var severity: ViolationSeverity {
         return severityConfiguration.severity
@@ -73,6 +74,12 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
         }
         if let severityString = configurationDict["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)
+        }
+        if let captureGroup = configurationDict["capture_group"] as? Int {
+            guard (0 ... regex.numberOfCaptureGroups).contains(captureGroup) else {
+                throw ConfigurationError.unknownConfiguration
+            }
+            self.captureGroup = captureGroup
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -88,8 +88,9 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
 
         return configurations.flatMap { configuration -> [StyleViolation] in
             let pattern = configuration.regex.pattern
+            let captureGroup = configuration.captureGroup
             let excludingKinds = SyntaxKind.allKinds.subtracting(configuration.matchKinds)
-            return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map({
+            return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds, captureGroup: captureGroup).map({
                 StyleViolation(ruleDescription: configuration.description,
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location),

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -112,9 +112,18 @@ class CustomRulesTests: XCTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
-    private func getCustomRules(_ extraConfig: [String: String] = [:]) -> (RegexConfiguration, CustomRules) {
-        var config = ["regex": "pattern",
-                      "match_kinds": "comment"]
+    func testCustomRulesCaptureGroup() {
+        let (_, customRules) = getCustomRules(["regex": #"\ba\s+(\w+)"#,
+                                               "capture_group": 1])
+        let violations = customRules.validate(file: getTestTextFile())
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations[0].location.line, 2)
+        XCTAssertEqual(violations[0].location.character, 6)
+    }
+
+    private func getCustomRules(_ extraConfig: [String: Any] = [:]) -> (RegexConfiguration, CustomRules) {
+        var config: [String: Any] = ["regex": "pattern",
+                                     "match_kinds": "comment"]
         extraConfig.forEach { config[$0] = $1 }
 
         var regexConfig = RegexConfiguration(identifier: "custom")


### PR DESCRIPTION
This option allows for more fine-grained placement of the location marker for code violating a custom rule, e.g.:

```swift
print("Hello world.")
             ^~~~~
```

for this `.swiftlint.yml`:

```yaml
custom_rules:
  world_preceded_by_hello:
    name: "World Preceded by Hello"
    included: ".+\\.swift"
    message: "The word World predeced by the word hello should be capitalised."
    severity: warning
    regex: "(?i:hello)\\s+(world)"
    match_kinds: [string]
    capture_group: 1
```