### PR TITLE
Add AutomaticTestableRule conformance to EnumCaseAssociatedValuesLengthRule

### DIFF
--- a/Source/SwiftLintFramework/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct EnumCaseAssociatedValuesLengthRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct EnumCaseAssociatedValuesLengthRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityLevelsConfiguration(warning: 5, error: 6)
 
     public init() {}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -394,6 +394,12 @@ extension EmptyXCTestMethodRuleTests {
     ]
 }
 
+extension EnumCaseAssociatedValuesLengthRuleTests {
+    static var allTests: [(String, (EnumCaseAssociatedValuesLengthRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension ExpiringTodoRuleTests {
     static var allTests: [(String, (ExpiringTodoRuleTests) -> () throws -> Void)] = [
         ("testExpiringTodo", testExpiringTodo),
@@ -1634,6 +1640,7 @@ XCTMain([
     testCase(EmptyParenthesesWithTrailingClosureRuleTests.allTests),
     testCase(EmptyStringRuleTests.allTests),
     testCase(EmptyXCTestMethodRuleTests.allTests),
+    testCase(EnumCaseAssociatedValuesLengthRuleTests.allTests),
     testCase(ExpiringTodoRuleTests.allTests),
     testCase(ExplicitACLRuleTests.allTests),
     testCase(ExplicitEnumRawValueRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -174,7 +174,7 @@ class EmptyXCTestMethodRuleTests: XCTestCase {
     }
 }
 
-final class EnumCaseAssociatedValuesLengthRuleTests: XCTestCase {
+class EnumCaseAssociatedValuesLengthRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EnumCaseAssociatedValuesLengthRule.description)
     }


### PR DESCRIPTION
Follow up from #2998