### PR TITLE
Return early if all imports are used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 #### Enhancements
 
-* None.
+* Speedup unused_import rule..  
+  [niilohlin](https://github.com/niilohlin)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -201,6 +201,11 @@ private extension SwiftLintFile {
             }
 
             appendUsedImports(cursorInfo: cursorInfo, usrFragments: &usrFragments)
+
+            // Return early if all imports are used.
+            if imports.subtracting(usrFragments).isEmpty && !imports.isEmpty {
+                return []
+            }
         }
 
         // Always disallow 'import Swift' because it's available without importing.


### PR DESCRIPTION
This fix speeds up the `unused_import` rule. However it assumes that all imports are clustered and will probably cause false negatives if modules are imported later in the file. However this is a very rare case. 