### PR TITLE
Rules command options for correctable rules only and ignore terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 #### Enhancements
 
-* None.
+* Modified `rules` command to allow displaying only correctable rules, and to always print the full configuration details regardless of your terminal width.
+  [Optional Endeavors](https://github.com/optionalendeavors)
 
 #### Bug Fixes
 
@@ -153,7 +154,7 @@
   using `flatMap` over `map { ... }.reduce([], +)`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2883](https://github.com/realm/SwiftLint/issues/2883)
-  
+
 * Add autocorrection to `syntactic_sugar`.  
   [Ivan Vavilov](https://github.com/vani2)
 
@@ -167,7 +168,7 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2874](https://github.com/realm/SwiftLint/issues/2874)
 
-* Add `raw_value_for_camel_cased_codable_enum` opt-in rule to enforce raw values 
+* Add `raw_value_for_camel_cased_codable_enum` opt-in rule to enforce raw values
   for camel cased Codable String enum cases.  
   [Marko Pejovic](https://github.com/00FA9A)
   [#2888](https://github.com/realm/SwiftLint/issues/2888)
@@ -354,7 +355,7 @@ This is the last release to support building with Swift 4.2.x.
   [Kevin Randrup](https://github.com/kevinrandrup)
 
 * Make `testSimulateHomebrewTest()` test opt-in because it may fail on unknown
-  condition. Set `SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST` 
+  condition. Set `SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST`
   environment variable to test like:
     ```terminal.sh-session
     $ SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST=1 \
@@ -398,7 +399,7 @@ This is the last release to support building with Swift 4.2.x.
   [alvarhansen](https://github.com/alvarhansen)
   [#2746](https://github.com/realm/SwiftLint/issues/2746)
 
-* Don't trigger `file_types_order` violations in files only containing 
+* Don't trigger `file_types_order` violations in files only containing
   extensions.  
   [Sam Rayner](https://github.com/samrayner)
   [#2749](https://github.com/realm/SwiftLint/issues/2749)
@@ -505,7 +506,7 @@ This is the last release to support building with Swift 4.2.x.
   declaring extensions that add protocol conformances with Swift 5.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2705](https://github.com/realm/SwiftLint/issues/2705)
-  
+
 * Let `disable all` command override `superfluous_disable_command` rule.  
   [Frederick Pietschmann](https://github.com/fredpi)
   [#2670](https://github.com/realm/SwiftLint/issues/2670)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* Modified `rules` command to allow displaying only correctable rules, and to always print the full configuration details regardless of your terminal width.
+* Modified `rules` command to allow displaying only correctable rules, and
+  to always print the full configuration details regardless of your terminal 
+  width.
   [Optional Endeavors](https://github.com/optionalendeavors)
 
 #### Bug Fixes

--- a/Source/swiftlint/Commands/RulesCommand.swift
+++ b/Source/swiftlint/Commands/RulesCommand.swift
@@ -46,12 +46,12 @@ struct RulesCommand: CommandProtocol {
         let configuration = Configuration(options: options)
         let rules = ruleList(for: options, configuration: configuration)
 
-        print(TextTable(ruleList: rules, configuration: configuration).render())
+        print(TextTable(ruleList: rules, configuration: configuration, verbose: options.verbose).render())
         return .success(())
     }
 
     private func ruleList(for options: RulesOptions, configuration: Configuration) -> RuleList {
-        guard options.onlyEnabledRules || options.onlyDisabledRules else {
+        guard options.onlyEnabledRules || options.onlyDisabledRules || options.onlyCorrectableRules else {
             return masterRuleList
         }
 
@@ -63,6 +63,8 @@ struct RulesCommand: CommandProtocol {
             if options.onlyEnabledRules && configuredRule == nil {
                 return nil
             } else if options.onlyDisabledRules && configuredRule != nil {
+                return nil
+            } else if options.onlyCorrectableRules && !(configuredRule is CorrectableRule) {
                 return nil
             }
 
@@ -78,15 +80,19 @@ struct RulesOptions: OptionsProtocol {
     let configurationFile: String
     fileprivate let onlyEnabledRules: Bool
     fileprivate let onlyDisabledRules: Bool
+    fileprivate let onlyCorrectableRules: Bool
+    fileprivate let verbose: Bool
 
     // swiftlint:disable line_length
-    static func create(_ configurationFile: String) -> (_ ruleID: String) -> (_ onlyEnabledRules: Bool) -> (_ onlyDisabledRules: Bool) -> RulesOptions {
-        return { ruleID in { onlyEnabledRules in { onlyDisabledRules in
+    static func create(_ configurationFile: String) -> (_ ruleID: String) -> (_ onlyEnabledRules: Bool) -> (_ onlyDisabledRules: Bool) -> (_ onlyCorrectableRules: Bool) -> (_ verbose: Bool) -> RulesOptions {
+        return { ruleID in { onlyEnabledRules in { onlyDisabledRules in { onlyCorrectableRules in { verbose in
             self.init(ruleID: (ruleID.isEmpty ? nil : ruleID),
                       configurationFile: configurationFile,
                       onlyEnabledRules: onlyEnabledRules,
-                      onlyDisabledRules: onlyDisabledRules)
-        }}}
+                      onlyDisabledRules: onlyDisabledRules,
+                      onlyCorrectableRules: onlyCorrectableRules,
+                      verbose: verbose)
+        }}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<RulesOptions, CommandantError<CommandantError<()>>> {
@@ -100,13 +106,19 @@ struct RulesOptions: OptionsProtocol {
             <*> mode <| Switch(flag: "d",
                                key: "disabled",
                                usage: "only display disabled rules")
+            <*> mode <| Switch(flag: "c",
+                               key: "correctable",
+                               usage: "only display correctable rules")
+            <*> mode <| Switch(flag: "v",
+                               key: "verbose",
+                               usage: "display full configuration detail")
     }
 }
 
 // MARK: - SwiftyTextTable
 
 extension TextTable {
-    init(ruleList: RuleList, configuration: Configuration) {
+    init(ruleList: RuleList, configuration: Configuration, verbose: Bool) {
         let columns = [
             TextTableColumn(header: "identifier"),
             TextTableColumn(header: "opt-in"),
@@ -122,9 +134,10 @@ extension TextTable {
             let stringWithNoNewlines = string.replacingOccurrences(of: "\n", with: "\\n")
             let minWidth = "configuration".count - "...".count
             let configurationStartColumn = 124
+            let maxWidth = verbose ? Int.max : Terminal.currentWidth()
             let truncatedEndIndex = stringWithNoNewlines.index(
                 stringWithNoNewlines.startIndex,
-                offsetBy: max(minWidth, Terminal.currentWidth() - configurationStartColumn),
+                offsetBy: max(minWidth, maxWidth - configurationStartColumn),
                 limitedBy: stringWithNoNewlines.endIndex
             )
             if let truncatedEndIndex = truncatedEndIndex {


### PR DESCRIPTION
Add support to the `rules` command for only showing correctable rules, and a switch for ignoring the width of the terminal so full configuration detail is always shown in the table.