### PR TITLE
Fix FileLengthRule with empty syntaxKinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,9 @@
 
 * Fix crash when SourceKit returns out of bounds string byte offsets.  
   [JP Simard](https://github.com/jpsim)
+* Fix `file_length` rule misidentifying non-whitespace lines without any syntax
+  tokens as whitespace-only lines.  
+  [Keith Smiley](https://github.com/keith)
 
 ## 0.38.0: Toroidal Agitation
 

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -25,7 +25,7 @@ public struct FileLengthRule: ConfigurationProviderRule {
             let lineCount = file.syntaxKindsByLines.filter { kinds in
                 return kinds.isEmpty || !Set(kinds).isSubset(of: commentKinds)
             }.count
-            return lineCount
+            return lineCount - 1
         }
 
         var lineCount = file.lines.count

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -23,7 +23,7 @@ public struct FileLengthRule: ConfigurationProviderRule {
         func lineCountWithoutComments() -> Int {
             let commentKinds = SyntaxKind.commentKinds
             let lineCount = file.syntaxKindsByLines.filter { kinds in
-                return !Set(kinds).isSubset(of: commentKinds)
+                return kinds.isEmpty || !Set(kinds).isSubset(of: commentKinds)
             }.count
             return lineCount
         }

--- a/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
@@ -9,7 +9,8 @@ class FileLengthRuleTests: XCTestCase {
 
     func testFileLengthIgnoringLinesWithOnlyComments() {
         let triggeringExamples = [
-            Example(repeatElement("print(\"swiftlint\")\n", count: 401).joined())
+            Example(repeatElement("print(\"swiftlint\")\n", count: 401).joined()),
+            Example(repeatElement("\n", count: 401).joined())
         ]
         let nonTriggeringExamples = [
             Example((repeatElement("print(\"swiftlint\")\n", count: 400) + ["//\n"]).joined()),


### PR DESCRIPTION
Sometimes `syntaxKindsByLines` contains empty `kinds` and since the
empty set is a subset of all sets, we would incorrectly remove those
lines from our count.