### PR TITLE
[DO NOT MERGE] Add return_value_from_void_function using SwiftSyntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -56,6 +56,15 @@
         }
       },
       {
+        "package": "SwiftSyntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "state": {
+          "branch": null,
+          "revision": "3e3eb191fcdbecc6031522660c4ed6ce25282c25",
+          "version": "0.50100.0"
+        }
+      },
+      {
         "package": "SwiftyTextTable",
         "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.28.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
     ] + (addCryptoSwift ? [.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.0.0"))] : []),
     targets: [
         .target(
@@ -33,6 +34,7 @@ let package = Package(
             dependencies: [
                 "SourceKittenFramework",
                 "Yams",
+                "SwiftSyntax",
             ] + (addCryptoSwift ? ["CryptoSwift"] : [])
         ),
         .testTarget(

--- a/Rules.md
+++ b/Rules.md
@@ -143,6 +143,7 @@
 * [Required Deinit](#required-deinit)
 * [Required Enum Case](#required-enum-case)
 * [Returning Whitespace](#returning-whitespace)
+* [Return Value from Void Function](#return-value-from-void-function)
 * [Shorthand Operator](#shorthand-operator)
 * [Single Test Class](#single-test-class)
 * [Min or Max over Sorted First or Last](#min-or-max-over-sorted-first-or-last)
@@ -18630,6 +18631,284 @@ var abc = {(param: Int)↓ ->Bool in }
 ```swift
 var abc = {(param: Int)↓->Bool in }
 
+```
+
+</details>
+
+
+
+## Return Value from Void Function
+
+Identifier | Enabled by default | Supports autocorrection | Kind | Analyzer | Minimum Swift Compiler Version
+--- | --- | --- | --- | --- | ---
+`return_value_from_void_function` | Enabled | No | lint | No | 3.0.0 
+
+Returning values Void functions should be avoided.
+
+### Examples
+
+<details>
+<summary>Non Triggering Examples</summary>
+
+```swift
+func foo() {
+    return
+}
+```
+
+```swift
+func foo() {
+    return /* a comment */
+}
+```
+
+```swift
+func foo() -> Int {
+    return 1
+}
+```
+
+```swift
+func foo() -> Void {
+    if condition {
+        return
+    }
+    bar()
+}
+```
+
+```swift
+func foo() {
+    return;
+    bar()
+}
+```
+
+```swift
+
+```
+
+```swift
+func test() {}
+```
+
+```swift
+init?() {
+    guard condition else {
+        return nil
+    }
+}
+```
+
+```swift
+init?(arg: String?) {
+    guard arg != nil else {
+        return nil
+    }
+}
+```
+
+```swift
+func test() {
+    guard condition else {
+        return
+    }
+}
+```
+
+```swift
+func test() -> Result<String, Error> {
+    func other() {}
+    func otherVoid() -> Void {}
+}
+```
+
+```swift
+func test() -> Int? {
+    return nil
+}
+```
+
+```swift
+func test() {
+    if bar {
+        print("")
+        return
+    }
+    let foo = [1, 2, 3].filter { return true }
+    return
+}
+```
+
+```swift
+func test() {
+    guard foo else {
+        bar()
+        return
+    }
+}
+```
+
+</details>
+<details>
+<summary>Triggering Examples</summary>
+
+```swift
+func foo() {
+    ↓return bar()
+}
+```
+
+```swift
+func foo() {
+    ↓return self.bar()
+}
+```
+
+```swift
+func foo() -> Void {
+    ↓return bar()
+}
+```
+
+```swift
+func foo() -> Void {
+    ↓return /* comment */ bar()
+}
+```
+
+```swift
+func foo() {
+    ↓return
+    self.bar()
+}
+```
+
+```swift
+func foo() {
+    variable += 1
+    ↓return
+    variable += 1
+}
+```
+
+```swift
+func initThing() {
+    guard foo else {
+        ↓return print("")
+    }
+}
+```
+
+```swift
+// Leading comment
+func test() {
+    guard condition else {
+        ↓return assertionfailure("")
+    }
+}
+```
+
+```swift
+func test() -> Result<String, Error> {
+    func other() {
+        guard false else {
+            ↓return assertionfailure("")
+        }
+    }
+    func otherVoid() -> Void {}
+}
+```
+
+```swift
+func test() {
+    guard conditionIsTrue else {
+        sideEffects()
+        return // comment
+    }
+    guard otherCondition else {
+        ↓return assertionfailure("")
+    }
+    differentSideEffect()
+}
+```
+
+```swift
+func test() {
+    guard otherCondition else {
+        ↓return assertionfailure(""); // comment
+    }
+    differentSideEffect()
+}
+```
+
+```swift
+func test() {
+  if x {
+    ↓return foo()
+  }
+  bar()
+}
+```
+
+```swift
+func test() {
+  switch x {
+    case .a:
+      ↓return foo() // return to skip baz()
+    case .b:
+      bar()
+  }
+  baz()
+}
+```
+
+```swift
+func test() {
+  if check {
+    if otherCheck {
+      ↓return foo()
+    }
+  }
+  bar()
+}
+```
+
+```swift
+func test() {
+    ↓return foo()
+}
+```
+
+```swift
+func test() {
+  ↓return foo({
+    return bar()
+  })
+}
+```
+
+```swift
+func test() {
+  guard x else {
+    ↓return foo()
+  }
+  bar()
+}
+```
+
+```swift
+func test() {
+  let closure: () -> () = {
+    return assert()
+  }
+  if check {
+    if otherCheck {
+      return // comments are fine
+    }
+  }
+  ↓return foo()
+}
 ```
 
 </details>

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -144,6 +144,7 @@ public let masterRuleList = RuleList(rules: [
     RequiredDeinitRule.self,
     RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,
+    ReturnValueFromVoidFunctionRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,
     SortedFirstLastRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ReturnValueFromVoidFunctionRule.swift
@@ -1,0 +1,80 @@
+import Foundation
+import SourceKittenFramework
+import SwiftSyntax
+
+public struct ReturnValueFromVoidFunctionRule: ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "return_value_from_void_function",
+        name: "Return Value from Void Function",
+        description: "Returning values Void functions should be avoided.",
+        kind: .lint,
+        nonTriggeringExamples: ReturnValueFromVoidFunctionRuleExamples.nonTriggeringExamples,
+        triggeringExamples: ReturnValueFromVoidFunctionRuleExamples.triggeringExamples
+    )
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        var visitor = ReturnVisitor()
+
+        // https://bugs.swift.org/browse/SR-11170
+        let work = DispatchWorkItem {
+            file.syntax.walk(&visitor)
+        }
+        if #available(OSX 10.12, *) {
+            let thread = Thread {
+                work.perform()
+            }
+            thread.stackSize = 8 << 20 // 8 MB.
+            thread.start()
+            work.wait()
+        } else {
+            queuedFatalError("macOS < 10.12")
+        }
+
+        return visitor.positions.map { position in
+            StyleViolation(ruleDescription: type(of: self).description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: position.utf8Offset))
+        }
+    }
+}
+
+private struct ReturnVisitor: SyntaxVisitor {
+    private(set) var positions = [AbsolutePosition]()
+
+    mutating func visit(_ node: ReturnStmtSyntax) -> SyntaxVisitorContinueKind {
+        if node.expression != nil,
+            let functionNode = node.enclosingFunction(),
+            functionNode.returnsVoid {
+            positions.append(node.positionAfterSkippingLeadingTrivia)
+        }
+        return .visitChildren
+    }
+}
+
+private extension Syntax {
+    func enclosingFunction() -> FunctionDeclSyntax? {
+        if let node = self as? FunctionDeclSyntax {
+            return node
+        }
+
+        if self is ClosureExprSyntax {
+            return nil
+        }
+
+        return parent?.enclosingFunction()
+    }
+}
+
+private extension FunctionDeclSyntax {
+    var returnsVoid: Bool {
+        if let type = signature.output?.returnType as? SimpleTypeIdentifierSyntax {
+            return type.name.text == "Void"
+        } else {
+            return signature.output?.returnType == nil
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/ReturnValueFromVoidFunctionRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ReturnValueFromVoidFunctionRuleExamples.swift
@@ -1,0 +1,229 @@
+// swiftlint:disable:next type_body_length
+internal struct ReturnValueFromVoidFunctionRuleExamples {
+    static let nonTriggeringExamples = [
+        """
+        func foo() {
+            return
+        }
+        """,
+        """
+        func foo() {
+            return /* a comment */
+        }
+        """,
+        """
+        func foo() -> Int {
+            return 1
+        }
+        """,
+        """
+        func foo() -> Void {
+            if condition {
+                return
+            }
+            bar()
+        }
+        """,
+        """
+        func foo() {
+            return;
+            bar()
+        }
+        """,
+        "",
+        "func test() {}",
+        """
+        init?() {
+            guard condition else {
+                return nil
+            }
+        }
+        """,
+        """
+        init?(arg: String?) {
+            guard arg != nil else {
+                return nil
+            }
+        }
+        """,
+        """
+        func test() {
+            guard condition else {
+                return
+            }
+        }
+        """,
+        """
+        func test() -> Result<String, Error> {
+            func other() {}
+            func otherVoid() -> Void {}
+        }
+        """,
+        """
+        func test() -> Int? {
+            return nil
+        }
+        """,
+        """
+        func test() {
+            if bar {
+                print("")
+                return
+            }
+            let foo = [1, 2, 3].filter { return true }
+            return
+        }
+        """,
+        """
+        func test() {
+            guard foo else {
+                bar()
+                return
+            }
+        }
+        """
+    ]
+
+    static let triggeringExamples = [
+        """
+        func foo() {
+            ↓return bar()
+        }
+        """,
+        """
+        func foo() {
+            ↓return self.bar()
+        }
+        """,
+        """
+        func foo() -> Void {
+            ↓return bar()
+        }
+        """,
+        """
+        func foo() -> Void {
+            ↓return /* comment */ bar()
+        }
+        """,
+        """
+        func foo() {
+            ↓return
+            self.bar()
+        }
+        """,
+        """
+        func foo() {
+            variable += 1
+            ↓return
+            variable += 1
+        }
+        """,
+        """
+        func initThing() {
+            guard foo else {
+                ↓return print("")
+            }
+        }
+        """,
+        """
+        // Leading comment
+        func test() {
+            guard condition else {
+                ↓return assertionfailure("")
+            }
+        }
+        """,
+        """
+        func test() -> Result<String, Error> {
+            func other() {
+                guard false else {
+                    ↓return assertionfailure("")
+                }
+            }
+            func otherVoid() -> Void {}
+        }
+        """,
+        """
+        func test() {
+            guard conditionIsTrue else {
+                sideEffects()
+                return // comment
+            }
+            guard otherCondition else {
+                ↓return assertionfailure("")
+            }
+            differentSideEffect()
+        }
+        """,
+        """
+        func test() {
+            guard otherCondition else {
+                ↓return assertionfailure(""); // comment
+            }
+            differentSideEffect()
+        }
+        """,
+        """
+        func test() {
+          if x {
+            ↓return foo()
+          }
+          bar()
+        }
+        """,
+        """
+        func test() {
+          switch x {
+            case .a:
+              ↓return foo() // return to skip baz()
+            case .b:
+              bar()
+          }
+          baz()
+        }
+        """,
+        """
+        func test() {
+          if check {
+            if otherCheck {
+              ↓return foo()
+            }
+          }
+          bar()
+        }
+        """,
+        """
+        func test() {
+            ↓return foo()
+        }
+        """,
+        """
+        func test() {
+          ↓return foo({
+            return bar()
+          })
+        }
+        """,
+        """
+        func test() {
+          guard x else {
+            ↓return foo()
+          }
+          bar()
+        }
+        """,
+        """
+        func test() {
+          let closure: () -> () = {
+            return assert()
+          }
+          if check {
+            if otherCheck {
+              return // comments are fine
+            }
+          }
+          ↓return foo()
+        }
+        """
+    ]
+}

--- a/SwiftLint.xcodeproj/CYaml_Info.plist
+++ b/SwiftLint.xcodeproj/CYaml_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/Clang_C_Info.plist
+++ b/SwiftLint.xcodeproj/Clang_C_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/Commandant_Info.plist
+++ b/SwiftLint.xcodeproj/Commandant_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap
+++ b/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap
@@ -1,0 +1,4 @@
+module _CSwiftSyntax {
+    umbrella "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include"
+    export *
+}

--- a/SwiftLint.xcodeproj/SWXMLHash_Info.plist
+++ b/SwiftLint.xcodeproj/SWXMLHash_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/SourceKit_Info.plist
+++ b/SwiftLint.xcodeproj/SourceKit_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/SourceKittenFramework_Info.plist
+++ b/SwiftLint.xcodeproj/SourceKittenFramework_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/SwiftLintFrameworkTests_Info.plist
+++ b/SwiftLint.xcodeproj/SwiftLintFrameworkTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/SwiftLintFramework_Info.plist
+++ b/SwiftLint.xcodeproj/SwiftLintFramework_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/SwiftSyntax_Info.plist
+++ b/SwiftLint.xcodeproj/SwiftSyntax_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/SwiftyTextTable_Info.plist
+++ b/SwiftLint.xcodeproj/SwiftyTextTable_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/Yams_Info.plist
+++ b/SwiftLint.xcodeproj/Yams_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/_CSwiftSyntax_Info.plist
+++ b/SwiftLint.xcodeproj/_CSwiftSyntax_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -1,9259 +1,5024 @@
 // !$*UTF8*$!
 {
-   archiveVersion = "1";
-   objectVersion = "46";
-   objects = {
-      "Commandant::Commandant" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_668";
-         buildPhases = (
-            "OBJ_671",
-            "OBJ_682"
-         );
-         dependencies = (
-         );
-         name = "Commandant";
-         productName = "Commandant";
-         productReference = "Commandant::Commandant::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "Commandant::Commandant::Product" = {
-         isa = "PBXFileReference";
-         path = "Commandant.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "Commandant::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_684";
-         buildPhases = (
-            "OBJ_687"
-         );
-         dependencies = (
-         );
-         name = "CommandantPackageDescription";
-         productName = "CommandantPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "OBJ_1" = {
-         isa = "PBXProject";
-         attributes = {
-            LastSwiftMigration = "9999";
-            LastUpgradeCheck = "9999";
-         };
-         buildConfigurationList = "OBJ_2";
-         compatibilityVersion = "Xcode 3.2";
-         developmentRegion = "en";
-         hasScannedForEncodings = "0";
-         knownRegions = (
-            "en"
-         );
-         mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_599";
-         projectDirPath = ".";
-         targets = (
-            "Yams::CYaml",
-            "SourceKitten::Clang_C",
-            "Commandant::Commandant",
-            "Commandant::SwiftPMPackageDescription",
-            "SWXMLHash::SWXMLHash",
-            "SWXMLHash::SwiftPMPackageDescription",
-            "SourceKitten::SourceKit",
-            "SourceKitten::SourceKittenFramework",
-            "SourceKitten::SwiftPMPackageDescription",
-            "SwiftLint::SwiftLintFramework",
-            "SwiftLint::SwiftLintFrameworkTests",
-            "SwiftLint::SwiftPMPackageDescription",
-            "SwiftLint::SwiftLintPackageTests::ProductTarget",
-            "SwiftSyntax::SwiftSyntax",
-            "SwiftSyntax::SwiftPMPackageDescription",
-            "SwiftyTextTable::SwiftyTextTable",
-            "SwiftyTextTable::SwiftPMPackageDescription",
-            "Yams::Yams",
-            "Yams::SwiftPMPackageDescription",
-            "SwiftSyntax::_CSwiftSyntax",
-            "SwiftLint::swiftlint"
-         );
-      };
-      "OBJ_10" = {
-         isa = "PBXFileReference";
-         path = "Array+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_100" = {
-         isa = "PBXFileReference";
-         path = "FileNameRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1000" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_234";
-      };
-      "OBJ_1001" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_235";
-      };
-      "OBJ_1002" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_236";
-      };
-      "OBJ_1003" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_237";
-      };
-      "OBJ_1004" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_238";
-      };
-      "OBJ_1005" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_239";
-      };
-      "OBJ_1006" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_240";
-      };
-      "OBJ_1007" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_241";
-      };
-      "OBJ_1008" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_242";
-      };
-      "OBJ_1009" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_243";
-      };
-      "OBJ_101" = {
-         isa = "PBXFileReference";
-         path = "ForWhereRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1010" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_244";
-      };
-      "OBJ_1011" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_245";
-      };
-      "OBJ_1012" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_246";
-      };
-      "OBJ_1013" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_247";
-      };
-      "OBJ_1014" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_248";
-      };
-      "OBJ_1015" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_249";
-      };
-      "OBJ_1016" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_250";
-      };
-      "OBJ_1017" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_251";
-      };
-      "OBJ_1018" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_252";
-      };
-      "OBJ_1019" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_253";
-      };
-      "OBJ_102" = {
-         isa = "PBXFileReference";
-         path = "ForceCastRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1020" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_254";
-      };
-      "OBJ_1021" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_255";
-      };
-      "OBJ_1022" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_256";
-      };
-      "OBJ_1023" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_257";
-      };
-      "OBJ_1024" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_258";
-      };
-      "OBJ_1025" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_259";
-      };
-      "OBJ_1026" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_260";
-      };
-      "OBJ_1027" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_261";
-      };
-      "OBJ_1028" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_262";
-      };
-      "OBJ_1029" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_263";
-      };
-      "OBJ_103" = {
-         isa = "PBXFileReference";
-         path = "ForceTryRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1030" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_264";
-      };
-      "OBJ_1031" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_265";
-      };
-      "OBJ_1032" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_266";
-      };
-      "OBJ_1033" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_267";
-      };
-      "OBJ_1034" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_268";
-      };
-      "OBJ_1035" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_269";
-      };
-      "OBJ_1036" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_270";
-      };
-      "OBJ_1037" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_272";
-      };
-      "OBJ_1038" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_273";
-      };
-      "OBJ_1039" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_274";
-      };
-      "OBJ_104" = {
-         isa = "PBXFileReference";
-         path = "ForceUnwrappingRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1040" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_275";
-      };
-      "OBJ_1041" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_276";
-      };
-      "OBJ_1042" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_277";
-      };
-      "OBJ_1043" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_278";
-      };
-      "OBJ_1044" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_279";
-      };
-      "OBJ_1045" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_280";
-      };
-      "OBJ_1046" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_281";
-      };
-      "OBJ_1047" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_282";
-      };
-      "OBJ_1048" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_283";
-      };
-      "OBJ_1049" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_284";
-      };
-      "OBJ_105" = {
-         isa = "PBXFileReference";
-         path = "FunctionDefaultParameterAtEndRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1050" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_285";
-      };
-      "OBJ_1051" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_286";
-      };
-      "OBJ_1052" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_287";
-      };
-      "OBJ_1053" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_288";
-      };
-      "OBJ_1054" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_289";
-      };
-      "OBJ_1055" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_290";
-      };
-      "OBJ_1056" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_291";
-      };
-      "OBJ_1057" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_292";
-      };
-      "OBJ_1058" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_293";
-      };
-      "OBJ_1059" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_294";
-      };
-      "OBJ_106" = {
-         isa = "PBXFileReference";
-         path = "GenericTypeNameRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1060" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_295";
-      };
-      "OBJ_1061" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_296";
-      };
-      "OBJ_1062" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_297";
-      };
-      "OBJ_1063" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_298";
-      };
-      "OBJ_1064" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_299";
-      };
-      "OBJ_1065" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_300";
-      };
-      "OBJ_1066" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_301";
-      };
-      "OBJ_1067" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_302";
-      };
-      "OBJ_1068" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_303";
-      };
-      "OBJ_1069" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_304";
-      };
-      "OBJ_107" = {
-         isa = "PBXFileReference";
-         path = "ImplicitlyUnwrappedOptionalRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1070" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_305";
-      };
-      "OBJ_1071" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_306";
-      };
-      "OBJ_1072" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_307";
-      };
-      "OBJ_1073" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_308";
-      };
-      "OBJ_1074" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_309";
-      };
-      "OBJ_1075" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_310";
-      };
-      "OBJ_1076" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_311";
-      };
-      "OBJ_1077" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_312";
-      };
-      "OBJ_1078" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_313";
-      };
-      "OBJ_1079" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_314";
-      };
-      "OBJ_108" = {
-         isa = "PBXFileReference";
-         path = "IsDisjointRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1080" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_315";
-      };
-      "OBJ_1081" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_316";
-      };
-      "OBJ_1082" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_317";
-      };
-      "OBJ_1083" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_318";
-      };
-      "OBJ_1084" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_319";
-      };
-      "OBJ_1085" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_320";
-      };
-      "OBJ_1086" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_321";
-      };
-      "OBJ_1087" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_322";
-      };
-      "OBJ_1088" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_323";
-      };
-      "OBJ_1089" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_324";
-      };
-      "OBJ_109" = {
-         isa = "PBXFileReference";
-         path = "JoinedDefaultParameterRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1090" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_325";
-      };
-      "OBJ_1091" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_326";
-      };
-      "OBJ_1092" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_327";
-      };
-      "OBJ_1093" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_328";
-      };
-      "OBJ_1094" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_329";
-      };
-      "OBJ_1095" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_330";
-      };
-      "OBJ_1096" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_331";
-      };
-      "OBJ_1097" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_332";
-      };
-      "OBJ_1098" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_333";
-      };
-      "OBJ_1099" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_334";
-      };
-      "OBJ_11" = {
-         isa = "PBXFileReference";
-         path = "Configuration+Cache.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_110" = {
-         isa = "PBXFileReference";
-         path = "LegacyCGGeometryFunctionsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1100" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_335";
-      };
-      "OBJ_1101" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_336";
-      };
-      "OBJ_1102" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_337";
-      };
-      "OBJ_1103" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_338";
-      };
-      "OBJ_1104" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_339";
-      };
-      "OBJ_1105" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_340";
-      };
-      "OBJ_1106" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_341";
-      };
-      "OBJ_1107" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_342";
-      };
-      "OBJ_1108" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_343";
-      };
-      "OBJ_1109" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_344";
-      };
-      "OBJ_111" = {
-         isa = "PBXFileReference";
-         path = "LegacyConstantRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1110" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_345";
-      };
-      "OBJ_1111" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_346";
-      };
-      "OBJ_1112" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_347";
-      };
-      "OBJ_1113" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_1114",
-            "OBJ_1115",
-            "OBJ_1116",
-            "OBJ_1117",
-            "OBJ_1118",
-            "OBJ_1119",
-            "OBJ_1120",
-            "OBJ_1121"
-         );
-      };
-      "OBJ_1114" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftSyntax::SwiftSyntax::Product";
-      };
-      "OBJ_1115" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftSyntax::_CSwiftSyntax::Product";
-      };
-      "OBJ_1116" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::SourceKittenFramework::Product";
-      };
-      "OBJ_1117" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::Yams::Product";
-      };
-      "OBJ_1118" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::CYaml::Product";
-      };
-      "OBJ_1119" = {
-         isa = "PBXBuildFile";
-         fileRef = "SWXMLHash::SWXMLHash::Product";
-      };
-      "OBJ_112" = {
-         isa = "PBXFileReference";
-         path = "LegacyConstantRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1120" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::SourceKit::Product";
-      };
-      "OBJ_1121" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::Clang_C::Product";
-      };
-      "OBJ_1122" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftSyntax::SwiftSyntax";
-      };
-      "OBJ_1124" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftSyntax::_CSwiftSyntax";
-      };
-      "OBJ_1126" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::SourceKittenFramework";
-      };
-      "OBJ_1127" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::Yams";
-      };
-      "OBJ_1128" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::CYaml";
-      };
-      "OBJ_1129" = {
-         isa = "PBXTargetDependency";
-         target = "SWXMLHash::SWXMLHash";
-      };
-      "OBJ_113" = {
-         isa = "PBXFileReference";
-         path = "LegacyConstructorRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1130" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::SourceKit";
-      };
-      "OBJ_1131" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::Clang_C";
-      };
-      "OBJ_1133" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1134",
-            "OBJ_1135"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1134" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
-               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftLintFrameworkTests_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-Xcc",
-               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftLintFrameworkTests";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_1135" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
-               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftLintFrameworkTests_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-Xcc",
-               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftLintFrameworkTests";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_1136" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1137",
-            "OBJ_1138",
-            "OBJ_1139",
-            "OBJ_1140",
-            "OBJ_1141",
-            "OBJ_1142",
-            "OBJ_1143",
-            "OBJ_1144",
-            "OBJ_1145",
-            "OBJ_1146",
-            "OBJ_1147",
-            "OBJ_1148",
-            "OBJ_1149",
-            "OBJ_1150",
-            "OBJ_1151",
-            "OBJ_1152",
-            "OBJ_1153",
-            "OBJ_1154",
-            "OBJ_1155",
-            "OBJ_1156",
-            "OBJ_1157",
-            "OBJ_1158",
-            "OBJ_1159",
-            "OBJ_1160",
-            "OBJ_1161",
-            "OBJ_1162",
-            "OBJ_1163",
-            "OBJ_1164",
-            "OBJ_1165",
-            "OBJ_1166",
-            "OBJ_1167",
-            "OBJ_1168",
-            "OBJ_1169",
-            "OBJ_1170",
-            "OBJ_1171",
-            "OBJ_1172",
-            "OBJ_1173",
-            "OBJ_1174",
-            "OBJ_1175",
-            "OBJ_1176",
-            "OBJ_1177",
-            "OBJ_1178",
-            "OBJ_1179",
-            "OBJ_1180",
-            "OBJ_1181",
-            "OBJ_1182",
-            "OBJ_1183",
-            "OBJ_1184",
-            "OBJ_1185",
-            "OBJ_1186",
-            "OBJ_1187",
-            "OBJ_1188",
-            "OBJ_1189",
-            "OBJ_1190",
-            "OBJ_1191",
-            "OBJ_1192",
-            "OBJ_1193",
-            "OBJ_1194",
-            "OBJ_1195",
-            "OBJ_1196",
-            "OBJ_1197",
-            "OBJ_1198",
-            "OBJ_1199",
-            "OBJ_1200",
-            "OBJ_1201",
-            "OBJ_1202",
-            "OBJ_1203",
-            "OBJ_1204",
-            "OBJ_1205",
-            "OBJ_1206",
-            "OBJ_1207",
-            "OBJ_1208",
-            "OBJ_1209",
-            "OBJ_1210"
-         );
-      };
-      "OBJ_1137" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_369";
-      };
-      "OBJ_1138" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_370";
-      };
-      "OBJ_1139" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_371";
-      };
-      "OBJ_114" = {
-         isa = "PBXFileReference";
-         path = "LegacyHashingRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1140" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_372";
-      };
-      "OBJ_1141" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_373";
-      };
-      "OBJ_1142" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_374";
-      };
-      "OBJ_1143" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_375";
-      };
-      "OBJ_1144" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_376";
-      };
-      "OBJ_1145" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_377";
-      };
-      "OBJ_1146" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_378";
-      };
-      "OBJ_1147" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_379";
-      };
-      "OBJ_1148" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_380";
-      };
-      "OBJ_1149" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_381";
-      };
-      "OBJ_115" = {
-         isa = "PBXFileReference";
-         path = "LegacyMultipleRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1150" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_382";
-      };
-      "OBJ_1151" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_383";
-      };
-      "OBJ_1152" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_384";
-      };
-      "OBJ_1153" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_385";
-      };
-      "OBJ_1154" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_386";
-      };
-      "OBJ_1155" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_387";
-      };
-      "OBJ_1156" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_388";
-      };
-      "OBJ_1157" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_389";
-      };
-      "OBJ_1158" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_390";
-      };
-      "OBJ_1159" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_391";
-      };
-      "OBJ_116" = {
-         isa = "PBXFileReference";
-         path = "LegacyNSGeometryFunctionsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1160" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_392";
-      };
-      "OBJ_1161" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_393";
-      };
-      "OBJ_1162" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_394";
-      };
-      "OBJ_1163" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_395";
-      };
-      "OBJ_1164" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_396";
-      };
-      "OBJ_1165" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_397";
-      };
-      "OBJ_1166" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_398";
-      };
-      "OBJ_1167" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_399";
-      };
-      "OBJ_1168" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_400";
-      };
-      "OBJ_1169" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_401";
-      };
-      "OBJ_117" = {
-         isa = "PBXFileReference";
-         path = "LegacyRandomRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1170" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_402";
-      };
-      "OBJ_1171" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_403";
-      };
-      "OBJ_1172" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_404";
-      };
-      "OBJ_1173" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_405";
-      };
-      "OBJ_1174" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_406";
-      };
-      "OBJ_1175" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_407";
-      };
-      "OBJ_1176" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_408";
-      };
-      "OBJ_1177" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_409";
-      };
-      "OBJ_1178" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_410";
-      };
-      "OBJ_1179" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_411";
-      };
-      "OBJ_118" = {
-         isa = "PBXFileReference";
-         path = "NimbleOperatorRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1180" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_412";
-      };
-      "OBJ_1181" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_413";
-      };
-      "OBJ_1182" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_414";
-      };
-      "OBJ_1183" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_415";
-      };
-      "OBJ_1184" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_416";
-      };
-      "OBJ_1185" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_417";
-      };
-      "OBJ_1186" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_418";
-      };
-      "OBJ_1187" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_419";
-      };
-      "OBJ_1188" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_420";
-      };
-      "OBJ_1189" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_421";
-      };
-      "OBJ_119" = {
-         isa = "PBXFileReference";
-         path = "NoExtensionAccessModifierRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1190" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_422";
-      };
-      "OBJ_1191" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_423";
-      };
-      "OBJ_1192" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_424";
-      };
-      "OBJ_1193" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_425";
-      };
-      "OBJ_1194" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_426";
-      };
-      "OBJ_1195" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_427";
-      };
-      "OBJ_1196" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_428";
-      };
-      "OBJ_1197" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_429";
-      };
-      "OBJ_1198" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_430";
-      };
-      "OBJ_1199" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_431";
-      };
-      "OBJ_12" = {
-         isa = "PBXFileReference";
-         path = "Configuration+IndentationStyle.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_120" = {
-         isa = "PBXFileReference";
-         path = "NoFallthroughOnlyRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1200" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_432";
-      };
-      "OBJ_1201" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_433";
-      };
-      "OBJ_1202" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_434";
-      };
-      "OBJ_1203" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_435";
-      };
-      "OBJ_1204" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_436";
-      };
-      "OBJ_1205" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_437";
-      };
-      "OBJ_1206" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_438";
-      };
-      "OBJ_1207" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_439";
-      };
-      "OBJ_1208" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_440";
-      };
-      "OBJ_1209" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_441";
-      };
-      "OBJ_121" = {
-         isa = "PBXFileReference";
-         path = "NoFallthroughOnlyRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1210" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_442";
-      };
-      "OBJ_1211" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_1212",
-            "OBJ_1213",
-            "OBJ_1214",
-            "OBJ_1215",
-            "OBJ_1216",
-            "OBJ_1217",
-            "OBJ_1218",
-            "OBJ_1219",
-            "OBJ_1220"
-         );
-      };
-      "OBJ_1212" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftLint::SwiftLintFramework::Product";
-      };
-      "OBJ_1213" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftSyntax::SwiftSyntax::Product";
-      };
-      "OBJ_1214" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftSyntax::_CSwiftSyntax::Product";
-      };
-      "OBJ_1215" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::SourceKittenFramework::Product";
-      };
-      "OBJ_1216" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::Yams::Product";
-      };
-      "OBJ_1217" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::CYaml::Product";
-      };
-      "OBJ_1218" = {
-         isa = "PBXBuildFile";
-         fileRef = "SWXMLHash::SWXMLHash::Product";
-      };
-      "OBJ_1219" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::SourceKit::Product";
-      };
-      "OBJ_122" = {
-         isa = "PBXFileReference";
-         path = "NoGroupingExtensionRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1220" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::Clang_C::Product";
-      };
-      "OBJ_1221" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftLint::SwiftLintFramework";
-      };
-      "OBJ_1222" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftSyntax::SwiftSyntax";
-      };
-      "OBJ_1223" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftSyntax::_CSwiftSyntax";
-      };
-      "OBJ_1224" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::SourceKittenFramework";
-      };
-      "OBJ_1225" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::Yams";
-      };
-      "OBJ_1226" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::CYaml";
-      };
-      "OBJ_1227" = {
-         isa = "PBXTargetDependency";
-         target = "SWXMLHash::SWXMLHash";
-      };
-      "OBJ_1228" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::SourceKit";
-      };
-      "OBJ_1229" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::Clang_C";
-      };
-      "OBJ_123" = {
-         isa = "PBXFileReference";
-         path = "ObjectLiteralRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1231" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1232",
-            "OBJ_1233"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1232" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_1233" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Release";
-      };
-      "OBJ_1234" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1235"
-         );
-      };
-      "OBJ_1235" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
-      };
-      "OBJ_1237" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1238",
-            "OBJ_1239"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1238" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Debug";
-      };
-      "OBJ_1239" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Release";
-      };
-      "OBJ_124" = {
-         isa = "PBXFileReference";
-         path = "PatternMatchingKeywordsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1240" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftLint::SwiftLintFrameworkTests";
-      };
-      "OBJ_1241" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1242",
-            "OBJ_1243"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1242" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
-               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftSyntax_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-Xcc",
-               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftSyntax";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.2";
-            TARGET_NAME = "SwiftSyntax";
-         };
-         name = "Debug";
-      };
-      "OBJ_1243" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
-               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftSyntax_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-Xcc",
-               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftSyntax";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.2";
-            TARGET_NAME = "SwiftSyntax";
-         };
-         name = "Release";
-      };
-      "OBJ_1244" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1245",
-            "OBJ_1246",
-            "OBJ_1247",
-            "OBJ_1248",
-            "OBJ_1249",
-            "OBJ_1250",
-            "OBJ_1251",
-            "OBJ_1252",
-            "OBJ_1253",
-            "OBJ_1254",
-            "OBJ_1255",
-            "OBJ_1256",
-            "OBJ_1257",
-            "OBJ_1258",
-            "OBJ_1259",
-            "OBJ_1260",
-            "OBJ_1261",
-            "OBJ_1262",
-            "OBJ_1263",
-            "OBJ_1264",
-            "OBJ_1265",
-            "OBJ_1266",
-            "OBJ_1267",
-            "OBJ_1268",
-            "OBJ_1269",
-            "OBJ_1270",
-            "OBJ_1271",
-            "OBJ_1272"
-         );
-      };
-      "OBJ_1245" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_446";
-      };
-      "OBJ_1246" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_447";
-      };
-      "OBJ_1247" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_448";
-      };
-      "OBJ_1248" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_449";
-      };
-      "OBJ_1249" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_450";
-      };
-      "OBJ_125" = {
-         isa = "PBXFileReference";
-         path = "PrivateOverFilePrivateRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1250" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_451";
-      };
-      "OBJ_1251" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_452";
-      };
-      "OBJ_1252" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_453";
-      };
-      "OBJ_1253" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_454";
-      };
-      "OBJ_1254" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_455";
-      };
-      "OBJ_1255" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_456";
-      };
-      "OBJ_1256" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_457";
-      };
-      "OBJ_1257" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_458";
-      };
-      "OBJ_1258" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_459";
-      };
-      "OBJ_1259" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_460";
-      };
-      "OBJ_126" = {
-         isa = "PBXFileReference";
-         path = "RedundantNilCoalescingRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1260" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_461";
-      };
-      "OBJ_1261" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_462";
-      };
-      "OBJ_1262" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_463";
-      };
-      "OBJ_1263" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_464";
-      };
-      "OBJ_1264" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_466";
-      };
-      "OBJ_1265" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_467";
-      };
-      "OBJ_1266" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_468";
-      };
-      "OBJ_1267" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_469";
-      };
-      "OBJ_1268" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_470";
-      };
-      "OBJ_1269" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_471";
-      };
-      "OBJ_127" = {
-         isa = "PBXFileReference";
-         path = "RedundantObjcAttributeRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1270" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_472";
-      };
-      "OBJ_1271" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_473";
-      };
-      "OBJ_1272" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_474";
-      };
-      "OBJ_1273" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_1274"
-         );
-      };
-      "OBJ_1274" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftSyntax::_CSwiftSyntax::Product";
-      };
-      "OBJ_1275" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftSyntax::_CSwiftSyntax";
-      };
-      "OBJ_1277" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1278",
-            "OBJ_1279"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1278" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4.2",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "4.2"
-            );
-            SWIFT_VERSION = "4.2";
-         };
-         name = "Debug";
-      };
-      "OBJ_1279" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4.2",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "4.2"
-            );
-            SWIFT_VERSION = "4.2";
-         };
-         name = "Release";
-      };
-      "OBJ_128" = {
-         isa = "PBXFileReference";
-         path = "RedundantObjcAttributeRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1280" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1281"
-         );
-      };
-      "OBJ_1281" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_482";
-      };
-      "OBJ_1283" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1284",
-            "OBJ_1285"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1284" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftyTextTable_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftyTextTable";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "SwiftyTextTable";
-         };
-         name = "Debug";
-      };
-      "OBJ_1285" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftyTextTable_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftyTextTable";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "SwiftyTextTable";
-         };
-         name = "Release";
-      };
-      "OBJ_1286" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1287"
-         );
-      };
-      "OBJ_1287" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_485";
-      };
-      "OBJ_1288" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_129" = {
-         isa = "PBXFileReference";
-         path = "RedundantOptionalInitializationRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1290" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1291",
-            "OBJ_1292"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1291" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "4"
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_1292" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "4"
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Release";
-      };
-      "OBJ_1293" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1294"
-         );
-      };
-      "OBJ_1294" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_486";
-      };
-      "OBJ_1295" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1296",
-            "OBJ_1297"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1296" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/Yams_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Yams";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "Yams";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_1297" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/Yams_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Yams";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "Yams";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_1298" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1299",
-            "OBJ_1300",
-            "OBJ_1301",
-            "OBJ_1302",
-            "OBJ_1303",
-            "OBJ_1304",
-            "OBJ_1305",
-            "OBJ_1306",
-            "OBJ_1307",
-            "OBJ_1308",
-            "OBJ_1309",
-            "OBJ_1310",
-            "OBJ_1311",
-            "OBJ_1312",
-            "OBJ_1313",
-            "OBJ_1314"
-         );
-      };
-      "OBJ_1299" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_564";
-      };
-      "OBJ_13" = {
-         isa = "PBXFileReference";
-         path = "Configuration+LintableFiles.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_130" = {
-         isa = "PBXFileReference";
-         path = "RedundantSetAccessControlRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1300" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_565";
-      };
-      "OBJ_1301" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_566";
-      };
-      "OBJ_1302" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_567";
-      };
-      "OBJ_1303" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_568";
-      };
-      "OBJ_1304" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_569";
-      };
-      "OBJ_1305" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_570";
-      };
-      "OBJ_1306" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_571";
-      };
-      "OBJ_1307" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_572";
-      };
-      "OBJ_1308" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_573";
-      };
-      "OBJ_1309" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_574";
-      };
-      "OBJ_131" = {
-         isa = "PBXFileReference";
-         path = "RedundantStringEnumValueRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1310" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_575";
-      };
-      "OBJ_1311" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_576";
-      };
-      "OBJ_1312" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_577";
-      };
-      "OBJ_1313" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_578";
-      };
-      "OBJ_1314" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_579";
-      };
-      "OBJ_1315" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_1316"
-         );
-      };
-      "OBJ_1316" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::CYaml::Product";
-      };
-      "OBJ_1317" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::CYaml";
-      };
-      "OBJ_1319" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1320",
-            "OBJ_1321"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_132" = {
-         isa = "PBXFileReference";
-         path = "RedundantTypeAnnotationRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1320" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_1321" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Release";
-      };
-      "OBJ_1322" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1323"
-         );
-      };
-      "OBJ_1323" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_580";
-      };
-      "OBJ_1324" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1325",
-            "OBJ_1326"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1325" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            DEFINES_MODULE = "NO";
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/_CSwiftSyntax_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "-CSwiftSyntax";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            TARGET_NAME = "_CSwiftSyntax";
-         };
-         name = "Debug";
-      };
-      "OBJ_1326" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            DEFINES_MODULE = "NO";
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/_CSwiftSyntax_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "-CSwiftSyntax";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            TARGET_NAME = "_CSwiftSyntax";
-         };
-         name = "Release";
-      };
-      "OBJ_1327" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1328"
-         );
-      };
-      "OBJ_1328" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_477";
-      };
-      "OBJ_1329" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_133" = {
-         isa = "PBXFileReference";
-         path = "RedundantVoidReturnRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1331" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_1332",
-            "OBJ_1333"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_1332" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
-               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/swiftlint_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-               "@executable_path"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-Xcc",
-               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES";
-            SWIFT_FORCE_STATIC_LINK_STDLIB = "NO";
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "swiftlint";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_1333" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
-               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/swiftlint_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-               "@executable_path"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-Xcc",
-               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES";
-            SWIFT_FORCE_STATIC_LINK_STDLIB = "NO";
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "swiftlint";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_1334" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_1335",
-            "OBJ_1336",
-            "OBJ_1337",
-            "OBJ_1338",
-            "OBJ_1339",
-            "OBJ_1340",
-            "OBJ_1341",
-            "OBJ_1342",
-            "OBJ_1343",
-            "OBJ_1344",
-            "OBJ_1345",
-            "OBJ_1346",
-            "OBJ_1347",
-            "OBJ_1348",
-            "OBJ_1349"
-         );
-      };
-      "OBJ_1335" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_350";
-      };
-      "OBJ_1336" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_351";
-      };
-      "OBJ_1337" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_352";
-      };
-      "OBJ_1338" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_353";
-      };
-      "OBJ_1339" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_354";
-      };
-      "OBJ_134" = {
-         isa = "PBXFileReference";
-         path = "StaticOperatorRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1340" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_355";
-      };
-      "OBJ_1341" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_357";
-      };
-      "OBJ_1342" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_358";
-      };
-      "OBJ_1343" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_359";
-      };
-      "OBJ_1344" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_361";
-      };
-      "OBJ_1345" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_362";
-      };
-      "OBJ_1346" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_363";
-      };
-      "OBJ_1347" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_364";
-      };
-      "OBJ_1348" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_365";
-      };
-      "OBJ_1349" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_366";
-      };
-      "OBJ_135" = {
-         isa = "PBXFileReference";
-         path = "StrictFilePrivateRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1350" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_1351",
-            "OBJ_1352",
-            "OBJ_1353",
-            "OBJ_1354",
-            "OBJ_1355",
-            "OBJ_1356",
-            "OBJ_1357",
-            "OBJ_1358",
-            "OBJ_1359",
-            "OBJ_1360",
-            "OBJ_1361"
-         );
-      };
-      "OBJ_1351" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftyTextTable::SwiftyTextTable::Product";
-      };
-      "OBJ_1352" = {
-         isa = "PBXBuildFile";
-         fileRef = "Commandant::Commandant::Product";
-      };
-      "OBJ_1353" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftLint::SwiftLintFramework::Product";
-      };
-      "OBJ_1354" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftSyntax::SwiftSyntax::Product";
-      };
-      "OBJ_1355" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftSyntax::_CSwiftSyntax::Product";
-      };
-      "OBJ_1356" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::SourceKittenFramework::Product";
-      };
-      "OBJ_1357" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::Yams::Product";
-      };
-      "OBJ_1358" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::CYaml::Product";
-      };
-      "OBJ_1359" = {
-         isa = "PBXBuildFile";
-         fileRef = "SWXMLHash::SWXMLHash::Product";
-      };
-      "OBJ_136" = {
-         isa = "PBXFileReference";
-         path = "SyntacticSugarRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1360" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::SourceKit::Product";
-      };
-      "OBJ_1361" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::Clang_C::Product";
-      };
-      "OBJ_1362" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftyTextTable::SwiftyTextTable";
-      };
-      "OBJ_1363" = {
-         isa = "PBXTargetDependency";
-         target = "Commandant::Commandant";
-      };
-      "OBJ_1364" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftLint::SwiftLintFramework";
-      };
-      "OBJ_1365" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftSyntax::SwiftSyntax";
-      };
-      "OBJ_1366" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftSyntax::_CSwiftSyntax";
-      };
-      "OBJ_1367" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::SourceKittenFramework";
-      };
-      "OBJ_1368" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::Yams";
-      };
-      "OBJ_1369" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::CYaml";
-      };
-      "OBJ_137" = {
-         isa = "PBXFileReference";
-         path = "ToggleBoolRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_1370" = {
-         isa = "PBXTargetDependency";
-         target = "SWXMLHash::SWXMLHash";
-      };
-      "OBJ_1371" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::SourceKit";
-      };
-      "OBJ_1372" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::Clang_C";
-      };
-      "OBJ_138" = {
-         isa = "PBXFileReference";
-         path = "TrailingSemicolonRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_139" = {
-         isa = "PBXFileReference";
-         path = "TypeNameRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_14" = {
-         isa = "PBXFileReference";
-         path = "Configuration+Merging.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_140" = {
-         isa = "PBXFileReference";
-         path = "TypeNameRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_141" = {
-         isa = "PBXFileReference";
-         path = "UnavailableFunctionRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_142" = {
-         isa = "PBXFileReference";
-         path = "UnneededBreakInSwitchRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_143" = {
-         isa = "PBXFileReference";
-         path = "UntypedErrorInCatchRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_144" = {
-         isa = "PBXFileReference";
-         path = "UnusedEnumeratedRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_145" = {
-         isa = "PBXFileReference";
-         path = "XCTFailMessageRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_146" = {
-         isa = "PBXFileReference";
-         path = "XCTSpecificMatcherRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_147" = {
-         isa = "PBXFileReference";
-         path = "XCTSpecificMatcherRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_148" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_149",
-            "OBJ_150",
-            "OBJ_151",
-            "OBJ_152",
-            "OBJ_153",
-            "OBJ_154",
-            "OBJ_155",
-            "OBJ_156",
-            "OBJ_157",
-            "OBJ_158",
-            "OBJ_159",
-            "OBJ_160",
-            "OBJ_161",
-            "OBJ_162",
-            "OBJ_163",
-            "OBJ_164",
-            "OBJ_165",
-            "OBJ_166",
-            "OBJ_167",
-            "OBJ_168",
-            "OBJ_169",
-            "OBJ_170",
-            "OBJ_171",
-            "OBJ_172",
-            "OBJ_173",
-            "OBJ_174",
-            "OBJ_175",
-            "OBJ_176",
-            "OBJ_177",
-            "OBJ_178",
-            "OBJ_179",
-            "OBJ_180",
-            "OBJ_181",
-            "OBJ_182",
-            "OBJ_183",
-            "OBJ_184",
-            "OBJ_185",
-            "OBJ_186",
-            "OBJ_187",
-            "OBJ_188",
-            "OBJ_189",
-            "OBJ_190",
-            "OBJ_191",
-            "OBJ_192",
-            "OBJ_193",
-            "OBJ_194",
-            "OBJ_195",
-            "OBJ_196",
-            "OBJ_197",
-            "OBJ_198",
-            "OBJ_199",
-            "OBJ_200"
-         );
-         name = "Lint";
-         path = "Lint";
-         sourceTree = "<group>";
-      };
-      "OBJ_149" = {
-         isa = "PBXFileReference";
-         path = "AnyObjectProtocolRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_15" = {
-         isa = "PBXFileReference";
-         path = "Configuration+Parsing.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_150" = {
-         isa = "PBXFileReference";
-         path = "ArrayInitRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_151" = {
-         isa = "PBXFileReference";
-         path = "ClassDelegateProtocolRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_152" = {
-         isa = "PBXFileReference";
-         path = "CompilerProtocolInitRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_153" = {
-         isa = "PBXFileReference";
-         path = "DeploymentTargetRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_154" = {
-         isa = "PBXFileReference";
-         path = "DiscardedNotificationCenterObserverRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_155" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedDirectInitRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_156" = {
-         isa = "PBXFileReference";
-         path = "DuplicateEnumCasesRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_157" = {
-         isa = "PBXFileReference";
-         path = "DynamicInlineRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_158" = {
-         isa = "PBXFileReference";
-         path = "EmptyXCTestMethodRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_159" = {
-         isa = "PBXFileReference";
-         path = "EmptyXCTestMethodRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_16" = {
-         isa = "PBXFileReference";
-         path = "Dictionary+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_160" = {
-         isa = "PBXFileReference";
-         path = "ExpiringTodoRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_161" = {
-         isa = "PBXFileReference";
-         path = "IdenticalOperandsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_162" = {
-         isa = "PBXFileReference";
-         path = "InertDeferRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_163" = {
-         isa = "PBXFileReference";
-         path = "LowerACLThanParentRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_164" = {
-         isa = "PBXFileReference";
-         path = "MarkRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_165" = {
-         isa = "PBXFileReference";
-         path = "MissingDocsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_166" = {
-         isa = "PBXFileReference";
-         path = "NSLocalizedStringKeyRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_167" = {
-         isa = "PBXFileReference";
-         path = "NSLocalizedStringRequireBundleRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_168" = {
-         isa = "PBXFileReference";
-         path = "NSObjectPreferIsEqualRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_169" = {
-         isa = "PBXFileReference";
-         path = "NSObjectPreferIsEqualRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_17" = {
-         isa = "PBXFileReference";
-         path = "FileManager+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_170" = {
-         isa = "PBXFileReference";
-         path = "NotificationCenterDetachmentRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_171" = {
-         isa = "PBXFileReference";
-         path = "NotificationCenterDetachmentRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_172" = {
-         isa = "PBXFileReference";
-         path = "OverriddenSuperCallRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_173" = {
-         isa = "PBXFileReference";
-         path = "OverrideInExtensionRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_174" = {
-         isa = "PBXFileReference";
-         path = "PrivateActionRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_175" = {
-         isa = "PBXFileReference";
-         path = "PrivateOutletRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_176" = {
-         isa = "PBXFileReference";
-         path = "PrivateUnitTestRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_177" = {
-         isa = "PBXFileReference";
-         path = "ProhibitedInterfaceBuilderRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_178" = {
-         isa = "PBXFileReference";
-         path = "ProhibitedSuperRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_179" = {
-         isa = "PBXFileReference";
-         path = "QuickDiscouragedCallRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_18" = {
-         isa = "PBXFileReference";
-         path = "NSRange+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_180" = {
-         isa = "PBXFileReference";
-         path = "QuickDiscouragedCallRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_181" = {
-         isa = "PBXFileReference";
-         path = "QuickDiscouragedFocusedTestRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_182" = {
-         isa = "PBXFileReference";
-         path = "QuickDiscouragedFocusedTestRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_183" = {
-         isa = "PBXFileReference";
-         path = "QuickDiscouragedPendingTestRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_184" = {
-         isa = "PBXFileReference";
-         path = "QuickDiscouragedPendingTestRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_185" = {
-         isa = "PBXFileReference";
-         path = "RawValueForCamelCasedCodableEnumRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_186" = {
-         isa = "PBXFileReference";
-         path = "RequiredDeinitRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_187" = {
-         isa = "PBXFileReference";
-         path = "RequiredEnumCaseRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_188" = {
-         isa = "PBXFileReference";
-         path = "StrongIBOutletRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_189" = {
-         isa = "PBXFileReference";
-         path = "SuperfluousDisableCommandRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_19" = {
-         isa = "PBXFileReference";
-         path = "NSRegularExpression+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_190" = {
-         isa = "PBXFileReference";
-         path = "TodoRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_191" = {
-         isa = "PBXFileReference";
-         path = "UnownedVariableCaptureRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_192" = {
-         isa = "PBXFileReference";
-         path = "UnusedCaptureListRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_193" = {
-         isa = "PBXFileReference";
-         path = "UnusedClosureParameterRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_194" = {
-         isa = "PBXFileReference";
-         path = "UnusedControlFlowLabelRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_195" = {
-         isa = "PBXFileReference";
-         path = "UnusedDeclarationRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_196" = {
-         isa = "PBXFileReference";
-         path = "UnusedImportRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_197" = {
-         isa = "PBXFileReference";
-         path = "UnusedSetterValueRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_198" = {
-         isa = "PBXFileReference";
-         path = "ValidIBInspectableRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_199" = {
-         isa = "PBXFileReference";
-         path = "WeakDelegateRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_2" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_3",
-            "OBJ_4"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_20" = {
-         isa = "PBXFileReference";
-         path = "QueuedPrint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_200" = {
-         isa = "PBXFileReference";
-         path = "YodaConditionRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_201" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_202",
-            "OBJ_203",
-            "OBJ_204",
-            "OBJ_205",
-            "OBJ_206",
-            "OBJ_207",
-            "OBJ_208",
-            "OBJ_209",
-            "OBJ_210",
-            "OBJ_211",
-            "OBJ_212"
-         );
-         name = "Metrics";
-         path = "Metrics";
-         sourceTree = "<group>";
-      };
-      "OBJ_202" = {
-         isa = "PBXFileReference";
-         path = "ClosureBodyLengthRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_203" = {
-         isa = "PBXFileReference";
-         path = "ClosureBodyLengthRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_204" = {
-         isa = "PBXFileReference";
-         path = "CyclomaticComplexityRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_205" = {
-         isa = "PBXFileReference";
-         path = "EnumCaseAssociatedValuesLengthRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_206" = {
-         isa = "PBXFileReference";
-         path = "FileLengthRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_207" = {
-         isa = "PBXFileReference";
-         path = "FunctionBodyLengthRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_208" = {
-         isa = "PBXFileReference";
-         path = "FunctionParameterCountRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_209" = {
-         isa = "PBXFileReference";
-         path = "LargeTupleRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_21" = {
-         isa = "PBXFileReference";
-         path = "RandomAccessCollection+Swiftlint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_210" = {
-         isa = "PBXFileReference";
-         path = "LineLengthRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_211" = {
-         isa = "PBXFileReference";
-         path = "NestingRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_212" = {
-         isa = "PBXFileReference";
-         path = "TypeBodyLengthRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_213" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_214",
-            "OBJ_215",
-            "OBJ_216",
-            "OBJ_217",
-            "OBJ_218",
-            "OBJ_219",
-            "OBJ_220",
-            "OBJ_221",
-            "OBJ_222",
-            "OBJ_223",
-            "OBJ_224",
-            "OBJ_225",
-            "OBJ_226"
-         );
-         name = "Performance";
-         path = "Performance";
-         sourceTree = "<group>";
-      };
-      "OBJ_214" = {
-         isa = "PBXFileReference";
-         path = "ContainsOverFilterCountRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_215" = {
-         isa = "PBXFileReference";
-         path = "ContainsOverFilterIsEmptyRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_216" = {
-         isa = "PBXFileReference";
-         path = "ContainsOverFirstNotNilRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_217" = {
-         isa = "PBXFileReference";
-         path = "ContainsOverRangeNilComparisonRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_218" = {
-         isa = "PBXFileReference";
-         path = "EmptyCollectionLiteralRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_219" = {
-         isa = "PBXFileReference";
-         path = "EmptyCountRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_22" = {
-         isa = "PBXFileReference";
-         path = "Request+DisableSourceKit.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_220" = {
-         isa = "PBXFileReference";
-         path = "EmptyStringRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_221" = {
-         isa = "PBXFileReference";
-         path = "FirstWhereRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_222" = {
-         isa = "PBXFileReference";
-         path = "FlatMapOverMapReduceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_223" = {
-         isa = "PBXFileReference";
-         path = "LastWhereRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_224" = {
-         isa = "PBXFileReference";
-         path = "ReduceBooleanRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_225" = {
-         isa = "PBXFileReference";
-         path = "ReduceIntoRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_226" = {
-         isa = "PBXFileReference";
-         path = "SortedFirstLastRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_227" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_228",
-            "OBJ_229",
-            "OBJ_230",
-            "OBJ_231",
-            "OBJ_232",
-            "OBJ_233",
-            "OBJ_234",
-            "OBJ_235",
-            "OBJ_236",
-            "OBJ_237",
-            "OBJ_238",
-            "OBJ_239",
-            "OBJ_240",
-            "OBJ_241",
-            "OBJ_242",
-            "OBJ_243",
-            "OBJ_244",
-            "OBJ_245",
-            "OBJ_246",
-            "OBJ_247",
-            "OBJ_248",
-            "OBJ_249",
-            "OBJ_250",
-            "OBJ_251",
-            "OBJ_252",
-            "OBJ_253",
-            "OBJ_254",
-            "OBJ_255",
-            "OBJ_256",
-            "OBJ_257",
-            "OBJ_258",
-            "OBJ_259",
-            "OBJ_260",
-            "OBJ_261",
-            "OBJ_262",
-            "OBJ_263",
-            "OBJ_264",
-            "OBJ_265",
-            "OBJ_266",
-            "OBJ_267",
-            "OBJ_268",
-            "OBJ_269",
-            "OBJ_270"
-         );
-         name = "RuleConfigurations";
-         path = "RuleConfigurations";
-         sourceTree = "<group>";
-      };
-      "OBJ_228" = {
-         isa = "PBXFileReference";
-         path = "AttributesConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_229" = {
-         isa = "PBXFileReference";
-         path = "CollectionAlignmentConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_23" = {
-         isa = "PBXFileReference";
-         path = "SourceKittenDictionary+Swiftlint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_230" = {
-         isa = "PBXFileReference";
-         path = "ColonConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_231" = {
-         isa = "PBXFileReference";
-         path = "ConditionalReturnsOnNewlineConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_232" = {
-         isa = "PBXFileReference";
-         path = "CyclomaticComplexityConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_233" = {
-         isa = "PBXFileReference";
-         path = "DeploymentTargetConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_234" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedDirectInitConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_235" = {
-         isa = "PBXFileReference";
-         path = "ExpiringTodoConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_236" = {
-         isa = "PBXFileReference";
-         path = "ExplicitTypeInterfaceConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_237" = {
-         isa = "PBXFileReference";
-         path = "FileHeaderConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_238" = {
-         isa = "PBXFileReference";
-         path = "FileLengthRuleConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_239" = {
-         isa = "PBXFileReference";
-         path = "FileNameConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_24" = {
-         isa = "PBXFileReference";
-         path = "String+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_240" = {
-         isa = "PBXFileReference";
-         path = "FileNameNoSpaceConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_241" = {
-         isa = "PBXFileReference";
-         path = "FileTypesOrderConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_242" = {
-         isa = "PBXFileReference";
-         path = "FunctionParameterCountConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_243" = {
-         isa = "PBXFileReference";
-         path = "ImplicitlyUnwrappedOptionalConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_244" = {
-         isa = "PBXFileReference";
-         path = "LineLengthConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_245" = {
-         isa = "PBXFileReference";
-         path = "MissingDocsRuleConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_246" = {
-         isa = "PBXFileReference";
-         path = "ModifierOrderConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_247" = {
-         isa = "PBXFileReference";
-         path = "MultilineArgumentsConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_248" = {
-         isa = "PBXFileReference";
-         path = "NameConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_249" = {
-         isa = "PBXFileReference";
-         path = "NestingConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_25" = {
-         isa = "PBXFileReference";
-         path = "String+XML.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_250" = {
-         isa = "PBXFileReference";
-         path = "NumberSeparatorConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_251" = {
-         isa = "PBXFileReference";
-         path = "ObjectLiteralConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_252" = {
-         isa = "PBXFileReference";
-         path = "OverridenSuperCallConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_253" = {
-         isa = "PBXFileReference";
-         path = "PrefixedConstantRuleConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_254" = {
-         isa = "PBXFileReference";
-         path = "PrivateOutletRuleConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_255" = {
-         isa = "PBXFileReference";
-         path = "PrivateOverFilePrivateRuleConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_256" = {
-         isa = "PBXFileReference";
-         path = "PrivateUnitTestConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_257" = {
-         isa = "PBXFileReference";
-         path = "ProhibitedSuperConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_258" = {
-         isa = "PBXFileReference";
-         path = "RegexConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_259" = {
-         isa = "PBXFileReference";
-         path = "RequiredEnumCaseRuleConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_26" = {
-         isa = "PBXFileReference";
-         path = "SwiftDeclarationAttributeKind+Swiftlint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_260" = {
-         isa = "PBXFileReference";
-         path = "SeverityConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_261" = {
-         isa = "PBXFileReference";
-         path = "SeverityLevelsConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_262" = {
-         isa = "PBXFileReference";
-         path = "StatementModeConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_263" = {
-         isa = "PBXFileReference";
-         path = "SwitchCaseAlignmentConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_264" = {
-         isa = "PBXFileReference";
-         path = "TrailingClosureConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_265" = {
-         isa = "PBXFileReference";
-         path = "TrailingCommaConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_266" = {
-         isa = "PBXFileReference";
-         path = "TrailingWhitespaceConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_267" = {
-         isa = "PBXFileReference";
-         path = "TypeContentsOrderConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_268" = {
-         isa = "PBXFileReference";
-         path = "UnusedDeclarationConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_269" = {
-         isa = "PBXFileReference";
-         path = "UnusedOptionalBindingConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_27" = {
-         isa = "PBXFileReference";
-         path = "SwiftDeclarationKind+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_270" = {
-         isa = "PBXFileReference";
-         path = "VerticalWhitespaceConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_271" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_272",
-            "OBJ_273",
-            "OBJ_274",
-            "OBJ_275",
-            "OBJ_276",
-            "OBJ_277",
-            "OBJ_278",
-            "OBJ_279",
-            "OBJ_280",
-            "OBJ_281",
-            "OBJ_282",
-            "OBJ_283",
-            "OBJ_284",
-            "OBJ_285",
-            "OBJ_286",
-            "OBJ_287",
-            "OBJ_288",
-            "OBJ_289",
-            "OBJ_290",
-            "OBJ_291",
-            "OBJ_292",
-            "OBJ_293",
-            "OBJ_294",
-            "OBJ_295",
-            "OBJ_296",
-            "OBJ_297",
-            "OBJ_298",
-            "OBJ_299",
-            "OBJ_300",
-            "OBJ_301",
-            "OBJ_302",
-            "OBJ_303",
-            "OBJ_304",
-            "OBJ_305",
-            "OBJ_306",
-            "OBJ_307",
-            "OBJ_308",
-            "OBJ_309",
-            "OBJ_310",
-            "OBJ_311",
-            "OBJ_312",
-            "OBJ_313",
-            "OBJ_314",
-            "OBJ_315",
-            "OBJ_316",
-            "OBJ_317",
-            "OBJ_318",
-            "OBJ_319",
-            "OBJ_320",
-            "OBJ_321",
-            "OBJ_322",
-            "OBJ_323",
-            "OBJ_324",
-            "OBJ_325",
-            "OBJ_326",
-            "OBJ_327",
-            "OBJ_328",
-            "OBJ_329",
-            "OBJ_330",
-            "OBJ_331",
-            "OBJ_332",
-            "OBJ_333",
-            "OBJ_334",
-            "OBJ_335",
-            "OBJ_336",
-            "OBJ_337",
-            "OBJ_338",
-            "OBJ_339",
-            "OBJ_340",
-            "OBJ_341",
-            "OBJ_342",
-            "OBJ_343",
-            "OBJ_344",
-            "OBJ_345",
-            "OBJ_346",
-            "OBJ_347"
-         );
-         name = "Style";
-         path = "Style";
-         sourceTree = "<group>";
-      };
-      "OBJ_272" = {
-         isa = "PBXFileReference";
-         path = "AttributesRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_273" = {
-         isa = "PBXFileReference";
-         path = "AttributesRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_274" = {
-         isa = "PBXFileReference";
-         path = "ClosingBraceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_275" = {
-         isa = "PBXFileReference";
-         path = "ClosureEndIndentationRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_276" = {
-         isa = "PBXFileReference";
-         path = "ClosureEndIndentationRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_277" = {
-         isa = "PBXFileReference";
-         path = "ClosureParameterPositionRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_278" = {
-         isa = "PBXFileReference";
-         path = "ClosureSpacingRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_279" = {
-         isa = "PBXFileReference";
-         path = "CollectionAlignmentRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_28" = {
-         isa = "PBXFileReference";
-         path = "SwiftExpressionKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_280" = {
-         isa = "PBXFileReference";
-         path = "ColonRule+Dictionary.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_281" = {
-         isa = "PBXFileReference";
-         path = "ColonRule+FunctionCall.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_282" = {
-         isa = "PBXFileReference";
-         path = "ColonRule+Type.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_283" = {
-         isa = "PBXFileReference";
-         path = "ColonRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_284" = {
-         isa = "PBXFileReference";
-         path = "ColonRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_285" = {
-         isa = "PBXFileReference";
-         path = "CommaRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_286" = {
-         isa = "PBXFileReference";
-         path = "ConditionalReturnsOnNewlineRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_287" = {
-         isa = "PBXFileReference";
-         path = "ControlStatementRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_288" = {
-         isa = "PBXFileReference";
-         path = "CustomRules.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_289" = {
-         isa = "PBXFileReference";
-         path = "EmptyEnumArgumentsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_29" = {
-         isa = "PBXFileReference";
-         path = "SwiftLintFile+Cache.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_290" = {
-         isa = "PBXFileReference";
-         path = "EmptyParametersRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_291" = {
-         isa = "PBXFileReference";
-         path = "EmptyParenthesesWithTrailingClosureRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_292" = {
-         isa = "PBXFileReference";
-         path = "ExplicitSelfRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_293" = {
-         isa = "PBXFileReference";
-         path = "FileHeaderRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_294" = {
-         isa = "PBXFileReference";
-         path = "FileTypesOrderRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_295" = {
-         isa = "PBXFileReference";
-         path = "FileTypesOrderRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_296" = {
-         isa = "PBXFileReference";
-         path = "IdentifierNameRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_297" = {
-         isa = "PBXFileReference";
-         path = "IdentifierNameRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_298" = {
-         isa = "PBXFileReference";
-         path = "ImplicitGetterRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_299" = {
-         isa = "PBXFileReference";
-         path = "ImplicitReturnRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_3" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "NO";
-            DEBUG_INFORMATION_FORMAT = "dwarf";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            ENABLE_NS_ASSERTIONS = "YES";
-            GCC_OPTIMIZATION_LEVEL = "0";
-            GCC_PREPROCESSOR_DEFINITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE=1",
-               "DEBUG=1"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            ONLY_ACTIVE_ARCH = "YES";
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE",
-               "DEBUG"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Debug";
-      };
-      "OBJ_30" = {
-         isa = "PBXFileReference";
-         path = "SwiftLintFile+Regex.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_300" = {
-         isa = "PBXFileReference";
-         path = "LeadingWhitespaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_301" = {
-         isa = "PBXFileReference";
-         path = "LetVarWhitespaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_302" = {
-         isa = "PBXFileReference";
-         path = "LiteralExpressionEndIdentationRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_303" = {
-         isa = "PBXFileReference";
-         path = "ModifierOrderRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_304" = {
-         isa = "PBXFileReference";
-         path = "ModifierOrderRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_305" = {
-         isa = "PBXFileReference";
-         path = "MultilineArgumentsBracketsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_306" = {
-         isa = "PBXFileReference";
-         path = "MultilineArgumentsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_307" = {
-         isa = "PBXFileReference";
-         path = "MultilineArgumentsRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_308" = {
-         isa = "PBXFileReference";
-         path = "MultilineFunctionChainsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_309" = {
-         isa = "PBXFileReference";
-         path = "MultilineLiteralBracketsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_31" = {
-         isa = "PBXFileReference";
-         path = "SyntaxKind+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_310" = {
-         isa = "PBXFileReference";
-         path = "MultilineParametersBracketsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_311" = {
-         isa = "PBXFileReference";
-         path = "MultilineParametersRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_312" = {
-         isa = "PBXFileReference";
-         path = "MultilineParametersRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_313" = {
-         isa = "PBXFileReference";
-         path = "MultipleClosuresWithTrailingClosureRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_314" = {
-         isa = "PBXFileReference";
-         path = "NoSpaceInMethodCallRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_315" = {
-         isa = "PBXFileReference";
-         path = "NumberSeparatorRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_316" = {
-         isa = "PBXFileReference";
-         path = "NumberSeparatorRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_317" = {
-         isa = "PBXFileReference";
-         path = "OpeningBraceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_318" = {
-         isa = "PBXFileReference";
-         path = "OperatorFunctionWhitespaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_319" = {
-         isa = "PBXFileReference";
-         path = "OperatorUsageWhitespaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_32" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_33",
-            "OBJ_34",
-            "OBJ_35"
-         );
-         name = "Helpers";
-         path = "Helpers";
-         sourceTree = "<group>";
-      };
-      "OBJ_320" = {
-         isa = "PBXFileReference";
-         path = "OptionalEnumCaseMatchingRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_321" = {
-         isa = "PBXFileReference";
-         path = "PreferSelfTypeOverTypeOfSelfRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_322" = {
-         isa = "PBXFileReference";
-         path = "PrefixedTopLevelConstantRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_323" = {
-         isa = "PBXFileReference";
-         path = "ProtocolPropertyAccessorsOrderRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_324" = {
-         isa = "PBXFileReference";
-         path = "RedundantDiscardableLetRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_325" = {
-         isa = "PBXFileReference";
-         path = "ReturnArrowWhitespaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_326" = {
-         isa = "PBXFileReference";
-         path = "ShorthandOperatorRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_327" = {
-         isa = "PBXFileReference";
-         path = "SingleTestClassRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_328" = {
-         isa = "PBXFileReference";
-         path = "SortedImportsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_329" = {
-         isa = "PBXFileReference";
-         path = "StatementPositionRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_33" = {
-         isa = "PBXFileReference";
-         path = "Glob.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_330" = {
-         isa = "PBXFileReference";
-         path = "SwitchCaseAlignmentRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_331" = {
-         isa = "PBXFileReference";
-         path = "SwitchCaseOnNewlineRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_332" = {
-         isa = "PBXFileReference";
-         path = "TrailingClosureRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_333" = {
-         isa = "PBXFileReference";
-         path = "TrailingCommaRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_334" = {
-         isa = "PBXFileReference";
-         path = "TrailingNewlineRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_335" = {
-         isa = "PBXFileReference";
-         path = "TrailingWhitespaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_336" = {
-         isa = "PBXFileReference";
-         path = "TypeContentsOrderRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_337" = {
-         isa = "PBXFileReference";
-         path = "TypeContentsOrderRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_338" = {
-         isa = "PBXFileReference";
-         path = "UnneededParenthesesInClosureArgumentRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_339" = {
-         isa = "PBXFileReference";
-         path = "UnusedOptionalBindingRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_34" = {
-         isa = "PBXFileReference";
-         path = "NamespaceCollector.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_340" = {
-         isa = "PBXFileReference";
-         path = "VerticalParameterAlignmentOnCallRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_341" = {
-         isa = "PBXFileReference";
-         path = "VerticalParameterAlignmentRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_342" = {
-         isa = "PBXFileReference";
-         path = "VerticalParameterAlignmentRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_343" = {
-         isa = "PBXFileReference";
-         path = "VerticalWhitespaceBetweenCasesRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_344" = {
-         isa = "PBXFileReference";
-         path = "VerticalWhitespaceClosingBracesRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_345" = {
-         isa = "PBXFileReference";
-         path = "VerticalWhitespaceOpeningBracesRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_346" = {
-         isa = "PBXFileReference";
-         path = "VerticalWhitespaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_347" = {
-         isa = "PBXFileReference";
-         path = "VoidReturnRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_348" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_349",
-            "OBJ_356",
-            "OBJ_360",
-            "OBJ_366"
-         );
-         name = "swiftlint";
-         path = "Source/swiftlint";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_349" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_350",
-            "OBJ_351",
-            "OBJ_352",
-            "OBJ_353",
-            "OBJ_354",
-            "OBJ_355"
-         );
-         name = "Commands";
-         path = "Commands";
-         sourceTree = "<group>";
-      };
-      "OBJ_35" = {
-         isa = "PBXFileReference";
-         path = "RegexHelpers.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_350" = {
-         isa = "PBXFileReference";
-         path = "AnalyzeCommand.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_351" = {
-         isa = "PBXFileReference";
-         path = "AutoCorrectCommand.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_352" = {
-         isa = "PBXFileReference";
-         path = "GenerateDocsCommand.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_353" = {
-         isa = "PBXFileReference";
-         path = "LintCommand.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_354" = {
-         isa = "PBXFileReference";
-         path = "RulesCommand.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_355" = {
-         isa = "PBXFileReference";
-         path = "VersionCommand.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_356" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_357",
-            "OBJ_358",
-            "OBJ_359"
-         );
-         name = "Extensions";
-         path = "Extensions";
-         sourceTree = "<group>";
-      };
-      "OBJ_357" = {
-         isa = "PBXFileReference";
-         path = "Array+SwiftLint.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_358" = {
-         isa = "PBXFileReference";
-         path = "Configuration+CommandLine.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_359" = {
-         isa = "PBXFileReference";
-         path = "Reporter+CommandLine.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_36" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_37",
-            "OBJ_38",
-            "OBJ_39",
-            "OBJ_40",
-            "OBJ_41",
-            "OBJ_42",
-            "OBJ_43",
-            "OBJ_44",
-            "OBJ_45",
-            "OBJ_46",
-            "OBJ_47",
-            "OBJ_48",
-            "OBJ_49",
-            "OBJ_50",
-            "OBJ_51",
-            "OBJ_52",
-            "OBJ_53",
-            "OBJ_54",
-            "OBJ_55",
-            "OBJ_56",
-            "OBJ_57",
-            "OBJ_58",
-            "OBJ_59",
-            "OBJ_60",
-            "OBJ_61"
-         );
-         name = "Models";
-         path = "Models";
-         sourceTree = "<group>";
-      };
-      "OBJ_360" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_361",
-            "OBJ_362",
-            "OBJ_363",
-            "OBJ_364",
-            "OBJ_365"
-         );
-         name = "Helpers";
-         path = "Helpers";
-         sourceTree = "<group>";
-      };
-      "OBJ_361" = {
-         isa = "PBXFileReference";
-         path = "Benchmark.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_362" = {
-         isa = "PBXFileReference";
-         path = "CommonOptions.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_363" = {
-         isa = "PBXFileReference";
-         path = "CompilerArgumentsExtractor.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_364" = {
-         isa = "PBXFileReference";
-         path = "LintOrAnalyzeCommand.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_365" = {
-         isa = "PBXFileReference";
-         path = "LintableFilesVisitor.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_366" = {
-         isa = "PBXFileReference";
-         path = "main.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_367" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_368"
-         );
-         name = "Tests";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_368" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_369",
-            "OBJ_370",
-            "OBJ_371",
-            "OBJ_372",
-            "OBJ_373",
-            "OBJ_374",
-            "OBJ_375",
-            "OBJ_376",
-            "OBJ_377",
-            "OBJ_378",
-            "OBJ_379",
-            "OBJ_380",
-            "OBJ_381",
-            "OBJ_382",
-            "OBJ_383",
-            "OBJ_384",
-            "OBJ_385",
-            "OBJ_386",
-            "OBJ_387",
-            "OBJ_388",
-            "OBJ_389",
-            "OBJ_390",
-            "OBJ_391",
-            "OBJ_392",
-            "OBJ_393",
-            "OBJ_394",
-            "OBJ_395",
-            "OBJ_396",
-            "OBJ_397",
-            "OBJ_398",
-            "OBJ_399",
-            "OBJ_400",
-            "OBJ_401",
-            "OBJ_402",
-            "OBJ_403",
-            "OBJ_404",
-            "OBJ_405",
-            "OBJ_406",
-            "OBJ_407",
-            "OBJ_408",
-            "OBJ_409",
-            "OBJ_410",
-            "OBJ_411",
-            "OBJ_412",
-            "OBJ_413",
-            "OBJ_414",
-            "OBJ_415",
-            "OBJ_416",
-            "OBJ_417",
-            "OBJ_418",
-            "OBJ_419",
-            "OBJ_420",
-            "OBJ_421",
-            "OBJ_422",
-            "OBJ_423",
-            "OBJ_424",
-            "OBJ_425",
-            "OBJ_426",
-            "OBJ_427",
-            "OBJ_428",
-            "OBJ_429",
-            "OBJ_430",
-            "OBJ_431",
-            "OBJ_432",
-            "OBJ_433",
-            "OBJ_434",
-            "OBJ_435",
-            "OBJ_436",
-            "OBJ_437",
-            "OBJ_438",
-            "OBJ_439",
-            "OBJ_440",
-            "OBJ_441",
-            "OBJ_442"
-         );
-         name = "SwiftLintFrameworkTests";
-         path = "Tests/SwiftLintFrameworkTests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_369" = {
-         isa = "PBXFileReference";
-         path = "AttributesRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_37" = {
-         isa = "PBXFileReference";
-         path = "AccessControlLevel.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_370" = {
-         isa = "PBXFileReference";
-         path = "AutomaticRuleTests.generated.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_371" = {
-         isa = "PBXFileReference";
-         path = "CollectingRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_372" = {
-         isa = "PBXFileReference";
-         path = "CollectionAlignmentRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_373" = {
-         isa = "PBXFileReference";
-         path = "ColonRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_374" = {
-         isa = "PBXFileReference";
-         path = "CommandTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_375" = {
-         isa = "PBXFileReference";
-         path = "CompilerProtocolInitRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_376" = {
-         isa = "PBXFileReference";
-         path = "ConditionalReturnsOnNewlineRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_377" = {
-         isa = "PBXFileReference";
-         path = "ConfigurationAliasesTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_378" = {
-         isa = "PBXFileReference";
-         path = "ConfigurationTests+Nested.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_379" = {
-         isa = "PBXFileReference";
-         path = "ConfigurationTests+ProjectMock.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_38" = {
-         isa = "PBXFileReference";
-         path = "Command.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_380" = {
-         isa = "PBXFileReference";
-         path = "ConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_381" = {
-         isa = "PBXFileReference";
-         path = "ContainsOverFirstNotNilRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_382" = {
-         isa = "PBXFileReference";
-         path = "CustomRulesTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_383" = {
-         isa = "PBXFileReference";
-         path = "CyclomaticComplexityConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_384" = {
-         isa = "PBXFileReference";
-         path = "CyclomaticComplexityRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_385" = {
-         isa = "PBXFileReference";
-         path = "DeploymentTargetConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_386" = {
-         isa = "PBXFileReference";
-         path = "DeploymentTargetRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_387" = {
-         isa = "PBXFileReference";
-         path = "DisableAllTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_388" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedDirectInitRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_389" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedObjectLiteralRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_39" = {
-         isa = "PBXFileReference";
-         path = "Configuration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_390" = {
-         isa = "PBXFileReference";
-         path = "DocumentationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_391" = {
-         isa = "PBXFileReference";
-         path = "ExpiringTodoRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_392" = {
-         isa = "PBXFileReference";
-         path = "ExplicitTypeInterfaceConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_393" = {
-         isa = "PBXFileReference";
-         path = "ExplicitTypeInterfaceRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_394" = {
-         isa = "PBXFileReference";
-         path = "ExtendedNSStringTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_395" = {
-         isa = "PBXFileReference";
-         path = "FileHeaderRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_396" = {
-         isa = "PBXFileReference";
-         path = "FileLengthRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_397" = {
-         isa = "PBXFileReference";
-         path = "FileNameNoSpaceRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_398" = {
-         isa = "PBXFileReference";
-         path = "FileNameRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_399" = {
-         isa = "PBXFileReference";
-         path = "FileTypesOrderRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_4" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "YES";
-            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            GCC_OPTIMIZATION_LEVEL = "s";
-            GCC_PREPROCESSOR_DEFINITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE=1"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Release";
-      };
-      "OBJ_40" = {
-         isa = "PBXFileReference";
-         path = "ConfigurationError.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_400" = {
-         isa = "PBXFileReference";
-         path = "FunctionBodyLengthRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_401" = {
-         isa = "PBXFileReference";
-         path = "FunctionParameterCountRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_402" = {
-         isa = "PBXFileReference";
-         path = "GenericTypeNameRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_403" = {
-         isa = "PBXFileReference";
-         path = "GlobTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_404" = {
-         isa = "PBXFileReference";
-         path = "IdentifierNameRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_405" = {
-         isa = "PBXFileReference";
-         path = "ImplicitlyUnwrappedOptionalConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_406" = {
-         isa = "PBXFileReference";
-         path = "ImplicitlyUnwrappedOptionalRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_407" = {
-         isa = "PBXFileReference";
-         path = "IntegrationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_408" = {
-         isa = "PBXFileReference";
-         path = "LineLengthConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_409" = {
-         isa = "PBXFileReference";
-         path = "LineLengthRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_41" = {
-         isa = "PBXFileReference";
-         path = "Correction.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_410" = {
-         isa = "PBXFileReference";
-         path = "LinterCacheTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_411" = {
-         isa = "PBXFileReference";
-         path = "MissingDocsRuleConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_412" = {
-         isa = "PBXFileReference";
-         path = "ModifierOrderTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_413" = {
-         isa = "PBXFileReference";
-         path = "MultilineArgumentsRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_414" = {
-         isa = "PBXFileReference";
-         path = "NumberSeparatorRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_415" = {
-         isa = "PBXFileReference";
-         path = "ObjectLiteralRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_416" = {
-         isa = "PBXFileReference";
-         path = "PrefixedTopLevelConstantRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_417" = {
-         isa = "PBXFileReference";
-         path = "PrivateOutletRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_418" = {
-         isa = "PBXFileReference";
-         path = "PrivateOverFilePrivateRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_419" = {
-         isa = "PBXFileReference";
-         path = "RegionTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_42" = {
-         isa = "PBXFileReference";
-         path = "Linter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_420" = {
-         isa = "PBXFileReference";
-         path = "ReporterTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_421" = {
-         isa = "PBXFileReference";
-         path = "RequiredEnumCaseRuleTestCase.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_422" = {
-         isa = "PBXFileReference";
-         path = "RuleConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_423" = {
-         isa = "PBXFileReference";
-         path = "RuleDescription+Examples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_424" = {
-         isa = "PBXFileReference";
-         path = "RuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_425" = {
-         isa = "PBXFileReference";
-         path = "RulesTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_426" = {
-         isa = "PBXFileReference";
-         path = "SourceKitCrashTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_427" = {
-         isa = "PBXFileReference";
-         path = "StatementPositionRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_428" = {
-         isa = "PBXFileReference";
-         path = "SwitchCaseAlignmentRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_429" = {
-         isa = "PBXFileReference";
-         path = "TestHelpers.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_43" = {
-         isa = "PBXFileReference";
-         path = "LinterCache.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_430" = {
-         isa = "PBXFileReference";
-         path = "TodoRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_431" = {
-         isa = "PBXFileReference";
-         path = "TrailingClosureConfigurationTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_432" = {
-         isa = "PBXFileReference";
-         path = "TrailingClosureRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_433" = {
-         isa = "PBXFileReference";
-         path = "TrailingCommaRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_434" = {
-         isa = "PBXFileReference";
-         path = "TrailingWhitespaceTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_435" = {
-         isa = "PBXFileReference";
-         path = "TypeContentsOrderRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_436" = {
-         isa = "PBXFileReference";
-         path = "TypeNameRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_437" = {
-         isa = "PBXFileReference";
-         path = "UnusedOptionalBindingRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_438" = {
-         isa = "PBXFileReference";
-         path = "VerticalWhitespaceRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_439" = {
-         isa = "PBXFileReference";
-         path = "XCTSpecificMatcherRuleTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_44" = {
-         isa = "PBXFileReference";
-         path = "Location.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_440" = {
-         isa = "PBXFileReference";
-         path = "XCTestCase+BundlePath.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_441" = {
-         isa = "PBXFileReference";
-         path = "YamlParserTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_442" = {
-         isa = "PBXFileReference";
-         path = "YamlSwiftLintTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_443" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_444",
-            "OBJ_483",
-            "OBJ_487",
-            "OBJ_551",
-            "OBJ_581",
-            "OBJ_586"
-         );
-         name = "Dependencies";
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_444" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_445",
-            "OBJ_475",
-            "OBJ_481",
-            "OBJ_482"
-         );
-         name = "SwiftSyntax 0.50100.0";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_445" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_446",
-            "OBJ_447",
-            "OBJ_448",
-            "OBJ_449",
-            "OBJ_450",
-            "OBJ_451",
-            "OBJ_452",
-            "OBJ_453",
-            "OBJ_454",
-            "OBJ_455",
-            "OBJ_456",
-            "OBJ_457",
-            "OBJ_458",
-            "OBJ_459",
-            "OBJ_460",
-            "OBJ_461",
-            "OBJ_462",
-            "OBJ_463",
-            "OBJ_464",
-            "OBJ_465"
-         );
-         name = "SwiftSyntax";
-         path = ".build/checkouts/swift-syntax/Sources/SwiftSyntax";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_446" = {
-         isa = "PBXFileReference";
-         path = "AbsolutePosition.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_447" = {
-         isa = "PBXFileReference";
-         path = "AtomicCounter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_448" = {
-         isa = "PBXFileReference";
-         path = "Diagnostic.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_449" = {
-         isa = "PBXFileReference";
-         path = "DiagnosticConsumer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_45" = {
-         isa = "PBXFileReference";
-         path = "MasterRuleList.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_450" = {
-         isa = "PBXFileReference";
-         path = "DiagnosticEngine.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_451" = {
-         isa = "PBXFileReference";
-         path = "IncrementalParseTransition.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_452" = {
-         isa = "PBXFileReference";
-         path = "JSONDiagnosticConsumer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_453" = {
-         isa = "PBXFileReference";
-         path = "PrintingDiagnosticConsumer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_454" = {
-         isa = "PBXFileReference";
-         path = "RawSyntax.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_455" = {
-         isa = "PBXFileReference";
-         path = "SourceLength.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_456" = {
-         isa = "PBXFileReference";
-         path = "SourceLocation.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_457" = {
-         isa = "PBXFileReference";
-         path = "SourcePresence.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_458" = {
-         isa = "PBXFileReference";
-         path = "Syntax.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_459" = {
-         isa = "PBXFileReference";
-         path = "SyntaxChildren.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_46" = {
-         isa = "PBXFileReference";
-         path = "Region.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_460" = {
-         isa = "PBXFileReference";
-         path = "SyntaxClassifier.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_461" = {
-         isa = "PBXFileReference";
-         path = "SyntaxData.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_462" = {
-         isa = "PBXFileReference";
-         path = "SyntaxParser.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_463" = {
-         isa = "PBXFileReference";
-         path = "SyntaxVerifier.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_464" = {
-         isa = "PBXFileReference";
-         path = "Utils.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_465" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_466",
-            "OBJ_467",
-            "OBJ_468",
-            "OBJ_469",
-            "OBJ_470",
-            "OBJ_471",
-            "OBJ_472",
-            "OBJ_473",
-            "OBJ_474"
-         );
-         name = "gyb_generated";
-         path = "gyb_generated";
-         sourceTree = "<group>";
-      };
-      "OBJ_466" = {
-         isa = "PBXFileReference";
-         path = "SyntaxBuilders.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_467" = {
-         isa = "PBXFileReference";
-         path = "SyntaxClassification.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_468" = {
-         isa = "PBXFileReference";
-         path = "SyntaxCollections.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_469" = {
-         isa = "PBXFileReference";
-         path = "SyntaxFactory.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_47" = {
-         isa = "PBXFileReference";
-         path = "RuleDescription.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_470" = {
-         isa = "PBXFileReference";
-         path = "SyntaxKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_471" = {
-         isa = "PBXFileReference";
-         path = "SyntaxNodes.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_472" = {
-         isa = "PBXFileReference";
-         path = "SyntaxRewriter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_473" = {
-         isa = "PBXFileReference";
-         path = "TokenKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_474" = {
-         isa = "PBXFileReference";
-         path = "Trivia.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_475" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_476",
-            "OBJ_478"
-         );
-         name = "_CSwiftSyntax";
-         path = ".build/checkouts/swift-syntax/Sources/_CSwiftSyntax";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_476" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_477"
-         );
-         name = "src";
-         path = "src";
-         sourceTree = "<group>";
-      };
-      "OBJ_477" = {
-         isa = "PBXFileReference";
-         path = "atomic-counter.c";
-         sourceTree = "<group>";
-      };
-      "OBJ_478" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_479",
-            "OBJ_480"
-         );
-         name = "include";
-         path = "include";
-         sourceTree = "<group>";
-      };
-      "OBJ_479" = {
-         isa = "PBXFileReference";
-         path = "atomic-counter.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_48" = {
-         isa = "PBXFileReference";
-         path = "RuleIdentifier.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_480" = {
-         isa = "PBXFileReference";
-         name = "module.modulemap";
-         path = "/Users/marcelofabri/projetos/SwiftLint/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
-         sourceTree = "<group>";
-      };
-      "OBJ_481" = {
-         isa = "PBXGroup";
-         children = (
-         );
-         name = "lit-test-helper";
-         path = ".build/checkouts/swift-syntax/Sources/lit-test-helper";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_482" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/swift-syntax/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_483" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_484",
-            "OBJ_486"
-         );
-         name = "SwiftyTextTable 0.9.0";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_484" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_485"
-         );
-         name = "SwiftyTextTable";
-         path = ".build/checkouts/SwiftyTextTable/Source/SwiftyTextTable";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_485" = {
-         isa = "PBXFileReference";
-         path = "TextTable.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_486" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SwiftyTextTable/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_487" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_488",
-            "OBJ_499",
-            "OBJ_504",
-            "OBJ_549",
-            "OBJ_550"
-         );
-         name = "SourceKitten 0.28.0";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_488" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_489",
-            "OBJ_490"
-         );
-         name = "Clang_C";
-         path = ".build/checkouts/SourceKitten/Source/Clang_C";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_489" = {
-         isa = "PBXFileReference";
-         path = "Clang_C.m";
-         sourceTree = "<group>";
-      };
-      "OBJ_49" = {
-         isa = "PBXFileReference";
-         path = "RuleKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_490" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_491",
-            "OBJ_492",
-            "OBJ_493",
-            "OBJ_494",
-            "OBJ_495",
-            "OBJ_496",
-            "OBJ_497",
-            "OBJ_498"
-         );
-         name = "include";
-         path = "include";
-         sourceTree = "<group>";
-      };
-      "OBJ_491" = {
-         isa = "PBXFileReference";
-         path = "Index.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_492" = {
-         isa = "PBXFileReference";
-         path = "BuildSystem.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_493" = {
-         isa = "PBXFileReference";
-         path = "Documentation.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_494" = {
-         isa = "PBXFileReference";
-         path = "CXCompilationDatabase.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_495" = {
-         isa = "PBXFileReference";
-         path = "Clang_C.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_496" = {
-         isa = "PBXFileReference";
-         path = "CXErrorCode.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_497" = {
-         isa = "PBXFileReference";
-         path = "CXString.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_498" = {
-         isa = "PBXFileReference";
-         path = "Platform.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_499" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_500",
-            "OBJ_501"
-         );
-         name = "SourceKit";
-         path = ".build/checkouts/SourceKitten/Source/SourceKit";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_5" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_6",
-            "OBJ_7",
-            "OBJ_367",
-            "OBJ_443",
-            "OBJ_599",
-            "OBJ_613",
-            "OBJ_614",
-            "OBJ_615",
-            "OBJ_616",
-            "OBJ_617",
-            "OBJ_618",
-            "OBJ_619",
-            "OBJ_620",
-            "OBJ_621",
-            "OBJ_622",
-            "OBJ_623",
-            "OBJ_624",
-            "OBJ_625",
-            "OBJ_626",
-            "OBJ_627",
-            "OBJ_628",
-            "OBJ_629",
-            "OBJ_630",
-            "OBJ_631",
-            "OBJ_632",
-            "OBJ_633",
-            "OBJ_634",
-            "OBJ_635"
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_50" = {
-         isa = "PBXFileReference";
-         path = "RuleList+Documentation.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_500" = {
-         isa = "PBXFileReference";
-         path = "SourceKit.m";
-         sourceTree = "<group>";
-      };
-      "OBJ_501" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_502",
-            "OBJ_503"
-         );
-         name = "include";
-         path = "include";
-         sourceTree = "<group>";
-      };
-      "OBJ_502" = {
-         isa = "PBXFileReference";
-         path = "SourceKit.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_503" = {
-         isa = "PBXFileReference";
-         path = "sourcekitd.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_504" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_505",
-            "OBJ_506",
-            "OBJ_507",
-            "OBJ_508",
-            "OBJ_509",
-            "OBJ_510",
-            "OBJ_511",
-            "OBJ_512",
-            "OBJ_513",
-            "OBJ_514",
-            "OBJ_515",
-            "OBJ_516",
-            "OBJ_517",
-            "OBJ_518",
-            "OBJ_519",
-            "OBJ_520",
-            "OBJ_521",
-            "OBJ_522",
-            "OBJ_523",
-            "OBJ_524",
-            "OBJ_525",
-            "OBJ_526",
-            "OBJ_527",
-            "OBJ_528",
-            "OBJ_529",
-            "OBJ_530",
-            "OBJ_531",
-            "OBJ_532",
-            "OBJ_533",
-            "OBJ_534",
-            "OBJ_535",
-            "OBJ_536",
-            "OBJ_537",
-            "OBJ_538",
-            "OBJ_539",
-            "OBJ_540",
-            "OBJ_541",
-            "OBJ_542",
-            "OBJ_543",
-            "OBJ_544",
-            "OBJ_545",
-            "OBJ_546",
-            "OBJ_547",
-            "OBJ_548"
-         );
-         name = "SourceKittenFramework";
-         path = ".build/checkouts/SourceKitten/Source/SourceKittenFramework";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_505" = {
-         isa = "PBXFileReference";
-         path = "Clang+SourceKitten.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_506" = {
-         isa = "PBXFileReference";
-         path = "ClangTranslationUnit.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_507" = {
-         isa = "PBXFileReference";
-         path = "CodeCompletionItem.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_508" = {
-         isa = "PBXFileReference";
-         path = "CursorInfo+Parsing.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_509" = {
-         isa = "PBXFileReference";
-         path = "Dictionary+Merge.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_51" = {
-         isa = "PBXFileReference";
-         path = "RuleList.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_510" = {
-         isa = "PBXFileReference";
-         path = "Documentation.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_511" = {
-         isa = "PBXFileReference";
-         path = "Exec.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_512" = {
-         isa = "PBXFileReference";
-         path = "File+Hashable.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_513" = {
-         isa = "PBXFileReference";
-         path = "File.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_514" = {
-         isa = "PBXFileReference";
-         path = "JSONOutput.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_515" = {
-         isa = "PBXFileReference";
-         path = "Language.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_516" = {
-         isa = "PBXFileReference";
-         path = "Line.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_517" = {
-         isa = "PBXFileReference";
-         path = "LinuxCompatibility.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_518" = {
-         isa = "PBXFileReference";
-         path = "Module.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_519" = {
-         isa = "PBXFileReference";
-         path = "ObjCDeclarationKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_52" = {
-         isa = "PBXFileReference";
-         path = "RuleParameter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_520" = {
-         isa = "PBXFileReference";
-         path = "OffsetMap.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_521" = {
-         isa = "PBXFileReference";
-         path = "Parameter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_522" = {
-         isa = "PBXFileReference";
-         path = "Request.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_523" = {
-         isa = "PBXFileReference";
-         path = "SourceDeclaration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_524" = {
-         isa = "PBXFileReference";
-         path = "SourceKitObject.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_525" = {
-         isa = "PBXFileReference";
-         path = "SourceLocation.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_526" = {
-         isa = "PBXFileReference";
-         path = "StatementKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_527" = {
-         isa = "PBXFileReference";
-         path = "String+SourceKitten.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_528" = {
-         isa = "PBXFileReference";
-         path = "StringView+SourceKitten.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_529" = {
-         isa = "PBXFileReference";
-         path = "StringView.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_53" = {
-         isa = "PBXFileReference";
-         path = "RuleStorage.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_530" = {
-         isa = "PBXFileReference";
-         path = "Structure.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_531" = {
-         isa = "PBXFileReference";
-         path = "SwiftDeclarationAttributeKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_532" = {
-         isa = "PBXFileReference";
-         path = "SwiftDeclarationKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_533" = {
-         isa = "PBXFileReference";
-         path = "SwiftDocKey.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_534" = {
-         isa = "PBXFileReference";
-         path = "SwiftDocs.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_535" = {
-         isa = "PBXFileReference";
-         path = "SyntaxKind.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_536" = {
-         isa = "PBXFileReference";
-         path = "SyntaxMap.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_537" = {
-         isa = "PBXFileReference";
-         path = "SyntaxToken.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_538" = {
-         isa = "PBXFileReference";
-         path = "Text.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_539" = {
-         isa = "PBXFileReference";
-         path = "UID.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_54" = {
-         isa = "PBXFileReference";
-         path = "StyleViolation.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_540" = {
-         isa = "PBXFileReference";
-         path = "UIDRepresentable.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_541" = {
-         isa = "PBXFileReference";
-         path = "Version.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_542" = {
-         isa = "PBXFileReference";
-         path = "Xcode.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_543" = {
-         isa = "PBXFileReference";
-         path = "XcodeBuildSetting.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_544" = {
-         isa = "PBXFileReference";
-         path = "library_wrapper.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_545" = {
-         isa = "PBXFileReference";
-         path = "library_wrapper_CXString.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_546" = {
-         isa = "PBXFileReference";
-         path = "library_wrapper_Documentation.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_547" = {
-         isa = "PBXFileReference";
-         path = "library_wrapper_Index.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_548" = {
-         isa = "PBXFileReference";
-         path = "library_wrapper_sourcekitd.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_549" = {
-         isa = "PBXGroup";
-         children = (
-         );
-         name = "sourcekitten";
-         path = ".build/checkouts/SourceKitten/Source/sourcekitten";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_55" = {
-         isa = "PBXFileReference";
-         path = "SwiftLintFile.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_550" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SourceKitten/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_551" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_552",
-            "OBJ_563",
-            "OBJ_580"
-         );
-         name = "Yams 2.0.0";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_552" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_553",
-            "OBJ_560"
-         );
-         name = "CYaml";
-         path = ".build/checkouts/Yams/Sources/CYaml";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_553" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_554",
-            "OBJ_555",
-            "OBJ_556",
-            "OBJ_557",
-            "OBJ_558",
-            "OBJ_559"
-         );
-         name = "src";
-         path = "src";
-         sourceTree = "<group>";
-      };
-      "OBJ_554" = {
-         isa = "PBXFileReference";
-         path = "api.c";
-         sourceTree = "<group>";
-      };
-      "OBJ_555" = {
-         isa = "PBXFileReference";
-         path = "emitter.c";
-         sourceTree = "<group>";
-      };
-      "OBJ_556" = {
-         isa = "PBXFileReference";
-         path = "parser.c";
-         sourceTree = "<group>";
-      };
-      "OBJ_557" = {
-         isa = "PBXFileReference";
-         path = "reader.c";
-         sourceTree = "<group>";
-      };
-      "OBJ_558" = {
-         isa = "PBXFileReference";
-         path = "scanner.c";
-         sourceTree = "<group>";
-      };
-      "OBJ_559" = {
-         isa = "PBXFileReference";
-         path = "writer.c";
-         sourceTree = "<group>";
-      };
-      "OBJ_56" = {
-         isa = "PBXFileReference";
-         path = "SwiftLintSyntaxMap.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_560" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_561",
-            "OBJ_562"
-         );
-         name = "include";
-         path = "include";
-         sourceTree = "<group>";
-      };
-      "OBJ_561" = {
-         isa = "PBXFileReference";
-         path = "CYaml.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_562" = {
-         isa = "PBXFileReference";
-         path = "yaml.h";
-         sourceTree = "<group>";
-      };
-      "OBJ_563" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_564",
-            "OBJ_565",
-            "OBJ_566",
-            "OBJ_567",
-            "OBJ_568",
-            "OBJ_569",
-            "OBJ_570",
-            "OBJ_571",
-            "OBJ_572",
-            "OBJ_573",
-            "OBJ_574",
-            "OBJ_575",
-            "OBJ_576",
-            "OBJ_577",
-            "OBJ_578",
-            "OBJ_579"
-         );
-         name = "Yams";
-         path = ".build/checkouts/Yams/Sources/Yams";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_564" = {
-         isa = "PBXFileReference";
-         path = "Constructor.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_565" = {
-         isa = "PBXFileReference";
-         path = "Decoder.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_566" = {
-         isa = "PBXFileReference";
-         path = "Emitter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_567" = {
-         isa = "PBXFileReference";
-         path = "Encoder.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_568" = {
-         isa = "PBXFileReference";
-         path = "Mark.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_569" = {
-         isa = "PBXFileReference";
-         path = "Node.Mapping.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_57" = {
-         isa = "PBXFileReference";
-         path = "SwiftLintSyntaxToken.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_570" = {
-         isa = "PBXFileReference";
-         path = "Node.Scalar.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_571" = {
-         isa = "PBXFileReference";
-         path = "Node.Sequence.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_572" = {
-         isa = "PBXFileReference";
-         path = "Node.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_573" = {
-         isa = "PBXFileReference";
-         path = "Parser.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_574" = {
-         isa = "PBXFileReference";
-         path = "Representer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_575" = {
-         isa = "PBXFileReference";
-         path = "Resolver.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_576" = {
-         isa = "PBXFileReference";
-         path = "String+Yams.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_577" = {
-         isa = "PBXFileReference";
-         path = "Tag.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_578" = {
-         isa = "PBXFileReference";
-         path = "YamlError.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_579" = {
-         isa = "PBXFileReference";
-         path = "shim.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_58" = {
-         isa = "PBXFileReference";
-         path = "SwiftVersion.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_580" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/Yams/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_581" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_582",
-            "OBJ_583",
-            "OBJ_584",
-            "OBJ_585"
-         );
-         name = "SWXMLHash 5.0.1";
-         path = ".build/checkouts/SWXMLHash/Source";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_582" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SWXMLHash/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_583" = {
-         isa = "PBXFileReference";
-         path = "SWXMLHash.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_584" = {
-         isa = "PBXFileReference";
-         path = "XMLIndexer+XMLIndexerDeserializable.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_585" = {
-         isa = "PBXFileReference";
-         path = "shim.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_586" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_587",
-            "OBJ_598"
-         );
-         name = "Commandant 0.17.0";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_587" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_588",
-            "OBJ_589",
-            "OBJ_590",
-            "OBJ_591",
-            "OBJ_592",
-            "OBJ_593",
-            "OBJ_594",
-            "OBJ_595",
-            "OBJ_596",
-            "OBJ_597"
-         );
-         name = "Commandant";
-         path = ".build/checkouts/Commandant/Sources/Commandant";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_588" = {
-         isa = "PBXFileReference";
-         path = "Argument.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_589" = {
-         isa = "PBXFileReference";
-         path = "ArgumentParser.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_59" = {
-         isa = "PBXFileReference";
-         path = "Version.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_590" = {
-         isa = "PBXFileReference";
-         path = "ArgumentProtocol.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_591" = {
-         isa = "PBXFileReference";
-         path = "Command.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_592" = {
-         isa = "PBXFileReference";
-         path = "Errors.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_593" = {
-         isa = "PBXFileReference";
-         path = "HelpCommand.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_594" = {
-         isa = "PBXFileReference";
-         path = "Option.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_595" = {
-         isa = "PBXFileReference";
-         path = "OrderedSet.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_596" = {
-         isa = "PBXFileReference";
-         path = "Result+Additions.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_597" = {
-         isa = "PBXFileReference";
-         path = "Switch.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_598" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/Commandant/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_599" = {
-         isa = "PBXGroup";
-         children = (
-            "Commandant::Commandant::Product",
-            "SwiftSyntax::_CSwiftSyntax::Product",
-            "SourceKitten::SourceKittenFramework::Product",
-            "SourceKitten::SourceKit::Product",
-            "SwiftLint::SwiftLintFramework::Product",
-            "SWXMLHash::SWXMLHash::Product",
-            "SwiftLint::SwiftLintFrameworkTests::Product",
-            "SourceKitten::Clang_C::Product",
-            "Yams::CYaml::Product",
-            "SwiftyTextTable::SwiftyTextTable::Product",
-            "SwiftSyntax::SwiftSyntax::Product",
-            "SwiftLint::swiftlint::Product",
-            "Yams::Yams::Product"
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "OBJ_6" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_60" = {
-         isa = "PBXFileReference";
-         path = "ViolationSeverity.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_61" = {
-         isa = "PBXFileReference";
-         path = "YamlParser.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_613" = {
-         isa = "PBXFileReference";
-         path = "SwiftLint.xcworkspace";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_614" = {
-         isa = "PBXFileReference";
-         path = "Carthage";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_615" = {
-         isa = "PBXFileReference";
-         path = "script";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_616" = {
-         isa = "PBXFileReference";
-         path = "portable_swiftlint";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_617" = {
-         isa = "PBXFileReference";
-         path = "assets";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_618" = {
-         isa = "PBXFileReference";
-         path = "Cartfile.resolved";
-         sourceTree = "<group>";
-      };
-      "OBJ_619" = {
-         isa = "PBXFileReference";
-         path = "Releasing.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_62" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_63",
-            "OBJ_64",
-            "OBJ_65",
-            "OBJ_66",
-            "OBJ_67",
-            "OBJ_68"
-         );
-         name = "Protocols";
-         path = "Protocols";
-         sourceTree = "<group>";
-      };
-      "OBJ_620" = {
-         isa = "PBXFileReference";
-         path = "LICENSE";
-         sourceTree = "<group>";
-      };
-      "OBJ_621" = {
-         isa = "PBXFileReference";
-         path = "CHANGELOG.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_622" = {
-         isa = "PBXFileReference";
-         path = "Makefile";
-         sourceTree = "<group>";
-      };
-      "OBJ_623" = {
-         isa = "PBXFileReference";
-         path = "Cartfile";
-         sourceTree = "<group>";
-      };
-      "OBJ_624" = {
-         isa = "PBXFileReference";
-         path = "README_KR.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_625" = {
-         isa = "PBXFileReference";
-         path = "azure-pipelines.yml";
-         sourceTree = "<group>";
-      };
-      "OBJ_626" = {
-         isa = "PBXFileReference";
-         path = "README.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_627" = {
-         isa = "PBXFileReference";
-         path = "README_CN.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_628" = {
-         isa = "PBXFileReference";
-         path = "Cartfile.private";
-         sourceTree = "<group>";
-      };
-      "OBJ_629" = {
-         isa = "PBXFileReference";
-         path = "CONTRIBUTING.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_63" = {
-         isa = "PBXFileReference";
-         path = "ASTRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_630" = {
-         isa = "PBXFileReference";
-         path = "SwiftLint.podspec";
-         sourceTree = "<group>";
-      };
-      "OBJ_631" = {
-         isa = "PBXFileReference";
-         path = "SwiftLintFramework.podspec";
-         sourceTree = "<group>";
-      };
-      "OBJ_632" = {
-         isa = "PBXFileReference";
-         path = "Dangerfile";
-         sourceTree = "<group>";
-      };
-      "OBJ_633" = {
-         isa = "PBXFileReference";
-         path = "Gemfile";
-         sourceTree = "<group>";
-      };
-      "OBJ_634" = {
-         isa = "PBXFileReference";
-         path = "Gemfile.lock";
-         sourceTree = "<group>";
-      };
-      "OBJ_635" = {
-         isa = "PBXFileReference";
-         path = "Rules.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_637" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_638",
-            "OBJ_639"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_638" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            DEFINES_MODULE = "YES";
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/CYaml_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "CYaml";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            TARGET_NAME = "CYaml";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_639" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            DEFINES_MODULE = "YES";
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/CYaml_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "CYaml";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            TARGET_NAME = "CYaml";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_64" = {
-         isa = "PBXFileReference";
-         path = "CacheDescriptionProvider.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_640" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_641",
-            "OBJ_642",
-            "OBJ_643",
-            "OBJ_644",
-            "OBJ_645",
-            "OBJ_646"
-         );
-      };
-      "OBJ_641" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_554";
-      };
-      "OBJ_642" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_555";
-      };
-      "OBJ_643" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_556";
-      };
-      "OBJ_644" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_557";
-      };
-      "OBJ_645" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_558";
-      };
-      "OBJ_646" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_559";
-      };
-      "OBJ_647" = {
-         isa = "PBXHeadersBuildPhase";
-         files = (
-            "OBJ_648",
-            "OBJ_649"
-         );
-      };
-      "OBJ_648" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_561";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_649" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_562";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_65" = {
-         isa = "PBXFileReference";
-         path = "CallPairRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_650" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_652" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_653",
-            "OBJ_654"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_653" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            DEFINES_MODULE = "YES";
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/Clang_C_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Clang-C";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            TARGET_NAME = "Clang_C";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_654" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            DEFINES_MODULE = "YES";
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/Clang_C_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Clang-C";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            TARGET_NAME = "Clang_C";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_655" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_656"
-         );
-      };
-      "OBJ_656" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_489";
-      };
-      "OBJ_657" = {
-         isa = "PBXHeadersBuildPhase";
-         files = (
-            "OBJ_658",
-            "OBJ_659",
-            "OBJ_660",
-            "OBJ_661",
-            "OBJ_662",
-            "OBJ_663",
-            "OBJ_664",
-            "OBJ_665"
-         );
-      };
-      "OBJ_658" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_491";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_659" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_492";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_66" = {
-         isa = "PBXFileReference";
-         path = "Reporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_660" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_493";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_661" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_494";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_662" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_495";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_663" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_496";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_664" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_497";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_665" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_498";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_666" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_668" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_669",
-            "OBJ_670"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_669" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/Commandant_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Commandant";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "Commandant";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_67" = {
-         isa = "PBXFileReference";
-         path = "Rule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_670" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/Commandant_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Commandant";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "Commandant";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_671" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_672",
-            "OBJ_673",
-            "OBJ_674",
-            "OBJ_675",
-            "OBJ_676",
-            "OBJ_677",
-            "OBJ_678",
-            "OBJ_679",
-            "OBJ_680",
-            "OBJ_681"
-         );
-      };
-      "OBJ_672" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_588";
-      };
-      "OBJ_673" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_589";
-      };
-      "OBJ_674" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_590";
-      };
-      "OBJ_675" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_591";
-      };
-      "OBJ_676" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_592";
-      };
-      "OBJ_677" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_593";
-      };
-      "OBJ_678" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_594";
-      };
-      "OBJ_679" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_595";
-      };
-      "OBJ_68" = {
-         isa = "PBXFileReference";
-         path = "RuleConfiguration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_680" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_596";
-      };
-      "OBJ_681" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_597";
-      };
-      "OBJ_682" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_684" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_685",
-            "OBJ_686"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_685" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_686" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Release";
-      };
-      "OBJ_687" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_688"
-         );
-      };
-      "OBJ_688" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_598";
-      };
-      "OBJ_69" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_70",
-            "OBJ_71",
-            "OBJ_72",
-            "OBJ_73",
-            "OBJ_74",
-            "OBJ_75",
-            "OBJ_76",
-            "OBJ_77",
-            "OBJ_78",
-            "OBJ_79"
-         );
-         name = "Reporters";
-         path = "Reporters";
-         sourceTree = "<group>";
-      };
-      "OBJ_690" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_691",
-            "OBJ_692"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_691" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SWXMLHash_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SWXMLHash";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "SWXMLHash";
-         };
-         name = "Debug";
-      };
-      "OBJ_692" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SWXMLHash_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SWXMLHash";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "SWXMLHash";
-         };
-         name = "Release";
-      };
-      "OBJ_693" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_694",
-            "OBJ_695",
-            "OBJ_696"
-         );
-      };
-      "OBJ_694" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_583";
-      };
-      "OBJ_695" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_584";
-      };
-      "OBJ_696" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_585";
-      };
-      "OBJ_697" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_699" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_700",
-            "OBJ_701"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_7" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_8",
-            "OBJ_348"
-         );
-         name = "Sources";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_70" = {
-         isa = "PBXFileReference";
-         path = "CSVReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_700" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "4"
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_701" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "4"
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Release";
-      };
-      "OBJ_702" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_703"
-         );
-      };
-      "OBJ_703" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_582";
-      };
-      "OBJ_705" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_706",
-            "OBJ_707"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_706" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            DEFINES_MODULE = "YES";
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SourceKit_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SourceKit";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            TARGET_NAME = "SourceKit";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_707" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            DEFINES_MODULE = "YES";
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SourceKit_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SourceKit";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            TARGET_NAME = "SourceKit";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_708" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_709"
-         );
-      };
-      "OBJ_709" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_500";
-      };
-      "OBJ_71" = {
-         isa = "PBXFileReference";
-         path = "CheckstyleReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_710" = {
-         isa = "PBXHeadersBuildPhase";
-         files = (
-            "OBJ_711",
-            "OBJ_712"
-         );
-      };
-      "OBJ_711" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_502";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_712" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_503";
-         settings = {
-            ATTRIBUTES = (
-               "Public"
-            );
-         };
-      };
-      "OBJ_713" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_715" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_716",
-            "OBJ_717"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_716" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SourceKittenFramework_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SourceKittenFramework";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SourceKittenFramework";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_717" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SourceKittenFramework_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SourceKittenFramework";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SourceKittenFramework";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_718" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_719",
-            "OBJ_720",
-            "OBJ_721",
-            "OBJ_722",
-            "OBJ_723",
-            "OBJ_724",
-            "OBJ_725",
-            "OBJ_726",
-            "OBJ_727",
-            "OBJ_728",
-            "OBJ_729",
-            "OBJ_730",
-            "OBJ_731",
-            "OBJ_732",
-            "OBJ_733",
-            "OBJ_734",
-            "OBJ_735",
-            "OBJ_736",
-            "OBJ_737",
-            "OBJ_738",
-            "OBJ_739",
-            "OBJ_740",
-            "OBJ_741",
-            "OBJ_742",
-            "OBJ_743",
-            "OBJ_744",
-            "OBJ_745",
-            "OBJ_746",
-            "OBJ_747",
-            "OBJ_748",
-            "OBJ_749",
-            "OBJ_750",
-            "OBJ_751",
-            "OBJ_752",
-            "OBJ_753",
-            "OBJ_754",
-            "OBJ_755",
-            "OBJ_756",
-            "OBJ_757",
-            "OBJ_758",
-            "OBJ_759",
-            "OBJ_760",
-            "OBJ_761",
-            "OBJ_762"
-         );
-      };
-      "OBJ_719" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_505";
-      };
-      "OBJ_72" = {
-         isa = "PBXFileReference";
-         path = "EmojiReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_720" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_506";
-      };
-      "OBJ_721" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_507";
-      };
-      "OBJ_722" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_508";
-      };
-      "OBJ_723" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_509";
-      };
-      "OBJ_724" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_510";
-      };
-      "OBJ_725" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_511";
-      };
-      "OBJ_726" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_512";
-      };
-      "OBJ_727" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_513";
-      };
-      "OBJ_728" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_514";
-      };
-      "OBJ_729" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_515";
-      };
-      "OBJ_73" = {
-         isa = "PBXFileReference";
-         path = "GitHubActionsLoggingReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_730" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_516";
-      };
-      "OBJ_731" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_517";
-      };
-      "OBJ_732" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_518";
-      };
-      "OBJ_733" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_519";
-      };
-      "OBJ_734" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_520";
-      };
-      "OBJ_735" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_521";
-      };
-      "OBJ_736" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_522";
-      };
-      "OBJ_737" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_523";
-      };
-      "OBJ_738" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_524";
-      };
-      "OBJ_739" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_525";
-      };
-      "OBJ_74" = {
-         isa = "PBXFileReference";
-         path = "HTMLReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_740" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_526";
-      };
-      "OBJ_741" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_527";
-      };
-      "OBJ_742" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_528";
-      };
-      "OBJ_743" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_529";
-      };
-      "OBJ_744" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_530";
-      };
-      "OBJ_745" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_531";
-      };
-      "OBJ_746" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_532";
-      };
-      "OBJ_747" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_533";
-      };
-      "OBJ_748" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_534";
-      };
-      "OBJ_749" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_535";
-      };
-      "OBJ_75" = {
-         isa = "PBXFileReference";
-         path = "JSONReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_750" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_536";
-      };
-      "OBJ_751" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_537";
-      };
-      "OBJ_752" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_538";
-      };
-      "OBJ_753" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_539";
-      };
-      "OBJ_754" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_540";
-      };
-      "OBJ_755" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_541";
-      };
-      "OBJ_756" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_542";
-      };
-      "OBJ_757" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_543";
-      };
-      "OBJ_758" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_544";
-      };
-      "OBJ_759" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_545";
-      };
-      "OBJ_76" = {
-         isa = "PBXFileReference";
-         path = "JUnitReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_760" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_546";
-      };
-      "OBJ_761" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_547";
-      };
-      "OBJ_762" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_548";
-      };
-      "OBJ_763" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_764",
-            "OBJ_765",
-            "OBJ_766",
-            "OBJ_767",
-            "OBJ_768"
-         );
-      };
-      "OBJ_764" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::Yams::Product";
-      };
-      "OBJ_765" = {
-         isa = "PBXBuildFile";
-         fileRef = "Yams::CYaml::Product";
-      };
-      "OBJ_766" = {
-         isa = "PBXBuildFile";
-         fileRef = "SWXMLHash::SWXMLHash::Product";
-      };
-      "OBJ_767" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::SourceKit::Product";
-      };
-      "OBJ_768" = {
-         isa = "PBXBuildFile";
-         fileRef = "SourceKitten::Clang_C::Product";
-      };
-      "OBJ_769" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::Yams";
-      };
-      "OBJ_77" = {
-         isa = "PBXFileReference";
-         path = "MarkdownReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_771" = {
-         isa = "PBXTargetDependency";
-         target = "Yams::CYaml";
-      };
-      "OBJ_772" = {
-         isa = "PBXTargetDependency";
-         target = "SWXMLHash::SWXMLHash";
-      };
-      "OBJ_773" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::SourceKit";
-      };
-      "OBJ_774" = {
-         isa = "PBXTargetDependency";
-         target = "SourceKitten::Clang_C";
-      };
-      "OBJ_776" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_777",
-            "OBJ_778"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_777" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_778" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Release";
-      };
-      "OBJ_779" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_780"
-         );
-      };
-      "OBJ_78" = {
-         isa = "PBXFileReference";
-         path = "SonarQubeReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_780" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_550";
-      };
-      "OBJ_782" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_783",
-            "OBJ_784"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_783" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
-               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftLintFramework_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-Xcc",
-               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftLintFramework";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftLintFramework";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_784" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
-               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
-               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
-               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
-            );
-            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftLintFramework_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-Xcc",
-               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftLintFramework";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftLintFramework";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_785" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_786",
-            "OBJ_787",
-            "OBJ_788",
-            "OBJ_789",
-            "OBJ_790",
-            "OBJ_791",
-            "OBJ_792",
-            "OBJ_793",
-            "OBJ_794",
-            "OBJ_795",
-            "OBJ_796",
-            "OBJ_797",
-            "OBJ_798",
-            "OBJ_799",
-            "OBJ_800",
-            "OBJ_801",
-            "OBJ_802",
-            "OBJ_803",
-            "OBJ_804",
-            "OBJ_805",
-            "OBJ_806",
-            "OBJ_807",
-            "OBJ_808",
-            "OBJ_809",
-            "OBJ_810",
-            "OBJ_811",
-            "OBJ_812",
-            "OBJ_813",
-            "OBJ_814",
-            "OBJ_815",
-            "OBJ_816",
-            "OBJ_817",
-            "OBJ_818",
-            "OBJ_819",
-            "OBJ_820",
-            "OBJ_821",
-            "OBJ_822",
-            "OBJ_823",
-            "OBJ_824",
-            "OBJ_825",
-            "OBJ_826",
-            "OBJ_827",
-            "OBJ_828",
-            "OBJ_829",
-            "OBJ_830",
-            "OBJ_831",
-            "OBJ_832",
-            "OBJ_833",
-            "OBJ_834",
-            "OBJ_835",
-            "OBJ_836",
-            "OBJ_837",
-            "OBJ_838",
-            "OBJ_839",
-            "OBJ_840",
-            "OBJ_841",
-            "OBJ_842",
-            "OBJ_843",
-            "OBJ_844",
-            "OBJ_845",
-            "OBJ_846",
-            "OBJ_847",
-            "OBJ_848",
-            "OBJ_849",
-            "OBJ_850",
-            "OBJ_851",
-            "OBJ_852",
-            "OBJ_853",
-            "OBJ_854",
-            "OBJ_855",
-            "OBJ_856",
-            "OBJ_857",
-            "OBJ_858",
-            "OBJ_859",
-            "OBJ_860",
-            "OBJ_861",
-            "OBJ_862",
-            "OBJ_863",
-            "OBJ_864",
-            "OBJ_865",
-            "OBJ_866",
-            "OBJ_867",
-            "OBJ_868",
-            "OBJ_869",
-            "OBJ_870",
-            "OBJ_871",
-            "OBJ_872",
-            "OBJ_873",
-            "OBJ_874",
-            "OBJ_875",
-            "OBJ_876",
-            "OBJ_877",
-            "OBJ_878",
-            "OBJ_879",
-            "OBJ_880",
-            "OBJ_881",
-            "OBJ_882",
-            "OBJ_883",
-            "OBJ_884",
-            "OBJ_885",
-            "OBJ_886",
-            "OBJ_887",
-            "OBJ_888",
-            "OBJ_889",
-            "OBJ_890",
-            "OBJ_891",
-            "OBJ_892",
-            "OBJ_893",
-            "OBJ_894",
-            "OBJ_895",
-            "OBJ_896",
-            "OBJ_897",
-            "OBJ_898",
-            "OBJ_899",
-            "OBJ_900",
-            "OBJ_901",
-            "OBJ_902",
-            "OBJ_903",
-            "OBJ_904",
-            "OBJ_905",
-            "OBJ_906",
-            "OBJ_907",
-            "OBJ_908",
-            "OBJ_909",
-            "OBJ_910",
-            "OBJ_911",
-            "OBJ_912",
-            "OBJ_913",
-            "OBJ_914",
-            "OBJ_915",
-            "OBJ_916",
-            "OBJ_917",
-            "OBJ_918",
-            "OBJ_919",
-            "OBJ_920",
-            "OBJ_921",
-            "OBJ_922",
-            "OBJ_923",
-            "OBJ_924",
-            "OBJ_925",
-            "OBJ_926",
-            "OBJ_927",
-            "OBJ_928",
-            "OBJ_929",
-            "OBJ_930",
-            "OBJ_931",
-            "OBJ_932",
-            "OBJ_933",
-            "OBJ_934",
-            "OBJ_935",
-            "OBJ_936",
-            "OBJ_937",
-            "OBJ_938",
-            "OBJ_939",
-            "OBJ_940",
-            "OBJ_941",
-            "OBJ_942",
-            "OBJ_943",
-            "OBJ_944",
-            "OBJ_945",
-            "OBJ_946",
-            "OBJ_947",
-            "OBJ_948",
-            "OBJ_949",
-            "OBJ_950",
-            "OBJ_951",
-            "OBJ_952",
-            "OBJ_953",
-            "OBJ_954",
-            "OBJ_955",
-            "OBJ_956",
-            "OBJ_957",
-            "OBJ_958",
-            "OBJ_959",
-            "OBJ_960",
-            "OBJ_961",
-            "OBJ_962",
-            "OBJ_963",
-            "OBJ_964",
-            "OBJ_965",
-            "OBJ_966",
-            "OBJ_967",
-            "OBJ_968",
-            "OBJ_969",
-            "OBJ_970",
-            "OBJ_971",
-            "OBJ_972",
-            "OBJ_973",
-            "OBJ_974",
-            "OBJ_975",
-            "OBJ_976",
-            "OBJ_977",
-            "OBJ_978",
-            "OBJ_979",
-            "OBJ_980",
-            "OBJ_981",
-            "OBJ_982",
-            "OBJ_983",
-            "OBJ_984",
-            "OBJ_985",
-            "OBJ_986",
-            "OBJ_987",
-            "OBJ_988",
-            "OBJ_989",
-            "OBJ_990",
-            "OBJ_991",
-            "OBJ_992",
-            "OBJ_993",
-            "OBJ_994",
-            "OBJ_995",
-            "OBJ_996",
-            "OBJ_997",
-            "OBJ_998",
-            "OBJ_999",
-            "OBJ_1000",
-            "OBJ_1001",
-            "OBJ_1002",
-            "OBJ_1003",
-            "OBJ_1004",
-            "OBJ_1005",
-            "OBJ_1006",
-            "OBJ_1007",
-            "OBJ_1008",
-            "OBJ_1009",
-            "OBJ_1010",
-            "OBJ_1011",
-            "OBJ_1012",
-            "OBJ_1013",
-            "OBJ_1014",
-            "OBJ_1015",
-            "OBJ_1016",
-            "OBJ_1017",
-            "OBJ_1018",
-            "OBJ_1019",
-            "OBJ_1020",
-            "OBJ_1021",
-            "OBJ_1022",
-            "OBJ_1023",
-            "OBJ_1024",
-            "OBJ_1025",
-            "OBJ_1026",
-            "OBJ_1027",
-            "OBJ_1028",
-            "OBJ_1029",
-            "OBJ_1030",
-            "OBJ_1031",
-            "OBJ_1032",
-            "OBJ_1033",
-            "OBJ_1034",
-            "OBJ_1035",
-            "OBJ_1036",
-            "OBJ_1037",
-            "OBJ_1038",
-            "OBJ_1039",
-            "OBJ_1040",
-            "OBJ_1041",
-            "OBJ_1042",
-            "OBJ_1043",
-            "OBJ_1044",
-            "OBJ_1045",
-            "OBJ_1046",
-            "OBJ_1047",
-            "OBJ_1048",
-            "OBJ_1049",
-            "OBJ_1050",
-            "OBJ_1051",
-            "OBJ_1052",
-            "OBJ_1053",
-            "OBJ_1054",
-            "OBJ_1055",
-            "OBJ_1056",
-            "OBJ_1057",
-            "OBJ_1058",
-            "OBJ_1059",
-            "OBJ_1060",
-            "OBJ_1061",
-            "OBJ_1062",
-            "OBJ_1063",
-            "OBJ_1064",
-            "OBJ_1065",
-            "OBJ_1066",
-            "OBJ_1067",
-            "OBJ_1068",
-            "OBJ_1069",
-            "OBJ_1070",
-            "OBJ_1071",
-            "OBJ_1072",
-            "OBJ_1073",
-            "OBJ_1074",
-            "OBJ_1075",
-            "OBJ_1076",
-            "OBJ_1077",
-            "OBJ_1078",
-            "OBJ_1079",
-            "OBJ_1080",
-            "OBJ_1081",
-            "OBJ_1082",
-            "OBJ_1083",
-            "OBJ_1084",
-            "OBJ_1085",
-            "OBJ_1086",
-            "OBJ_1087",
-            "OBJ_1088",
-            "OBJ_1089",
-            "OBJ_1090",
-            "OBJ_1091",
-            "OBJ_1092",
-            "OBJ_1093",
-            "OBJ_1094",
-            "OBJ_1095",
-            "OBJ_1096",
-            "OBJ_1097",
-            "OBJ_1098",
-            "OBJ_1099",
-            "OBJ_1100",
-            "OBJ_1101",
-            "OBJ_1102",
-            "OBJ_1103",
-            "OBJ_1104",
-            "OBJ_1105",
-            "OBJ_1106",
-            "OBJ_1107",
-            "OBJ_1108",
-            "OBJ_1109",
-            "OBJ_1110",
-            "OBJ_1111",
-            "OBJ_1112"
-         );
-      };
-      "OBJ_786" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_10";
-      };
-      "OBJ_787" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_11";
-      };
-      "OBJ_788" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_12";
-      };
-      "OBJ_789" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
-      };
-      "OBJ_79" = {
-         isa = "PBXFileReference";
-         path = "XcodeReporter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_790" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_14";
-      };
-      "OBJ_791" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_15";
-      };
-      "OBJ_792" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_16";
-      };
-      "OBJ_793" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_17";
-      };
-      "OBJ_794" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_18";
-      };
-      "OBJ_795" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_19";
-      };
-      "OBJ_796" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
-      };
-      "OBJ_797" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_21";
-      };
-      "OBJ_798" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_22";
-      };
-      "OBJ_799" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_23";
-      };
-      "OBJ_8" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_9",
-            "OBJ_32",
-            "OBJ_36",
-            "OBJ_62",
-            "OBJ_69",
-            "OBJ_80"
-         );
-         name = "SwiftLintFramework";
-         path = "Source/SwiftLintFramework";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_80" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_81",
-            "OBJ_148",
-            "OBJ_201",
-            "OBJ_213",
-            "OBJ_227",
-            "OBJ_271"
-         );
-         name = "Rules";
-         path = "Rules";
-         sourceTree = "<group>";
-      };
-      "OBJ_800" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_24";
-      };
-      "OBJ_801" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_25";
-      };
-      "OBJ_802" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
-      };
-      "OBJ_803" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_27";
-      };
-      "OBJ_804" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_28";
-      };
-      "OBJ_805" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_29";
-      };
-      "OBJ_806" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_30";
-      };
-      "OBJ_807" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_31";
-      };
-      "OBJ_808" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_33";
-      };
-      "OBJ_809" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_34";
-      };
-      "OBJ_81" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_82",
-            "OBJ_83",
-            "OBJ_84",
-            "OBJ_85",
-            "OBJ_86",
-            "OBJ_87",
-            "OBJ_88",
-            "OBJ_89",
-            "OBJ_90",
-            "OBJ_91",
-            "OBJ_92",
-            "OBJ_93",
-            "OBJ_94",
-            "OBJ_95",
-            "OBJ_96",
-            "OBJ_97",
-            "OBJ_98",
-            "OBJ_99",
-            "OBJ_100",
-            "OBJ_101",
-            "OBJ_102",
-            "OBJ_103",
-            "OBJ_104",
-            "OBJ_105",
-            "OBJ_106",
-            "OBJ_107",
-            "OBJ_108",
-            "OBJ_109",
-            "OBJ_110",
-            "OBJ_111",
-            "OBJ_112",
-            "OBJ_113",
-            "OBJ_114",
-            "OBJ_115",
-            "OBJ_116",
-            "OBJ_117",
-            "OBJ_118",
-            "OBJ_119",
-            "OBJ_120",
-            "OBJ_121",
-            "OBJ_122",
-            "OBJ_123",
-            "OBJ_124",
-            "OBJ_125",
-            "OBJ_126",
-            "OBJ_127",
-            "OBJ_128",
-            "OBJ_129",
-            "OBJ_130",
-            "OBJ_131",
-            "OBJ_132",
-            "OBJ_133",
-            "OBJ_134",
-            "OBJ_135",
-            "OBJ_136",
-            "OBJ_137",
-            "OBJ_138",
-            "OBJ_139",
-            "OBJ_140",
-            "OBJ_141",
-            "OBJ_142",
-            "OBJ_143",
-            "OBJ_144",
-            "OBJ_145",
-            "OBJ_146",
-            "OBJ_147"
-         );
-         name = "Idiomatic";
-         path = "Idiomatic";
-         sourceTree = "<group>";
-      };
-      "OBJ_810" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_35";
-      };
-      "OBJ_811" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_37";
-      };
-      "OBJ_812" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_38";
-      };
-      "OBJ_813" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_39";
-      };
-      "OBJ_814" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_40";
-      };
-      "OBJ_815" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_41";
-      };
-      "OBJ_816" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_42";
-      };
-      "OBJ_817" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_43";
-      };
-      "OBJ_818" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_44";
-      };
-      "OBJ_819" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_45";
-      };
-      "OBJ_82" = {
-         isa = "PBXFileReference";
-         path = "BlockBasedKVORule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_820" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_46";
-      };
-      "OBJ_821" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_47";
-      };
-      "OBJ_822" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_48";
-      };
-      "OBJ_823" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_49";
-      };
-      "OBJ_824" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_50";
-      };
-      "OBJ_825" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_51";
-      };
-      "OBJ_826" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_52";
-      };
-      "OBJ_827" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_53";
-      };
-      "OBJ_828" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_54";
-      };
-      "OBJ_829" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_55";
-      };
-      "OBJ_83" = {
-         isa = "PBXFileReference";
-         path = "ConvenienceTypeRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_830" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_56";
-      };
-      "OBJ_831" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_57";
-      };
-      "OBJ_832" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_58";
-      };
-      "OBJ_833" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_59";
-      };
-      "OBJ_834" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_60";
-      };
-      "OBJ_835" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_61";
-      };
-      "OBJ_836" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_63";
-      };
-      "OBJ_837" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_64";
-      };
-      "OBJ_838" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_65";
-      };
-      "OBJ_839" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_66";
-      };
-      "OBJ_84" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedObjectLiteralRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_840" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_67";
-      };
-      "OBJ_841" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_68";
-      };
-      "OBJ_842" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_70";
-      };
-      "OBJ_843" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_71";
-      };
-      "OBJ_844" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_72";
-      };
-      "OBJ_845" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_73";
-      };
-      "OBJ_846" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_74";
-      };
-      "OBJ_847" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_75";
-      };
-      "OBJ_848" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_76";
-      };
-      "OBJ_849" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_77";
-      };
-      "OBJ_85" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedOptionalBooleanRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_850" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_78";
-      };
-      "OBJ_851" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_79";
-      };
-      "OBJ_852" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_82";
-      };
-      "OBJ_853" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_83";
-      };
-      "OBJ_854" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_84";
-      };
-      "OBJ_855" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_85";
-      };
-      "OBJ_856" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_86";
-      };
-      "OBJ_857" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_87";
-      };
-      "OBJ_858" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_88";
-      };
-      "OBJ_859" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_89";
-      };
-      "OBJ_86" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedOptionalBooleanRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_860" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_90";
-      };
-      "OBJ_861" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_91";
-      };
-      "OBJ_862" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_92";
-      };
-      "OBJ_863" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_93";
-      };
-      "OBJ_864" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_94";
-      };
-      "OBJ_865" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_95";
-      };
-      "OBJ_866" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_96";
-      };
-      "OBJ_867" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_97";
-      };
-      "OBJ_868" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_98";
-      };
-      "OBJ_869" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_99";
-      };
-      "OBJ_87" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedOptionalCollectionExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_870" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_100";
-      };
-      "OBJ_871" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_101";
-      };
-      "OBJ_872" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_102";
-      };
-      "OBJ_873" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_103";
-      };
-      "OBJ_874" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_104";
-      };
-      "OBJ_875" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_105";
-      };
-      "OBJ_876" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_106";
-      };
-      "OBJ_877" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_107";
-      };
-      "OBJ_878" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_108";
-      };
-      "OBJ_879" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_109";
-      };
-      "OBJ_88" = {
-         isa = "PBXFileReference";
-         path = "DiscouragedOptionalCollectionRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_880" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_110";
-      };
-      "OBJ_881" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_111";
-      };
-      "OBJ_882" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_112";
-      };
-      "OBJ_883" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_113";
-      };
-      "OBJ_884" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_114";
-      };
-      "OBJ_885" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_115";
-      };
-      "OBJ_886" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_116";
-      };
-      "OBJ_887" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_117";
-      };
-      "OBJ_888" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_118";
-      };
-      "OBJ_889" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_119";
-      };
-      "OBJ_89" = {
-         isa = "PBXFileReference";
-         path = "DuplicateImportsRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_890" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_120";
-      };
-      "OBJ_891" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_121";
-      };
-      "OBJ_892" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_122";
-      };
-      "OBJ_893" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_123";
-      };
-      "OBJ_894" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_124";
-      };
-      "OBJ_895" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_125";
-      };
-      "OBJ_896" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_126";
-      };
-      "OBJ_897" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_127";
-      };
-      "OBJ_898" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_128";
-      };
-      "OBJ_899" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_129";
-      };
-      "OBJ_9" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_10",
-            "OBJ_11",
-            "OBJ_12",
-            "OBJ_13",
-            "OBJ_14",
-            "OBJ_15",
-            "OBJ_16",
-            "OBJ_17",
-            "OBJ_18",
-            "OBJ_19",
-            "OBJ_20",
-            "OBJ_21",
-            "OBJ_22",
-            "OBJ_23",
-            "OBJ_24",
-            "OBJ_25",
-            "OBJ_26",
-            "OBJ_27",
-            "OBJ_28",
-            "OBJ_29",
-            "OBJ_30",
-            "OBJ_31"
-         );
-         name = "Extensions";
-         path = "Extensions";
-         sourceTree = "<group>";
-      };
-      "OBJ_90" = {
-         isa = "PBXFileReference";
-         path = "DuplicateImportsRuleExamples.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_900" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_130";
-      };
-      "OBJ_901" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_131";
-      };
-      "OBJ_902" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_132";
-      };
-      "OBJ_903" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_133";
-      };
-      "OBJ_904" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_134";
-      };
-      "OBJ_905" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_135";
-      };
-      "OBJ_906" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_136";
-      };
-      "OBJ_907" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_137";
-      };
-      "OBJ_908" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_138";
-      };
-      "OBJ_909" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_139";
-      };
-      "OBJ_91" = {
-         isa = "PBXFileReference";
-         path = "ExplicitACLRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_910" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_140";
-      };
-      "OBJ_911" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_141";
-      };
-      "OBJ_912" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_142";
-      };
-      "OBJ_913" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_143";
-      };
-      "OBJ_914" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_144";
-      };
-      "OBJ_915" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_145";
-      };
-      "OBJ_916" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_146";
-      };
-      "OBJ_917" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_147";
-      };
-      "OBJ_918" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_149";
-      };
-      "OBJ_919" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_150";
-      };
-      "OBJ_92" = {
-         isa = "PBXFileReference";
-         path = "ExplicitEnumRawValueRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_920" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_151";
-      };
-      "OBJ_921" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_152";
-      };
-      "OBJ_922" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_153";
-      };
-      "OBJ_923" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_154";
-      };
-      "OBJ_924" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_155";
-      };
-      "OBJ_925" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_156";
-      };
-      "OBJ_926" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_157";
-      };
-      "OBJ_927" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_158";
-      };
-      "OBJ_928" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_159";
-      };
-      "OBJ_929" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_160";
-      };
-      "OBJ_93" = {
-         isa = "PBXFileReference";
-         path = "ExplicitInitRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_930" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_161";
-      };
-      "OBJ_931" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_162";
-      };
-      "OBJ_932" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_163";
-      };
-      "OBJ_933" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_164";
-      };
-      "OBJ_934" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_165";
-      };
-      "OBJ_935" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_166";
-      };
-      "OBJ_936" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_167";
-      };
-      "OBJ_937" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_168";
-      };
-      "OBJ_938" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_169";
-      };
-      "OBJ_939" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_170";
-      };
-      "OBJ_94" = {
-         isa = "PBXFileReference";
-         path = "ExplicitTopLevelACLRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_940" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_171";
-      };
-      "OBJ_941" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_172";
-      };
-      "OBJ_942" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_173";
-      };
-      "OBJ_943" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_174";
-      };
-      "OBJ_944" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_175";
-      };
-      "OBJ_945" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_176";
-      };
-      "OBJ_946" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_177";
-      };
-      "OBJ_947" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_178";
-      };
-      "OBJ_948" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_179";
-      };
-      "OBJ_949" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_180";
-      };
-      "OBJ_95" = {
-         isa = "PBXFileReference";
-         path = "ExplicitTypeInterfaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_950" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_181";
-      };
-      "OBJ_951" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_182";
-      };
-      "OBJ_952" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_183";
-      };
-      "OBJ_953" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_184";
-      };
-      "OBJ_954" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_185";
-      };
-      "OBJ_955" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_186";
-      };
-      "OBJ_956" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_187";
-      };
-      "OBJ_957" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_188";
-      };
-      "OBJ_958" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_189";
-      };
-      "OBJ_959" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_190";
-      };
-      "OBJ_96" = {
-         isa = "PBXFileReference";
-         path = "ExtensionAccessModifierRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_960" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_191";
-      };
-      "OBJ_961" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_192";
-      };
-      "OBJ_962" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_193";
-      };
-      "OBJ_963" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_194";
-      };
-      "OBJ_964" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_195";
-      };
-      "OBJ_965" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_196";
-      };
-      "OBJ_966" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_197";
-      };
-      "OBJ_967" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_198";
-      };
-      "OBJ_968" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_199";
-      };
-      "OBJ_969" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_200";
-      };
-      "OBJ_97" = {
-         isa = "PBXFileReference";
-         path = "FallthroughRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_970" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_202";
-      };
-      "OBJ_971" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_203";
-      };
-      "OBJ_972" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_204";
-      };
-      "OBJ_973" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_205";
-      };
-      "OBJ_974" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_206";
-      };
-      "OBJ_975" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_207";
-      };
-      "OBJ_976" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_208";
-      };
-      "OBJ_977" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_209";
-      };
-      "OBJ_978" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_210";
-      };
-      "OBJ_979" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_211";
-      };
-      "OBJ_98" = {
-         isa = "PBXFileReference";
-         path = "FatalErrorMessageRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_980" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_212";
-      };
-      "OBJ_981" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_214";
-      };
-      "OBJ_982" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_215";
-      };
-      "OBJ_983" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_216";
-      };
-      "OBJ_984" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_217";
-      };
-      "OBJ_985" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_218";
-      };
-      "OBJ_986" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_219";
-      };
-      "OBJ_987" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_220";
-      };
-      "OBJ_988" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_221";
-      };
-      "OBJ_989" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_222";
-      };
-      "OBJ_99" = {
-         isa = "PBXFileReference";
-         path = "FileNameNoSpaceRule.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_990" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_223";
-      };
-      "OBJ_991" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_224";
-      };
-      "OBJ_992" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_225";
-      };
-      "OBJ_993" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_226";
-      };
-      "OBJ_994" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_228";
-      };
-      "OBJ_995" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_229";
-      };
-      "OBJ_996" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_230";
-      };
-      "OBJ_997" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_231";
-      };
-      "OBJ_998" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_232";
-      };
-      "OBJ_999" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_233";
-      };
-      "SWXMLHash::SWXMLHash" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_690";
-         buildPhases = (
-            "OBJ_693",
-            "OBJ_697"
-         );
-         dependencies = (
-         );
-         name = "SWXMLHash";
-         productName = "SWXMLHash";
-         productReference = "SWXMLHash::SWXMLHash::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SWXMLHash::SWXMLHash::Product" = {
-         isa = "PBXFileReference";
-         path = "SWXMLHash.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SWXMLHash::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_699";
-         buildPhases = (
-            "OBJ_702"
-         );
-         dependencies = (
-         );
-         name = "SWXMLHashPackageDescription";
-         productName = "SWXMLHashPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "SourceKitten::Clang_C" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_652";
-         buildPhases = (
-            "OBJ_655",
-            "OBJ_657",
-            "OBJ_666"
-         );
-         dependencies = (
-         );
-         name = "Clang_C";
-         productName = "Clang_C";
-         productReference = "SourceKitten::Clang_C::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SourceKitten::Clang_C::Product" = {
-         isa = "PBXFileReference";
-         path = "Clang_C.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SourceKitten::SourceKit" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_705";
-         buildPhases = (
-            "OBJ_708",
-            "OBJ_710",
-            "OBJ_713"
-         );
-         dependencies = (
-         );
-         name = "SourceKit";
-         productName = "SourceKit";
-         productReference = "SourceKitten::SourceKit::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SourceKitten::SourceKit::Product" = {
-         isa = "PBXFileReference";
-         path = "SourceKit.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SourceKitten::SourceKittenFramework" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_715";
-         buildPhases = (
-            "OBJ_718",
-            "OBJ_763"
-         );
-         dependencies = (
-            "OBJ_769",
-            "OBJ_771",
-            "OBJ_772",
-            "OBJ_773",
-            "OBJ_774"
-         );
-         name = "SourceKittenFramework";
-         productName = "SourceKittenFramework";
-         productReference = "SourceKitten::SourceKittenFramework::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SourceKitten::SourceKittenFramework::Product" = {
-         isa = "PBXFileReference";
-         path = "SourceKittenFramework.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SourceKitten::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_776";
-         buildPhases = (
-            "OBJ_779"
-         );
-         dependencies = (
-         );
-         name = "SourceKittenPackageDescription";
-         productName = "SourceKittenPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftLint::SwiftLintFramework" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_782";
-         buildPhases = (
-            "OBJ_785",
-            "OBJ_1113"
-         );
-         dependencies = (
-            "OBJ_1122",
-            "OBJ_1124",
-            "OBJ_1126",
-            "OBJ_1127",
-            "OBJ_1128",
-            "OBJ_1129",
-            "OBJ_1130",
-            "OBJ_1131"
-         );
-         name = "SwiftLintFramework";
-         productName = "SwiftLintFramework";
-         productReference = "SwiftLint::SwiftLintFramework::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftLint::SwiftLintFramework::Product" = {
-         isa = "PBXFileReference";
-         path = "SwiftLintFramework.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SwiftLint::SwiftLintFrameworkTests" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1133";
-         buildPhases = (
-            "OBJ_1136",
-            "OBJ_1211"
-         );
-         dependencies = (
-            "OBJ_1221",
-            "OBJ_1222",
-            "OBJ_1223",
-            "OBJ_1224",
-            "OBJ_1225",
-            "OBJ_1226",
-            "OBJ_1227",
-            "OBJ_1228",
-            "OBJ_1229"
-         );
-         name = "SwiftLintFrameworkTests";
-         productName = "SwiftLintFrameworkTests";
-         productReference = "SwiftLint::SwiftLintFrameworkTests::Product";
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      "SwiftLint::SwiftLintFrameworkTests::Product" = {
-         isa = "PBXFileReference";
-         path = "SwiftLintFrameworkTests.xctest";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SwiftLint::SwiftLintPackageTests::ProductTarget" = {
-         isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_1237";
-         buildPhases = (
-         );
-         dependencies = (
-            "OBJ_1240"
-         );
-         name = "SwiftLintPackageTests";
-         productName = "SwiftLintPackageTests";
-      };
-      "SwiftLint::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1231";
-         buildPhases = (
-            "OBJ_1234"
-         );
-         dependencies = (
-         );
-         name = "SwiftLintPackageDescription";
-         productName = "SwiftLintPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftLint::swiftlint" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1331";
-         buildPhases = (
-            "OBJ_1334",
-            "OBJ_1350"
-         );
-         dependencies = (
-            "OBJ_1362",
-            "OBJ_1363",
-            "OBJ_1364",
-            "OBJ_1365",
-            "OBJ_1366",
-            "OBJ_1367",
-            "OBJ_1368",
-            "OBJ_1369",
-            "OBJ_1370",
-            "OBJ_1371",
-            "OBJ_1372"
-         );
-         name = "swiftlint";
-         productName = "swiftlint";
-         productReference = "SwiftLint::swiftlint::Product";
-         productType = "com.apple.product-type.tool";
-      };
-      "SwiftLint::swiftlint::Product" = {
-         isa = "PBXFileReference";
-         path = "swiftlint";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SwiftSyntax::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1277";
-         buildPhases = (
-            "OBJ_1280"
-         );
-         dependencies = (
-         );
-         name = "SwiftSyntaxPackageDescription";
-         productName = "SwiftSyntaxPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftSyntax::SwiftSyntax" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1241";
-         buildPhases = (
-            "OBJ_1244",
-            "OBJ_1273"
-         );
-         dependencies = (
-            "OBJ_1275"
-         );
-         name = "SwiftSyntax";
-         productName = "SwiftSyntax";
-         productReference = "SwiftSyntax::SwiftSyntax::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftSyntax::SwiftSyntax::Product" = {
-         isa = "PBXFileReference";
-         path = "SwiftSyntax.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SwiftSyntax::_CSwiftSyntax" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1324";
-         buildPhases = (
-            "OBJ_1327",
-            "OBJ_1329"
-         );
-         dependencies = (
-         );
-         name = "_CSwiftSyntax";
-         productName = "_CSwiftSyntax";
-         productReference = "SwiftSyntax::_CSwiftSyntax::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftSyntax::_CSwiftSyntax::Product" = {
-         isa = "PBXFileReference";
-         path = "_CSwiftSyntax.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SwiftyTextTable::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1290";
-         buildPhases = (
-            "OBJ_1293"
-         );
-         dependencies = (
-         );
-         name = "SwiftyTextTablePackageDescription";
-         productName = "SwiftyTextTablePackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftyTextTable::SwiftyTextTable" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1283";
-         buildPhases = (
-            "OBJ_1286",
-            "OBJ_1288"
-         );
-         dependencies = (
-         );
-         name = "SwiftyTextTable";
-         productName = "SwiftyTextTable";
-         productReference = "SwiftyTextTable::SwiftyTextTable::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftyTextTable::SwiftyTextTable::Product" = {
-         isa = "PBXFileReference";
-         path = "SwiftyTextTable.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "Yams::CYaml" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_637";
-         buildPhases = (
-            "OBJ_640",
-            "OBJ_647",
-            "OBJ_650"
-         );
-         dependencies = (
-         );
-         name = "CYaml";
-         productName = "CYaml";
-         productReference = "Yams::CYaml::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "Yams::CYaml::Product" = {
-         isa = "PBXFileReference";
-         path = "CYaml.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "Yams::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1319";
-         buildPhases = (
-            "OBJ_1322"
-         );
-         dependencies = (
-         );
-         name = "YamsPackageDescription";
-         productName = "YamsPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "Yams::Yams" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_1295";
-         buildPhases = (
-            "OBJ_1298",
-            "OBJ_1315"
-         );
-         dependencies = (
-            "OBJ_1317"
-         );
-         name = "Yams";
-         productName = "Yams";
-         productReference = "Yams::Yams::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "Yams::Yams::Product" = {
-         isa = "PBXFileReference";
-         path = "Yams.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-   };
-   rootObject = "OBJ_1";
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"SwiftLint::SwiftLintPackageTests::ProductTarget" /* SwiftLintPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_1239 /* Build configuration list for PBXAggregateTarget "SwiftLintPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_1242 /* PBXTargetDependency */,
+			);
+			name = SwiftLintPackageTests;
+			productName = SwiftLintPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		D4A115F323C2194400D1122A /* ReturnValueFromVoidFunctionRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A115F223C2194400D1122A /* ReturnValueFromVoidFunctionRuleExamples.swift */; };
+		OBJ_1000 /* CyclomaticComplexityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_233 /* CyclomaticComplexityConfiguration.swift */; };
+		OBJ_1001 /* DeploymentTargetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_234 /* DeploymentTargetConfiguration.swift */; };
+		OBJ_1002 /* DiscouragedDirectInitConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_235 /* DiscouragedDirectInitConfiguration.swift */; };
+		OBJ_1003 /* ExpiringTodoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_236 /* ExpiringTodoConfiguration.swift */; };
+		OBJ_1004 /* ExplicitTypeInterfaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_237 /* ExplicitTypeInterfaceConfiguration.swift */; };
+		OBJ_1005 /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_238 /* FileHeaderConfiguration.swift */; };
+		OBJ_1006 /* FileLengthRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_239 /* FileLengthRuleConfiguration.swift */; };
+		OBJ_1007 /* FileNameConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_240 /* FileNameConfiguration.swift */; };
+		OBJ_1008 /* FileNameNoSpaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_241 /* FileNameNoSpaceConfiguration.swift */; };
+		OBJ_1009 /* FileTypesOrderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_242 /* FileTypesOrderConfiguration.swift */; };
+		OBJ_1010 /* FunctionParameterCountConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_243 /* FunctionParameterCountConfiguration.swift */; };
+		OBJ_1011 /* ImplicitlyUnwrappedOptionalConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_244 /* ImplicitlyUnwrappedOptionalConfiguration.swift */; };
+		OBJ_1012 /* LineLengthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_245 /* LineLengthConfiguration.swift */; };
+		OBJ_1013 /* MissingDocsRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_246 /* MissingDocsRuleConfiguration.swift */; };
+		OBJ_1014 /* ModifierOrderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_247 /* ModifierOrderConfiguration.swift */; };
+		OBJ_1015 /* MultilineArgumentsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_248 /* MultilineArgumentsConfiguration.swift */; };
+		OBJ_1016 /* NameConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_249 /* NameConfiguration.swift */; };
+		OBJ_1017 /* NestingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_250 /* NestingConfiguration.swift */; };
+		OBJ_1018 /* NumberSeparatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_251 /* NumberSeparatorConfiguration.swift */; };
+		OBJ_1019 /* ObjectLiteralConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_252 /* ObjectLiteralConfiguration.swift */; };
+		OBJ_1020 /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_253 /* OverridenSuperCallConfiguration.swift */; };
+		OBJ_1021 /* PrefixedConstantRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_254 /* PrefixedConstantRuleConfiguration.swift */; };
+		OBJ_1022 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_255 /* PrivateOutletRuleConfiguration.swift */; };
+		OBJ_1023 /* PrivateOverFilePrivateRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_256 /* PrivateOverFilePrivateRuleConfiguration.swift */; };
+		OBJ_1024 /* PrivateUnitTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_257 /* PrivateUnitTestConfiguration.swift */; };
+		OBJ_1025 /* ProhibitedSuperConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_258 /* ProhibitedSuperConfiguration.swift */; };
+		OBJ_1026 /* RegexConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_259 /* RegexConfiguration.swift */; };
+		OBJ_1027 /* RequiredEnumCaseRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_260 /* RequiredEnumCaseRuleConfiguration.swift */; };
+		OBJ_1028 /* SeverityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_261 /* SeverityConfiguration.swift */; };
+		OBJ_1029 /* SeverityLevelsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_262 /* SeverityLevelsConfiguration.swift */; };
+		OBJ_1030 /* StatementModeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_263 /* StatementModeConfiguration.swift */; };
+		OBJ_1031 /* SwitchCaseAlignmentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_264 /* SwitchCaseAlignmentConfiguration.swift */; };
+		OBJ_1032 /* TrailingClosureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_265 /* TrailingClosureConfiguration.swift */; };
+		OBJ_1033 /* TrailingCommaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_266 /* TrailingCommaConfiguration.swift */; };
+		OBJ_1034 /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_267 /* TrailingWhitespaceConfiguration.swift */; };
+		OBJ_1035 /* TypeContentsOrderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_268 /* TypeContentsOrderConfiguration.swift */; };
+		OBJ_1036 /* UnusedDeclarationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_269 /* UnusedDeclarationConfiguration.swift */; };
+		OBJ_1037 /* UnusedOptionalBindingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_270 /* UnusedOptionalBindingConfiguration.swift */; };
+		OBJ_1038 /* VerticalWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_271 /* VerticalWhitespaceConfiguration.swift */; };
+		OBJ_1039 /* AttributesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_273 /* AttributesRule.swift */; };
+		OBJ_1040 /* AttributesRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_274 /* AttributesRuleExamples.swift */; };
+		OBJ_1041 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_275 /* ClosingBraceRule.swift */; };
+		OBJ_1042 /* ClosureEndIndentationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_276 /* ClosureEndIndentationRule.swift */; };
+		OBJ_1043 /* ClosureEndIndentationRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_277 /* ClosureEndIndentationRuleExamples.swift */; };
+		OBJ_1044 /* ClosureParameterPositionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_278 /* ClosureParameterPositionRule.swift */; };
+		OBJ_1045 /* ClosureSpacingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_279 /* ClosureSpacingRule.swift */; };
+		OBJ_1046 /* CollectionAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_280 /* CollectionAlignmentRule.swift */; };
+		OBJ_1047 /* ColonRule+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_281 /* ColonRule+Dictionary.swift */; };
+		OBJ_1048 /* ColonRule+FunctionCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_282 /* ColonRule+FunctionCall.swift */; };
+		OBJ_1049 /* ColonRule+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_283 /* ColonRule+Type.swift */; };
+		OBJ_1050 /* ColonRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_284 /* ColonRule.swift */; };
+		OBJ_1051 /* ColonRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_285 /* ColonRuleExamples.swift */; };
+		OBJ_1052 /* CommaRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_286 /* CommaRule.swift */; };
+		OBJ_1053 /* ConditionalReturnsOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_287 /* ConditionalReturnsOnNewlineRule.swift */; };
+		OBJ_1054 /* ControlStatementRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_288 /* ControlStatementRule.swift */; };
+		OBJ_1055 /* CustomRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_289 /* CustomRules.swift */; };
+		OBJ_1056 /* EmptyEnumArgumentsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_290 /* EmptyEnumArgumentsRule.swift */; };
+		OBJ_1057 /* EmptyParametersRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_291 /* EmptyParametersRule.swift */; };
+		OBJ_1058 /* EmptyParenthesesWithTrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_292 /* EmptyParenthesesWithTrailingClosureRule.swift */; };
+		OBJ_1059 /* ExplicitSelfRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_293 /* ExplicitSelfRule.swift */; };
+		OBJ_1060 /* FileHeaderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_294 /* FileHeaderRule.swift */; };
+		OBJ_1061 /* FileTypesOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_295 /* FileTypesOrderRule.swift */; };
+		OBJ_1062 /* FileTypesOrderRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_296 /* FileTypesOrderRuleExamples.swift */; };
+		OBJ_1063 /* IdentifierNameRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_297 /* IdentifierNameRule.swift */; };
+		OBJ_1064 /* IdentifierNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_298 /* IdentifierNameRuleExamples.swift */; };
+		OBJ_1065 /* ImplicitGetterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_299 /* ImplicitGetterRule.swift */; };
+		OBJ_1066 /* ImplicitReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_300 /* ImplicitReturnRule.swift */; };
+		OBJ_1067 /* LeadingWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_301 /* LeadingWhitespaceRule.swift */; };
+		OBJ_1068 /* LetVarWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_302 /* LetVarWhitespaceRule.swift */; };
+		OBJ_1069 /* LiteralExpressionEndIdentationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_303 /* LiteralExpressionEndIdentationRule.swift */; };
+		OBJ_1070 /* ModifierOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_304 /* ModifierOrderRule.swift */; };
+		OBJ_1071 /* ModifierOrderRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_305 /* ModifierOrderRuleExamples.swift */; };
+		OBJ_1072 /* MultilineArgumentsBracketsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_306 /* MultilineArgumentsBracketsRule.swift */; };
+		OBJ_1073 /* MultilineArgumentsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_307 /* MultilineArgumentsRule.swift */; };
+		OBJ_1074 /* MultilineArgumentsRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_308 /* MultilineArgumentsRuleExamples.swift */; };
+		OBJ_1075 /* MultilineFunctionChainsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_309 /* MultilineFunctionChainsRule.swift */; };
+		OBJ_1076 /* MultilineLiteralBracketsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_310 /* MultilineLiteralBracketsRule.swift */; };
+		OBJ_1077 /* MultilineParametersBracketsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_311 /* MultilineParametersBracketsRule.swift */; };
+		OBJ_1078 /* MultilineParametersRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_312 /* MultilineParametersRule.swift */; };
+		OBJ_1079 /* MultilineParametersRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_313 /* MultilineParametersRuleExamples.swift */; };
+		OBJ_1080 /* MultipleClosuresWithTrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_314 /* MultipleClosuresWithTrailingClosureRule.swift */; };
+		OBJ_1081 /* NoSpaceInMethodCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_315 /* NoSpaceInMethodCallRule.swift */; };
+		OBJ_1082 /* NumberSeparatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_316 /* NumberSeparatorRule.swift */; };
+		OBJ_1083 /* NumberSeparatorRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_317 /* NumberSeparatorRuleExamples.swift */; };
+		OBJ_1084 /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_318 /* OpeningBraceRule.swift */; };
+		OBJ_1085 /* OperatorFunctionWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_319 /* OperatorFunctionWhitespaceRule.swift */; };
+		OBJ_1086 /* OperatorUsageWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_320 /* OperatorUsageWhitespaceRule.swift */; };
+		OBJ_1087 /* OptionalEnumCaseMatchingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_321 /* OptionalEnumCaseMatchingRule.swift */; };
+		OBJ_1088 /* PreferSelfTypeOverTypeOfSelfRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_322 /* PreferSelfTypeOverTypeOfSelfRule.swift */; };
+		OBJ_1089 /* PrefixedTopLevelConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_323 /* PrefixedTopLevelConstantRule.swift */; };
+		OBJ_1090 /* ProtocolPropertyAccessorsOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_324 /* ProtocolPropertyAccessorsOrderRule.swift */; };
+		OBJ_1091 /* RedundantDiscardableLetRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_325 /* RedundantDiscardableLetRule.swift */; };
+		OBJ_1092 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_326 /* ReturnArrowWhitespaceRule.swift */; };
+		OBJ_1093 /* ShorthandOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_327 /* ShorthandOperatorRule.swift */; };
+		OBJ_1094 /* SingleTestClassRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_328 /* SingleTestClassRule.swift */; };
+		OBJ_1095 /* SortedImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_329 /* SortedImportsRule.swift */; };
+		OBJ_1096 /* StatementPositionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_330 /* StatementPositionRule.swift */; };
+		OBJ_1097 /* SwitchCaseAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_331 /* SwitchCaseAlignmentRule.swift */; };
+		OBJ_1098 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_332 /* SwitchCaseOnNewlineRule.swift */; };
+		OBJ_1099 /* TrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_333 /* TrailingClosureRule.swift */; };
+		OBJ_1100 /* TrailingCommaRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_334 /* TrailingCommaRule.swift */; };
+		OBJ_1101 /* TrailingNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_335 /* TrailingNewlineRule.swift */; };
+		OBJ_1102 /* TrailingWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_336 /* TrailingWhitespaceRule.swift */; };
+		OBJ_1103 /* TypeContentsOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_337 /* TypeContentsOrderRule.swift */; };
+		OBJ_1104 /* TypeContentsOrderRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_338 /* TypeContentsOrderRuleExamples.swift */; };
+		OBJ_1105 /* UnneededParenthesesInClosureArgumentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_339 /* UnneededParenthesesInClosureArgumentRule.swift */; };
+		OBJ_1106 /* UnusedOptionalBindingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_340 /* UnusedOptionalBindingRule.swift */; };
+		OBJ_1107 /* VerticalParameterAlignmentOnCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_341 /* VerticalParameterAlignmentOnCallRule.swift */; };
+		OBJ_1108 /* VerticalParameterAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_342 /* VerticalParameterAlignmentRule.swift */; };
+		OBJ_1109 /* VerticalParameterAlignmentRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_343 /* VerticalParameterAlignmentRuleExamples.swift */; };
+		OBJ_1110 /* VerticalWhitespaceBetweenCasesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_344 /* VerticalWhitespaceBetweenCasesRule.swift */; };
+		OBJ_1111 /* VerticalWhitespaceClosingBracesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_345 /* VerticalWhitespaceClosingBracesRule.swift */; };
+		OBJ_1112 /* VerticalWhitespaceOpeningBracesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_346 /* VerticalWhitespaceOpeningBracesRule.swift */; };
+		OBJ_1113 /* VerticalWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_347 /* VerticalWhitespaceRule.swift */; };
+		OBJ_1114 /* VoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_348 /* VoidReturnRule.swift */; };
+		OBJ_1116 /* SwiftSyntax.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftSyntax::SwiftSyntax::Product" /* SwiftSyntax.framework */; };
+		OBJ_1117 /* _CSwiftSyntax.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftSyntax::_CSwiftSyntax::Product" /* _CSwiftSyntax.framework */; };
+		OBJ_1118 /* SourceKittenFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::SourceKittenFramework::Product" /* SourceKittenFramework.framework */; };
+		OBJ_1119 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::Yams::Product" /* Yams.framework */; };
+		OBJ_1120 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
+		OBJ_1121 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SWXMLHash::SWXMLHash::Product" /* SWXMLHash.framework */; };
+		OBJ_1122 /* SourceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::SourceKit::Product" /* SourceKit.framework */; };
+		OBJ_1123 /* Clang_C.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::Clang_C::Product" /* Clang_C.framework */; };
+		OBJ_1139 /* AttributesRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_370 /* AttributesRuleTests.swift */; };
+		OBJ_1140 /* AutomaticRuleTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_371 /* AutomaticRuleTests.generated.swift */; };
+		OBJ_1141 /* CollectingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_372 /* CollectingRuleTests.swift */; };
+		OBJ_1142 /* CollectionAlignmentRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_373 /* CollectionAlignmentRuleTests.swift */; };
+		OBJ_1143 /* ColonRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_374 /* ColonRuleTests.swift */; };
+		OBJ_1144 /* CommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_375 /* CommandTests.swift */; };
+		OBJ_1145 /* CompilerProtocolInitRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_376 /* CompilerProtocolInitRuleTests.swift */; };
+		OBJ_1146 /* ConditionalReturnsOnNewlineRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_377 /* ConditionalReturnsOnNewlineRuleTests.swift */; };
+		OBJ_1147 /* ConfigurationAliasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_378 /* ConfigurationAliasesTests.swift */; };
+		OBJ_1148 /* ConfigurationTests+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_379 /* ConfigurationTests+Nested.swift */; };
+		OBJ_1149 /* ConfigurationTests+ProjectMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* ConfigurationTests+ProjectMock.swift */; };
+		OBJ_1150 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* ConfigurationTests.swift */; };
+		OBJ_1151 /* ContainsOverFirstNotNilRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_382 /* ContainsOverFirstNotNilRuleTests.swift */; };
+		OBJ_1152 /* CustomRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_383 /* CustomRulesTests.swift */; };
+		OBJ_1153 /* CyclomaticComplexityConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_384 /* CyclomaticComplexityConfigurationTests.swift */; };
+		OBJ_1154 /* CyclomaticComplexityRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_385 /* CyclomaticComplexityRuleTests.swift */; };
+		OBJ_1155 /* DeploymentTargetConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_386 /* DeploymentTargetConfigurationTests.swift */; };
+		OBJ_1156 /* DeploymentTargetRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_387 /* DeploymentTargetRuleTests.swift */; };
+		OBJ_1157 /* DisableAllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_388 /* DisableAllTests.swift */; };
+		OBJ_1158 /* DiscouragedDirectInitRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_389 /* DiscouragedDirectInitRuleTests.swift */; };
+		OBJ_1159 /* DiscouragedObjectLiteralRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_390 /* DiscouragedObjectLiteralRuleTests.swift */; };
+		OBJ_1160 /* DocumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_391 /* DocumentationTests.swift */; };
+		OBJ_1161 /* ExpiringTodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_392 /* ExpiringTodoRuleTests.swift */; };
+		OBJ_1162 /* ExplicitTypeInterfaceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_393 /* ExplicitTypeInterfaceConfigurationTests.swift */; };
+		OBJ_1163 /* ExplicitTypeInterfaceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_394 /* ExplicitTypeInterfaceRuleTests.swift */; };
+		OBJ_1164 /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_395 /* ExtendedNSStringTests.swift */; };
+		OBJ_1165 /* FileHeaderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_396 /* FileHeaderRuleTests.swift */; };
+		OBJ_1166 /* FileLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_397 /* FileLengthRuleTests.swift */; };
+		OBJ_1167 /* FileNameNoSpaceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_398 /* FileNameNoSpaceRuleTests.swift */; };
+		OBJ_1168 /* FileNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_399 /* FileNameRuleTests.swift */; };
+		OBJ_1169 /* FileTypesOrderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_400 /* FileTypesOrderRuleTests.swift */; };
+		OBJ_1170 /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_401 /* FunctionBodyLengthRuleTests.swift */; };
+		OBJ_1171 /* FunctionParameterCountRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_402 /* FunctionParameterCountRuleTests.swift */; };
+		OBJ_1172 /* GenericTypeNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_403 /* GenericTypeNameRuleTests.swift */; };
+		OBJ_1173 /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_404 /* GlobTests.swift */; };
+		OBJ_1174 /* IdentifierNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_405 /* IdentifierNameRuleTests.swift */; };
+		OBJ_1175 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_406 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */; };
+		OBJ_1176 /* ImplicitlyUnwrappedOptionalRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_407 /* ImplicitlyUnwrappedOptionalRuleTests.swift */; };
+		OBJ_1177 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_408 /* IntegrationTests.swift */; };
+		OBJ_1178 /* LineLengthConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_409 /* LineLengthConfigurationTests.swift */; };
+		OBJ_1179 /* LineLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_410 /* LineLengthRuleTests.swift */; };
+		OBJ_1180 /* LinterCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_411 /* LinterCacheTests.swift */; };
+		OBJ_1181 /* MissingDocsRuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_412 /* MissingDocsRuleConfigurationTests.swift */; };
+		OBJ_1182 /* ModifierOrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_413 /* ModifierOrderTests.swift */; };
+		OBJ_1183 /* MultilineArgumentsRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_414 /* MultilineArgumentsRuleTests.swift */; };
+		OBJ_1184 /* NumberSeparatorRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_415 /* NumberSeparatorRuleTests.swift */; };
+		OBJ_1185 /* ObjectLiteralRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_416 /* ObjectLiteralRuleTests.swift */; };
+		OBJ_1186 /* PrefixedTopLevelConstantRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_417 /* PrefixedTopLevelConstantRuleTests.swift */; };
+		OBJ_1187 /* PrivateOutletRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_418 /* PrivateOutletRuleTests.swift */; };
+		OBJ_1188 /* PrivateOverFilePrivateRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_419 /* PrivateOverFilePrivateRuleTests.swift */; };
+		OBJ_1189 /* RegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_420 /* RegionTests.swift */; };
+		OBJ_1190 /* ReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_421 /* ReporterTests.swift */; };
+		OBJ_1191 /* RequiredEnumCaseRuleTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_422 /* RequiredEnumCaseRuleTestCase.swift */; };
+		OBJ_1192 /* RuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_423 /* RuleConfigurationTests.swift */; };
+		OBJ_1193 /* RuleDescription+Examples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_424 /* RuleDescription+Examples.swift */; };
+		OBJ_1194 /* RuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_425 /* RuleTests.swift */; };
+		OBJ_1195 /* RulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_426 /* RulesTests.swift */; };
+		OBJ_1196 /* SourceKitCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_427 /* SourceKitCrashTests.swift */; };
+		OBJ_1197 /* StatementPositionRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_428 /* StatementPositionRuleTests.swift */; };
+		OBJ_1198 /* SwitchCaseAlignmentRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_429 /* SwitchCaseAlignmentRuleTests.swift */; };
+		OBJ_1199 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_430 /* TestHelpers.swift */; };
+		OBJ_1200 /* TodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_431 /* TodoRuleTests.swift */; };
+		OBJ_1201 /* TrailingClosureConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_432 /* TrailingClosureConfigurationTests.swift */; };
+		OBJ_1202 /* TrailingClosureRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_433 /* TrailingClosureRuleTests.swift */; };
+		OBJ_1203 /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_434 /* TrailingCommaRuleTests.swift */; };
+		OBJ_1204 /* TrailingWhitespaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_435 /* TrailingWhitespaceTests.swift */; };
+		OBJ_1205 /* TypeContentsOrderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_436 /* TypeContentsOrderRuleTests.swift */; };
+		OBJ_1206 /* TypeNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_437 /* TypeNameRuleTests.swift */; };
+		OBJ_1207 /* UnusedOptionalBindingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_438 /* UnusedOptionalBindingRuleTests.swift */; };
+		OBJ_1208 /* VerticalWhitespaceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_439 /* VerticalWhitespaceRuleTests.swift */; };
+		OBJ_1209 /* XCTSpecificMatcherRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_440 /* XCTSpecificMatcherRuleTests.swift */; };
+		OBJ_1210 /* XCTestCase+BundlePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_441 /* XCTestCase+BundlePath.swift */; };
+		OBJ_1211 /* YamlParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_442 /* YamlParserTests.swift */; };
+		OBJ_1212 /* YamlSwiftLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_443 /* YamlSwiftLintTests.swift */; };
+		OBJ_1214 /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftLint::SwiftLintFramework::Product" /* SwiftLintFramework.framework */; };
+		OBJ_1215 /* SwiftSyntax.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftSyntax::SwiftSyntax::Product" /* SwiftSyntax.framework */; };
+		OBJ_1216 /* _CSwiftSyntax.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftSyntax::_CSwiftSyntax::Product" /* _CSwiftSyntax.framework */; };
+		OBJ_1217 /* SourceKittenFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::SourceKittenFramework::Product" /* SourceKittenFramework.framework */; };
+		OBJ_1218 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::Yams::Product" /* Yams.framework */; };
+		OBJ_1219 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
+		OBJ_1220 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SWXMLHash::SWXMLHash::Product" /* SWXMLHash.framework */; };
+		OBJ_1221 /* SourceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::SourceKit::Product" /* SourceKit.framework */; };
+		OBJ_1222 /* Clang_C.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::Clang_C::Product" /* Clang_C.framework */; };
+		OBJ_1237 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_1247 /* AbsolutePosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_447 /* AbsolutePosition.swift */; };
+		OBJ_1248 /* AtomicCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_448 /* AtomicCounter.swift */; };
+		OBJ_1249 /* Diagnostic.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_449 /* Diagnostic.swift */; };
+		OBJ_1250 /* DiagnosticConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_450 /* DiagnosticConsumer.swift */; };
+		OBJ_1251 /* DiagnosticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_451 /* DiagnosticEngine.swift */; };
+		OBJ_1252 /* IncrementalParseTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_452 /* IncrementalParseTransition.swift */; };
+		OBJ_1253 /* JSONDiagnosticConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_453 /* JSONDiagnosticConsumer.swift */; };
+		OBJ_1254 /* PrintingDiagnosticConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_454 /* PrintingDiagnosticConsumer.swift */; };
+		OBJ_1255 /* RawSyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_455 /* RawSyntax.swift */; };
+		OBJ_1256 /* SourceLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_456 /* SourceLength.swift */; };
+		OBJ_1257 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_457 /* SourceLocation.swift */; };
+		OBJ_1258 /* SourcePresence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_458 /* SourcePresence.swift */; };
+		OBJ_1259 /* Syntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_459 /* Syntax.swift */; };
+		OBJ_1260 /* SyntaxChildren.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_460 /* SyntaxChildren.swift */; };
+		OBJ_1261 /* SyntaxClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_461 /* SyntaxClassifier.swift */; };
+		OBJ_1262 /* SyntaxData.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_462 /* SyntaxData.swift */; };
+		OBJ_1263 /* SyntaxParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_463 /* SyntaxParser.swift */; };
+		OBJ_1264 /* SyntaxVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_464 /* SyntaxVerifier.swift */; };
+		OBJ_1265 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_465 /* Utils.swift */; };
+		OBJ_1266 /* SyntaxBuilders.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_467 /* SyntaxBuilders.swift */; };
+		OBJ_1267 /* SyntaxClassification.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_468 /* SyntaxClassification.swift */; };
+		OBJ_1268 /* SyntaxCollections.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_469 /* SyntaxCollections.swift */; };
+		OBJ_1269 /* SyntaxFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_470 /* SyntaxFactory.swift */; };
+		OBJ_1270 /* SyntaxKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_471 /* SyntaxKind.swift */; };
+		OBJ_1271 /* SyntaxNodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_472 /* SyntaxNodes.swift */; };
+		OBJ_1272 /* SyntaxRewriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_473 /* SyntaxRewriter.swift */; };
+		OBJ_1273 /* TokenKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_474 /* TokenKind.swift */; };
+		OBJ_1274 /* Trivia.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_475 /* Trivia.swift */; };
+		OBJ_1276 /* _CSwiftSyntax.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftSyntax::_CSwiftSyntax::Product" /* _CSwiftSyntax.framework */; };
+		OBJ_1283 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_483 /* Package.swift */; };
+		OBJ_1289 /* TextTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_486 /* TextTable.swift */; };
+		OBJ_1296 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_487 /* Package.swift */; };
+		OBJ_1301 /* Constructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_565 /* Constructor.swift */; };
+		OBJ_1302 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_566 /* Decoder.swift */; };
+		OBJ_1303 /* Emitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_567 /* Emitter.swift */; };
+		OBJ_1304 /* Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_568 /* Encoder.swift */; };
+		OBJ_1305 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_569 /* Mark.swift */; };
+		OBJ_1306 /* Node.Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_570 /* Node.Mapping.swift */; };
+		OBJ_1307 /* Node.Scalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_571 /* Node.Scalar.swift */; };
+		OBJ_1308 /* Node.Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_572 /* Node.Sequence.swift */; };
+		OBJ_1309 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_573 /* Node.swift */; };
+		OBJ_1310 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_574 /* Parser.swift */; };
+		OBJ_1311 /* Representer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_575 /* Representer.swift */; };
+		OBJ_1312 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_576 /* Resolver.swift */; };
+		OBJ_1313 /* String+Yams.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_577 /* String+Yams.swift */; };
+		OBJ_1314 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_578 /* Tag.swift */; };
+		OBJ_1315 /* YamlError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_579 /* YamlError.swift */; };
+		OBJ_1316 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_580 /* shim.swift */; };
+		OBJ_1318 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
+		OBJ_1325 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_581 /* Package.swift */; };
+		OBJ_1330 /* atomic-counter.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_478 /* atomic-counter.c */; };
+		OBJ_1337 /* AnalyzeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_351 /* AnalyzeCommand.swift */; };
+		OBJ_1338 /* AutoCorrectCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_352 /* AutoCorrectCommand.swift */; };
+		OBJ_1339 /* GenerateDocsCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_353 /* GenerateDocsCommand.swift */; };
+		OBJ_1340 /* LintCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_354 /* LintCommand.swift */; };
+		OBJ_1341 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_355 /* RulesCommand.swift */; };
+		OBJ_1342 /* VersionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_356 /* VersionCommand.swift */; };
+		OBJ_1343 /* Array+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_358 /* Array+SwiftLint.swift */; };
+		OBJ_1344 /* Configuration+CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_359 /* Configuration+CommandLine.swift */; };
+		OBJ_1345 /* Reporter+CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_360 /* Reporter+CommandLine.swift */; };
+		OBJ_1346 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_362 /* Benchmark.swift */; };
+		OBJ_1347 /* CommonOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_363 /* CommonOptions.swift */; };
+		OBJ_1348 /* CompilerArgumentsExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_364 /* CompilerArgumentsExtractor.swift */; };
+		OBJ_1349 /* LintOrAnalyzeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_365 /* LintOrAnalyzeCommand.swift */; };
+		OBJ_1350 /* LintableFilesVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_366 /* LintableFilesVisitor.swift */; };
+		OBJ_1351 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_367 /* main.swift */; };
+		OBJ_1353 /* SwiftyTextTable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftyTextTable::SwiftyTextTable::Product" /* SwiftyTextTable.framework */; };
+		OBJ_1354 /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Commandant::Commandant::Product" /* Commandant.framework */; };
+		OBJ_1355 /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftLint::SwiftLintFramework::Product" /* SwiftLintFramework.framework */; };
+		OBJ_1356 /* SwiftSyntax.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftSyntax::SwiftSyntax::Product" /* SwiftSyntax.framework */; };
+		OBJ_1357 /* _CSwiftSyntax.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftSyntax::_CSwiftSyntax::Product" /* _CSwiftSyntax.framework */; };
+		OBJ_1358 /* SourceKittenFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::SourceKittenFramework::Product" /* SourceKittenFramework.framework */; };
+		OBJ_1359 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::Yams::Product" /* Yams.framework */; };
+		OBJ_1360 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
+		OBJ_1361 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SWXMLHash::SWXMLHash::Product" /* SWXMLHash.framework */; };
+		OBJ_1362 /* SourceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::SourceKit::Product" /* SourceKit.framework */; };
+		OBJ_1363 /* Clang_C.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::Clang_C::Product" /* Clang_C.framework */; };
+		OBJ_642 /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_555 /* api.c */; };
+		OBJ_643 /* emitter.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_556 /* emitter.c */; };
+		OBJ_644 /* parser.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_557 /* parser.c */; };
+		OBJ_645 /* reader.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_558 /* reader.c */; };
+		OBJ_646 /* scanner.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_559 /* scanner.c */; };
+		OBJ_647 /* writer.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_560 /* writer.c */; };
+		OBJ_649 /* CYaml.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_562 /* CYaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_650 /* yaml.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_563 /* yaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_657 /* Clang_C.m in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_490 /* Clang_C.m */; };
+		OBJ_659 /* Index.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_492 /* Index.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_660 /* BuildSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_493 /* BuildSystem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_661 /* Documentation.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_494 /* Documentation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_662 /* CXCompilationDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_495 /* CXCompilationDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_663 /* Clang_C.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_496 /* Clang_C.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_664 /* CXErrorCode.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_497 /* CXErrorCode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_665 /* CXString.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_498 /* CXString.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_666 /* Platform.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_499 /* Platform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_673 /* Argument.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_589 /* Argument.swift */; };
+		OBJ_674 /* ArgumentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_590 /* ArgumentParser.swift */; };
+		OBJ_675 /* ArgumentProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_591 /* ArgumentProtocol.swift */; };
+		OBJ_676 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_592 /* Command.swift */; };
+		OBJ_677 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_593 /* Errors.swift */; };
+		OBJ_678 /* HelpCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_594 /* HelpCommand.swift */; };
+		OBJ_679 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_595 /* Option.swift */; };
+		OBJ_680 /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_596 /* OrderedSet.swift */; };
+		OBJ_681 /* Result+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_597 /* Result+Additions.swift */; };
+		OBJ_682 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_598 /* Switch.swift */; };
+		OBJ_689 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_599 /* Package.swift */; };
+		OBJ_695 /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_584 /* SWXMLHash.swift */; };
+		OBJ_696 /* XMLIndexer+XMLIndexerDeserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_585 /* XMLIndexer+XMLIndexerDeserializable.swift */; };
+		OBJ_697 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_586 /* shim.swift */; };
+		OBJ_704 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_583 /* Package.swift */; };
+		OBJ_710 /* SourceKit.m in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_501 /* SourceKit.m */; };
+		OBJ_712 /* SourceKit.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_503 /* SourceKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_713 /* sourcekitd.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_504 /* sourcekitd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_720 /* Clang+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_506 /* Clang+SourceKitten.swift */; };
+		OBJ_721 /* ClangTranslationUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_507 /* ClangTranslationUnit.swift */; };
+		OBJ_722 /* CodeCompletionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_508 /* CodeCompletionItem.swift */; };
+		OBJ_723 /* CursorInfo+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_509 /* CursorInfo+Parsing.swift */; };
+		OBJ_724 /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_510 /* Dictionary+Merge.swift */; };
+		OBJ_725 /* Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_511 /* Documentation.swift */; };
+		OBJ_726 /* Exec.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_512 /* Exec.swift */; };
+		OBJ_727 /* File+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_513 /* File+Hashable.swift */; };
+		OBJ_728 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_514 /* File.swift */; };
+		OBJ_729 /* JSONOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_515 /* JSONOutput.swift */; };
+		OBJ_730 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_516 /* Language.swift */; };
+		OBJ_731 /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_517 /* Line.swift */; };
+		OBJ_732 /* LinuxCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_518 /* LinuxCompatibility.swift */; };
+		OBJ_733 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_519 /* Module.swift */; };
+		OBJ_734 /* ObjCDeclarationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_520 /* ObjCDeclarationKind.swift */; };
+		OBJ_735 /* OffsetMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_521 /* OffsetMap.swift */; };
+		OBJ_736 /* Parameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_522 /* Parameter.swift */; };
+		OBJ_737 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_523 /* Request.swift */; };
+		OBJ_738 /* SourceDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_524 /* SourceDeclaration.swift */; };
+		OBJ_739 /* SourceKitObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_525 /* SourceKitObject.swift */; };
+		OBJ_740 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_526 /* SourceLocation.swift */; };
+		OBJ_741 /* StatementKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_527 /* StatementKind.swift */; };
+		OBJ_742 /* String+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_528 /* String+SourceKitten.swift */; };
+		OBJ_743 /* StringView+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_529 /* StringView+SourceKitten.swift */; };
+		OBJ_744 /* StringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_530 /* StringView.swift */; };
+		OBJ_745 /* Structure.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_531 /* Structure.swift */; };
+		OBJ_746 /* SwiftDeclarationAttributeKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_532 /* SwiftDeclarationAttributeKind.swift */; };
+		OBJ_747 /* SwiftDeclarationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_533 /* SwiftDeclarationKind.swift */; };
+		OBJ_748 /* SwiftDocKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_534 /* SwiftDocKey.swift */; };
+		OBJ_749 /* SwiftDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_535 /* SwiftDocs.swift */; };
+		OBJ_750 /* SyntaxKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_536 /* SyntaxKind.swift */; };
+		OBJ_751 /* SyntaxMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_537 /* SyntaxMap.swift */; };
+		OBJ_752 /* SyntaxToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_538 /* SyntaxToken.swift */; };
+		OBJ_753 /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_539 /* Text.swift */; };
+		OBJ_754 /* UID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_540 /* UID.swift */; };
+		OBJ_755 /* UIDRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_541 /* UIDRepresentable.swift */; };
+		OBJ_756 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_542 /* Version.swift */; };
+		OBJ_757 /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_543 /* Xcode.swift */; };
+		OBJ_758 /* XcodeBuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_544 /* XcodeBuildSetting.swift */; };
+		OBJ_759 /* library_wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_545 /* library_wrapper.swift */; };
+		OBJ_760 /* library_wrapper_CXString.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_546 /* library_wrapper_CXString.swift */; };
+		OBJ_761 /* library_wrapper_Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_547 /* library_wrapper_Documentation.swift */; };
+		OBJ_762 /* library_wrapper_Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_548 /* library_wrapper_Index.swift */; };
+		OBJ_763 /* library_wrapper_sourcekitd.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_549 /* library_wrapper_sourcekitd.swift */; };
+		OBJ_765 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::Yams::Product" /* Yams.framework */; };
+		OBJ_766 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
+		OBJ_767 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SWXMLHash::SWXMLHash::Product" /* SWXMLHash.framework */; };
+		OBJ_768 /* SourceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::SourceKit::Product" /* SourceKit.framework */; };
+		OBJ_769 /* Clang_C.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SourceKitten::Clang_C::Product" /* Clang_C.framework */; };
+		OBJ_781 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_551 /* Package.swift */; };
+		OBJ_787 /* Array+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Array+SwiftLint.swift */; };
+		OBJ_788 /* Configuration+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Configuration+Cache.swift */; };
+		OBJ_789 /* Configuration+IndentationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Configuration+IndentationStyle.swift */; };
+		OBJ_790 /* Configuration+LintableFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Configuration+LintableFiles.swift */; };
+		OBJ_791 /* Configuration+Merging.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Configuration+Merging.swift */; };
+		OBJ_792 /* Configuration+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Configuration+Parsing.swift */; };
+		OBJ_793 /* Dictionary+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* Dictionary+SwiftLint.swift */; };
+		OBJ_794 /* FileManager+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* FileManager+SwiftLint.swift */; };
+		OBJ_795 /* NSRange+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* NSRange+SwiftLint.swift */; };
+		OBJ_796 /* NSRegularExpression+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* NSRegularExpression+SwiftLint.swift */; };
+		OBJ_797 /* QueuedPrint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* QueuedPrint.swift */; };
+		OBJ_798 /* RandomAccessCollection+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* RandomAccessCollection+Swiftlint.swift */; };
+		OBJ_799 /* Request+DisableSourceKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Request+DisableSourceKit.swift */; };
+		OBJ_800 /* SourceKittenDictionary+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* SourceKittenDictionary+Swiftlint.swift */; };
+		OBJ_801 /* String+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* String+SwiftLint.swift */; };
+		OBJ_802 /* String+XML.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* String+XML.swift */; };
+		OBJ_803 /* SwiftDeclarationAttributeKind+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* SwiftDeclarationAttributeKind+Swiftlint.swift */; };
+		OBJ_804 /* SwiftDeclarationKind+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* SwiftDeclarationKind+SwiftLint.swift */; };
+		OBJ_805 /* SwiftExpressionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* SwiftExpressionKind.swift */; };
+		OBJ_806 /* SwiftLintFile+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* SwiftLintFile+Cache.swift */; };
+		OBJ_807 /* SwiftLintFile+Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* SwiftLintFile+Regex.swift */; };
+		OBJ_808 /* SyntaxKind+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* SyntaxKind+SwiftLint.swift */; };
+		OBJ_809 /* Glob.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* Glob.swift */; };
+		OBJ_810 /* NamespaceCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* NamespaceCollector.swift */; };
+		OBJ_811 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* RegexHelpers.swift */; };
+		OBJ_812 /* AccessControlLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* AccessControlLevel.swift */; };
+		OBJ_813 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* Command.swift */; };
+		OBJ_814 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* Configuration.swift */; };
+		OBJ_815 /* ConfigurationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* ConfigurationError.swift */; };
+		OBJ_816 /* Correction.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* Correction.swift */; };
+		OBJ_817 /* Linter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* Linter.swift */; };
+		OBJ_818 /* LinterCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* LinterCache.swift */; };
+		OBJ_819 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* Location.swift */; };
+		OBJ_820 /* MasterRuleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* MasterRuleList.swift */; };
+		OBJ_821 /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* Region.swift */; };
+		OBJ_822 /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* RuleDescription.swift */; };
+		OBJ_823 /* RuleIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* RuleIdentifier.swift */; };
+		OBJ_824 /* RuleKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_49 /* RuleKind.swift */; };
+		OBJ_825 /* RuleList+Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* RuleList+Documentation.swift */; };
+		OBJ_826 /* RuleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* RuleList.swift */; };
+		OBJ_827 /* RuleParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_52 /* RuleParameter.swift */; };
+		OBJ_828 /* RuleStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* RuleStorage.swift */; };
+		OBJ_829 /* StyleViolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* StyleViolation.swift */; };
+		OBJ_830 /* SwiftLintFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* SwiftLintFile.swift */; };
+		OBJ_831 /* SwiftLintSyntaxMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_56 /* SwiftLintSyntaxMap.swift */; };
+		OBJ_832 /* SwiftLintSyntaxToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_57 /* SwiftLintSyntaxToken.swift */; };
+		OBJ_833 /* SwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_58 /* SwiftVersion.swift */; };
+		OBJ_834 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_59 /* Version.swift */; };
+		OBJ_835 /* ViolationSeverity.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_60 /* ViolationSeverity.swift */; };
+		OBJ_836 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_61 /* YamlParser.swift */; };
+		OBJ_837 /* ASTRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* ASTRule.swift */; };
+		OBJ_838 /* CacheDescriptionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_64 /* CacheDescriptionProvider.swift */; };
+		OBJ_839 /* CallPairRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_65 /* CallPairRule.swift */; };
+		OBJ_840 /* Reporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_66 /* Reporter.swift */; };
+		OBJ_841 /* Rule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_67 /* Rule.swift */; };
+		OBJ_842 /* RuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* RuleConfiguration.swift */; };
+		OBJ_843 /* CSVReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_70 /* CSVReporter.swift */; };
+		OBJ_844 /* CheckstyleReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* CheckstyleReporter.swift */; };
+		OBJ_845 /* EmojiReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* EmojiReporter.swift */; };
+		OBJ_846 /* GitHubActionsLoggingReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* GitHubActionsLoggingReporter.swift */; };
+		OBJ_847 /* HTMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* HTMLReporter.swift */; };
+		OBJ_848 /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_75 /* JSONReporter.swift */; };
+		OBJ_849 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* JUnitReporter.swift */; };
+		OBJ_850 /* MarkdownReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* MarkdownReporter.swift */; };
+		OBJ_851 /* SonarQubeReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_78 /* SonarQubeReporter.swift */; };
+		OBJ_852 /* XcodeReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_79 /* XcodeReporter.swift */; };
+		OBJ_853 /* BlockBasedKVORule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_82 /* BlockBasedKVORule.swift */; };
+		OBJ_854 /* ConvenienceTypeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_83 /* ConvenienceTypeRule.swift */; };
+		OBJ_855 /* DiscouragedObjectLiteralRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_84 /* DiscouragedObjectLiteralRule.swift */; };
+		OBJ_856 /* DiscouragedOptionalBooleanRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_85 /* DiscouragedOptionalBooleanRule.swift */; };
+		OBJ_857 /* DiscouragedOptionalBooleanRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_86 /* DiscouragedOptionalBooleanRuleExamples.swift */; };
+		OBJ_858 /* DiscouragedOptionalCollectionExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_87 /* DiscouragedOptionalCollectionExamples.swift */; };
+		OBJ_859 /* DiscouragedOptionalCollectionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_88 /* DiscouragedOptionalCollectionRule.swift */; };
+		OBJ_860 /* DuplicateImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_89 /* DuplicateImportsRule.swift */; };
+		OBJ_861 /* DuplicateImportsRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_90 /* DuplicateImportsRuleExamples.swift */; };
+		OBJ_862 /* ExplicitACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_91 /* ExplicitACLRule.swift */; };
+		OBJ_863 /* ExplicitEnumRawValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_92 /* ExplicitEnumRawValueRule.swift */; };
+		OBJ_864 /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_93 /* ExplicitInitRule.swift */; };
+		OBJ_865 /* ExplicitTopLevelACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_94 /* ExplicitTopLevelACLRule.swift */; };
+		OBJ_866 /* ExplicitTypeInterfaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_95 /* ExplicitTypeInterfaceRule.swift */; };
+		OBJ_867 /* ExtensionAccessModifierRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_96 /* ExtensionAccessModifierRule.swift */; };
+		OBJ_868 /* FallthroughRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_97 /* FallthroughRule.swift */; };
+		OBJ_869 /* FatalErrorMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_98 /* FatalErrorMessageRule.swift */; };
+		OBJ_870 /* FileNameNoSpaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_99 /* FileNameNoSpaceRule.swift */; };
+		OBJ_871 /* FileNameRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_100 /* FileNameRule.swift */; };
+		OBJ_872 /* ForWhereRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_101 /* ForWhereRule.swift */; };
+		OBJ_873 /* ForceCastRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_102 /* ForceCastRule.swift */; };
+		OBJ_874 /* ForceTryRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_103 /* ForceTryRule.swift */; };
+		OBJ_875 /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_104 /* ForceUnwrappingRule.swift */; };
+		OBJ_876 /* FunctionDefaultParameterAtEndRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_105 /* FunctionDefaultParameterAtEndRule.swift */; };
+		OBJ_877 /* GenericTypeNameRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_106 /* GenericTypeNameRule.swift */; };
+		OBJ_878 /* ImplicitlyUnwrappedOptionalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_107 /* ImplicitlyUnwrappedOptionalRule.swift */; };
+		OBJ_879 /* IsDisjointRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_108 /* IsDisjointRule.swift */; };
+		OBJ_880 /* JoinedDefaultParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_109 /* JoinedDefaultParameterRule.swift */; };
+		OBJ_881 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_110 /* LegacyCGGeometryFunctionsRule.swift */; };
+		OBJ_882 /* LegacyConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_111 /* LegacyConstantRule.swift */; };
+		OBJ_883 /* LegacyConstantRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_112 /* LegacyConstantRuleExamples.swift */; };
+		OBJ_884 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_113 /* LegacyConstructorRule.swift */; };
+		OBJ_885 /* LegacyHashingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_114 /* LegacyHashingRule.swift */; };
+		OBJ_886 /* LegacyMultipleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_115 /* LegacyMultipleRule.swift */; };
+		OBJ_887 /* LegacyNSGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_116 /* LegacyNSGeometryFunctionsRule.swift */; };
+		OBJ_888 /* LegacyRandomRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_117 /* LegacyRandomRule.swift */; };
+		OBJ_889 /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_118 /* NimbleOperatorRule.swift */; };
+		OBJ_890 /* NoExtensionAccessModifierRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_119 /* NoExtensionAccessModifierRule.swift */; };
+		OBJ_891 /* NoFallthroughOnlyRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_120 /* NoFallthroughOnlyRule.swift */; };
+		OBJ_892 /* NoFallthroughOnlyRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_121 /* NoFallthroughOnlyRuleExamples.swift */; };
+		OBJ_893 /* NoGroupingExtensionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_122 /* NoGroupingExtensionRule.swift */; };
+		OBJ_894 /* ObjectLiteralRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_123 /* ObjectLiteralRule.swift */; };
+		OBJ_895 /* PatternMatchingKeywordsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_124 /* PatternMatchingKeywordsRule.swift */; };
+		OBJ_896 /* PrivateOverFilePrivateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_125 /* PrivateOverFilePrivateRule.swift */; };
+		OBJ_897 /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_126 /* RedundantNilCoalescingRule.swift */; };
+		OBJ_898 /* RedundantObjcAttributeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_127 /* RedundantObjcAttributeRule.swift */; };
+		OBJ_899 /* RedundantObjcAttributeRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_128 /* RedundantObjcAttributeRuleExamples.swift */; };
+		OBJ_900 /* RedundantOptionalInitializationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_129 /* RedundantOptionalInitializationRule.swift */; };
+		OBJ_901 /* RedundantSetAccessControlRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_130 /* RedundantSetAccessControlRule.swift */; };
+		OBJ_902 /* RedundantStringEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_131 /* RedundantStringEnumValueRule.swift */; };
+		OBJ_903 /* RedundantTypeAnnotationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_132 /* RedundantTypeAnnotationRule.swift */; };
+		OBJ_904 /* RedundantVoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_133 /* RedundantVoidReturnRule.swift */; };
+		OBJ_905 /* StaticOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_134 /* StaticOperatorRule.swift */; };
+		OBJ_906 /* StrictFilePrivateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_135 /* StrictFilePrivateRule.swift */; };
+		OBJ_907 /* SyntacticSugarRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_136 /* SyntacticSugarRule.swift */; };
+		OBJ_908 /* ToggleBoolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_137 /* ToggleBoolRule.swift */; };
+		OBJ_909 /* TrailingSemicolonRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_138 /* TrailingSemicolonRule.swift */; };
+		OBJ_910 /* TypeNameRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_139 /* TypeNameRule.swift */; };
+		OBJ_911 /* TypeNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_140 /* TypeNameRuleExamples.swift */; };
+		OBJ_912 /* UnavailableFunctionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_141 /* UnavailableFunctionRule.swift */; };
+		OBJ_913 /* UnneededBreakInSwitchRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_142 /* UnneededBreakInSwitchRule.swift */; };
+		OBJ_914 /* UntypedErrorInCatchRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_143 /* UntypedErrorInCatchRule.swift */; };
+		OBJ_915 /* UnusedEnumeratedRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_144 /* UnusedEnumeratedRule.swift */; };
+		OBJ_916 /* XCTFailMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_145 /* XCTFailMessageRule.swift */; };
+		OBJ_917 /* XCTSpecificMatcherRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_146 /* XCTSpecificMatcherRule.swift */; };
+		OBJ_918 /* XCTSpecificMatcherRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_147 /* XCTSpecificMatcherRuleExamples.swift */; };
+		OBJ_919 /* AnyObjectProtocolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_149 /* AnyObjectProtocolRule.swift */; };
+		OBJ_920 /* ArrayInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_150 /* ArrayInitRule.swift */; };
+		OBJ_921 /* ClassDelegateProtocolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_151 /* ClassDelegateProtocolRule.swift */; };
+		OBJ_922 /* CompilerProtocolInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_152 /* CompilerProtocolInitRule.swift */; };
+		OBJ_923 /* DeploymentTargetRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_153 /* DeploymentTargetRule.swift */; };
+		OBJ_924 /* DiscardedNotificationCenterObserverRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_154 /* DiscardedNotificationCenterObserverRule.swift */; };
+		OBJ_925 /* DiscouragedDirectInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_155 /* DiscouragedDirectInitRule.swift */; };
+		OBJ_926 /* DuplicateEnumCasesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_156 /* DuplicateEnumCasesRule.swift */; };
+		OBJ_927 /* DynamicInlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_157 /* DynamicInlineRule.swift */; };
+		OBJ_928 /* EmptyXCTestMethodRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_158 /* EmptyXCTestMethodRule.swift */; };
+		OBJ_929 /* EmptyXCTestMethodRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_159 /* EmptyXCTestMethodRuleExamples.swift */; };
+		OBJ_930 /* ExpiringTodoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_160 /* ExpiringTodoRule.swift */; };
+		OBJ_931 /* IdenticalOperandsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_161 /* IdenticalOperandsRule.swift */; };
+		OBJ_932 /* InertDeferRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_162 /* InertDeferRule.swift */; };
+		OBJ_933 /* LowerACLThanParentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_163 /* LowerACLThanParentRule.swift */; };
+		OBJ_934 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_164 /* MarkRule.swift */; };
+		OBJ_935 /* MissingDocsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_165 /* MissingDocsRule.swift */; };
+		OBJ_936 /* NSLocalizedStringKeyRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_166 /* NSLocalizedStringKeyRule.swift */; };
+		OBJ_937 /* NSLocalizedStringRequireBundleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_167 /* NSLocalizedStringRequireBundleRule.swift */; };
+		OBJ_938 /* NSObjectPreferIsEqualRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_168 /* NSObjectPreferIsEqualRule.swift */; };
+		OBJ_939 /* NSObjectPreferIsEqualRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_169 /* NSObjectPreferIsEqualRuleExamples.swift */; };
+		OBJ_940 /* NotificationCenterDetachmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_170 /* NotificationCenterDetachmentRule.swift */; };
+		OBJ_941 /* NotificationCenterDetachmentRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_171 /* NotificationCenterDetachmentRuleExamples.swift */; };
+		OBJ_942 /* OverriddenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_172 /* OverriddenSuperCallRule.swift */; };
+		OBJ_943 /* OverrideInExtensionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_173 /* OverrideInExtensionRule.swift */; };
+		OBJ_944 /* PrivateActionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_174 /* PrivateActionRule.swift */; };
+		OBJ_945 /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_175 /* PrivateOutletRule.swift */; };
+		OBJ_946 /* PrivateUnitTestRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_176 /* PrivateUnitTestRule.swift */; };
+		OBJ_947 /* ProhibitedInterfaceBuilderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_177 /* ProhibitedInterfaceBuilderRule.swift */; };
+		OBJ_948 /* ProhibitedSuperRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_178 /* ProhibitedSuperRule.swift */; };
+		OBJ_949 /* QuickDiscouragedCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_179 /* QuickDiscouragedCallRule.swift */; };
+		OBJ_950 /* QuickDiscouragedCallRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_180 /* QuickDiscouragedCallRuleExamples.swift */; };
+		OBJ_951 /* QuickDiscouragedFocusedTestRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_181 /* QuickDiscouragedFocusedTestRule.swift */; };
+		OBJ_952 /* QuickDiscouragedFocusedTestRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_182 /* QuickDiscouragedFocusedTestRuleExamples.swift */; };
+		OBJ_953 /* QuickDiscouragedPendingTestRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_183 /* QuickDiscouragedPendingTestRule.swift */; };
+		OBJ_954 /* QuickDiscouragedPendingTestRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_184 /* QuickDiscouragedPendingTestRuleExamples.swift */; };
+		OBJ_955 /* RawValueForCamelCasedCodableEnumRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_185 /* RawValueForCamelCasedCodableEnumRule.swift */; };
+		OBJ_956 /* RequiredDeinitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_186 /* RequiredDeinitRule.swift */; };
+		OBJ_957 /* RequiredEnumCaseRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_187 /* RequiredEnumCaseRule.swift */; };
+		OBJ_958 /* ReturnValueFromVoidFunctionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_188 /* ReturnValueFromVoidFunctionRule.swift */; };
+		OBJ_959 /* StrongIBOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_189 /* StrongIBOutletRule.swift */; };
+		OBJ_960 /* SuperfluousDisableCommandRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_190 /* SuperfluousDisableCommandRule.swift */; };
+		OBJ_961 /* TodoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_191 /* TodoRule.swift */; };
+		OBJ_962 /* UnownedVariableCaptureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_192 /* UnownedVariableCaptureRule.swift */; };
+		OBJ_963 /* UnusedCaptureListRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_193 /* UnusedCaptureListRule.swift */; };
+		OBJ_964 /* UnusedClosureParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_194 /* UnusedClosureParameterRule.swift */; };
+		OBJ_965 /* UnusedControlFlowLabelRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_195 /* UnusedControlFlowLabelRule.swift */; };
+		OBJ_966 /* UnusedDeclarationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_196 /* UnusedDeclarationRule.swift */; };
+		OBJ_967 /* UnusedImportRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_197 /* UnusedImportRule.swift */; };
+		OBJ_968 /* UnusedSetterValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_198 /* UnusedSetterValueRule.swift */; };
+		OBJ_969 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_199 /* ValidIBInspectableRule.swift */; };
+		OBJ_970 /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_200 /* WeakDelegateRule.swift */; };
+		OBJ_971 /* YodaConditionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_201 /* YodaConditionRule.swift */; };
+		OBJ_972 /* ClosureBodyLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_203 /* ClosureBodyLengthRule.swift */; };
+		OBJ_973 /* ClosureBodyLengthRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_204 /* ClosureBodyLengthRuleExamples.swift */; };
+		OBJ_974 /* CyclomaticComplexityRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_205 /* CyclomaticComplexityRule.swift */; };
+		OBJ_975 /* EnumCaseAssociatedValuesLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_206 /* EnumCaseAssociatedValuesLengthRule.swift */; };
+		OBJ_976 /* FileLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_207 /* FileLengthRule.swift */; };
+		OBJ_977 /* FunctionBodyLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_208 /* FunctionBodyLengthRule.swift */; };
+		OBJ_978 /* FunctionParameterCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_209 /* FunctionParameterCountRule.swift */; };
+		OBJ_979 /* LargeTupleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_210 /* LargeTupleRule.swift */; };
+		OBJ_980 /* LineLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_211 /* LineLengthRule.swift */; };
+		OBJ_981 /* NestingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_212 /* NestingRule.swift */; };
+		OBJ_982 /* TypeBodyLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_213 /* TypeBodyLengthRule.swift */; };
+		OBJ_983 /* ContainsOverFilterCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_215 /* ContainsOverFilterCountRule.swift */; };
+		OBJ_984 /* ContainsOverFilterIsEmptyRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_216 /* ContainsOverFilterIsEmptyRule.swift */; };
+		OBJ_985 /* ContainsOverFirstNotNilRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_217 /* ContainsOverFirstNotNilRule.swift */; };
+		OBJ_986 /* ContainsOverRangeNilComparisonRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_218 /* ContainsOverRangeNilComparisonRule.swift */; };
+		OBJ_987 /* EmptyCollectionLiteralRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_219 /* EmptyCollectionLiteralRule.swift */; };
+		OBJ_988 /* EmptyCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_220 /* EmptyCountRule.swift */; };
+		OBJ_989 /* EmptyStringRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_221 /* EmptyStringRule.swift */; };
+		OBJ_990 /* FirstWhereRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_222 /* FirstWhereRule.swift */; };
+		OBJ_991 /* FlatMapOverMapReduceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_223 /* FlatMapOverMapReduceRule.swift */; };
+		OBJ_992 /* LastWhereRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_224 /* LastWhereRule.swift */; };
+		OBJ_993 /* ReduceBooleanRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_225 /* ReduceBooleanRule.swift */; };
+		OBJ_994 /* ReduceIntoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_226 /* ReduceIntoRule.swift */; };
+		OBJ_995 /* SortedFirstLastRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_227 /* SortedFirstLastRule.swift */; };
+		OBJ_996 /* AttributesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_229 /* AttributesConfiguration.swift */; };
+		OBJ_997 /* CollectionAlignmentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_230 /* CollectionAlignmentConfiguration.swift */; };
+		OBJ_998 /* ColonConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_231 /* ColonConfiguration.swift */; };
+		OBJ_999 /* ConditionalReturnsOnNewlineConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_232 /* ConditionalReturnsOnNewlineConfiguration.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D4A115CE23C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftyTextTable::SwiftyTextTable";
+			remoteInfo = SwiftyTextTable;
+		};
+		D4A115CF23C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Commandant::Commandant";
+			remoteInfo = Commandant;
+		};
+		D4A115D023C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftLint::SwiftLintFramework";
+			remoteInfo = SwiftLintFramework;
+		};
+		D4A115D123C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftSyntax::SwiftSyntax";
+			remoteInfo = SwiftSyntax;
+		};
+		D4A115D223C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftSyntax::_CSwiftSyntax";
+			remoteInfo = _CSwiftSyntax;
+		};
+		D4A115D323C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftSyntax::_CSwiftSyntax";
+			remoteInfo = _CSwiftSyntax;
+		};
+		D4A115D423C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::SourceKittenFramework";
+			remoteInfo = SourceKittenFramework;
+		};
+		D4A115D523C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::Yams";
+			remoteInfo = Yams;
+		};
+		D4A115D623C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::CYaml";
+			remoteInfo = CYaml;
+		};
+		D4A115D723C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::CYaml";
+			remoteInfo = CYaml;
+		};
+		D4A115D823C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SWXMLHash::SWXMLHash";
+			remoteInfo = SWXMLHash;
+		};
+		D4A115D923C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::SourceKit";
+			remoteInfo = SourceKit;
+		};
+		D4A115DA23C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::Clang_C";
+			remoteInfo = Clang_C;
+		};
+		D4A115DB23C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::Yams";
+			remoteInfo = Yams;
+		};
+		D4A115DC23C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::CYaml";
+			remoteInfo = CYaml;
+		};
+		D4A115DD23C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SWXMLHash::SWXMLHash";
+			remoteInfo = SWXMLHash;
+		};
+		D4A115DE23C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::SourceKit";
+			remoteInfo = SourceKit;
+		};
+		D4A115DF23C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::Clang_C";
+			remoteInfo = Clang_C;
+		};
+		D4A115E023C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftSyntax::SwiftSyntax";
+			remoteInfo = SwiftSyntax;
+		};
+		D4A115E123C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftSyntax::_CSwiftSyntax";
+			remoteInfo = _CSwiftSyntax;
+		};
+		D4A115E223C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::SourceKittenFramework";
+			remoteInfo = SourceKittenFramework;
+		};
+		D4A115E323C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::Yams";
+			remoteInfo = Yams;
+		};
+		D4A115E423C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::CYaml";
+			remoteInfo = CYaml;
+		};
+		D4A115E523C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SWXMLHash::SWXMLHash";
+			remoteInfo = SWXMLHash;
+		};
+		D4A115E623C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::SourceKit";
+			remoteInfo = SourceKit;
+		};
+		D4A115E723C210BC00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::Clang_C";
+			remoteInfo = Clang_C;
+		};
+		D4A115E823C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftLint::SwiftLintFramework";
+			remoteInfo = SwiftLintFramework;
+		};
+		D4A115E923C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftSyntax::SwiftSyntax";
+			remoteInfo = SwiftSyntax;
+		};
+		D4A115EA23C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftSyntax::_CSwiftSyntax";
+			remoteInfo = _CSwiftSyntax;
+		};
+		D4A115EB23C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::SourceKittenFramework";
+			remoteInfo = SourceKittenFramework;
+		};
+		D4A115EC23C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::Yams";
+			remoteInfo = Yams;
+		};
+		D4A115ED23C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Yams::CYaml";
+			remoteInfo = CYaml;
+		};
+		D4A115EE23C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SWXMLHash::SWXMLHash";
+			remoteInfo = SWXMLHash;
+		};
+		D4A115EF23C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::SourceKit";
+			remoteInfo = SourceKit;
+		};
+		D4A115F023C210BD00D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SourceKitten::Clang_C";
+			remoteInfo = Clang_C;
+		};
+		D4A115F123C210C000D1122A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftLint::SwiftLintFrameworkTests";
+			remoteInfo = SwiftLintFrameworkTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		"Commandant::Commandant::Product" /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D4A115F223C2194400D1122A /* ReturnValueFromVoidFunctionRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnValueFromVoidFunctionRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_10 /* Array+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_100 /* FileNameRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameRule.swift; sourceTree = "<group>"; };
+		OBJ_101 /* ForWhereRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForWhereRule.swift; sourceTree = "<group>"; };
+		OBJ_102 /* ForceCastRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForceCastRule.swift; sourceTree = "<group>"; };
+		OBJ_103 /* ForceTryRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForceTryRule.swift; sourceTree = "<group>"; };
+		OBJ_104 /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
+		OBJ_105 /* FunctionDefaultParameterAtEndRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionDefaultParameterAtEndRule.swift; sourceTree = "<group>"; };
+		OBJ_106 /* GenericTypeNameRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericTypeNameRule.swift; sourceTree = "<group>"; };
+		OBJ_107 /* ImplicitlyUnwrappedOptionalRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalRule.swift; sourceTree = "<group>"; };
+		OBJ_108 /* IsDisjointRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsDisjointRule.swift; sourceTree = "<group>"; };
+		OBJ_109 /* JoinedDefaultParameterRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedDefaultParameterRule.swift; sourceTree = "<group>"; };
+		OBJ_11 /* Configuration+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+Cache.swift"; sourceTree = "<group>"; };
+		OBJ_110 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
+		OBJ_111 /* LegacyConstantRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyConstantRule.swift; sourceTree = "<group>"; };
+		OBJ_112 /* LegacyConstantRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyConstantRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_113 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
+		OBJ_114 /* LegacyHashingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHashingRule.swift; sourceTree = "<group>"; };
+		OBJ_115 /* LegacyMultipleRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyMultipleRule.swift; sourceTree = "<group>"; };
+		OBJ_116 /* LegacyNSGeometryFunctionsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNSGeometryFunctionsRule.swift; sourceTree = "<group>"; };
+		OBJ_117 /* LegacyRandomRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyRandomRule.swift; sourceTree = "<group>"; };
+		OBJ_118 /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
+		OBJ_119 /* NoExtensionAccessModifierRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoExtensionAccessModifierRule.swift; sourceTree = "<group>"; };
+		OBJ_12 /* Configuration+IndentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+IndentationStyle.swift"; sourceTree = "<group>"; };
+		OBJ_120 /* NoFallthroughOnlyRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoFallthroughOnlyRule.swift; sourceTree = "<group>"; };
+		OBJ_121 /* NoFallthroughOnlyRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoFallthroughOnlyRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_122 /* NoGroupingExtensionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoGroupingExtensionRule.swift; sourceTree = "<group>"; };
+		OBJ_123 /* ObjectLiteralRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectLiteralRule.swift; sourceTree = "<group>"; };
+		OBJ_124 /* PatternMatchingKeywordsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternMatchingKeywordsRule.swift; sourceTree = "<group>"; };
+		OBJ_125 /* PrivateOverFilePrivateRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRule.swift; sourceTree = "<group>"; };
+		OBJ_126 /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
+		OBJ_127 /* RedundantObjcAttributeRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantObjcAttributeRule.swift; sourceTree = "<group>"; };
+		OBJ_128 /* RedundantObjcAttributeRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantObjcAttributeRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_129 /* RedundantOptionalInitializationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantOptionalInitializationRule.swift; sourceTree = "<group>"; };
+		OBJ_13 /* Configuration+LintableFiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+LintableFiles.swift"; sourceTree = "<group>"; };
+		OBJ_130 /* RedundantSetAccessControlRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantSetAccessControlRule.swift; sourceTree = "<group>"; };
+		OBJ_131 /* RedundantStringEnumValueRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantStringEnumValueRule.swift; sourceTree = "<group>"; };
+		OBJ_132 /* RedundantTypeAnnotationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantTypeAnnotationRule.swift; sourceTree = "<group>"; };
+		OBJ_133 /* RedundantVoidReturnRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantVoidReturnRule.swift; sourceTree = "<group>"; };
+		OBJ_134 /* StaticOperatorRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticOperatorRule.swift; sourceTree = "<group>"; };
+		OBJ_135 /* StrictFilePrivateRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrictFilePrivateRule.swift; sourceTree = "<group>"; };
+		OBJ_136 /* SyntacticSugarRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntacticSugarRule.swift; sourceTree = "<group>"; };
+		OBJ_137 /* ToggleBoolRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleBoolRule.swift; sourceTree = "<group>"; };
+		OBJ_138 /* TrailingSemicolonRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingSemicolonRule.swift; sourceTree = "<group>"; };
+		OBJ_139 /* TypeNameRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeNameRule.swift; sourceTree = "<group>"; };
+		OBJ_14 /* Configuration+Merging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+Merging.swift"; sourceTree = "<group>"; };
+		OBJ_140 /* TypeNameRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeNameRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_141 /* UnavailableFunctionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnavailableFunctionRule.swift; sourceTree = "<group>"; };
+		OBJ_142 /* UnneededBreakInSwitchRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnneededBreakInSwitchRule.swift; sourceTree = "<group>"; };
+		OBJ_143 /* UntypedErrorInCatchRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntypedErrorInCatchRule.swift; sourceTree = "<group>"; };
+		OBJ_144 /* UnusedEnumeratedRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedEnumeratedRule.swift; sourceTree = "<group>"; };
+		OBJ_145 /* XCTFailMessageRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTFailMessageRule.swift; sourceTree = "<group>"; };
+		OBJ_146 /* XCTSpecificMatcherRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTSpecificMatcherRule.swift; sourceTree = "<group>"; };
+		OBJ_147 /* XCTSpecificMatcherRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTSpecificMatcherRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_149 /* AnyObjectProtocolRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyObjectProtocolRule.swift; sourceTree = "<group>"; };
+		OBJ_15 /* Configuration+Parsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+Parsing.swift"; sourceTree = "<group>"; };
+		OBJ_150 /* ArrayInitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayInitRule.swift; sourceTree = "<group>"; };
+		OBJ_151 /* ClassDelegateProtocolRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassDelegateProtocolRule.swift; sourceTree = "<group>"; };
+		OBJ_152 /* CompilerProtocolInitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompilerProtocolInitRule.swift; sourceTree = "<group>"; };
+		OBJ_153 /* DeploymentTargetRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentTargetRule.swift; sourceTree = "<group>"; };
+		OBJ_154 /* DiscardedNotificationCenterObserverRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscardedNotificationCenterObserverRule.swift; sourceTree = "<group>"; };
+		OBJ_155 /* DiscouragedDirectInitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedDirectInitRule.swift; sourceTree = "<group>"; };
+		OBJ_156 /* DuplicateEnumCasesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateEnumCasesRule.swift; sourceTree = "<group>"; };
+		OBJ_157 /* DynamicInlineRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicInlineRule.swift; sourceTree = "<group>"; };
+		OBJ_158 /* EmptyXCTestMethodRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyXCTestMethodRule.swift; sourceTree = "<group>"; };
+		OBJ_159 /* EmptyXCTestMethodRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyXCTestMethodRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_16 /* Dictionary+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_160 /* ExpiringTodoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRule.swift; sourceTree = "<group>"; };
+		OBJ_161 /* IdenticalOperandsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdenticalOperandsRule.swift; sourceTree = "<group>"; };
+		OBJ_162 /* InertDeferRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InertDeferRule.swift; sourceTree = "<group>"; };
+		OBJ_163 /* LowerACLThanParentRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowerACLThanParentRule.swift; sourceTree = "<group>"; };
+		OBJ_164 /* MarkRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
+		OBJ_165 /* MissingDocsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRule.swift; sourceTree = "<group>"; };
+		OBJ_166 /* NSLocalizedStringKeyRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLocalizedStringKeyRule.swift; sourceTree = "<group>"; };
+		OBJ_167 /* NSLocalizedStringRequireBundleRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLocalizedStringRequireBundleRule.swift; sourceTree = "<group>"; };
+		OBJ_168 /* NSObjectPreferIsEqualRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectPreferIsEqualRule.swift; sourceTree = "<group>"; };
+		OBJ_169 /* NSObjectPreferIsEqualRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectPreferIsEqualRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_17 /* FileManager+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_170 /* NotificationCenterDetachmentRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterDetachmentRule.swift; sourceTree = "<group>"; };
+		OBJ_171 /* NotificationCenterDetachmentRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterDetachmentRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_172 /* OverriddenSuperCallRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverriddenSuperCallRule.swift; sourceTree = "<group>"; };
+		OBJ_173 /* OverrideInExtensionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideInExtensionRule.swift; sourceTree = "<group>"; };
+		OBJ_174 /* PrivateActionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateActionRule.swift; sourceTree = "<group>"; };
+		OBJ_175 /* PrivateOutletRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
+		OBJ_176 /* PrivateUnitTestRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateUnitTestRule.swift; sourceTree = "<group>"; };
+		OBJ_177 /* ProhibitedInterfaceBuilderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProhibitedInterfaceBuilderRule.swift; sourceTree = "<group>"; };
+		OBJ_178 /* ProhibitedSuperRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProhibitedSuperRule.swift; sourceTree = "<group>"; };
+		OBJ_179 /* QuickDiscouragedCallRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedCallRule.swift; sourceTree = "<group>"; };
+		OBJ_18 /* NSRange+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRange+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_180 /* QuickDiscouragedCallRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedCallRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_181 /* QuickDiscouragedFocusedTestRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedFocusedTestRule.swift; sourceTree = "<group>"; };
+		OBJ_182 /* QuickDiscouragedFocusedTestRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedFocusedTestRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_183 /* QuickDiscouragedPendingTestRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedPendingTestRule.swift; sourceTree = "<group>"; };
+		OBJ_184 /* QuickDiscouragedPendingTestRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedPendingTestRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_185 /* RawValueForCamelCasedCodableEnumRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawValueForCamelCasedCodableEnumRule.swift; sourceTree = "<group>"; };
+		OBJ_186 /* RequiredDeinitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredDeinitRule.swift; sourceTree = "<group>"; };
+		OBJ_187 /* RequiredEnumCaseRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRule.swift; sourceTree = "<group>"; };
+		OBJ_188 /* ReturnValueFromVoidFunctionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnValueFromVoidFunctionRule.swift; sourceTree = "<group>"; };
+		OBJ_189 /* StrongIBOutletRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrongIBOutletRule.swift; sourceTree = "<group>"; };
+		OBJ_19 /* NSRegularExpression+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_190 /* SuperfluousDisableCommandRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperfluousDisableCommandRule.swift; sourceTree = "<group>"; };
+		OBJ_191 /* TodoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoRule.swift; sourceTree = "<group>"; };
+		OBJ_192 /* UnownedVariableCaptureRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnownedVariableCaptureRule.swift; sourceTree = "<group>"; };
+		OBJ_193 /* UnusedCaptureListRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedCaptureListRule.swift; sourceTree = "<group>"; };
+		OBJ_194 /* UnusedClosureParameterRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedClosureParameterRule.swift; sourceTree = "<group>"; };
+		OBJ_195 /* UnusedControlFlowLabelRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedControlFlowLabelRule.swift; sourceTree = "<group>"; };
+		OBJ_196 /* UnusedDeclarationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedDeclarationRule.swift; sourceTree = "<group>"; };
+		OBJ_197 /* UnusedImportRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedImportRule.swift; sourceTree = "<group>"; };
+		OBJ_198 /* UnusedSetterValueRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedSetterValueRule.swift; sourceTree = "<group>"; };
+		OBJ_199 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
+		OBJ_20 /* QueuedPrint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPrint.swift; sourceTree = "<group>"; };
+		OBJ_200 /* WeakDelegateRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
+		OBJ_201 /* YodaConditionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YodaConditionRule.swift; sourceTree = "<group>"; };
+		OBJ_203 /* ClosureBodyLengthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureBodyLengthRule.swift; sourceTree = "<group>"; };
+		OBJ_204 /* ClosureBodyLengthRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureBodyLengthRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_205 /* CyclomaticComplexityRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityRule.swift; sourceTree = "<group>"; };
+		OBJ_206 /* EnumCaseAssociatedValuesLengthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumCaseAssociatedValuesLengthRule.swift; sourceTree = "<group>"; };
+		OBJ_207 /* FileLengthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLengthRule.swift; sourceTree = "<group>"; };
+		OBJ_208 /* FunctionBodyLengthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRule.swift; sourceTree = "<group>"; };
+		OBJ_209 /* FunctionParameterCountRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRule.swift; sourceTree = "<group>"; };
+		OBJ_21 /* RandomAccessCollection+Swiftlint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RandomAccessCollection+Swiftlint.swift"; sourceTree = "<group>"; };
+		OBJ_210 /* LargeTupleRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeTupleRule.swift; sourceTree = "<group>"; };
+		OBJ_211 /* LineLengthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineLengthRule.swift; sourceTree = "<group>"; };
+		OBJ_212 /* NestingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestingRule.swift; sourceTree = "<group>"; };
+		OBJ_213 /* TypeBodyLengthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeBodyLengthRule.swift; sourceTree = "<group>"; };
+		OBJ_215 /* ContainsOverFilterCountRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFilterCountRule.swift; sourceTree = "<group>"; };
+		OBJ_216 /* ContainsOverFilterIsEmptyRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFilterIsEmptyRule.swift; sourceTree = "<group>"; };
+		OBJ_217 /* ContainsOverFirstNotNilRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFirstNotNilRule.swift; sourceTree = "<group>"; };
+		OBJ_218 /* ContainsOverRangeNilComparisonRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverRangeNilComparisonRule.swift; sourceTree = "<group>"; };
+		OBJ_219 /* EmptyCollectionLiteralRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCollectionLiteralRule.swift; sourceTree = "<group>"; };
+		OBJ_22 /* Request+DisableSourceKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+DisableSourceKit.swift"; sourceTree = "<group>"; };
+		OBJ_220 /* EmptyCountRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCountRule.swift; sourceTree = "<group>"; };
+		OBJ_221 /* EmptyStringRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStringRule.swift; sourceTree = "<group>"; };
+		OBJ_222 /* FirstWhereRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstWhereRule.swift; sourceTree = "<group>"; };
+		OBJ_223 /* FlatMapOverMapReduceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatMapOverMapReduceRule.swift; sourceTree = "<group>"; };
+		OBJ_224 /* LastWhereRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastWhereRule.swift; sourceTree = "<group>"; };
+		OBJ_225 /* ReduceBooleanRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduceBooleanRule.swift; sourceTree = "<group>"; };
+		OBJ_226 /* ReduceIntoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduceIntoRule.swift; sourceTree = "<group>"; };
+		OBJ_227 /* SortedFirstLastRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortedFirstLastRule.swift; sourceTree = "<group>"; };
+		OBJ_229 /* AttributesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_23 /* SourceKittenDictionary+Swiftlint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SourceKittenDictionary+Swiftlint.swift"; sourceTree = "<group>"; };
+		OBJ_230 /* CollectionAlignmentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionAlignmentConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_231 /* ColonConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColonConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_232 /* ConditionalReturnsOnNewlineConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_233 /* CyclomaticComplexityConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_234 /* DeploymentTargetConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentTargetConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_235 /* DiscouragedDirectInitConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedDirectInitConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_236 /* ExpiringTodoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_237 /* ExplicitTypeInterfaceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_238 /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_239 /* FileLengthRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLengthRuleConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_24 /* String+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_240 /* FileNameConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_241 /* FileNameNoSpaceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameNoSpaceConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_242 /* FileTypesOrderConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypesOrderConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_243 /* FunctionParameterCountConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_244 /* ImplicitlyUnwrappedOptionalConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_245 /* LineLengthConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineLengthConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_246 /* MissingDocsRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRuleConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_247 /* ModifierOrderConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierOrderConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_248 /* MultilineArgumentsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_249 /* NameConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_25 /* String+XML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+XML.swift"; sourceTree = "<group>"; };
+		OBJ_250 /* NestingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestingConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_251 /* NumberSeparatorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSeparatorConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_252 /* ObjectLiteralConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectLiteralConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_253 /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_254 /* PrefixedConstantRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedConstantRuleConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_255 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_256 /* PrivateOverFilePrivateRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRuleConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_257 /* PrivateUnitTestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateUnitTestConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_258 /* ProhibitedSuperConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProhibitedSuperConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_259 /* RegexConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_26 /* SwiftDeclarationAttributeKind+Swiftlint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftDeclarationAttributeKind+Swiftlint.swift"; sourceTree = "<group>"; };
+		OBJ_260 /* RequiredEnumCaseRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRuleConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_261 /* SeverityConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeverityConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_262 /* SeverityLevelsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeverityLevelsConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_263 /* StatementModeConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementModeConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_264 /* SwitchCaseAlignmentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_265 /* TrailingClosureConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingClosureConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_266 /* TrailingCommaConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingCommaConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_267 /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_268 /* TypeContentsOrderConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeContentsOrderConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_269 /* UnusedDeclarationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedDeclarationConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_27 /* SwiftDeclarationKind+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftDeclarationKind+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_270 /* UnusedOptionalBindingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_271 /* VerticalWhitespaceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_273 /* AttributesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesRule.swift; sourceTree = "<group>"; };
+		OBJ_274 /* AttributesRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_275 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
+		OBJ_276 /* ClosureEndIndentationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureEndIndentationRule.swift; sourceTree = "<group>"; };
+		OBJ_277 /* ClosureEndIndentationRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureEndIndentationRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_278 /* ClosureParameterPositionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureParameterPositionRule.swift; sourceTree = "<group>"; };
+		OBJ_279 /* ClosureSpacingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureSpacingRule.swift; sourceTree = "<group>"; };
+		OBJ_28 /* SwiftExpressionKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExpressionKind.swift; sourceTree = "<group>"; };
+		OBJ_280 /* CollectionAlignmentRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionAlignmentRule.swift; sourceTree = "<group>"; };
+		OBJ_281 /* ColonRule+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColonRule+Dictionary.swift"; sourceTree = "<group>"; };
+		OBJ_282 /* ColonRule+FunctionCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColonRule+FunctionCall.swift"; sourceTree = "<group>"; };
+		OBJ_283 /* ColonRule+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColonRule+Type.swift"; sourceTree = "<group>"; };
+		OBJ_284 /* ColonRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColonRule.swift; sourceTree = "<group>"; };
+		OBJ_285 /* ColonRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColonRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_286 /* CommaRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
+		OBJ_287 /* ConditionalReturnsOnNewlineRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineRule.swift; sourceTree = "<group>"; };
+		OBJ_288 /* ControlStatementRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlStatementRule.swift; sourceTree = "<group>"; };
+		OBJ_289 /* CustomRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRules.swift; sourceTree = "<group>"; };
+		OBJ_29 /* SwiftLintFile+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftLintFile+Cache.swift"; sourceTree = "<group>"; };
+		OBJ_290 /* EmptyEnumArgumentsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyEnumArgumentsRule.swift; sourceTree = "<group>"; };
+		OBJ_291 /* EmptyParametersRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyParametersRule.swift; sourceTree = "<group>"; };
+		OBJ_292 /* EmptyParenthesesWithTrailingClosureRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyParenthesesWithTrailingClosureRule.swift; sourceTree = "<group>"; };
+		OBJ_293 /* ExplicitSelfRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitSelfRule.swift; sourceTree = "<group>"; };
+		OBJ_294 /* FileHeaderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHeaderRule.swift; sourceTree = "<group>"; };
+		OBJ_295 /* FileTypesOrderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypesOrderRule.swift; sourceTree = "<group>"; };
+		OBJ_296 /* FileTypesOrderRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypesOrderRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_297 /* IdentifierNameRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierNameRule.swift; sourceTree = "<group>"; };
+		OBJ_298 /* IdentifierNameRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierNameRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_299 /* ImplicitGetterRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitGetterRule.swift; sourceTree = "<group>"; };
+		OBJ_30 /* SwiftLintFile+Regex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftLintFile+Regex.swift"; sourceTree = "<group>"; };
+		OBJ_300 /* ImplicitReturnRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitReturnRule.swift; sourceTree = "<group>"; };
+		OBJ_301 /* LeadingWhitespaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeadingWhitespaceRule.swift; sourceTree = "<group>"; };
+		OBJ_302 /* LetVarWhitespaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetVarWhitespaceRule.swift; sourceTree = "<group>"; };
+		OBJ_303 /* LiteralExpressionEndIdentationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiteralExpressionEndIdentationRule.swift; sourceTree = "<group>"; };
+		OBJ_304 /* ModifierOrderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierOrderRule.swift; sourceTree = "<group>"; };
+		OBJ_305 /* ModifierOrderRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierOrderRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_306 /* MultilineArgumentsBracketsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsBracketsRule.swift; sourceTree = "<group>"; };
+		OBJ_307 /* MultilineArgumentsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRule.swift; sourceTree = "<group>"; };
+		OBJ_308 /* MultilineArgumentsRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_309 /* MultilineFunctionChainsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineFunctionChainsRule.swift; sourceTree = "<group>"; };
+		OBJ_31 /* SyntaxKind+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SyntaxKind+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_310 /* MultilineLiteralBracketsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineLiteralBracketsRule.swift; sourceTree = "<group>"; };
+		OBJ_311 /* MultilineParametersBracketsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineParametersBracketsRule.swift; sourceTree = "<group>"; };
+		OBJ_312 /* MultilineParametersRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineParametersRule.swift; sourceTree = "<group>"; };
+		OBJ_313 /* MultilineParametersRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineParametersRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_314 /* MultipleClosuresWithTrailingClosureRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleClosuresWithTrailingClosureRule.swift; sourceTree = "<group>"; };
+		OBJ_315 /* NoSpaceInMethodCallRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSpaceInMethodCallRule.swift; sourceTree = "<group>"; };
+		OBJ_316 /* NumberSeparatorRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRule.swift; sourceTree = "<group>"; };
+		OBJ_317 /* NumberSeparatorRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_318 /* OpeningBraceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningBraceRule.swift; sourceTree = "<group>"; };
+		OBJ_319 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
+		OBJ_320 /* OperatorUsageWhitespaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorUsageWhitespaceRule.swift; sourceTree = "<group>"; };
+		OBJ_321 /* OptionalEnumCaseMatchingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalEnumCaseMatchingRule.swift; sourceTree = "<group>"; };
+		OBJ_322 /* PreferSelfTypeOverTypeOfSelfRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferSelfTypeOverTypeOfSelfRule.swift; sourceTree = "<group>"; };
+		OBJ_323 /* PrefixedTopLevelConstantRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedTopLevelConstantRule.swift; sourceTree = "<group>"; };
+		OBJ_324 /* ProtocolPropertyAccessorsOrderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolPropertyAccessorsOrderRule.swift; sourceTree = "<group>"; };
+		OBJ_325 /* RedundantDiscardableLetRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantDiscardableLetRule.swift; sourceTree = "<group>"; };
+		OBJ_326 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
+		OBJ_327 /* ShorthandOperatorRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShorthandOperatorRule.swift; sourceTree = "<group>"; };
+		OBJ_328 /* SingleTestClassRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTestClassRule.swift; sourceTree = "<group>"; };
+		OBJ_329 /* SortedImportsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortedImportsRule.swift; sourceTree = "<group>"; };
+		OBJ_33 /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
+		OBJ_330 /* StatementPositionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementPositionRule.swift; sourceTree = "<group>"; };
+		OBJ_331 /* SwitchCaseAlignmentRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentRule.swift; sourceTree = "<group>"; };
+		OBJ_332 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
+		OBJ_333 /* TrailingClosureRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingClosureRule.swift; sourceTree = "<group>"; };
+		OBJ_334 /* TrailingCommaRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingCommaRule.swift; sourceTree = "<group>"; };
+		OBJ_335 /* TrailingNewlineRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingNewlineRule.swift; sourceTree = "<group>"; };
+		OBJ_336 /* TrailingWhitespaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceRule.swift; sourceTree = "<group>"; };
+		OBJ_337 /* TypeContentsOrderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeContentsOrderRule.swift; sourceTree = "<group>"; };
+		OBJ_338 /* TypeContentsOrderRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeContentsOrderRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_339 /* UnneededParenthesesInClosureArgumentRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnneededParenthesesInClosureArgumentRule.swift; sourceTree = "<group>"; };
+		OBJ_34 /* NamespaceCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamespaceCollector.swift; sourceTree = "<group>"; };
+		OBJ_340 /* UnusedOptionalBindingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRule.swift; sourceTree = "<group>"; };
+		OBJ_341 /* VerticalParameterAlignmentOnCallRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentOnCallRule.swift; sourceTree = "<group>"; };
+		OBJ_342 /* VerticalParameterAlignmentRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentRule.swift; sourceTree = "<group>"; };
+		OBJ_343 /* VerticalParameterAlignmentRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_344 /* VerticalWhitespaceBetweenCasesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceBetweenCasesRule.swift; sourceTree = "<group>"; };
+		OBJ_345 /* VerticalWhitespaceClosingBracesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceClosingBracesRule.swift; sourceTree = "<group>"; };
+		OBJ_346 /* VerticalWhitespaceOpeningBracesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceOpeningBracesRule.swift; sourceTree = "<group>"; };
+		OBJ_347 /* VerticalWhitespaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRule.swift; sourceTree = "<group>"; };
+		OBJ_348 /* VoidReturnRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoidReturnRule.swift; sourceTree = "<group>"; };
+		OBJ_35 /* RegexHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
+		OBJ_351 /* AnalyzeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyzeCommand.swift; sourceTree = "<group>"; };
+		OBJ_352 /* AutoCorrectCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCorrectCommand.swift; sourceTree = "<group>"; };
+		OBJ_353 /* GenerateDocsCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateDocsCommand.swift; sourceTree = "<group>"; };
+		OBJ_354 /* LintCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LintCommand.swift; sourceTree = "<group>"; };
+		OBJ_355 /* RulesCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
+		OBJ_356 /* VersionCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCommand.swift; sourceTree = "<group>"; };
+		OBJ_358 /* Array+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SwiftLint.swift"; sourceTree = "<group>"; };
+		OBJ_359 /* Configuration+CommandLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+CommandLine.swift"; sourceTree = "<group>"; };
+		OBJ_360 /* Reporter+CommandLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reporter+CommandLine.swift"; sourceTree = "<group>"; };
+		OBJ_362 /* Benchmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
+		OBJ_363 /* CommonOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonOptions.swift; sourceTree = "<group>"; };
+		OBJ_364 /* CompilerArgumentsExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompilerArgumentsExtractor.swift; sourceTree = "<group>"; };
+		OBJ_365 /* LintOrAnalyzeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LintOrAnalyzeCommand.swift; sourceTree = "<group>"; };
+		OBJ_366 /* LintableFilesVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LintableFilesVisitor.swift; sourceTree = "<group>"; };
+		OBJ_367 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		OBJ_37 /* AccessControlLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessControlLevel.swift; sourceTree = "<group>"; };
+		OBJ_370 /* AttributesRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_371 /* AutomaticRuleTests.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticRuleTests.generated.swift; sourceTree = "<group>"; };
+		OBJ_372 /* CollectingRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectingRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_373 /* CollectionAlignmentRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionAlignmentRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_374 /* ColonRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColonRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_375 /* CommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandTests.swift; sourceTree = "<group>"; };
+		OBJ_376 /* CompilerProtocolInitRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompilerProtocolInitRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_377 /* ConditionalReturnsOnNewlineRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_378 /* ConfigurationAliasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationAliasesTests.swift; sourceTree = "<group>"; };
+		OBJ_379 /* ConfigurationTests+Nested.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+Nested.swift"; sourceTree = "<group>"; };
+		OBJ_38 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		OBJ_380 /* ConfigurationTests+ProjectMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+ProjectMock.swift"; sourceTree = "<group>"; };
+		OBJ_381 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_382 /* ContainsOverFirstNotNilRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFirstNotNilRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_383 /* CustomRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesTests.swift; sourceTree = "<group>"; };
+		OBJ_384 /* CyclomaticComplexityConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_385 /* CyclomaticComplexityRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_386 /* DeploymentTargetConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentTargetConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_387 /* DeploymentTargetRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentTargetRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_388 /* DisableAllTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableAllTests.swift; sourceTree = "<group>"; };
+		OBJ_389 /* DiscouragedDirectInitRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedDirectInitRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_39 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		OBJ_390 /* DiscouragedObjectLiteralRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedObjectLiteralRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_391 /* DocumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentationTests.swift; sourceTree = "<group>"; };
+		OBJ_392 /* ExpiringTodoRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_393 /* ExplicitTypeInterfaceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_394 /* ExplicitTypeInterfaceRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_395 /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
+		OBJ_396 /* FileHeaderRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHeaderRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_397 /* FileLengthRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLengthRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_398 /* FileNameNoSpaceRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameNoSpaceRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_399 /* FileNameRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_40 /* ConfigurationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationError.swift; sourceTree = "<group>"; };
+		OBJ_400 /* FileTypesOrderRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypesOrderRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_401 /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_402 /* FunctionParameterCountRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_403 /* GenericTypeNameRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericTypeNameRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_404 /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
+		OBJ_405 /* IdentifierNameRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierNameRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_406 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_407 /* ImplicitlyUnwrappedOptionalRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_408 /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
+		OBJ_409 /* LineLengthConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineLengthConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_41 /* Correction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Correction.swift; sourceTree = "<group>"; };
+		OBJ_410 /* LineLengthRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineLengthRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_411 /* LinterCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinterCacheTests.swift; sourceTree = "<group>"; };
+		OBJ_412 /* MissingDocsRuleConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRuleConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_413 /* ModifierOrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierOrderTests.swift; sourceTree = "<group>"; };
+		OBJ_414 /* MultilineArgumentsRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_415 /* NumberSeparatorRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_416 /* ObjectLiteralRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectLiteralRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_417 /* PrefixedTopLevelConstantRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedTopLevelConstantRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_418 /* PrivateOutletRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_419 /* PrivateOverFilePrivateRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_42 /* Linter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Linter.swift; sourceTree = "<group>"; };
+		OBJ_420 /* RegionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionTests.swift; sourceTree = "<group>"; };
+		OBJ_421 /* ReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReporterTests.swift; sourceTree = "<group>"; };
+		OBJ_422 /* RequiredEnumCaseRuleTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRuleTestCase.swift; sourceTree = "<group>"; };
+		OBJ_423 /* RuleConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_424 /* RuleDescription+Examples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RuleDescription+Examples.swift"; sourceTree = "<group>"; };
+		OBJ_425 /* RuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleTests.swift; sourceTree = "<group>"; };
+		OBJ_426 /* RulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesTests.swift; sourceTree = "<group>"; };
+		OBJ_427 /* SourceKitCrashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceKitCrashTests.swift; sourceTree = "<group>"; };
+		OBJ_428 /* StatementPositionRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementPositionRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_429 /* SwitchCaseAlignmentRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_43 /* LinterCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinterCache.swift; sourceTree = "<group>"; };
+		OBJ_430 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		OBJ_431 /* TodoRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_432 /* TrailingClosureConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingClosureConfigurationTests.swift; sourceTree = "<group>"; };
+		OBJ_433 /* TrailingClosureRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingClosureRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_434 /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_435 /* TrailingWhitespaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceTests.swift; sourceTree = "<group>"; };
+		OBJ_436 /* TypeContentsOrderRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeContentsOrderRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_437 /* TypeNameRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeNameRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_438 /* UnusedOptionalBindingRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_439 /* VerticalWhitespaceRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_44 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
+		OBJ_440 /* XCTSpecificMatcherRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTSpecificMatcherRuleTests.swift; sourceTree = "<group>"; };
+		OBJ_441 /* XCTestCase+BundlePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+BundlePath.swift"; sourceTree = "<group>"; };
+		OBJ_442 /* YamlParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlParserTests.swift; sourceTree = "<group>"; };
+		OBJ_443 /* YamlSwiftLintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlSwiftLintTests.swift; sourceTree = "<group>"; };
+		OBJ_447 /* AbsolutePosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbsolutePosition.swift; sourceTree = "<group>"; };
+		OBJ_448 /* AtomicCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicCounter.swift; sourceTree = "<group>"; };
+		OBJ_449 /* Diagnostic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostic.swift; sourceTree = "<group>"; };
+		OBJ_45 /* MasterRuleList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterRuleList.swift; sourceTree = "<group>"; };
+		OBJ_450 /* DiagnosticConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticConsumer.swift; sourceTree = "<group>"; };
+		OBJ_451 /* DiagnosticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticEngine.swift; sourceTree = "<group>"; };
+		OBJ_452 /* IncrementalParseTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncrementalParseTransition.swift; sourceTree = "<group>"; };
+		OBJ_453 /* JSONDiagnosticConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDiagnosticConsumer.swift; sourceTree = "<group>"; };
+		OBJ_454 /* PrintingDiagnosticConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintingDiagnosticConsumer.swift; sourceTree = "<group>"; };
+		OBJ_455 /* RawSyntax.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawSyntax.swift; sourceTree = "<group>"; };
+		OBJ_456 /* SourceLength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceLength.swift; sourceTree = "<group>"; };
+		OBJ_457 /* SourceLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceLocation.swift; sourceTree = "<group>"; };
+		OBJ_458 /* SourcePresence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourcePresence.swift; sourceTree = "<group>"; };
+		OBJ_459 /* Syntax.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Syntax.swift; sourceTree = "<group>"; };
+		OBJ_46 /* Region.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Region.swift; sourceTree = "<group>"; };
+		OBJ_460 /* SyntaxChildren.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxChildren.swift; sourceTree = "<group>"; };
+		OBJ_461 /* SyntaxClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxClassifier.swift; sourceTree = "<group>"; };
+		OBJ_462 /* SyntaxData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxData.swift; sourceTree = "<group>"; };
+		OBJ_463 /* SyntaxParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxParser.swift; sourceTree = "<group>"; };
+		OBJ_464 /* SyntaxVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxVerifier.swift; sourceTree = "<group>"; };
+		OBJ_465 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		OBJ_467 /* SyntaxBuilders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxBuilders.swift; sourceTree = "<group>"; };
+		OBJ_468 /* SyntaxClassification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxClassification.swift; sourceTree = "<group>"; };
+		OBJ_469 /* SyntaxCollections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxCollections.swift; sourceTree = "<group>"; };
+		OBJ_47 /* RuleDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
+		OBJ_470 /* SyntaxFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxFactory.swift; sourceTree = "<group>"; };
+		OBJ_471 /* SyntaxKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxKind.swift; sourceTree = "<group>"; };
+		OBJ_472 /* SyntaxNodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxNodes.swift; sourceTree = "<group>"; };
+		OBJ_473 /* SyntaxRewriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxRewriter.swift; sourceTree = "<group>"; };
+		OBJ_474 /* TokenKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenKind.swift; sourceTree = "<group>"; };
+		OBJ_475 /* Trivia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trivia.swift; sourceTree = "<group>"; };
+		OBJ_478 /* atomic-counter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "atomic-counter.c"; sourceTree = "<group>"; };
+		OBJ_48 /* RuleIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleIdentifier.swift; sourceTree = "<group>"; };
+		OBJ_480 /* atomic-counter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "atomic-counter.h"; sourceTree = "<group>"; };
+		OBJ_481 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = /Users/marcelofabri/projetos/SwiftLint/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap; sourceTree = "<group>"; };
+		OBJ_483 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/swift-syntax/Package.swift"; sourceTree = "<group>"; };
+		OBJ_486 /* TextTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTable.swift; sourceTree = "<group>"; };
+		OBJ_487 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SwiftyTextTable/Package.swift; sourceTree = "<group>"; };
+		OBJ_49 /* RuleKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleKind.swift; sourceTree = "<group>"; };
+		OBJ_490 /* Clang_C.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Clang_C.m; sourceTree = "<group>"; };
+		OBJ_492 /* Index.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Index.h; sourceTree = "<group>"; };
+		OBJ_493 /* BuildSystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuildSystem.h; sourceTree = "<group>"; };
+		OBJ_494 /* Documentation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Documentation.h; sourceTree = "<group>"; };
+		OBJ_495 /* CXCompilationDatabase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CXCompilationDatabase.h; sourceTree = "<group>"; };
+		OBJ_496 /* Clang_C.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Clang_C.h; sourceTree = "<group>"; };
+		OBJ_497 /* CXErrorCode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CXErrorCode.h; sourceTree = "<group>"; };
+		OBJ_498 /* CXString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CXString.h; sourceTree = "<group>"; };
+		OBJ_499 /* Platform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Platform.h; sourceTree = "<group>"; };
+		OBJ_50 /* RuleList+Documentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RuleList+Documentation.swift"; sourceTree = "<group>"; };
+		OBJ_501 /* SourceKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SourceKit.m; sourceTree = "<group>"; };
+		OBJ_503 /* SourceKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SourceKit.h; sourceTree = "<group>"; };
+		OBJ_504 /* sourcekitd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sourcekitd.h; sourceTree = "<group>"; };
+		OBJ_506 /* Clang+SourceKitten.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Clang+SourceKitten.swift"; sourceTree = "<group>"; };
+		OBJ_507 /* ClangTranslationUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClangTranslationUnit.swift; sourceTree = "<group>"; };
+		OBJ_508 /* CodeCompletionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeCompletionItem.swift; sourceTree = "<group>"; };
+		OBJ_509 /* CursorInfo+Parsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CursorInfo+Parsing.swift"; sourceTree = "<group>"; };
+		OBJ_51 /* RuleList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleList.swift; sourceTree = "<group>"; };
+		OBJ_510 /* Dictionary+Merge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Merge.swift"; sourceTree = "<group>"; };
+		OBJ_511 /* Documentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Documentation.swift; sourceTree = "<group>"; };
+		OBJ_512 /* Exec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exec.swift; sourceTree = "<group>"; };
+		OBJ_513 /* File+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "File+Hashable.swift"; sourceTree = "<group>"; };
+		OBJ_514 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
+		OBJ_515 /* JSONOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONOutput.swift; sourceTree = "<group>"; };
+		OBJ_516 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Language.swift; sourceTree = "<group>"; };
+		OBJ_517 /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
+		OBJ_518 /* LinuxCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinuxCompatibility.swift; sourceTree = "<group>"; };
+		OBJ_519 /* Module.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Module.swift; sourceTree = "<group>"; };
+		OBJ_52 /* RuleParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleParameter.swift; sourceTree = "<group>"; };
+		OBJ_520 /* ObjCDeclarationKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCDeclarationKind.swift; sourceTree = "<group>"; };
+		OBJ_521 /* OffsetMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetMap.swift; sourceTree = "<group>"; };
+		OBJ_522 /* Parameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parameter.swift; sourceTree = "<group>"; };
+		OBJ_523 /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		OBJ_524 /* SourceDeclaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceDeclaration.swift; sourceTree = "<group>"; };
+		OBJ_525 /* SourceKitObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceKitObject.swift; sourceTree = "<group>"; };
+		OBJ_526 /* SourceLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceLocation.swift; sourceTree = "<group>"; };
+		OBJ_527 /* StatementKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementKind.swift; sourceTree = "<group>"; };
+		OBJ_528 /* String+SourceKitten.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SourceKitten.swift"; sourceTree = "<group>"; };
+		OBJ_529 /* StringView+SourceKitten.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringView+SourceKitten.swift"; sourceTree = "<group>"; };
+		OBJ_53 /* RuleStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleStorage.swift; sourceTree = "<group>"; };
+		OBJ_530 /* StringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringView.swift; sourceTree = "<group>"; };
+		OBJ_531 /* Structure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Structure.swift; sourceTree = "<group>"; };
+		OBJ_532 /* SwiftDeclarationAttributeKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDeclarationAttributeKind.swift; sourceTree = "<group>"; };
+		OBJ_533 /* SwiftDeclarationKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDeclarationKind.swift; sourceTree = "<group>"; };
+		OBJ_534 /* SwiftDocKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDocKey.swift; sourceTree = "<group>"; };
+		OBJ_535 /* SwiftDocs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDocs.swift; sourceTree = "<group>"; };
+		OBJ_536 /* SyntaxKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxKind.swift; sourceTree = "<group>"; };
+		OBJ_537 /* SyntaxMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxMap.swift; sourceTree = "<group>"; };
+		OBJ_538 /* SyntaxToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxToken.swift; sourceTree = "<group>"; };
+		OBJ_539 /* Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
+		OBJ_54 /* StyleViolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleViolation.swift; sourceTree = "<group>"; };
+		OBJ_540 /* UID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UID.swift; sourceTree = "<group>"; };
+		OBJ_541 /* UIDRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDRepresentable.swift; sourceTree = "<group>"; };
+		OBJ_542 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		OBJ_543 /* Xcode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Xcode.swift; sourceTree = "<group>"; };
+		OBJ_544 /* XcodeBuildSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeBuildSetting.swift; sourceTree = "<group>"; };
+		OBJ_545 /* library_wrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = library_wrapper.swift; sourceTree = "<group>"; };
+		OBJ_546 /* library_wrapper_CXString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = library_wrapper_CXString.swift; sourceTree = "<group>"; };
+		OBJ_547 /* library_wrapper_Documentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = library_wrapper_Documentation.swift; sourceTree = "<group>"; };
+		OBJ_548 /* library_wrapper_Index.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = library_wrapper_Index.swift; sourceTree = "<group>"; };
+		OBJ_549 /* library_wrapper_sourcekitd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = library_wrapper_sourcekitd.swift; sourceTree = "<group>"; };
+		OBJ_55 /* SwiftLintFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLintFile.swift; sourceTree = "<group>"; };
+		OBJ_551 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SourceKitten/Package.swift; sourceTree = "<group>"; };
+		OBJ_555 /* api.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = api.c; sourceTree = "<group>"; };
+		OBJ_556 /* emitter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = emitter.c; sourceTree = "<group>"; };
+		OBJ_557 /* parser.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = parser.c; sourceTree = "<group>"; };
+		OBJ_558 /* reader.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = reader.c; sourceTree = "<group>"; };
+		OBJ_559 /* scanner.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scanner.c; sourceTree = "<group>"; };
+		OBJ_56 /* SwiftLintSyntaxMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLintSyntaxMap.swift; sourceTree = "<group>"; };
+		OBJ_560 /* writer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = writer.c; sourceTree = "<group>"; };
+		OBJ_562 /* CYaml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CYaml.h; sourceTree = "<group>"; };
+		OBJ_563 /* yaml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = yaml.h; sourceTree = "<group>"; };
+		OBJ_565 /* Constructor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constructor.swift; sourceTree = "<group>"; };
+		OBJ_566 /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
+		OBJ_567 /* Emitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emitter.swift; sourceTree = "<group>"; };
+		OBJ_568 /* Encoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoder.swift; sourceTree = "<group>"; };
+		OBJ_569 /* Mark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mark.swift; sourceTree = "<group>"; };
+		OBJ_57 /* SwiftLintSyntaxToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLintSyntaxToken.swift; sourceTree = "<group>"; };
+		OBJ_570 /* Node.Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Mapping.swift; sourceTree = "<group>"; };
+		OBJ_571 /* Node.Scalar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Scalar.swift; sourceTree = "<group>"; };
+		OBJ_572 /* Node.Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Sequence.swift; sourceTree = "<group>"; };
+		OBJ_573 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		OBJ_574 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		OBJ_575 /* Representer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Representer.swift; sourceTree = "<group>"; };
+		OBJ_576 /* Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
+		OBJ_577 /* String+Yams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Yams.swift"; sourceTree = "<group>"; };
+		OBJ_578 /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
+		OBJ_579 /* YamlError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlError.swift; sourceTree = "<group>"; };
+		OBJ_58 /* SwiftVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftVersion.swift; sourceTree = "<group>"; };
+		OBJ_580 /* shim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = shim.swift; sourceTree = "<group>"; };
+		OBJ_581 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/marcelofabri/projetos/SwiftLint/.build/checkouts/Yams/Package.swift; sourceTree = "<group>"; };
+		OBJ_583 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SWXMLHash/Package.swift; sourceTree = "<group>"; };
+		OBJ_584 /* SWXMLHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWXMLHash.swift; sourceTree = "<group>"; };
+		OBJ_585 /* XMLIndexer+XMLIndexerDeserializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XMLIndexer+XMLIndexerDeserializable.swift"; sourceTree = "<group>"; };
+		OBJ_586 /* shim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = shim.swift; sourceTree = "<group>"; };
+		OBJ_589 /* Argument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Argument.swift; sourceTree = "<group>"; };
+		OBJ_59 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		OBJ_590 /* ArgumentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentParser.swift; sourceTree = "<group>"; };
+		OBJ_591 /* ArgumentProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentProtocol.swift; sourceTree = "<group>"; };
+		OBJ_592 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		OBJ_593 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		OBJ_594 /* HelpCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpCommand.swift; sourceTree = "<group>"; };
+		OBJ_595 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
+		OBJ_596 /* OrderedSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedSet.swift; sourceTree = "<group>"; };
+		OBJ_597 /* Result+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Additions.swift"; sourceTree = "<group>"; };
+		OBJ_598 /* Switch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Switch.swift; sourceTree = "<group>"; };
+		OBJ_599 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/marcelofabri/projetos/SwiftLint/.build/checkouts/Commandant/Package.swift; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_60 /* ViolationSeverity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViolationSeverity.swift; sourceTree = "<group>"; };
+		OBJ_61 /* YamlParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlParser.swift; sourceTree = "<group>"; };
+		OBJ_614 /* SwiftLint.xcworkspace */ = {isa = PBXFileReference; lastKnownFileType = wrapper.workspace; path = SwiftLint.xcworkspace; sourceTree = SOURCE_ROOT; };
+		OBJ_615 /* Carthage */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Carthage; sourceTree = SOURCE_ROOT; };
+		OBJ_616 /* script */ = {isa = PBXFileReference; lastKnownFileType = folder; path = script; sourceTree = SOURCE_ROOT; };
+		OBJ_617 /* portable_swiftlint */ = {isa = PBXFileReference; lastKnownFileType = folder; path = portable_swiftlint; sourceTree = SOURCE_ROOT; };
+		OBJ_618 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = assets; sourceTree = SOURCE_ROOT; };
+		OBJ_619 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
+		OBJ_620 /* Releasing.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Releasing.md; sourceTree = "<group>"; };
+		OBJ_621 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		OBJ_622 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		OBJ_623 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		OBJ_624 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
+		OBJ_625 /* README_KR.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_KR.md; sourceTree = "<group>"; };
+		OBJ_626 /* azure-pipelines.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "azure-pipelines.yml"; sourceTree = "<group>"; };
+		OBJ_627 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		OBJ_628 /* README_CN.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_CN.md; sourceTree = "<group>"; };
+		OBJ_629 /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
+		OBJ_63 /* ASTRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTRule.swift; sourceTree = "<group>"; };
+		OBJ_630 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		OBJ_631 /* SwiftLint.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftLint.podspec; sourceTree = "<group>"; };
+		OBJ_632 /* SwiftLintFramework.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftLintFramework.podspec; sourceTree = "<group>"; };
+		OBJ_633 /* Dangerfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Dangerfile; sourceTree = "<group>"; };
+		OBJ_634 /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
+		OBJ_635 /* Gemfile.lock */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile.lock; sourceTree = "<group>"; };
+		OBJ_636 /* Rules.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Rules.md; sourceTree = "<group>"; };
+		OBJ_64 /* CacheDescriptionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheDescriptionProvider.swift; sourceTree = "<group>"; };
+		OBJ_65 /* CallPairRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallPairRule.swift; sourceTree = "<group>"; };
+		OBJ_66 /* Reporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reporter.swift; sourceTree = "<group>"; };
+		OBJ_67 /* Rule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rule.swift; sourceTree = "<group>"; };
+		OBJ_68 /* RuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_70 /* CSVReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVReporter.swift; sourceTree = "<group>"; };
+		OBJ_71 /* CheckstyleReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckstyleReporter.swift; sourceTree = "<group>"; };
+		OBJ_72 /* EmojiReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiReporter.swift; sourceTree = "<group>"; };
+		OBJ_73 /* GitHubActionsLoggingReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubActionsLoggingReporter.swift; sourceTree = "<group>"; };
+		OBJ_74 /* HTMLReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLReporter.swift; sourceTree = "<group>"; };
+		OBJ_75 /* JSONReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONReporter.swift; sourceTree = "<group>"; };
+		OBJ_76 /* JUnitReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JUnitReporter.swift; sourceTree = "<group>"; };
+		OBJ_77 /* MarkdownReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownReporter.swift; sourceTree = "<group>"; };
+		OBJ_78 /* SonarQubeReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonarQubeReporter.swift; sourceTree = "<group>"; };
+		OBJ_79 /* XcodeReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeReporter.swift; sourceTree = "<group>"; };
+		OBJ_82 /* BlockBasedKVORule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockBasedKVORule.swift; sourceTree = "<group>"; };
+		OBJ_83 /* ConvenienceTypeRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvenienceTypeRule.swift; sourceTree = "<group>"; };
+		OBJ_84 /* DiscouragedObjectLiteralRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedObjectLiteralRule.swift; sourceTree = "<group>"; };
+		OBJ_85 /* DiscouragedOptionalBooleanRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalBooleanRule.swift; sourceTree = "<group>"; };
+		OBJ_86 /* DiscouragedOptionalBooleanRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalBooleanRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_87 /* DiscouragedOptionalCollectionExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalCollectionExamples.swift; sourceTree = "<group>"; };
+		OBJ_88 /* DiscouragedOptionalCollectionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalCollectionRule.swift; sourceTree = "<group>"; };
+		OBJ_89 /* DuplicateImportsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateImportsRule.swift; sourceTree = "<group>"; };
+		OBJ_90 /* DuplicateImportsRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateImportsRuleExamples.swift; sourceTree = "<group>"; };
+		OBJ_91 /* ExplicitACLRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitACLRule.swift; sourceTree = "<group>"; };
+		OBJ_92 /* ExplicitEnumRawValueRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitEnumRawValueRule.swift; sourceTree = "<group>"; };
+		OBJ_93 /* ExplicitInitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
+		OBJ_94 /* ExplicitTopLevelACLRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTopLevelACLRule.swift; sourceTree = "<group>"; };
+		OBJ_95 /* ExplicitTypeInterfaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRule.swift; sourceTree = "<group>"; };
+		OBJ_96 /* ExtensionAccessModifierRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionAccessModifierRule.swift; sourceTree = "<group>"; };
+		OBJ_97 /* FallthroughRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallthroughRule.swift; sourceTree = "<group>"; };
+		OBJ_98 /* FatalErrorMessageRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorMessageRule.swift; sourceTree = "<group>"; };
+		OBJ_99 /* FileNameNoSpaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameNoSpaceRule.swift; sourceTree = "<group>"; };
+		"SWXMLHash::SWXMLHash::Product" /* SWXMLHash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SourceKitten::Clang_C::Product" /* Clang_C.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Clang_C.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SourceKitten::SourceKit::Product" /* SourceKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SourceKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SourceKitten::SourceKittenFramework::Product" /* SourceKittenFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SourceKittenFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftLint::SwiftLintFramework::Product" /* SwiftLintFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftLintFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftLint::SwiftLintFrameworkTests::Product" /* SwiftLintFrameworkTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = SwiftLintFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftLint::swiftlint::Product" /* swiftlint */ = {isa = PBXFileReference; lastKnownFileType = text; path = swiftlint; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftSyntax::SwiftSyntax::Product" /* SwiftSyntax.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftSyntax.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftSyntax::_CSwiftSyntax::Product" /* _CSwiftSyntax.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = _CSwiftSyntax.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftyTextTable::SwiftyTextTable::Product" /* SwiftyTextTable.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftyTextTable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"Yams::CYaml::Product" /* CYaml.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CYaml.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"Yams::Yams::Product" /* Yams.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Yams.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_1115 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1116 /* SwiftSyntax.framework in Frameworks */,
+				OBJ_1117 /* _CSwiftSyntax.framework in Frameworks */,
+				OBJ_1118 /* SourceKittenFramework.framework in Frameworks */,
+				OBJ_1119 /* Yams.framework in Frameworks */,
+				OBJ_1120 /* CYaml.framework in Frameworks */,
+				OBJ_1121 /* SWXMLHash.framework in Frameworks */,
+				OBJ_1122 /* SourceKit.framework in Frameworks */,
+				OBJ_1123 /* Clang_C.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1213 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1214 /* SwiftLintFramework.framework in Frameworks */,
+				OBJ_1215 /* SwiftSyntax.framework in Frameworks */,
+				OBJ_1216 /* _CSwiftSyntax.framework in Frameworks */,
+				OBJ_1217 /* SourceKittenFramework.framework in Frameworks */,
+				OBJ_1218 /* Yams.framework in Frameworks */,
+				OBJ_1219 /* CYaml.framework in Frameworks */,
+				OBJ_1220 /* SWXMLHash.framework in Frameworks */,
+				OBJ_1221 /* SourceKit.framework in Frameworks */,
+				OBJ_1222 /* Clang_C.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1275 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1276 /* _CSwiftSyntax.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1290 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1317 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1318 /* CYaml.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1331 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1352 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1353 /* SwiftyTextTable.framework in Frameworks */,
+				OBJ_1354 /* Commandant.framework in Frameworks */,
+				OBJ_1355 /* SwiftLintFramework.framework in Frameworks */,
+				OBJ_1356 /* SwiftSyntax.framework in Frameworks */,
+				OBJ_1357 /* _CSwiftSyntax.framework in Frameworks */,
+				OBJ_1358 /* SourceKittenFramework.framework in Frameworks */,
+				OBJ_1359 /* Yams.framework in Frameworks */,
+				OBJ_1360 /* CYaml.framework in Frameworks */,
+				OBJ_1361 /* SWXMLHash.framework in Frameworks */,
+				OBJ_1362 /* SourceKit.framework in Frameworks */,
+				OBJ_1363 /* Clang_C.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_651 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_667 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_683 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_698 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_714 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_764 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_765 /* Yams.framework in Frameworks */,
+				OBJ_766 /* CYaml.framework in Frameworks */,
+				OBJ_767 /* SWXMLHash.framework in Frameworks */,
+				OBJ_768 /* SourceKit.framework in Frameworks */,
+				OBJ_769 /* Clang_C.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_148 /* Lint */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_149 /* AnyObjectProtocolRule.swift */,
+				OBJ_150 /* ArrayInitRule.swift */,
+				OBJ_151 /* ClassDelegateProtocolRule.swift */,
+				OBJ_152 /* CompilerProtocolInitRule.swift */,
+				OBJ_153 /* DeploymentTargetRule.swift */,
+				OBJ_154 /* DiscardedNotificationCenterObserverRule.swift */,
+				OBJ_155 /* DiscouragedDirectInitRule.swift */,
+				OBJ_156 /* DuplicateEnumCasesRule.swift */,
+				OBJ_157 /* DynamicInlineRule.swift */,
+				OBJ_158 /* EmptyXCTestMethodRule.swift */,
+				OBJ_159 /* EmptyXCTestMethodRuleExamples.swift */,
+				OBJ_160 /* ExpiringTodoRule.swift */,
+				OBJ_161 /* IdenticalOperandsRule.swift */,
+				OBJ_162 /* InertDeferRule.swift */,
+				OBJ_163 /* LowerACLThanParentRule.swift */,
+				OBJ_164 /* MarkRule.swift */,
+				OBJ_165 /* MissingDocsRule.swift */,
+				OBJ_166 /* NSLocalizedStringKeyRule.swift */,
+				OBJ_167 /* NSLocalizedStringRequireBundleRule.swift */,
+				OBJ_168 /* NSObjectPreferIsEqualRule.swift */,
+				OBJ_169 /* NSObjectPreferIsEqualRuleExamples.swift */,
+				OBJ_170 /* NotificationCenterDetachmentRule.swift */,
+				OBJ_171 /* NotificationCenterDetachmentRuleExamples.swift */,
+				OBJ_172 /* OverriddenSuperCallRule.swift */,
+				OBJ_173 /* OverrideInExtensionRule.swift */,
+				OBJ_174 /* PrivateActionRule.swift */,
+				OBJ_175 /* PrivateOutletRule.swift */,
+				OBJ_176 /* PrivateUnitTestRule.swift */,
+				OBJ_177 /* ProhibitedInterfaceBuilderRule.swift */,
+				OBJ_178 /* ProhibitedSuperRule.swift */,
+				OBJ_179 /* QuickDiscouragedCallRule.swift */,
+				OBJ_180 /* QuickDiscouragedCallRuleExamples.swift */,
+				OBJ_181 /* QuickDiscouragedFocusedTestRule.swift */,
+				OBJ_182 /* QuickDiscouragedFocusedTestRuleExamples.swift */,
+				OBJ_183 /* QuickDiscouragedPendingTestRule.swift */,
+				OBJ_184 /* QuickDiscouragedPendingTestRuleExamples.swift */,
+				OBJ_185 /* RawValueForCamelCasedCodableEnumRule.swift */,
+				OBJ_186 /* RequiredDeinitRule.swift */,
+				OBJ_187 /* RequiredEnumCaseRule.swift */,
+				OBJ_188 /* ReturnValueFromVoidFunctionRule.swift */,
+				D4A115F223C2194400D1122A /* ReturnValueFromVoidFunctionRuleExamples.swift */,
+				OBJ_189 /* StrongIBOutletRule.swift */,
+				OBJ_190 /* SuperfluousDisableCommandRule.swift */,
+				OBJ_191 /* TodoRule.swift */,
+				OBJ_192 /* UnownedVariableCaptureRule.swift */,
+				OBJ_193 /* UnusedCaptureListRule.swift */,
+				OBJ_194 /* UnusedClosureParameterRule.swift */,
+				OBJ_195 /* UnusedControlFlowLabelRule.swift */,
+				OBJ_196 /* UnusedDeclarationRule.swift */,
+				OBJ_197 /* UnusedImportRule.swift */,
+				OBJ_198 /* UnusedSetterValueRule.swift */,
+				OBJ_199 /* ValidIBInspectableRule.swift */,
+				OBJ_200 /* WeakDelegateRule.swift */,
+				OBJ_201 /* YodaConditionRule.swift */,
+			);
+			path = Lint;
+			sourceTree = "<group>";
+		};
+		OBJ_202 /* Metrics */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_203 /* ClosureBodyLengthRule.swift */,
+				OBJ_204 /* ClosureBodyLengthRuleExamples.swift */,
+				OBJ_205 /* CyclomaticComplexityRule.swift */,
+				OBJ_206 /* EnumCaseAssociatedValuesLengthRule.swift */,
+				OBJ_207 /* FileLengthRule.swift */,
+				OBJ_208 /* FunctionBodyLengthRule.swift */,
+				OBJ_209 /* FunctionParameterCountRule.swift */,
+				OBJ_210 /* LargeTupleRule.swift */,
+				OBJ_211 /* LineLengthRule.swift */,
+				OBJ_212 /* NestingRule.swift */,
+				OBJ_213 /* TypeBodyLengthRule.swift */,
+			);
+			path = Metrics;
+			sourceTree = "<group>";
+		};
+		OBJ_214 /* Performance */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_215 /* ContainsOverFilterCountRule.swift */,
+				OBJ_216 /* ContainsOverFilterIsEmptyRule.swift */,
+				OBJ_217 /* ContainsOverFirstNotNilRule.swift */,
+				OBJ_218 /* ContainsOverRangeNilComparisonRule.swift */,
+				OBJ_219 /* EmptyCollectionLiteralRule.swift */,
+				OBJ_220 /* EmptyCountRule.swift */,
+				OBJ_221 /* EmptyStringRule.swift */,
+				OBJ_222 /* FirstWhereRule.swift */,
+				OBJ_223 /* FlatMapOverMapReduceRule.swift */,
+				OBJ_224 /* LastWhereRule.swift */,
+				OBJ_225 /* ReduceBooleanRule.swift */,
+				OBJ_226 /* ReduceIntoRule.swift */,
+				OBJ_227 /* SortedFirstLastRule.swift */,
+			);
+			path = Performance;
+			sourceTree = "<group>";
+		};
+		OBJ_228 /* RuleConfigurations */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_229 /* AttributesConfiguration.swift */,
+				OBJ_230 /* CollectionAlignmentConfiguration.swift */,
+				OBJ_231 /* ColonConfiguration.swift */,
+				OBJ_232 /* ConditionalReturnsOnNewlineConfiguration.swift */,
+				OBJ_233 /* CyclomaticComplexityConfiguration.swift */,
+				OBJ_234 /* DeploymentTargetConfiguration.swift */,
+				OBJ_235 /* DiscouragedDirectInitConfiguration.swift */,
+				OBJ_236 /* ExpiringTodoConfiguration.swift */,
+				OBJ_237 /* ExplicitTypeInterfaceConfiguration.swift */,
+				OBJ_238 /* FileHeaderConfiguration.swift */,
+				OBJ_239 /* FileLengthRuleConfiguration.swift */,
+				OBJ_240 /* FileNameConfiguration.swift */,
+				OBJ_241 /* FileNameNoSpaceConfiguration.swift */,
+				OBJ_242 /* FileTypesOrderConfiguration.swift */,
+				OBJ_243 /* FunctionParameterCountConfiguration.swift */,
+				OBJ_244 /* ImplicitlyUnwrappedOptionalConfiguration.swift */,
+				OBJ_245 /* LineLengthConfiguration.swift */,
+				OBJ_246 /* MissingDocsRuleConfiguration.swift */,
+				OBJ_247 /* ModifierOrderConfiguration.swift */,
+				OBJ_248 /* MultilineArgumentsConfiguration.swift */,
+				OBJ_249 /* NameConfiguration.swift */,
+				OBJ_250 /* NestingConfiguration.swift */,
+				OBJ_251 /* NumberSeparatorConfiguration.swift */,
+				OBJ_252 /* ObjectLiteralConfiguration.swift */,
+				OBJ_253 /* OverridenSuperCallConfiguration.swift */,
+				OBJ_254 /* PrefixedConstantRuleConfiguration.swift */,
+				OBJ_255 /* PrivateOutletRuleConfiguration.swift */,
+				OBJ_256 /* PrivateOverFilePrivateRuleConfiguration.swift */,
+				OBJ_257 /* PrivateUnitTestConfiguration.swift */,
+				OBJ_258 /* ProhibitedSuperConfiguration.swift */,
+				OBJ_259 /* RegexConfiguration.swift */,
+				OBJ_260 /* RequiredEnumCaseRuleConfiguration.swift */,
+				OBJ_261 /* SeverityConfiguration.swift */,
+				OBJ_262 /* SeverityLevelsConfiguration.swift */,
+				OBJ_263 /* StatementModeConfiguration.swift */,
+				OBJ_264 /* SwitchCaseAlignmentConfiguration.swift */,
+				OBJ_265 /* TrailingClosureConfiguration.swift */,
+				OBJ_266 /* TrailingCommaConfiguration.swift */,
+				OBJ_267 /* TrailingWhitespaceConfiguration.swift */,
+				OBJ_268 /* TypeContentsOrderConfiguration.swift */,
+				OBJ_269 /* UnusedDeclarationConfiguration.swift */,
+				OBJ_270 /* UnusedOptionalBindingConfiguration.swift */,
+				OBJ_271 /* VerticalWhitespaceConfiguration.swift */,
+			);
+			path = RuleConfigurations;
+			sourceTree = "<group>";
+		};
+		OBJ_272 /* Style */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_273 /* AttributesRule.swift */,
+				OBJ_274 /* AttributesRuleExamples.swift */,
+				OBJ_275 /* ClosingBraceRule.swift */,
+				OBJ_276 /* ClosureEndIndentationRule.swift */,
+				OBJ_277 /* ClosureEndIndentationRuleExamples.swift */,
+				OBJ_278 /* ClosureParameterPositionRule.swift */,
+				OBJ_279 /* ClosureSpacingRule.swift */,
+				OBJ_280 /* CollectionAlignmentRule.swift */,
+				OBJ_281 /* ColonRule+Dictionary.swift */,
+				OBJ_282 /* ColonRule+FunctionCall.swift */,
+				OBJ_283 /* ColonRule+Type.swift */,
+				OBJ_284 /* ColonRule.swift */,
+				OBJ_285 /* ColonRuleExamples.swift */,
+				OBJ_286 /* CommaRule.swift */,
+				OBJ_287 /* ConditionalReturnsOnNewlineRule.swift */,
+				OBJ_288 /* ControlStatementRule.swift */,
+				OBJ_289 /* CustomRules.swift */,
+				OBJ_290 /* EmptyEnumArgumentsRule.swift */,
+				OBJ_291 /* EmptyParametersRule.swift */,
+				OBJ_292 /* EmptyParenthesesWithTrailingClosureRule.swift */,
+				OBJ_293 /* ExplicitSelfRule.swift */,
+				OBJ_294 /* FileHeaderRule.swift */,
+				OBJ_295 /* FileTypesOrderRule.swift */,
+				OBJ_296 /* FileTypesOrderRuleExamples.swift */,
+				OBJ_297 /* IdentifierNameRule.swift */,
+				OBJ_298 /* IdentifierNameRuleExamples.swift */,
+				OBJ_299 /* ImplicitGetterRule.swift */,
+				OBJ_300 /* ImplicitReturnRule.swift */,
+				OBJ_301 /* LeadingWhitespaceRule.swift */,
+				OBJ_302 /* LetVarWhitespaceRule.swift */,
+				OBJ_303 /* LiteralExpressionEndIdentationRule.swift */,
+				OBJ_304 /* ModifierOrderRule.swift */,
+				OBJ_305 /* ModifierOrderRuleExamples.swift */,
+				OBJ_306 /* MultilineArgumentsBracketsRule.swift */,
+				OBJ_307 /* MultilineArgumentsRule.swift */,
+				OBJ_308 /* MultilineArgumentsRuleExamples.swift */,
+				OBJ_309 /* MultilineFunctionChainsRule.swift */,
+				OBJ_310 /* MultilineLiteralBracketsRule.swift */,
+				OBJ_311 /* MultilineParametersBracketsRule.swift */,
+				OBJ_312 /* MultilineParametersRule.swift */,
+				OBJ_313 /* MultilineParametersRuleExamples.swift */,
+				OBJ_314 /* MultipleClosuresWithTrailingClosureRule.swift */,
+				OBJ_315 /* NoSpaceInMethodCallRule.swift */,
+				OBJ_316 /* NumberSeparatorRule.swift */,
+				OBJ_317 /* NumberSeparatorRuleExamples.swift */,
+				OBJ_318 /* OpeningBraceRule.swift */,
+				OBJ_319 /* OperatorFunctionWhitespaceRule.swift */,
+				OBJ_320 /* OperatorUsageWhitespaceRule.swift */,
+				OBJ_321 /* OptionalEnumCaseMatchingRule.swift */,
+				OBJ_322 /* PreferSelfTypeOverTypeOfSelfRule.swift */,
+				OBJ_323 /* PrefixedTopLevelConstantRule.swift */,
+				OBJ_324 /* ProtocolPropertyAccessorsOrderRule.swift */,
+				OBJ_325 /* RedundantDiscardableLetRule.swift */,
+				OBJ_326 /* ReturnArrowWhitespaceRule.swift */,
+				OBJ_327 /* ShorthandOperatorRule.swift */,
+				OBJ_328 /* SingleTestClassRule.swift */,
+				OBJ_329 /* SortedImportsRule.swift */,
+				OBJ_330 /* StatementPositionRule.swift */,
+				OBJ_331 /* SwitchCaseAlignmentRule.swift */,
+				OBJ_332 /* SwitchCaseOnNewlineRule.swift */,
+				OBJ_333 /* TrailingClosureRule.swift */,
+				OBJ_334 /* TrailingCommaRule.swift */,
+				OBJ_335 /* TrailingNewlineRule.swift */,
+				OBJ_336 /* TrailingWhitespaceRule.swift */,
+				OBJ_337 /* TypeContentsOrderRule.swift */,
+				OBJ_338 /* TypeContentsOrderRuleExamples.swift */,
+				OBJ_339 /* UnneededParenthesesInClosureArgumentRule.swift */,
+				OBJ_340 /* UnusedOptionalBindingRule.swift */,
+				OBJ_341 /* VerticalParameterAlignmentOnCallRule.swift */,
+				OBJ_342 /* VerticalParameterAlignmentRule.swift */,
+				OBJ_343 /* VerticalParameterAlignmentRuleExamples.swift */,
+				OBJ_344 /* VerticalWhitespaceBetweenCasesRule.swift */,
+				OBJ_345 /* VerticalWhitespaceClosingBracesRule.swift */,
+				OBJ_346 /* VerticalWhitespaceOpeningBracesRule.swift */,
+				OBJ_347 /* VerticalWhitespaceRule.swift */,
+				OBJ_348 /* VoidReturnRule.swift */,
+			);
+			path = Style;
+			sourceTree = "<group>";
+		};
+		OBJ_32 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_33 /* Glob.swift */,
+				OBJ_34 /* NamespaceCollector.swift */,
+				OBJ_35 /* RegexHelpers.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		OBJ_349 /* swiftlint */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_350 /* Commands */,
+				OBJ_357 /* Extensions */,
+				OBJ_361 /* Helpers */,
+				OBJ_367 /* main.swift */,
+			);
+			name = swiftlint;
+			path = Source/swiftlint;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_350 /* Commands */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_351 /* AnalyzeCommand.swift */,
+				OBJ_352 /* AutoCorrectCommand.swift */,
+				OBJ_353 /* GenerateDocsCommand.swift */,
+				OBJ_354 /* LintCommand.swift */,
+				OBJ_355 /* RulesCommand.swift */,
+				OBJ_356 /* VersionCommand.swift */,
+			);
+			path = Commands;
+			sourceTree = "<group>";
+		};
+		OBJ_357 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_358 /* Array+SwiftLint.swift */,
+				OBJ_359 /* Configuration+CommandLine.swift */,
+				OBJ_360 /* Reporter+CommandLine.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		OBJ_36 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_37 /* AccessControlLevel.swift */,
+				OBJ_38 /* Command.swift */,
+				OBJ_39 /* Configuration.swift */,
+				OBJ_40 /* ConfigurationError.swift */,
+				OBJ_41 /* Correction.swift */,
+				OBJ_42 /* Linter.swift */,
+				OBJ_43 /* LinterCache.swift */,
+				OBJ_44 /* Location.swift */,
+				OBJ_45 /* MasterRuleList.swift */,
+				OBJ_46 /* Region.swift */,
+				OBJ_47 /* RuleDescription.swift */,
+				OBJ_48 /* RuleIdentifier.swift */,
+				OBJ_49 /* RuleKind.swift */,
+				OBJ_50 /* RuleList+Documentation.swift */,
+				OBJ_51 /* RuleList.swift */,
+				OBJ_52 /* RuleParameter.swift */,
+				OBJ_53 /* RuleStorage.swift */,
+				OBJ_54 /* StyleViolation.swift */,
+				OBJ_55 /* SwiftLintFile.swift */,
+				OBJ_56 /* SwiftLintSyntaxMap.swift */,
+				OBJ_57 /* SwiftLintSyntaxToken.swift */,
+				OBJ_58 /* SwiftVersion.swift */,
+				OBJ_59 /* Version.swift */,
+				OBJ_60 /* ViolationSeverity.swift */,
+				OBJ_61 /* YamlParser.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		OBJ_361 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_362 /* Benchmark.swift */,
+				OBJ_363 /* CommonOptions.swift */,
+				OBJ_364 /* CompilerArgumentsExtractor.swift */,
+				OBJ_365 /* LintOrAnalyzeCommand.swift */,
+				OBJ_366 /* LintableFilesVisitor.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		OBJ_368 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_369 /* SwiftLintFrameworkTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_369 /* SwiftLintFrameworkTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_370 /* AttributesRuleTests.swift */,
+				OBJ_371 /* AutomaticRuleTests.generated.swift */,
+				OBJ_372 /* CollectingRuleTests.swift */,
+				OBJ_373 /* CollectionAlignmentRuleTests.swift */,
+				OBJ_374 /* ColonRuleTests.swift */,
+				OBJ_375 /* CommandTests.swift */,
+				OBJ_376 /* CompilerProtocolInitRuleTests.swift */,
+				OBJ_377 /* ConditionalReturnsOnNewlineRuleTests.swift */,
+				OBJ_378 /* ConfigurationAliasesTests.swift */,
+				OBJ_379 /* ConfigurationTests+Nested.swift */,
+				OBJ_380 /* ConfigurationTests+ProjectMock.swift */,
+				OBJ_381 /* ConfigurationTests.swift */,
+				OBJ_382 /* ContainsOverFirstNotNilRuleTests.swift */,
+				OBJ_383 /* CustomRulesTests.swift */,
+				OBJ_384 /* CyclomaticComplexityConfigurationTests.swift */,
+				OBJ_385 /* CyclomaticComplexityRuleTests.swift */,
+				OBJ_386 /* DeploymentTargetConfigurationTests.swift */,
+				OBJ_387 /* DeploymentTargetRuleTests.swift */,
+				OBJ_388 /* DisableAllTests.swift */,
+				OBJ_389 /* DiscouragedDirectInitRuleTests.swift */,
+				OBJ_390 /* DiscouragedObjectLiteralRuleTests.swift */,
+				OBJ_391 /* DocumentationTests.swift */,
+				OBJ_392 /* ExpiringTodoRuleTests.swift */,
+				OBJ_393 /* ExplicitTypeInterfaceConfigurationTests.swift */,
+				OBJ_394 /* ExplicitTypeInterfaceRuleTests.swift */,
+				OBJ_395 /* ExtendedNSStringTests.swift */,
+				OBJ_396 /* FileHeaderRuleTests.swift */,
+				OBJ_397 /* FileLengthRuleTests.swift */,
+				OBJ_398 /* FileNameNoSpaceRuleTests.swift */,
+				OBJ_399 /* FileNameRuleTests.swift */,
+				OBJ_400 /* FileTypesOrderRuleTests.swift */,
+				OBJ_401 /* FunctionBodyLengthRuleTests.swift */,
+				OBJ_402 /* FunctionParameterCountRuleTests.swift */,
+				OBJ_403 /* GenericTypeNameRuleTests.swift */,
+				OBJ_404 /* GlobTests.swift */,
+				OBJ_405 /* IdentifierNameRuleTests.swift */,
+				OBJ_406 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */,
+				OBJ_407 /* ImplicitlyUnwrappedOptionalRuleTests.swift */,
+				OBJ_408 /* IntegrationTests.swift */,
+				OBJ_409 /* LineLengthConfigurationTests.swift */,
+				OBJ_410 /* LineLengthRuleTests.swift */,
+				OBJ_411 /* LinterCacheTests.swift */,
+				OBJ_412 /* MissingDocsRuleConfigurationTests.swift */,
+				OBJ_413 /* ModifierOrderTests.swift */,
+				OBJ_414 /* MultilineArgumentsRuleTests.swift */,
+				OBJ_415 /* NumberSeparatorRuleTests.swift */,
+				OBJ_416 /* ObjectLiteralRuleTests.swift */,
+				OBJ_417 /* PrefixedTopLevelConstantRuleTests.swift */,
+				OBJ_418 /* PrivateOutletRuleTests.swift */,
+				OBJ_419 /* PrivateOverFilePrivateRuleTests.swift */,
+				OBJ_420 /* RegionTests.swift */,
+				OBJ_421 /* ReporterTests.swift */,
+				OBJ_422 /* RequiredEnumCaseRuleTestCase.swift */,
+				OBJ_423 /* RuleConfigurationTests.swift */,
+				OBJ_424 /* RuleDescription+Examples.swift */,
+				OBJ_425 /* RuleTests.swift */,
+				OBJ_426 /* RulesTests.swift */,
+				OBJ_427 /* SourceKitCrashTests.swift */,
+				OBJ_428 /* StatementPositionRuleTests.swift */,
+				OBJ_429 /* SwitchCaseAlignmentRuleTests.swift */,
+				OBJ_430 /* TestHelpers.swift */,
+				OBJ_431 /* TodoRuleTests.swift */,
+				OBJ_432 /* TrailingClosureConfigurationTests.swift */,
+				OBJ_433 /* TrailingClosureRuleTests.swift */,
+				OBJ_434 /* TrailingCommaRuleTests.swift */,
+				OBJ_435 /* TrailingWhitespaceTests.swift */,
+				OBJ_436 /* TypeContentsOrderRuleTests.swift */,
+				OBJ_437 /* TypeNameRuleTests.swift */,
+				OBJ_438 /* UnusedOptionalBindingRuleTests.swift */,
+				OBJ_439 /* VerticalWhitespaceRuleTests.swift */,
+				OBJ_440 /* XCTSpecificMatcherRuleTests.swift */,
+				OBJ_441 /* XCTestCase+BundlePath.swift */,
+				OBJ_442 /* YamlParserTests.swift */,
+				OBJ_443 /* YamlSwiftLintTests.swift */,
+			);
+			name = SwiftLintFrameworkTests;
+			path = Tests/SwiftLintFrameworkTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_444 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_445 /* SwiftSyntax 0.50100.0 */,
+				OBJ_484 /* SwiftyTextTable 0.9.0 */,
+				OBJ_488 /* SourceKitten 0.28.0 */,
+				OBJ_552 /* Yams 2.0.0 */,
+				OBJ_582 /* SWXMLHash 5.0.1 */,
+				OBJ_587 /* Commandant 0.17.0 */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		OBJ_445 /* SwiftSyntax 0.50100.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_446 /* SwiftSyntax */,
+				OBJ_476 /* _CSwiftSyntax */,
+				OBJ_482 /* lit-test-helper */,
+				OBJ_483 /* Package.swift */,
+			);
+			name = "SwiftSyntax 0.50100.0";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_446 /* SwiftSyntax */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_447 /* AbsolutePosition.swift */,
+				OBJ_448 /* AtomicCounter.swift */,
+				OBJ_449 /* Diagnostic.swift */,
+				OBJ_450 /* DiagnosticConsumer.swift */,
+				OBJ_451 /* DiagnosticEngine.swift */,
+				OBJ_452 /* IncrementalParseTransition.swift */,
+				OBJ_453 /* JSONDiagnosticConsumer.swift */,
+				OBJ_454 /* PrintingDiagnosticConsumer.swift */,
+				OBJ_455 /* RawSyntax.swift */,
+				OBJ_456 /* SourceLength.swift */,
+				OBJ_457 /* SourceLocation.swift */,
+				OBJ_458 /* SourcePresence.swift */,
+				OBJ_459 /* Syntax.swift */,
+				OBJ_460 /* SyntaxChildren.swift */,
+				OBJ_461 /* SyntaxClassifier.swift */,
+				OBJ_462 /* SyntaxData.swift */,
+				OBJ_463 /* SyntaxParser.swift */,
+				OBJ_464 /* SyntaxVerifier.swift */,
+				OBJ_465 /* Utils.swift */,
+				OBJ_466 /* gyb_generated */,
+			);
+			name = SwiftSyntax;
+			path = ".build/checkouts/swift-syntax/Sources/SwiftSyntax";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_466 /* gyb_generated */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_467 /* SyntaxBuilders.swift */,
+				OBJ_468 /* SyntaxClassification.swift */,
+				OBJ_469 /* SyntaxCollections.swift */,
+				OBJ_470 /* SyntaxFactory.swift */,
+				OBJ_471 /* SyntaxKind.swift */,
+				OBJ_472 /* SyntaxNodes.swift */,
+				OBJ_473 /* SyntaxRewriter.swift */,
+				OBJ_474 /* TokenKind.swift */,
+				OBJ_475 /* Trivia.swift */,
+			);
+			path = gyb_generated;
+			sourceTree = "<group>";
+		};
+		OBJ_476 /* _CSwiftSyntax */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_477 /* src */,
+				OBJ_479 /* include */,
+			);
+			name = _CSwiftSyntax;
+			path = ".build/checkouts/swift-syntax/Sources/_CSwiftSyntax";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_477 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_478 /* atomic-counter.c */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		OBJ_479 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_480 /* atomic-counter.h */,
+				OBJ_481 /* module.modulemap */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		OBJ_482 /* lit-test-helper */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = "lit-test-helper";
+			path = ".build/checkouts/swift-syntax/Sources/lit-test-helper";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_484 /* SwiftyTextTable 0.9.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_485 /* SwiftyTextTable */,
+				OBJ_487 /* Package.swift */,
+			);
+			name = "SwiftyTextTable 0.9.0";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_485 /* SwiftyTextTable */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_486 /* TextTable.swift */,
+			);
+			name = SwiftyTextTable;
+			path = .build/checkouts/SwiftyTextTable/Source/SwiftyTextTable;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_488 /* SourceKitten 0.28.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_489 /* Clang_C */,
+				OBJ_500 /* SourceKit */,
+				OBJ_505 /* SourceKittenFramework */,
+				OBJ_550 /* sourcekitten */,
+				OBJ_551 /* Package.swift */,
+			);
+			name = "SourceKitten 0.28.0";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_489 /* Clang_C */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_490 /* Clang_C.m */,
+				OBJ_491 /* include */,
+			);
+			name = Clang_C;
+			path = .build/checkouts/SourceKitten/Source/Clang_C;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_491 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_492 /* Index.h */,
+				OBJ_493 /* BuildSystem.h */,
+				OBJ_494 /* Documentation.h */,
+				OBJ_495 /* CXCompilationDatabase.h */,
+				OBJ_496 /* Clang_C.h */,
+				OBJ_497 /* CXErrorCode.h */,
+				OBJ_498 /* CXString.h */,
+				OBJ_499 /* Platform.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_368 /* Tests */,
+				OBJ_444 /* Dependencies */,
+				OBJ_600 /* Products */,
+				OBJ_614 /* SwiftLint.xcworkspace */,
+				OBJ_615 /* Carthage */,
+				OBJ_616 /* script */,
+				OBJ_617 /* portable_swiftlint */,
+				OBJ_618 /* assets */,
+				OBJ_619 /* Cartfile.resolved */,
+				OBJ_620 /* Releasing.md */,
+				OBJ_621 /* LICENSE */,
+				OBJ_622 /* CHANGELOG.md */,
+				OBJ_623 /* Makefile */,
+				OBJ_624 /* Cartfile */,
+				OBJ_625 /* README_KR.md */,
+				OBJ_626 /* azure-pipelines.yml */,
+				OBJ_627 /* README.md */,
+				OBJ_628 /* README_CN.md */,
+				OBJ_629 /* Cartfile.private */,
+				OBJ_630 /* CONTRIBUTING.md */,
+				OBJ_631 /* SwiftLint.podspec */,
+				OBJ_632 /* SwiftLintFramework.podspec */,
+				OBJ_633 /* Dangerfile */,
+				OBJ_634 /* Gemfile */,
+				OBJ_635 /* Gemfile.lock */,
+				OBJ_636 /* Rules.md */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_500 /* SourceKit */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_501 /* SourceKit.m */,
+				OBJ_502 /* include */,
+			);
+			name = SourceKit;
+			path = .build/checkouts/SourceKitten/Source/SourceKit;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_502 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_503 /* SourceKit.h */,
+				OBJ_504 /* sourcekitd.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		OBJ_505 /* SourceKittenFramework */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_506 /* Clang+SourceKitten.swift */,
+				OBJ_507 /* ClangTranslationUnit.swift */,
+				OBJ_508 /* CodeCompletionItem.swift */,
+				OBJ_509 /* CursorInfo+Parsing.swift */,
+				OBJ_510 /* Dictionary+Merge.swift */,
+				OBJ_511 /* Documentation.swift */,
+				OBJ_512 /* Exec.swift */,
+				OBJ_513 /* File+Hashable.swift */,
+				OBJ_514 /* File.swift */,
+				OBJ_515 /* JSONOutput.swift */,
+				OBJ_516 /* Language.swift */,
+				OBJ_517 /* Line.swift */,
+				OBJ_518 /* LinuxCompatibility.swift */,
+				OBJ_519 /* Module.swift */,
+				OBJ_520 /* ObjCDeclarationKind.swift */,
+				OBJ_521 /* OffsetMap.swift */,
+				OBJ_522 /* Parameter.swift */,
+				OBJ_523 /* Request.swift */,
+				OBJ_524 /* SourceDeclaration.swift */,
+				OBJ_525 /* SourceKitObject.swift */,
+				OBJ_526 /* SourceLocation.swift */,
+				OBJ_527 /* StatementKind.swift */,
+				OBJ_528 /* String+SourceKitten.swift */,
+				OBJ_529 /* StringView+SourceKitten.swift */,
+				OBJ_530 /* StringView.swift */,
+				OBJ_531 /* Structure.swift */,
+				OBJ_532 /* SwiftDeclarationAttributeKind.swift */,
+				OBJ_533 /* SwiftDeclarationKind.swift */,
+				OBJ_534 /* SwiftDocKey.swift */,
+				OBJ_535 /* SwiftDocs.swift */,
+				OBJ_536 /* SyntaxKind.swift */,
+				OBJ_537 /* SyntaxMap.swift */,
+				OBJ_538 /* SyntaxToken.swift */,
+				OBJ_539 /* Text.swift */,
+				OBJ_540 /* UID.swift */,
+				OBJ_541 /* UIDRepresentable.swift */,
+				OBJ_542 /* Version.swift */,
+				OBJ_543 /* Xcode.swift */,
+				OBJ_544 /* XcodeBuildSetting.swift */,
+				OBJ_545 /* library_wrapper.swift */,
+				OBJ_546 /* library_wrapper_CXString.swift */,
+				OBJ_547 /* library_wrapper_Documentation.swift */,
+				OBJ_548 /* library_wrapper_Index.swift */,
+				OBJ_549 /* library_wrapper_sourcekitd.swift */,
+			);
+			name = SourceKittenFramework;
+			path = .build/checkouts/SourceKitten/Source/SourceKittenFramework;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_550 /* sourcekitten */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = sourcekitten;
+			path = .build/checkouts/SourceKitten/Source/sourcekitten;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_552 /* Yams 2.0.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_553 /* CYaml */,
+				OBJ_564 /* Yams */,
+				OBJ_581 /* Package.swift */,
+			);
+			name = "Yams 2.0.0";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_553 /* CYaml */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_554 /* src */,
+				OBJ_561 /* include */,
+			);
+			name = CYaml;
+			path = .build/checkouts/Yams/Sources/CYaml;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_554 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_555 /* api.c */,
+				OBJ_556 /* emitter.c */,
+				OBJ_557 /* parser.c */,
+				OBJ_558 /* reader.c */,
+				OBJ_559 /* scanner.c */,
+				OBJ_560 /* writer.c */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		OBJ_561 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_562 /* CYaml.h */,
+				OBJ_563 /* yaml.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		OBJ_564 /* Yams */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_565 /* Constructor.swift */,
+				OBJ_566 /* Decoder.swift */,
+				OBJ_567 /* Emitter.swift */,
+				OBJ_568 /* Encoder.swift */,
+				OBJ_569 /* Mark.swift */,
+				OBJ_570 /* Node.Mapping.swift */,
+				OBJ_571 /* Node.Scalar.swift */,
+				OBJ_572 /* Node.Sequence.swift */,
+				OBJ_573 /* Node.swift */,
+				OBJ_574 /* Parser.swift */,
+				OBJ_575 /* Representer.swift */,
+				OBJ_576 /* Resolver.swift */,
+				OBJ_577 /* String+Yams.swift */,
+				OBJ_578 /* Tag.swift */,
+				OBJ_579 /* YamlError.swift */,
+				OBJ_580 /* shim.swift */,
+			);
+			name = Yams;
+			path = .build/checkouts/Yams/Sources/Yams;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_582 /* SWXMLHash 5.0.1 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_583 /* Package.swift */,
+				OBJ_584 /* SWXMLHash.swift */,
+				OBJ_585 /* XMLIndexer+XMLIndexerDeserializable.swift */,
+				OBJ_586 /* shim.swift */,
+			);
+			name = "SWXMLHash 5.0.1";
+			path = .build/checkouts/SWXMLHash/Source;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_587 /* Commandant 0.17.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_588 /* Commandant */,
+				OBJ_599 /* Package.swift */,
+			);
+			name = "Commandant 0.17.0";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_588 /* Commandant */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_589 /* Argument.swift */,
+				OBJ_590 /* ArgumentParser.swift */,
+				OBJ_591 /* ArgumentProtocol.swift */,
+				OBJ_592 /* Command.swift */,
+				OBJ_593 /* Errors.swift */,
+				OBJ_594 /* HelpCommand.swift */,
+				OBJ_595 /* Option.swift */,
+				OBJ_596 /* OrderedSet.swift */,
+				OBJ_597 /* Result+Additions.swift */,
+				OBJ_598 /* Switch.swift */,
+			);
+			name = Commandant;
+			path = .build/checkouts/Commandant/Sources/Commandant;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_600 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"SwiftSyntax::_CSwiftSyntax::Product" /* _CSwiftSyntax.framework */,
+				"SwiftLint::swiftlint::Product" /* swiftlint */,
+				"SwiftLint::SwiftLintFrameworkTests::Product" /* SwiftLintFrameworkTests.xctest */,
+				"SWXMLHash::SWXMLHash::Product" /* SWXMLHash.framework */,
+				"Yams::CYaml::Product" /* CYaml.framework */,
+				"SourceKitten::SourceKit::Product" /* SourceKit.framework */,
+				"SwiftLint::SwiftLintFramework::Product" /* SwiftLintFramework.framework */,
+				"SwiftyTextTable::SwiftyTextTable::Product" /* SwiftyTextTable.framework */,
+				"SourceKitten::Clang_C::Product" /* Clang_C.framework */,
+				"Yams::Yams::Product" /* Yams.framework */,
+				"SourceKitten::SourceKittenFramework::Product" /* SourceKittenFramework.framework */,
+				"SwiftSyntax::SwiftSyntax::Product" /* SwiftSyntax.framework */,
+				"Commandant::Commandant::Product" /* Commandant.framework */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_62 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_63 /* ASTRule.swift */,
+				OBJ_64 /* CacheDescriptionProvider.swift */,
+				OBJ_65 /* CallPairRule.swift */,
+				OBJ_66 /* Reporter.swift */,
+				OBJ_67 /* Rule.swift */,
+				OBJ_68 /* RuleConfiguration.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		OBJ_69 /* Reporters */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_70 /* CSVReporter.swift */,
+				OBJ_71 /* CheckstyleReporter.swift */,
+				OBJ_72 /* EmojiReporter.swift */,
+				OBJ_73 /* GitHubActionsLoggingReporter.swift */,
+				OBJ_74 /* HTMLReporter.swift */,
+				OBJ_75 /* JSONReporter.swift */,
+				OBJ_76 /* JUnitReporter.swift */,
+				OBJ_77 /* MarkdownReporter.swift */,
+				OBJ_78 /* SonarQubeReporter.swift */,
+				OBJ_79 /* XcodeReporter.swift */,
+			);
+			path = Reporters;
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* SwiftLintFramework */,
+				OBJ_349 /* swiftlint */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* SwiftLintFramework */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Extensions */,
+				OBJ_32 /* Helpers */,
+				OBJ_36 /* Models */,
+				OBJ_62 /* Protocols */,
+				OBJ_69 /* Reporters */,
+				OBJ_80 /* Rules */,
+			);
+			name = SwiftLintFramework;
+			path = Source/SwiftLintFramework;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_80 /* Rules */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_81 /* Idiomatic */,
+				OBJ_148 /* Lint */,
+				OBJ_202 /* Metrics */,
+				OBJ_214 /* Performance */,
+				OBJ_228 /* RuleConfigurations */,
+				OBJ_272 /* Style */,
+			);
+			path = Rules;
+			sourceTree = "<group>";
+		};
+		OBJ_81 /* Idiomatic */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_82 /* BlockBasedKVORule.swift */,
+				OBJ_83 /* ConvenienceTypeRule.swift */,
+				OBJ_84 /* DiscouragedObjectLiteralRule.swift */,
+				OBJ_85 /* DiscouragedOptionalBooleanRule.swift */,
+				OBJ_86 /* DiscouragedOptionalBooleanRuleExamples.swift */,
+				OBJ_87 /* DiscouragedOptionalCollectionExamples.swift */,
+				OBJ_88 /* DiscouragedOptionalCollectionRule.swift */,
+				OBJ_89 /* DuplicateImportsRule.swift */,
+				OBJ_90 /* DuplicateImportsRuleExamples.swift */,
+				OBJ_91 /* ExplicitACLRule.swift */,
+				OBJ_92 /* ExplicitEnumRawValueRule.swift */,
+				OBJ_93 /* ExplicitInitRule.swift */,
+				OBJ_94 /* ExplicitTopLevelACLRule.swift */,
+				OBJ_95 /* ExplicitTypeInterfaceRule.swift */,
+				OBJ_96 /* ExtensionAccessModifierRule.swift */,
+				OBJ_97 /* FallthroughRule.swift */,
+				OBJ_98 /* FatalErrorMessageRule.swift */,
+				OBJ_99 /* FileNameNoSpaceRule.swift */,
+				OBJ_100 /* FileNameRule.swift */,
+				OBJ_101 /* ForWhereRule.swift */,
+				OBJ_102 /* ForceCastRule.swift */,
+				OBJ_103 /* ForceTryRule.swift */,
+				OBJ_104 /* ForceUnwrappingRule.swift */,
+				OBJ_105 /* FunctionDefaultParameterAtEndRule.swift */,
+				OBJ_106 /* GenericTypeNameRule.swift */,
+				OBJ_107 /* ImplicitlyUnwrappedOptionalRule.swift */,
+				OBJ_108 /* IsDisjointRule.swift */,
+				OBJ_109 /* JoinedDefaultParameterRule.swift */,
+				OBJ_110 /* LegacyCGGeometryFunctionsRule.swift */,
+				OBJ_111 /* LegacyConstantRule.swift */,
+				OBJ_112 /* LegacyConstantRuleExamples.swift */,
+				OBJ_113 /* LegacyConstructorRule.swift */,
+				OBJ_114 /* LegacyHashingRule.swift */,
+				OBJ_115 /* LegacyMultipleRule.swift */,
+				OBJ_116 /* LegacyNSGeometryFunctionsRule.swift */,
+				OBJ_117 /* LegacyRandomRule.swift */,
+				OBJ_118 /* NimbleOperatorRule.swift */,
+				OBJ_119 /* NoExtensionAccessModifierRule.swift */,
+				OBJ_120 /* NoFallthroughOnlyRule.swift */,
+				OBJ_121 /* NoFallthroughOnlyRuleExamples.swift */,
+				OBJ_122 /* NoGroupingExtensionRule.swift */,
+				OBJ_123 /* ObjectLiteralRule.swift */,
+				OBJ_124 /* PatternMatchingKeywordsRule.swift */,
+				OBJ_125 /* PrivateOverFilePrivateRule.swift */,
+				OBJ_126 /* RedundantNilCoalescingRule.swift */,
+				OBJ_127 /* RedundantObjcAttributeRule.swift */,
+				OBJ_128 /* RedundantObjcAttributeRuleExamples.swift */,
+				OBJ_129 /* RedundantOptionalInitializationRule.swift */,
+				OBJ_130 /* RedundantSetAccessControlRule.swift */,
+				OBJ_131 /* RedundantStringEnumValueRule.swift */,
+				OBJ_132 /* RedundantTypeAnnotationRule.swift */,
+				OBJ_133 /* RedundantVoidReturnRule.swift */,
+				OBJ_134 /* StaticOperatorRule.swift */,
+				OBJ_135 /* StrictFilePrivateRule.swift */,
+				OBJ_136 /* SyntacticSugarRule.swift */,
+				OBJ_137 /* ToggleBoolRule.swift */,
+				OBJ_138 /* TrailingSemicolonRule.swift */,
+				OBJ_139 /* TypeNameRule.swift */,
+				OBJ_140 /* TypeNameRuleExamples.swift */,
+				OBJ_141 /* UnavailableFunctionRule.swift */,
+				OBJ_142 /* UnneededBreakInSwitchRule.swift */,
+				OBJ_143 /* UntypedErrorInCatchRule.swift */,
+				OBJ_144 /* UnusedEnumeratedRule.swift */,
+				OBJ_145 /* XCTFailMessageRule.swift */,
+				OBJ_146 /* XCTSpecificMatcherRule.swift */,
+				OBJ_147 /* XCTSpecificMatcherRuleExamples.swift */,
+			);
+			path = Idiomatic;
+			sourceTree = "<group>";
+		};
+		OBJ_9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_10 /* Array+SwiftLint.swift */,
+				OBJ_11 /* Configuration+Cache.swift */,
+				OBJ_12 /* Configuration+IndentationStyle.swift */,
+				OBJ_13 /* Configuration+LintableFiles.swift */,
+				OBJ_14 /* Configuration+Merging.swift */,
+				OBJ_15 /* Configuration+Parsing.swift */,
+				OBJ_16 /* Dictionary+SwiftLint.swift */,
+				OBJ_17 /* FileManager+SwiftLint.swift */,
+				OBJ_18 /* NSRange+SwiftLint.swift */,
+				OBJ_19 /* NSRegularExpression+SwiftLint.swift */,
+				OBJ_20 /* QueuedPrint.swift */,
+				OBJ_21 /* RandomAccessCollection+Swiftlint.swift */,
+				OBJ_22 /* Request+DisableSourceKit.swift */,
+				OBJ_23 /* SourceKittenDictionary+Swiftlint.swift */,
+				OBJ_24 /* String+SwiftLint.swift */,
+				OBJ_25 /* String+XML.swift */,
+				OBJ_26 /* SwiftDeclarationAttributeKind+Swiftlint.swift */,
+				OBJ_27 /* SwiftDeclarationKind+SwiftLint.swift */,
+				OBJ_28 /* SwiftExpressionKind.swift */,
+				OBJ_29 /* SwiftLintFile+Cache.swift */,
+				OBJ_30 /* SwiftLintFile+Regex.swift */,
+				OBJ_31 /* SyntaxKind+SwiftLint.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		OBJ_648 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_649 /* CYaml.h in Headers */,
+				OBJ_650 /* yaml.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_658 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_659 /* Index.h in Headers */,
+				OBJ_660 /* BuildSystem.h in Headers */,
+				OBJ_661 /* Documentation.h in Headers */,
+				OBJ_662 /* CXCompilationDatabase.h in Headers */,
+				OBJ_663 /* Clang_C.h in Headers */,
+				OBJ_664 /* CXErrorCode.h in Headers */,
+				OBJ_665 /* CXString.h in Headers */,
+				OBJ_666 /* Platform.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_711 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_712 /* SourceKit.h in Headers */,
+				OBJ_713 /* sourcekitd.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		"Commandant::Commandant" /* Commandant */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_669 /* Build configuration list for PBXNativeTarget "Commandant" */;
+			buildPhases = (
+				OBJ_672 /* Sources */,
+				OBJ_683 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Commandant;
+			productName = Commandant;
+			productReference = "Commandant::Commandant::Product" /* Commandant.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"Commandant::SwiftPMPackageDescription" /* CommandantPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_685 /* Build configuration list for PBXNativeTarget "CommandantPackageDescription" */;
+			buildPhases = (
+				OBJ_688 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CommandantPackageDescription;
+			productName = CommandantPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SWXMLHash::SWXMLHash" /* SWXMLHash */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_691 /* Build configuration list for PBXNativeTarget "SWXMLHash" */;
+			buildPhases = (
+				OBJ_694 /* Sources */,
+				OBJ_698 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SWXMLHash;
+			productName = SWXMLHash;
+			productReference = "SWXMLHash::SWXMLHash::Product" /* SWXMLHash.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SWXMLHash::SwiftPMPackageDescription" /* SWXMLHashPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_700 /* Build configuration list for PBXNativeTarget "SWXMLHashPackageDescription" */;
+			buildPhases = (
+				OBJ_703 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SWXMLHashPackageDescription;
+			productName = SWXMLHashPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SourceKitten::Clang_C" /* Clang_C */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_653 /* Build configuration list for PBXNativeTarget "Clang_C" */;
+			buildPhases = (
+				OBJ_656 /* Sources */,
+				OBJ_658 /* Headers */,
+				OBJ_667 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Clang_C;
+			productName = Clang_C;
+			productReference = "SourceKitten::Clang_C::Product" /* Clang_C.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SourceKitten::SourceKit" /* SourceKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_706 /* Build configuration list for PBXNativeTarget "SourceKit" */;
+			buildPhases = (
+				OBJ_709 /* Sources */,
+				OBJ_711 /* Headers */,
+				OBJ_714 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SourceKit;
+			productName = SourceKit;
+			productReference = "SourceKitten::SourceKit::Product" /* SourceKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SourceKitten::SourceKittenFramework" /* SourceKittenFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_716 /* Build configuration list for PBXNativeTarget "SourceKittenFramework" */;
+			buildPhases = (
+				OBJ_719 /* Sources */,
+				OBJ_764 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_770 /* PBXTargetDependency */,
+				OBJ_772 /* PBXTargetDependency */,
+				OBJ_773 /* PBXTargetDependency */,
+				OBJ_774 /* PBXTargetDependency */,
+				OBJ_775 /* PBXTargetDependency */,
+			);
+			name = SourceKittenFramework;
+			productName = SourceKittenFramework;
+			productReference = "SourceKitten::SourceKittenFramework::Product" /* SourceKittenFramework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SourceKitten::SwiftPMPackageDescription" /* SourceKittenPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_777 /* Build configuration list for PBXNativeTarget "SourceKittenPackageDescription" */;
+			buildPhases = (
+				OBJ_780 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SourceKittenPackageDescription;
+			productName = SourceKittenPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftLint::SwiftLintFramework" /* SwiftLintFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_783 /* Build configuration list for PBXNativeTarget "SwiftLintFramework" */;
+			buildPhases = (
+				OBJ_786 /* Sources */,
+				OBJ_1115 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1124 /* PBXTargetDependency */,
+				OBJ_1126 /* PBXTargetDependency */,
+				OBJ_1128 /* PBXTargetDependency */,
+				OBJ_1129 /* PBXTargetDependency */,
+				OBJ_1130 /* PBXTargetDependency */,
+				OBJ_1131 /* PBXTargetDependency */,
+				OBJ_1132 /* PBXTargetDependency */,
+				OBJ_1133 /* PBXTargetDependency */,
+			);
+			name = SwiftLintFramework;
+			productName = SwiftLintFramework;
+			productReference = "SwiftLint::SwiftLintFramework::Product" /* SwiftLintFramework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftLint::SwiftLintFrameworkTests" /* SwiftLintFrameworkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1135 /* Build configuration list for PBXNativeTarget "SwiftLintFrameworkTests" */;
+			buildPhases = (
+				OBJ_1138 /* Sources */,
+				OBJ_1213 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1223 /* PBXTargetDependency */,
+				OBJ_1224 /* PBXTargetDependency */,
+				OBJ_1225 /* PBXTargetDependency */,
+				OBJ_1226 /* PBXTargetDependency */,
+				OBJ_1227 /* PBXTargetDependency */,
+				OBJ_1228 /* PBXTargetDependency */,
+				OBJ_1229 /* PBXTargetDependency */,
+				OBJ_1230 /* PBXTargetDependency */,
+				OBJ_1231 /* PBXTargetDependency */,
+			);
+			name = SwiftLintFrameworkTests;
+			productName = SwiftLintFrameworkTests;
+			productReference = "SwiftLint::SwiftLintFrameworkTests::Product" /* SwiftLintFrameworkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"SwiftLint::SwiftPMPackageDescription" /* SwiftLintPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1233 /* Build configuration list for PBXNativeTarget "SwiftLintPackageDescription" */;
+			buildPhases = (
+				OBJ_1236 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftLintPackageDescription;
+			productName = SwiftLintPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftLint::swiftlint" /* swiftlint */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1333 /* Build configuration list for PBXNativeTarget "swiftlint" */;
+			buildPhases = (
+				OBJ_1336 /* Sources */,
+				OBJ_1352 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1364 /* PBXTargetDependency */,
+				OBJ_1365 /* PBXTargetDependency */,
+				OBJ_1366 /* PBXTargetDependency */,
+				OBJ_1367 /* PBXTargetDependency */,
+				OBJ_1368 /* PBXTargetDependency */,
+				OBJ_1369 /* PBXTargetDependency */,
+				OBJ_1370 /* PBXTargetDependency */,
+				OBJ_1371 /* PBXTargetDependency */,
+				OBJ_1372 /* PBXTargetDependency */,
+				OBJ_1373 /* PBXTargetDependency */,
+				OBJ_1374 /* PBXTargetDependency */,
+			);
+			name = swiftlint;
+			productName = swiftlint;
+			productReference = "SwiftLint::swiftlint::Product" /* swiftlint */;
+			productType = "com.apple.product-type.tool";
+		};
+		"SwiftSyntax::SwiftPMPackageDescription" /* SwiftSyntaxPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1279 /* Build configuration list for PBXNativeTarget "SwiftSyntaxPackageDescription" */;
+			buildPhases = (
+				OBJ_1282 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftSyntaxPackageDescription;
+			productName = SwiftSyntaxPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftSyntax::SwiftSyntax" /* SwiftSyntax */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1243 /* Build configuration list for PBXNativeTarget "SwiftSyntax" */;
+			buildPhases = (
+				OBJ_1246 /* Sources */,
+				OBJ_1275 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1277 /* PBXTargetDependency */,
+			);
+			name = SwiftSyntax;
+			productName = SwiftSyntax;
+			productReference = "SwiftSyntax::SwiftSyntax::Product" /* SwiftSyntax.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftSyntax::_CSwiftSyntax" /* _CSwiftSyntax */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1326 /* Build configuration list for PBXNativeTarget "_CSwiftSyntax" */;
+			buildPhases = (
+				OBJ_1329 /* Sources */,
+				OBJ_1331 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = _CSwiftSyntax;
+			productName = _CSwiftSyntax;
+			productReference = "SwiftSyntax::_CSwiftSyntax::Product" /* _CSwiftSyntax.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftyTextTable::SwiftPMPackageDescription" /* SwiftyTextTablePackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1292 /* Build configuration list for PBXNativeTarget "SwiftyTextTablePackageDescription" */;
+			buildPhases = (
+				OBJ_1295 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftyTextTablePackageDescription;
+			productName = SwiftyTextTablePackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftyTextTable::SwiftyTextTable" /* SwiftyTextTable */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1285 /* Build configuration list for PBXNativeTarget "SwiftyTextTable" */;
+			buildPhases = (
+				OBJ_1288 /* Sources */,
+				OBJ_1290 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftyTextTable;
+			productName = SwiftyTextTable;
+			productReference = "SwiftyTextTable::SwiftyTextTable::Product" /* SwiftyTextTable.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"Yams::CYaml" /* CYaml */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_638 /* Build configuration list for PBXNativeTarget "CYaml" */;
+			buildPhases = (
+				OBJ_641 /* Sources */,
+				OBJ_648 /* Headers */,
+				OBJ_651 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CYaml;
+			productName = CYaml;
+			productReference = "Yams::CYaml::Product" /* CYaml.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"Yams::SwiftPMPackageDescription" /* YamsPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1321 /* Build configuration list for PBXNativeTarget "YamsPackageDescription" */;
+			buildPhases = (
+				OBJ_1324 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = YamsPackageDescription;
+			productName = YamsPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"Yams::Yams" /* Yams */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1297 /* Build configuration list for PBXNativeTarget "Yams" */;
+			buildPhases = (
+				OBJ_1300 /* Sources */,
+				OBJ_1317 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1319 /* PBXTargetDependency */,
+			);
+			name = Yams;
+			productName = Yams;
+			productReference = "Yams::Yams::Product" /* Yams.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftMigration = 9999;
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "SwiftLint" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_600 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"Yams::CYaml" /* CYaml */,
+				"SourceKitten::Clang_C" /* Clang_C */,
+				"Commandant::Commandant" /* Commandant */,
+				"Commandant::SwiftPMPackageDescription" /* CommandantPackageDescription */,
+				"SWXMLHash::SWXMLHash" /* SWXMLHash */,
+				"SWXMLHash::SwiftPMPackageDescription" /* SWXMLHashPackageDescription */,
+				"SourceKitten::SourceKit" /* SourceKit */,
+				"SourceKitten::SourceKittenFramework" /* SourceKittenFramework */,
+				"SourceKitten::SwiftPMPackageDescription" /* SourceKittenPackageDescription */,
+				"SwiftLint::SwiftLintFramework" /* SwiftLintFramework */,
+				"SwiftLint::SwiftLintFrameworkTests" /* SwiftLintFrameworkTests */,
+				"SwiftLint::SwiftPMPackageDescription" /* SwiftLintPackageDescription */,
+				"SwiftLint::SwiftLintPackageTests::ProductTarget" /* SwiftLintPackageTests */,
+				"SwiftSyntax::SwiftSyntax" /* SwiftSyntax */,
+				"SwiftSyntax::SwiftPMPackageDescription" /* SwiftSyntaxPackageDescription */,
+				"SwiftyTextTable::SwiftyTextTable" /* SwiftyTextTable */,
+				"SwiftyTextTable::SwiftPMPackageDescription" /* SwiftyTextTablePackageDescription */,
+				"Yams::Yams" /* Yams */,
+				"Yams::SwiftPMPackageDescription" /* YamsPackageDescription */,
+				"SwiftSyntax::_CSwiftSyntax" /* _CSwiftSyntax */,
+				"SwiftLint::swiftlint" /* swiftlint */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_1138 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1139 /* AttributesRuleTests.swift in Sources */,
+				OBJ_1140 /* AutomaticRuleTests.generated.swift in Sources */,
+				OBJ_1141 /* CollectingRuleTests.swift in Sources */,
+				OBJ_1142 /* CollectionAlignmentRuleTests.swift in Sources */,
+				OBJ_1143 /* ColonRuleTests.swift in Sources */,
+				OBJ_1144 /* CommandTests.swift in Sources */,
+				OBJ_1145 /* CompilerProtocolInitRuleTests.swift in Sources */,
+				OBJ_1146 /* ConditionalReturnsOnNewlineRuleTests.swift in Sources */,
+				OBJ_1147 /* ConfigurationAliasesTests.swift in Sources */,
+				OBJ_1148 /* ConfigurationTests+Nested.swift in Sources */,
+				OBJ_1149 /* ConfigurationTests+ProjectMock.swift in Sources */,
+				OBJ_1150 /* ConfigurationTests.swift in Sources */,
+				OBJ_1151 /* ContainsOverFirstNotNilRuleTests.swift in Sources */,
+				OBJ_1152 /* CustomRulesTests.swift in Sources */,
+				OBJ_1153 /* CyclomaticComplexityConfigurationTests.swift in Sources */,
+				OBJ_1154 /* CyclomaticComplexityRuleTests.swift in Sources */,
+				OBJ_1155 /* DeploymentTargetConfigurationTests.swift in Sources */,
+				OBJ_1156 /* DeploymentTargetRuleTests.swift in Sources */,
+				OBJ_1157 /* DisableAllTests.swift in Sources */,
+				OBJ_1158 /* DiscouragedDirectInitRuleTests.swift in Sources */,
+				OBJ_1159 /* DiscouragedObjectLiteralRuleTests.swift in Sources */,
+				OBJ_1160 /* DocumentationTests.swift in Sources */,
+				OBJ_1161 /* ExpiringTodoRuleTests.swift in Sources */,
+				OBJ_1162 /* ExplicitTypeInterfaceConfigurationTests.swift in Sources */,
+				OBJ_1163 /* ExplicitTypeInterfaceRuleTests.swift in Sources */,
+				OBJ_1164 /* ExtendedNSStringTests.swift in Sources */,
+				OBJ_1165 /* FileHeaderRuleTests.swift in Sources */,
+				OBJ_1166 /* FileLengthRuleTests.swift in Sources */,
+				OBJ_1167 /* FileNameNoSpaceRuleTests.swift in Sources */,
+				OBJ_1168 /* FileNameRuleTests.swift in Sources */,
+				OBJ_1169 /* FileTypesOrderRuleTests.swift in Sources */,
+				OBJ_1170 /* FunctionBodyLengthRuleTests.swift in Sources */,
+				OBJ_1171 /* FunctionParameterCountRuleTests.swift in Sources */,
+				OBJ_1172 /* GenericTypeNameRuleTests.swift in Sources */,
+				OBJ_1173 /* GlobTests.swift in Sources */,
+				OBJ_1174 /* IdentifierNameRuleTests.swift in Sources */,
+				OBJ_1175 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift in Sources */,
+				OBJ_1176 /* ImplicitlyUnwrappedOptionalRuleTests.swift in Sources */,
+				OBJ_1177 /* IntegrationTests.swift in Sources */,
+				OBJ_1178 /* LineLengthConfigurationTests.swift in Sources */,
+				OBJ_1179 /* LineLengthRuleTests.swift in Sources */,
+				OBJ_1180 /* LinterCacheTests.swift in Sources */,
+				OBJ_1181 /* MissingDocsRuleConfigurationTests.swift in Sources */,
+				OBJ_1182 /* ModifierOrderTests.swift in Sources */,
+				OBJ_1183 /* MultilineArgumentsRuleTests.swift in Sources */,
+				OBJ_1184 /* NumberSeparatorRuleTests.swift in Sources */,
+				OBJ_1185 /* ObjectLiteralRuleTests.swift in Sources */,
+				OBJ_1186 /* PrefixedTopLevelConstantRuleTests.swift in Sources */,
+				OBJ_1187 /* PrivateOutletRuleTests.swift in Sources */,
+				OBJ_1188 /* PrivateOverFilePrivateRuleTests.swift in Sources */,
+				OBJ_1189 /* RegionTests.swift in Sources */,
+				OBJ_1190 /* ReporterTests.swift in Sources */,
+				OBJ_1191 /* RequiredEnumCaseRuleTestCase.swift in Sources */,
+				OBJ_1192 /* RuleConfigurationTests.swift in Sources */,
+				OBJ_1193 /* RuleDescription+Examples.swift in Sources */,
+				OBJ_1194 /* RuleTests.swift in Sources */,
+				OBJ_1195 /* RulesTests.swift in Sources */,
+				OBJ_1196 /* SourceKitCrashTests.swift in Sources */,
+				OBJ_1197 /* StatementPositionRuleTests.swift in Sources */,
+				OBJ_1198 /* SwitchCaseAlignmentRuleTests.swift in Sources */,
+				OBJ_1199 /* TestHelpers.swift in Sources */,
+				OBJ_1200 /* TodoRuleTests.swift in Sources */,
+				OBJ_1201 /* TrailingClosureConfigurationTests.swift in Sources */,
+				OBJ_1202 /* TrailingClosureRuleTests.swift in Sources */,
+				OBJ_1203 /* TrailingCommaRuleTests.swift in Sources */,
+				OBJ_1204 /* TrailingWhitespaceTests.swift in Sources */,
+				OBJ_1205 /* TypeContentsOrderRuleTests.swift in Sources */,
+				OBJ_1206 /* TypeNameRuleTests.swift in Sources */,
+				OBJ_1207 /* UnusedOptionalBindingRuleTests.swift in Sources */,
+				OBJ_1208 /* VerticalWhitespaceRuleTests.swift in Sources */,
+				OBJ_1209 /* XCTSpecificMatcherRuleTests.swift in Sources */,
+				OBJ_1210 /* XCTestCase+BundlePath.swift in Sources */,
+				OBJ_1211 /* YamlParserTests.swift in Sources */,
+				OBJ_1212 /* YamlSwiftLintTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1236 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1237 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1246 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1247 /* AbsolutePosition.swift in Sources */,
+				OBJ_1248 /* AtomicCounter.swift in Sources */,
+				OBJ_1249 /* Diagnostic.swift in Sources */,
+				OBJ_1250 /* DiagnosticConsumer.swift in Sources */,
+				OBJ_1251 /* DiagnosticEngine.swift in Sources */,
+				OBJ_1252 /* IncrementalParseTransition.swift in Sources */,
+				OBJ_1253 /* JSONDiagnosticConsumer.swift in Sources */,
+				OBJ_1254 /* PrintingDiagnosticConsumer.swift in Sources */,
+				OBJ_1255 /* RawSyntax.swift in Sources */,
+				OBJ_1256 /* SourceLength.swift in Sources */,
+				OBJ_1257 /* SourceLocation.swift in Sources */,
+				OBJ_1258 /* SourcePresence.swift in Sources */,
+				OBJ_1259 /* Syntax.swift in Sources */,
+				OBJ_1260 /* SyntaxChildren.swift in Sources */,
+				OBJ_1261 /* SyntaxClassifier.swift in Sources */,
+				OBJ_1262 /* SyntaxData.swift in Sources */,
+				OBJ_1263 /* SyntaxParser.swift in Sources */,
+				OBJ_1264 /* SyntaxVerifier.swift in Sources */,
+				OBJ_1265 /* Utils.swift in Sources */,
+				OBJ_1266 /* SyntaxBuilders.swift in Sources */,
+				OBJ_1267 /* SyntaxClassification.swift in Sources */,
+				OBJ_1268 /* SyntaxCollections.swift in Sources */,
+				OBJ_1269 /* SyntaxFactory.swift in Sources */,
+				OBJ_1270 /* SyntaxKind.swift in Sources */,
+				OBJ_1271 /* SyntaxNodes.swift in Sources */,
+				OBJ_1272 /* SyntaxRewriter.swift in Sources */,
+				OBJ_1273 /* TokenKind.swift in Sources */,
+				OBJ_1274 /* Trivia.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1282 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1283 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1288 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1289 /* TextTable.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1295 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1296 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1300 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1301 /* Constructor.swift in Sources */,
+				OBJ_1302 /* Decoder.swift in Sources */,
+				OBJ_1303 /* Emitter.swift in Sources */,
+				OBJ_1304 /* Encoder.swift in Sources */,
+				OBJ_1305 /* Mark.swift in Sources */,
+				OBJ_1306 /* Node.Mapping.swift in Sources */,
+				OBJ_1307 /* Node.Scalar.swift in Sources */,
+				OBJ_1308 /* Node.Sequence.swift in Sources */,
+				OBJ_1309 /* Node.swift in Sources */,
+				OBJ_1310 /* Parser.swift in Sources */,
+				OBJ_1311 /* Representer.swift in Sources */,
+				OBJ_1312 /* Resolver.swift in Sources */,
+				OBJ_1313 /* String+Yams.swift in Sources */,
+				OBJ_1314 /* Tag.swift in Sources */,
+				OBJ_1315 /* YamlError.swift in Sources */,
+				OBJ_1316 /* shim.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1324 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1325 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1329 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1330 /* atomic-counter.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1336 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1337 /* AnalyzeCommand.swift in Sources */,
+				OBJ_1338 /* AutoCorrectCommand.swift in Sources */,
+				OBJ_1339 /* GenerateDocsCommand.swift in Sources */,
+				OBJ_1340 /* LintCommand.swift in Sources */,
+				OBJ_1341 /* RulesCommand.swift in Sources */,
+				OBJ_1342 /* VersionCommand.swift in Sources */,
+				OBJ_1343 /* Array+SwiftLint.swift in Sources */,
+				OBJ_1344 /* Configuration+CommandLine.swift in Sources */,
+				OBJ_1345 /* Reporter+CommandLine.swift in Sources */,
+				OBJ_1346 /* Benchmark.swift in Sources */,
+				OBJ_1347 /* CommonOptions.swift in Sources */,
+				OBJ_1348 /* CompilerArgumentsExtractor.swift in Sources */,
+				OBJ_1349 /* LintOrAnalyzeCommand.swift in Sources */,
+				OBJ_1350 /* LintableFilesVisitor.swift in Sources */,
+				OBJ_1351 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_641 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_642 /* api.c in Sources */,
+				OBJ_643 /* emitter.c in Sources */,
+				OBJ_644 /* parser.c in Sources */,
+				OBJ_645 /* reader.c in Sources */,
+				OBJ_646 /* scanner.c in Sources */,
+				OBJ_647 /* writer.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_656 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_657 /* Clang_C.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_672 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_673 /* Argument.swift in Sources */,
+				OBJ_674 /* ArgumentParser.swift in Sources */,
+				OBJ_675 /* ArgumentProtocol.swift in Sources */,
+				OBJ_676 /* Command.swift in Sources */,
+				OBJ_677 /* Errors.swift in Sources */,
+				OBJ_678 /* HelpCommand.swift in Sources */,
+				OBJ_679 /* Option.swift in Sources */,
+				OBJ_680 /* OrderedSet.swift in Sources */,
+				OBJ_681 /* Result+Additions.swift in Sources */,
+				OBJ_682 /* Switch.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_688 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_689 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_694 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_695 /* SWXMLHash.swift in Sources */,
+				OBJ_696 /* XMLIndexer+XMLIndexerDeserializable.swift in Sources */,
+				OBJ_697 /* shim.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_703 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_704 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_709 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_710 /* SourceKit.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_719 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_720 /* Clang+SourceKitten.swift in Sources */,
+				OBJ_721 /* ClangTranslationUnit.swift in Sources */,
+				OBJ_722 /* CodeCompletionItem.swift in Sources */,
+				OBJ_723 /* CursorInfo+Parsing.swift in Sources */,
+				OBJ_724 /* Dictionary+Merge.swift in Sources */,
+				OBJ_725 /* Documentation.swift in Sources */,
+				OBJ_726 /* Exec.swift in Sources */,
+				OBJ_727 /* File+Hashable.swift in Sources */,
+				OBJ_728 /* File.swift in Sources */,
+				OBJ_729 /* JSONOutput.swift in Sources */,
+				OBJ_730 /* Language.swift in Sources */,
+				OBJ_731 /* Line.swift in Sources */,
+				OBJ_732 /* LinuxCompatibility.swift in Sources */,
+				OBJ_733 /* Module.swift in Sources */,
+				OBJ_734 /* ObjCDeclarationKind.swift in Sources */,
+				OBJ_735 /* OffsetMap.swift in Sources */,
+				OBJ_736 /* Parameter.swift in Sources */,
+				OBJ_737 /* Request.swift in Sources */,
+				OBJ_738 /* SourceDeclaration.swift in Sources */,
+				OBJ_739 /* SourceKitObject.swift in Sources */,
+				OBJ_740 /* SourceLocation.swift in Sources */,
+				OBJ_741 /* StatementKind.swift in Sources */,
+				OBJ_742 /* String+SourceKitten.swift in Sources */,
+				OBJ_743 /* StringView+SourceKitten.swift in Sources */,
+				OBJ_744 /* StringView.swift in Sources */,
+				OBJ_745 /* Structure.swift in Sources */,
+				OBJ_746 /* SwiftDeclarationAttributeKind.swift in Sources */,
+				OBJ_747 /* SwiftDeclarationKind.swift in Sources */,
+				OBJ_748 /* SwiftDocKey.swift in Sources */,
+				OBJ_749 /* SwiftDocs.swift in Sources */,
+				OBJ_750 /* SyntaxKind.swift in Sources */,
+				OBJ_751 /* SyntaxMap.swift in Sources */,
+				OBJ_752 /* SyntaxToken.swift in Sources */,
+				OBJ_753 /* Text.swift in Sources */,
+				OBJ_754 /* UID.swift in Sources */,
+				OBJ_755 /* UIDRepresentable.swift in Sources */,
+				OBJ_756 /* Version.swift in Sources */,
+				OBJ_757 /* Xcode.swift in Sources */,
+				OBJ_758 /* XcodeBuildSetting.swift in Sources */,
+				OBJ_759 /* library_wrapper.swift in Sources */,
+				OBJ_760 /* library_wrapper_CXString.swift in Sources */,
+				OBJ_761 /* library_wrapper_Documentation.swift in Sources */,
+				OBJ_762 /* library_wrapper_Index.swift in Sources */,
+				OBJ_763 /* library_wrapper_sourcekitd.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_780 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_781 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_786 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_787 /* Array+SwiftLint.swift in Sources */,
+				OBJ_788 /* Configuration+Cache.swift in Sources */,
+				OBJ_789 /* Configuration+IndentationStyle.swift in Sources */,
+				OBJ_790 /* Configuration+LintableFiles.swift in Sources */,
+				OBJ_791 /* Configuration+Merging.swift in Sources */,
+				OBJ_792 /* Configuration+Parsing.swift in Sources */,
+				OBJ_793 /* Dictionary+SwiftLint.swift in Sources */,
+				OBJ_794 /* FileManager+SwiftLint.swift in Sources */,
+				OBJ_795 /* NSRange+SwiftLint.swift in Sources */,
+				OBJ_796 /* NSRegularExpression+SwiftLint.swift in Sources */,
+				OBJ_797 /* QueuedPrint.swift in Sources */,
+				OBJ_798 /* RandomAccessCollection+Swiftlint.swift in Sources */,
+				OBJ_799 /* Request+DisableSourceKit.swift in Sources */,
+				OBJ_800 /* SourceKittenDictionary+Swiftlint.swift in Sources */,
+				OBJ_801 /* String+SwiftLint.swift in Sources */,
+				OBJ_802 /* String+XML.swift in Sources */,
+				OBJ_803 /* SwiftDeclarationAttributeKind+Swiftlint.swift in Sources */,
+				OBJ_804 /* SwiftDeclarationKind+SwiftLint.swift in Sources */,
+				OBJ_805 /* SwiftExpressionKind.swift in Sources */,
+				OBJ_806 /* SwiftLintFile+Cache.swift in Sources */,
+				OBJ_807 /* SwiftLintFile+Regex.swift in Sources */,
+				OBJ_808 /* SyntaxKind+SwiftLint.swift in Sources */,
+				OBJ_809 /* Glob.swift in Sources */,
+				OBJ_810 /* NamespaceCollector.swift in Sources */,
+				OBJ_811 /* RegexHelpers.swift in Sources */,
+				OBJ_812 /* AccessControlLevel.swift in Sources */,
+				OBJ_813 /* Command.swift in Sources */,
+				OBJ_814 /* Configuration.swift in Sources */,
+				OBJ_815 /* ConfigurationError.swift in Sources */,
+				OBJ_816 /* Correction.swift in Sources */,
+				OBJ_817 /* Linter.swift in Sources */,
+				OBJ_818 /* LinterCache.swift in Sources */,
+				OBJ_819 /* Location.swift in Sources */,
+				OBJ_820 /* MasterRuleList.swift in Sources */,
+				OBJ_821 /* Region.swift in Sources */,
+				OBJ_822 /* RuleDescription.swift in Sources */,
+				OBJ_823 /* RuleIdentifier.swift in Sources */,
+				OBJ_824 /* RuleKind.swift in Sources */,
+				OBJ_825 /* RuleList+Documentation.swift in Sources */,
+				OBJ_826 /* RuleList.swift in Sources */,
+				OBJ_827 /* RuleParameter.swift in Sources */,
+				OBJ_828 /* RuleStorage.swift in Sources */,
+				OBJ_829 /* StyleViolation.swift in Sources */,
+				OBJ_830 /* SwiftLintFile.swift in Sources */,
+				OBJ_831 /* SwiftLintSyntaxMap.swift in Sources */,
+				OBJ_832 /* SwiftLintSyntaxToken.swift in Sources */,
+				OBJ_833 /* SwiftVersion.swift in Sources */,
+				OBJ_834 /* Version.swift in Sources */,
+				OBJ_835 /* ViolationSeverity.swift in Sources */,
+				OBJ_836 /* YamlParser.swift in Sources */,
+				OBJ_837 /* ASTRule.swift in Sources */,
+				OBJ_838 /* CacheDescriptionProvider.swift in Sources */,
+				OBJ_839 /* CallPairRule.swift in Sources */,
+				OBJ_840 /* Reporter.swift in Sources */,
+				OBJ_841 /* Rule.swift in Sources */,
+				OBJ_842 /* RuleConfiguration.swift in Sources */,
+				OBJ_843 /* CSVReporter.swift in Sources */,
+				OBJ_844 /* CheckstyleReporter.swift in Sources */,
+				OBJ_845 /* EmojiReporter.swift in Sources */,
+				OBJ_846 /* GitHubActionsLoggingReporter.swift in Sources */,
+				OBJ_847 /* HTMLReporter.swift in Sources */,
+				OBJ_848 /* JSONReporter.swift in Sources */,
+				OBJ_849 /* JUnitReporter.swift in Sources */,
+				OBJ_850 /* MarkdownReporter.swift in Sources */,
+				OBJ_851 /* SonarQubeReporter.swift in Sources */,
+				OBJ_852 /* XcodeReporter.swift in Sources */,
+				OBJ_853 /* BlockBasedKVORule.swift in Sources */,
+				OBJ_854 /* ConvenienceTypeRule.swift in Sources */,
+				OBJ_855 /* DiscouragedObjectLiteralRule.swift in Sources */,
+				OBJ_856 /* DiscouragedOptionalBooleanRule.swift in Sources */,
+				OBJ_857 /* DiscouragedOptionalBooleanRuleExamples.swift in Sources */,
+				OBJ_858 /* DiscouragedOptionalCollectionExamples.swift in Sources */,
+				OBJ_859 /* DiscouragedOptionalCollectionRule.swift in Sources */,
+				OBJ_860 /* DuplicateImportsRule.swift in Sources */,
+				OBJ_861 /* DuplicateImportsRuleExamples.swift in Sources */,
+				OBJ_862 /* ExplicitACLRule.swift in Sources */,
+				OBJ_863 /* ExplicitEnumRawValueRule.swift in Sources */,
+				OBJ_864 /* ExplicitInitRule.swift in Sources */,
+				OBJ_865 /* ExplicitTopLevelACLRule.swift in Sources */,
+				D4A115F323C2194400D1122A /* ReturnValueFromVoidFunctionRuleExamples.swift in Sources */,
+				OBJ_866 /* ExplicitTypeInterfaceRule.swift in Sources */,
+				OBJ_867 /* ExtensionAccessModifierRule.swift in Sources */,
+				OBJ_868 /* FallthroughRule.swift in Sources */,
+				OBJ_869 /* FatalErrorMessageRule.swift in Sources */,
+				OBJ_870 /* FileNameNoSpaceRule.swift in Sources */,
+				OBJ_871 /* FileNameRule.swift in Sources */,
+				OBJ_872 /* ForWhereRule.swift in Sources */,
+				OBJ_873 /* ForceCastRule.swift in Sources */,
+				OBJ_874 /* ForceTryRule.swift in Sources */,
+				OBJ_875 /* ForceUnwrappingRule.swift in Sources */,
+				OBJ_876 /* FunctionDefaultParameterAtEndRule.swift in Sources */,
+				OBJ_877 /* GenericTypeNameRule.swift in Sources */,
+				OBJ_878 /* ImplicitlyUnwrappedOptionalRule.swift in Sources */,
+				OBJ_879 /* IsDisjointRule.swift in Sources */,
+				OBJ_880 /* JoinedDefaultParameterRule.swift in Sources */,
+				OBJ_881 /* LegacyCGGeometryFunctionsRule.swift in Sources */,
+				OBJ_882 /* LegacyConstantRule.swift in Sources */,
+				OBJ_883 /* LegacyConstantRuleExamples.swift in Sources */,
+				OBJ_884 /* LegacyConstructorRule.swift in Sources */,
+				OBJ_885 /* LegacyHashingRule.swift in Sources */,
+				OBJ_886 /* LegacyMultipleRule.swift in Sources */,
+				OBJ_887 /* LegacyNSGeometryFunctionsRule.swift in Sources */,
+				OBJ_888 /* LegacyRandomRule.swift in Sources */,
+				OBJ_889 /* NimbleOperatorRule.swift in Sources */,
+				OBJ_890 /* NoExtensionAccessModifierRule.swift in Sources */,
+				OBJ_891 /* NoFallthroughOnlyRule.swift in Sources */,
+				OBJ_892 /* NoFallthroughOnlyRuleExamples.swift in Sources */,
+				OBJ_893 /* NoGroupingExtensionRule.swift in Sources */,
+				OBJ_894 /* ObjectLiteralRule.swift in Sources */,
+				OBJ_895 /* PatternMatchingKeywordsRule.swift in Sources */,
+				OBJ_896 /* PrivateOverFilePrivateRule.swift in Sources */,
+				OBJ_897 /* RedundantNilCoalescingRule.swift in Sources */,
+				OBJ_898 /* RedundantObjcAttributeRule.swift in Sources */,
+				OBJ_899 /* RedundantObjcAttributeRuleExamples.swift in Sources */,
+				OBJ_900 /* RedundantOptionalInitializationRule.swift in Sources */,
+				OBJ_901 /* RedundantSetAccessControlRule.swift in Sources */,
+				OBJ_902 /* RedundantStringEnumValueRule.swift in Sources */,
+				OBJ_903 /* RedundantTypeAnnotationRule.swift in Sources */,
+				OBJ_904 /* RedundantVoidReturnRule.swift in Sources */,
+				OBJ_905 /* StaticOperatorRule.swift in Sources */,
+				OBJ_906 /* StrictFilePrivateRule.swift in Sources */,
+				OBJ_907 /* SyntacticSugarRule.swift in Sources */,
+				OBJ_908 /* ToggleBoolRule.swift in Sources */,
+				OBJ_909 /* TrailingSemicolonRule.swift in Sources */,
+				OBJ_910 /* TypeNameRule.swift in Sources */,
+				OBJ_911 /* TypeNameRuleExamples.swift in Sources */,
+				OBJ_912 /* UnavailableFunctionRule.swift in Sources */,
+				OBJ_913 /* UnneededBreakInSwitchRule.swift in Sources */,
+				OBJ_914 /* UntypedErrorInCatchRule.swift in Sources */,
+				OBJ_915 /* UnusedEnumeratedRule.swift in Sources */,
+				OBJ_916 /* XCTFailMessageRule.swift in Sources */,
+				OBJ_917 /* XCTSpecificMatcherRule.swift in Sources */,
+				OBJ_918 /* XCTSpecificMatcherRuleExamples.swift in Sources */,
+				OBJ_919 /* AnyObjectProtocolRule.swift in Sources */,
+				OBJ_920 /* ArrayInitRule.swift in Sources */,
+				OBJ_921 /* ClassDelegateProtocolRule.swift in Sources */,
+				OBJ_922 /* CompilerProtocolInitRule.swift in Sources */,
+				OBJ_923 /* DeploymentTargetRule.swift in Sources */,
+				OBJ_924 /* DiscardedNotificationCenterObserverRule.swift in Sources */,
+				OBJ_925 /* DiscouragedDirectInitRule.swift in Sources */,
+				OBJ_926 /* DuplicateEnumCasesRule.swift in Sources */,
+				OBJ_927 /* DynamicInlineRule.swift in Sources */,
+				OBJ_928 /* EmptyXCTestMethodRule.swift in Sources */,
+				OBJ_929 /* EmptyXCTestMethodRuleExamples.swift in Sources */,
+				OBJ_930 /* ExpiringTodoRule.swift in Sources */,
+				OBJ_931 /* IdenticalOperandsRule.swift in Sources */,
+				OBJ_932 /* InertDeferRule.swift in Sources */,
+				OBJ_933 /* LowerACLThanParentRule.swift in Sources */,
+				OBJ_934 /* MarkRule.swift in Sources */,
+				OBJ_935 /* MissingDocsRule.swift in Sources */,
+				OBJ_936 /* NSLocalizedStringKeyRule.swift in Sources */,
+				OBJ_937 /* NSLocalizedStringRequireBundleRule.swift in Sources */,
+				OBJ_938 /* NSObjectPreferIsEqualRule.swift in Sources */,
+				OBJ_939 /* NSObjectPreferIsEqualRuleExamples.swift in Sources */,
+				OBJ_940 /* NotificationCenterDetachmentRule.swift in Sources */,
+				OBJ_941 /* NotificationCenterDetachmentRuleExamples.swift in Sources */,
+				OBJ_942 /* OverriddenSuperCallRule.swift in Sources */,
+				OBJ_943 /* OverrideInExtensionRule.swift in Sources */,
+				OBJ_944 /* PrivateActionRule.swift in Sources */,
+				OBJ_945 /* PrivateOutletRule.swift in Sources */,
+				OBJ_946 /* PrivateUnitTestRule.swift in Sources */,
+				OBJ_947 /* ProhibitedInterfaceBuilderRule.swift in Sources */,
+				OBJ_948 /* ProhibitedSuperRule.swift in Sources */,
+				OBJ_949 /* QuickDiscouragedCallRule.swift in Sources */,
+				OBJ_950 /* QuickDiscouragedCallRuleExamples.swift in Sources */,
+				OBJ_951 /* QuickDiscouragedFocusedTestRule.swift in Sources */,
+				OBJ_952 /* QuickDiscouragedFocusedTestRuleExamples.swift in Sources */,
+				OBJ_953 /* QuickDiscouragedPendingTestRule.swift in Sources */,
+				OBJ_954 /* QuickDiscouragedPendingTestRuleExamples.swift in Sources */,
+				OBJ_955 /* RawValueForCamelCasedCodableEnumRule.swift in Sources */,
+				OBJ_956 /* RequiredDeinitRule.swift in Sources */,
+				OBJ_957 /* RequiredEnumCaseRule.swift in Sources */,
+				OBJ_958 /* ReturnValueFromVoidFunctionRule.swift in Sources */,
+				OBJ_959 /* StrongIBOutletRule.swift in Sources */,
+				OBJ_960 /* SuperfluousDisableCommandRule.swift in Sources */,
+				OBJ_961 /* TodoRule.swift in Sources */,
+				OBJ_962 /* UnownedVariableCaptureRule.swift in Sources */,
+				OBJ_963 /* UnusedCaptureListRule.swift in Sources */,
+				OBJ_964 /* UnusedClosureParameterRule.swift in Sources */,
+				OBJ_965 /* UnusedControlFlowLabelRule.swift in Sources */,
+				OBJ_966 /* UnusedDeclarationRule.swift in Sources */,
+				OBJ_967 /* UnusedImportRule.swift in Sources */,
+				OBJ_968 /* UnusedSetterValueRule.swift in Sources */,
+				OBJ_969 /* ValidIBInspectableRule.swift in Sources */,
+				OBJ_970 /* WeakDelegateRule.swift in Sources */,
+				OBJ_971 /* YodaConditionRule.swift in Sources */,
+				OBJ_972 /* ClosureBodyLengthRule.swift in Sources */,
+				OBJ_973 /* ClosureBodyLengthRuleExamples.swift in Sources */,
+				OBJ_974 /* CyclomaticComplexityRule.swift in Sources */,
+				OBJ_975 /* EnumCaseAssociatedValuesLengthRule.swift in Sources */,
+				OBJ_976 /* FileLengthRule.swift in Sources */,
+				OBJ_977 /* FunctionBodyLengthRule.swift in Sources */,
+				OBJ_978 /* FunctionParameterCountRule.swift in Sources */,
+				OBJ_979 /* LargeTupleRule.swift in Sources */,
+				OBJ_980 /* LineLengthRule.swift in Sources */,
+				OBJ_981 /* NestingRule.swift in Sources */,
+				OBJ_982 /* TypeBodyLengthRule.swift in Sources */,
+				OBJ_983 /* ContainsOverFilterCountRule.swift in Sources */,
+				OBJ_984 /* ContainsOverFilterIsEmptyRule.swift in Sources */,
+				OBJ_985 /* ContainsOverFirstNotNilRule.swift in Sources */,
+				OBJ_986 /* ContainsOverRangeNilComparisonRule.swift in Sources */,
+				OBJ_987 /* EmptyCollectionLiteralRule.swift in Sources */,
+				OBJ_988 /* EmptyCountRule.swift in Sources */,
+				OBJ_989 /* EmptyStringRule.swift in Sources */,
+				OBJ_990 /* FirstWhereRule.swift in Sources */,
+				OBJ_991 /* FlatMapOverMapReduceRule.swift in Sources */,
+				OBJ_992 /* LastWhereRule.swift in Sources */,
+				OBJ_993 /* ReduceBooleanRule.swift in Sources */,
+				OBJ_994 /* ReduceIntoRule.swift in Sources */,
+				OBJ_995 /* SortedFirstLastRule.swift in Sources */,
+				OBJ_996 /* AttributesConfiguration.swift in Sources */,
+				OBJ_997 /* CollectionAlignmentConfiguration.swift in Sources */,
+				OBJ_998 /* ColonConfiguration.swift in Sources */,
+				OBJ_999 /* ConditionalReturnsOnNewlineConfiguration.swift in Sources */,
+				OBJ_1000 /* CyclomaticComplexityConfiguration.swift in Sources */,
+				OBJ_1001 /* DeploymentTargetConfiguration.swift in Sources */,
+				OBJ_1002 /* DiscouragedDirectInitConfiguration.swift in Sources */,
+				OBJ_1003 /* ExpiringTodoConfiguration.swift in Sources */,
+				OBJ_1004 /* ExplicitTypeInterfaceConfiguration.swift in Sources */,
+				OBJ_1005 /* FileHeaderConfiguration.swift in Sources */,
+				OBJ_1006 /* FileLengthRuleConfiguration.swift in Sources */,
+				OBJ_1007 /* FileNameConfiguration.swift in Sources */,
+				OBJ_1008 /* FileNameNoSpaceConfiguration.swift in Sources */,
+				OBJ_1009 /* FileTypesOrderConfiguration.swift in Sources */,
+				OBJ_1010 /* FunctionParameterCountConfiguration.swift in Sources */,
+				OBJ_1011 /* ImplicitlyUnwrappedOptionalConfiguration.swift in Sources */,
+				OBJ_1012 /* LineLengthConfiguration.swift in Sources */,
+				OBJ_1013 /* MissingDocsRuleConfiguration.swift in Sources */,
+				OBJ_1014 /* ModifierOrderConfiguration.swift in Sources */,
+				OBJ_1015 /* MultilineArgumentsConfiguration.swift in Sources */,
+				OBJ_1016 /* NameConfiguration.swift in Sources */,
+				OBJ_1017 /* NestingConfiguration.swift in Sources */,
+				OBJ_1018 /* NumberSeparatorConfiguration.swift in Sources */,
+				OBJ_1019 /* ObjectLiteralConfiguration.swift in Sources */,
+				OBJ_1020 /* OverridenSuperCallConfiguration.swift in Sources */,
+				OBJ_1021 /* PrefixedConstantRuleConfiguration.swift in Sources */,
+				OBJ_1022 /* PrivateOutletRuleConfiguration.swift in Sources */,
+				OBJ_1023 /* PrivateOverFilePrivateRuleConfiguration.swift in Sources */,
+				OBJ_1024 /* PrivateUnitTestConfiguration.swift in Sources */,
+				OBJ_1025 /* ProhibitedSuperConfiguration.swift in Sources */,
+				OBJ_1026 /* RegexConfiguration.swift in Sources */,
+				OBJ_1027 /* RequiredEnumCaseRuleConfiguration.swift in Sources */,
+				OBJ_1028 /* SeverityConfiguration.swift in Sources */,
+				OBJ_1029 /* SeverityLevelsConfiguration.swift in Sources */,
+				OBJ_1030 /* StatementModeConfiguration.swift in Sources */,
+				OBJ_1031 /* SwitchCaseAlignmentConfiguration.swift in Sources */,
+				OBJ_1032 /* TrailingClosureConfiguration.swift in Sources */,
+				OBJ_1033 /* TrailingCommaConfiguration.swift in Sources */,
+				OBJ_1034 /* TrailingWhitespaceConfiguration.swift in Sources */,
+				OBJ_1035 /* TypeContentsOrderConfiguration.swift in Sources */,
+				OBJ_1036 /* UnusedDeclarationConfiguration.swift in Sources */,
+				OBJ_1037 /* UnusedOptionalBindingConfiguration.swift in Sources */,
+				OBJ_1038 /* VerticalWhitespaceConfiguration.swift in Sources */,
+				OBJ_1039 /* AttributesRule.swift in Sources */,
+				OBJ_1040 /* AttributesRuleExamples.swift in Sources */,
+				OBJ_1041 /* ClosingBraceRule.swift in Sources */,
+				OBJ_1042 /* ClosureEndIndentationRule.swift in Sources */,
+				OBJ_1043 /* ClosureEndIndentationRuleExamples.swift in Sources */,
+				OBJ_1044 /* ClosureParameterPositionRule.swift in Sources */,
+				OBJ_1045 /* ClosureSpacingRule.swift in Sources */,
+				OBJ_1046 /* CollectionAlignmentRule.swift in Sources */,
+				OBJ_1047 /* ColonRule+Dictionary.swift in Sources */,
+				OBJ_1048 /* ColonRule+FunctionCall.swift in Sources */,
+				OBJ_1049 /* ColonRule+Type.swift in Sources */,
+				OBJ_1050 /* ColonRule.swift in Sources */,
+				OBJ_1051 /* ColonRuleExamples.swift in Sources */,
+				OBJ_1052 /* CommaRule.swift in Sources */,
+				OBJ_1053 /* ConditionalReturnsOnNewlineRule.swift in Sources */,
+				OBJ_1054 /* ControlStatementRule.swift in Sources */,
+				OBJ_1055 /* CustomRules.swift in Sources */,
+				OBJ_1056 /* EmptyEnumArgumentsRule.swift in Sources */,
+				OBJ_1057 /* EmptyParametersRule.swift in Sources */,
+				OBJ_1058 /* EmptyParenthesesWithTrailingClosureRule.swift in Sources */,
+				OBJ_1059 /* ExplicitSelfRule.swift in Sources */,
+				OBJ_1060 /* FileHeaderRule.swift in Sources */,
+				OBJ_1061 /* FileTypesOrderRule.swift in Sources */,
+				OBJ_1062 /* FileTypesOrderRuleExamples.swift in Sources */,
+				OBJ_1063 /* IdentifierNameRule.swift in Sources */,
+				OBJ_1064 /* IdentifierNameRuleExamples.swift in Sources */,
+				OBJ_1065 /* ImplicitGetterRule.swift in Sources */,
+				OBJ_1066 /* ImplicitReturnRule.swift in Sources */,
+				OBJ_1067 /* LeadingWhitespaceRule.swift in Sources */,
+				OBJ_1068 /* LetVarWhitespaceRule.swift in Sources */,
+				OBJ_1069 /* LiteralExpressionEndIdentationRule.swift in Sources */,
+				OBJ_1070 /* ModifierOrderRule.swift in Sources */,
+				OBJ_1071 /* ModifierOrderRuleExamples.swift in Sources */,
+				OBJ_1072 /* MultilineArgumentsBracketsRule.swift in Sources */,
+				OBJ_1073 /* MultilineArgumentsRule.swift in Sources */,
+				OBJ_1074 /* MultilineArgumentsRuleExamples.swift in Sources */,
+				OBJ_1075 /* MultilineFunctionChainsRule.swift in Sources */,
+				OBJ_1076 /* MultilineLiteralBracketsRule.swift in Sources */,
+				OBJ_1077 /* MultilineParametersBracketsRule.swift in Sources */,
+				OBJ_1078 /* MultilineParametersRule.swift in Sources */,
+				OBJ_1079 /* MultilineParametersRuleExamples.swift in Sources */,
+				OBJ_1080 /* MultipleClosuresWithTrailingClosureRule.swift in Sources */,
+				OBJ_1081 /* NoSpaceInMethodCallRule.swift in Sources */,
+				OBJ_1082 /* NumberSeparatorRule.swift in Sources */,
+				OBJ_1083 /* NumberSeparatorRuleExamples.swift in Sources */,
+				OBJ_1084 /* OpeningBraceRule.swift in Sources */,
+				OBJ_1085 /* OperatorFunctionWhitespaceRule.swift in Sources */,
+				OBJ_1086 /* OperatorUsageWhitespaceRule.swift in Sources */,
+				OBJ_1087 /* OptionalEnumCaseMatchingRule.swift in Sources */,
+				OBJ_1088 /* PreferSelfTypeOverTypeOfSelfRule.swift in Sources */,
+				OBJ_1089 /* PrefixedTopLevelConstantRule.swift in Sources */,
+				OBJ_1090 /* ProtocolPropertyAccessorsOrderRule.swift in Sources */,
+				OBJ_1091 /* RedundantDiscardableLetRule.swift in Sources */,
+				OBJ_1092 /* ReturnArrowWhitespaceRule.swift in Sources */,
+				OBJ_1093 /* ShorthandOperatorRule.swift in Sources */,
+				OBJ_1094 /* SingleTestClassRule.swift in Sources */,
+				OBJ_1095 /* SortedImportsRule.swift in Sources */,
+				OBJ_1096 /* StatementPositionRule.swift in Sources */,
+				OBJ_1097 /* SwitchCaseAlignmentRule.swift in Sources */,
+				OBJ_1098 /* SwitchCaseOnNewlineRule.swift in Sources */,
+				OBJ_1099 /* TrailingClosureRule.swift in Sources */,
+				OBJ_1100 /* TrailingCommaRule.swift in Sources */,
+				OBJ_1101 /* TrailingNewlineRule.swift in Sources */,
+				OBJ_1102 /* TrailingWhitespaceRule.swift in Sources */,
+				OBJ_1103 /* TypeContentsOrderRule.swift in Sources */,
+				OBJ_1104 /* TypeContentsOrderRuleExamples.swift in Sources */,
+				OBJ_1105 /* UnneededParenthesesInClosureArgumentRule.swift in Sources */,
+				OBJ_1106 /* UnusedOptionalBindingRule.swift in Sources */,
+				OBJ_1107 /* VerticalParameterAlignmentOnCallRule.swift in Sources */,
+				OBJ_1108 /* VerticalParameterAlignmentRule.swift in Sources */,
+				OBJ_1109 /* VerticalParameterAlignmentRuleExamples.swift in Sources */,
+				OBJ_1110 /* VerticalWhitespaceBetweenCasesRule.swift in Sources */,
+				OBJ_1111 /* VerticalWhitespaceClosingBracesRule.swift in Sources */,
+				OBJ_1112 /* VerticalWhitespaceOpeningBracesRule.swift in Sources */,
+				OBJ_1113 /* VerticalWhitespaceRule.swift in Sources */,
+				OBJ_1114 /* VoidReturnRule.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_1124 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftSyntax::SwiftSyntax" /* SwiftSyntax */;
+			targetProxy = D4A115D123C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1126 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftSyntax::_CSwiftSyntax" /* _CSwiftSyntax */;
+			targetProxy = D4A115D323C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1128 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::SourceKittenFramework" /* SourceKittenFramework */;
+			targetProxy = D4A115D423C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1129 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::Yams" /* Yams */;
+			targetProxy = D4A115DB23C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1130 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::CYaml" /* CYaml */;
+			targetProxy = D4A115DC23C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1131 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SWXMLHash::SWXMLHash" /* SWXMLHash */;
+			targetProxy = D4A115DD23C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1132 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::SourceKit" /* SourceKit */;
+			targetProxy = D4A115DE23C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1133 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::Clang_C" /* Clang_C */;
+			targetProxy = D4A115DF23C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1223 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftLint::SwiftLintFramework" /* SwiftLintFramework */;
+			targetProxy = D4A115E823C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1224 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftSyntax::SwiftSyntax" /* SwiftSyntax */;
+			targetProxy = D4A115E923C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1225 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftSyntax::_CSwiftSyntax" /* _CSwiftSyntax */;
+			targetProxy = D4A115EA23C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1226 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::SourceKittenFramework" /* SourceKittenFramework */;
+			targetProxy = D4A115EB23C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1227 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::Yams" /* Yams */;
+			targetProxy = D4A115EC23C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1228 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::CYaml" /* CYaml */;
+			targetProxy = D4A115ED23C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1229 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SWXMLHash::SWXMLHash" /* SWXMLHash */;
+			targetProxy = D4A115EE23C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1230 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::SourceKit" /* SourceKit */;
+			targetProxy = D4A115EF23C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1231 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::Clang_C" /* Clang_C */;
+			targetProxy = D4A115F023C210BD00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1242 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftLint::SwiftLintFrameworkTests" /* SwiftLintFrameworkTests */;
+			targetProxy = D4A115F123C210C000D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1277 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftSyntax::_CSwiftSyntax" /* _CSwiftSyntax */;
+			targetProxy = D4A115D223C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1319 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::CYaml" /* CYaml */;
+			targetProxy = D4A115D623C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1364 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftyTextTable::SwiftyTextTable" /* SwiftyTextTable */;
+			targetProxy = D4A115CE23C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1365 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Commandant::Commandant" /* Commandant */;
+			targetProxy = D4A115CF23C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1366 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftLint::SwiftLintFramework" /* SwiftLintFramework */;
+			targetProxy = D4A115D023C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1367 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftSyntax::SwiftSyntax" /* SwiftSyntax */;
+			targetProxy = D4A115E023C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1368 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftSyntax::_CSwiftSyntax" /* _CSwiftSyntax */;
+			targetProxy = D4A115E123C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1369 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::SourceKittenFramework" /* SourceKittenFramework */;
+			targetProxy = D4A115E223C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1370 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::Yams" /* Yams */;
+			targetProxy = D4A115E323C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1371 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::CYaml" /* CYaml */;
+			targetProxy = D4A115E423C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1372 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SWXMLHash::SWXMLHash" /* SWXMLHash */;
+			targetProxy = D4A115E523C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1373 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::SourceKit" /* SourceKit */;
+			targetProxy = D4A115E623C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_1374 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::Clang_C" /* Clang_C */;
+			targetProxy = D4A115E723C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_770 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::Yams" /* Yams */;
+			targetProxy = D4A115D523C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_772 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::CYaml" /* CYaml */;
+			targetProxy = D4A115D723C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_773 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SWXMLHash::SWXMLHash" /* SWXMLHash */;
+			targetProxy = D4A115D823C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_774 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::SourceKit" /* SourceKit */;
+			targetProxy = D4A115D923C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+		OBJ_775 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SourceKitten::Clang_C" /* Clang_C */;
+			targetProxy = D4A115DA23C210BC00D1122A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_1136 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+					"$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SwiftLintFrameworkTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftLintFrameworkTests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_1137 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+					"$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SwiftLintFrameworkTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftLintFrameworkTests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_1234 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_1235 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_1240 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_1241 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_1244 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+					"$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SwiftSyntax_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftSyntax;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.2;
+				TARGET_NAME = SwiftSyntax;
+			};
+			name = Debug;
+		};
+		OBJ_1245 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+					"$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SwiftSyntax_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftSyntax;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.2;
+				TARGET_NAME = SwiftSyntax;
+			};
+			name = Release;
+		};
+		OBJ_1280 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		OBJ_1281 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Release;
+		};
+		OBJ_1286 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SwiftyTextTable_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftyTextTable;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftyTextTable;
+			};
+			name = Debug;
+		};
+		OBJ_1287 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SwiftyTextTable_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftyTextTable;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftyTextTable;
+			};
+			name = Release;
+		};
+		OBJ_1293 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_1294 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_1298 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/Yams_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Yams;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = Yams;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_1299 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/Yams_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Yams;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = Yams;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_1322 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_1323 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_1327 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/_CSwiftSyntax_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "-CSwiftSyntax";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = _CSwiftSyntax;
+			};
+			name = Debug;
+		};
+		OBJ_1328 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/_CSwiftSyntax_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "-CSwiftSyntax";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = _CSwiftSyntax;
+			};
+			name = Release;
+		};
+		OBJ_1334 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+					"$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/swiftlint_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = swiftlint;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_1335 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+					"$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/swiftlint_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = swiftlint;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+					"DEBUG=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_639 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/CYaml_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CYaml;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = CYaml;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_640 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/CYaml_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CYaml;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = CYaml;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_654 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/Clang_C_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "Clang-C";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = Clang_C;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_655 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/Clang_C_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "Clang-C";
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = Clang_C;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_670 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftLint.xcodeproj/Commandant_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Commandant;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = Commandant;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_671 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftLint.xcodeproj/Commandant_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Commandant;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = Commandant;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_686 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_687 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_692 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SWXMLHash_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SWXMLHash;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SWXMLHash;
+			};
+			name = Debug;
+		};
+		OBJ_693 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SWXMLHash_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SWXMLHash;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SWXMLHash;
+			};
+			name = Release;
+		};
+		OBJ_701 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_702 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_707 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SourceKit_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SourceKit;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = SourceKit;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_708 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SourceKit_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SourceKit;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = SourceKit;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_717 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SourceKittenFramework_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SourceKittenFramework;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SourceKittenFramework;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_718 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SourceKittenFramework_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SourceKittenFramework;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SourceKittenFramework;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_778 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_779 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_784 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+					"$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SwiftLintFramework_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftLintFramework;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftLintFramework;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_785 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+					"$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+					"$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax",
+				);
+				INFOPLIST_FILE = SwiftLint.xcodeproj/SwiftLintFramework_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftLintFramework;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftLintFramework;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_1135 /* Build configuration list for PBXNativeTarget "SwiftLintFrameworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1136 /* Debug */,
+				OBJ_1137 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1233 /* Build configuration list for PBXNativeTarget "SwiftLintPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1234 /* Debug */,
+				OBJ_1235 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1239 /* Build configuration list for PBXAggregateTarget "SwiftLintPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1240 /* Debug */,
+				OBJ_1241 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1243 /* Build configuration list for PBXNativeTarget "SwiftSyntax" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1244 /* Debug */,
+				OBJ_1245 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1279 /* Build configuration list for PBXNativeTarget "SwiftSyntaxPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1280 /* Debug */,
+				OBJ_1281 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1285 /* Build configuration list for PBXNativeTarget "SwiftyTextTable" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1286 /* Debug */,
+				OBJ_1287 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1292 /* Build configuration list for PBXNativeTarget "SwiftyTextTablePackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1293 /* Debug */,
+				OBJ_1294 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1297 /* Build configuration list for PBXNativeTarget "Yams" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1298 /* Debug */,
+				OBJ_1299 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1321 /* Build configuration list for PBXNativeTarget "YamsPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1322 /* Debug */,
+				OBJ_1323 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1326 /* Build configuration list for PBXNativeTarget "_CSwiftSyntax" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1327 /* Debug */,
+				OBJ_1328 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1333 /* Build configuration list for PBXNativeTarget "swiftlint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1334 /* Debug */,
+				OBJ_1335 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2 /* Build configuration list for PBXProject "SwiftLint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_638 /* Build configuration list for PBXNativeTarget "CYaml" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_639 /* Debug */,
+				OBJ_640 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_653 /* Build configuration list for PBXNativeTarget "Clang_C" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_654 /* Debug */,
+				OBJ_655 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_669 /* Build configuration list for PBXNativeTarget "Commandant" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_670 /* Debug */,
+				OBJ_671 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_685 /* Build configuration list for PBXNativeTarget "CommandantPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_686 /* Debug */,
+				OBJ_687 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_691 /* Build configuration list for PBXNativeTarget "SWXMLHash" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_692 /* Debug */,
+				OBJ_693 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_700 /* Build configuration list for PBXNativeTarget "SWXMLHashPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_701 /* Debug */,
+				OBJ_702 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_706 /* Build configuration list for PBXNativeTarget "SourceKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_707 /* Debug */,
+				OBJ_708 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_716 /* Build configuration list for PBXNativeTarget "SourceKittenFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_717 /* Debug */,
+				OBJ_718 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_777 /* Build configuration list for PBXNativeTarget "SourceKittenPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_778 /* Debug */,
+				OBJ_779 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_783 /* Build configuration list for PBXNativeTarget "SwiftLintFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_784 /* Debug */,
+				OBJ_785 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -1,2697 +1,9259 @@
 // !$*UTF8*$!
 {
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		006204DC1E1E492F00FFFBE1 /* VerticalWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006204DA1E1E48F900FFFBE1 /* VerticalWhitespaceConfiguration.swift */; };
-		006204DE1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006204DD1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift */; };
-		006ECFC41C44E99E00EF6364 /* LegacyConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */; };
-		009E09281DFEE4C200B588A7 /* ProhibitedSuperRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009E09271DFEE4C200B588A7 /* ProhibitedSuperRule.swift */; };
-		009E092A1DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009E09291DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift */; };
-		00B8D9791E2D1223004E0EEC /* LegacyConstantRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */; };
-		02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */; };
-		094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094384FF1D5D2382009168CF /* WeakDelegateRule.swift */; };
-		094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094385021D5D4F78009168CF /* PrivateOutletRule.swift */; };
-		125AAC78203AA82D0004BCE0 /* ExplicitTypeInterfaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125AAC77203AA82D0004BCE0 /* ExplicitTypeInterfaceConfiguration.swift */; };
-		125CE52F20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125CE52E20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift */; };
-		12E3D4DC2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E3D4DB2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift */; };
-		181D9E172038343D001F6887 /* UntypedErrorInCatchRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 181D9E162038343D001F6887 /* UntypedErrorInCatchRule.swift */; };
-		183B6B4921FF672B00425134 /* RedundantObjcAttributeRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183B6B4721FF66B700425134 /* RedundantObjcAttributeRuleExamples.swift */; };
-		187290721FC37CA50016BEA2 /* YodaConditionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */; };
-		188B3FF2207D61040073C2D6 /* ModifierOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188B3FF1207D61040073C2D6 /* ModifierOrderRule.swift */; };
-		188B3FF4207D61230073C2D6 /* ModifierOrderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */; };
-		1894D746207D585400BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1894D740207D57AD00BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift */; };
-		18B90B6B21ADD99800B60749 /* RedundantObjcAttributeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B90B6A21ADD99800B60749 /* RedundantObjcAttributeRule.swift */; };
-		1E18574B1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */; };
-		1E3C2D711EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */; };
-		1E82D5591D7775C7009553D7 /* ClosureSpacingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */; };
-		1EB7C8531F0C45C2004BAD22 /* ModifierOrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB7C8521F0C45C2004BAD22 /* ModifierOrderTests.swift */; };
-		1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */; };
-		1EF115921EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */; };
-		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
-		224E7F9D235A5E800051368B /* ExpiringTodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */; };
-		22A36FDF235673F50037B47D /* ExpiringTodoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */; };
-		22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */; };
-		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
-		24E17F721B14BB3F008195BE /* SwiftLintFile+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* SwiftLintFile+Cache.swift */; };
-		260F66A0225C5B6D00407CF5 /* CollectingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260F669F225C5B6D00407CF5 /* CollectingRuleTests.swift */; };
-		264E080F2248BA2800ADC4C5 /* RuleStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264E080E2248BA2800ADC4C5 /* RuleStorage.swift */; };
-		26CE462D228532CD00264485 /* Array+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CE462C228532CD00264485 /* Array+SwiftLint.swift */; };
-		287F8B642230843000BDC504 /* NSLocalizedStringRequireBundleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F8B62223083ED00BDC504 /* NSLocalizedStringRequireBundleRule.swift */; };
-		2882895F222975D00037CF5F /* NSObjectPreferIsEqualRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */; };
-		288289602229776C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */; };
-		29AD4C661F6EA1D5009B66E1 /* ContainsOverFirstNotNilRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AD4C641F6EA16C009B66E1 /* ContainsOverFirstNotNilRule.swift */; };
-		29FC197921382C07006D208C /* DuplicateImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC197721382C06006D208C /* DuplicateImportsRule.swift */; };
-		29FC197A21382C07006D208C /* DuplicateImportsRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC197821382C07006D208C /* DuplicateImportsRuleExamples.swift */; };
-		29FFC37A1F15764D007E4825 /* FileLengthRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FFC3781F1574FD007E4825 /* FileLengthRuleConfiguration.swift */; };
-		29FFC37D1F157BDE007E4825 /* FileLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FFC37B1F157BA8007E4825 /* FileLengthRuleTests.swift */; };
-		2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */; };
-		2E336D1B1DF08BFB00CCFE77 /* EmojiReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */; };
-		2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */; };
-		31F1B6CC1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F1B6CB1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift */; };
-		341FDB1F21AD66550022E8E9 /* CannedMarkdownReporterOutput.md in Resources */ = {isa = PBXBuildFile; fileRef = 341FDB1E21AD66550022E8E9 /* CannedMarkdownReporterOutput.md */; };
-		341FDB2021AD69970022E8E9 /* MarkdownReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341FDB1C21AD61B20022E8E9 /* MarkdownReporter.swift */; };
-		37B3FA8B1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */; };
-		3A915E5B20A1543700519F3A /* ClosureEndIndentationRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A915E5920A1543000519F3A /* ClosureEndIndentationRuleExamples.swift */; };
-		3ABE19CF20B7CE32009C2EC2 /* MultilineFunctionChainsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABE19CD20B7CDE0009C2EC2 /* MultilineFunctionChainsRule.swift */; };
-		3B034B6E1E0BE549005D49A9 /* LineLengthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */; };
-		3B0B14541C505D6300BE82F7 /* SeverityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */; };
-		3B12C9C11C3209CB000B423F /* test.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3B12C9BF1C3209AC000B423F /* test.yml */; };
-		3B12C9C31C320A53000B423F /* YamlSwiftLintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B12C9C21C320A53000B423F /* YamlSwiftLintTests.swift */; };
-		3B12C9C51C322032000B423F /* MasterRuleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B12C9C41C322032000B423F /* MasterRuleList.swift */; };
-		3B12C9C71C3361CB000B423F /* RuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B12C9C61C3361CB000B423F /* RuleTests.swift */; };
-		3B1DF0121C5148140011BCED /* CustomRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1DF0111C5148140011BCED /* CustomRules.swift */; };
-		3B20CD0A1EB699380069EF2E /* GenericTypeNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B20CD091EB699380069EF2E /* GenericTypeNameRuleTests.swift */; };
-		3B20CD0C1EB699C20069EF2E /* TypeNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B20CD0B1EB699C20069EF2E /* TypeNameRuleTests.swift */; };
-		3B30C4A11C3785B300E04027 /* YamlParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B30C4A01C3785B300E04027 /* YamlParserTests.swift */; };
-		3B3A9A331EA3DFD90075B121 /* IdentifierNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A9A321EA3DFD90075B121 /* IdentifierNameRuleTests.swift */; };
-		3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5B9FE01C444DA20009AD27 /* Array+SwiftLint.swift */; };
-		3B63D46D1E1F05160057BE35 /* LineLengthConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */; };
-		3B63D46F1E1F09DF0057BE35 /* LineLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */; };
-		3B828E531C546468000D180E /* RuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B828E521C546468000D180E /* RuleConfiguration.swift */; };
-		3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA79C9A1C4767910057E705 /* NSRange+SwiftLint.swift */; };
-		3BB47D831C514E8100AE6A10 /* RegexConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB47D821C514E8100AE6A10 /* RegexConfiguration.swift */; };
-		3BB47D851C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */; };
-		3BB47D871C51DE6E00AE6A10 /* CustomRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB47D861C51DE6E00AE6A10 /* CustomRulesTests.swift */; };
-		3BBF2F9D1C640A0F006CD775 /* SwiftyTextTable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BBF2F9C1C640A0F006CD775 /* SwiftyTextTable.framework */; };
-		3BCC04CD1C4F5694006073C3 /* ConfigurationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCC04CC1C4F5694006073C3 /* ConfigurationError.swift */; };
-		3BCC04D11C4F56D3006073C3 /* SeverityLevelsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCC04CF1C4F56D3006073C3 /* SeverityLevelsConfiguration.swift */; };
-		3BCC04D21C4F56D3006073C3 /* NameConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCC04D01C4F56D3006073C3 /* NameConfiguration.swift */; };
-		3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */; };
-		3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */; };
-		3BDB224B1C345B4900473680 /* ProjectMock in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB224A1C345B4900473680 /* ProjectMock */; };
-		4100D7A323BEAB69009464E0 /* FileNameNoSpaceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4100D7A123BEAB5A009464E0 /* FileNameNoSpaceRuleTests.swift */; };
-		4100D7A423BEAB78009464E0 /* FileNameNoSpaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41715DE023BEA08E00544BDF /* FileNameNoSpaceRule.swift */; };
-		4100D7A723BEACBF009464E0 /* FileNameNoSpaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4100D7A523BEACBF009464E0 /* FileNameNoSpaceConfiguration.swift */; };
-		4100D7BA23BEC285009464E0 /* FileNameNoSpaceRuleFixtures in Resources */ = {isa = PBXBuildFile; fileRef = 4100D7B923BEC284009464E0 /* FileNameNoSpaceRuleFixtures */; };
-		4100D7BC23BEC35F009464E0 /* FileNameNoSpaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4100D7BB23BEC35F009464E0 /* FileNameNoSpaceRule.swift */; };
-		429644B61FB0A9B400D75128 /* SortedFirstLastRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429644B41FB0A99E00D75128 /* SortedFirstLastRule.swift */; };
-		47ACC8981E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */; };
-		47ACC89A1E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */; };
-		47ACC89C1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */; };
-		47FF3BE11E7C75B600187E6D /* ImplicitlyUnwrappedOptionalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FF3BDF1E7C745100187E6D /* ImplicitlyUnwrappedOptionalRule.swift */; };
-		4968919223BEAC3D00AB8EF9 /* EnumCaseAssociatedValuesLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4968919123BEAC3D00AB8EF9 /* EnumCaseAssociatedValuesLengthRule.swift */; };
-		4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */; };
-		4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */; };
-		4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */; };
-		4E342B4C2215C793008E4EF8 /* ReduceBooleanRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E342B4A2215C6DF008E4EF8 /* ReduceBooleanRule.swift */; };
-		550DA0E022DB95AD00B67F03 /* EmptyCollectionLiteralRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550DA0DE22DB958400B67F03 /* EmptyCollectionLiteralRule.swift */; };
-		55CE0585231899100023BA72 /* ContainsOverRangeNilComparisonRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550DA0E122DB9E6B00B67F03 /* ContainsOverRangeNilComparisonRule.swift */; };
-		57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED82791CF65183002B3513 /* JUnitReporter.swift */; };
-		584B0D3A2112BA78002F7E25 /* SonarQubeReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584B0D392112BA78002F7E25 /* SonarQubeReporter.swift */; };
-		584B0D3C2112E8FB002F7E25 /* CannedSonarQubeReporterOutput.json in Resources */ = {isa = PBXBuildFile; fileRef = 584B0D3B2112E8FB002F7E25 /* CannedSonarQubeReporterOutput.json */; };
-		621061BF1ED57E640082D51E /* MultilineParametersRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */; };
-		621C8EA420CBC7A10007DA74 /* RedundantTypeAnnotationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6208ED4E20C297AC004E78D1 /* RedundantTypeAnnotationRule.swift */; };
-		622AD800216ACE6300A002C6 /* XCTSpecificMatcherRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622AD7FE216ACE6200A002C6 /* XCTSpecificMatcherRuleExamples.swift */; };
-		622AD801216ACE6300A002C6 /* XCTSpecificMatcherRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622AD7FF216ACE6200A002C6 /* XCTSpecificMatcherRule.swift */; };
-		62329C2B1F30B2310035737E /* DiscouragedDirectInitRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AF35D71F30B183009B11EE /* DiscouragedDirectInitRuleTests.swift */; };
-		623675B01F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623675AF1F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift */; };
-		623675B21F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623675B11F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift */; };
-		623E36F01F3DB1B1002E5B71 /* QuickDiscouragedCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623E36EF1F3DB1B1002E5B71 /* QuickDiscouragedCallRule.swift */; };
-		623E36F21F3DB988002E5B71 /* QuickDiscouragedCallRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623E36F11F3DB988002E5B71 /* QuickDiscouragedCallRuleExamples.swift */; };
-		62426A032118BA6E007E6340 /* ClosureBodyLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62426A022118BA6E007E6340 /* ClosureBodyLengthRule.swift */; };
-		62426A062118F995007E6340 /* ClosureBodyLengthRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62426A042118F991007E6340 /* ClosureBodyLengthRuleExamples.swift */; };
-		6250D32A1ED4DFEB00735129 /* MultilineParametersRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6238AE411ED4D734006C3601 /* MultilineParametersRule.swift */; };
-		6258783B1FFC458100AC34F2 /* DiscouragedObjectLiteralRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6258783A1FFC458100AC34F2 /* DiscouragedObjectLiteralRule.swift */; };
-		62622F6B1F2F2E3500D5D099 /* DiscouragedDirectInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62622F6A1F2F2E3500D5D099 /* DiscouragedDirectInitRule.swift */; };
-		62640152201552FD005B9C4A /* DiscouragedOptionalBooleanRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62640150201552E0005B9C4A /* DiscouragedOptionalBooleanRule.swift */; };
-		6264015520155556005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6264015320155533005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift */; };
-		626B01B620A173F100D2C42F /* EmptyXCTestMethodRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626B01B420A1735900D2C42F /* EmptyXCTestMethodRuleExamples.swift */; };
-		626C16E21F948EBC00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626C16E01F948E1C00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift */; };
-		626D02971F31CBCC0054788D /* XCTFailMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */; };
-		627BC48D1F9405160004A6C2 /* QuickDiscouragedFocusedTestRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E54FED1F93AD57005B367B /* QuickDiscouragedFocusedTestRule.swift */; };
-		627C7A322004F9290053C79D /* XCTSpecificMatcherRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627C7A312004F9290053C79D /* XCTSpecificMatcherRuleTests.swift */; };
-		629ADD062006302D0009E362 /* DiscouragedOptionalCollectionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629ADD052006302D0009E362 /* DiscouragedOptionalCollectionRule.swift */; };
-		629C60D91F43906700B4AF92 /* SingleTestClassRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629C60D81F43906700B4AF92 /* SingleTestClassRule.swift */; };
-		62A3E95D209E084000547A86 /* EmptyXCTestMethodRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A3E95B209E078000547A86 /* EmptyXCTestMethodRule.swift */; };
-		62A498561F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A498551F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift */; };
-		62A6E7931F3317E3003A0479 /* JoinedDefaultParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A6E7911F3317E3003A0479 /* JoinedDefaultParameterRule.swift */; };
-		62A7127520F1178F00E604A6 /* AnyObjectProtocolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A7127420F1178F00E604A6 /* AnyObjectProtocolRule.swift */; };
-		62DADC481FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DADC471FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift */; };
-		62DEA1661FB21A9E00BCCCC6 /* PrivateActionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DEA1651FB21A9E00BCCCC6 /* PrivateActionRule.swift */; };
-		62FE5D32200CABDD00F68793 /* DiscouragedOptionalCollectionExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FE5D30200CAB6E00F68793 /* DiscouragedOptionalCollectionExamples.swift */; };
-		67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */; };
-		67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */; };
-		67EB4DFC1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */; };
-		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
-		6BE79EB12204EC0700B5A2FE /* RequiredDeinitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE79EB02204EC0700B5A2FE /* RequiredDeinitRule.swift */; };
-		6C15818D237026AC00F582A2 /* GitHubActionsLoggingReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C15818C237026AC00F582A2 /* GitHubActionsLoggingReporter.swift */; };
-		6C15818F23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */; };
-		6C1D763221A4E69600DEF783 /* Request+DisableSourceKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */; };
-		6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */; };
-		6CB8A80C1D11A7E10052816E /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8BA7E101B07A3EC003E02D0 /* Commandant.framework */; };
-		6CCFCF2A1CFEF729003239EB /* Commandant.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = E8BA7E101B07A3EC003E02D0 /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		6CCFCF2D1CFEF731003239EB /* SourceKittenFramework.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = E876BFBD1B07828500114ED5 /* SourceKittenFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		6CCFCF2E1CFEF73A003239EB /* SWXMLHash.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		6CCFCF2F1CFEF73E003239EB /* SwiftyTextTable.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = 3BBF2F9C1C640A0F006CD775 /* SwiftyTextTable.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		7250948A1D0859260039B353 /* StatementModeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725094881D0855760039B353 /* StatementModeConfiguration.swift */; };
-		72EA17B61FD31F10009D5CE6 /* ExplicitACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */; };
-		740DF1B1203F62BB0081F694 /* EmptyStringRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */; };
-		750BBD0B214180AF007EC437 /* CollectionAlignmentRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7578C915214173BE0080FEC9 /* CollectionAlignmentRuleTests.swift */; };
-		75161FDF213B9D73009DE767 /* CollectionAlignmentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75161FDD213B9D67009DE767 /* CollectionAlignmentConfiguration.swift */; };
-		7551DF6D21382C9A00AA1F4D /* ToggleBoolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7551DF6C21382C9A00AA1F4D /* ToggleBoolRule.swift */; };
-		7565E5F12262BA0900B0597C /* UnusedCaptureListRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7565E5F02262BA0900B0597C /* UnusedCaptureListRule.swift */; };
-		756B585D2138ECD300D1A4E9 /* CollectionAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756B585C2138ECD300D1A4E9 /* CollectionAlignmentRule.swift */; };
-		756C0779222EA4F400A111F4 /* ReduceIntoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756C0777222EA49400A111F4 /* ReduceIntoRule.swift */; };
-		77DFF0E923442DE30041EEB4 /* RawValueForCamelCasedCodableEnumRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7723A4DE23442D7100F38590 /* RawValueForCamelCasedCodableEnumRule.swift */; };
-		787CDE39208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */; };
-		787CDE3B208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */; };
-		78F032461D7C877E00BE709A /* OverriddenSuperCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */; };
-		78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */; };
-		7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */; };
-		820F451C2107292500AA056A /* TypeContentsOrderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820F451B2107292500AA056A /* TypeContentsOrderRuleTests.swift */; };
-		820F451E21073D7200AA056A /* ConditionalReturnsOnNewlineRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820F451D21073D7200AA056A /* ConditionalReturnsOnNewlineRuleTests.swift */; };
-		82144ACC20F640F200B06695 /* VerticalWhitespaceBetweenCasesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82144ACB20F640F200B06695 /* VerticalWhitespaceBetweenCasesRule.swift */; };
-		821F70B7210720C700E2C84F /* FileTypesOrderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821F70B6210720C700E2C84F /* FileTypesOrderRuleTests.swift */; };
-		823EDC6221020D850070B7CD /* MultilineLiteralBracketsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823EDC6121020D850070B7CD /* MultilineLiteralBracketsRule.swift */; };
-		824AB64D2105C39F004B5A8F /* ConditionalReturnsOnNewlineConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824AB64C2105C39F004B5A8F /* ConditionalReturnsOnNewlineConfiguration.swift */; };
-		825F19D11EEFF19700969EF1 /* ObjectLiteralRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */; };
-		827009FD20FE26B700ECA185 /* FileTypesOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827009FC20FE26B700ECA185 /* FileTypesOrderRule.swift */; };
-		827009FF20FE26C500ECA185 /* TypeContentsOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827009FE20FE26C500ECA185 /* TypeContentsOrderRule.swift */; };
-		827169B31F488181003FB9AF /* ExplicitEnumRawValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827169B21F488181003FB9AF /* ExplicitEnumRawValueRule.swift */; };
-		827169B51F48D712003FB9AF /* NoGroupingExtensionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827169B41F48D712003FB9AF /* NoGroupingExtensionRule.swift */; };
-		82DB55FE21008F3E001C62FF /* FileTypesOrderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DB55FD21008F3E001C62FF /* FileTypesOrderConfiguration.swift */; };
-		82DB560021008F54001C62FF /* TypeContentsOrderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DB55FF21008F54001C62FF /* TypeContentsOrderConfiguration.swift */; };
-		82EB7885215BAE790042E0FD /* FileTypesOrderRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EB7883215BAE780042E0FD /* FileTypesOrderRuleExamples.swift */; };
-		82EB7886215BAE790042E0FD /* TypeContentsOrderRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EB7884215BAE780042E0FD /* TypeContentsOrderRuleExamples.swift */; };
-		82F614F22106014500D23904 /* MultilineParametersBracketsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F614F12106014500D23904 /* MultilineParametersBracketsRule.swift */; };
-		82F614F42106015100D23904 /* MultilineArgumentsBracketsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F614F32106015100D23904 /* MultilineArgumentsBracketsRule.swift */; };
-		82FE253F20F604AD00295958 /* VerticalWhitespaceOpeningBracesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FE253E20F604AD00295958 /* VerticalWhitespaceOpeningBracesRule.swift */; };
-		82FE254120F604CB00295958 /* VerticalWhitespaceClosingBracesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FE254020F604CB00295958 /* VerticalWhitespaceClosingBracesRule.swift */; };
-		83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83894F211B0C928A006214E1 /* RulesCommand.swift */; };
-		83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D71E261B131EB5000395DE /* RuleDescription.swift */; };
-		85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856651A61D6B395F005E6B29 /* MarkRule.swift */; };
-		8B01E4FD20A41C8700C9233E /* FunctionParameterCountConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B01E4FB20A4183C00C9233E /* FunctionParameterCountConfiguration.swift */; };
-		8B01E50220A4349100C9233E /* FunctionParameterCountRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B01E4FF20A4340A00C9233E /* FunctionParameterCountRuleTests.swift */; };
-		8F0856EB22DA8508001FF4D4 /* UnusedDeclarationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0856EA22DA8508001FF4D4 /* UnusedDeclarationRule.swift */; };
-		8F2CC1CB20A6A070006ED34F /* FileNameConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2CC1CA20A6A070006ED34F /* FileNameConfiguration.swift */; };
-		8F2CC1CD20A6A189006ED34F /* FileNameRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2CC1CC20A6A189006ED34F /* FileNameRuleTests.swift */; };
-		8F6AA75B211905B8009BA28A /* LintableFilesVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA75A211905B8009BA28A /* LintableFilesVisitor.swift */; };
-		8F6AA75D21190830009BA28A /* CompilerArgumentsExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6AA75C21190830009BA28A /* CompilerArgumentsExtractor.swift */; };
-		8F715B83213B528B00427BD9 /* UnusedImportRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F715B82213B528B00427BD9 /* UnusedImportRule.swift */; };
-		8F8050821FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8050811FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift */; };
-		8FC8523B2117BDDE0015269B /* ExplicitSelfRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC8523A2117BDDE0015269B /* ExplicitSelfRule.swift */; };
-		8FC9F5111F4B8E48006826C1 /* IsDisjointRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */; };
-		8FDF482C2122476D00521605 /* AnalyzeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDF482B2122476D00521605 /* AnalyzeCommand.swift */; };
-		8FDF482E21234BFF00521605 /* LintOrAnalyzeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDF482D21234BFF00521605 /* LintOrAnalyzeCommand.swift */; };
-		8FE3CCBC22DBF8D000B8EA87 /* UnusedDeclarationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE3CCBB22DBF8D000B8EA87 /* UnusedDeclarationConfiguration.swift */; };
-		92CCB2D71E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */; };
-		93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */; };
-		A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */; };
-		A3184D56215BCEFF00621EA2 /* LegacyRandomRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3184D55215BCEFF00621EA2 /* LegacyRandomRule.swift */; };
-		A73469421FB121BA009B57C7 /* CallPairRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73469401FB12149009B57C7 /* CallPairRule.swift */; };
-		B25DCD0B1F7E9F9E0028A199 /* MultilineArgumentsRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */; };
-		B25DCD0C1F7E9FA20028A199 /* MultilineArgumentsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */; };
-		B25DCD0E1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD0D1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift */; };
-		B25DCD101F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */; };
-		B2902A0C1D66815600BFCCF7 /* PrivateUnitTestRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2902A0B1D66815600BFCCF7 /* PrivateUnitTestRule.swift */; };
-		B2902A0E1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2902A0D1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift */; };
-		B3935371E92E0CF3F7668303 /* CannedJunitReporterOutput.xml in Resources */ = {isa = PBXBuildFile; fileRef = B39359A325FE84B7EDD1C455 /* CannedJunitReporterOutput.xml */; };
-		B3935522DC192D38D4852FA3 /* CannedXcodeReporterOutput.txt in Resources */ = {isa = PBXBuildFile; fileRef = B39352E4EA2A06BE66BD661A /* CannedXcodeReporterOutput.txt */; };
-		B39357173B43C9B5E351C360 /* CannedCheckstyleReporterOutput.xml in Resources */ = {isa = PBXBuildFile; fileRef = B39356DE1F73BDA1CA21C504 /* CannedCheckstyleReporterOutput.xml */; };
-		B3935797FF80C7F97953D375 /* CannedHTMLReporterOutput.html in Resources */ = {isa = PBXBuildFile; fileRef = B3935250C8E0DBACFB27E021 /* CannedHTMLReporterOutput.html */; };
-		B39358AA2D2AF5219D3FD7C0 /* CannedEmojiReporterOutput.txt in Resources */ = {isa = PBXBuildFile; fileRef = B3935001033261E5A70CE101 /* CannedEmojiReporterOutput.txt */; };
-		B3935A1C3BCA03A6B902E7AF /* CannedJSONReporterOutput.json in Resources */ = {isa = PBXBuildFile; fileRef = B39350463894A3FC1338E0AF /* CannedJSONReporterOutput.json */; };
-		B3935A32BE03C4D11B4364D6 /* CannedCSVReporterOutput.csv in Resources */ = {isa = PBXBuildFile; fileRef = B3935939C8366514D2694722 /* CannedCSVReporterOutput.csv */; };
-		B3935EE74B1E8E14FBD65E7F /* String+XML.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39353F28BCCA39247B316BD /* String+XML.swift */; };
-		B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */; };
-		B89F3BCD1FD5EDFB00931E59 /* RequiredEnumCaseRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */; };
-		B89F3BCE1FD5EE0200931E59 /* RequiredEnumCaseRuleTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89F3BCB1FD5EDA900931E59 /* RequiredEnumCaseRuleTestCase.swift */; };
-		B89F3BCF1FD5EE1400931E59 /* RequiredEnumCaseRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89F3BC71FD5ED7D00931E59 /* RequiredEnumCaseRuleConfiguration.swift */; };
-		BB00B4E91F5216090079869F /* MultipleClosuresWithTrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00B4E71F5216070079869F /* MultipleClosuresWithTrailingClosureRule.swift */; };
-		BC87573B2195CF2A00CA7A74 /* ModifierOrderRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8757392195CDD500CA7A74 /* ModifierOrderRuleExamples.swift */; };
-		BCB68283216213130078E4C3 /* CompilerProtocolInitRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB68282216213130078E4C3 /* CompilerProtocolInitRuleTests.swift */; };
-		BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */; };
-		C25EBBDF2107884200E27603 /* PrefixedTopLevelConstantRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25EBBDD210787B200E27603 /* PrefixedTopLevelConstantRuleTests.swift */; };
-		C25EBBE221078D5F00E27603 /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25EBBE021078D5B00E27603 /* GlobTests.swift */; };
-		C25EBBE521078DCE00E27603 /* Glob.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25EBBE321078DC700E27603 /* Glob.swift */; };
-		C26330382073DAC500D7B4FD /* LowerACLThanParentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C26330352073DAA200D7B4FD /* LowerACLThanParentRule.swift */; };
-		C28B2B3D2106DF730009A0FE /* PrefixedConstantRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28B2B3B2106DF210009A0FE /* PrefixedConstantRuleConfiguration.swift */; };
-		C2B3C1612106F78C00088928 /* ConfigurationAliasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B3C15F2106F78100088928 /* ConfigurationAliasesTests.swift */; };
-		C328A2F71E6759AE00A9E4D7 /* ExplicitTypeInterfaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */; };
-		C3D23F1D21E3A33700E9BD1B /* UnusedControlFlowLabelRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D7320C21E15ED4001C07D9 /* UnusedControlFlowLabelRule.swift */; };
-		C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */; };
-		C3EF547821B5A4000009262F /* LegacyHashingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EF547521B5A2190009262F /* LegacyHashingRule.swift */; };
-		C946FECB1EAE67EE007DD778 /* LetVarWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */; };
-		C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */; };
-		CC26ED07204DEB510013BBBC /* RuleIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */; };
-		CCD8B87920559D1E00B75847 /* DisableAllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD8B87720559C4A00B75847 /* DisableAllTests.swift */; };
-		CE8178ED1EAC039D0063186E /* UnusedOptionalBindingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */; };
-		D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
-		D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */; };
-		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
-		D286EC021E02DF6F0003CF72 /* SortedImportsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286EC001E02DA190003CF72 /* SortedImportsRule.swift */; };
-		D401D9261ED85EF0005DA5D4 /* RuleKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D401D9251ED85EF0005DA5D4 /* RuleKind.swift */; };
-		D403A4A31F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D403A4A21F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift */; };
-		D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */; };
-		D40E041C1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40E041B1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift */; };
-		D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */; };
-		D40FE89D1F867BFF006433E2 /* OverrideInExtensionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40FE89C1F867BFF006433E2 /* OverrideInExtensionRule.swift */; };
-		D4130D971E16183F00242361 /* IdentifierNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4130D961E16183F00242361 /* IdentifierNameRuleExamples.swift */; };
-		D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */; };
-		D414D6AC21D0B77F00960935 /* DiscouragedObjectLiteralRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D414D6AB21D0B77F00960935 /* DiscouragedObjectLiteralRuleTests.swift */; };
-		D414D6AE21D22FF500960935 /* LastWhereRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D414D6AD21D22FF500960935 /* LastWhereRule.swift */; };
-		D41985E721F85014003BE2B7 /* NSLocalizedStringKeyRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41985E621F85014003BE2B7 /* NSLocalizedStringKeyRule.swift */; };
-		D41985E921FAB62F003BE2B7 /* DeploymentTargetRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41985E821FAB62F003BE2B7 /* DeploymentTargetRule.swift */; };
-		D41985EB21FAB63E003BE2B7 /* DeploymentTargetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41985EA21FAB63E003BE2B7 /* DeploymentTargetConfiguration.swift */; };
-		D41985ED21FAD033003BE2B7 /* DeploymentTargetConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41985EC21FAD033003BE2B7 /* DeploymentTargetConfigurationTests.swift */; };
-		D41985EF21FAD5E8003BE2B7 /* DeploymentTargetRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41985EE21FAD5E8003BE2B7 /* DeploymentTargetRuleTests.swift */; };
-		D41B57781ED8CEE0007B0470 /* ExtensionAccessModifierRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41B57771ED8CEE0007B0470 /* ExtensionAccessModifierRule.swift */; };
-		D41E7E0B1DF9DABB0065259A /* RedundantStringEnumValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */; };
-		D4246D6D1F30D8620097E658 /* PrivateOverFilePrivateRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4246D6C1F30D8620097E658 /* PrivateOverFilePrivateRuleConfiguration.swift */; };
-		D4246D6F1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4246D6E1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift */; };
-		D42B45D91F0AF5E30086B683 /* StrictFilePrivateRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42B45D81F0AF5E30086B683 /* StrictFilePrivateRule.swift */; };
-		D42D2B381E09CC0D00CD7A2E /* FirstWhereRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42D2B371E09CC0D00CD7A2E /* FirstWhereRule.swift */; };
-		D42DEAAB20D5EE4400E86F31 /* ConvenienceTypeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42DEAAA20D5EE4400E86F31 /* ConvenienceTypeRule.swift */; };
-		D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */; };
-		D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B04631E0620AB004016AF /* UnusedEnumeratedRule.swift */; };
-		D43B04661E071ED3004016AF /* ColonRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B04651E071ED3004016AF /* ColonRuleTests.swift */; };
-		D43B04691E072291004016AF /* ColonConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B04671E07228D004016AF /* ColonConfiguration.swift */; };
-		D43B046B1E075905004016AF /* ClosureEndIndentationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B046A1E075905004016AF /* ClosureEndIndentationRule.swift */; };
-		D43CDEDC23BDB8D30074F3EE /* OptionalEnumCaseMatchingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43CDEDB23BDB8D30074F3EE /* OptionalEnumCaseMatchingRule.swift */; };
-		D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */; };
-		D44037972132730000FDA77B /* ProhibitedInterfaceBuilderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44037962132730000FDA77B /* ProhibitedInterfaceBuilderRule.swift */; };
-		D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */; };
-		D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */; };
-		D4441A28213279950020896F /* InertDeferRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4441A27213279950020896F /* InertDeferRule.swift */; };
-		D4470D571EB69225008A1B2E /* ImplicitReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */; };
-		D4470D591EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D581EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift */; };
-		D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */; };
-		D4470D5D1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4470D5C1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift */; };
-		D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */; };
-		D450D1D121EC4A6900E60010 /* StrongIBOutletRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D450D1D021EC4A6900E60010 /* StrongIBOutletRule.swift */; };
-		D450D1DD21F199F700E60010 /* TrailingClosureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D450D1DA21F1992E00E60010 /* TrailingClosureConfiguration.swift */; };
-		D450D1E021F19AB300E60010 /* TrailingClosureRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D450D1DE21F19A9400E60010 /* TrailingClosureRuleTests.swift */; };
-		D450D1E221F19B1E00E60010 /* TrailingClosureConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D450D1E121F19B1E00E60010 /* TrailingClosureConfigurationTests.swift */; };
-		D45255C81F0932F8003C9B56 /* RuleDescription+Examples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45255C71F0932F8003C9B56 /* RuleDescription+Examples.swift */; };
-		D462021F1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */; };
-		D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */; };
-		D466B620233D229F0068190B /* FlatMapOverMapReduceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D466B61F233D229F0068190B /* FlatMapOverMapReduceRule.swift */; };
-		D46A317F1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46A317E1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift */; };
-		D46C7C3E23BF2F6A007C517F /* PreferSelfTypeOverTypeOfSelfRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46C7C3D23BF2F6A007C517F /* PreferSelfTypeOverTypeOfSelfRule.swift */; };
-		D46E041D1DE3712C00728374 /* TrailingCommaRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */; };
-		D47079A71DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */; };
-		D47079A91DFDBED000027086 /* ClosureParameterPositionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */; };
-		D47079AB1DFDCF7A00027086 /* SwiftExpressionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079AA1DFDCF7A00027086 /* SwiftExpressionKind.swift */; };
-		D47079AD1DFE2FA700027086 /* EmptyParametersRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079AC1DFE2FA700027086 /* EmptyParametersRule.swift */; };
-		D47079AF1DFE520000027086 /* VoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47079AE1DFE520000027086 /* VoidReturnRule.swift */; };
-		D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */; };
-		D47A51101DB2DD4800A4CC21 /* AttributesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */; };
-		D47EF4801F69E3100012C4CA /* ColonRule+FunctionCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47EF47F1F69E3100012C4CA /* ColonRule+FunctionCall.swift */; };
-		D47EF4821F69E34D0012C4CA /* ColonRule+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47EF4811F69E34D0012C4CA /* ColonRule+Dictionary.swift */; };
-		D47EF4841F69E3D60012C4CA /* ColonRule+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47EF4831F69E3D60012C4CA /* ColonRule+Type.swift */; };
-		D47F31151EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47F31141EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift */; };
-		D489B548231233A40090BAA0 /* ContainsOverFilterCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489B546231233490090BAA0 /* ContainsOverFilterCountRule.swift */; };
-		D489B54A231383350090BAA0 /* ContainsOverFilterIsEmptyRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489B549231383350090BAA0 /* ContainsOverFilterIsEmptyRule.swift */; };
-		D48AE2CC1DFB58C5001C6A4A /* AttributesRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48AE2CB1DFB58C5001C6A4A /* AttributesRuleExamples.swift */; };
-		D48B51211F4F5DEF0068AB98 /* RuleList+Documentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48B51201F4F5DEF0068AB98 /* RuleList+Documentation.swift */; };
-		D48B51231F4F5E4B0068AB98 /* DocumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48B51221F4F5E4B0068AB98 /* DocumentationTests.swift */; };
-		D48EE14B231CD34200DBB779 /* NoSpaceInMethodCallRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48EE14A231CD34200DBB779 /* NoSpaceInMethodCallRule.swift */; };
-		D495B1A221165DAA00E2CD7B /* FileNameRuleFixtures in Resources */ = {isa = PBXBuildFile; fileRef = D495B1A021165DAA00E2CD7B /* FileNameRuleFixtures */; };
-		D495B1A321165DAA00E2CD7B /* FileHeaderRuleFixtures in Resources */ = {isa = PBXBuildFile; fileRef = D495B1A121165DAA00E2CD7B /* FileHeaderRuleFixtures */; };
-		D49896F12026B36C00814A83 /* RedundantSetAccessControlRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49896F02026B36C00814A83 /* RedundantSetAccessControlRule.swift */; };
-		D4998DE71DF191380006E05D /* AttributesRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4998DE61DF191380006E05D /* AttributesRuleTests.swift */; };
-		D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */; };
-		D4A893351E15824100BF954D /* SwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A893341E15824100BF954D /* SwiftVersion.swift */; };
-		D4AB0EA21F8993DD00CEC380 /* NamespaceCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AB0EA11F8993DD00CEC380 /* NamespaceCollector.swift */; };
-		D4B0226F1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */; };
-		D4B0228E1E0CC608007E5297 /* ClassDelegateProtocolRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */; };
-		D4B022961E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */; };
-		D4B022981E102EE8007E5297 /* ObjectLiteralRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022971E102EE8007E5297 /* ObjectLiteralRule.swift */; };
-		D4B022A41E105636007E5297 /* GenericTypeNameRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022A31E105636007E5297 /* GenericTypeNameRule.swift */; };
-		D4B022B21E10B613007E5297 /* RedundantVoidReturnRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */; };
-		D4B31ADC22A0581B000300F1 /* DuplicateEnumCasesRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B31ADB22A0581B000300F1 /* DuplicateEnumCasesRule.swift */; };
-		D4B3409D21F16B110038C79A /* UnusedSetterValueRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B3409C21F16B110038C79A /* UnusedSetterValueRule.swift */; };
-		D4B472411F66486300BD6EF1 /* FallthroughRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B472401F66486300BD6EF1 /* FallthroughRule.swift */; };
-		D4BED5F82278AECC00D86BCE /* UnownedVariableCaptureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BED5F72278AECC00D86BCE /* UnownedVariableCaptureRule.swift */; };
-		D4C0E46F1E3D973600C560F2 /* ForWhereRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C0E46E1E3D973600C560F2 /* ForWhereRule.swift */; };
-		D4C27BFE1E12D53F00DF713E /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C27BFD1E12D53F00DF713E /* Version.swift */; };
-		D4C27C001E12DFF500DF713E /* LinterCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C27BFF1E12DFF500DF713E /* LinterCacheTests.swift */; };
-		D4C4A34C1DEA4FF000E0E04C /* AttributesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */; };
-		D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */; };
-		D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */; };
-		D4C889711E385B7B00BAE88D /* RedundantDiscardableLetRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C889701E385B7B00BAE88D /* RedundantDiscardableLetRule.swift */; };
-		D4CA758F1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */; };
-		D4CFC5D2209EC95A00668488 /* FunctionDefaultParameterAtEndRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CFC5D1209EC95A00668488 /* FunctionDefaultParameterAtEndRule.swift */; };
-		D4D0B8F42211428D0053A116 /* ColonRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D0B8F32211428D0053A116 /* ColonRuleExamples.swift */; };
-		D4D1B9BB1EAC2C910028BE6A /* AccessControlLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D1B9B91EAC2C870028BE6A /* AccessControlLevel.swift */; };
-		D4D383852145F550000235BD /* StaticOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D383842145F550000235BD /* StaticOperatorRule.swift */; };
-		D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5A5FE1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift */; };
-		D4DA1DF41E17511D0037413D /* CompilerProtocolInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DF31E17511D0037413D /* CompilerProtocolInitRule.swift */; };
-		D4DA1DFA1E18D6200037413D /* LargeTupleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */; };
-		D4DA1DFC1E19CD300037413D /* GenerateDocsCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DFB1E19CD300037413D /* GenerateDocsCommand.swift */; };
-		D4DA1DFE1E1A10DB0037413D /* NumberSeparatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */; };
-		D4DABFD31E29B4A5009617B6 /* DiscardedNotificationCenterObserverRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DABFD21E29B4A5009617B6 /* DiscardedNotificationCenterObserverRule.swift */; };
-		D4DABFD51E2B350F009617B6 /* TrailingClosureRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DABFD41E2B350F009617B6 /* TrailingClosureRule.swift */; };
-		D4DABFD71E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */; };
-		D4DABFD91E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */; };
-		D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */; };
-		D4DB92251E628898005DE9C1 /* TodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */; };
-		D4DDFF9822396D62006C3629 /* ContainsOverFirstNotNilRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DDFF9722396D62006C3629 /* ContainsOverFirstNotNilRuleTests.swift */; };
-		D4DE9133207B4750000FFAA8 /* UnavailableFunctionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DE9131207B4731000FFAA8 /* UnavailableFunctionRule.swift */; };
-		D4E2BA851F6CD77B00E8E184 /* ArrayInitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */; };
-		D4E92D1F2137B4C9002EDD48 /* IdenticalOperandsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E92D1E2137B4C9002EDD48 /* IdenticalOperandsRule.swift */; };
-		D4EA77C81F817FD200C315FB /* UnneededBreakInSwitchRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EA77C71F817FD200C315FB /* UnneededBreakInSwitchRule.swift */; };
-		D4EA77CA1F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */; };
-		D4EAB3A420E9948E0051C09A /* AutomaticRuleTests.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAB3A320E9948D0051C09A /* AutomaticRuleTests.generated.swift */; };
-		D4EABD0C22CE6F5B00635667 /* VerticalParameterAlignmentRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EABD0B22CE6F5B00635667 /* VerticalParameterAlignmentRuleExamples.swift */; };
-		D4F10614229A2F5E00FDE319 /* NoFallthroughOnlyRuleExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F10613229A2F5E00FDE319 /* NoFallthroughOnlyRuleExamples.swift */; };
-		D4F10616229A331200FDE319 /* LegacyMultipleRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F10615229A331200FDE319 /* LegacyMultipleRule.swift */; };
-		D4F5851520E99A8A0085C6D8 /* TrailingWhitespaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F5851320E99A720085C6D8 /* TrailingWhitespaceTests.swift */; };
-		D4F5851720E99B260085C6D8 /* StatementPositionRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F5851620E99B260085C6D8 /* StatementPositionRuleTests.swift */; };
-		D4F5851920E99B5A0085C6D8 /* PrivateOutletRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F5851820E99B5A0085C6D8 /* PrivateOutletRuleTests.swift */; };
-		D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */; };
-		D4FD4C851F2A260A00DD8AA8 /* BlockBasedKVORule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD4C841F2A260A00DD8AA8 /* BlockBasedKVORule.swift */; };
-		D4FD58B21E12A0200019503C /* LinterCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD58B11E12A0200019503C /* LinterCache.swift */; };
-		D93DA3D11E699E6300809827 /* NestingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */; };
-		DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */; };
-		E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */; };
-		E48F715E23789824003E1775 /* SwiftLintSyntaxMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48F715C23789823003E1775 /* SwiftLintSyntaxMap.swift */; };
-		E48F715F23789824003E1775 /* SwiftLintSyntaxToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48F715D23789824003E1775 /* SwiftLintSyntaxToken.swift */; };
-		E4A365D223653649003B4141 /* SourceKittenDictionary+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A365D123653648003B4141 /* SourceKittenDictionary+Swiftlint.swift */; };
-		E4A6CF752363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */; };
-		E4EA064C23688EB5002531D7 /* SwiftLintFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EA064B23688EB4002531D7 /* SwiftLintFile.swift */; };
-		E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */; };
-		E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = E802ECFF1C56A56000A35AE1 /* Benchmark.swift */; };
-		E80746F61ECB722F00548D31 /* CacheDescriptionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80746F51ECB722F00548D31 /* CacheDescriptionProvider.swift */; };
-		E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA01B8A71DF00399043 /* Configuration.swift */; };
-		E809EDA31B8A73FB00399043 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */; };
-		E80E018D1B92C0F60078EB70 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80E018C1B92C0F60078EB70 /* Command.swift */; };
-		E80E018F1B92C1350078EB70 /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80E018E1B92C1350078EB70 /* Region.swift */; };
-		E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81224991B04F85B001783D2 /* TestHelpers.swift */; };
-		E812249C1B04FADC001783D2 /* Linter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E812249B1B04FADC001783D2 /* Linter.swift */; };
-		E816194C1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E816194B1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift */; };
-		E816194E1BFBFEAB00946723 /* ForceTryRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E816194D1BFBFEAB00946723 /* ForceTryRule.swift */; };
-		E81619531BFC162C00946723 /* QueuedPrint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81619521BFC162C00946723 /* QueuedPrint.swift */; };
-		E81ADD721ED5ED9D000CD451 /* RegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81ADD711ED5ED9D000CD451 /* RegionTests.swift */; };
-		E81ADD741ED6052F000CD451 /* CommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81ADD731ED6052F000CD451 /* CommandTests.swift */; };
-		E81FB3E41C6D507B00DC988F /* CommonOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81FB3E31C6D507B00DC988F /* CommonOptions.swift */; };
-		E82367E01ED3BD1E0040A88E /* Configuration+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82367DF1ED3BD1E0040A88E /* Configuration+Cache.swift */; };
-		E832F10B1B17E2F5003F265F /* FileManager+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E832F10A1B17E2F5003F265F /* FileManager+SwiftLint.swift */; };
-		E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E832F10C1B17E725003F265F /* IntegrationTests.swift */; };
-		E83530C61ED6328A00FBAF79 /* FileNameRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83530C51ED6328A00FBAF79 /* FileNameRule.swift */; };
-		E83A0B351A5D382B0041A60A /* VersionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83A0B341A5D382B0041A60A /* VersionCommand.swift */; };
-		E847F0A91BFBBABD00EA9363 /* EmptyCountRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E847F0A81BFBBABD00EA9363 /* EmptyCountRule.swift */; };
-		E84E07471C13F95300F11122 /* AutoCorrectCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84E07461C13F95300F11122 /* AutoCorrectCommand.swift */; };
-		E861519B1B0573B900C54AC0 /* LintCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E861519A1B0573B900C54AC0 /* LintCommand.swift */; };
-		E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86396C11BADAAE5002C9E88 /* Reporter.swift */; };
-		E86396C51BADAC15002C9E88 /* XcodeReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86396C41BADAC15002C9E88 /* XcodeReporter.swift */; };
-		E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86396C61BADAFE6002C9E88 /* ReporterTests.swift */; };
-		E86396C91BADB2B9002C9E88 /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86396C81BADB2B9002C9E88 /* JSONReporter.swift */; };
-		E86396CB1BADB519002C9E88 /* CSVReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86396CA1BADB519002C9E88 /* CSVReporter.swift */; };
-		E86623671F1D377900AAA3A2 /* Configuration+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86623661F1D377900AAA3A2 /* Configuration+Parsing.swift */; };
-		E86E2B2E1E17443B001E823C /* Reporter+CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86E2B2D1E17443B001E823C /* Reporter+CommandLine.swift */; };
-		E876BFBE1B07828500114ED5 /* SourceKittenFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E876BFBD1B07828500114ED5 /* SourceKittenFramework.framework */; };
-		E87E4A051BFB927C00FCFE46 /* TrailingSemicolonRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */; };
-		E87E4A091BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87E4A081BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift */; };
-		E88198421BEA929F00333A11 /* NestingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA951B099CF200A66CB0 /* NestingRule.swift */; };
-		E88198441BEA93D200333A11 /* ColonRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA831B0990F500A66CB0 /* ColonRule.swift */; };
-		E88198521BEA941300333A11 /* TodoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA811B0990A700A66CB0 /* TodoRule.swift */; };
-		E88198531BEA944400333A11 /* LineLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */; };
-		E88198541BEA945100333A11 /* CommaRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695BE9CE1BDFD92B0071E985 /* CommaRule.swift */; };
-		E88198551BEA949A00333A11 /* ControlStatementRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65454F451B14D73800319A6C /* ControlStatementRule.swift */; };
-		E88198561BEA94D800333A11 /* FileLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA891B0992B300A66CB0 /* FileLengthRule.swift */; };
-		E88198571BEA953300333A11 /* ForceCastRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA7F1B09903300A66CB0 /* ForceCastRule.swift */; };
-		E88198581BEA956C00333A11 /* FunctionBodyLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */; };
-		E88198591BEA95F100333A11 /* LeadingWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */; };
-		E881985A1BEA96EA00333A11 /* OperatorFunctionWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */; };
-		E881985B1BEA974E00333A11 /* StatementPositionRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */; };
-		E881985C1BEA978500333A11 /* TrailingNewlineRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA871B09924C00A66CB0 /* TrailingNewlineRule.swift */; };
-		E881985D1BEA97EB00333A11 /* TrailingWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA851B0991BF00A66CB0 /* TrailingWhitespaceRule.swift */; };
-		E881985E1BEA982100333A11 /* TypeBodyLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */; };
-		E881985F1BEA987C00333A11 /* TypeNameRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */; };
-		E88198601BEA98F000333A11 /* IdentifierNameRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA931B099C0900A66CB0 /* IdentifierNameRule.swift */; };
-		E88198631BEA9A5400333A11 /* RulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */; };
-		E889D8C51F1D11A200058332 /* Configuration+LintableFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E889D8C41F1D11A200058332 /* Configuration+LintableFiles.swift */; };
-		E889D8C71F1D357B00058332 /* Configuration+Merging.swift in Sources */ = {isa = PBXBuildFile; fileRef = E889D8C61F1D357B00058332 /* Configuration+Merging.swift */; };
-		E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA6A1B0983FE00A66CB0 /* StyleViolation.swift */; };
-		E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA6E1B09843F00A66CB0 /* Location.swift */; };
-		E88DEA711B09847500A66CB0 /* ViolationSeverity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA701B09847500A66CB0 /* ViolationSeverity.swift */; };
-		E88DEA731B0984C400A66CB0 /* String+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */; };
-		E88DEA751B09852000A66CB0 /* SwiftLintFile+Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA741B09852000A66CB0 /* SwiftLintFile+Regex.swift */; };
-		E88DEA771B098D0C00A66CB0 /* Rule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA761B098D0C00A66CB0 /* Rule.swift */; };
-		E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA781B098D4400A66CB0 /* RuleParameter.swift */; };
-		E88DEA8C1B0999A000A66CB0 /* ASTRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88DEA8B1B0999A000A66CB0 /* ASTRule.swift */; };
-		E8B067811C13E49600E9E13F /* Configuration+CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B067801C13E49600E9E13F /* Configuration+CommandLine.swift */; };
-		E8B67C3E1C095E6300FDED8E /* Correction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B67C3D1C095E6300FDED8E /* Correction.swift */; };
-		E8BDE3FF1EDF91B6002EC12F /* RuleList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BDE3FE1EDF91B6002EC12F /* RuleList.swift */; };
-		E8BE1FCC1E07687400F781C7 /* Yams.framework in Embed Frameworks into SwiftLintFramework.framework */ = {isa = PBXBuildFile; fileRef = E8BE1FCB1E07687400F781C7 /* Yams.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E8C0DFCD1AD349DB007EE3D4 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */; };
-		E8EA41171C2D1DBE004F9930 /* CheckstyleReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EA41161C2D1DBE004F9930 /* CheckstyleReporter.swift */; };
-		ED641C3820AA07B400212C62 /* NoFallthroughOnlyRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED641C3620AA070700212C62 /* NoFallthroughOnlyRule.swift */; };
-		F22314B01D4FA4D7009AD165 /* LegacyNSGeometryFunctionsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */; };
-		F480DC7F1F26090000099465 /* ConfigurationTests+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */; };
-		F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */; };
-		F480DC831F2609D700099465 /* ConfigurationTests+ProjectMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */; };
-		F90DBD7F2092E669002CC310 /* MissingDocsRuleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */; };
-		F90DBD812092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */; };
-		F9D73F031D0CF15E00222FC4 /* test.txt in Resources */ = {isa = PBXBuildFile; fileRef = F9D73F021D0CF15E00222FC4 /* test.txt */; };
-		F9E691282091952E0085B53E /* MissingDocsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E691272091952E0085B53E /* MissingDocsRule.swift */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		D0AAAB5119FB0960007B24B3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D0D1211019E87861005E4BAA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D0D1216C19E87B05005E4BAA;
-			remoteInfo = SourceKittenFramework;
-		};
-		D0D1217919E87B05005E4BAA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D0D1211019E87861005E4BAA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D0D1216C19E87B05005E4BAA;
-			remoteInfo = SourceKittenFramework;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		6CCFCF291CFEF6D3003239EB /* Embed Frameworks into SwiftLintFramework.framework */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = SwiftLintFramework.framework/Versions/Current/Frameworks;
-			dstSubfolderSpec = 10;
-			files = (
-				6CCFCF2A1CFEF729003239EB /* Commandant.framework in Embed Frameworks into SwiftLintFramework.framework */,
-				6CCFCF2D1CFEF731003239EB /* SourceKittenFramework.framework in Embed Frameworks into SwiftLintFramework.framework */,
-				6CCFCF2E1CFEF73A003239EB /* SWXMLHash.framework in Embed Frameworks into SwiftLintFramework.framework */,
-				6CCFCF2F1CFEF73E003239EB /* SwiftyTextTable.framework in Embed Frameworks into SwiftLintFramework.framework */,
-				E8BE1FCC1E07687400F781C7 /* Yams.framework in Embed Frameworks into SwiftLintFramework.framework */,
-			);
-			name = "Embed Frameworks into SwiftLintFramework.framework";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D0AAAB5319FB0960007B24B3 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				D0AAAB5019FB0960007B24B3 /* SwiftLintFramework.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
-/* Begin PBXFileReference section */
-		006204DA1E1E48F900FFFBE1 /* VerticalWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceConfiguration.swift; sourceTree = "<group>"; };
-		006204DD1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRuleTests.swift; sourceTree = "<group>"; };
-		006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRule.swift; sourceTree = "<group>"; };
-		009E09271DFEE4C200B588A7 /* ProhibitedSuperRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProhibitedSuperRule.swift; sourceTree = "<group>"; };
-		009E09291DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProhibitedSuperConfiguration.swift; sourceTree = "<group>"; };
-		00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstantRuleExamples.swift; sourceTree = "<group>"; };
-		02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNSStringTests.swift; sourceTree = "<group>"; };
-		094384FF1D5D2382009168CF /* WeakDelegateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakDelegateRule.swift; sourceTree = "<group>"; };
-		094385021D5D4F78009168CF /* PrivateOutletRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRule.swift; sourceTree = "<group>"; };
-		125AAC77203AA82D0004BCE0 /* ExplicitTypeInterfaceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceConfiguration.swift; sourceTree = "<group>"; };
-		125CE52E20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceConfigurationTests.swift; sourceTree = "<group>"; };
-		12E3D4DB2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRuleTests.swift; sourceTree = "<group>"; };
-		181D9E162038343D001F6887 /* UntypedErrorInCatchRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntypedErrorInCatchRule.swift; sourceTree = "<group>"; };
-		183B6B4721FF66B700425134 /* RedundantObjcAttributeRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantObjcAttributeRuleExamples.swift; sourceTree = "<group>"; };
-		1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YodaConditionRule.swift; sourceTree = "<group>"; };
-		188B3FF1207D61040073C2D6 /* ModifierOrderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrderRule.swift; sourceTree = "<group>"; };
-		188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrderConfiguration.swift; sourceTree = "<group>"; };
-		1894D740207D57AD00BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftDeclarationAttributeKind+Swiftlint.swift"; sourceTree = "<group>"; };
-		18B90B6A21ADD99800B60749 /* RedundantObjcAttributeRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantObjcAttributeRule.swift; sourceTree = "<group>"; };
-		1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoExtensionAccessModifierRule.swift; sourceTree = "<group>"; };
-		1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRule.swift; sourceTree = "<group>"; };
-		1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureSpacingRule.swift; sourceTree = "<group>"; };
-		1EB7C8521F0C45C2004BAD22 /* ModifierOrderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrderTests.swift; sourceTree = "<group>"; };
-		1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRule.swift; sourceTree = "<group>"; };
-		1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTopLevelACLRule.swift; sourceTree = "<group>"; };
-		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
-		224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRuleTests.swift; sourceTree = "<group>"; };
-		22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRule.swift; sourceTree = "<group>"; };
-		22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoConfiguration.swift; sourceTree = "<group>"; };
-		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
-		24E17F701B1481FF008195BE /* SwiftLintFile+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftLintFile+Cache.swift"; sourceTree = "<group>"; };
-		260F669F225C5B6D00407CF5 /* CollectingRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectingRuleTests.swift; sourceTree = "<group>"; };
-		264E080E2248BA2800ADC4C5 /* RuleStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleStorage.swift; sourceTree = "<group>"; };
-		26CE462C228532CD00264485 /* Array+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Array+SwiftLint.swift"; path = "../../SwiftLintFramework/Extensions/Array+SwiftLint.swift"; sourceTree = "<group>"; };
-		287F8B62223083ED00BDC504 /* NSLocalizedStringRequireBundleRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLocalizedStringRequireBundleRule.swift; sourceTree = "<group>"; };
-		2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectPreferIsEqualRule.swift; sourceTree = "<group>"; };
-		2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectPreferIsEqualRuleExamples.swift; sourceTree = "<group>"; };
-		29AD4C641F6EA16C009B66E1 /* ContainsOverFirstNotNilRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFirstNotNilRule.swift; sourceTree = "<group>"; };
-		29FC197721382C06006D208C /* DuplicateImportsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuplicateImportsRule.swift; sourceTree = "<group>"; };
-		29FC197821382C07006D208C /* DuplicateImportsRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuplicateImportsRuleExamples.swift; sourceTree = "<group>"; };
-		29FFC3781F1574FD007E4825 /* FileLengthRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLengthRuleConfiguration.swift; sourceTree = "<group>"; };
-		29FFC37B1F157BA8007E4825 /* FileLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLengthRuleTests.swift; sourceTree = "<group>"; };
-		2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityRule.swift; sourceTree = "<group>"; };
-		2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiReporter.swift; sourceTree = "<group>"; };
-		2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRule.swift; sourceTree = "<group>"; };
-		31F1B6CB1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentRule.swift; sourceTree = "<group>"; };
-		341FDB1C21AD61B20022E8E9 /* MarkdownReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownReporter.swift; sourceTree = "<group>"; };
-		341FDB1E21AD66550022E8E9 /* CannedMarkdownReporterOutput.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CannedMarkdownReporterOutput.md; sourceTree = "<group>"; };
-		37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+SwiftLint.swift"; sourceTree = "<group>"; };
-		3A915E5920A1543000519F3A /* ClosureEndIndentationRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureEndIndentationRuleExamples.swift; sourceTree = "<group>"; };
-		3ABE19CD20B7CDE0009C2EC2 /* MultilineFunctionChainsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineFunctionChainsRule.swift; sourceTree = "<group>"; };
-		3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineLengthConfiguration.swift; sourceTree = "<group>"; };
-		3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeverityConfiguration.swift; sourceTree = "<group>"; };
-		3B12C9BF1C3209AC000B423F /* test.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = test.yml; sourceTree = "<group>"; };
-		3B12C9C21C320A53000B423F /* YamlSwiftLintTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlSwiftLintTests.swift; sourceTree = "<group>"; };
-		3B12C9C41C322032000B423F /* MasterRuleList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterRuleList.swift; sourceTree = "<group>"; };
-		3B12C9C61C3361CB000B423F /* RuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleTests.swift; sourceTree = "<group>"; };
-		3B1DF0111C5148140011BCED /* CustomRules.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomRules.swift; sourceTree = "<group>"; };
-		3B20CD091EB699380069EF2E /* GenericTypeNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericTypeNameRuleTests.swift; sourceTree = "<group>"; };
-		3B20CD0B1EB699C20069EF2E /* TypeNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRuleTests.swift; sourceTree = "<group>"; };
-		3B30C4A01C3785B300E04027 /* YamlParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlParserTests.swift; sourceTree = "<group>"; };
-		3B3A9A321EA3DFD90075B121 /* IdentifierNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierNameRuleTests.swift; sourceTree = "<group>"; };
-		3B5B9FE01C444DA20009AD27 /* Array+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+SwiftLint.swift"; sourceTree = "<group>"; };
-		3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineLengthConfigurationTests.swift; sourceTree = "<group>"; };
-		3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineLengthRuleTests.swift; sourceTree = "<group>"; };
-		3B828E521C546468000D180E /* RuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleConfiguration.swift; sourceTree = "<group>"; };
-		3BA79C9A1C4767910057E705 /* NSRange+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRange+SwiftLint.swift"; sourceTree = "<group>"; };
-		3BB47D821C514E8100AE6A10 /* RegexConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexConfiguration.swift; sourceTree = "<group>"; };
-		3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+SwiftLint.swift"; sourceTree = "<group>"; };
-		3BB47D861C51DE6E00AE6A10 /* CustomRulesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomRulesTests.swift; sourceTree = "<group>"; };
-		3BBF2F9C1C640A0F006CD775 /* SwiftyTextTable.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftyTextTable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3BCC04CC1C4F5694006073C3 /* ConfigurationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationError.swift; sourceTree = "<group>"; };
-		3BCC04CF1C4F56D3006073C3 /* SeverityLevelsConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeverityLevelsConfiguration.swift; sourceTree = "<group>"; };
-		3BCC04D01C4F56D3006073C3 /* NameConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NameConfiguration.swift; sourceTree = "<group>"; };
-		3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleConfigurationTests.swift; sourceTree = "<group>"; };
-		3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlParser.swift; sourceTree = "<group>"; };
-		3BDB224A1C345B4900473680 /* ProjectMock */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ProjectMock; sourceTree = "<group>"; };
-		4100D7A123BEAB5A009464E0 /* FileNameNoSpaceRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameNoSpaceRuleTests.swift; sourceTree = "<group>"; };
-		4100D7A523BEACBF009464E0 /* FileNameNoSpaceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameNoSpaceConfiguration.swift; sourceTree = "<group>"; };
-		4100D7B923BEC284009464E0 /* FileNameNoSpaceRuleFixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FileNameNoSpaceRuleFixtures; sourceTree = "<group>"; };
-		4100D7BB23BEC35F009464E0 /* FileNameNoSpaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileNameNoSpaceRule.swift; sourceTree = "<group>"; };
-		41715DE023BEA08E00544BDF /* FileNameNoSpaceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameNoSpaceRule.swift; sourceTree = "<group>"; };
-		429644B41FB0A99E00D75128 /* SortedFirstLastRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortedFirstLastRule.swift; sourceTree = "<group>"; };
-		47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalConfiguration.swift; sourceTree = "<group>"; };
-		47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalConfigurationTests.swift; sourceTree = "<group>"; };
-		47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalRuleTests.swift; sourceTree = "<group>"; };
-		47FF3BDF1E7C745100187E6D /* ImplicitlyUnwrappedOptionalRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitlyUnwrappedOptionalRule.swift; sourceTree = "<group>"; };
-		4968919123BEAC3D00AB8EF9 /* EnumCaseAssociatedValuesLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumCaseAssociatedValuesLengthRule.swift; sourceTree = "<group>"; };
-		4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLReporter.swift; sourceTree = "<group>"; };
-		4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyCGGeometryFunctionsRule.swift; sourceTree = "<group>"; };
-		4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexHelpers.swift; sourceTree = "<group>"; };
-		4E342B4A2215C6DF008E4EF8 /* ReduceBooleanRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduceBooleanRule.swift; sourceTree = "<group>"; };
-		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
-		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		550DA0DE22DB958400B67F03 /* EmptyCollectionLiteralRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCollectionLiteralRule.swift; sourceTree = "<group>"; };
-		550DA0E122DB9E6B00B67F03 /* ContainsOverRangeNilComparisonRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverRangeNilComparisonRule.swift; sourceTree = "<group>"; };
-		57ED82791CF65183002B3513 /* JUnitReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JUnitReporter.swift; sourceTree = "<group>"; };
-		584B0D392112BA78002F7E25 /* SonarQubeReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonarQubeReporter.swift; sourceTree = "<group>"; };
-		584B0D3B2112E8FB002F7E25 /* CannedSonarQubeReporterOutput.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CannedSonarQubeReporterOutput.json; sourceTree = "<group>"; };
-		6208ED4E20C297AC004E78D1 /* RedundantTypeAnnotationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantTypeAnnotationRule.swift; sourceTree = "<group>"; };
-		621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineParametersRuleExamples.swift; sourceTree = "<group>"; };
-		622AD7FE216ACE6200A002C6 /* XCTSpecificMatcherRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTSpecificMatcherRuleExamples.swift; sourceTree = "<group>"; };
-		622AD7FF216ACE6200A002C6 /* XCTSpecificMatcherRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTSpecificMatcherRule.swift; sourceTree = "<group>"; };
-		623675AF1F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedPendingTestRule.swift; sourceTree = "<group>"; };
-		623675B11F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedPendingTestRuleExamples.swift; sourceTree = "<group>"; };
-		6238AE411ED4D734006C3601 /* MultilineParametersRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineParametersRule.swift; sourceTree = "<group>"; };
-		623E36EF1F3DB1B1002E5B71 /* QuickDiscouragedCallRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedCallRule.swift; sourceTree = "<group>"; };
-		623E36F11F3DB988002E5B71 /* QuickDiscouragedCallRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedCallRuleExamples.swift; sourceTree = "<group>"; };
-		62426A022118BA6E007E6340 /* ClosureBodyLengthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureBodyLengthRule.swift; sourceTree = "<group>"; };
-		62426A042118F991007E6340 /* ClosureBodyLengthRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureBodyLengthRuleExamples.swift; sourceTree = "<group>"; };
-		6258783A1FFC458100AC34F2 /* DiscouragedObjectLiteralRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedObjectLiteralRule.swift; sourceTree = "<group>"; };
-		62622F6A1F2F2E3500D5D099 /* DiscouragedDirectInitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedDirectInitRule.swift; sourceTree = "<group>"; };
-		62640150201552E0005B9C4A /* DiscouragedOptionalBooleanRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalBooleanRule.swift; sourceTree = "<group>"; };
-		6264015320155533005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalBooleanRuleExamples.swift; sourceTree = "<group>"; };
-		626B01B420A1735900D2C42F /* EmptyXCTestMethodRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyXCTestMethodRuleExamples.swift; sourceTree = "<group>"; };
-		626C16E01F948E1C00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedFocusedTestRuleExamples.swift; sourceTree = "<group>"; };
-		626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTFailMessageRule.swift; sourceTree = "<group>"; };
-		627C7A312004F9290053C79D /* XCTSpecificMatcherRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTSpecificMatcherRuleTests.swift; sourceTree = "<group>"; };
-		629ADD052006302D0009E362 /* DiscouragedOptionalCollectionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalCollectionRule.swift; sourceTree = "<group>"; };
-		629C60D81F43906700B4AF92 /* SingleTestClassRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTestClassRule.swift; sourceTree = "<group>"; };
-		62A3E95B209E078000547A86 /* EmptyXCTestMethodRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyXCTestMethodRule.swift; sourceTree = "<group>"; };
-		62A498551F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedDirectInitConfiguration.swift; sourceTree = "<group>"; };
-		62A6E7911F3317E3003A0479 /* JoinedDefaultParameterRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedDefaultParameterRule.swift; sourceTree = "<group>"; };
-		62A7127420F1178F00E604A6 /* AnyObjectProtocolRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyObjectProtocolRule.swift; sourceTree = "<group>"; };
-		62AF35D71F30B183009B11EE /* DiscouragedDirectInitRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedDirectInitRuleTests.swift; sourceTree = "<group>"; };
-		62DADC471FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedTopLevelConstantRule.swift; sourceTree = "<group>"; };
-		62DEA1651FB21A9E00BCCCC6 /* PrivateActionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateActionRule.swift; sourceTree = "<group>"; };
-		62E54FED1F93AD57005B367B /* QuickDiscouragedFocusedTestRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickDiscouragedFocusedTestRule.swift; sourceTree = "<group>"; };
-		62FE5D30200CAB6E00F68793 /* DiscouragedOptionalCollectionExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedOptionalCollectionExamples.swift; sourceTree = "<group>"; };
-		65454F451B14D73800319A6C /* ControlStatementRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlStatementRule.swift; sourceTree = "<group>"; };
-		67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityConfigurationTests.swift; sourceTree = "<group>"; };
-		67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityConfiguration.swift; sourceTree = "<group>"; };
-		67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CyclomaticComplexityRuleTests.swift; sourceTree = "<group>"; };
-		692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpeningBraceRule.swift; sourceTree = "<group>"; };
-		692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionRule.swift; sourceTree = "<group>"; };
-		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
-		6BE79EB02204EC0700B5A2FE /* RequiredDeinitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredDeinitRule.swift; sourceTree = "<group>"; };
-		6C15818C237026AC00F582A2 /* GitHubActionsLoggingReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubActionsLoggingReporter.swift; sourceTree = "<group>"; };
-		6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CannedGitHubActionsLoggingReporterOutput.txt; sourceTree = "<group>"; };
-		6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+DisableSourceKit.swift"; sourceTree = "<group>"; };
-		6C27B5FC2079D33F00353E17 /* Mac-XCTest.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Mac-XCTest.xcconfig"; sourceTree = "<group>"; };
-		6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceKitCrashTests.swift; sourceTree = "<group>"; };
-		725094881D0855760039B353 /* StatementModeConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementModeConfiguration.swift; sourceTree = "<group>"; };
-		72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitACLRule.swift; sourceTree = "<group>"; };
-		740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyStringRule.swift; sourceTree = "<group>"; };
-		75161FDD213B9D67009DE767 /* CollectionAlignmentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionAlignmentConfiguration.swift; sourceTree = "<group>"; };
-		7551DF6C21382C9A00AA1F4D /* ToggleBoolRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleBoolRule.swift; sourceTree = "<group>"; };
-		7565E5F02262BA0900B0597C /* UnusedCaptureListRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedCaptureListRule.swift; sourceTree = "<group>"; };
-		756B585C2138ECD300D1A4E9 /* CollectionAlignmentRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionAlignmentRule.swift; sourceTree = "<group>"; };
-		756C0777222EA49400A111F4 /* ReduceIntoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduceIntoRule.swift; sourceTree = "<group>"; };
-		7578C915214173BE0080FEC9 /* CollectionAlignmentRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionAlignmentRuleTests.swift; sourceTree = "<group>"; };
-		7723A4DE23442D7100F38590 /* RawValueForCamelCasedCodableEnumRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawValueForCamelCasedCodableEnumRule.swift; sourceTree = "<group>"; };
-		787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentConfiguration.swift; sourceTree = "<group>"; };
-		787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseAlignmentRuleTests.swift; sourceTree = "<group>"; };
-		78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverriddenSuperCallRule.swift; sourceTree = "<group>"; };
-		78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridenSuperCallConfiguration.swift; sourceTree = "<group>"; };
-		7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitInitRule.swift; sourceTree = "<group>"; };
-		820F451B2107292500AA056A /* TypeContentsOrderRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeContentsOrderRuleTests.swift; sourceTree = "<group>"; };
-		820F451D21073D7200AA056A /* ConditionalReturnsOnNewlineRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineRuleTests.swift; sourceTree = "<group>"; };
-		82144ACB20F640F200B06695 /* VerticalWhitespaceBetweenCasesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceBetweenCasesRule.swift; sourceTree = "<group>"; };
-		821F70B6210720C700E2C84F /* FileTypesOrderRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypesOrderRuleTests.swift; sourceTree = "<group>"; };
-		823EDC6121020D850070B7CD /* MultilineLiteralBracketsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineLiteralBracketsRule.swift; sourceTree = "<group>"; };
-		824AB64C2105C39F004B5A8F /* ConditionalReturnsOnNewlineConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineConfiguration.swift; sourceTree = "<group>"; };
-		825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralRuleTests.swift; sourceTree = "<group>"; };
-		827009FC20FE26B700ECA185 /* FileTypesOrderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypesOrderRule.swift; sourceTree = "<group>"; };
-		827009FE20FE26C500ECA185 /* TypeContentsOrderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeContentsOrderRule.swift; sourceTree = "<group>"; };
-		827169B21F488181003FB9AF /* ExplicitEnumRawValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitEnumRawValueRule.swift; sourceTree = "<group>"; };
-		827169B41F48D712003FB9AF /* NoGroupingExtensionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoGroupingExtensionRule.swift; sourceTree = "<group>"; };
-		82DB55FD21008F3E001C62FF /* FileTypesOrderConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypesOrderConfiguration.swift; sourceTree = "<group>"; };
-		82DB55FF21008F54001C62FF /* TypeContentsOrderConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeContentsOrderConfiguration.swift; sourceTree = "<group>"; };
-		82EB7883215BAE780042E0FD /* FileTypesOrderRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileTypesOrderRuleExamples.swift; sourceTree = "<group>"; };
-		82EB7884215BAE780042E0FD /* TypeContentsOrderRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeContentsOrderRuleExamples.swift; sourceTree = "<group>"; };
-		82F614F12106014500D23904 /* MultilineParametersBracketsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineParametersBracketsRule.swift; sourceTree = "<group>"; };
-		82F614F32106015100D23904 /* MultilineArgumentsBracketsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsBracketsRule.swift; sourceTree = "<group>"; };
-		82FE253E20F604AD00295958 /* VerticalWhitespaceOpeningBracesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceOpeningBracesRule.swift; sourceTree = "<group>"; };
-		82FE254020F604CB00295958 /* VerticalWhitespaceClosingBracesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceClosingBracesRule.swift; sourceTree = "<group>"; };
-		83894F211B0C928A006214E1 /* RulesCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesCommand.swift; sourceTree = "<group>"; };
-		83D71E261B131EB5000395DE /* RuleDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleDescription.swift; sourceTree = "<group>"; };
-		856651A61D6B395F005E6B29 /* MarkRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkRule.swift; sourceTree = "<group>"; };
-		8B01E4FB20A4183C00C9233E /* FunctionParameterCountConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountConfiguration.swift; sourceTree = "<group>"; };
-		8B01E4FF20A4340A00C9233E /* FunctionParameterCountRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionParameterCountRuleTests.swift; sourceTree = "<group>"; };
-		8F0856EA22DA8508001FF4D4 /* UnusedDeclarationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedDeclarationRule.swift; sourceTree = "<group>"; };
-		8F2CC1CA20A6A070006ED34F /* FileNameConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNameConfiguration.swift; sourceTree = "<group>"; };
-		8F2CC1CC20A6A189006ED34F /* FileNameRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileNameRuleTests.swift; sourceTree = "<group>"; };
-		8F6AA75A211905B8009BA28A /* LintableFilesVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LintableFilesVisitor.swift; sourceTree = "<group>"; };
-		8F6AA75C21190830009BA28A /* CompilerArgumentsExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompilerArgumentsExtractor.swift; sourceTree = "<group>"; };
-		8F715B82213B528B00427BD9 /* UnusedImportRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedImportRule.swift; sourceTree = "<group>"; };
-		8F8050811FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+IndentationStyle.swift"; sourceTree = "<group>"; };
-		8FC8523A2117BDDE0015269B /* ExplicitSelfRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitSelfRule.swift; sourceTree = "<group>"; };
-		8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsDisjointRule.swift; sourceTree = "<group>"; };
-		8FDF482B2122476D00521605 /* AnalyzeCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyzeCommand.swift; sourceTree = "<group>"; };
-		8FDF482D21234BFF00521605 /* LintOrAnalyzeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LintOrAnalyzeCommand.swift; sourceTree = "<group>"; };
-		8FE3CCBB22DBF8D000B8EA87 /* UnusedDeclarationConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedDeclarationConfiguration.swift; sourceTree = "<group>"; };
-		92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRule.swift; sourceTree = "<group>"; };
-		93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalReturnsOnNewlineRule.swift; sourceTree = "<group>"; };
-		A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralConfiguration.swift; sourceTree = "<group>"; };
-		A3184D55215BCEFF00621EA2 /* LegacyRandomRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyRandomRule.swift; sourceTree = "<group>"; };
-		A73469401FB12149009B57C7 /* CallPairRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallPairRule.swift; sourceTree = "<group>"; };
-		B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRule.swift; sourceTree = "<group>"; };
-		B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRuleExamples.swift; sourceTree = "<group>"; };
-		B25DCD0D1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsConfiguration.swift; sourceTree = "<group>"; };
-		B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineArgumentsRuleTests.swift; sourceTree = "<group>"; };
-		B2902A0B1D66815600BFCCF7 /* PrivateUnitTestRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateUnitTestRule.swift; sourceTree = "<group>"; };
-		B2902A0D1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateUnitTestConfiguration.swift; sourceTree = "<group>"; };
-		B3935001033261E5A70CE101 /* CannedEmojiReporterOutput.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CannedEmojiReporterOutput.txt; sourceTree = "<group>"; };
-		B39350463894A3FC1338E0AF /* CannedJSONReporterOutput.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CannedJSONReporterOutput.json; sourceTree = "<group>"; };
-		B3935250C8E0DBACFB27E021 /* CannedHTMLReporterOutput.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = CannedHTMLReporterOutput.html; sourceTree = "<group>"; };
-		B39352E4EA2A06BE66BD661A /* CannedXcodeReporterOutput.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CannedXcodeReporterOutput.txt; sourceTree = "<group>"; };
-		B39353F28BCCA39247B316BD /* String+XML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+XML.swift"; sourceTree = "<group>"; };
-		B39356DE1F73BDA1CA21C504 /* CannedCheckstyleReporterOutput.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = CannedCheckstyleReporterOutput.xml; sourceTree = "<group>"; };
-		B3935939C8366514D2694722 /* CannedCSVReporterOutput.csv */ = {isa = PBXFileReference; lastKnownFileType = file.csv; path = CannedCSVReporterOutput.csv; sourceTree = "<group>"; };
-		B39359A325FE84B7EDD1C455 /* CannedJunitReporterOutput.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = CannedJunitReporterOutput.xml; sourceTree = "<group>"; };
-		B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceUnwrappingRule.swift; sourceTree = "<group>"; };
-		B89F3BC71FD5ED7D00931E59 /* RequiredEnumCaseRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRuleConfiguration.swift; sourceTree = "<group>"; };
-		B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRule.swift; sourceTree = "<group>"; };
-		B89F3BCB1FD5EDA900931E59 /* RequiredEnumCaseRuleTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequiredEnumCaseRuleTestCase.swift; sourceTree = "<group>"; };
-		BB00B4E71F5216070079869F /* MultipleClosuresWithTrailingClosureRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleClosuresWithTrailingClosureRule.swift; sourceTree = "<group>"; };
-		BC8757392195CDD500CA7A74 /* ModifierOrderRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierOrderRuleExamples.swift; sourceTree = "<group>"; };
-		BCB68282216213130078E4C3 /* CompilerProtocolInitRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompilerProtocolInitRuleTests.swift; sourceTree = "<group>"; };
-		BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceConfiguration.swift; sourceTree = "<group>"; };
-		C25EBBDD210787B200E27603 /* PrefixedTopLevelConstantRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedTopLevelConstantRuleTests.swift; sourceTree = "<group>"; };
-		C25EBBE021078D5B00E27603 /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
-		C25EBBE321078DC700E27603 /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
-		C26330352073DAA200D7B4FD /* LowerACLThanParentRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowerACLThanParentRule.swift; sourceTree = "<group>"; };
-		C28B2B3B2106DF210009A0FE /* PrefixedConstantRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedConstantRuleConfiguration.swift; sourceTree = "<group>"; };
-		C2B3C15F2106F78100088928 /* ConfigurationAliasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationAliasesTests.swift; sourceTree = "<group>"; };
-		C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTypeInterfaceRule.swift; sourceTree = "<group>"; };
-		C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FatalErrorMessageRule.swift; sourceTree = "<group>"; };
-		C3EF547521B5A2190009262F /* LegacyHashingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHashingRule.swift; sourceTree = "<group>"; };
-		C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LetVarWhitespaceRule.swift; sourceTree = "<group>"; };
-		C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRuleTests.swift; sourceTree = "<group>"; };
-		CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleIdentifier.swift; sourceTree = "<group>"; };
-		CCD8B87720559C4A00B75847 /* DisableAllTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableAllTests.swift; sourceTree = "<group>"; };
-		CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingConfiguration.swift; sourceTree = "<group>"; };
-		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
-		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
-		D0D1212619E878CC005E4BAA /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		D0D1212719E878CC005E4BAA /* Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Profile.xcconfig; sourceTree = "<group>"; };
-		D0D1212819E878CC005E4BAA /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		D0D1212919E878CC005E4BAA /* Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Test.xcconfig; sourceTree = "<group>"; };
-		D0D1212B19E878CC005E4BAA /* Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Application.xcconfig; sourceTree = "<group>"; };
-		D0D1212C19E878CC005E4BAA /* Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.xcconfig; sourceTree = "<group>"; };
-		D0D1212D19E878CC005E4BAA /* StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = StaticLibrary.xcconfig; sourceTree = "<group>"; };
-		D0D1212F19E878CC005E4BAA /* iOS-Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "iOS-Application.xcconfig"; sourceTree = "<group>"; };
-		D0D1213019E878CC005E4BAA /* iOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "iOS-Base.xcconfig"; sourceTree = "<group>"; };
-		D0D1213119E878CC005E4BAA /* iOS-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "iOS-Framework.xcconfig"; sourceTree = "<group>"; };
-		D0D1213219E878CC005E4BAA /* iOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "iOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
-		D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Mac-Application.xcconfig"; sourceTree = "<group>"; };
-		D0D1213519E878CC005E4BAA /* Mac-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Mac-Base.xcconfig"; sourceTree = "<group>"; };
-		D0D1213619E878CC005E4BAA /* Mac-DynamicLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Mac-DynamicLibrary.xcconfig"; sourceTree = "<group>"; };
-		D0D1213719E878CC005E4BAA /* Mac-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Mac-Framework.xcconfig"; sourceTree = "<group>"; };
-		D0D1213819E878CC005E4BAA /* Mac-StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Mac-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
-		D0D1213919E878CC005E4BAA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftLintFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D0D1217019E87B05005E4BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D0D1217719E87B05005E4BAA /* SwiftLintFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftLintFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D0D1217D19E87B05005E4BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D0E7B63219E9C64500EDBA4D /* swiftlint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftlint.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D286EC001E02DA190003CF72 /* SortedImportsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedImportsRule.swift; sourceTree = "<group>"; };
-		D401D9251ED85EF0005DA5D4 /* RuleKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleKind.swift; sourceTree = "<group>"; };
-		D403A4A21F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatternMatchingKeywordsRule.swift; sourceTree = "<group>"; };
-		D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedClosureParameterRule.swift; sourceTree = "<group>"; };
-		D40E041B1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuperfluousDisableCommandRule.swift; sourceTree = "<group>"; };
-		D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaConfiguration.swift; sourceTree = "<group>"; };
-		D40FE89C1F867BFF006433E2 /* OverrideInExtensionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideInExtensionRule.swift; sourceTree = "<group>"; };
-		D4130D961E16183F00242361 /* IdentifierNameRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierNameRuleExamples.swift; sourceTree = "<group>"; };
-		D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRuleExamples.swift; sourceTree = "<group>"; };
-		D414D6AB21D0B77F00960935 /* DiscouragedObjectLiteralRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscouragedObjectLiteralRuleTests.swift; sourceTree = "<group>"; };
-		D414D6AD21D22FF500960935 /* LastWhereRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastWhereRule.swift; sourceTree = "<group>"; };
-		D41985E621F85014003BE2B7 /* NSLocalizedStringKeyRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLocalizedStringKeyRule.swift; sourceTree = "<group>"; };
-		D41985E821FAB62F003BE2B7 /* DeploymentTargetRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentTargetRule.swift; sourceTree = "<group>"; };
-		D41985EA21FAB63E003BE2B7 /* DeploymentTargetConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentTargetConfiguration.swift; sourceTree = "<group>"; };
-		D41985EC21FAD033003BE2B7 /* DeploymentTargetConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentTargetConfigurationTests.swift; sourceTree = "<group>"; };
-		D41985EE21FAD5E8003BE2B7 /* DeploymentTargetRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentTargetRuleTests.swift; sourceTree = "<group>"; };
-		D41B57771ED8CEE0007B0470 /* ExtensionAccessModifierRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionAccessModifierRule.swift; sourceTree = "<group>"; };
-		D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStringEnumValueRule.swift; sourceTree = "<group>"; };
-		D4246D6C1F30D8620097E658 /* PrivateOverFilePrivateRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRuleConfiguration.swift; sourceTree = "<group>"; };
-		D4246D6E1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOverFilePrivateRuleTests.swift; sourceTree = "<group>"; };
-		D42B45D81F0AF5E30086B683 /* StrictFilePrivateRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrictFilePrivateRule.swift; sourceTree = "<group>"; };
-		D42D2B371E09CC0D00CD7A2E /* FirstWhereRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirstWhereRule.swift; sourceTree = "<group>"; };
-		D42DEAAA20D5EE4400E86F31 /* ConvenienceTypeRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvenienceTypeRule.swift; sourceTree = "<group>"; };
-		D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRuleTests.swift; sourceTree = "<group>"; };
-		D43B04631E0620AB004016AF /* UnusedEnumeratedRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedEnumeratedRule.swift; sourceTree = "<group>"; };
-		D43B04651E071ED3004016AF /* ColonRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColonRuleTests.swift; sourceTree = "<group>"; };
-		D43B04671E07228D004016AF /* ColonConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColonConfiguration.swift; sourceTree = "<group>"; };
-		D43B046A1E075905004016AF /* ClosureEndIndentationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureEndIndentationRule.swift; sourceTree = "<group>"; };
-		D43CDEDB23BDB8D30074F3EE /* OptionalEnumCaseMatchingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalEnumCaseMatchingRule.swift; sourceTree = "<group>"; };
-		D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitGetterRule.swift; sourceTree = "<group>"; };
-		D44037962132730000FDA77B /* ProhibitedInterfaceBuilderRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProhibitedInterfaceBuilderRule.swift; sourceTree = "<group>"; };
-		D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidIBInspectableRule.swift; sourceTree = "<group>"; };
-		D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyntacticSugarRule.swift; sourceTree = "<group>"; };
-		D4441A27213279950020896F /* InertDeferRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InertDeferRule.swift; sourceTree = "<group>"; };
-		D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitReturnRule.swift; sourceTree = "<group>"; };
-		D4470D581EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyEnumArgumentsRule.swift; sourceTree = "<group>"; };
-		D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedOptionalBindingRuleTests.swift; sourceTree = "<group>"; };
-		D4470D5C1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentOnCallRule.swift; sourceTree = "<group>"; };
-		D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyConstructorRule.swift; sourceTree = "<group>"; };
-		D450D1D021EC4A6900E60010 /* StrongIBOutletRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrongIBOutletRule.swift; sourceTree = "<group>"; };
-		D450D1DA21F1992E00E60010 /* TrailingClosureConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingClosureConfiguration.swift; sourceTree = "<group>"; };
-		D450D1DE21F19A9400E60010 /* TrailingClosureRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingClosureRuleTests.swift; sourceTree = "<group>"; };
-		D450D1E121F19B1E00E60010 /* TrailingClosureConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingClosureConfigurationTests.swift; sourceTree = "<group>"; };
-		D45255C71F0932F8003C9B56 /* RuleDescription+Examples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RuleDescription+Examples.swift"; sourceTree = "<group>"; };
-		D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleExamples.swift; sourceTree = "<group>"; };
-		D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRule.swift; sourceTree = "<group>"; };
-		D466B61F233D229F0068190B /* FlatMapOverMapReduceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatMapOverMapReduceRule.swift; sourceTree = "<group>"; };
-		D46A317E1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnneededParenthesesInClosureArgumentRule.swift; sourceTree = "<group>"; };
-		D46C7C3D23BF2F6A007C517F /* PreferSelfTypeOverTypeOfSelfRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferSelfTypeOverTypeOfSelfRule.swift; sourceTree = "<group>"; };
-		D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommaRule.swift; sourceTree = "<group>"; };
-		D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyParenthesesWithTrailingClosureRule.swift; sourceTree = "<group>"; };
-		D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosureParameterPositionRule.swift; sourceTree = "<group>"; };
-		D47079AA1DFDCF7A00027086 /* SwiftExpressionKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExpressionKind.swift; sourceTree = "<group>"; };
-		D47079AC1DFE2FA700027086 /* EmptyParametersRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyParametersRule.swift; sourceTree = "<group>"; };
-		D47079AE1DFE520000027086 /* VoidReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoidReturnRule.swift; sourceTree = "<group>"; };
-		D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchCaseOnNewlineRule.swift; sourceTree = "<group>"; };
-		D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRule.swift; sourceTree = "<group>"; };
-		D47EF47F1F69E3100012C4CA /* ColonRule+FunctionCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColonRule+FunctionCall.swift"; sourceTree = "<group>"; };
-		D47EF4811F69E34D0012C4CA /* ColonRule+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColonRule+Dictionary.swift"; sourceTree = "<group>"; };
-		D47EF4831F69E3D60012C4CA /* ColonRule+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColonRule+Type.swift"; sourceTree = "<group>"; };
-		D47F31141EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtocolPropertyAccessorsOrderRule.swift; sourceTree = "<group>"; };
-		D489B546231233490090BAA0 /* ContainsOverFilterCountRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFilterCountRule.swift; sourceTree = "<group>"; };
-		D489B549231383350090BAA0 /* ContainsOverFilterIsEmptyRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFilterIsEmptyRule.swift; sourceTree = "<group>"; };
-		D48AE2CB1DFB58C5001C6A4A /* AttributesRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRuleExamples.swift; sourceTree = "<group>"; };
-		D48B51201F4F5DEF0068AB98 /* RuleList+Documentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RuleList+Documentation.swift"; sourceTree = "<group>"; };
-		D48B51221F4F5E4B0068AB98 /* DocumentationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentationTests.swift; sourceTree = "<group>"; };
-		D48EE14A231CD34200DBB779 /* NoSpaceInMethodCallRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSpaceInMethodCallRule.swift; sourceTree = "<group>"; };
-		D495B1A021165DAA00E2CD7B /* FileNameRuleFixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FileNameRuleFixtures; sourceTree = "<group>"; };
-		D495B1A121165DAA00E2CD7B /* FileHeaderRuleFixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FileHeaderRuleFixtures; sourceTree = "<group>"; };
-		D49896F02026B36C00814A83 /* RedundantSetAccessControlRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantSetAccessControlRule.swift; sourceTree = "<group>"; };
-		D4998DE61DF191380006E05D /* AttributesRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesRuleTests.swift; sourceTree = "<group>"; };
-		D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRuleTests.swift; sourceTree = "<group>"; };
-		D4A893341E15824100BF954D /* SwiftVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftVersion.swift; sourceTree = "<group>"; };
-		D4AB0EA11F8993DD00CEC380 /* NamespaceCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamespaceCollector.swift; sourceTree = "<group>"; };
-		D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentRule.swift; sourceTree = "<group>"; };
-		D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClassDelegateProtocolRule.swift; sourceTree = "<group>"; };
-		D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantOptionalInitializationRule.swift; sourceTree = "<group>"; };
-		D4B022971E102EE8007E5297 /* ObjectLiteralRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralRule.swift; sourceTree = "<group>"; };
-		D4B022A31E105636007E5297 /* GenericTypeNameRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericTypeNameRule.swift; sourceTree = "<group>"; };
-		D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantVoidReturnRule.swift; sourceTree = "<group>"; };
-		D4B31ADB22A0581B000300F1 /* DuplicateEnumCasesRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateEnumCasesRule.swift; sourceTree = "<group>"; };
-		D4B3409C21F16B110038C79A /* UnusedSetterValueRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedSetterValueRule.swift; sourceTree = "<group>"; };
-		D4B472401F66486300BD6EF1 /* FallthroughRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FallthroughRule.swift; sourceTree = "<group>"; };
-		D4BED5F72278AECC00D86BCE /* UnownedVariableCaptureRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnownedVariableCaptureRule.swift; sourceTree = "<group>"; };
-		D4C0E46E1E3D973600C560F2 /* ForWhereRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForWhereRule.swift; sourceTree = "<group>"; };
-		D4C27BFD1E12D53F00DF713E /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
-		D4C27BFF1E12DFF500DF713E /* LinterCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinterCacheTests.swift; sourceTree = "<group>"; };
-		D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributesConfiguration.swift; sourceTree = "<group>"; };
-		D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderRule.swift; sourceTree = "<group>"; };
-		D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderConfiguration.swift; sourceTree = "<group>"; };
-		D4C889701E385B7B00BAE88D /* RedundantDiscardableLetRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantDiscardableLetRule.swift; sourceTree = "<group>"; };
-		D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorRuleTests.swift; sourceTree = "<group>"; };
-		D4CFC5D1209EC95A00668488 /* FunctionDefaultParameterAtEndRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionDefaultParameterAtEndRule.swift; sourceTree = "<group>"; };
-		D4D0B8F32211428D0053A116 /* ColonRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColonRuleExamples.swift; sourceTree = "<group>"; };
-		D4D1B9B91EAC2C870028BE6A /* AccessControlLevel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessControlLevel.swift; sourceTree = "<group>"; };
-		D4D383842145F550000235BD /* StaticOperatorRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticOperatorRule.swift; sourceTree = "<group>"; };
-		D4D5A5FE1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShorthandOperatorRule.swift; sourceTree = "<group>"; };
-		D4D7320C21E15ED4001C07D9 /* UnusedControlFlowLabelRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedControlFlowLabelRule.swift; sourceTree = "<group>"; };
-		D4DA1DF31E17511D0037413D /* CompilerProtocolInitRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompilerProtocolInitRule.swift; sourceTree = "<group>"; };
-		D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LargeTupleRule.swift; sourceTree = "<group>"; };
-		D4DA1DFB1E19CD300037413D /* GenerateDocsCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenerateDocsCommand.swift; sourceTree = "<group>"; };
-		D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberSeparatorConfiguration.swift; sourceTree = "<group>"; };
-		D4DABFD21E29B4A5009617B6 /* DiscardedNotificationCenterObserverRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardedNotificationCenterObserverRule.swift; sourceTree = "<group>"; };
-		D4DABFD41E2B350F009617B6 /* TrailingClosureRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingClosureRule.swift; sourceTree = "<group>"; };
-		D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenterDetachmentRule.swift; sourceTree = "<group>"; };
-		D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenterDetachmentRuleExamples.swift; sourceTree = "<group>"; };
-		D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleOperatorRule.swift; sourceTree = "<group>"; };
-		D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoRuleTests.swift; sourceTree = "<group>"; };
-		D4DDFF9722396D62006C3629 /* ContainsOverFirstNotNilRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainsOverFirstNotNilRuleTests.swift; sourceTree = "<group>"; };
-		D4DE9131207B4731000FFAA8 /* UnavailableFunctionRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnavailableFunctionRule.swift; sourceTree = "<group>"; };
-		D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayInitRule.swift; sourceTree = "<group>"; };
-		D4E92D1E2137B4C9002EDD48 /* IdenticalOperandsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdenticalOperandsRule.swift; sourceTree = "<group>"; };
-		D4EA77C71F817FD200C315FB /* UnneededBreakInSwitchRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnneededBreakInSwitchRule.swift; sourceTree = "<group>"; };
-		D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiteralExpressionEndIdentationRule.swift; sourceTree = "<group>"; };
-		D4EAB3A320E9948D0051C09A /* AutomaticRuleTests.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomaticRuleTests.generated.swift; sourceTree = "<group>"; };
-		D4EABD0B22CE6F5B00635667 /* VerticalParameterAlignmentRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalParameterAlignmentRuleExamples.swift; sourceTree = "<group>"; };
-		D4F10613229A2F5E00FDE319 /* NoFallthroughOnlyRuleExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoFallthroughOnlyRuleExamples.swift; sourceTree = "<group>"; };
-		D4F10615229A331200FDE319 /* LegacyMultipleRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyMultipleRule.swift; sourceTree = "<group>"; };
-		D4F5851320E99A720085C6D8 /* TrailingWhitespaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceTests.swift; sourceTree = "<group>"; };
-		D4F5851620E99B260085C6D8 /* StatementPositionRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementPositionRuleTests.swift; sourceTree = "<group>"; };
-		D4F5851820E99B5A0085C6D8 /* PrivateOutletRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleTests.swift; sourceTree = "<group>"; };
-		D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorUsageWhitespaceRule.swift; sourceTree = "<group>"; };
-		D4FD4C841F2A260A00DD8AA8 /* BlockBasedKVORule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockBasedKVORule.swift; sourceTree = "<group>"; };
-		D4FD58B11E12A0200019503C /* LinterCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinterCache.swift; sourceTree = "<group>"; };
-		D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestingConfiguration.swift; sourceTree = "<group>"; };
-		DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateOutletRuleConfiguration.swift; sourceTree = "<group>"; };
-		E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicInlineRule.swift; sourceTree = "<group>"; };
-		E48F715C23789823003E1775 /* SwiftLintSyntaxMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftLintSyntaxMap.swift; sourceTree = "<group>"; };
-		E48F715D23789824003E1775 /* SwiftLintSyntaxToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftLintSyntaxToken.swift; sourceTree = "<group>"; };
-		E4A365D123653648003B4141 /* SourceKittenDictionary+Swiftlint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SourceKittenDictionary+Swiftlint.swift"; sourceTree = "<group>"; };
-		E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RandomAccessCollection+Swiftlint.swift"; sourceTree = "<group>"; };
-		E4EA064B23688EB4002531D7 /* SwiftLintFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftLintFile.swift; sourceTree = "<group>"; };
-		E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnArrowWhitespaceRule.swift; sourceTree = "<group>"; };
-		E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorFunctionWhitespaceRule.swift; sourceTree = "<group>"; };
-		E802ECFF1C56A56000A35AE1 /* Benchmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
-		E80746F51ECB722F00548D31 /* CacheDescriptionProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheDescriptionProvider.swift; sourceTree = "<group>"; };
-		E809EDA01B8A71DF00399043 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
-		E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
-		E80E018C1B92C0F60078EB70 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
-		E80E018E1B92C1350078EB70 /* Region.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Region.swift; sourceTree = "<group>"; };
-		E81224991B04F85B001783D2 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
-		E812249B1B04FADC001783D2 /* Linter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Linter.swift; sourceTree = "<group>"; };
-		E816194B1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftDeclarationKind+SwiftLint.swift"; sourceTree = "<group>"; };
-		E816194D1BFBFEAB00946723 /* ForceTryRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceTryRule.swift; sourceTree = "<group>"; };
-		E81619521BFC162C00946723 /* QueuedPrint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueuedPrint.swift; sourceTree = "<group>"; };
-		E81ADD711ED5ED9D000CD451 /* RegionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegionTests.swift; sourceTree = "<group>"; };
-		E81ADD731ED6052F000CD451 /* CommandTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandTests.swift; sourceTree = "<group>"; };
-		E81FB3E31C6D507B00DC988F /* CommonOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommonOptions.swift; sourceTree = "<group>"; };
-		E82367DF1ED3BD1E0040A88E /* Configuration+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Configuration+Cache.swift"; sourceTree = "<group>"; };
-		E832F10A1B17E2F5003F265F /* FileManager+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+SwiftLint.swift"; sourceTree = "<group>"; };
-		E832F10C1B17E725003F265F /* IntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
-		E83530C51ED6328A00FBAF79 /* FileNameRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileNameRule.swift; sourceTree = "<group>"; };
-		E83A0B341A5D382B0041A60A /* VersionCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionCommand.swift; sourceTree = "<group>"; };
-		E847F0A81BFBBABD00EA9363 /* EmptyCountRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyCountRule.swift; sourceTree = "<group>"; };
-		E84E07461C13F95300F11122 /* AutoCorrectCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoCorrectCommand.swift; sourceTree = "<group>"; };
-		E861519A1B0573B900C54AC0 /* LintCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LintCommand.swift; sourceTree = "<group>"; };
-		E86396C11BADAAE5002C9E88 /* Reporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reporter.swift; sourceTree = "<group>"; };
-		E86396C41BADAC15002C9E88 /* XcodeReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeReporter.swift; sourceTree = "<group>"; };
-		E86396C61BADAFE6002C9E88 /* ReporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReporterTests.swift; sourceTree = "<group>"; };
-		E86396C81BADB2B9002C9E88 /* JSONReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONReporter.swift; sourceTree = "<group>"; };
-		E86396CA1BADB519002C9E88 /* CSVReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSVReporter.swift; sourceTree = "<group>"; };
-		E86623661F1D377900AAA3A2 /* Configuration+Parsing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Configuration+Parsing.swift"; sourceTree = "<group>"; };
-		E868473B1A587C6E0043DC65 /* sourcekitd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = sourcekitd.framework; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/sourcekitd.framework; sourceTree = DEVELOPER_DIR; };
-		E86E2B2D1E17443B001E823C /* Reporter+CommandLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Reporter+CommandLine.swift"; sourceTree = "<group>"; };
-		E876BFBD1B07828500114ED5 /* SourceKittenFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SourceKittenFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingSemicolonRule.swift; sourceTree = "<group>"; };
-		E87E4A081BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SyntaxKind+SwiftLint.swift"; sourceTree = "<group>"; };
-		E889D8C41F1D11A200058332 /* Configuration+LintableFiles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Configuration+LintableFiles.swift"; sourceTree = "<group>"; };
-		E889D8C61F1D357B00058332 /* Configuration+Merging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Configuration+Merging.swift"; sourceTree = "<group>"; };
-		E88DEA6A1B0983FE00A66CB0 /* StyleViolation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleViolation.swift; sourceTree = "<group>"; };
-		E88DEA6E1B09843F00A66CB0 /* Location.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; tabWidth = 4; };
-		E88DEA701B09847500A66CB0 /* ViolationSeverity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViolationSeverity.swift; sourceTree = "<group>"; };
-		E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SwiftLint.swift"; sourceTree = "<group>"; };
-		E88DEA741B09852000A66CB0 /* SwiftLintFile+Regex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftLintFile+Regex.swift"; sourceTree = "<group>"; };
-		E88DEA761B098D0C00A66CB0 /* Rule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Rule.swift; sourceTree = "<group>"; };
-		E88DEA781B098D4400A66CB0 /* RuleParameter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleParameter.swift; sourceTree = "<group>"; };
-		E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineLengthRule.swift; sourceTree = "<group>"; };
-		E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeadingWhitespaceRule.swift; sourceTree = "<group>"; };
-		E88DEA7F1B09903300A66CB0 /* ForceCastRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceCastRule.swift; sourceTree = "<group>"; };
-		E88DEA811B0990A700A66CB0 /* TodoRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoRule.swift; sourceTree = "<group>"; };
-		E88DEA831B0990F500A66CB0 /* ColonRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColonRule.swift; sourceTree = "<group>"; };
-		E88DEA851B0991BF00A66CB0 /* TrailingWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingWhitespaceRule.swift; sourceTree = "<group>"; };
-		E88DEA871B09924C00A66CB0 /* TrailingNewlineRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingNewlineRule.swift; sourceTree = "<group>"; };
-		E88DEA891B0992B300A66CB0 /* FileLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLengthRule.swift; sourceTree = "<group>"; };
-		E88DEA8B1B0999A000A66CB0 /* ASTRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASTRule.swift; sourceTree = "<group>"; };
-		E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeBodyLengthRule.swift; sourceTree = "<group>"; };
-		E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionBodyLengthRule.swift; sourceTree = "<group>"; };
-		E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeNameRule.swift; sourceTree = "<group>"; };
-		E88DEA931B099C0900A66CB0 /* IdentifierNameRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierNameRule.swift; sourceTree = "<group>"; };
-		E88DEA951B099CF200A66CB0 /* NestingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestingRule.swift; sourceTree = "<group>"; };
-		E89376AC1B8A701E0025708E /* Yaml.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Yaml.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E8AB1A2D1A649F2100452012 /* libclang.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libclang.dylib; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib; sourceTree = DEVELOPER_DIR; };
-		E8B067801C13E49600E9E13F /* Configuration+CommandLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Configuration+CommandLine.swift"; sourceTree = "<group>"; };
-		E8B67C3D1C095E6300FDED8E /* Correction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Correction.swift; sourceTree = "<group>"; };
-		E8BA7E101B07A3EC003E02D0 /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulesTests.swift; sourceTree = "<group>"; };
-		E8BDE3FE1EDF91B6002EC12F /* RuleList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleList.swift; sourceTree = "<group>"; };
-		E8BE1FCB1E07687400F781C7 /* Yams.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Yams.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E8EA41161C2D1DBE004F9930 /* CheckstyleReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckstyleReporter.swift; sourceTree = "<group>"; };
-		ED641C3620AA070700212C62 /* NoFallthroughOnlyRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoFallthroughOnlyRule.swift; sourceTree = "<group>"; };
-		F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyNSGeometryFunctionsRule.swift; sourceTree = "<group>"; };
-		F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+Nested.swift"; sourceTree = "<group>"; };
-		F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+BundlePath.swift"; sourceTree = "<group>"; };
-		F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConfigurationTests+ProjectMock.swift"; sourceTree = "<group>"; };
-		F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRuleConfiguration.swift; sourceTree = "<group>"; };
-		F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRuleConfigurationTests.swift; sourceTree = "<group>"; };
-		F9D73F021D0CF15E00222FC4 /* test.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = test.txt; sourceTree = "<group>"; };
-		F9E691272091952E0085B53E /* MissingDocsRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingDocsRule.swift; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		D0D1216919E87B05005E4BAA /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E876BFBE1B07828500114ED5 /* SourceKittenFramework.framework in Frameworks */,
-				E8C0DFCD1AD349DB007EE3D4 /* SWXMLHash.framework in Frameworks */,
-				3BBF2F9D1C640A0F006CD775 /* SwiftyTextTable.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D0D1217419E87B05005E4BAA /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D0D1217819E87B05005E4BAA /* SwiftLintFramework.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D0E7B62F19E9C64500EDBA4D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6CB8A80C1D11A7E10052816E /* Commandant.framework in Frameworks */,
-				D0E7B65319E9C6AD00EDBA4D /* SwiftLintFramework.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		3B12C9BE1C3209AC000B423F /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				D495B1A121165DAA00E2CD7B /* FileHeaderRuleFixtures */,
-				4100D7B923BEC284009464E0 /* FileNameNoSpaceRuleFixtures */,
-				D495B1A021165DAA00E2CD7B /* FileNameRuleFixtures */,
-				3B12C9BF1C3209AC000B423F /* test.yml */,
-				3BDB224A1C345B4900473680 /* ProjectMock */,
-				F9D73F021D0CF15E00222FC4 /* test.txt */,
-				B3935250C8E0DBACFB27E021 /* CannedHTMLReporterOutput.html */,
-				B39359A325FE84B7EDD1C455 /* CannedJunitReporterOutput.xml */,
-				B39356DE1F73BDA1CA21C504 /* CannedCheckstyleReporterOutput.xml */,
-				B3935939C8366514D2694722 /* CannedCSVReporterOutput.csv */,
-				6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */,
-				B39352E4EA2A06BE66BD661A /* CannedXcodeReporterOutput.txt */,
-				B3935001033261E5A70CE101 /* CannedEmojiReporterOutput.txt */,
-				B39350463894A3FC1338E0AF /* CannedJSONReporterOutput.json */,
-				584B0D3B2112E8FB002F7E25 /* CannedSonarQubeReporterOutput.json */,
-				341FDB1E21AD66550022E8E9 /* CannedMarkdownReporterOutput.md */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */ = {
-			isa = PBXGroup;
-			children = (
-				D4C4A34A1DEA4FD700E0E04C /* AttributesConfiguration.swift */,
-				75161FDD213B9D67009DE767 /* CollectionAlignmentConfiguration.swift */,
-				D43B04671E07228D004016AF /* ColonConfiguration.swift */,
-				824AB64C2105C39F004B5A8F /* ConditionalReturnsOnNewlineConfiguration.swift */,
-				67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */,
-				62A498551F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift */,
-				D41985EA21FAB63E003BE2B7 /* DeploymentTargetConfiguration.swift */,
-				125AAC77203AA82D0004BCE0 /* ExplicitTypeInterfaceConfiguration.swift */,
-				D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */,
-				29FFC3781F1574FD007E4825 /* FileLengthRuleConfiguration.swift */,
-				8F2CC1CA20A6A070006ED34F /* FileNameConfiguration.swift */,
-				82DB55FD21008F3E001C62FF /* FileTypesOrderConfiguration.swift */,
-				8B01E4FB20A4183C00C9233E /* FunctionParameterCountConfiguration.swift */,
-				47ACC8971E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift */,
-				3B034B6C1E0BE544005D49A9 /* LineLengthConfiguration.swift */,
-				F90DBD7E2092E669002CC310 /* MissingDocsRuleConfiguration.swift */,
-				188B3FF3207D61230073C2D6 /* ModifierOrderConfiguration.swift */,
-				B25DCD0D1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift */,
-				3BCC04D01C4F56D3006073C3 /* NameConfiguration.swift */,
-				D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */,
-				D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */,
-				A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */,
-				78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */,
-				C28B2B3B2106DF210009A0FE /* PrefixedConstantRuleConfiguration.swift */,
-				DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */,
-				D4246D6C1F30D8620097E658 /* PrivateOverFilePrivateRuleConfiguration.swift */,
-				B2902A0D1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift */,
-				009E09291DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift */,
-				3BB47D821C514E8100AE6A10 /* RegexConfiguration.swift */,
-				B89F3BC71FD5ED7D00931E59 /* RequiredEnumCaseRuleConfiguration.swift */,
-				3B0B14531C505D6300BE82F7 /* SeverityConfiguration.swift */,
-				3BCC04CF1C4F56D3006073C3 /* SeverityLevelsConfiguration.swift */,
-				725094881D0855760039B353 /* StatementModeConfiguration.swift */,
-				787CDE38208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift */,
-				D40F83871DE9179200524C62 /* TrailingCommaConfiguration.swift */,
-				D450D1DA21F1992E00E60010 /* TrailingClosureConfiguration.swift */,
-				22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */,
-				BF48D2D61CBCCA5F0080BDAE /* TrailingWhitespaceConfiguration.swift */,
-				82DB55FF21008F54001C62FF /* TypeContentsOrderConfiguration.swift */,
-				CE8178EB1EAC02CD0063186E /* UnusedOptionalBindingConfiguration.swift */,
-				8FE3CCBB22DBF8D000B8EA87 /* UnusedDeclarationConfiguration.swift */,
-				006204DA1E1E48F900FFFBE1 /* VerticalWhitespaceConfiguration.swift */,
-				4100D7A523BEACBF009464E0 /* FileNameNoSpaceConfiguration.swift */,
-			);
-			path = RuleConfigurations;
-			sourceTree = "<group>";
-		};
-		4DCB8E7C1CBE43530070FCF0 /* Helpers */ = {
-			isa = PBXGroup;
-			children = (
-				C25EBBE321078DC700E27603 /* Glob.swift */,
-				D4AB0EA11F8993DD00CEC380 /* NamespaceCollector.swift */,
-				4DCB8E7D1CBE43640070FCF0 /* RegexHelpers.swift */,
-			);
-			path = Helpers;
-			sourceTree = "<group>";
-		};
-		5499CA981A2394BD00783309 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				E8BA7E101B07A3EC003E02D0 /* Commandant.framework */,
-				5499CA961A2394B700783309 /* Components.plist */,
-				5499CA971A2394B700783309 /* Info.plist */,
-			);
-			path = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		8F2892B421176E1200691D58 /* Metrics */ = {
-			isa = PBXGroup;
-			children = (
-				62426A022118BA6E007E6340 /* ClosureBodyLengthRule.swift */,
-				62426A042118F991007E6340 /* ClosureBodyLengthRuleExamples.swift */,
-				2E02005E1C54BF680024D09D /* CyclomaticComplexityRule.swift */,
-				4968919123BEAC3D00AB8EF9 /* EnumCaseAssociatedValuesLengthRule.swift */,
-				E88DEA891B0992B300A66CB0 /* FileLengthRule.swift */,
-				E88DEA8F1B099A3100A66CB0 /* FunctionBodyLengthRule.swift */,
-				2E5761A91C573B83003271AF /* FunctionParameterCountRule.swift */,
-				D4DA1DF91E18D6200037413D /* LargeTupleRule.swift */,
-				E88DEA7B1B098D7D00A66CB0 /* LineLengthRule.swift */,
-				E88DEA951B099CF200A66CB0 /* NestingRule.swift */,
-				E88DEA8D1B0999CD00A66CB0 /* TypeBodyLengthRule.swift */,
-			);
-			path = Metrics;
-			sourceTree = "<group>";
-		};
-		8F2892B521176EA400691D58 /* Performance */ = {
-			isa = PBXGroup;
-			children = (
-				29AD4C641F6EA16C009B66E1 /* ContainsOverFirstNotNilRule.swift */,
-				D489B546231233490090BAA0 /* ContainsOverFilterCountRule.swift */,
-				D489B549231383350090BAA0 /* ContainsOverFilterIsEmptyRule.swift */,
-				550DA0E122DB9E6B00B67F03 /* ContainsOverRangeNilComparisonRule.swift */,
-				550DA0DE22DB958400B67F03 /* EmptyCollectionLiteralRule.swift */,
-				E847F0A81BFBBABD00EA9363 /* EmptyCountRule.swift */,
-				740DF1AF203F5AFC0081F694 /* EmptyStringRule.swift */,
-				D42D2B371E09CC0D00CD7A2E /* FirstWhereRule.swift */,
-				D466B61F233D229F0068190B /* FlatMapOverMapReduceRule.swift */,
-				D414D6AD21D22FF500960935 /* LastWhereRule.swift */,
-				756C0777222EA49400A111F4 /* ReduceIntoRule.swift */,
-				429644B41FB0A99E00D75128 /* SortedFirstLastRule.swift */,
-				4E342B4A2215C6DF008E4EF8 /* ReduceBooleanRule.swift */,
-			);
-			path = Performance;
-			sourceTree = "<group>";
-		};
-		8F2892B621176FBE00691D58 /* Lint */ = {
-			isa = PBXGroup;
-			children = (
-				62A7127420F1178F00E604A6 /* AnyObjectProtocolRule.swift */,
-				D4E2BA841F6CD77B00E8E184 /* ArrayInitRule.swift */,
-				D4B0228D1E0CC608007E5297 /* ClassDelegateProtocolRule.swift */,
-				D4DA1DF31E17511D0037413D /* CompilerProtocolInitRule.swift */,
-				D41985E821FAB62F003BE2B7 /* DeploymentTargetRule.swift */,
-				D4DABFD21E29B4A5009617B6 /* DiscardedNotificationCenterObserverRule.swift */,
-				62622F6A1F2F2E3500D5D099 /* DiscouragedDirectInitRule.swift */,
-				E315B83B1DFA4BC500621B44 /* DynamicInlineRule.swift */,
-				62A3E95B209E078000547A86 /* EmptyXCTestMethodRule.swift */,
-				626B01B420A1735900D2C42F /* EmptyXCTestMethodRuleExamples.swift */,
-				7723A4DE23442D7100F38590 /* RawValueForCamelCasedCodableEnumRule.swift */,
-				D4E92D1E2137B4C9002EDD48 /* IdenticalOperandsRule.swift */,
-				D4441A27213279950020896F /* InertDeferRule.swift */,
-				C26330352073DAA200D7B4FD /* LowerACLThanParentRule.swift */,
-				856651A61D6B395F005E6B29 /* MarkRule.swift */,
-				F9E691272091952E0085B53E /* MissingDocsRule.swift */,
-				D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */,
-				D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */,
-				D4B31ADB22A0581B000300F1 /* DuplicateEnumCasesRule.swift */,
-				D41985E621F85014003BE2B7 /* NSLocalizedStringKeyRule.swift */,
-				287F8B62223083ED00BDC504 /* NSLocalizedStringRequireBundleRule.swift */,
-				2882895B22287C9C0037CF5F /* NSObjectPreferIsEqualRule.swift */,
-				2882895D22287E2C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift */,
-				78F032441D7C877800BE709A /* OverriddenSuperCallRule.swift */,
-				D40FE89C1F867BFF006433E2 /* OverrideInExtensionRule.swift */,
-				62DEA1651FB21A9E00BCCCC6 /* PrivateActionRule.swift */,
-				094385021D5D4F78009168CF /* PrivateOutletRule.swift */,
-				B2902A0B1D66815600BFCCF7 /* PrivateUnitTestRule.swift */,
-				D44037962132730000FDA77B /* ProhibitedInterfaceBuilderRule.swift */,
-				009E09271DFEE4C200B588A7 /* ProhibitedSuperRule.swift */,
-				623E36EF1F3DB1B1002E5B71 /* QuickDiscouragedCallRule.swift */,
-				623E36F11F3DB988002E5B71 /* QuickDiscouragedCallRuleExamples.swift */,
-				62E54FED1F93AD57005B367B /* QuickDiscouragedFocusedTestRule.swift */,
-				626C16E01F948E1C00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift */,
-				623675AF1F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift */,
-				623675B11F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift */,
-				6BE79EB02204EC0700B5A2FE /* RequiredDeinitRule.swift */,
-				B89F3BC91FD5ED9000931E59 /* RequiredEnumCaseRule.swift */,
-				D450D1D021EC4A6900E60010 /* StrongIBOutletRule.swift */,
-				D40E041B1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift */,
-				E88DEA811B0990A700A66CB0 /* TodoRule.swift */,
-				7565E5F02262BA0900B0597C /* UnusedCaptureListRule.swift */,
-				D40AD0891E032F9700F48C30 /* UnusedClosureParameterRule.swift */,
-				D4D7320C21E15ED4001C07D9 /* UnusedControlFlowLabelRule.swift */,
-				8F0856EA22DA8508001FF4D4 /* UnusedDeclarationRule.swift */,
-				8F715B82213B528B00427BD9 /* UnusedImportRule.swift */,
-				D4BED5F72278AECC00D86BCE /* UnownedVariableCaptureRule.swift */,
-				D4B3409C21F16B110038C79A /* UnusedSetterValueRule.swift */,
-				D442541E1DB87C3D00492EA4 /* ValidIBInspectableRule.swift */,
-				094384FF1D5D2382009168CF /* WeakDelegateRule.swift */,
-				1872906F1FC37A9B0016BEA2 /* YodaConditionRule.swift */,
-				22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */,
-			);
-			path = Lint;
-			sourceTree = "<group>";
-		};
-		8F2892B7211770EC00691D58 /* Style */ = {
-			isa = PBXGroup;
-			children = (
-				D47A510F1DB2DD4800A4CC21 /* AttributesRule.swift */,
-				D48AE2CB1DFB58C5001C6A4A /* AttributesRuleExamples.swift */,
-				1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */,
-				D43B046A1E075905004016AF /* ClosureEndIndentationRule.swift */,
-				3A915E5920A1543000519F3A /* ClosureEndIndentationRuleExamples.swift */,
-				D47079A81DFDBED000027086 /* ClosureParameterPositionRule.swift */,
-				1E82D5581D7775C7009553D7 /* ClosureSpacingRule.swift */,
-				756B585C2138ECD300D1A4E9 /* CollectionAlignmentRule.swift */,
-				E88DEA831B0990F500A66CB0 /* ColonRule.swift */,
-				D4D0B8F32211428D0053A116 /* ColonRuleExamples.swift */,
-				D47EF4811F69E34D0012C4CA /* ColonRule+Dictionary.swift */,
-				D47EF47F1F69E3100012C4CA /* ColonRule+FunctionCall.swift */,
-				D47EF4831F69E3D60012C4CA /* ColonRule+Type.swift */,
-				695BE9CE1BDFD92B0071E985 /* CommaRule.swift */,
-				93E0C3CD1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift */,
-				65454F451B14D73800319A6C /* ControlStatementRule.swift */,
-				3B1DF0111C5148140011BCED /* CustomRules.swift */,
-				D4470D581EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift */,
-				D47079AC1DFE2FA700027086 /* EmptyParametersRule.swift */,
-				D47079A61DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift */,
-				8FC8523A2117BDDE0015269B /* ExplicitSelfRule.swift */,
-				D4C4A34D1DEA877200E0E04C /* FileHeaderRule.swift */,
-				827009FC20FE26B700ECA185 /* FileTypesOrderRule.swift */,
-				82EB7883215BAE780042E0FD /* FileTypesOrderRuleExamples.swift */,
-				E88DEA931B099C0900A66CB0 /* IdentifierNameRule.swift */,
-				D4130D961E16183F00242361 /* IdentifierNameRuleExamples.swift */,
-				D43DB1071DC573DA00281215 /* ImplicitGetterRule.swift */,
-				D4470D561EB69225008A1B2E /* ImplicitReturnRule.swift */,
-				E88DEA7D1B098F2A00A66CB0 /* LeadingWhitespaceRule.swift */,
-				C946FEC91EAE5E20007DD778 /* LetVarWhitespaceRule.swift */,
-				D4EA77C91F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift */,
-				188B3FF1207D61040073C2D6 /* ModifierOrderRule.swift */,
-				BC8757392195CDD500CA7A74 /* ModifierOrderRuleExamples.swift */,
-				82F614F32106015100D23904 /* MultilineArgumentsBracketsRule.swift */,
-				B25DCD071F7E9B5F0028A199 /* MultilineArgumentsRule.swift */,
-				B25DCD091F7E9BB50028A199 /* MultilineArgumentsRuleExamples.swift */,
-				3ABE19CD20B7CDE0009C2EC2 /* MultilineFunctionChainsRule.swift */,
-				823EDC6121020D850070B7CD /* MultilineLiteralBracketsRule.swift */,
-				82F614F12106014500D23904 /* MultilineParametersBracketsRule.swift */,
-				6238AE411ED4D734006C3601 /* MultilineParametersRule.swift */,
-				621061BE1ED57E640082D51E /* MultilineParametersRuleExamples.swift */,
-				BB00B4E71F5216070079869F /* MultipleClosuresWithTrailingClosureRule.swift */,
-				D48EE14A231CD34200DBB779 /* NoSpaceInMethodCallRule.swift */,
-				D46252531DF63FB200BE2CA1 /* NumberSeparatorRule.swift */,
-				D462021E1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift */,
-				692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */,
-				E5A167C81B25A0B000CF2D03 /* OperatorFunctionWhitespaceRule.swift */,
-				D4FBADCF1E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift */,
-				D43CDEDB23BDB8D30074F3EE /* OptionalEnumCaseMatchingRule.swift */,
-				D46C7C3D23BF2F6A007C517F /* PreferSelfTypeOverTypeOfSelfRule.swift */,
-				62DADC471FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift */,
-				D47F31141EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift */,
-				D4C889701E385B7B00BAE88D /* RedundantDiscardableLetRule.swift */,
-				E57B23C01B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift */,
-				D4D5A5FE1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift */,
-				629C60D81F43906700B4AF92 /* SingleTestClassRule.swift */,
-				D286EC001E02DA190003CF72 /* SortedImportsRule.swift */,
-				692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */,
-				31F1B6CB1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift */,
-				D47A510D1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift */,
-				D4DABFD41E2B350F009617B6 /* TrailingClosureRule.swift */,
-				D46E041C1DE3712C00728374 /* TrailingCommaRule.swift */,
-				E88DEA871B09924C00A66CB0 /* TrailingNewlineRule.swift */,
-				E88DEA851B0991BF00A66CB0 /* TrailingWhitespaceRule.swift */,
-				827009FE20FE26C500ECA185 /* TypeContentsOrderRule.swift */,
-				82EB7884215BAE780042E0FD /* TypeContentsOrderRuleExamples.swift */,
-				D46A317E1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift */,
-				92CCB2D61E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift */,
-				D4470D5C1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift */,
-				D4B0226E1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift */,
-				D4EABD0B22CE6F5B00635667 /* VerticalParameterAlignmentRuleExamples.swift */,
-				82144ACB20F640F200B06695 /* VerticalWhitespaceBetweenCasesRule.swift */,
-				82FE254020F604CB00295958 /* VerticalWhitespaceClosingBracesRule.swift */,
-				82FE253E20F604AD00295958 /* VerticalWhitespaceOpeningBracesRule.swift */,
-				1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */,
-				D47079AE1DFE520000027086 /* VoidReturnRule.swift */,
-			);
-			path = Style;
-			sourceTree = "<group>";
-		};
-		8F2892B8211770FB00691D58 /* Idiomatic */ = {
-			isa = PBXGroup;
-			children = (
-				D4FD4C841F2A260A00DD8AA8 /* BlockBasedKVORule.swift */,
-				D42DEAAA20D5EE4400E86F31 /* ConvenienceTypeRule.swift */,
-				6258783A1FFC458100AC34F2 /* DiscouragedObjectLiteralRule.swift */,
-				62640150201552E0005B9C4A /* DiscouragedOptionalBooleanRule.swift */,
-				6264015320155533005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift */,
-				62FE5D30200CAB6E00F68793 /* DiscouragedOptionalCollectionExamples.swift */,
-				629ADD052006302D0009E362 /* DiscouragedOptionalCollectionRule.swift */,
-				29FC197721382C06006D208C /* DuplicateImportsRule.swift */,
-				29FC197821382C07006D208C /* DuplicateImportsRuleExamples.swift */,
-				72EA17B51FD31F10009D5CE6 /* ExplicitACLRule.swift */,
-				827169B21F488181003FB9AF /* ExplicitEnumRawValueRule.swift */,
-				7C0C2E791D2866CB0076435A /* ExplicitInitRule.swift */,
-				1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */,
-				C328A2F51E67595500A9E4D7 /* ExplicitTypeInterfaceRule.swift */,
-				D41B57771ED8CEE0007B0470 /* ExtensionAccessModifierRule.swift */,
-				D4B472401F66486300BD6EF1 /* FallthroughRule.swift */,
-				C3DE5DAA1E7DF99B00761483 /* FatalErrorMessageRule.swift */,
-				4100D7BB23BEC35F009464E0 /* FileNameNoSpaceRule.swift */,
-				E83530C51ED6328A00FBAF79 /* FileNameRule.swift */,
-				E88DEA7F1B09903300A66CB0 /* ForceCastRule.swift */,
-				E816194D1BFBFEAB00946723 /* ForceTryRule.swift */,
-				B58AEED51C492C7B00E901FD /* ForceUnwrappingRule.swift */,
-				D4C0E46E1E3D973600C560F2 /* ForWhereRule.swift */,
-				D4CFC5D1209EC95A00668488 /* FunctionDefaultParameterAtEndRule.swift */,
-				D4B022A31E105636007E5297 /* GenericTypeNameRule.swift */,
-				47FF3BDF1E7C745100187E6D /* ImplicitlyUnwrappedOptionalRule.swift */,
-				8FC9F5101F4B8E48006826C1 /* IsDisjointRule.swift */,
-				62A6E7911F3317E3003A0479 /* JoinedDefaultParameterRule.swift */,
-				4DB7815C1CAD690100BC4723 /* LegacyCGGeometryFunctionsRule.swift */,
-				006ECFC31C44E99E00EF6364 /* LegacyConstantRule.swift */,
-				00B8D9771E2D0FBD004E0EEC /* LegacyConstantRuleExamples.swift */,
-				D44AD2741C0AA3730048F7B0 /* LegacyConstructorRule.swift */,
-				C3EF547521B5A2190009262F /* LegacyHashingRule.swift */,
-				D4F10615229A331200FDE319 /* LegacyMultipleRule.swift */,
-				F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */,
-				A3184D55215BCEFF00621EA2 /* LegacyRandomRule.swift */,
-				D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */,
-				1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */,
-				ED641C3620AA070700212C62 /* NoFallthroughOnlyRule.swift */,
-				D4F10613229A2F5E00FDE319 /* NoFallthroughOnlyRuleExamples.swift */,
-				827169B41F48D712003FB9AF /* NoGroupingExtensionRule.swift */,
-				D4B022971E102EE8007E5297 /* ObjectLiteralRule.swift */,
-				D403A4A21F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift */,
-				1E3C2D701EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift */,
-				24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */,
-				18B90B6A21ADD99800B60749 /* RedundantObjcAttributeRule.swift */,
-				183B6B4721FF66B700425134 /* RedundantObjcAttributeRuleExamples.swift */,
-				D4B022951E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift */,
-				D49896F02026B36C00814A83 /* RedundantSetAccessControlRule.swift */,
-				D41E7E0A1DF9DABB0065259A /* RedundantStringEnumValueRule.swift */,
-				6208ED4E20C297AC004E78D1 /* RedundantTypeAnnotationRule.swift */,
-				D4B022B11E10B613007E5297 /* RedundantVoidReturnRule.swift */,
-				D4D383842145F550000235BD /* StaticOperatorRule.swift */,
-				D42B45D81F0AF5E30086B683 /* StrictFilePrivateRule.swift */,
-				D44254251DB9C12300492EA4 /* SyntacticSugarRule.swift */,
-				7551DF6C21382C9A00AA1F4D /* ToggleBoolRule.swift */,
-				E87E4A041BFB927C00FCFE46 /* TrailingSemicolonRule.swift */,
-				E88DEA911B099B1F00A66CB0 /* TypeNameRule.swift */,
-				D4130D981E16CC1300242361 /* TypeNameRuleExamples.swift */,
-				D4DE9131207B4731000FFAA8 /* UnavailableFunctionRule.swift */,
-				D4EA77C71F817FD200C315FB /* UnneededBreakInSwitchRule.swift */,
-				181D9E162038343D001F6887 /* UntypedErrorInCatchRule.swift */,
-				D43B04631E0620AB004016AF /* UnusedEnumeratedRule.swift */,
-				41715DE023BEA08E00544BDF /* FileNameNoSpaceRule.swift */,
-				626D02961F31CBCC0054788D /* XCTFailMessageRule.swift */,
-				622AD7FF216ACE6200A002C6 /* XCTSpecificMatcherRule.swift */,
-				622AD7FE216ACE6200A002C6 /* XCTSpecificMatcherRuleExamples.swift */,
-			);
-			path = Idiomatic;
-			sourceTree = "<group>";
-		};
-		D0D1210F19E87861005E4BAA = {
-			isa = PBXGroup;
-			children = (
-				D0D1211919E87861005E4BAA /* Products */,
-				D0D1211A19E87861005E4BAA /* swiftlint */,
-				D0D1216E19E87B05005E4BAA /* SwiftLintFramework */,
-				D0D1217B19E87B05005E4BAA /* SwiftLintFrameworkTests */,
-			);
-			indentWidth = 4;
-			sourceTree = "<group>";
-			tabWidth = 4;
-			usesTabs = 0;
-		};
-		D0D1211919E87861005E4BAA /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */,
-				D0D1217719E87B05005E4BAA /* SwiftLintFrameworkTests.xctest */,
-				D0E7B63219E9C64500EDBA4D /* swiftlint.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		D0D1211A19E87861005E4BAA /* swiftlint */ = {
-			isa = PBXGroup;
-			children = (
-				E802ECFE1C56A54600A35AE1 /* Helpers */,
-				E8B0677F1C13E48100E9E13F /* Extensions */,
-				E85FF9921C13E35400714267 /* Commands */,
-				D0D1211B19E87861005E4BAA /* main.swift */,
-				5499CA981A2394BD00783309 /* Supporting Files */,
-			);
-			name = swiftlint;
-			path = Source/swiftlint;
-			sourceTree = "<group>";
-		};
-		D0D1212219E878CC005E4BAA /* Configuration */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1213919E878CC005E4BAA /* README.md */,
-				D0D1212319E878CC005E4BAA /* Base */,
-				D0D1212E19E878CC005E4BAA /* iOS */,
-				D0D1213319E878CC005E4BAA /* Mac OS X */,
-			);
-			name = Configuration;
-			path = Carthage/Checkouts/xcconfigs;
-			sourceTree = SOURCE_ROOT;
-		};
-		D0D1212319E878CC005E4BAA /* Base */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1212419E878CC005E4BAA /* Common.xcconfig */,
-				D0D1212519E878CC005E4BAA /* Configurations */,
-				D0D1212A19E878CC005E4BAA /* Targets */,
-			);
-			path = Base;
-			sourceTree = "<group>";
-		};
-		D0D1212519E878CC005E4BAA /* Configurations */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1212619E878CC005E4BAA /* Debug.xcconfig */,
-				D0D1212719E878CC005E4BAA /* Profile.xcconfig */,
-				D0D1212819E878CC005E4BAA /* Release.xcconfig */,
-				D0D1212919E878CC005E4BAA /* Test.xcconfig */,
-			);
-			path = Configurations;
-			sourceTree = "<group>";
-		};
-		D0D1212A19E878CC005E4BAA /* Targets */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1212B19E878CC005E4BAA /* Application.xcconfig */,
-				D0D1212C19E878CC005E4BAA /* Framework.xcconfig */,
-				D0D1212D19E878CC005E4BAA /* StaticLibrary.xcconfig */,
-			);
-			path = Targets;
-			sourceTree = "<group>";
-		};
-		D0D1212E19E878CC005E4BAA /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1212F19E878CC005E4BAA /* iOS-Application.xcconfig */,
-				D0D1213019E878CC005E4BAA /* iOS-Base.xcconfig */,
-				D0D1213119E878CC005E4BAA /* iOS-Framework.xcconfig */,
-				D0D1213219E878CC005E4BAA /* iOS-StaticLibrary.xcconfig */,
-			);
-			path = iOS;
-			sourceTree = "<group>";
-		};
-		D0D1213319E878CC005E4BAA /* Mac OS X */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */,
-				D0D1213519E878CC005E4BAA /* Mac-Base.xcconfig */,
-				D0D1213619E878CC005E4BAA /* Mac-DynamicLibrary.xcconfig */,
-				D0D1213719E878CC005E4BAA /* Mac-Framework.xcconfig */,
-				D0D1213819E878CC005E4BAA /* Mac-StaticLibrary.xcconfig */,
-				6C27B5FC2079D33F00353E17 /* Mac-XCTest.xcconfig */,
-			);
-			path = "Mac OS X";
-			sourceTree = "<group>";
-		};
-		D0D1216E19E87B05005E4BAA /* SwiftLintFramework */ = {
-			isa = PBXGroup;
-			children = (
-				E8A541811BF94604006BA322 /* Extensions */,
-				4DCB8E7C1CBE43530070FCF0 /* Helpers */,
-				E8A541801BF945FF006BA322 /* Models */,
-				E8A5417F1BF945F9006BA322 /* Protocols */,
-				E86396C31BADAC0D002C9E88 /* Reporters */,
-				E88DEA7A1B098D7300A66CB0 /* Rules */,
-				D0D1216F19E87B05005E4BAA /* Supporting Files */,
-			);
-			name = SwiftLintFramework;
-			path = Source/SwiftLintFramework;
-			sourceTree = "<group>";
-		};
-		D0D1216F19E87B05005E4BAA /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1217019E87B05005E4BAA /* Info.plist */,
-				E8AB1A2D1A649F2100452012 /* libclang.dylib */,
-				E868473B1A587C6E0043DC65 /* sourcekitd.framework */,
-				E876BFBD1B07828500114ED5 /* SourceKittenFramework.framework */,
-				3BBF2F9C1C640A0F006CD775 /* SwiftyTextTable.framework */,
-				E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */,
-				E89376AC1B8A701E0025708E /* Yaml.framework */,
-				E8BE1FCB1E07687400F781C7 /* Yams.framework */,
-			);
-			path = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		D0D1217B19E87B05005E4BAA /* SwiftLintFrameworkTests */ = {
-			isa = PBXGroup;
-			children = (
-				D4998DE61DF191380006E05D /* AttributesRuleTests.swift */,
-				D4EAB3A320E9948D0051C09A /* AutomaticRuleTests.generated.swift */,
-				260F669F225C5B6D00407CF5 /* CollectingRuleTests.swift */,
-				7578C915214173BE0080FEC9 /* CollectionAlignmentRuleTests.swift */,
-				D43B04651E071ED3004016AF /* ColonRuleTests.swift */,
-				E81ADD731ED6052F000CD451 /* CommandTests.swift */,
-				BCB68282216213130078E4C3 /* CompilerProtocolInitRuleTests.swift */,
-				820F451D21073D7200AA056A /* ConditionalReturnsOnNewlineRuleTests.swift */,
-				D0D1212219E878CC005E4BAA /* Configuration */,
-				C2B3C15F2106F78100088928 /* ConfigurationAliasesTests.swift */,
-				E809EDA21B8A73FB00399043 /* ConfigurationTests.swift */,
-				F480DC7E1F26090000099465 /* ConfigurationTests+Nested.swift */,
-				F480DC821F2609D700099465 /* ConfigurationTests+ProjectMock.swift */,
-				D4DDFF9722396D62006C3629 /* ContainsOverFirstNotNilRuleTests.swift */,
-				3BB47D861C51DE6E00AE6A10 /* CustomRulesTests.swift */,
-				67932E2C1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift */,
-				67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */,
-				D41985EC21FAD033003BE2B7 /* DeploymentTargetConfigurationTests.swift */,
-				D41985EE21FAD5E8003BE2B7 /* DeploymentTargetRuleTests.swift */,
-				CCD8B87720559C4A00B75847 /* DisableAllTests.swift */,
-				62AF35D71F30B183009B11EE /* DiscouragedDirectInitRuleTests.swift */,
-				D414D6AB21D0B77F00960935 /* DiscouragedObjectLiteralRuleTests.swift */,
-				D48B51221F4F5E4B0068AB98 /* DocumentationTests.swift */,
-				125CE52E20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift */,
-				12E3D4DB2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift */,
-				02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */,
-				D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */,
-				29FFC37B1F157BA8007E4825 /* FileLengthRuleTests.swift */,
-				4100D7A123BEAB5A009464E0 /* FileNameNoSpaceRuleTests.swift */,
-				8F2CC1CC20A6A189006ED34F /* FileNameRuleTests.swift */,
-				821F70B6210720C700E2C84F /* FileTypesOrderRuleTests.swift */,
-				D4348EE91C46122C007707FB /* FunctionBodyLengthRuleTests.swift */,
-				8B01E4FF20A4340A00C9233E /* FunctionParameterCountRuleTests.swift */,
-				3B20CD091EB699380069EF2E /* GenericTypeNameRuleTests.swift */,
-				C25EBBE021078D5B00E27603 /* GlobTests.swift */,
-				3B3A9A321EA3DFD90075B121 /* IdentifierNameRuleTests.swift */,
-				47ACC8991E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift */,
-				47ACC89B1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift */,
-				E832F10C1B17E725003F265F /* IntegrationTests.swift */,
-				3B63D46C1E1F05160057BE35 /* LineLengthConfigurationTests.swift */,
-				3B63D46E1E1F09DF0057BE35 /* LineLengthRuleTests.swift */,
-				D4C27BFF1E12DFF500DF713E /* LinterCacheTests.swift */,
-				F90DBD802092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift */,
-				1EB7C8521F0C45C2004BAD22 /* ModifierOrderTests.swift */,
-				B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */,
-				D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */,
-				825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */,
-				C25EBBDD210787B200E27603 /* PrefixedTopLevelConstantRuleTests.swift */,
-				D4F5851820E99B5A0085C6D8 /* PrivateOutletRuleTests.swift */,
-				D4246D6E1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift */,
-				E81ADD711ED5ED9D000CD451 /* RegionTests.swift */,
-				E86396C61BADAFE6002C9E88 /* ReporterTests.swift */,
-				B89F3BCB1FD5EDA900931E59 /* RequiredEnumCaseRuleTestCase.swift */,
-				3B12C9BE1C3209AC000B423F /* Resources */,
-				3BCC04D31C502BAB006073C3 /* RuleConfigurationTests.swift */,
-				D45255C71F0932F8003C9B56 /* RuleDescription+Examples.swift */,
-				E8BB8F9B1B17DE3B00199606 /* RulesTests.swift */,
-				3B12C9C61C3361CB000B423F /* RuleTests.swift */,
-				6C7045431C6ADA450003F15A /* SourceKitCrashTests.swift */,
-				D4F5851620E99B260085C6D8 /* StatementPositionRuleTests.swift */,
-				D0D1217C19E87B05005E4BAA /* Supporting Files */,
-				787CDE3A208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift */,
-				E81224991B04F85B001783D2 /* TestHelpers.swift */,
-				D4DB92241E628898005DE9C1 /* TodoRuleTests.swift */,
-				224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */,
-				D450D1E121F19B1E00E60010 /* TrailingClosureConfigurationTests.swift */,
-				D450D1DE21F19A9400E60010 /* TrailingClosureRuleTests.swift */,
-				C9802F2E1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift */,
-				D4F5851320E99A720085C6D8 /* TrailingWhitespaceTests.swift */,
-				820F451B2107292500AA056A /* TypeContentsOrderRuleTests.swift */,
-				3B20CD0B1EB699C20069EF2E /* TypeNameRuleTests.swift */,
-				D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */,
-				006204DD1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift */,
-				F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */,
-				627C7A312004F9290053C79D /* XCTSpecificMatcherRuleTests.swift */,
-				3B30C4A01C3785B300E04027 /* YamlParserTests.swift */,
-				3B12C9C21C320A53000B423F /* YamlSwiftLintTests.swift */,
-			);
-			name = SwiftLintFrameworkTests;
-			path = Tests/SwiftLintFrameworkTests;
-			sourceTree = "<group>";
-		};
-		D0D1217C19E87B05005E4BAA /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				D0D1217D19E87B05005E4BAA /* Info.plist */,
-			);
-			path = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		E802ECFE1C56A54600A35AE1 /* Helpers */ = {
-			isa = PBXGroup;
-			children = (
-				E802ECFF1C56A56000A35AE1 /* Benchmark.swift */,
-				E81FB3E31C6D507B00DC988F /* CommonOptions.swift */,
-				8F6AA75C21190830009BA28A /* CompilerArgumentsExtractor.swift */,
-				8F6AA75A211905B8009BA28A /* LintableFilesVisitor.swift */,
-				8FDF482D21234BFF00521605 /* LintOrAnalyzeCommand.swift */,
-			);
-			path = Helpers;
-			sourceTree = "<group>";
-		};
-		E85FF9921C13E35400714267 /* Commands */ = {
-			isa = PBXGroup;
-			children = (
-				8FDF482B2122476D00521605 /* AnalyzeCommand.swift */,
-				E84E07461C13F95300F11122 /* AutoCorrectCommand.swift */,
-				D4DA1DFB1E19CD300037413D /* GenerateDocsCommand.swift */,
-				E861519A1B0573B900C54AC0 /* LintCommand.swift */,
-				83894F211B0C928A006214E1 /* RulesCommand.swift */,
-				E83A0B341A5D382B0041A60A /* VersionCommand.swift */,
-			);
-			path = Commands;
-			sourceTree = "<group>";
-		};
-		E86396C31BADAC0D002C9E88 /* Reporters */ = {
-			isa = PBXGroup;
-			children = (
-				E8EA41161C2D1DBE004F9930 /* CheckstyleReporter.swift */,
-				E86396CA1BADB519002C9E88 /* CSVReporter.swift */,
-				2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */,
-				6C15818C237026AC00F582A2 /* GitHubActionsLoggingReporter.swift */,
-				4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */,
-				E86396C81BADB2B9002C9E88 /* JSONReporter.swift */,
-				57ED82791CF65183002B3513 /* JUnitReporter.swift */,
-				341FDB1C21AD61B20022E8E9 /* MarkdownReporter.swift */,
-				E86396C41BADAC15002C9E88 /* XcodeReporter.swift */,
-				584B0D392112BA78002F7E25 /* SonarQubeReporter.swift */,
-			);
-			path = Reporters;
-			sourceTree = "<group>";
-		};
-		E88DEA7A1B098D7300A66CB0 /* Rules */ = {
-			isa = PBXGroup;
-			children = (
-				8F2892B8211770FB00691D58 /* Idiomatic */,
-				8F2892B621176FBE00691D58 /* Lint */,
-				8F2892B421176E1200691D58 /* Metrics */,
-				8F2892B521176EA400691D58 /* Performance */,
-				8F2892B7211770EC00691D58 /* Style */,
-				3BCC04CE1C4F56D3006073C3 /* RuleConfigurations */,
-			);
-			path = Rules;
-			sourceTree = "<group>";
-		};
-		E8A5417F1BF945F9006BA322 /* Protocols */ = {
-			isa = PBXGroup;
-			children = (
-				E88DEA8B1B0999A000A66CB0 /* ASTRule.swift */,
-				E80746F51ECB722F00548D31 /* CacheDescriptionProvider.swift */,
-				A73469401FB12149009B57C7 /* CallPairRule.swift */,
-				E86396C11BADAAE5002C9E88 /* Reporter.swift */,
-				E88DEA761B098D0C00A66CB0 /* Rule.swift */,
-				3B828E521C546468000D180E /* RuleConfiguration.swift */,
-			);
-			path = Protocols;
-			sourceTree = "<group>";
-		};
-		E8A541801BF945FF006BA322 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				D4D1B9B91EAC2C870028BE6A /* AccessControlLevel.swift */,
-				E80E018C1B92C0F60078EB70 /* Command.swift */,
-				E809EDA01B8A71DF00399043 /* Configuration.swift */,
-				3BCC04CC1C4F5694006073C3 /* ConfigurationError.swift */,
-				E8B67C3D1C095E6300FDED8E /* Correction.swift */,
-				E812249B1B04FADC001783D2 /* Linter.swift */,
-				D4FD58B11E12A0200019503C /* LinterCache.swift */,
-				E88DEA6E1B09843F00A66CB0 /* Location.swift */,
-				3B12C9C41C322032000B423F /* MasterRuleList.swift */,
-				E80E018E1B92C1350078EB70 /* Region.swift */,
-				83D71E261B131EB5000395DE /* RuleDescription.swift */,
-				CC26ED05204DE86E0013BBBC /* RuleIdentifier.swift */,
-				E8BDE3FE1EDF91B6002EC12F /* RuleList.swift */,
-				D48B51201F4F5DEF0068AB98 /* RuleList+Documentation.swift */,
-				D401D9251ED85EF0005DA5D4 /* RuleKind.swift */,
-				E88DEA781B098D4400A66CB0 /* RuleParameter.swift */,
-				E88DEA6A1B0983FE00A66CB0 /* StyleViolation.swift */,
-				E4EA064B23688EB4002531D7 /* SwiftLintFile.swift */,
-				E48F715C23789823003E1775 /* SwiftLintSyntaxMap.swift */,
-				E48F715D23789824003E1775 /* SwiftLintSyntaxToken.swift */,
-				D4A893341E15824100BF954D /* SwiftVersion.swift */,
-				D4C27BFD1E12D53F00DF713E /* Version.swift */,
-				E88DEA701B09847500A66CB0 /* ViolationSeverity.swift */,
-				3BD9CD3C1C37175B009A5D25 /* YamlParser.swift */,
-				264E080E2248BA2800ADC4C5 /* RuleStorage.swift */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		E8A541811BF94604006BA322 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				3B5B9FE01C444DA20009AD27 /* Array+SwiftLint.swift */,
-				E82367DF1ED3BD1E0040A88E /* Configuration+Cache.swift */,
-				8F8050811FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift */,
-				E889D8C41F1D11A200058332 /* Configuration+LintableFiles.swift */,
-				E889D8C61F1D357B00058332 /* Configuration+Merging.swift */,
-				E86623661F1D377900AAA3A2 /* Configuration+Parsing.swift */,
-				37B3FA8A1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift */,
-				24E17F701B1481FF008195BE /* SwiftLintFile+Cache.swift */,
-				E88DEA741B09852000A66CB0 /* SwiftLintFile+Regex.swift */,
-				E832F10A1B17E2F5003F265F /* FileManager+SwiftLint.swift */,
-				3BA79C9A1C4767910057E705 /* NSRange+SwiftLint.swift */,
-				3BB47D841C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift */,
-				E81619521BFC162C00946723 /* QueuedPrint.swift */,
-				E4A6CF742363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift */,
-				6C1D763121A4E69600DEF783 /* Request+DisableSourceKit.swift */,
-				E4A365D123653648003B4141 /* SourceKittenDictionary+Swiftlint.swift */,
-				E88DEA721B0984C400A66CB0 /* String+SwiftLint.swift */,
-				B39353F28BCCA39247B316BD /* String+XML.swift */,
-				E816194B1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift */,
-				1894D740207D57AD00BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift */,
-				D47079AA1DFDCF7A00027086 /* SwiftExpressionKind.swift */,
-				E87E4A081BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		E8B0677F1C13E48100E9E13F /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				26CE462C228532CD00264485 /* Array+SwiftLint.swift */,
-				E8B067801C13E49600E9E13F /* Configuration+CommandLine.swift */,
-				E86E2B2D1E17443B001E823C /* Reporter+CommandLine.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXHeadersBuildPhase section */
-		D0D1216A19E87B05005E4BAA /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
-/* Begin PBXNativeTarget section */
-		D0D1216C19E87B05005E4BAA /* SwiftLintFramework */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D0D1218419E87B05005E4BAA /* Build configuration list for PBXNativeTarget "SwiftLintFramework" */;
-			buildPhases = (
-				6CF24C411FC9953E008CB0B1 /* Update Source/SwiftLintFramework/Models/MasterRuleList.swift */,
-				D4F5851220E999C40085C6D8 /* Update Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift */,
-				6CF24C421FC99616008CB0B1 /* Update Tests/LinuxMain.swift */,
-				D0D1216819E87B05005E4BAA /* Sources */,
-				D0D1216919E87B05005E4BAA /* Frameworks */,
-				D0D1216A19E87B05005E4BAA /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SwiftLintFramework;
-			productName = SourceKittenFramework;
-			productReference = D0D1216D19E87B05005E4BAA /* SwiftLintFramework.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		D0D1217619E87B05005E4BAA /* SwiftLintFrameworkTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D0D1218519E87B05005E4BAA /* Build configuration list for PBXNativeTarget "SwiftLintFrameworkTests" */;
-			buildPhases = (
-				D0D1217319E87B05005E4BAA /* Sources */,
-				D0D1217419E87B05005E4BAA /* Frameworks */,
-				3B12C9C01C3209C4000B423F /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				D0D1217A19E87B05005E4BAA /* PBXTargetDependency */,
-			);
-			name = SwiftLintFrameworkTests;
-			productName = SourceKittenFrameworkTests;
-			productReference = D0D1217719E87B05005E4BAA /* SwiftLintFrameworkTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		D0E7B63119E9C64500EDBA4D /* swiftlint */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D0E7B64919E9C64600EDBA4D /* Build configuration list for PBXNativeTarget "swiftlint" */;
-			buildPhases = (
-				C2265FAB1A4B86AC00158358 /* Check Xcode Version */,
-				D0E7B62E19E9C64500EDBA4D /* Sources */,
-				D0E7B62F19E9C64500EDBA4D /* Frameworks */,
-				D0E7B65719E9C7C700EDBA4D /* Extract CLI Tool */,
-				D0AAAB5319FB0960007B24B3 /* Embed Frameworks */,
-				6CCFCF291CFEF6D3003239EB /* Embed Frameworks into SwiftLintFramework.framework */,
-				6CCFCF321CFEF768003239EB /* Embed Swift libraries into SwiftLintFramework.framework */,
-				E819854B1B09A3CB00CEB0D9 /* Run SwiftLint */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				D0AAAB5219FB0960007B24B3 /* PBXTargetDependency */,
-			);
-			name = swiftlint;
-			productName = swiftlint;
-			productReference = D0E7B63219E9C64500EDBA4D /* swiftlint.app */;
-			productType = "com.apple.product-type.application";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		D0D1211019E87861005E4BAA /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0930;
-				ORGANIZATIONNAME = Realm;
-				TargetAttributes = {
-					D0D1216C19E87B05005E4BAA = {
-						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 1010;
-					};
-					D0D1217619E87B05005E4BAA = {
-						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 1010;
-					};
-					D0E7B63119E9C64500EDBA4D = {
-						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 1010;
-					};
-				};
-			};
-			buildConfigurationList = D0D1211319E87861005E4BAA /* Build configuration list for PBXProject "SwiftLint" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = en;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = D0D1210F19E87861005E4BAA;
-			productRefGroup = D0D1211919E87861005E4BAA /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				D0E7B63119E9C64500EDBA4D /* swiftlint */,
-				D0D1216C19E87B05005E4BAA /* SwiftLintFramework */,
-				D0D1217619E87B05005E4BAA /* SwiftLintFrameworkTests */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		3B12C9C01C3209C4000B423F /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3B12C9C11C3209CB000B423F /* test.yml in Resources */,
-				F9D73F031D0CF15E00222FC4 /* test.txt in Resources */,
-				341FDB1F21AD66550022E8E9 /* CannedMarkdownReporterOutput.md in Resources */,
-				3BDB224B1C345B4900473680 /* ProjectMock in Resources */,
-				B3935797FF80C7F97953D375 /* CannedHTMLReporterOutput.html in Resources */,
-				B3935371E92E0CF3F7668303 /* CannedJunitReporterOutput.xml in Resources */,
-				B39357173B43C9B5E351C360 /* CannedCheckstyleReporterOutput.xml in Resources */,
-				B3935A32BE03C4D11B4364D6 /* CannedCSVReporterOutput.csv in Resources */,
-				D495B1A321165DAA00E2CD7B /* FileHeaderRuleFixtures in Resources */,
-				584B0D3C2112E8FB002F7E25 /* CannedSonarQubeReporterOutput.json in Resources */,
-				B3935522DC192D38D4852FA3 /* CannedXcodeReporterOutput.txt in Resources */,
-				4100D7BA23BEC285009464E0 /* FileNameNoSpaceRuleFixtures in Resources */,
-				B39358AA2D2AF5219D3FD7C0 /* CannedEmojiReporterOutput.txt in Resources */,
-				B3935A1C3BCA03A6B902E7AF /* CannedJSONReporterOutput.json in Resources */,
-				6C15818F23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt in Resources */,
-				D495B1A221165DAA00E2CD7B /* FileNameRuleFixtures in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		6CCFCF321CFEF768003239EB /* Embed Swift libraries into SwiftLintFramework.framework */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Swift libraries into SwiftLintFramework.framework";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cd \"$TARGET_BUILD_DIR\"\nSWIFTLINTFRAMEWORK_BUNDLE=\"$FRAMEWORKS_FOLDER_PATH/SwiftLintFramework.framework\"\n\nxcrun swift-stdlib-tool --copy --verbose --Xcodesign --timestamp=none \\\n--scan-executable \"$EXECUTABLE_PATH\" \\\n--scan-folder \"$FRAMEWORKS_FOLDER_PATH\" \\\n--platform macosx --destination \"$SWIFTLINTFRAMEWORK_BUNDLE/Versions/Current/Frameworks\" \\\n--strip-bitcode\n";
-			showEnvVarsInLog = 0;
-		};
-		6CF24C411FC9953E008CB0B1 /* Update Source/SwiftLintFramework/Models/MasterRuleList.swift */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Source/SwiftLintFramework/Rules/*.swift",
-			);
-			name = "Update Source/SwiftLintFramework/Models/MasterRuleList.swift";
-			outputPaths = (
-				"$(SRCROOT)/Source/SwiftLintFramework/Models/MasterRuleList.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which sourcery >/dev/null; then\n  make Source/SwiftLintFramework/Models/MasterRuleList.swift\nelse\n  echo \"Sourcery not found, install with 'brew install sourcery'\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		6CF24C421FC99616008CB0B1 /* Update Tests/LinuxMain.swift */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Tests/*/*.swift",
-			);
-			name = "Update Tests/LinuxMain.swift";
-			outputPaths = (
-				"$(SRCROOT)/Tests/LinuxMain.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which sourcery >/dev/null; then\n  make Tests/LinuxMain.swift\nelse\n  echo \"Sourcery not found, install with 'brew install sourcery'\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		C2265FAB1A4B86AC00158358 /* Check Xcode Version */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Xcode Version";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/bash;
-			shellScript = ". script/check-xcode-version";
-		};
-		D0E7B65719E9C7C700EDBA4D /* Extract CLI Tool */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(EXECUTABLE_PATH)",
-			);
-			name = "Extract CLI Tool";
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(EXECUTABLE_NAME)",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/bash;
-			shellScript = ". script/extract-tool";
-		};
-		D4F5851220E999C40085C6D8 /* Update Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Source/SwiftLintFramework/Rules/*.swift",
-			);
-			name = "Update Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift";
-			outputPaths = (
-				"$(SRCROOT)/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which sourcery >/dev/null; then\n  make Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift\nelse\n  echo \"Sourcery not found, install with 'brew install sourcery'\"\nfi\n";
-		};
-		E819854B1B09A3CB00CEB0D9 /* Run SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run SwiftLint";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		D0D1216819E87B05005E4BAA /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				62426A062118F995007E6340 /* ClosureBodyLengthRuleExamples.swift in Sources */,
-				8B01E4FD20A41C8700C9233E /* FunctionParameterCountConfiguration.swift in Sources */,
-				740DF1B1203F62BB0081F694 /* EmptyStringRule.swift in Sources */,
-				4DB7815E1CAD72BA00BC4723 /* LegacyCGGeometryFunctionsRule.swift in Sources */,
-				D4F10614229A2F5E00FDE319 /* NoFallthroughOnlyRuleExamples.swift in Sources */,
-				3ABE19CF20B7CE32009C2EC2 /* MultilineFunctionChainsRule.swift in Sources */,
-				82FE253F20F604AD00295958 /* VerticalWhitespaceOpeningBracesRule.swift in Sources */,
-				827169B51F48D712003FB9AF /* NoGroupingExtensionRule.swift in Sources */,
-				D41B57781ED8CEE0007B0470 /* ExtensionAccessModifierRule.swift in Sources */,
-				E881985C1BEA978500333A11 /* TrailingNewlineRule.swift in Sources */,
-				D414D6AE21D22FF500960935 /* LastWhereRule.swift in Sources */,
-				D4EABD0C22CE6F5B00635667 /* VerticalParameterAlignmentRuleExamples.swift in Sources */,
-				D44037972132730000FDA77B /* ProhibitedInterfaceBuilderRule.swift in Sources */,
-				78F032481D7D614300BE709A /* OverridenSuperCallConfiguration.swift in Sources */,
-				D47079A71DFCEB2D00027086 /* EmptyParenthesesWithTrailingClosureRule.swift in Sources */,
-				E881985E1BEA982100333A11 /* TypeBodyLengthRule.swift in Sources */,
-				69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */,
-				C26330382073DAC500D7B4FD /* LowerACLThanParentRule.swift in Sources */,
-				78F032461D7C877E00BE709A /* OverriddenSuperCallRule.swift in Sources */,
-				E80E018D1B92C0F60078EB70 /* Command.swift in Sources */,
-				E88198571BEA953300333A11 /* ForceCastRule.swift in Sources */,
-				D44AD2761C0AA5350048F7B0 /* LegacyConstructorRule.swift in Sources */,
-				D41985E721F85014003BE2B7 /* NSLocalizedStringKeyRule.swift in Sources */,
-				4E342B4C2215C793008E4EF8 /* ReduceBooleanRule.swift in Sources */,
-				D286EC021E02DF6F0003CF72 /* SortedImportsRule.swift in Sources */,
-				D40E041C1F46E3B30043BC4E /* SuperfluousDisableCommandRule.swift in Sources */,
-				82F614F42106015100D23904 /* MultilineArgumentsBracketsRule.swift in Sources */,
-				E86623671F1D377900AAA3A2 /* Configuration+Parsing.swift in Sources */,
-				3BCC04CD1C4F5694006073C3 /* ConfigurationError.swift in Sources */,
-				D4C4A34E1DEA877200E0E04C /* FileHeaderRule.swift in Sources */,
-				1894D746207D585400BD94CF /* SwiftDeclarationAttributeKind+Swiftlint.swift in Sources */,
-				D4E92D1F2137B4C9002EDD48 /* IdenticalOperandsRule.swift in Sources */,
-				6250D32A1ED4DFEB00735129 /* MultilineParametersRule.swift in Sources */,
-				009E092A1DFEE4DD00B588A7 /* ProhibitedSuperConfiguration.swift in Sources */,
-				341FDB2021AD69970022E8E9 /* MarkdownReporter.swift in Sources */,
-				181D9E172038343D001F6887 /* UntypedErrorInCatchRule.swift in Sources */,
-				47FF3BE11E7C75B600187E6D /* ImplicitlyUnwrappedOptionalRule.swift in Sources */,
-				623E36F01F3DB1B1002E5B71 /* QuickDiscouragedCallRule.swift in Sources */,
-				288289602229776C0037CF5F /* NSObjectPreferIsEqualRuleExamples.swift in Sources */,
-				BFF028AE1CBCF8A500B38A9D /* TrailingWhitespaceConfiguration.swift in Sources */,
-				3B034B6E1E0BE549005D49A9 /* LineLengthConfiguration.swift in Sources */,
-				B25DCD0C1F7E9FA20028A199 /* MultilineArgumentsRule.swift in Sources */,
-				6258783B1FFC458100AC34F2 /* DiscouragedObjectLiteralRule.swift in Sources */,
-				62A3E95D209E084000547A86 /* EmptyXCTestMethodRule.swift in Sources */,
-				D4C4A34C1DEA4FF000E0E04C /* AttributesConfiguration.swift in Sources */,
-				29FC197A21382C07006D208C /* DuplicateImportsRuleExamples.swift in Sources */,
-				83D71E281B131ECE000395DE /* RuleDescription.swift in Sources */,
-				D4470D571EB69225008A1B2E /* ImplicitReturnRule.swift in Sources */,
-				8FE3CCBC22DBF8D000B8EA87 /* UnusedDeclarationConfiguration.swift in Sources */,
-				3B12C9C51C322032000B423F /* MasterRuleList.swift in Sources */,
-				E812249C1B04FADC001783D2 /* Linter.swift in Sources */,
-				1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */,
-				DAD3BE4A1D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift in Sources */,
-				188B3FF4207D61230073C2D6 /* ModifierOrderConfiguration.swift in Sources */,
-				183B6B4921FF672B00425134 /* RedundantObjcAttributeRuleExamples.swift in Sources */,
-				D4B022961E0EF80C007E5297 /* RedundantOptionalInitializationRule.swift in Sources */,
-				2E02005F1C54BF680024D09D /* CyclomaticComplexityRule.swift in Sources */,
-				D4FBADD01E00DA0400669C73 /* OperatorUsageWhitespaceRule.swift in Sources */,
-				D4C4A3521DEFBBB700E0E04C /* FileHeaderConfiguration.swift in Sources */,
-				623675B01F960C5C009BE6F3 /* QuickDiscouragedPendingTestRule.swift in Sources */,
-				287F8B642230843000BDC504 /* NSLocalizedStringRequireBundleRule.swift in Sources */,
-				D47079AD1DFE2FA700027086 /* EmptyParametersRule.swift in Sources */,
-				E87E4A091BFB9CAE00FCFE46 /* SyntaxKind+SwiftLint.swift in Sources */,
-				3B0B14541C505D6300BE82F7 /* SeverityConfiguration.swift in Sources */,
-				827009FF20FE26C500ECA185 /* TypeContentsOrderRule.swift in Sources */,
-				E88198551BEA949A00333A11 /* ControlStatementRule.swift in Sources */,
-				584B0D3A2112BA78002F7E25 /* SonarQubeReporter.swift in Sources */,
-				E57B23C11B1D8BF000DEA512 /* ReturnArrowWhitespaceRule.swift in Sources */,
-				D4246D6D1F30D8620097E658 /* PrivateOverFilePrivateRuleConfiguration.swift in Sources */,
-				3A915E5B20A1543700519F3A /* ClosureEndIndentationRuleExamples.swift in Sources */,
-				629ADD062006302D0009E362 /* DiscouragedOptionalCollectionRule.swift in Sources */,
-				29FC197921382C07006D208C /* DuplicateImportsRule.swift in Sources */,
-				E816194E1BFBFEAB00946723 /* ForceTryRule.swift in Sources */,
-				8F2CC1CB20A6A070006ED34F /* FileNameConfiguration.swift in Sources */,
-				D4CFC5D2209EC95A00668488 /* FunctionDefaultParameterAtEndRule.swift in Sources */,
-				E88198541BEA945100333A11 /* CommaRule.swift in Sources */,
-				22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */,
-				D4DA1DFE1E1A10DB0037413D /* NumberSeparatorConfiguration.swift in Sources */,
-				E88198601BEA98F000333A11 /* IdentifierNameRule.swift in Sources */,
-				E88DEA791B098D4400A66CB0 /* RuleParameter.swift in Sources */,
-				8F715B83213B528B00427BD9 /* UnusedImportRule.swift in Sources */,
-				626D02971F31CBCC0054788D /* XCTFailMessageRule.swift in Sources */,
-				D4DA1DFA1E18D6200037413D /* LargeTupleRule.swift in Sources */,
-				D4B022A41E105636007E5297 /* GenericTypeNameRule.swift in Sources */,
-				E86396CB1BADB519002C9E88 /* CSVReporter.swift in Sources */,
-				37B3FA8B1DFD45A700AD30D2 /* Dictionary+SwiftLint.swift in Sources */,
-				823EDC6221020D850070B7CD /* MultilineLiteralBracketsRule.swift in Sources */,
-				D47EF4801F69E3100012C4CA /* ColonRule+FunctionCall.swift in Sources */,
-				E88198561BEA94D800333A11 /* FileLengthRule.swift in Sources */,
-				D47079A91DFDBED000027086 /* ClosureParameterPositionRule.swift in Sources */,
-				E8B67C3E1C095E6300FDED8E /* Correction.swift in Sources */,
-				623E36F21F3DB988002E5B71 /* QuickDiscouragedCallRuleExamples.swift in Sources */,
-				BB00B4E91F5216090079869F /* MultipleClosuresWithTrailingClosureRule.swift in Sources */,
-				E88198531BEA944400333A11 /* LineLengthRule.swift in Sources */,
-				D47F31151EC918B600E3E1CA /* ProtocolPropertyAccessorsOrderRule.swift in Sources */,
-				82144ACC20F640F200B06695 /* VerticalWhitespaceBetweenCasesRule.swift in Sources */,
-				D4E2BA851F6CD77B00E8E184 /* ArrayInitRule.swift in Sources */,
-				92CCB2D71E1EEFA300C8E5A3 /* UnusedOptionalBindingRule.swift in Sources */,
-				D489B54A231383350090BAA0 /* ContainsOverFilterIsEmptyRule.swift in Sources */,
-				E847F0A91BFBBABD00EA9363 /* EmptyCountRule.swift in Sources */,
-				D46252541DF63FB200BE2CA1 /* NumberSeparatorRule.swift in Sources */,
-				82EB7885215BAE790042E0FD /* FileTypesOrderRuleExamples.swift in Sources */,
-				E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */,
-				125AAC78203AA82D0004BCE0 /* ExplicitTypeInterfaceConfiguration.swift in Sources */,
-				1E18574B1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift in Sources */,
-				D42D2B381E09CC0D00CD7A2E /* FirstWhereRule.swift in Sources */,
-				550DA0E022DB95AD00B67F03 /* EmptyCollectionLiteralRule.swift in Sources */,
-				D4B0226F1E0C75F9007E5297 /* VerticalParameterAlignmentRule.swift in Sources */,
-				E8BDE3FF1EDF91B6002EC12F /* RuleList.swift in Sources */,
-				E889D8C71F1D357B00058332 /* Configuration+Merging.swift in Sources */,
-				D44254271DB9C15C00492EA4 /* SyntacticSugarRule.swift in Sources */,
-				D4EA77C81F817FD200C315FB /* UnneededBreakInSwitchRule.swift in Sources */,
-				D4D383852145F550000235BD /* StaticOperatorRule.swift in Sources */,
-				006204DC1E1E492F00FFFBE1 /* VerticalWhitespaceConfiguration.swift in Sources */,
-				E88198441BEA93D200333A11 /* ColonRule.swift in Sources */,
-				623675B21F962FC4009BE6F3 /* QuickDiscouragedPendingTestRuleExamples.swift in Sources */,
-				D403A4A31F4DB5510020CA02 /* PatternMatchingKeywordsRule.swift in Sources */,
-				E809EDA11B8A71DF00399043 /* Configuration.swift in Sources */,
-				D4DABFD51E2B350F009617B6 /* TrailingClosureRule.swift in Sources */,
-				D4B022981E102EE8007E5297 /* ObjectLiteralRule.swift in Sources */,
-				2E336D1B1DF08BFB00CCFE77 /* EmojiReporter.swift in Sources */,
-				E8EA41171C2D1DBE004F9930 /* CheckstyleReporter.swift in Sources */,
-				006ECFC41C44E99E00EF6364 /* LegacyConstantRule.swift in Sources */,
-				82FE254120F604CB00295958 /* VerticalWhitespaceClosingBracesRule.swift in Sources */,
-				429644B61FB0A9B400D75128 /* SortedFirstLastRule.swift in Sources */,
-				C3EF547821B5A4000009262F /* LegacyHashingRule.swift in Sources */,
-				31F1B6CC1F60BF4500A57456 /* SwitchCaseAlignmentRule.swift in Sources */,
-				E88DEA731B0984C400A66CB0 /* String+SwiftLint.swift in Sources */,
-				E88198591BEA95F100333A11 /* LeadingWhitespaceRule.swift in Sources */,
-				D42B45D91F0AF5E30086B683 /* StrictFilePrivateRule.swift in Sources */,
-				E48F715F23789824003E1775 /* SwiftLintSyntaxToken.swift in Sources */,
-				1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */,
-				F90DBD7F2092E669002CC310 /* MissingDocsRuleConfiguration.swift in Sources */,
-				67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */,
-				4100D7A423BEAB78009464E0 /* FileNameNoSpaceRule.swift in Sources */,
-				57ED827B1CF656E3002B3513 /* JUnitReporter.swift in Sources */,
-				D43B04691E072291004016AF /* ColonConfiguration.swift in Sources */,
-				E82367E01ED3BD1E0040A88E /* Configuration+Cache.swift in Sources */,
-				756B585D2138ECD300D1A4E9 /* CollectionAlignmentRule.swift in Sources */,
-				621C8EA420CBC7A10007DA74 /* RedundantTypeAnnotationRule.swift in Sources */,
-				62DADC481FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift in Sources */,
-				D4BED5F82278AECC00D86BCE /* UnownedVariableCaptureRule.swift in Sources */,
-				D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */,
-				24E17F721B14BB3F008195BE /* SwiftLintFile+Cache.swift in Sources */,
-				C3D23F1D21E3A33700E9BD1B /* UnusedControlFlowLabelRule.swift in Sources */,
-				55CE0585231899100023BA72 /* ContainsOverRangeNilComparisonRule.swift in Sources */,
-				6C1D763221A4E69600DEF783 /* Request+DisableSourceKit.swift in Sources */,
-				47ACC8981E7DC74E0088EEB2 /* ImplicitlyUnwrappedOptionalConfiguration.swift in Sources */,
-				787CDE39208E7D41005F3D2F /* SwitchCaseAlignmentConfiguration.swift in Sources */,
-				D450D1DD21F199F700E60010 /* TrailingClosureConfiguration.swift in Sources */,
-				009E09281DFEE4C200B588A7 /* ProhibitedSuperRule.swift in Sources */,
-				E80E018F1B92C1350078EB70 /* Region.swift in Sources */,
-				E88198581BEA956C00333A11 /* FunctionBodyLengthRule.swift in Sources */,
-				E88DEA751B09852000A66CB0 /* SwiftLintFile+Regex.swift in Sources */,
-				D47EF4841F69E3D60012C4CA /* ColonRule+Type.swift in Sources */,
-				3BCC04D11C4F56D3006073C3 /* SeverityLevelsConfiguration.swift in Sources */,
-				D4DAE8BC1DE14E8F00B0AE7A /* NimbleOperatorRule.swift in Sources */,
-				D4C0E46F1E3D973600C560F2 /* ForWhereRule.swift in Sources */,
-				7565E5F12262BA0900B0597C /* UnusedCaptureListRule.swift in Sources */,
-				D4EA77CA1F81FACC00C315FB /* LiteralExpressionEndIdentationRule.swift in Sources */,
-				E86396C51BADAC15002C9E88 /* XcodeReporter.swift in Sources */,
-				E889D8C51F1D11A200058332 /* Configuration+LintableFiles.swift in Sources */,
-				D43CDEDC23BDB8D30074F3EE /* OptionalEnumCaseMatchingRule.swift in Sources */,
-				094385011D5D2894009168CF /* WeakDelegateRule.swift in Sources */,
-				82F614F22106014500D23904 /* MultilineParametersBracketsRule.swift in Sources */,
-				4100D7A723BEACBF009464E0 /* FileNameNoSpaceConfiguration.swift in Sources */,
-				6BE79EB12204EC0700B5A2FE /* RequiredDeinitRule.swift in Sources */,
-				3B1DF0121C5148140011BCED /* CustomRules.swift in Sources */,
-				2E5761AA1C573B83003271AF /* FunctionParameterCountRule.swift in Sources */,
-				E86396C91BADB2B9002C9E88 /* JSONReporter.swift in Sources */,
-				D42DEAAB20D5EE4400E86F31 /* ConvenienceTypeRule.swift in Sources */,
-				E881985A1BEA96EA00333A11 /* OperatorFunctionWhitespaceRule.swift in Sources */,
-				D44254201DB87CA200492EA4 /* ValidIBInspectableRule.swift in Sources */,
-				62640152201552FD005B9C4A /* DiscouragedOptionalBooleanRule.swift in Sources */,
-				85DA81321D6B471000951BC4 /* MarkRule.swift in Sources */,
-				D4A893351E15824100BF954D /* SwiftVersion.swift in Sources */,
-				D4F10616229A331200FDE319 /* LegacyMultipleRule.swift in Sources */,
-				D4470D5D1EB8004B008A1B2E /* VerticalParameterAlignmentOnCallRule.swift in Sources */,
-				D4DABFD31E29B4A5009617B6 /* DiscardedNotificationCenterObserverRule.swift in Sources */,
-				D4AB0EA21F8993DD00CEC380 /* NamespaceCollector.swift in Sources */,
-				D4B3409D21F16B110038C79A /* UnusedSetterValueRule.swift in Sources */,
-				756C0779222EA4F400A111F4 /* ReduceIntoRule.swift in Sources */,
-				75161FDF213B9D73009DE767 /* CollectionAlignmentConfiguration.swift in Sources */,
-				D4B022B21E10B613007E5297 /* RedundantVoidReturnRule.swift in Sources */,
-				3BCC04D21C4F56D3006073C3 /* NameConfiguration.swift in Sources */,
-				D4C27BFE1E12D53F00DF713E /* Version.swift in Sources */,
-				B2902A0E1D6681F700BFCCF7 /* PrivateUnitTestConfiguration.swift in Sources */,
-				D4DE9133207B4750000FFAA8 /* UnavailableFunctionRule.swift in Sources */,
-				D47A510E1DB29EEB00A4CC21 /* SwitchCaseOnNewlineRule.swift in Sources */,
-				D462021F1E15F52D0027AAD1 /* NumberSeparatorRuleExamples.swift in Sources */,
-				D4DA1DF41E17511D0037413D /* CompilerProtocolInitRule.swift in Sources */,
-				629C60D91F43906700B4AF92 /* SingleTestClassRule.swift in Sources */,
-				621061BF1ED57E640082D51E /* MultilineParametersRuleExamples.swift in Sources */,
-				D41985EB21FAB63E003BE2B7 /* DeploymentTargetConfiguration.swift in Sources */,
-				D48AE2CC1DFB58C5001C6A4A /* AttributesRuleExamples.swift in Sources */,
-				E4A365D223653649003B4141 /* SourceKittenDictionary+Swiftlint.swift in Sources */,
-				D48EE14B231CD34200DBB779 /* NoSpaceInMethodCallRule.swift in Sources */,
-				C28B2B3D2106DF730009A0FE /* PrefixedConstantRuleConfiguration.swift in Sources */,
-				62A7127520F1178F00E604A6 /* AnyObjectProtocolRule.swift in Sources */,
-				D4D0B8F42211428D0053A116 /* ColonRuleExamples.swift in Sources */,
-				E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */,
-				D43B046B1E075905004016AF /* ClosureEndIndentationRule.swift in Sources */,
-				D47EF4821F69E34D0012C4CA /* ColonRule+Dictionary.swift in Sources */,
-				D93DA3D11E699E6300809827 /* NestingConfiguration.swift in Sources */,
-				CC26ED07204DEB510013BBBC /* RuleIdentifier.swift in Sources */,
-				C328A2F71E6759AE00A9E4D7 /* ExplicitTypeInterfaceRule.swift in Sources */,
-				4968919223BEAC3D00AB8EF9 /* EnumCaseAssociatedValuesLengthRule.swift in Sources */,
-				2882895F222975D00037CF5F /* NSObjectPreferIsEqualRule.swift in Sources */,
-				18B90B6B21ADD99800B60749 /* RedundantObjcAttributeRule.swift in Sources */,
-				D46C7C3E23BF2F6A007C517F /* PreferSelfTypeOverTypeOfSelfRule.swift in Sources */,
-				93E0C3CE1D67BD7F007FA25D /* ConditionalReturnsOnNewlineRule.swift in Sources */,
-				D43DB1081DC573DA00281215 /* ImplicitGetterRule.swift in Sources */,
-				D450D1D121EC4A6900E60010 /* StrongIBOutletRule.swift in Sources */,
-				824AB64D2105C39F004B5A8F /* ConditionalReturnsOnNewlineConfiguration.swift in Sources */,
-				62A6E7931F3317E3003A0479 /* JoinedDefaultParameterRule.swift in Sources */,
-				82DB55FE21008F3E001C62FF /* FileTypesOrderConfiguration.swift in Sources */,
-				D4FD4C851F2A260A00DD8AA8 /* BlockBasedKVORule.swift in Sources */,
-				7C0C2E7A1D2866CB0076435A /* ExplicitInitRule.swift in Sources */,
-				E88DEA771B098D0C00A66CB0 /* Rule.swift in Sources */,
-				D47079AB1DFDCF7A00027086 /* SwiftExpressionKind.swift in Sources */,
-				00B8D9791E2D1223004E0EEC /* LegacyConstantRuleExamples.swift in Sources */,
-				B25DCD0E1F7EF2280028A199 /* MultilineArgumentsConfiguration.swift in Sources */,
-				827009FD20FE26B700ECA185 /* FileTypesOrderRule.swift in Sources */,
-				E4EA064C23688EB5002531D7 /* SwiftLintFile.swift in Sources */,
-				22A36FDF235673F50037B47D /* ExpiringTodoRule.swift in Sources */,
-				24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */,
-				D4130D971E16183F00242361 /* IdentifierNameRuleExamples.swift in Sources */,
-				7250948A1D0859260039B353 /* StatementModeConfiguration.swift in Sources */,
-				E81619531BFC162C00946723 /* QueuedPrint.swift in Sources */,
-				E87E4A051BFB927C00FCFE46 /* TrailingSemicolonRule.swift in Sources */,
-				D4B472411F66486300BD6EF1 /* FallthroughRule.swift in Sources */,
-				B25DCD0B1F7E9F9E0028A199 /* MultilineArgumentsRuleExamples.swift in Sources */,
-				82DB560021008F54001C62FF /* TypeContentsOrderConfiguration.swift in Sources */,
-				E88198421BEA929F00333A11 /* NestingRule.swift in Sources */,
-				D46A317F1F1CEDCD00AF914A /* UnneededParenthesesInClosureArgumentRule.swift in Sources */,
-				D4470D591EB6B4D1008A1B2E /* EmptyEnumArgumentsRule.swift in Sources */,
-				8F0856EB22DA8508001FF4D4 /* UnusedDeclarationRule.swift in Sources */,
-				264E080F2248BA2800ADC4C5 /* RuleStorage.swift in Sources */,
-				627BC48D1F9405160004A6C2 /* QuickDiscouragedFocusedTestRule.swift in Sources */,
-				3BB47D851C51D80000AE6A10 /* NSRegularExpression+SwiftLint.swift in Sources */,
-				E881985B1BEA974E00333A11 /* StatementPositionRule.swift in Sources */,
-				B58AEED61C492C7B00E901FD /* ForceUnwrappingRule.swift in Sources */,
-				1EF115921EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift in Sources */,
-				D40FE89D1F867BFF006433E2 /* OverrideInExtensionRule.swift in Sources */,
-				D41E7E0B1DF9DABB0065259A /* RedundantStringEnumValueRule.swift in Sources */,
-				C25EBBE521078DCE00E27603 /* Glob.swift in Sources */,
-				E88DEA711B09847500A66CB0 /* ViolationSeverity.swift in Sources */,
-				187290721FC37CA50016BEA2 /* YodaConditionRule.swift in Sources */,
-				1E3C2D711EE36C6F00C8386D /* PrivateOverFilePrivateRule.swift in Sources */,
-				188B3FF2207D61040073C2D6 /* ModifierOrderRule.swift in Sources */,
-				72EA17B61FD31F10009D5CE6 /* ExplicitACLRule.swift in Sources */,
-				77DFF0E923442DE30041EEB4 /* RawValueForCamelCasedCodableEnumRule.swift in Sources */,
-				B2902A0C1D66815600BFCCF7 /* PrivateUnitTestRule.swift in Sources */,
-				D47A51101DB2DD4800A4CC21 /* AttributesRule.swift in Sources */,
-				CE8178ED1EAC039D0063186E /* UnusedOptionalBindingConfiguration.swift in Sources */,
-				62DEA1661FB21A9E00BCCCC6 /* PrivateActionRule.swift in Sources */,
-				D4FD58B21E12A0200019503C /* LinterCache.swift in Sources */,
-				3BD9CD3D1C37175B009A5D25 /* YamlParser.swift in Sources */,
-				F22314B01D4FA4D7009AD165 /* LegacyNSGeometryFunctionsRule.swift in Sources */,
-				E88DEA8C1B0999A000A66CB0 /* ASTRule.swift in Sources */,
-				62426A032118BA6E007E6340 /* ClosureBodyLengthRule.swift in Sources */,
-				1E82D5591D7775C7009553D7 /* ClosureSpacingRule.swift in Sources */,
-				E80746F61ECB722F00548D31 /* CacheDescriptionProvider.swift in Sources */,
-				094385041D5D4F7C009168CF /* PrivateOutletRule.swift in Sources */,
-				6264015520155556005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift in Sources */,
-				8F8050821FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift in Sources */,
-				E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */,
-				62622F6B1F2F2E3500D5D099 /* DiscouragedDirectInitRule.swift in Sources */,
-				B89F3BCD1FD5EDFB00931E59 /* RequiredEnumCaseRule.swift in Sources */,
-				E83530C61ED6328A00FBAF79 /* FileNameRule.swift in Sources */,
-				3BB47D831C514E8100AE6A10 /* RegexConfiguration.swift in Sources */,
-				D401D9261ED85EF0005DA5D4 /* RuleKind.swift in Sources */,
-				622AD800216ACE6300A002C6 /* XCTSpecificMatcherRuleExamples.swift in Sources */,
-				82EB7886215BAE790042E0FD /* TypeContentsOrderRuleExamples.swift in Sources */,
-				7551DF6D21382C9A00AA1F4D /* ToggleBoolRule.swift in Sources */,
-				626B01B620A173F100D2C42F /* EmptyXCTestMethodRuleExamples.swift in Sources */,
-				D4C889711E385B7B00BAE88D /* RedundantDiscardableLetRule.swift in Sources */,
-				D4D1B9BB1EAC2C910028BE6A /* AccessControlLevel.swift in Sources */,
-				622AD801216ACE6300A002C6 /* XCTSpecificMatcherRule.swift in Sources */,
-				4A9A3A3A1DC1D75F00DF5183 /* HTMLReporter.swift in Sources */,
-				D40F83881DE9179200524C62 /* TrailingCommaConfiguration.swift in Sources */,
-				827169B31F488181003FB9AF /* ExplicitEnumRawValueRule.swift in Sources */,
-				D466B620233D229F0068190B /* FlatMapOverMapReduceRule.swift in Sources */,
-				D41985E921FAB62F003BE2B7 /* DeploymentTargetRule.swift in Sources */,
-				6C15818D237026AC00F582A2 /* GitHubActionsLoggingReporter.swift in Sources */,
-				62FE5D32200CABDD00F68793 /* DiscouragedOptionalCollectionExamples.swift in Sources */,
-				D49896F12026B36C00814A83 /* RedundantSetAccessControlRule.swift in Sources */,
-				E4A6CF752363CBFB00DD5B18 /* RandomAccessCollection+Swiftlint.swift in Sources */,
-				4100D7BC23BEC35F009464E0 /* FileNameNoSpaceRule.swift in Sources */,
-				29FFC37A1F15764D007E4825 /* FileLengthRuleConfiguration.swift in Sources */,
-				ED641C3820AA07B400212C62 /* NoFallthroughOnlyRule.swift in Sources */,
-				D4B31ADC22A0581B000300F1 /* DuplicateEnumCasesRule.swift in Sources */,
-				3B5B9FE11C444DA20009AD27 /* Array+SwiftLint.swift in Sources */,
-				F9E691282091952E0085B53E /* MissingDocsRule.swift in Sources */,
-				D43B04641E0620AB004016AF /* UnusedEnumeratedRule.swift in Sources */,
-				62A498561F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift in Sources */,
-				29AD4C661F6EA1D5009B66E1 /* ContainsOverFirstNotNilRule.swift in Sources */,
-				C946FECB1EAE67EE007DD778 /* LetVarWhitespaceRule.swift in Sources */,
-				E881985D1BEA97EB00333A11 /* TrailingWhitespaceRule.swift in Sources */,
-				E832F10B1B17E2F5003F265F /* FileManager+SwiftLint.swift in Sources */,
-				E816194C1BFBF35D00946723 /* SwiftDeclarationKind+SwiftLint.swift in Sources */,
-				D4DABFD71E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift in Sources */,
-				3BA79C9B1C4767910057E705 /* NSRange+SwiftLint.swift in Sources */,
-				D4D5A5FF1E1F3A1C00D15E0C /* ShorthandOperatorRule.swift in Sources */,
-				C3DE5DAC1E7DF9CA00761483 /* FatalErrorMessageRule.swift in Sources */,
-				A3184D56215BCEFF00621EA2 /* LegacyRandomRule.swift in Sources */,
-				626C16E21F948EBC00BB7475 /* QuickDiscouragedFocusedTestRuleExamples.swift in Sources */,
-				D4441A28213279950020896F /* InertDeferRule.swift in Sources */,
-				B89F3BCF1FD5EE1400931E59 /* RequiredEnumCaseRuleConfiguration.swift in Sources */,
-				D48B51211F4F5DEF0068AB98 /* RuleList+Documentation.swift in Sources */,
-				8FC9F5111F4B8E48006826C1 /* IsDisjointRule.swift in Sources */,
-				8FC8523B2117BDDE0015269B /* ExplicitSelfRule.swift in Sources */,
-				E48F715E23789824003E1775 /* SwiftLintSyntaxMap.swift in Sources */,
-				4DCB8E7F1CBE494E0070FCF0 /* RegexHelpers.swift in Sources */,
-				E86396C21BADAAE5002C9E88 /* Reporter.swift in Sources */,
-				A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */,
-				D489B548231233A40090BAA0 /* ContainsOverFilterCountRule.swift in Sources */,
-				D4B0228E1E0CC608007E5297 /* ClassDelegateProtocolRule.swift in Sources */,
-				E881985F1BEA987C00333A11 /* TypeNameRule.swift in Sources */,
-				D40AD08A1E032F9700F48C30 /* UnusedClosureParameterRule.swift in Sources */,
-				D46E041D1DE3712C00728374 /* TrailingCommaRule.swift in Sources */,
-				D4DABFD91E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift in Sources */,
-				E88198521BEA941300333A11 /* TodoRule.swift in Sources */,
-				3B828E531C546468000D180E /* RuleConfiguration.swift in Sources */,
-				A73469421FB121BA009B57C7 /* CallPairRule.swift in Sources */,
-				D47079AF1DFE520000027086 /* VoidReturnRule.swift in Sources */,
-				B3935EE74B1E8E14FBD65E7F /* String+XML.swift in Sources */,
-				BC87573B2195CF2A00CA7A74 /* ModifierOrderRuleExamples.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D0D1217319E87B05005E4BAA /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				825F19D11EEFF19700969EF1 /* ObjectLiteralRuleTests.swift in Sources */,
-				D4F5851520E99A8A0085C6D8 /* TrailingWhitespaceTests.swift in Sources */,
-				D450D1E021F19AB300E60010 /* TrailingClosureRuleTests.swift in Sources */,
-				3B12C9C31C320A53000B423F /* YamlSwiftLintTests.swift in Sources */,
-				D41985ED21FAD033003BE2B7 /* DeploymentTargetConfigurationTests.swift in Sources */,
-				D450D1E221F19B1E00E60010 /* TrailingClosureConfigurationTests.swift in Sources */,
-				D4DDFF9822396D62006C3629 /* ContainsOverFirstNotNilRuleTests.swift in Sources */,
-				E832F10D1B17E725003F265F /* IntegrationTests.swift in Sources */,
-				D4C27C001E12DFF500DF713E /* LinterCacheTests.swift in Sources */,
-				D45255C81F0932F8003C9B56 /* RuleDescription+Examples.swift in Sources */,
-				E81ADD721ED5ED9D000CD451 /* RegionTests.swift in Sources */,
-				D4998DE91DF194F20006E05D /* FileHeaderRuleTests.swift in Sources */,
-				750BBD0B214180AF007EC437 /* CollectionAlignmentRuleTests.swift in Sources */,
-				8B01E50220A4349100C9233E /* FunctionParameterCountRuleTests.swift in Sources */,
-				47ACC89C1E7DCFA00088EEB2 /* ImplicitlyUnwrappedOptionalRuleTests.swift in Sources */,
-				E81ADD741ED6052F000CD451 /* CommandTests.swift in Sources */,
-				29FFC37D1F157BDE007E4825 /* FileLengthRuleTests.swift in Sources */,
-				006204DE1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift in Sources */,
-				02FD8AEF1BFC18D60014BFFB /* ExtendedNSStringTests.swift in Sources */,
-				12E3D4DC2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift in Sources */,
-				D48B51231F4F5E4B0068AB98 /* DocumentationTests.swift in Sources */,
-				D4CA758F1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift in Sources */,
-				D4DB92251E628898005DE9C1 /* TodoRuleTests.swift in Sources */,
-				D4348EEA1C46122C007707FB /* FunctionBodyLengthRuleTests.swift in Sources */,
-				F480DC831F2609D700099465 /* ConfigurationTests+ProjectMock.swift in Sources */,
-				820F451C2107292500AA056A /* TypeContentsOrderRuleTests.swift in Sources */,
-				3B63D46D1E1F05160057BE35 /* LineLengthConfigurationTests.swift in Sources */,
-				D41985EF21FAD5E8003BE2B7 /* DeploymentTargetRuleTests.swift in Sources */,
-				6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */,
-				820F451E21073D7200AA056A /* ConditionalReturnsOnNewlineRuleTests.swift in Sources */,
-				D4246D6F1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift in Sources */,
-				B25DCD101F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift in Sources */,
-				3BB47D871C51DE6E00AE6A10 /* CustomRulesTests.swift in Sources */,
-				E812249A1B04F85B001783D2 /* TestHelpers.swift in Sources */,
-				D414D6AC21D0B77F00960935 /* DiscouragedObjectLiteralRuleTests.swift in Sources */,
-				3B20CD0C1EB699C20069EF2E /* TypeNameRuleTests.swift in Sources */,
-				CCD8B87920559D1E00B75847 /* DisableAllTests.swift in Sources */,
-				821F70B7210720C700E2C84F /* FileTypesOrderRuleTests.swift in Sources */,
-				3B3A9A331EA3DFD90075B121 /* IdentifierNameRuleTests.swift in Sources */,
-				62329C2B1F30B2310035737E /* DiscouragedDirectInitRuleTests.swift in Sources */,
-				C25EBBE221078D5F00E27603 /* GlobTests.swift in Sources */,
-				E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */,
-				BCB68283216213130078E4C3 /* CompilerProtocolInitRuleTests.swift in Sources */,
-				D43B04661E071ED3004016AF /* ColonRuleTests.swift in Sources */,
-				D4F5851920E99B5A0085C6D8 /* PrivateOutletRuleTests.swift in Sources */,
-				3B12C9C71C3361CB000B423F /* RuleTests.swift in Sources */,
-				125CE52F20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift in Sources */,
-				D4EAB3A420E9948E0051C09A /* AutomaticRuleTests.generated.swift in Sources */,
-				67EB4DFC1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift in Sources */,
-				3B30C4A11C3785B300E04027 /* YamlParserTests.swift in Sources */,
-				3B20CD0A1EB699380069EF2E /* GenericTypeNameRuleTests.swift in Sources */,
-				D4998DE71DF191380006E05D /* AttributesRuleTests.swift in Sources */,
-				F480DC7F1F26090000099465 /* ConfigurationTests+Nested.swift in Sources */,
-				E88198631BEA9A5400333A11 /* RulesTests.swift in Sources */,
-				47ACC89A1E7DCCAD0088EEB2 /* ImplicitlyUnwrappedOptionalConfigurationTests.swift in Sources */,
-				D4F5851720E99B260085C6D8 /* StatementPositionRuleTests.swift in Sources */,
-				1EB7C8531F0C45C2004BAD22 /* ModifierOrderTests.swift in Sources */,
-				67932E2D1E54AF4B00CB0629 /* CyclomaticComplexityConfigurationTests.swift in Sources */,
-				224E7F9D235A5E800051368B /* ExpiringTodoRuleTests.swift in Sources */,
-				F90DBD812092EA81002CC310 /* MissingDocsRuleConfigurationTests.swift in Sources */,
-				C25EBBDF2107884200E27603 /* PrefixedTopLevelConstantRuleTests.swift in Sources */,
-				C2B3C1612106F78C00088928 /* ConfigurationAliasesTests.swift in Sources */,
-				D4470D5B1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift in Sources */,
-				787CDE3B208F9C34005F3D2F /* SwitchCaseAlignmentRuleTests.swift in Sources */,
-				F480DC811F2609AB00099465 /* XCTestCase+BundlePath.swift in Sources */,
-				B89F3BCE1FD5EE0200931E59 /* RequiredEnumCaseRuleTestCase.swift in Sources */,
-				C9802F2F1E0C8AEE008AB27F /* TrailingCommaRuleTests.swift in Sources */,
-				3B63D46F1E1F09DF0057BE35 /* LineLengthRuleTests.swift in Sources */,
-				627C7A322004F9290053C79D /* XCTSpecificMatcherRuleTests.swift in Sources */,
-				260F66A0225C5B6D00407CF5 /* CollectingRuleTests.swift in Sources */,
-				3BCC04D41C502BAB006073C3 /* RuleConfigurationTests.swift in Sources */,
-				E809EDA31B8A73FB00399043 /* ConfigurationTests.swift in Sources */,
-				8F2CC1CD20A6A189006ED34F /* FileNameRuleTests.swift in Sources */,
-				4100D7A323BEAB69009464E0 /* FileNameNoSpaceRuleTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D0E7B62E19E9C64500EDBA4D /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E86E2B2E1E17443B001E823C /* Reporter+CommandLine.swift in Sources */,
-				8F6AA75D21190830009BA28A /* CompilerArgumentsExtractor.swift in Sources */,
-				8FDF482C2122476D00521605 /* AnalyzeCommand.swift in Sources */,
-				E8B067811C13E49600E9E13F /* Configuration+CommandLine.swift in Sources */,
-				E802ED001C56A56000A35AE1 /* Benchmark.swift in Sources */,
-				E83A0B351A5D382B0041A60A /* VersionCommand.swift in Sources */,
-				E81FB3E41C6D507B00DC988F /* CommonOptions.swift in Sources */,
-				26CE462D228532CD00264485 /* Array+SwiftLint.swift in Sources */,
-				E861519B1B0573B900C54AC0 /* LintCommand.swift in Sources */,
-				D0E7B65619E9C76900EDBA4D /* main.swift in Sources */,
-				83894F221B0C928A006214E1 /* RulesCommand.swift in Sources */,
-				D4DA1DFC1E19CD300037413D /* GenerateDocsCommand.swift in Sources */,
-				E84E07471C13F95300F11122 /* AutoCorrectCommand.swift in Sources */,
-				8FDF482E21234BFF00521605 /* LintOrAnalyzeCommand.swift in Sources */,
-				8F6AA75B211905B8009BA28A /* LintableFilesVisitor.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		D0AAAB5219FB0960007B24B3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D0D1216C19E87B05005E4BAA /* SwiftLintFramework */;
-			targetProxy = D0AAAB5119FB0960007B24B3 /* PBXContainerItemProxy */;
-		};
-		D0D1217A19E87B05005E4BAA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D0D1216C19E87B05005E4BAA /* SwiftLintFramework */;
-			targetProxy = D0D1217919E87B05005E4BAA /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		D0D1211D19E87861005E4BAA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1212619E878CC005E4BAA /* Debug.xcconfig */;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				SWIFT_VERSION = 4.0;
-			};
-			name = Debug;
-		};
-		D0D1211E19E87861005E4BAA /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1212819E878CC005E4BAA /* Release.xcconfig */;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				SWIFT_VERSION = 4.0;
-			};
-			name = Release;
-		};
-		D0D1218019E87B05005E4BAA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1213719E878CC005E4BAA /* Mac-Framework.xcconfig */;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "Source/SwiftLintFramework/Supporting Files/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = SwiftLintFramework;
-				SWIFT_VERSION = 4.2;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-				WARNING_CFLAGS = (
-					"-Wno-error=unknown-warning-option",
-					"-Wno-gcc-compat",
-					"-Wno-unused-const-variable",
-				);
-			};
-			name = Debug;
-		};
-		D0D1218119E87B05005E4BAA /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1213719E878CC005E4BAA /* Mac-Framework.xcconfig */;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "Source/SwiftLintFramework/Supporting Files/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = SwiftLintFramework;
-				SWIFT_VERSION = 4.2;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-				WARNING_CFLAGS = (
-					"-Wno-error=unknown-warning-option",
-					"-Wno-gcc-compat",
-					"-Wno-unused-const-variable",
-				);
-			};
-			name = Release;
-		};
-		D0D1218219E87B05005E4BAA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6C27B5FC2079D33F00353E17 /* Mac-XCTest.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = "Tests/SwiftLintFrameworkTests/Supporting Files/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = SwiftLintFrameworkTests;
-				SWIFT_VERSION = 4.2;
-			};
-			name = Debug;
-		};
-		D0D1218319E87B05005E4BAA /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6C27B5FC2079D33F00353E17 /* Mac-XCTest.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = "Tests/SwiftLintFrameworkTests/Supporting Files/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = SwiftLintFrameworkTests;
-				SWIFT_VERSION = 4.2;
-			};
-			name = Release;
-		};
-		D0D1218719E87B38005E4BAA /* Profile */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1212719E878CC005E4BAA /* Profile.xcconfig */;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				SWIFT_VERSION = 4.0;
-			};
-			name = Profile;
-		};
-		D0D1218919E87B38005E4BAA /* Profile */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1213719E878CC005E4BAA /* Mac-Framework.xcconfig */;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "Source/SwiftLintFramework/Supporting Files/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = SwiftLintFramework;
-				SWIFT_VERSION = 4.2;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-				WARNING_CFLAGS = (
-					"-Wno-error=unknown-warning-option",
-					"-Wno-gcc-compat",
-					"-Wno-unused-const-variable",
-				);
-			};
-			name = Profile;
-		};
-		D0D1218A19E87B38005E4BAA /* Profile */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6C27B5FC2079D33F00353E17 /* Mac-XCTest.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = "Tests/SwiftLintFrameworkTests/Supporting Files/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = SwiftLintFrameworkTests;
-				SWIFT_VERSION = 4.2;
-			};
-			name = Profile;
-		};
-		D0D1218B19E87B3B005E4BAA /* Test */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1212919E878CC005E4BAA /* Test.xcconfig */;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				SWIFT_VERSION = 4.0;
-			};
-			name = Test;
-		};
-		D0D1218D19E87B3B005E4BAA /* Test */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1213719E878CC005E4BAA /* Mac-Framework.xcconfig */;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "Source/SwiftLintFramework/Supporting Files/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = SwiftLintFramework;
-				SWIFT_VERSION = 4.2;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-				WARNING_CFLAGS = (
-					"-Wno-error=unknown-warning-option",
-					"-Wno-gcc-compat",
-					"-Wno-unused-const-variable",
-				);
-			};
-			name = Test;
-		};
-		D0D1218E19E87B3B005E4BAA /* Test */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6C27B5FC2079D33F00353E17 /* Mac-XCTest.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = "Tests/SwiftLintFrameworkTests/Supporting Files/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = SwiftLintFrameworkTests;
-				SWIFT_VERSION = 4.2;
-			};
-			name = Test;
-		};
-		D0E7B64A19E9C64600EDBA4D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = "Source/swiftlint/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Debug;
-		};
-		D0E7B64B19E9C64600EDBA4D /* Test */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = "Source/swiftlint/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Test;
-		};
-		D0E7B64C19E9C64600EDBA4D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = "Source/swiftlint/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Release;
-		};
-		D0E7B64D19E9C64600EDBA4D /* Profile */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0D1213419E878CC005E4BAA /* Mac-Application.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = "Source/swiftlint/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks /Library/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Profile;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		D0D1211319E87861005E4BAA /* Build configuration list for PBXProject "SwiftLint" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D0D1211D19E87861005E4BAA /* Debug */,
-				D0D1218B19E87B3B005E4BAA /* Test */,
-				D0D1211E19E87861005E4BAA /* Release */,
-				D0D1218719E87B38005E4BAA /* Profile */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D0D1218419E87B05005E4BAA /* Build configuration list for PBXNativeTarget "SwiftLintFramework" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D0D1218019E87B05005E4BAA /* Debug */,
-				D0D1218D19E87B3B005E4BAA /* Test */,
-				D0D1218119E87B05005E4BAA /* Release */,
-				D0D1218919E87B38005E4BAA /* Profile */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D0D1218519E87B05005E4BAA /* Build configuration list for PBXNativeTarget "SwiftLintFrameworkTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D0D1218219E87B05005E4BAA /* Debug */,
-				D0D1218E19E87B3B005E4BAA /* Test */,
-				D0D1218319E87B05005E4BAA /* Release */,
-				D0D1218A19E87B38005E4BAA /* Profile */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D0E7B64919E9C64600EDBA4D /* Build configuration list for PBXNativeTarget "swiftlint" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D0E7B64A19E9C64600EDBA4D /* Debug */,
-				D0E7B64B19E9C64600EDBA4D /* Test */,
-				D0E7B64C19E9C64600EDBA4D /* Release */,
-				D0E7B64D19E9C64600EDBA4D /* Profile */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = D0D1211019E87861005E4BAA /* Project object */;
+   archiveVersion = "1";
+   objectVersion = "46";
+   objects = {
+      "Commandant::Commandant" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_668";
+         buildPhases = (
+            "OBJ_671",
+            "OBJ_682"
+         );
+         dependencies = (
+         );
+         name = "Commandant";
+         productName = "Commandant";
+         productReference = "Commandant::Commandant::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "Commandant::Commandant::Product" = {
+         isa = "PBXFileReference";
+         path = "Commandant.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "Commandant::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_684";
+         buildPhases = (
+            "OBJ_687"
+         );
+         dependencies = (
+         );
+         name = "CommandantPackageDescription";
+         productName = "CommandantPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "OBJ_1" = {
+         isa = "PBXProject";
+         attributes = {
+            LastSwiftMigration = "9999";
+            LastUpgradeCheck = "9999";
+         };
+         buildConfigurationList = "OBJ_2";
+         compatibilityVersion = "Xcode 3.2";
+         developmentRegion = "en";
+         hasScannedForEncodings = "0";
+         knownRegions = (
+            "en"
+         );
+         mainGroup = "OBJ_5";
+         productRefGroup = "OBJ_599";
+         projectDirPath = ".";
+         targets = (
+            "Yams::CYaml",
+            "SourceKitten::Clang_C",
+            "Commandant::Commandant",
+            "Commandant::SwiftPMPackageDescription",
+            "SWXMLHash::SWXMLHash",
+            "SWXMLHash::SwiftPMPackageDescription",
+            "SourceKitten::SourceKit",
+            "SourceKitten::SourceKittenFramework",
+            "SourceKitten::SwiftPMPackageDescription",
+            "SwiftLint::SwiftLintFramework",
+            "SwiftLint::SwiftLintFrameworkTests",
+            "SwiftLint::SwiftPMPackageDescription",
+            "SwiftLint::SwiftLintPackageTests::ProductTarget",
+            "SwiftSyntax::SwiftSyntax",
+            "SwiftSyntax::SwiftPMPackageDescription",
+            "SwiftyTextTable::SwiftyTextTable",
+            "SwiftyTextTable::SwiftPMPackageDescription",
+            "Yams::Yams",
+            "Yams::SwiftPMPackageDescription",
+            "SwiftSyntax::_CSwiftSyntax",
+            "SwiftLint::swiftlint"
+         );
+      };
+      "OBJ_10" = {
+         isa = "PBXFileReference";
+         path = "Array+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_100" = {
+         isa = "PBXFileReference";
+         path = "FileNameRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1000" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_234";
+      };
+      "OBJ_1001" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_235";
+      };
+      "OBJ_1002" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_236";
+      };
+      "OBJ_1003" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_237";
+      };
+      "OBJ_1004" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_238";
+      };
+      "OBJ_1005" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_239";
+      };
+      "OBJ_1006" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_240";
+      };
+      "OBJ_1007" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_241";
+      };
+      "OBJ_1008" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_242";
+      };
+      "OBJ_1009" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_243";
+      };
+      "OBJ_101" = {
+         isa = "PBXFileReference";
+         path = "ForWhereRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1010" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_244";
+      };
+      "OBJ_1011" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_245";
+      };
+      "OBJ_1012" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_246";
+      };
+      "OBJ_1013" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_247";
+      };
+      "OBJ_1014" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_248";
+      };
+      "OBJ_1015" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_249";
+      };
+      "OBJ_1016" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_250";
+      };
+      "OBJ_1017" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_251";
+      };
+      "OBJ_1018" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_252";
+      };
+      "OBJ_1019" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_253";
+      };
+      "OBJ_102" = {
+         isa = "PBXFileReference";
+         path = "ForceCastRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1020" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_254";
+      };
+      "OBJ_1021" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_255";
+      };
+      "OBJ_1022" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_256";
+      };
+      "OBJ_1023" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_257";
+      };
+      "OBJ_1024" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_258";
+      };
+      "OBJ_1025" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_259";
+      };
+      "OBJ_1026" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_260";
+      };
+      "OBJ_1027" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_261";
+      };
+      "OBJ_1028" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_262";
+      };
+      "OBJ_1029" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_263";
+      };
+      "OBJ_103" = {
+         isa = "PBXFileReference";
+         path = "ForceTryRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1030" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_264";
+      };
+      "OBJ_1031" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_265";
+      };
+      "OBJ_1032" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_266";
+      };
+      "OBJ_1033" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_267";
+      };
+      "OBJ_1034" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_268";
+      };
+      "OBJ_1035" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_269";
+      };
+      "OBJ_1036" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_270";
+      };
+      "OBJ_1037" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_272";
+      };
+      "OBJ_1038" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_273";
+      };
+      "OBJ_1039" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_274";
+      };
+      "OBJ_104" = {
+         isa = "PBXFileReference";
+         path = "ForceUnwrappingRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1040" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_275";
+      };
+      "OBJ_1041" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_276";
+      };
+      "OBJ_1042" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_277";
+      };
+      "OBJ_1043" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_278";
+      };
+      "OBJ_1044" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_279";
+      };
+      "OBJ_1045" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_280";
+      };
+      "OBJ_1046" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_281";
+      };
+      "OBJ_1047" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_282";
+      };
+      "OBJ_1048" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_283";
+      };
+      "OBJ_1049" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_284";
+      };
+      "OBJ_105" = {
+         isa = "PBXFileReference";
+         path = "FunctionDefaultParameterAtEndRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1050" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_285";
+      };
+      "OBJ_1051" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_286";
+      };
+      "OBJ_1052" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_287";
+      };
+      "OBJ_1053" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_288";
+      };
+      "OBJ_1054" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_289";
+      };
+      "OBJ_1055" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_290";
+      };
+      "OBJ_1056" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_291";
+      };
+      "OBJ_1057" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_292";
+      };
+      "OBJ_1058" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_293";
+      };
+      "OBJ_1059" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_294";
+      };
+      "OBJ_106" = {
+         isa = "PBXFileReference";
+         path = "GenericTypeNameRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1060" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_295";
+      };
+      "OBJ_1061" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_296";
+      };
+      "OBJ_1062" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_297";
+      };
+      "OBJ_1063" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_298";
+      };
+      "OBJ_1064" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_299";
+      };
+      "OBJ_1065" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_300";
+      };
+      "OBJ_1066" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_301";
+      };
+      "OBJ_1067" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_302";
+      };
+      "OBJ_1068" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_303";
+      };
+      "OBJ_1069" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_304";
+      };
+      "OBJ_107" = {
+         isa = "PBXFileReference";
+         path = "ImplicitlyUnwrappedOptionalRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1070" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_305";
+      };
+      "OBJ_1071" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_306";
+      };
+      "OBJ_1072" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_307";
+      };
+      "OBJ_1073" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_308";
+      };
+      "OBJ_1074" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_309";
+      };
+      "OBJ_1075" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_310";
+      };
+      "OBJ_1076" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_311";
+      };
+      "OBJ_1077" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_312";
+      };
+      "OBJ_1078" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_313";
+      };
+      "OBJ_1079" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_314";
+      };
+      "OBJ_108" = {
+         isa = "PBXFileReference";
+         path = "IsDisjointRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1080" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_315";
+      };
+      "OBJ_1081" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_316";
+      };
+      "OBJ_1082" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_317";
+      };
+      "OBJ_1083" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_318";
+      };
+      "OBJ_1084" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_319";
+      };
+      "OBJ_1085" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_320";
+      };
+      "OBJ_1086" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_321";
+      };
+      "OBJ_1087" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_322";
+      };
+      "OBJ_1088" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_323";
+      };
+      "OBJ_1089" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_324";
+      };
+      "OBJ_109" = {
+         isa = "PBXFileReference";
+         path = "JoinedDefaultParameterRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1090" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_325";
+      };
+      "OBJ_1091" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_326";
+      };
+      "OBJ_1092" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_327";
+      };
+      "OBJ_1093" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_328";
+      };
+      "OBJ_1094" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_329";
+      };
+      "OBJ_1095" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_330";
+      };
+      "OBJ_1096" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_331";
+      };
+      "OBJ_1097" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_332";
+      };
+      "OBJ_1098" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_333";
+      };
+      "OBJ_1099" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_334";
+      };
+      "OBJ_11" = {
+         isa = "PBXFileReference";
+         path = "Configuration+Cache.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_110" = {
+         isa = "PBXFileReference";
+         path = "LegacyCGGeometryFunctionsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1100" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_335";
+      };
+      "OBJ_1101" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_336";
+      };
+      "OBJ_1102" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_337";
+      };
+      "OBJ_1103" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_338";
+      };
+      "OBJ_1104" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_339";
+      };
+      "OBJ_1105" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_340";
+      };
+      "OBJ_1106" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_341";
+      };
+      "OBJ_1107" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_342";
+      };
+      "OBJ_1108" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_343";
+      };
+      "OBJ_1109" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_344";
+      };
+      "OBJ_111" = {
+         isa = "PBXFileReference";
+         path = "LegacyConstantRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1110" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_345";
+      };
+      "OBJ_1111" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_346";
+      };
+      "OBJ_1112" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_347";
+      };
+      "OBJ_1113" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_1114",
+            "OBJ_1115",
+            "OBJ_1116",
+            "OBJ_1117",
+            "OBJ_1118",
+            "OBJ_1119",
+            "OBJ_1120",
+            "OBJ_1121"
+         );
+      };
+      "OBJ_1114" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftSyntax::SwiftSyntax::Product";
+      };
+      "OBJ_1115" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftSyntax::_CSwiftSyntax::Product";
+      };
+      "OBJ_1116" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::SourceKittenFramework::Product";
+      };
+      "OBJ_1117" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::Yams::Product";
+      };
+      "OBJ_1118" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::CYaml::Product";
+      };
+      "OBJ_1119" = {
+         isa = "PBXBuildFile";
+         fileRef = "SWXMLHash::SWXMLHash::Product";
+      };
+      "OBJ_112" = {
+         isa = "PBXFileReference";
+         path = "LegacyConstantRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1120" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::SourceKit::Product";
+      };
+      "OBJ_1121" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::Clang_C::Product";
+      };
+      "OBJ_1122" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftSyntax::SwiftSyntax";
+      };
+      "OBJ_1124" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftSyntax::_CSwiftSyntax";
+      };
+      "OBJ_1126" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::SourceKittenFramework";
+      };
+      "OBJ_1127" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::Yams";
+      };
+      "OBJ_1128" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::CYaml";
+      };
+      "OBJ_1129" = {
+         isa = "PBXTargetDependency";
+         target = "SWXMLHash::SWXMLHash";
+      };
+      "OBJ_113" = {
+         isa = "PBXFileReference";
+         path = "LegacyConstructorRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1130" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::SourceKit";
+      };
+      "OBJ_1131" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::Clang_C";
+      };
+      "OBJ_1133" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1134",
+            "OBJ_1135"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1134" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftLintFrameworkTests_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "SwiftLintFrameworkTests";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_1135" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftLintFrameworkTests_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "SwiftLintFrameworkTests";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_1136" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1137",
+            "OBJ_1138",
+            "OBJ_1139",
+            "OBJ_1140",
+            "OBJ_1141",
+            "OBJ_1142",
+            "OBJ_1143",
+            "OBJ_1144",
+            "OBJ_1145",
+            "OBJ_1146",
+            "OBJ_1147",
+            "OBJ_1148",
+            "OBJ_1149",
+            "OBJ_1150",
+            "OBJ_1151",
+            "OBJ_1152",
+            "OBJ_1153",
+            "OBJ_1154",
+            "OBJ_1155",
+            "OBJ_1156",
+            "OBJ_1157",
+            "OBJ_1158",
+            "OBJ_1159",
+            "OBJ_1160",
+            "OBJ_1161",
+            "OBJ_1162",
+            "OBJ_1163",
+            "OBJ_1164",
+            "OBJ_1165",
+            "OBJ_1166",
+            "OBJ_1167",
+            "OBJ_1168",
+            "OBJ_1169",
+            "OBJ_1170",
+            "OBJ_1171",
+            "OBJ_1172",
+            "OBJ_1173",
+            "OBJ_1174",
+            "OBJ_1175",
+            "OBJ_1176",
+            "OBJ_1177",
+            "OBJ_1178",
+            "OBJ_1179",
+            "OBJ_1180",
+            "OBJ_1181",
+            "OBJ_1182",
+            "OBJ_1183",
+            "OBJ_1184",
+            "OBJ_1185",
+            "OBJ_1186",
+            "OBJ_1187",
+            "OBJ_1188",
+            "OBJ_1189",
+            "OBJ_1190",
+            "OBJ_1191",
+            "OBJ_1192",
+            "OBJ_1193",
+            "OBJ_1194",
+            "OBJ_1195",
+            "OBJ_1196",
+            "OBJ_1197",
+            "OBJ_1198",
+            "OBJ_1199",
+            "OBJ_1200",
+            "OBJ_1201",
+            "OBJ_1202",
+            "OBJ_1203",
+            "OBJ_1204",
+            "OBJ_1205",
+            "OBJ_1206",
+            "OBJ_1207",
+            "OBJ_1208",
+            "OBJ_1209",
+            "OBJ_1210"
+         );
+      };
+      "OBJ_1137" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_369";
+      };
+      "OBJ_1138" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_370";
+      };
+      "OBJ_1139" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_371";
+      };
+      "OBJ_114" = {
+         isa = "PBXFileReference";
+         path = "LegacyHashingRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1140" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_372";
+      };
+      "OBJ_1141" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_373";
+      };
+      "OBJ_1142" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_374";
+      };
+      "OBJ_1143" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_375";
+      };
+      "OBJ_1144" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_376";
+      };
+      "OBJ_1145" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_377";
+      };
+      "OBJ_1146" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_378";
+      };
+      "OBJ_1147" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_379";
+      };
+      "OBJ_1148" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_380";
+      };
+      "OBJ_1149" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_381";
+      };
+      "OBJ_115" = {
+         isa = "PBXFileReference";
+         path = "LegacyMultipleRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1150" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_382";
+      };
+      "OBJ_1151" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_383";
+      };
+      "OBJ_1152" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_384";
+      };
+      "OBJ_1153" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_385";
+      };
+      "OBJ_1154" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_386";
+      };
+      "OBJ_1155" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_387";
+      };
+      "OBJ_1156" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_388";
+      };
+      "OBJ_1157" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_389";
+      };
+      "OBJ_1158" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_390";
+      };
+      "OBJ_1159" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_391";
+      };
+      "OBJ_116" = {
+         isa = "PBXFileReference";
+         path = "LegacyNSGeometryFunctionsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1160" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_392";
+      };
+      "OBJ_1161" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_393";
+      };
+      "OBJ_1162" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_394";
+      };
+      "OBJ_1163" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_395";
+      };
+      "OBJ_1164" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_396";
+      };
+      "OBJ_1165" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_397";
+      };
+      "OBJ_1166" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_398";
+      };
+      "OBJ_1167" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_399";
+      };
+      "OBJ_1168" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_400";
+      };
+      "OBJ_1169" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_401";
+      };
+      "OBJ_117" = {
+         isa = "PBXFileReference";
+         path = "LegacyRandomRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1170" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_402";
+      };
+      "OBJ_1171" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_403";
+      };
+      "OBJ_1172" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_404";
+      };
+      "OBJ_1173" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_405";
+      };
+      "OBJ_1174" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_406";
+      };
+      "OBJ_1175" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_407";
+      };
+      "OBJ_1176" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_408";
+      };
+      "OBJ_1177" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_409";
+      };
+      "OBJ_1178" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_410";
+      };
+      "OBJ_1179" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_411";
+      };
+      "OBJ_118" = {
+         isa = "PBXFileReference";
+         path = "NimbleOperatorRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1180" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_412";
+      };
+      "OBJ_1181" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_413";
+      };
+      "OBJ_1182" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_414";
+      };
+      "OBJ_1183" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_415";
+      };
+      "OBJ_1184" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_416";
+      };
+      "OBJ_1185" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_417";
+      };
+      "OBJ_1186" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_418";
+      };
+      "OBJ_1187" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_419";
+      };
+      "OBJ_1188" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_420";
+      };
+      "OBJ_1189" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_421";
+      };
+      "OBJ_119" = {
+         isa = "PBXFileReference";
+         path = "NoExtensionAccessModifierRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1190" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_422";
+      };
+      "OBJ_1191" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_423";
+      };
+      "OBJ_1192" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_424";
+      };
+      "OBJ_1193" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_425";
+      };
+      "OBJ_1194" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_426";
+      };
+      "OBJ_1195" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_427";
+      };
+      "OBJ_1196" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_428";
+      };
+      "OBJ_1197" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_429";
+      };
+      "OBJ_1198" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_430";
+      };
+      "OBJ_1199" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_431";
+      };
+      "OBJ_12" = {
+         isa = "PBXFileReference";
+         path = "Configuration+IndentationStyle.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_120" = {
+         isa = "PBXFileReference";
+         path = "NoFallthroughOnlyRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1200" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_432";
+      };
+      "OBJ_1201" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_433";
+      };
+      "OBJ_1202" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_434";
+      };
+      "OBJ_1203" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_435";
+      };
+      "OBJ_1204" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_436";
+      };
+      "OBJ_1205" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_437";
+      };
+      "OBJ_1206" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_438";
+      };
+      "OBJ_1207" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_439";
+      };
+      "OBJ_1208" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_440";
+      };
+      "OBJ_1209" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_441";
+      };
+      "OBJ_121" = {
+         isa = "PBXFileReference";
+         path = "NoFallthroughOnlyRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1210" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_442";
+      };
+      "OBJ_1211" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_1212",
+            "OBJ_1213",
+            "OBJ_1214",
+            "OBJ_1215",
+            "OBJ_1216",
+            "OBJ_1217",
+            "OBJ_1218",
+            "OBJ_1219",
+            "OBJ_1220"
+         );
+      };
+      "OBJ_1212" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftLint::SwiftLintFramework::Product";
+      };
+      "OBJ_1213" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftSyntax::SwiftSyntax::Product";
+      };
+      "OBJ_1214" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftSyntax::_CSwiftSyntax::Product";
+      };
+      "OBJ_1215" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::SourceKittenFramework::Product";
+      };
+      "OBJ_1216" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::Yams::Product";
+      };
+      "OBJ_1217" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::CYaml::Product";
+      };
+      "OBJ_1218" = {
+         isa = "PBXBuildFile";
+         fileRef = "SWXMLHash::SWXMLHash::Product";
+      };
+      "OBJ_1219" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::SourceKit::Product";
+      };
+      "OBJ_122" = {
+         isa = "PBXFileReference";
+         path = "NoGroupingExtensionRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1220" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::Clang_C::Product";
+      };
+      "OBJ_1221" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftLint::SwiftLintFramework";
+      };
+      "OBJ_1222" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftSyntax::SwiftSyntax";
+      };
+      "OBJ_1223" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftSyntax::_CSwiftSyntax";
+      };
+      "OBJ_1224" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::SourceKittenFramework";
+      };
+      "OBJ_1225" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::Yams";
+      };
+      "OBJ_1226" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::CYaml";
+      };
+      "OBJ_1227" = {
+         isa = "PBXTargetDependency";
+         target = "SWXMLHash::SWXMLHash";
+      };
+      "OBJ_1228" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::SourceKit";
+      };
+      "OBJ_1229" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::Clang_C";
+      };
+      "OBJ_123" = {
+         isa = "PBXFileReference";
+         path = "ObjectLiteralRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1231" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1232",
+            "OBJ_1233"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1232" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_1233" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Release";
+      };
+      "OBJ_1234" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1235"
+         );
+      };
+      "OBJ_1235" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_6";
+      };
+      "OBJ_1237" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1238",
+            "OBJ_1239"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1238" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Debug";
+      };
+      "OBJ_1239" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Release";
+      };
+      "OBJ_124" = {
+         isa = "PBXFileReference";
+         path = "PatternMatchingKeywordsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1240" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftLint::SwiftLintFrameworkTests";
+      };
+      "OBJ_1241" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1242",
+            "OBJ_1243"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1242" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftSyntax_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftSyntax";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.2";
+            TARGET_NAME = "SwiftSyntax";
+         };
+         name = "Debug";
+      };
+      "OBJ_1243" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftSyntax_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftSyntax";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.2";
+            TARGET_NAME = "SwiftSyntax";
+         };
+         name = "Release";
+      };
+      "OBJ_1244" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1245",
+            "OBJ_1246",
+            "OBJ_1247",
+            "OBJ_1248",
+            "OBJ_1249",
+            "OBJ_1250",
+            "OBJ_1251",
+            "OBJ_1252",
+            "OBJ_1253",
+            "OBJ_1254",
+            "OBJ_1255",
+            "OBJ_1256",
+            "OBJ_1257",
+            "OBJ_1258",
+            "OBJ_1259",
+            "OBJ_1260",
+            "OBJ_1261",
+            "OBJ_1262",
+            "OBJ_1263",
+            "OBJ_1264",
+            "OBJ_1265",
+            "OBJ_1266",
+            "OBJ_1267",
+            "OBJ_1268",
+            "OBJ_1269",
+            "OBJ_1270",
+            "OBJ_1271",
+            "OBJ_1272"
+         );
+      };
+      "OBJ_1245" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_446";
+      };
+      "OBJ_1246" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_447";
+      };
+      "OBJ_1247" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_448";
+      };
+      "OBJ_1248" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_449";
+      };
+      "OBJ_1249" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_450";
+      };
+      "OBJ_125" = {
+         isa = "PBXFileReference";
+         path = "PrivateOverFilePrivateRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1250" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_451";
+      };
+      "OBJ_1251" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_452";
+      };
+      "OBJ_1252" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_453";
+      };
+      "OBJ_1253" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_454";
+      };
+      "OBJ_1254" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_455";
+      };
+      "OBJ_1255" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_456";
+      };
+      "OBJ_1256" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_457";
+      };
+      "OBJ_1257" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_458";
+      };
+      "OBJ_1258" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_459";
+      };
+      "OBJ_1259" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_460";
+      };
+      "OBJ_126" = {
+         isa = "PBXFileReference";
+         path = "RedundantNilCoalescingRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1260" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_461";
+      };
+      "OBJ_1261" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_462";
+      };
+      "OBJ_1262" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_463";
+      };
+      "OBJ_1263" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_464";
+      };
+      "OBJ_1264" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_466";
+      };
+      "OBJ_1265" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_467";
+      };
+      "OBJ_1266" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_468";
+      };
+      "OBJ_1267" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_469";
+      };
+      "OBJ_1268" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_470";
+      };
+      "OBJ_1269" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_471";
+      };
+      "OBJ_127" = {
+         isa = "PBXFileReference";
+         path = "RedundantObjcAttributeRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1270" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_472";
+      };
+      "OBJ_1271" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_473";
+      };
+      "OBJ_1272" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_474";
+      };
+      "OBJ_1273" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_1274"
+         );
+      };
+      "OBJ_1274" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftSyntax::_CSwiftSyntax::Product";
+      };
+      "OBJ_1275" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftSyntax::_CSwiftSyntax";
+      };
+      "OBJ_1277" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1278",
+            "OBJ_1279"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1278" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4.2",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "4.2"
+            );
+            SWIFT_VERSION = "4.2";
+         };
+         name = "Debug";
+      };
+      "OBJ_1279" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4.2",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "4.2"
+            );
+            SWIFT_VERSION = "4.2";
+         };
+         name = "Release";
+      };
+      "OBJ_128" = {
+         isa = "PBXFileReference";
+         path = "RedundantObjcAttributeRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1280" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1281"
+         );
+      };
+      "OBJ_1281" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_482";
+      };
+      "OBJ_1283" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1284",
+            "OBJ_1285"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1284" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftyTextTable_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftyTextTable";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "SwiftyTextTable";
+         };
+         name = "Debug";
+      };
+      "OBJ_1285" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftyTextTable_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftyTextTable";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "SwiftyTextTable";
+         };
+         name = "Release";
+      };
+      "OBJ_1286" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1287"
+         );
+      };
+      "OBJ_1287" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_485";
+      };
+      "OBJ_1288" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_129" = {
+         isa = "PBXFileReference";
+         path = "RedundantOptionalInitializationRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1290" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1291",
+            "OBJ_1292"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1291" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "4"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_1292" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "4"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Release";
+      };
+      "OBJ_1293" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1294"
+         );
+      };
+      "OBJ_1294" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_486";
+      };
+      "OBJ_1295" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1296",
+            "OBJ_1297"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1296" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/Yams_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Yams";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "Yams";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_1297" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/Yams_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Yams";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "Yams";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_1298" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1299",
+            "OBJ_1300",
+            "OBJ_1301",
+            "OBJ_1302",
+            "OBJ_1303",
+            "OBJ_1304",
+            "OBJ_1305",
+            "OBJ_1306",
+            "OBJ_1307",
+            "OBJ_1308",
+            "OBJ_1309",
+            "OBJ_1310",
+            "OBJ_1311",
+            "OBJ_1312",
+            "OBJ_1313",
+            "OBJ_1314"
+         );
+      };
+      "OBJ_1299" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_564";
+      };
+      "OBJ_13" = {
+         isa = "PBXFileReference";
+         path = "Configuration+LintableFiles.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_130" = {
+         isa = "PBXFileReference";
+         path = "RedundantSetAccessControlRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1300" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_565";
+      };
+      "OBJ_1301" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_566";
+      };
+      "OBJ_1302" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_567";
+      };
+      "OBJ_1303" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_568";
+      };
+      "OBJ_1304" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_569";
+      };
+      "OBJ_1305" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_570";
+      };
+      "OBJ_1306" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_571";
+      };
+      "OBJ_1307" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_572";
+      };
+      "OBJ_1308" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_573";
+      };
+      "OBJ_1309" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_574";
+      };
+      "OBJ_131" = {
+         isa = "PBXFileReference";
+         path = "RedundantStringEnumValueRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1310" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_575";
+      };
+      "OBJ_1311" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_576";
+      };
+      "OBJ_1312" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_577";
+      };
+      "OBJ_1313" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_578";
+      };
+      "OBJ_1314" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_579";
+      };
+      "OBJ_1315" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_1316"
+         );
+      };
+      "OBJ_1316" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::CYaml::Product";
+      };
+      "OBJ_1317" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::CYaml";
+      };
+      "OBJ_1319" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1320",
+            "OBJ_1321"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_132" = {
+         isa = "PBXFileReference";
+         path = "RedundantTypeAnnotationRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1320" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_1321" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Release";
+      };
+      "OBJ_1322" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1323"
+         );
+      };
+      "OBJ_1323" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_580";
+      };
+      "OBJ_1324" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1325",
+            "OBJ_1326"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1325" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            DEFINES_MODULE = "NO";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/_CSwiftSyntax_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "-CSwiftSyntax";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "_CSwiftSyntax";
+         };
+         name = "Debug";
+      };
+      "OBJ_1326" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            DEFINES_MODULE = "NO";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/_CSwiftSyntax_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "-CSwiftSyntax";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "_CSwiftSyntax";
+         };
+         name = "Release";
+      };
+      "OBJ_1327" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1328"
+         );
+      };
+      "OBJ_1328" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_477";
+      };
+      "OBJ_1329" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_133" = {
+         isa = "PBXFileReference";
+         path = "RedundantVoidReturnRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1331" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1332",
+            "OBJ_1333"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1332" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/swiftlint_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+               "@executable_path"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES";
+            SWIFT_FORCE_STATIC_LINK_STDLIB = "NO";
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "swiftlint";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_1333" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/swiftlint_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+               "@executable_path"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES";
+            SWIFT_FORCE_STATIC_LINK_STDLIB = "NO";
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "swiftlint";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_1334" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1335",
+            "OBJ_1336",
+            "OBJ_1337",
+            "OBJ_1338",
+            "OBJ_1339",
+            "OBJ_1340",
+            "OBJ_1341",
+            "OBJ_1342",
+            "OBJ_1343",
+            "OBJ_1344",
+            "OBJ_1345",
+            "OBJ_1346",
+            "OBJ_1347",
+            "OBJ_1348",
+            "OBJ_1349"
+         );
+      };
+      "OBJ_1335" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_350";
+      };
+      "OBJ_1336" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_351";
+      };
+      "OBJ_1337" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_352";
+      };
+      "OBJ_1338" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_353";
+      };
+      "OBJ_1339" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_354";
+      };
+      "OBJ_134" = {
+         isa = "PBXFileReference";
+         path = "StaticOperatorRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1340" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_355";
+      };
+      "OBJ_1341" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_357";
+      };
+      "OBJ_1342" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_358";
+      };
+      "OBJ_1343" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_359";
+      };
+      "OBJ_1344" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_361";
+      };
+      "OBJ_1345" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_362";
+      };
+      "OBJ_1346" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_363";
+      };
+      "OBJ_1347" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_364";
+      };
+      "OBJ_1348" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_365";
+      };
+      "OBJ_1349" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_366";
+      };
+      "OBJ_135" = {
+         isa = "PBXFileReference";
+         path = "StrictFilePrivateRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1350" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_1351",
+            "OBJ_1352",
+            "OBJ_1353",
+            "OBJ_1354",
+            "OBJ_1355",
+            "OBJ_1356",
+            "OBJ_1357",
+            "OBJ_1358",
+            "OBJ_1359",
+            "OBJ_1360",
+            "OBJ_1361"
+         );
+      };
+      "OBJ_1351" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftyTextTable::SwiftyTextTable::Product";
+      };
+      "OBJ_1352" = {
+         isa = "PBXBuildFile";
+         fileRef = "Commandant::Commandant::Product";
+      };
+      "OBJ_1353" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftLint::SwiftLintFramework::Product";
+      };
+      "OBJ_1354" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftSyntax::SwiftSyntax::Product";
+      };
+      "OBJ_1355" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftSyntax::_CSwiftSyntax::Product";
+      };
+      "OBJ_1356" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::SourceKittenFramework::Product";
+      };
+      "OBJ_1357" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::Yams::Product";
+      };
+      "OBJ_1358" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::CYaml::Product";
+      };
+      "OBJ_1359" = {
+         isa = "PBXBuildFile";
+         fileRef = "SWXMLHash::SWXMLHash::Product";
+      };
+      "OBJ_136" = {
+         isa = "PBXFileReference";
+         path = "SyntacticSugarRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1360" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::SourceKit::Product";
+      };
+      "OBJ_1361" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::Clang_C::Product";
+      };
+      "OBJ_1362" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftyTextTable::SwiftyTextTable";
+      };
+      "OBJ_1363" = {
+         isa = "PBXTargetDependency";
+         target = "Commandant::Commandant";
+      };
+      "OBJ_1364" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftLint::SwiftLintFramework";
+      };
+      "OBJ_1365" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftSyntax::SwiftSyntax";
+      };
+      "OBJ_1366" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftSyntax::_CSwiftSyntax";
+      };
+      "OBJ_1367" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::SourceKittenFramework";
+      };
+      "OBJ_1368" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::Yams";
+      };
+      "OBJ_1369" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::CYaml";
+      };
+      "OBJ_137" = {
+         isa = "PBXFileReference";
+         path = "ToggleBoolRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1370" = {
+         isa = "PBXTargetDependency";
+         target = "SWXMLHash::SWXMLHash";
+      };
+      "OBJ_1371" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::SourceKit";
+      };
+      "OBJ_1372" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::Clang_C";
+      };
+      "OBJ_138" = {
+         isa = "PBXFileReference";
+         path = "TrailingSemicolonRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_139" = {
+         isa = "PBXFileReference";
+         path = "TypeNameRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_14" = {
+         isa = "PBXFileReference";
+         path = "Configuration+Merging.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_140" = {
+         isa = "PBXFileReference";
+         path = "TypeNameRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_141" = {
+         isa = "PBXFileReference";
+         path = "UnavailableFunctionRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_142" = {
+         isa = "PBXFileReference";
+         path = "UnneededBreakInSwitchRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_143" = {
+         isa = "PBXFileReference";
+         path = "UntypedErrorInCatchRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_144" = {
+         isa = "PBXFileReference";
+         path = "UnusedEnumeratedRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_145" = {
+         isa = "PBXFileReference";
+         path = "XCTFailMessageRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_146" = {
+         isa = "PBXFileReference";
+         path = "XCTSpecificMatcherRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_147" = {
+         isa = "PBXFileReference";
+         path = "XCTSpecificMatcherRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_148" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_149",
+            "OBJ_150",
+            "OBJ_151",
+            "OBJ_152",
+            "OBJ_153",
+            "OBJ_154",
+            "OBJ_155",
+            "OBJ_156",
+            "OBJ_157",
+            "OBJ_158",
+            "OBJ_159",
+            "OBJ_160",
+            "OBJ_161",
+            "OBJ_162",
+            "OBJ_163",
+            "OBJ_164",
+            "OBJ_165",
+            "OBJ_166",
+            "OBJ_167",
+            "OBJ_168",
+            "OBJ_169",
+            "OBJ_170",
+            "OBJ_171",
+            "OBJ_172",
+            "OBJ_173",
+            "OBJ_174",
+            "OBJ_175",
+            "OBJ_176",
+            "OBJ_177",
+            "OBJ_178",
+            "OBJ_179",
+            "OBJ_180",
+            "OBJ_181",
+            "OBJ_182",
+            "OBJ_183",
+            "OBJ_184",
+            "OBJ_185",
+            "OBJ_186",
+            "OBJ_187",
+            "OBJ_188",
+            "OBJ_189",
+            "OBJ_190",
+            "OBJ_191",
+            "OBJ_192",
+            "OBJ_193",
+            "OBJ_194",
+            "OBJ_195",
+            "OBJ_196",
+            "OBJ_197",
+            "OBJ_198",
+            "OBJ_199",
+            "OBJ_200"
+         );
+         name = "Lint";
+         path = "Lint";
+         sourceTree = "<group>";
+      };
+      "OBJ_149" = {
+         isa = "PBXFileReference";
+         path = "AnyObjectProtocolRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_15" = {
+         isa = "PBXFileReference";
+         path = "Configuration+Parsing.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_150" = {
+         isa = "PBXFileReference";
+         path = "ArrayInitRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_151" = {
+         isa = "PBXFileReference";
+         path = "ClassDelegateProtocolRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_152" = {
+         isa = "PBXFileReference";
+         path = "CompilerProtocolInitRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_153" = {
+         isa = "PBXFileReference";
+         path = "DeploymentTargetRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_154" = {
+         isa = "PBXFileReference";
+         path = "DiscardedNotificationCenterObserverRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_155" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedDirectInitRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_156" = {
+         isa = "PBXFileReference";
+         path = "DuplicateEnumCasesRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_157" = {
+         isa = "PBXFileReference";
+         path = "DynamicInlineRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_158" = {
+         isa = "PBXFileReference";
+         path = "EmptyXCTestMethodRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_159" = {
+         isa = "PBXFileReference";
+         path = "EmptyXCTestMethodRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_16" = {
+         isa = "PBXFileReference";
+         path = "Dictionary+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_160" = {
+         isa = "PBXFileReference";
+         path = "ExpiringTodoRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_161" = {
+         isa = "PBXFileReference";
+         path = "IdenticalOperandsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_162" = {
+         isa = "PBXFileReference";
+         path = "InertDeferRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_163" = {
+         isa = "PBXFileReference";
+         path = "LowerACLThanParentRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_164" = {
+         isa = "PBXFileReference";
+         path = "MarkRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_165" = {
+         isa = "PBXFileReference";
+         path = "MissingDocsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_166" = {
+         isa = "PBXFileReference";
+         path = "NSLocalizedStringKeyRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_167" = {
+         isa = "PBXFileReference";
+         path = "NSLocalizedStringRequireBundleRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_168" = {
+         isa = "PBXFileReference";
+         path = "NSObjectPreferIsEqualRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_169" = {
+         isa = "PBXFileReference";
+         path = "NSObjectPreferIsEqualRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_17" = {
+         isa = "PBXFileReference";
+         path = "FileManager+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_170" = {
+         isa = "PBXFileReference";
+         path = "NotificationCenterDetachmentRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_171" = {
+         isa = "PBXFileReference";
+         path = "NotificationCenterDetachmentRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_172" = {
+         isa = "PBXFileReference";
+         path = "OverriddenSuperCallRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_173" = {
+         isa = "PBXFileReference";
+         path = "OverrideInExtensionRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_174" = {
+         isa = "PBXFileReference";
+         path = "PrivateActionRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_175" = {
+         isa = "PBXFileReference";
+         path = "PrivateOutletRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_176" = {
+         isa = "PBXFileReference";
+         path = "PrivateUnitTestRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_177" = {
+         isa = "PBXFileReference";
+         path = "ProhibitedInterfaceBuilderRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_178" = {
+         isa = "PBXFileReference";
+         path = "ProhibitedSuperRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_179" = {
+         isa = "PBXFileReference";
+         path = "QuickDiscouragedCallRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_18" = {
+         isa = "PBXFileReference";
+         path = "NSRange+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_180" = {
+         isa = "PBXFileReference";
+         path = "QuickDiscouragedCallRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_181" = {
+         isa = "PBXFileReference";
+         path = "QuickDiscouragedFocusedTestRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_182" = {
+         isa = "PBXFileReference";
+         path = "QuickDiscouragedFocusedTestRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_183" = {
+         isa = "PBXFileReference";
+         path = "QuickDiscouragedPendingTestRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_184" = {
+         isa = "PBXFileReference";
+         path = "QuickDiscouragedPendingTestRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_185" = {
+         isa = "PBXFileReference";
+         path = "RawValueForCamelCasedCodableEnumRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_186" = {
+         isa = "PBXFileReference";
+         path = "RequiredDeinitRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_187" = {
+         isa = "PBXFileReference";
+         path = "RequiredEnumCaseRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_188" = {
+         isa = "PBXFileReference";
+         path = "StrongIBOutletRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_189" = {
+         isa = "PBXFileReference";
+         path = "SuperfluousDisableCommandRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_19" = {
+         isa = "PBXFileReference";
+         path = "NSRegularExpression+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_190" = {
+         isa = "PBXFileReference";
+         path = "TodoRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_191" = {
+         isa = "PBXFileReference";
+         path = "UnownedVariableCaptureRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_192" = {
+         isa = "PBXFileReference";
+         path = "UnusedCaptureListRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_193" = {
+         isa = "PBXFileReference";
+         path = "UnusedClosureParameterRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_194" = {
+         isa = "PBXFileReference";
+         path = "UnusedControlFlowLabelRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_195" = {
+         isa = "PBXFileReference";
+         path = "UnusedDeclarationRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_196" = {
+         isa = "PBXFileReference";
+         path = "UnusedImportRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_197" = {
+         isa = "PBXFileReference";
+         path = "UnusedSetterValueRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_198" = {
+         isa = "PBXFileReference";
+         path = "ValidIBInspectableRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_199" = {
+         isa = "PBXFileReference";
+         path = "WeakDelegateRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_3",
+            "OBJ_4"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_20" = {
+         isa = "PBXFileReference";
+         path = "QueuedPrint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_200" = {
+         isa = "PBXFileReference";
+         path = "YodaConditionRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_201" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_202",
+            "OBJ_203",
+            "OBJ_204",
+            "OBJ_205",
+            "OBJ_206",
+            "OBJ_207",
+            "OBJ_208",
+            "OBJ_209",
+            "OBJ_210",
+            "OBJ_211",
+            "OBJ_212"
+         );
+         name = "Metrics";
+         path = "Metrics";
+         sourceTree = "<group>";
+      };
+      "OBJ_202" = {
+         isa = "PBXFileReference";
+         path = "ClosureBodyLengthRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_203" = {
+         isa = "PBXFileReference";
+         path = "ClosureBodyLengthRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_204" = {
+         isa = "PBXFileReference";
+         path = "CyclomaticComplexityRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_205" = {
+         isa = "PBXFileReference";
+         path = "EnumCaseAssociatedValuesLengthRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_206" = {
+         isa = "PBXFileReference";
+         path = "FileLengthRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_207" = {
+         isa = "PBXFileReference";
+         path = "FunctionBodyLengthRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_208" = {
+         isa = "PBXFileReference";
+         path = "FunctionParameterCountRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_209" = {
+         isa = "PBXFileReference";
+         path = "LargeTupleRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_21" = {
+         isa = "PBXFileReference";
+         path = "RandomAccessCollection+Swiftlint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_210" = {
+         isa = "PBXFileReference";
+         path = "LineLengthRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_211" = {
+         isa = "PBXFileReference";
+         path = "NestingRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_212" = {
+         isa = "PBXFileReference";
+         path = "TypeBodyLengthRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_213" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_214",
+            "OBJ_215",
+            "OBJ_216",
+            "OBJ_217",
+            "OBJ_218",
+            "OBJ_219",
+            "OBJ_220",
+            "OBJ_221",
+            "OBJ_222",
+            "OBJ_223",
+            "OBJ_224",
+            "OBJ_225",
+            "OBJ_226"
+         );
+         name = "Performance";
+         path = "Performance";
+         sourceTree = "<group>";
+      };
+      "OBJ_214" = {
+         isa = "PBXFileReference";
+         path = "ContainsOverFilterCountRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_215" = {
+         isa = "PBXFileReference";
+         path = "ContainsOverFilterIsEmptyRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_216" = {
+         isa = "PBXFileReference";
+         path = "ContainsOverFirstNotNilRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_217" = {
+         isa = "PBXFileReference";
+         path = "ContainsOverRangeNilComparisonRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_218" = {
+         isa = "PBXFileReference";
+         path = "EmptyCollectionLiteralRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_219" = {
+         isa = "PBXFileReference";
+         path = "EmptyCountRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_22" = {
+         isa = "PBXFileReference";
+         path = "Request+DisableSourceKit.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_220" = {
+         isa = "PBXFileReference";
+         path = "EmptyStringRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_221" = {
+         isa = "PBXFileReference";
+         path = "FirstWhereRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_222" = {
+         isa = "PBXFileReference";
+         path = "FlatMapOverMapReduceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_223" = {
+         isa = "PBXFileReference";
+         path = "LastWhereRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_224" = {
+         isa = "PBXFileReference";
+         path = "ReduceBooleanRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_225" = {
+         isa = "PBXFileReference";
+         path = "ReduceIntoRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_226" = {
+         isa = "PBXFileReference";
+         path = "SortedFirstLastRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_227" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_228",
+            "OBJ_229",
+            "OBJ_230",
+            "OBJ_231",
+            "OBJ_232",
+            "OBJ_233",
+            "OBJ_234",
+            "OBJ_235",
+            "OBJ_236",
+            "OBJ_237",
+            "OBJ_238",
+            "OBJ_239",
+            "OBJ_240",
+            "OBJ_241",
+            "OBJ_242",
+            "OBJ_243",
+            "OBJ_244",
+            "OBJ_245",
+            "OBJ_246",
+            "OBJ_247",
+            "OBJ_248",
+            "OBJ_249",
+            "OBJ_250",
+            "OBJ_251",
+            "OBJ_252",
+            "OBJ_253",
+            "OBJ_254",
+            "OBJ_255",
+            "OBJ_256",
+            "OBJ_257",
+            "OBJ_258",
+            "OBJ_259",
+            "OBJ_260",
+            "OBJ_261",
+            "OBJ_262",
+            "OBJ_263",
+            "OBJ_264",
+            "OBJ_265",
+            "OBJ_266",
+            "OBJ_267",
+            "OBJ_268",
+            "OBJ_269",
+            "OBJ_270"
+         );
+         name = "RuleConfigurations";
+         path = "RuleConfigurations";
+         sourceTree = "<group>";
+      };
+      "OBJ_228" = {
+         isa = "PBXFileReference";
+         path = "AttributesConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_229" = {
+         isa = "PBXFileReference";
+         path = "CollectionAlignmentConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_23" = {
+         isa = "PBXFileReference";
+         path = "SourceKittenDictionary+Swiftlint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_230" = {
+         isa = "PBXFileReference";
+         path = "ColonConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_231" = {
+         isa = "PBXFileReference";
+         path = "ConditionalReturnsOnNewlineConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_232" = {
+         isa = "PBXFileReference";
+         path = "CyclomaticComplexityConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_233" = {
+         isa = "PBXFileReference";
+         path = "DeploymentTargetConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_234" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedDirectInitConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_235" = {
+         isa = "PBXFileReference";
+         path = "ExpiringTodoConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_236" = {
+         isa = "PBXFileReference";
+         path = "ExplicitTypeInterfaceConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_237" = {
+         isa = "PBXFileReference";
+         path = "FileHeaderConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_238" = {
+         isa = "PBXFileReference";
+         path = "FileLengthRuleConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_239" = {
+         isa = "PBXFileReference";
+         path = "FileNameConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_24" = {
+         isa = "PBXFileReference";
+         path = "String+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_240" = {
+         isa = "PBXFileReference";
+         path = "FileNameNoSpaceConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_241" = {
+         isa = "PBXFileReference";
+         path = "FileTypesOrderConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_242" = {
+         isa = "PBXFileReference";
+         path = "FunctionParameterCountConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_243" = {
+         isa = "PBXFileReference";
+         path = "ImplicitlyUnwrappedOptionalConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_244" = {
+         isa = "PBXFileReference";
+         path = "LineLengthConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_245" = {
+         isa = "PBXFileReference";
+         path = "MissingDocsRuleConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_246" = {
+         isa = "PBXFileReference";
+         path = "ModifierOrderConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_247" = {
+         isa = "PBXFileReference";
+         path = "MultilineArgumentsConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_248" = {
+         isa = "PBXFileReference";
+         path = "NameConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_249" = {
+         isa = "PBXFileReference";
+         path = "NestingConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_25" = {
+         isa = "PBXFileReference";
+         path = "String+XML.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_250" = {
+         isa = "PBXFileReference";
+         path = "NumberSeparatorConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_251" = {
+         isa = "PBXFileReference";
+         path = "ObjectLiteralConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_252" = {
+         isa = "PBXFileReference";
+         path = "OverridenSuperCallConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_253" = {
+         isa = "PBXFileReference";
+         path = "PrefixedConstantRuleConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_254" = {
+         isa = "PBXFileReference";
+         path = "PrivateOutletRuleConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_255" = {
+         isa = "PBXFileReference";
+         path = "PrivateOverFilePrivateRuleConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_256" = {
+         isa = "PBXFileReference";
+         path = "PrivateUnitTestConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_257" = {
+         isa = "PBXFileReference";
+         path = "ProhibitedSuperConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_258" = {
+         isa = "PBXFileReference";
+         path = "RegexConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_259" = {
+         isa = "PBXFileReference";
+         path = "RequiredEnumCaseRuleConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_26" = {
+         isa = "PBXFileReference";
+         path = "SwiftDeclarationAttributeKind+Swiftlint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_260" = {
+         isa = "PBXFileReference";
+         path = "SeverityConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_261" = {
+         isa = "PBXFileReference";
+         path = "SeverityLevelsConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_262" = {
+         isa = "PBXFileReference";
+         path = "StatementModeConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_263" = {
+         isa = "PBXFileReference";
+         path = "SwitchCaseAlignmentConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_264" = {
+         isa = "PBXFileReference";
+         path = "TrailingClosureConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_265" = {
+         isa = "PBXFileReference";
+         path = "TrailingCommaConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_266" = {
+         isa = "PBXFileReference";
+         path = "TrailingWhitespaceConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_267" = {
+         isa = "PBXFileReference";
+         path = "TypeContentsOrderConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_268" = {
+         isa = "PBXFileReference";
+         path = "UnusedDeclarationConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_269" = {
+         isa = "PBXFileReference";
+         path = "UnusedOptionalBindingConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_27" = {
+         isa = "PBXFileReference";
+         path = "SwiftDeclarationKind+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_270" = {
+         isa = "PBXFileReference";
+         path = "VerticalWhitespaceConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_271" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_272",
+            "OBJ_273",
+            "OBJ_274",
+            "OBJ_275",
+            "OBJ_276",
+            "OBJ_277",
+            "OBJ_278",
+            "OBJ_279",
+            "OBJ_280",
+            "OBJ_281",
+            "OBJ_282",
+            "OBJ_283",
+            "OBJ_284",
+            "OBJ_285",
+            "OBJ_286",
+            "OBJ_287",
+            "OBJ_288",
+            "OBJ_289",
+            "OBJ_290",
+            "OBJ_291",
+            "OBJ_292",
+            "OBJ_293",
+            "OBJ_294",
+            "OBJ_295",
+            "OBJ_296",
+            "OBJ_297",
+            "OBJ_298",
+            "OBJ_299",
+            "OBJ_300",
+            "OBJ_301",
+            "OBJ_302",
+            "OBJ_303",
+            "OBJ_304",
+            "OBJ_305",
+            "OBJ_306",
+            "OBJ_307",
+            "OBJ_308",
+            "OBJ_309",
+            "OBJ_310",
+            "OBJ_311",
+            "OBJ_312",
+            "OBJ_313",
+            "OBJ_314",
+            "OBJ_315",
+            "OBJ_316",
+            "OBJ_317",
+            "OBJ_318",
+            "OBJ_319",
+            "OBJ_320",
+            "OBJ_321",
+            "OBJ_322",
+            "OBJ_323",
+            "OBJ_324",
+            "OBJ_325",
+            "OBJ_326",
+            "OBJ_327",
+            "OBJ_328",
+            "OBJ_329",
+            "OBJ_330",
+            "OBJ_331",
+            "OBJ_332",
+            "OBJ_333",
+            "OBJ_334",
+            "OBJ_335",
+            "OBJ_336",
+            "OBJ_337",
+            "OBJ_338",
+            "OBJ_339",
+            "OBJ_340",
+            "OBJ_341",
+            "OBJ_342",
+            "OBJ_343",
+            "OBJ_344",
+            "OBJ_345",
+            "OBJ_346",
+            "OBJ_347"
+         );
+         name = "Style";
+         path = "Style";
+         sourceTree = "<group>";
+      };
+      "OBJ_272" = {
+         isa = "PBXFileReference";
+         path = "AttributesRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_273" = {
+         isa = "PBXFileReference";
+         path = "AttributesRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_274" = {
+         isa = "PBXFileReference";
+         path = "ClosingBraceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_275" = {
+         isa = "PBXFileReference";
+         path = "ClosureEndIndentationRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_276" = {
+         isa = "PBXFileReference";
+         path = "ClosureEndIndentationRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_277" = {
+         isa = "PBXFileReference";
+         path = "ClosureParameterPositionRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_278" = {
+         isa = "PBXFileReference";
+         path = "ClosureSpacingRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_279" = {
+         isa = "PBXFileReference";
+         path = "CollectionAlignmentRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_28" = {
+         isa = "PBXFileReference";
+         path = "SwiftExpressionKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_280" = {
+         isa = "PBXFileReference";
+         path = "ColonRule+Dictionary.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_281" = {
+         isa = "PBXFileReference";
+         path = "ColonRule+FunctionCall.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_282" = {
+         isa = "PBXFileReference";
+         path = "ColonRule+Type.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_283" = {
+         isa = "PBXFileReference";
+         path = "ColonRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_284" = {
+         isa = "PBXFileReference";
+         path = "ColonRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_285" = {
+         isa = "PBXFileReference";
+         path = "CommaRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_286" = {
+         isa = "PBXFileReference";
+         path = "ConditionalReturnsOnNewlineRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_287" = {
+         isa = "PBXFileReference";
+         path = "ControlStatementRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_288" = {
+         isa = "PBXFileReference";
+         path = "CustomRules.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_289" = {
+         isa = "PBXFileReference";
+         path = "EmptyEnumArgumentsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_29" = {
+         isa = "PBXFileReference";
+         path = "SwiftLintFile+Cache.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_290" = {
+         isa = "PBXFileReference";
+         path = "EmptyParametersRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_291" = {
+         isa = "PBXFileReference";
+         path = "EmptyParenthesesWithTrailingClosureRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_292" = {
+         isa = "PBXFileReference";
+         path = "ExplicitSelfRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_293" = {
+         isa = "PBXFileReference";
+         path = "FileHeaderRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_294" = {
+         isa = "PBXFileReference";
+         path = "FileTypesOrderRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_295" = {
+         isa = "PBXFileReference";
+         path = "FileTypesOrderRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_296" = {
+         isa = "PBXFileReference";
+         path = "IdentifierNameRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_297" = {
+         isa = "PBXFileReference";
+         path = "IdentifierNameRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_298" = {
+         isa = "PBXFileReference";
+         path = "ImplicitGetterRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_299" = {
+         isa = "PBXFileReference";
+         path = "ImplicitReturnRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_3" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_OBJC_ARC = "YES";
+            COMBINE_HIDPI_IMAGES = "YES";
+            COPY_PHASE_STRIP = "NO";
+            DEBUG_INFORMATION_FORMAT = "dwarf";
+            DYLIB_INSTALL_NAME_BASE = "@rpath";
+            ENABLE_NS_ASSERTIONS = "YES";
+            GCC_OPTIMIZATION_LEVEL = "0";
+            GCC_PREPROCESSOR_DEFINITIONS = (
+               "$(inherited)",
+               "SWIFT_PACKAGE=1",
+               "DEBUG=1"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            ONLY_ACTIVE_ARCH = "YES";
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-DXcode"
+            );
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SDKROOT = "macosx";
+            SUPPORTED_PLATFORMS = (
+               "macosx",
+               "iphoneos",
+               "iphonesimulator",
+               "appletvos",
+               "appletvsimulator",
+               "watchos",
+               "watchsimulator"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)",
+               "SWIFT_PACKAGE",
+               "DEBUG"
+            );
+            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+            USE_HEADERMAP = "NO";
+         };
+         name = "Debug";
+      };
+      "OBJ_30" = {
+         isa = "PBXFileReference";
+         path = "SwiftLintFile+Regex.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_300" = {
+         isa = "PBXFileReference";
+         path = "LeadingWhitespaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_301" = {
+         isa = "PBXFileReference";
+         path = "LetVarWhitespaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_302" = {
+         isa = "PBXFileReference";
+         path = "LiteralExpressionEndIdentationRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_303" = {
+         isa = "PBXFileReference";
+         path = "ModifierOrderRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_304" = {
+         isa = "PBXFileReference";
+         path = "ModifierOrderRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_305" = {
+         isa = "PBXFileReference";
+         path = "MultilineArgumentsBracketsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_306" = {
+         isa = "PBXFileReference";
+         path = "MultilineArgumentsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_307" = {
+         isa = "PBXFileReference";
+         path = "MultilineArgumentsRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_308" = {
+         isa = "PBXFileReference";
+         path = "MultilineFunctionChainsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_309" = {
+         isa = "PBXFileReference";
+         path = "MultilineLiteralBracketsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_31" = {
+         isa = "PBXFileReference";
+         path = "SyntaxKind+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_310" = {
+         isa = "PBXFileReference";
+         path = "MultilineParametersBracketsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_311" = {
+         isa = "PBXFileReference";
+         path = "MultilineParametersRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_312" = {
+         isa = "PBXFileReference";
+         path = "MultilineParametersRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_313" = {
+         isa = "PBXFileReference";
+         path = "MultipleClosuresWithTrailingClosureRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_314" = {
+         isa = "PBXFileReference";
+         path = "NoSpaceInMethodCallRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_315" = {
+         isa = "PBXFileReference";
+         path = "NumberSeparatorRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_316" = {
+         isa = "PBXFileReference";
+         path = "NumberSeparatorRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_317" = {
+         isa = "PBXFileReference";
+         path = "OpeningBraceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_318" = {
+         isa = "PBXFileReference";
+         path = "OperatorFunctionWhitespaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_319" = {
+         isa = "PBXFileReference";
+         path = "OperatorUsageWhitespaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_32" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_33",
+            "OBJ_34",
+            "OBJ_35"
+         );
+         name = "Helpers";
+         path = "Helpers";
+         sourceTree = "<group>";
+      };
+      "OBJ_320" = {
+         isa = "PBXFileReference";
+         path = "OptionalEnumCaseMatchingRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_321" = {
+         isa = "PBXFileReference";
+         path = "PreferSelfTypeOverTypeOfSelfRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_322" = {
+         isa = "PBXFileReference";
+         path = "PrefixedTopLevelConstantRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_323" = {
+         isa = "PBXFileReference";
+         path = "ProtocolPropertyAccessorsOrderRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_324" = {
+         isa = "PBXFileReference";
+         path = "RedundantDiscardableLetRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_325" = {
+         isa = "PBXFileReference";
+         path = "ReturnArrowWhitespaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_326" = {
+         isa = "PBXFileReference";
+         path = "ShorthandOperatorRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_327" = {
+         isa = "PBXFileReference";
+         path = "SingleTestClassRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_328" = {
+         isa = "PBXFileReference";
+         path = "SortedImportsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_329" = {
+         isa = "PBXFileReference";
+         path = "StatementPositionRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_33" = {
+         isa = "PBXFileReference";
+         path = "Glob.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_330" = {
+         isa = "PBXFileReference";
+         path = "SwitchCaseAlignmentRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_331" = {
+         isa = "PBXFileReference";
+         path = "SwitchCaseOnNewlineRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_332" = {
+         isa = "PBXFileReference";
+         path = "TrailingClosureRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_333" = {
+         isa = "PBXFileReference";
+         path = "TrailingCommaRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_334" = {
+         isa = "PBXFileReference";
+         path = "TrailingNewlineRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_335" = {
+         isa = "PBXFileReference";
+         path = "TrailingWhitespaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_336" = {
+         isa = "PBXFileReference";
+         path = "TypeContentsOrderRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_337" = {
+         isa = "PBXFileReference";
+         path = "TypeContentsOrderRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_338" = {
+         isa = "PBXFileReference";
+         path = "UnneededParenthesesInClosureArgumentRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_339" = {
+         isa = "PBXFileReference";
+         path = "UnusedOptionalBindingRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_34" = {
+         isa = "PBXFileReference";
+         path = "NamespaceCollector.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_340" = {
+         isa = "PBXFileReference";
+         path = "VerticalParameterAlignmentOnCallRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_341" = {
+         isa = "PBXFileReference";
+         path = "VerticalParameterAlignmentRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_342" = {
+         isa = "PBXFileReference";
+         path = "VerticalParameterAlignmentRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_343" = {
+         isa = "PBXFileReference";
+         path = "VerticalWhitespaceBetweenCasesRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_344" = {
+         isa = "PBXFileReference";
+         path = "VerticalWhitespaceClosingBracesRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_345" = {
+         isa = "PBXFileReference";
+         path = "VerticalWhitespaceOpeningBracesRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_346" = {
+         isa = "PBXFileReference";
+         path = "VerticalWhitespaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_347" = {
+         isa = "PBXFileReference";
+         path = "VoidReturnRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_348" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_349",
+            "OBJ_356",
+            "OBJ_360",
+            "OBJ_366"
+         );
+         name = "swiftlint";
+         path = "Source/swiftlint";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_349" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_350",
+            "OBJ_351",
+            "OBJ_352",
+            "OBJ_353",
+            "OBJ_354",
+            "OBJ_355"
+         );
+         name = "Commands";
+         path = "Commands";
+         sourceTree = "<group>";
+      };
+      "OBJ_35" = {
+         isa = "PBXFileReference";
+         path = "RegexHelpers.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_350" = {
+         isa = "PBXFileReference";
+         path = "AnalyzeCommand.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_351" = {
+         isa = "PBXFileReference";
+         path = "AutoCorrectCommand.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_352" = {
+         isa = "PBXFileReference";
+         path = "GenerateDocsCommand.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_353" = {
+         isa = "PBXFileReference";
+         path = "LintCommand.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_354" = {
+         isa = "PBXFileReference";
+         path = "RulesCommand.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_355" = {
+         isa = "PBXFileReference";
+         path = "VersionCommand.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_356" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_357",
+            "OBJ_358",
+            "OBJ_359"
+         );
+         name = "Extensions";
+         path = "Extensions";
+         sourceTree = "<group>";
+      };
+      "OBJ_357" = {
+         isa = "PBXFileReference";
+         path = "Array+SwiftLint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_358" = {
+         isa = "PBXFileReference";
+         path = "Configuration+CommandLine.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_359" = {
+         isa = "PBXFileReference";
+         path = "Reporter+CommandLine.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_36" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_37",
+            "OBJ_38",
+            "OBJ_39",
+            "OBJ_40",
+            "OBJ_41",
+            "OBJ_42",
+            "OBJ_43",
+            "OBJ_44",
+            "OBJ_45",
+            "OBJ_46",
+            "OBJ_47",
+            "OBJ_48",
+            "OBJ_49",
+            "OBJ_50",
+            "OBJ_51",
+            "OBJ_52",
+            "OBJ_53",
+            "OBJ_54",
+            "OBJ_55",
+            "OBJ_56",
+            "OBJ_57",
+            "OBJ_58",
+            "OBJ_59",
+            "OBJ_60",
+            "OBJ_61"
+         );
+         name = "Models";
+         path = "Models";
+         sourceTree = "<group>";
+      };
+      "OBJ_360" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_361",
+            "OBJ_362",
+            "OBJ_363",
+            "OBJ_364",
+            "OBJ_365"
+         );
+         name = "Helpers";
+         path = "Helpers";
+         sourceTree = "<group>";
+      };
+      "OBJ_361" = {
+         isa = "PBXFileReference";
+         path = "Benchmark.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_362" = {
+         isa = "PBXFileReference";
+         path = "CommonOptions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_363" = {
+         isa = "PBXFileReference";
+         path = "CompilerArgumentsExtractor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_364" = {
+         isa = "PBXFileReference";
+         path = "LintOrAnalyzeCommand.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_365" = {
+         isa = "PBXFileReference";
+         path = "LintableFilesVisitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_366" = {
+         isa = "PBXFileReference";
+         path = "main.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_367" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_368"
+         );
+         name = "Tests";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_368" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_369",
+            "OBJ_370",
+            "OBJ_371",
+            "OBJ_372",
+            "OBJ_373",
+            "OBJ_374",
+            "OBJ_375",
+            "OBJ_376",
+            "OBJ_377",
+            "OBJ_378",
+            "OBJ_379",
+            "OBJ_380",
+            "OBJ_381",
+            "OBJ_382",
+            "OBJ_383",
+            "OBJ_384",
+            "OBJ_385",
+            "OBJ_386",
+            "OBJ_387",
+            "OBJ_388",
+            "OBJ_389",
+            "OBJ_390",
+            "OBJ_391",
+            "OBJ_392",
+            "OBJ_393",
+            "OBJ_394",
+            "OBJ_395",
+            "OBJ_396",
+            "OBJ_397",
+            "OBJ_398",
+            "OBJ_399",
+            "OBJ_400",
+            "OBJ_401",
+            "OBJ_402",
+            "OBJ_403",
+            "OBJ_404",
+            "OBJ_405",
+            "OBJ_406",
+            "OBJ_407",
+            "OBJ_408",
+            "OBJ_409",
+            "OBJ_410",
+            "OBJ_411",
+            "OBJ_412",
+            "OBJ_413",
+            "OBJ_414",
+            "OBJ_415",
+            "OBJ_416",
+            "OBJ_417",
+            "OBJ_418",
+            "OBJ_419",
+            "OBJ_420",
+            "OBJ_421",
+            "OBJ_422",
+            "OBJ_423",
+            "OBJ_424",
+            "OBJ_425",
+            "OBJ_426",
+            "OBJ_427",
+            "OBJ_428",
+            "OBJ_429",
+            "OBJ_430",
+            "OBJ_431",
+            "OBJ_432",
+            "OBJ_433",
+            "OBJ_434",
+            "OBJ_435",
+            "OBJ_436",
+            "OBJ_437",
+            "OBJ_438",
+            "OBJ_439",
+            "OBJ_440",
+            "OBJ_441",
+            "OBJ_442"
+         );
+         name = "SwiftLintFrameworkTests";
+         path = "Tests/SwiftLintFrameworkTests";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_369" = {
+         isa = "PBXFileReference";
+         path = "AttributesRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_37" = {
+         isa = "PBXFileReference";
+         path = "AccessControlLevel.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_370" = {
+         isa = "PBXFileReference";
+         path = "AutomaticRuleTests.generated.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_371" = {
+         isa = "PBXFileReference";
+         path = "CollectingRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_372" = {
+         isa = "PBXFileReference";
+         path = "CollectionAlignmentRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_373" = {
+         isa = "PBXFileReference";
+         path = "ColonRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_374" = {
+         isa = "PBXFileReference";
+         path = "CommandTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_375" = {
+         isa = "PBXFileReference";
+         path = "CompilerProtocolInitRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_376" = {
+         isa = "PBXFileReference";
+         path = "ConditionalReturnsOnNewlineRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_377" = {
+         isa = "PBXFileReference";
+         path = "ConfigurationAliasesTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_378" = {
+         isa = "PBXFileReference";
+         path = "ConfigurationTests+Nested.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_379" = {
+         isa = "PBXFileReference";
+         path = "ConfigurationTests+ProjectMock.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_38" = {
+         isa = "PBXFileReference";
+         path = "Command.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_380" = {
+         isa = "PBXFileReference";
+         path = "ConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_381" = {
+         isa = "PBXFileReference";
+         path = "ContainsOverFirstNotNilRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_382" = {
+         isa = "PBXFileReference";
+         path = "CustomRulesTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_383" = {
+         isa = "PBXFileReference";
+         path = "CyclomaticComplexityConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_384" = {
+         isa = "PBXFileReference";
+         path = "CyclomaticComplexityRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_385" = {
+         isa = "PBXFileReference";
+         path = "DeploymentTargetConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_386" = {
+         isa = "PBXFileReference";
+         path = "DeploymentTargetRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_387" = {
+         isa = "PBXFileReference";
+         path = "DisableAllTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_388" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedDirectInitRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_389" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedObjectLiteralRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_39" = {
+         isa = "PBXFileReference";
+         path = "Configuration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_390" = {
+         isa = "PBXFileReference";
+         path = "DocumentationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_391" = {
+         isa = "PBXFileReference";
+         path = "ExpiringTodoRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_392" = {
+         isa = "PBXFileReference";
+         path = "ExplicitTypeInterfaceConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_393" = {
+         isa = "PBXFileReference";
+         path = "ExplicitTypeInterfaceRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_394" = {
+         isa = "PBXFileReference";
+         path = "ExtendedNSStringTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_395" = {
+         isa = "PBXFileReference";
+         path = "FileHeaderRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_396" = {
+         isa = "PBXFileReference";
+         path = "FileLengthRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_397" = {
+         isa = "PBXFileReference";
+         path = "FileNameNoSpaceRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_398" = {
+         isa = "PBXFileReference";
+         path = "FileNameRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_399" = {
+         isa = "PBXFileReference";
+         path = "FileTypesOrderRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_4" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_OBJC_ARC = "YES";
+            COMBINE_HIDPI_IMAGES = "YES";
+            COPY_PHASE_STRIP = "YES";
+            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+            DYLIB_INSTALL_NAME_BASE = "@rpath";
+            GCC_OPTIMIZATION_LEVEL = "s";
+            GCC_PREPROCESSOR_DEFINITIONS = (
+               "$(inherited)",
+               "SWIFT_PACKAGE=1"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-DXcode"
+            );
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SDKROOT = "macosx";
+            SUPPORTED_PLATFORMS = (
+               "macosx",
+               "iphoneos",
+               "iphonesimulator",
+               "appletvos",
+               "appletvsimulator",
+               "watchos",
+               "watchsimulator"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)",
+               "SWIFT_PACKAGE"
+            );
+            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+            USE_HEADERMAP = "NO";
+         };
+         name = "Release";
+      };
+      "OBJ_40" = {
+         isa = "PBXFileReference";
+         path = "ConfigurationError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_400" = {
+         isa = "PBXFileReference";
+         path = "FunctionBodyLengthRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_401" = {
+         isa = "PBXFileReference";
+         path = "FunctionParameterCountRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_402" = {
+         isa = "PBXFileReference";
+         path = "GenericTypeNameRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_403" = {
+         isa = "PBXFileReference";
+         path = "GlobTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_404" = {
+         isa = "PBXFileReference";
+         path = "IdentifierNameRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_405" = {
+         isa = "PBXFileReference";
+         path = "ImplicitlyUnwrappedOptionalConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_406" = {
+         isa = "PBXFileReference";
+         path = "ImplicitlyUnwrappedOptionalRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_407" = {
+         isa = "PBXFileReference";
+         path = "IntegrationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_408" = {
+         isa = "PBXFileReference";
+         path = "LineLengthConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_409" = {
+         isa = "PBXFileReference";
+         path = "LineLengthRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_41" = {
+         isa = "PBXFileReference";
+         path = "Correction.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_410" = {
+         isa = "PBXFileReference";
+         path = "LinterCacheTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_411" = {
+         isa = "PBXFileReference";
+         path = "MissingDocsRuleConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_412" = {
+         isa = "PBXFileReference";
+         path = "ModifierOrderTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_413" = {
+         isa = "PBXFileReference";
+         path = "MultilineArgumentsRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_414" = {
+         isa = "PBXFileReference";
+         path = "NumberSeparatorRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_415" = {
+         isa = "PBXFileReference";
+         path = "ObjectLiteralRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_416" = {
+         isa = "PBXFileReference";
+         path = "PrefixedTopLevelConstantRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_417" = {
+         isa = "PBXFileReference";
+         path = "PrivateOutletRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_418" = {
+         isa = "PBXFileReference";
+         path = "PrivateOverFilePrivateRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_419" = {
+         isa = "PBXFileReference";
+         path = "RegionTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_42" = {
+         isa = "PBXFileReference";
+         path = "Linter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_420" = {
+         isa = "PBXFileReference";
+         path = "ReporterTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_421" = {
+         isa = "PBXFileReference";
+         path = "RequiredEnumCaseRuleTestCase.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_422" = {
+         isa = "PBXFileReference";
+         path = "RuleConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_423" = {
+         isa = "PBXFileReference";
+         path = "RuleDescription+Examples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_424" = {
+         isa = "PBXFileReference";
+         path = "RuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_425" = {
+         isa = "PBXFileReference";
+         path = "RulesTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_426" = {
+         isa = "PBXFileReference";
+         path = "SourceKitCrashTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_427" = {
+         isa = "PBXFileReference";
+         path = "StatementPositionRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_428" = {
+         isa = "PBXFileReference";
+         path = "SwitchCaseAlignmentRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_429" = {
+         isa = "PBXFileReference";
+         path = "TestHelpers.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_43" = {
+         isa = "PBXFileReference";
+         path = "LinterCache.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_430" = {
+         isa = "PBXFileReference";
+         path = "TodoRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_431" = {
+         isa = "PBXFileReference";
+         path = "TrailingClosureConfigurationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_432" = {
+         isa = "PBXFileReference";
+         path = "TrailingClosureRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_433" = {
+         isa = "PBXFileReference";
+         path = "TrailingCommaRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_434" = {
+         isa = "PBXFileReference";
+         path = "TrailingWhitespaceTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_435" = {
+         isa = "PBXFileReference";
+         path = "TypeContentsOrderRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_436" = {
+         isa = "PBXFileReference";
+         path = "TypeNameRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_437" = {
+         isa = "PBXFileReference";
+         path = "UnusedOptionalBindingRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_438" = {
+         isa = "PBXFileReference";
+         path = "VerticalWhitespaceRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_439" = {
+         isa = "PBXFileReference";
+         path = "XCTSpecificMatcherRuleTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_44" = {
+         isa = "PBXFileReference";
+         path = "Location.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_440" = {
+         isa = "PBXFileReference";
+         path = "XCTestCase+BundlePath.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_441" = {
+         isa = "PBXFileReference";
+         path = "YamlParserTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_442" = {
+         isa = "PBXFileReference";
+         path = "YamlSwiftLintTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_443" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_444",
+            "OBJ_483",
+            "OBJ_487",
+            "OBJ_551",
+            "OBJ_581",
+            "OBJ_586"
+         );
+         name = "Dependencies";
+         path = "";
+         sourceTree = "<group>";
+      };
+      "OBJ_444" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_445",
+            "OBJ_475",
+            "OBJ_481",
+            "OBJ_482"
+         );
+         name = "SwiftSyntax 0.50100.0";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_445" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_446",
+            "OBJ_447",
+            "OBJ_448",
+            "OBJ_449",
+            "OBJ_450",
+            "OBJ_451",
+            "OBJ_452",
+            "OBJ_453",
+            "OBJ_454",
+            "OBJ_455",
+            "OBJ_456",
+            "OBJ_457",
+            "OBJ_458",
+            "OBJ_459",
+            "OBJ_460",
+            "OBJ_461",
+            "OBJ_462",
+            "OBJ_463",
+            "OBJ_464",
+            "OBJ_465"
+         );
+         name = "SwiftSyntax";
+         path = ".build/checkouts/swift-syntax/Sources/SwiftSyntax";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_446" = {
+         isa = "PBXFileReference";
+         path = "AbsolutePosition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_447" = {
+         isa = "PBXFileReference";
+         path = "AtomicCounter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_448" = {
+         isa = "PBXFileReference";
+         path = "Diagnostic.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_449" = {
+         isa = "PBXFileReference";
+         path = "DiagnosticConsumer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_45" = {
+         isa = "PBXFileReference";
+         path = "MasterRuleList.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_450" = {
+         isa = "PBXFileReference";
+         path = "DiagnosticEngine.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_451" = {
+         isa = "PBXFileReference";
+         path = "IncrementalParseTransition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_452" = {
+         isa = "PBXFileReference";
+         path = "JSONDiagnosticConsumer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_453" = {
+         isa = "PBXFileReference";
+         path = "PrintingDiagnosticConsumer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_454" = {
+         isa = "PBXFileReference";
+         path = "RawSyntax.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_455" = {
+         isa = "PBXFileReference";
+         path = "SourceLength.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_456" = {
+         isa = "PBXFileReference";
+         path = "SourceLocation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_457" = {
+         isa = "PBXFileReference";
+         path = "SourcePresence.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_458" = {
+         isa = "PBXFileReference";
+         path = "Syntax.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_459" = {
+         isa = "PBXFileReference";
+         path = "SyntaxChildren.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_46" = {
+         isa = "PBXFileReference";
+         path = "Region.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_460" = {
+         isa = "PBXFileReference";
+         path = "SyntaxClassifier.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_461" = {
+         isa = "PBXFileReference";
+         path = "SyntaxData.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_462" = {
+         isa = "PBXFileReference";
+         path = "SyntaxParser.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_463" = {
+         isa = "PBXFileReference";
+         path = "SyntaxVerifier.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_464" = {
+         isa = "PBXFileReference";
+         path = "Utils.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_465" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_466",
+            "OBJ_467",
+            "OBJ_468",
+            "OBJ_469",
+            "OBJ_470",
+            "OBJ_471",
+            "OBJ_472",
+            "OBJ_473",
+            "OBJ_474"
+         );
+         name = "gyb_generated";
+         path = "gyb_generated";
+         sourceTree = "<group>";
+      };
+      "OBJ_466" = {
+         isa = "PBXFileReference";
+         path = "SyntaxBuilders.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_467" = {
+         isa = "PBXFileReference";
+         path = "SyntaxClassification.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_468" = {
+         isa = "PBXFileReference";
+         path = "SyntaxCollections.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_469" = {
+         isa = "PBXFileReference";
+         path = "SyntaxFactory.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_47" = {
+         isa = "PBXFileReference";
+         path = "RuleDescription.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_470" = {
+         isa = "PBXFileReference";
+         path = "SyntaxKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_471" = {
+         isa = "PBXFileReference";
+         path = "SyntaxNodes.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_472" = {
+         isa = "PBXFileReference";
+         path = "SyntaxRewriter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_473" = {
+         isa = "PBXFileReference";
+         path = "TokenKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_474" = {
+         isa = "PBXFileReference";
+         path = "Trivia.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_475" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_476",
+            "OBJ_478"
+         );
+         name = "_CSwiftSyntax";
+         path = ".build/checkouts/swift-syntax/Sources/_CSwiftSyntax";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_476" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_477"
+         );
+         name = "src";
+         path = "src";
+         sourceTree = "<group>";
+      };
+      "OBJ_477" = {
+         isa = "PBXFileReference";
+         path = "atomic-counter.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_478" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_479",
+            "OBJ_480"
+         );
+         name = "include";
+         path = "include";
+         sourceTree = "<group>";
+      };
+      "OBJ_479" = {
+         isa = "PBXFileReference";
+         path = "atomic-counter.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_48" = {
+         isa = "PBXFileReference";
+         path = "RuleIdentifier.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_480" = {
+         isa = "PBXFileReference";
+         name = "module.modulemap";
+         path = "/Users/marcelofabri/projetos/SwiftLint/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap";
+         sourceTree = "<group>";
+      };
+      "OBJ_481" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "lit-test-helper";
+         path = ".build/checkouts/swift-syntax/Sources/lit-test-helper";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_482" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/swift-syntax/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_483" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_484",
+            "OBJ_486"
+         );
+         name = "SwiftyTextTable 0.9.0";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_484" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_485"
+         );
+         name = "SwiftyTextTable";
+         path = ".build/checkouts/SwiftyTextTable/Source/SwiftyTextTable";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_485" = {
+         isa = "PBXFileReference";
+         path = "TextTable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_486" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SwiftyTextTable/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_487" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_488",
+            "OBJ_499",
+            "OBJ_504",
+            "OBJ_549",
+            "OBJ_550"
+         );
+         name = "SourceKitten 0.28.0";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_488" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_489",
+            "OBJ_490"
+         );
+         name = "Clang_C";
+         path = ".build/checkouts/SourceKitten/Source/Clang_C";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_489" = {
+         isa = "PBXFileReference";
+         path = "Clang_C.m";
+         sourceTree = "<group>";
+      };
+      "OBJ_49" = {
+         isa = "PBXFileReference";
+         path = "RuleKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_490" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_491",
+            "OBJ_492",
+            "OBJ_493",
+            "OBJ_494",
+            "OBJ_495",
+            "OBJ_496",
+            "OBJ_497",
+            "OBJ_498"
+         );
+         name = "include";
+         path = "include";
+         sourceTree = "<group>";
+      };
+      "OBJ_491" = {
+         isa = "PBXFileReference";
+         path = "Index.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_492" = {
+         isa = "PBXFileReference";
+         path = "BuildSystem.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_493" = {
+         isa = "PBXFileReference";
+         path = "Documentation.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_494" = {
+         isa = "PBXFileReference";
+         path = "CXCompilationDatabase.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_495" = {
+         isa = "PBXFileReference";
+         path = "Clang_C.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_496" = {
+         isa = "PBXFileReference";
+         path = "CXErrorCode.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_497" = {
+         isa = "PBXFileReference";
+         path = "CXString.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_498" = {
+         isa = "PBXFileReference";
+         path = "Platform.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_499" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_500",
+            "OBJ_501"
+         );
+         name = "SourceKit";
+         path = ".build/checkouts/SourceKitten/Source/SourceKit";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_5" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_6",
+            "OBJ_7",
+            "OBJ_367",
+            "OBJ_443",
+            "OBJ_599",
+            "OBJ_613",
+            "OBJ_614",
+            "OBJ_615",
+            "OBJ_616",
+            "OBJ_617",
+            "OBJ_618",
+            "OBJ_619",
+            "OBJ_620",
+            "OBJ_621",
+            "OBJ_622",
+            "OBJ_623",
+            "OBJ_624",
+            "OBJ_625",
+            "OBJ_626",
+            "OBJ_627",
+            "OBJ_628",
+            "OBJ_629",
+            "OBJ_630",
+            "OBJ_631",
+            "OBJ_632",
+            "OBJ_633",
+            "OBJ_634",
+            "OBJ_635"
+         );
+         path = "";
+         sourceTree = "<group>";
+      };
+      "OBJ_50" = {
+         isa = "PBXFileReference";
+         path = "RuleList+Documentation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_500" = {
+         isa = "PBXFileReference";
+         path = "SourceKit.m";
+         sourceTree = "<group>";
+      };
+      "OBJ_501" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_502",
+            "OBJ_503"
+         );
+         name = "include";
+         path = "include";
+         sourceTree = "<group>";
+      };
+      "OBJ_502" = {
+         isa = "PBXFileReference";
+         path = "SourceKit.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_503" = {
+         isa = "PBXFileReference";
+         path = "sourcekitd.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_504" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_505",
+            "OBJ_506",
+            "OBJ_507",
+            "OBJ_508",
+            "OBJ_509",
+            "OBJ_510",
+            "OBJ_511",
+            "OBJ_512",
+            "OBJ_513",
+            "OBJ_514",
+            "OBJ_515",
+            "OBJ_516",
+            "OBJ_517",
+            "OBJ_518",
+            "OBJ_519",
+            "OBJ_520",
+            "OBJ_521",
+            "OBJ_522",
+            "OBJ_523",
+            "OBJ_524",
+            "OBJ_525",
+            "OBJ_526",
+            "OBJ_527",
+            "OBJ_528",
+            "OBJ_529",
+            "OBJ_530",
+            "OBJ_531",
+            "OBJ_532",
+            "OBJ_533",
+            "OBJ_534",
+            "OBJ_535",
+            "OBJ_536",
+            "OBJ_537",
+            "OBJ_538",
+            "OBJ_539",
+            "OBJ_540",
+            "OBJ_541",
+            "OBJ_542",
+            "OBJ_543",
+            "OBJ_544",
+            "OBJ_545",
+            "OBJ_546",
+            "OBJ_547",
+            "OBJ_548"
+         );
+         name = "SourceKittenFramework";
+         path = ".build/checkouts/SourceKitten/Source/SourceKittenFramework";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_505" = {
+         isa = "PBXFileReference";
+         path = "Clang+SourceKitten.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_506" = {
+         isa = "PBXFileReference";
+         path = "ClangTranslationUnit.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_507" = {
+         isa = "PBXFileReference";
+         path = "CodeCompletionItem.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_508" = {
+         isa = "PBXFileReference";
+         path = "CursorInfo+Parsing.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_509" = {
+         isa = "PBXFileReference";
+         path = "Dictionary+Merge.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_51" = {
+         isa = "PBXFileReference";
+         path = "RuleList.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_510" = {
+         isa = "PBXFileReference";
+         path = "Documentation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_511" = {
+         isa = "PBXFileReference";
+         path = "Exec.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_512" = {
+         isa = "PBXFileReference";
+         path = "File+Hashable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_513" = {
+         isa = "PBXFileReference";
+         path = "File.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_514" = {
+         isa = "PBXFileReference";
+         path = "JSONOutput.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_515" = {
+         isa = "PBXFileReference";
+         path = "Language.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_516" = {
+         isa = "PBXFileReference";
+         path = "Line.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_517" = {
+         isa = "PBXFileReference";
+         path = "LinuxCompatibility.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_518" = {
+         isa = "PBXFileReference";
+         path = "Module.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_519" = {
+         isa = "PBXFileReference";
+         path = "ObjCDeclarationKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_52" = {
+         isa = "PBXFileReference";
+         path = "RuleParameter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_520" = {
+         isa = "PBXFileReference";
+         path = "OffsetMap.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_521" = {
+         isa = "PBXFileReference";
+         path = "Parameter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_522" = {
+         isa = "PBXFileReference";
+         path = "Request.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_523" = {
+         isa = "PBXFileReference";
+         path = "SourceDeclaration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_524" = {
+         isa = "PBXFileReference";
+         path = "SourceKitObject.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_525" = {
+         isa = "PBXFileReference";
+         path = "SourceLocation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_526" = {
+         isa = "PBXFileReference";
+         path = "StatementKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_527" = {
+         isa = "PBXFileReference";
+         path = "String+SourceKitten.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_528" = {
+         isa = "PBXFileReference";
+         path = "StringView+SourceKitten.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_529" = {
+         isa = "PBXFileReference";
+         path = "StringView.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_53" = {
+         isa = "PBXFileReference";
+         path = "RuleStorage.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_530" = {
+         isa = "PBXFileReference";
+         path = "Structure.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_531" = {
+         isa = "PBXFileReference";
+         path = "SwiftDeclarationAttributeKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_532" = {
+         isa = "PBXFileReference";
+         path = "SwiftDeclarationKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_533" = {
+         isa = "PBXFileReference";
+         path = "SwiftDocKey.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_534" = {
+         isa = "PBXFileReference";
+         path = "SwiftDocs.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_535" = {
+         isa = "PBXFileReference";
+         path = "SyntaxKind.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_536" = {
+         isa = "PBXFileReference";
+         path = "SyntaxMap.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_537" = {
+         isa = "PBXFileReference";
+         path = "SyntaxToken.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_538" = {
+         isa = "PBXFileReference";
+         path = "Text.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_539" = {
+         isa = "PBXFileReference";
+         path = "UID.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_54" = {
+         isa = "PBXFileReference";
+         path = "StyleViolation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_540" = {
+         isa = "PBXFileReference";
+         path = "UIDRepresentable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_541" = {
+         isa = "PBXFileReference";
+         path = "Version.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_542" = {
+         isa = "PBXFileReference";
+         path = "Xcode.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_543" = {
+         isa = "PBXFileReference";
+         path = "XcodeBuildSetting.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_544" = {
+         isa = "PBXFileReference";
+         path = "library_wrapper.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_545" = {
+         isa = "PBXFileReference";
+         path = "library_wrapper_CXString.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_546" = {
+         isa = "PBXFileReference";
+         path = "library_wrapper_Documentation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_547" = {
+         isa = "PBXFileReference";
+         path = "library_wrapper_Index.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_548" = {
+         isa = "PBXFileReference";
+         path = "library_wrapper_sourcekitd.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_549" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "sourcekitten";
+         path = ".build/checkouts/SourceKitten/Source/sourcekitten";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_55" = {
+         isa = "PBXFileReference";
+         path = "SwiftLintFile.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_550" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SourceKitten/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_551" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_552",
+            "OBJ_563",
+            "OBJ_580"
+         );
+         name = "Yams 2.0.0";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_552" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_553",
+            "OBJ_560"
+         );
+         name = "CYaml";
+         path = ".build/checkouts/Yams/Sources/CYaml";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_553" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_554",
+            "OBJ_555",
+            "OBJ_556",
+            "OBJ_557",
+            "OBJ_558",
+            "OBJ_559"
+         );
+         name = "src";
+         path = "src";
+         sourceTree = "<group>";
+      };
+      "OBJ_554" = {
+         isa = "PBXFileReference";
+         path = "api.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_555" = {
+         isa = "PBXFileReference";
+         path = "emitter.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_556" = {
+         isa = "PBXFileReference";
+         path = "parser.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_557" = {
+         isa = "PBXFileReference";
+         path = "reader.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_558" = {
+         isa = "PBXFileReference";
+         path = "scanner.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_559" = {
+         isa = "PBXFileReference";
+         path = "writer.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_56" = {
+         isa = "PBXFileReference";
+         path = "SwiftLintSyntaxMap.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_560" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_561",
+            "OBJ_562"
+         );
+         name = "include";
+         path = "include";
+         sourceTree = "<group>";
+      };
+      "OBJ_561" = {
+         isa = "PBXFileReference";
+         path = "CYaml.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_562" = {
+         isa = "PBXFileReference";
+         path = "yaml.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_563" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_564",
+            "OBJ_565",
+            "OBJ_566",
+            "OBJ_567",
+            "OBJ_568",
+            "OBJ_569",
+            "OBJ_570",
+            "OBJ_571",
+            "OBJ_572",
+            "OBJ_573",
+            "OBJ_574",
+            "OBJ_575",
+            "OBJ_576",
+            "OBJ_577",
+            "OBJ_578",
+            "OBJ_579"
+         );
+         name = "Yams";
+         path = ".build/checkouts/Yams/Sources/Yams";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_564" = {
+         isa = "PBXFileReference";
+         path = "Constructor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_565" = {
+         isa = "PBXFileReference";
+         path = "Decoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_566" = {
+         isa = "PBXFileReference";
+         path = "Emitter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_567" = {
+         isa = "PBXFileReference";
+         path = "Encoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_568" = {
+         isa = "PBXFileReference";
+         path = "Mark.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_569" = {
+         isa = "PBXFileReference";
+         path = "Node.Mapping.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_57" = {
+         isa = "PBXFileReference";
+         path = "SwiftLintSyntaxToken.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_570" = {
+         isa = "PBXFileReference";
+         path = "Node.Scalar.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_571" = {
+         isa = "PBXFileReference";
+         path = "Node.Sequence.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_572" = {
+         isa = "PBXFileReference";
+         path = "Node.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_573" = {
+         isa = "PBXFileReference";
+         path = "Parser.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_574" = {
+         isa = "PBXFileReference";
+         path = "Representer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_575" = {
+         isa = "PBXFileReference";
+         path = "Resolver.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_576" = {
+         isa = "PBXFileReference";
+         path = "String+Yams.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_577" = {
+         isa = "PBXFileReference";
+         path = "Tag.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_578" = {
+         isa = "PBXFileReference";
+         path = "YamlError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_579" = {
+         isa = "PBXFileReference";
+         path = "shim.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_58" = {
+         isa = "PBXFileReference";
+         path = "SwiftVersion.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_580" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/Yams/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_581" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_582",
+            "OBJ_583",
+            "OBJ_584",
+            "OBJ_585"
+         );
+         name = "SWXMLHash 5.0.1";
+         path = ".build/checkouts/SWXMLHash/Source";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_582" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/SWXMLHash/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_583" = {
+         isa = "PBXFileReference";
+         path = "SWXMLHash.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_584" = {
+         isa = "PBXFileReference";
+         path = "XMLIndexer+XMLIndexerDeserializable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_585" = {
+         isa = "PBXFileReference";
+         path = "shim.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_586" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_587",
+            "OBJ_598"
+         );
+         name = "Commandant 0.17.0";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_587" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_588",
+            "OBJ_589",
+            "OBJ_590",
+            "OBJ_591",
+            "OBJ_592",
+            "OBJ_593",
+            "OBJ_594",
+            "OBJ_595",
+            "OBJ_596",
+            "OBJ_597"
+         );
+         name = "Commandant";
+         path = ".build/checkouts/Commandant/Sources/Commandant";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_588" = {
+         isa = "PBXFileReference";
+         path = "Argument.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_589" = {
+         isa = "PBXFileReference";
+         path = "ArgumentParser.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_59" = {
+         isa = "PBXFileReference";
+         path = "Version.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_590" = {
+         isa = "PBXFileReference";
+         path = "ArgumentProtocol.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_591" = {
+         isa = "PBXFileReference";
+         path = "Command.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_592" = {
+         isa = "PBXFileReference";
+         path = "Errors.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_593" = {
+         isa = "PBXFileReference";
+         path = "HelpCommand.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_594" = {
+         isa = "PBXFileReference";
+         path = "Option.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_595" = {
+         isa = "PBXFileReference";
+         path = "OrderedSet.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_596" = {
+         isa = "PBXFileReference";
+         path = "Result+Additions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_597" = {
+         isa = "PBXFileReference";
+         path = "Switch.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_598" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Users/marcelofabri/projetos/SwiftLint/.build/checkouts/Commandant/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_599" = {
+         isa = "PBXGroup";
+         children = (
+            "Commandant::Commandant::Product",
+            "SwiftSyntax::_CSwiftSyntax::Product",
+            "SourceKitten::SourceKittenFramework::Product",
+            "SourceKitten::SourceKit::Product",
+            "SwiftLint::SwiftLintFramework::Product",
+            "SWXMLHash::SWXMLHash::Product",
+            "SwiftLint::SwiftLintFrameworkTests::Product",
+            "SourceKitten::Clang_C::Product",
+            "Yams::CYaml::Product",
+            "SwiftyTextTable::SwiftyTextTable::Product",
+            "SwiftSyntax::SwiftSyntax::Product",
+            "SwiftLint::swiftlint::Product",
+            "Yams::Yams::Product"
+         );
+         name = "Products";
+         path = "";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "OBJ_6" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         path = "Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_60" = {
+         isa = "PBXFileReference";
+         path = "ViolationSeverity.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_61" = {
+         isa = "PBXFileReference";
+         path = "YamlParser.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_613" = {
+         isa = "PBXFileReference";
+         path = "SwiftLint.xcworkspace";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_614" = {
+         isa = "PBXFileReference";
+         path = "Carthage";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_615" = {
+         isa = "PBXFileReference";
+         path = "script";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_616" = {
+         isa = "PBXFileReference";
+         path = "portable_swiftlint";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_617" = {
+         isa = "PBXFileReference";
+         path = "assets";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_618" = {
+         isa = "PBXFileReference";
+         path = "Cartfile.resolved";
+         sourceTree = "<group>";
+      };
+      "OBJ_619" = {
+         isa = "PBXFileReference";
+         path = "Releasing.md";
+         sourceTree = "<group>";
+      };
+      "OBJ_62" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_63",
+            "OBJ_64",
+            "OBJ_65",
+            "OBJ_66",
+            "OBJ_67",
+            "OBJ_68"
+         );
+         name = "Protocols";
+         path = "Protocols";
+         sourceTree = "<group>";
+      };
+      "OBJ_620" = {
+         isa = "PBXFileReference";
+         path = "LICENSE";
+         sourceTree = "<group>";
+      };
+      "OBJ_621" = {
+         isa = "PBXFileReference";
+         path = "CHANGELOG.md";
+         sourceTree = "<group>";
+      };
+      "OBJ_622" = {
+         isa = "PBXFileReference";
+         path = "Makefile";
+         sourceTree = "<group>";
+      };
+      "OBJ_623" = {
+         isa = "PBXFileReference";
+         path = "Cartfile";
+         sourceTree = "<group>";
+      };
+      "OBJ_624" = {
+         isa = "PBXFileReference";
+         path = "README_KR.md";
+         sourceTree = "<group>";
+      };
+      "OBJ_625" = {
+         isa = "PBXFileReference";
+         path = "azure-pipelines.yml";
+         sourceTree = "<group>";
+      };
+      "OBJ_626" = {
+         isa = "PBXFileReference";
+         path = "README.md";
+         sourceTree = "<group>";
+      };
+      "OBJ_627" = {
+         isa = "PBXFileReference";
+         path = "README_CN.md";
+         sourceTree = "<group>";
+      };
+      "OBJ_628" = {
+         isa = "PBXFileReference";
+         path = "Cartfile.private";
+         sourceTree = "<group>";
+      };
+      "OBJ_629" = {
+         isa = "PBXFileReference";
+         path = "CONTRIBUTING.md";
+         sourceTree = "<group>";
+      };
+      "OBJ_63" = {
+         isa = "PBXFileReference";
+         path = "ASTRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_630" = {
+         isa = "PBXFileReference";
+         path = "SwiftLint.podspec";
+         sourceTree = "<group>";
+      };
+      "OBJ_631" = {
+         isa = "PBXFileReference";
+         path = "SwiftLintFramework.podspec";
+         sourceTree = "<group>";
+      };
+      "OBJ_632" = {
+         isa = "PBXFileReference";
+         path = "Dangerfile";
+         sourceTree = "<group>";
+      };
+      "OBJ_633" = {
+         isa = "PBXFileReference";
+         path = "Gemfile";
+         sourceTree = "<group>";
+      };
+      "OBJ_634" = {
+         isa = "PBXFileReference";
+         path = "Gemfile.lock";
+         sourceTree = "<group>";
+      };
+      "OBJ_635" = {
+         isa = "PBXFileReference";
+         path = "Rules.md";
+         sourceTree = "<group>";
+      };
+      "OBJ_637" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_638",
+            "OBJ_639"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_638" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            DEFINES_MODULE = "YES";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/CYaml_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "CYaml";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "CYaml";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_639" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            DEFINES_MODULE = "YES";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/CYaml_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "CYaml";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "CYaml";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_64" = {
+         isa = "PBXFileReference";
+         path = "CacheDescriptionProvider.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_640" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_641",
+            "OBJ_642",
+            "OBJ_643",
+            "OBJ_644",
+            "OBJ_645",
+            "OBJ_646"
+         );
+      };
+      "OBJ_641" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_554";
+      };
+      "OBJ_642" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_555";
+      };
+      "OBJ_643" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_556";
+      };
+      "OBJ_644" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_557";
+      };
+      "OBJ_645" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_558";
+      };
+      "OBJ_646" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_559";
+      };
+      "OBJ_647" = {
+         isa = "PBXHeadersBuildPhase";
+         files = (
+            "OBJ_648",
+            "OBJ_649"
+         );
+      };
+      "OBJ_648" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_561";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_649" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_562";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_65" = {
+         isa = "PBXFileReference";
+         path = "CallPairRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_650" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_652" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_653",
+            "OBJ_654"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_653" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            DEFINES_MODULE = "YES";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/Clang_C_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Clang-C";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "Clang_C";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_654" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            DEFINES_MODULE = "YES";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/Clang_C_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Clang-C";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "Clang_C";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_655" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_656"
+         );
+      };
+      "OBJ_656" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_489";
+      };
+      "OBJ_657" = {
+         isa = "PBXHeadersBuildPhase";
+         files = (
+            "OBJ_658",
+            "OBJ_659",
+            "OBJ_660",
+            "OBJ_661",
+            "OBJ_662",
+            "OBJ_663",
+            "OBJ_664",
+            "OBJ_665"
+         );
+      };
+      "OBJ_658" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_491";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_659" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_492";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_66" = {
+         isa = "PBXFileReference";
+         path = "Reporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_660" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_493";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_661" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_494";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_662" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_495";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_663" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_496";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_664" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_497";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_665" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_498";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_666" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_668" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_669",
+            "OBJ_670"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_669" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/Commandant_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Commandant";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "Commandant";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_67" = {
+         isa = "PBXFileReference";
+         path = "Rule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_670" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/Commandant_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Commandant";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "Commandant";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_671" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_672",
+            "OBJ_673",
+            "OBJ_674",
+            "OBJ_675",
+            "OBJ_676",
+            "OBJ_677",
+            "OBJ_678",
+            "OBJ_679",
+            "OBJ_680",
+            "OBJ_681"
+         );
+      };
+      "OBJ_672" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_588";
+      };
+      "OBJ_673" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_589";
+      };
+      "OBJ_674" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_590";
+      };
+      "OBJ_675" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_591";
+      };
+      "OBJ_676" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_592";
+      };
+      "OBJ_677" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_593";
+      };
+      "OBJ_678" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_594";
+      };
+      "OBJ_679" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_595";
+      };
+      "OBJ_68" = {
+         isa = "PBXFileReference";
+         path = "RuleConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_680" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_596";
+      };
+      "OBJ_681" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_597";
+      };
+      "OBJ_682" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_684" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_685",
+            "OBJ_686"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_685" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_686" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Release";
+      };
+      "OBJ_687" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_688"
+         );
+      };
+      "OBJ_688" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_598";
+      };
+      "OBJ_69" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_70",
+            "OBJ_71",
+            "OBJ_72",
+            "OBJ_73",
+            "OBJ_74",
+            "OBJ_75",
+            "OBJ_76",
+            "OBJ_77",
+            "OBJ_78",
+            "OBJ_79"
+         );
+         name = "Reporters";
+         path = "Reporters";
+         sourceTree = "<group>";
+      };
+      "OBJ_690" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_691",
+            "OBJ_692"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_691" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SWXMLHash_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SWXMLHash";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "SWXMLHash";
+         };
+         name = "Debug";
+      };
+      "OBJ_692" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SWXMLHash_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SWXMLHash";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "SWXMLHash";
+         };
+         name = "Release";
+      };
+      "OBJ_693" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_694",
+            "OBJ_695",
+            "OBJ_696"
+         );
+      };
+      "OBJ_694" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_583";
+      };
+      "OBJ_695" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_584";
+      };
+      "OBJ_696" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_585";
+      };
+      "OBJ_697" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_699" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_700",
+            "OBJ_701"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_7" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_8",
+            "OBJ_348"
+         );
+         name = "Sources";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_70" = {
+         isa = "PBXFileReference";
+         path = "CSVReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_700" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "4"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_701" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "4"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Release";
+      };
+      "OBJ_702" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_703"
+         );
+      };
+      "OBJ_703" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_582";
+      };
+      "OBJ_705" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_706",
+            "OBJ_707"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_706" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            DEFINES_MODULE = "YES";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SourceKit_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SourceKit";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "SourceKit";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_707" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            DEFINES_MODULE = "YES";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SourceKit_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SourceKit";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "SourceKit";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_708" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_709"
+         );
+      };
+      "OBJ_709" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_500";
+      };
+      "OBJ_71" = {
+         isa = "PBXFileReference";
+         path = "CheckstyleReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_710" = {
+         isa = "PBXHeadersBuildPhase";
+         files = (
+            "OBJ_711",
+            "OBJ_712"
+         );
+      };
+      "OBJ_711" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_502";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_712" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_503";
+         settings = {
+            ATTRIBUTES = (
+               "Public"
+            );
+         };
+      };
+      "OBJ_713" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_715" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_716",
+            "OBJ_717"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_716" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SourceKittenFramework_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SourceKittenFramework";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "SourceKittenFramework";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_717" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SourceKittenFramework_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SourceKittenFramework";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "SourceKittenFramework";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_718" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_719",
+            "OBJ_720",
+            "OBJ_721",
+            "OBJ_722",
+            "OBJ_723",
+            "OBJ_724",
+            "OBJ_725",
+            "OBJ_726",
+            "OBJ_727",
+            "OBJ_728",
+            "OBJ_729",
+            "OBJ_730",
+            "OBJ_731",
+            "OBJ_732",
+            "OBJ_733",
+            "OBJ_734",
+            "OBJ_735",
+            "OBJ_736",
+            "OBJ_737",
+            "OBJ_738",
+            "OBJ_739",
+            "OBJ_740",
+            "OBJ_741",
+            "OBJ_742",
+            "OBJ_743",
+            "OBJ_744",
+            "OBJ_745",
+            "OBJ_746",
+            "OBJ_747",
+            "OBJ_748",
+            "OBJ_749",
+            "OBJ_750",
+            "OBJ_751",
+            "OBJ_752",
+            "OBJ_753",
+            "OBJ_754",
+            "OBJ_755",
+            "OBJ_756",
+            "OBJ_757",
+            "OBJ_758",
+            "OBJ_759",
+            "OBJ_760",
+            "OBJ_761",
+            "OBJ_762"
+         );
+      };
+      "OBJ_719" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_505";
+      };
+      "OBJ_72" = {
+         isa = "PBXFileReference";
+         path = "EmojiReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_720" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_506";
+      };
+      "OBJ_721" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_507";
+      };
+      "OBJ_722" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_508";
+      };
+      "OBJ_723" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_509";
+      };
+      "OBJ_724" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_510";
+      };
+      "OBJ_725" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_511";
+      };
+      "OBJ_726" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_512";
+      };
+      "OBJ_727" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_513";
+      };
+      "OBJ_728" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_514";
+      };
+      "OBJ_729" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_515";
+      };
+      "OBJ_73" = {
+         isa = "PBXFileReference";
+         path = "GitHubActionsLoggingReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_730" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_516";
+      };
+      "OBJ_731" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_517";
+      };
+      "OBJ_732" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_518";
+      };
+      "OBJ_733" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_519";
+      };
+      "OBJ_734" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_520";
+      };
+      "OBJ_735" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_521";
+      };
+      "OBJ_736" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_522";
+      };
+      "OBJ_737" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_523";
+      };
+      "OBJ_738" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_524";
+      };
+      "OBJ_739" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_525";
+      };
+      "OBJ_74" = {
+         isa = "PBXFileReference";
+         path = "HTMLReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_740" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_526";
+      };
+      "OBJ_741" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_527";
+      };
+      "OBJ_742" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_528";
+      };
+      "OBJ_743" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_529";
+      };
+      "OBJ_744" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_530";
+      };
+      "OBJ_745" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_531";
+      };
+      "OBJ_746" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_532";
+      };
+      "OBJ_747" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_533";
+      };
+      "OBJ_748" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_534";
+      };
+      "OBJ_749" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_535";
+      };
+      "OBJ_75" = {
+         isa = "PBXFileReference";
+         path = "JSONReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_750" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_536";
+      };
+      "OBJ_751" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_537";
+      };
+      "OBJ_752" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_538";
+      };
+      "OBJ_753" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_539";
+      };
+      "OBJ_754" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_540";
+      };
+      "OBJ_755" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_541";
+      };
+      "OBJ_756" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_542";
+      };
+      "OBJ_757" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_543";
+      };
+      "OBJ_758" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_544";
+      };
+      "OBJ_759" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_545";
+      };
+      "OBJ_76" = {
+         isa = "PBXFileReference";
+         path = "JUnitReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_760" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_546";
+      };
+      "OBJ_761" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_547";
+      };
+      "OBJ_762" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_548";
+      };
+      "OBJ_763" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_764",
+            "OBJ_765",
+            "OBJ_766",
+            "OBJ_767",
+            "OBJ_768"
+         );
+      };
+      "OBJ_764" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::Yams::Product";
+      };
+      "OBJ_765" = {
+         isa = "PBXBuildFile";
+         fileRef = "Yams::CYaml::Product";
+      };
+      "OBJ_766" = {
+         isa = "PBXBuildFile";
+         fileRef = "SWXMLHash::SWXMLHash::Product";
+      };
+      "OBJ_767" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::SourceKit::Product";
+      };
+      "OBJ_768" = {
+         isa = "PBXBuildFile";
+         fileRef = "SourceKitten::Clang_C::Product";
+      };
+      "OBJ_769" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::Yams";
+      };
+      "OBJ_77" = {
+         isa = "PBXFileReference";
+         path = "MarkdownReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_771" = {
+         isa = "PBXTargetDependency";
+         target = "Yams::CYaml";
+      };
+      "OBJ_772" = {
+         isa = "PBXTargetDependency";
+         target = "SWXMLHash::SWXMLHash";
+      };
+      "OBJ_773" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::SourceKit";
+      };
+      "OBJ_774" = {
+         isa = "PBXTargetDependency";
+         target = "SourceKitten::Clang_C";
+      };
+      "OBJ_776" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_777",
+            "OBJ_778"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_777" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_778" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Release";
+      };
+      "OBJ_779" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_780"
+         );
+      };
+      "OBJ_78" = {
+         isa = "PBXFileReference";
+         path = "SonarQubeReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_780" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_550";
+      };
+      "OBJ_782" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_783",
+            "OBJ_784"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_783" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftLintFramework_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftLintFramework";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "SwiftLintFramework";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_784" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/swift-syntax/Sources/_CSwiftSyntax/include",
+               "$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/SourceKit/include",
+               "$(SRCROOT)/.build/checkouts/SourceKitten/Source/Clang_C/include",
+               "$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax"
+            );
+            INFOPLIST_FILE = "SwiftLint.xcodeproj/SwiftLintFramework_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/SwiftLint.xcodeproj/GeneratedModuleMap/_CSwiftSyntax/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftLintFramework";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "SwiftLintFramework";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_785" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_786",
+            "OBJ_787",
+            "OBJ_788",
+            "OBJ_789",
+            "OBJ_790",
+            "OBJ_791",
+            "OBJ_792",
+            "OBJ_793",
+            "OBJ_794",
+            "OBJ_795",
+            "OBJ_796",
+            "OBJ_797",
+            "OBJ_798",
+            "OBJ_799",
+            "OBJ_800",
+            "OBJ_801",
+            "OBJ_802",
+            "OBJ_803",
+            "OBJ_804",
+            "OBJ_805",
+            "OBJ_806",
+            "OBJ_807",
+            "OBJ_808",
+            "OBJ_809",
+            "OBJ_810",
+            "OBJ_811",
+            "OBJ_812",
+            "OBJ_813",
+            "OBJ_814",
+            "OBJ_815",
+            "OBJ_816",
+            "OBJ_817",
+            "OBJ_818",
+            "OBJ_819",
+            "OBJ_820",
+            "OBJ_821",
+            "OBJ_822",
+            "OBJ_823",
+            "OBJ_824",
+            "OBJ_825",
+            "OBJ_826",
+            "OBJ_827",
+            "OBJ_828",
+            "OBJ_829",
+            "OBJ_830",
+            "OBJ_831",
+            "OBJ_832",
+            "OBJ_833",
+            "OBJ_834",
+            "OBJ_835",
+            "OBJ_836",
+            "OBJ_837",
+            "OBJ_838",
+            "OBJ_839",
+            "OBJ_840",
+            "OBJ_841",
+            "OBJ_842",
+            "OBJ_843",
+            "OBJ_844",
+            "OBJ_845",
+            "OBJ_846",
+            "OBJ_847",
+            "OBJ_848",
+            "OBJ_849",
+            "OBJ_850",
+            "OBJ_851",
+            "OBJ_852",
+            "OBJ_853",
+            "OBJ_854",
+            "OBJ_855",
+            "OBJ_856",
+            "OBJ_857",
+            "OBJ_858",
+            "OBJ_859",
+            "OBJ_860",
+            "OBJ_861",
+            "OBJ_862",
+            "OBJ_863",
+            "OBJ_864",
+            "OBJ_865",
+            "OBJ_866",
+            "OBJ_867",
+            "OBJ_868",
+            "OBJ_869",
+            "OBJ_870",
+            "OBJ_871",
+            "OBJ_872",
+            "OBJ_873",
+            "OBJ_874",
+            "OBJ_875",
+            "OBJ_876",
+            "OBJ_877",
+            "OBJ_878",
+            "OBJ_879",
+            "OBJ_880",
+            "OBJ_881",
+            "OBJ_882",
+            "OBJ_883",
+            "OBJ_884",
+            "OBJ_885",
+            "OBJ_886",
+            "OBJ_887",
+            "OBJ_888",
+            "OBJ_889",
+            "OBJ_890",
+            "OBJ_891",
+            "OBJ_892",
+            "OBJ_893",
+            "OBJ_894",
+            "OBJ_895",
+            "OBJ_896",
+            "OBJ_897",
+            "OBJ_898",
+            "OBJ_899",
+            "OBJ_900",
+            "OBJ_901",
+            "OBJ_902",
+            "OBJ_903",
+            "OBJ_904",
+            "OBJ_905",
+            "OBJ_906",
+            "OBJ_907",
+            "OBJ_908",
+            "OBJ_909",
+            "OBJ_910",
+            "OBJ_911",
+            "OBJ_912",
+            "OBJ_913",
+            "OBJ_914",
+            "OBJ_915",
+            "OBJ_916",
+            "OBJ_917",
+            "OBJ_918",
+            "OBJ_919",
+            "OBJ_920",
+            "OBJ_921",
+            "OBJ_922",
+            "OBJ_923",
+            "OBJ_924",
+            "OBJ_925",
+            "OBJ_926",
+            "OBJ_927",
+            "OBJ_928",
+            "OBJ_929",
+            "OBJ_930",
+            "OBJ_931",
+            "OBJ_932",
+            "OBJ_933",
+            "OBJ_934",
+            "OBJ_935",
+            "OBJ_936",
+            "OBJ_937",
+            "OBJ_938",
+            "OBJ_939",
+            "OBJ_940",
+            "OBJ_941",
+            "OBJ_942",
+            "OBJ_943",
+            "OBJ_944",
+            "OBJ_945",
+            "OBJ_946",
+            "OBJ_947",
+            "OBJ_948",
+            "OBJ_949",
+            "OBJ_950",
+            "OBJ_951",
+            "OBJ_952",
+            "OBJ_953",
+            "OBJ_954",
+            "OBJ_955",
+            "OBJ_956",
+            "OBJ_957",
+            "OBJ_958",
+            "OBJ_959",
+            "OBJ_960",
+            "OBJ_961",
+            "OBJ_962",
+            "OBJ_963",
+            "OBJ_964",
+            "OBJ_965",
+            "OBJ_966",
+            "OBJ_967",
+            "OBJ_968",
+            "OBJ_969",
+            "OBJ_970",
+            "OBJ_971",
+            "OBJ_972",
+            "OBJ_973",
+            "OBJ_974",
+            "OBJ_975",
+            "OBJ_976",
+            "OBJ_977",
+            "OBJ_978",
+            "OBJ_979",
+            "OBJ_980",
+            "OBJ_981",
+            "OBJ_982",
+            "OBJ_983",
+            "OBJ_984",
+            "OBJ_985",
+            "OBJ_986",
+            "OBJ_987",
+            "OBJ_988",
+            "OBJ_989",
+            "OBJ_990",
+            "OBJ_991",
+            "OBJ_992",
+            "OBJ_993",
+            "OBJ_994",
+            "OBJ_995",
+            "OBJ_996",
+            "OBJ_997",
+            "OBJ_998",
+            "OBJ_999",
+            "OBJ_1000",
+            "OBJ_1001",
+            "OBJ_1002",
+            "OBJ_1003",
+            "OBJ_1004",
+            "OBJ_1005",
+            "OBJ_1006",
+            "OBJ_1007",
+            "OBJ_1008",
+            "OBJ_1009",
+            "OBJ_1010",
+            "OBJ_1011",
+            "OBJ_1012",
+            "OBJ_1013",
+            "OBJ_1014",
+            "OBJ_1015",
+            "OBJ_1016",
+            "OBJ_1017",
+            "OBJ_1018",
+            "OBJ_1019",
+            "OBJ_1020",
+            "OBJ_1021",
+            "OBJ_1022",
+            "OBJ_1023",
+            "OBJ_1024",
+            "OBJ_1025",
+            "OBJ_1026",
+            "OBJ_1027",
+            "OBJ_1028",
+            "OBJ_1029",
+            "OBJ_1030",
+            "OBJ_1031",
+            "OBJ_1032",
+            "OBJ_1033",
+            "OBJ_1034",
+            "OBJ_1035",
+            "OBJ_1036",
+            "OBJ_1037",
+            "OBJ_1038",
+            "OBJ_1039",
+            "OBJ_1040",
+            "OBJ_1041",
+            "OBJ_1042",
+            "OBJ_1043",
+            "OBJ_1044",
+            "OBJ_1045",
+            "OBJ_1046",
+            "OBJ_1047",
+            "OBJ_1048",
+            "OBJ_1049",
+            "OBJ_1050",
+            "OBJ_1051",
+            "OBJ_1052",
+            "OBJ_1053",
+            "OBJ_1054",
+            "OBJ_1055",
+            "OBJ_1056",
+            "OBJ_1057",
+            "OBJ_1058",
+            "OBJ_1059",
+            "OBJ_1060",
+            "OBJ_1061",
+            "OBJ_1062",
+            "OBJ_1063",
+            "OBJ_1064",
+            "OBJ_1065",
+            "OBJ_1066",
+            "OBJ_1067",
+            "OBJ_1068",
+            "OBJ_1069",
+            "OBJ_1070",
+            "OBJ_1071",
+            "OBJ_1072",
+            "OBJ_1073",
+            "OBJ_1074",
+            "OBJ_1075",
+            "OBJ_1076",
+            "OBJ_1077",
+            "OBJ_1078",
+            "OBJ_1079",
+            "OBJ_1080",
+            "OBJ_1081",
+            "OBJ_1082",
+            "OBJ_1083",
+            "OBJ_1084",
+            "OBJ_1085",
+            "OBJ_1086",
+            "OBJ_1087",
+            "OBJ_1088",
+            "OBJ_1089",
+            "OBJ_1090",
+            "OBJ_1091",
+            "OBJ_1092",
+            "OBJ_1093",
+            "OBJ_1094",
+            "OBJ_1095",
+            "OBJ_1096",
+            "OBJ_1097",
+            "OBJ_1098",
+            "OBJ_1099",
+            "OBJ_1100",
+            "OBJ_1101",
+            "OBJ_1102",
+            "OBJ_1103",
+            "OBJ_1104",
+            "OBJ_1105",
+            "OBJ_1106",
+            "OBJ_1107",
+            "OBJ_1108",
+            "OBJ_1109",
+            "OBJ_1110",
+            "OBJ_1111",
+            "OBJ_1112"
+         );
+      };
+      "OBJ_786" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_10";
+      };
+      "OBJ_787" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_11";
+      };
+      "OBJ_788" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_12";
+      };
+      "OBJ_789" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_13";
+      };
+      "OBJ_79" = {
+         isa = "PBXFileReference";
+         path = "XcodeReporter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_790" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_14";
+      };
+      "OBJ_791" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_15";
+      };
+      "OBJ_792" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_16";
+      };
+      "OBJ_793" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_17";
+      };
+      "OBJ_794" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_18";
+      };
+      "OBJ_795" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_19";
+      };
+      "OBJ_796" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_20";
+      };
+      "OBJ_797" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_21";
+      };
+      "OBJ_798" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_22";
+      };
+      "OBJ_799" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_23";
+      };
+      "OBJ_8" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_9",
+            "OBJ_32",
+            "OBJ_36",
+            "OBJ_62",
+            "OBJ_69",
+            "OBJ_80"
+         );
+         name = "SwiftLintFramework";
+         path = "Source/SwiftLintFramework";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_80" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_81",
+            "OBJ_148",
+            "OBJ_201",
+            "OBJ_213",
+            "OBJ_227",
+            "OBJ_271"
+         );
+         name = "Rules";
+         path = "Rules";
+         sourceTree = "<group>";
+      };
+      "OBJ_800" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_24";
+      };
+      "OBJ_801" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_25";
+      };
+      "OBJ_802" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_26";
+      };
+      "OBJ_803" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_27";
+      };
+      "OBJ_804" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_28";
+      };
+      "OBJ_805" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_29";
+      };
+      "OBJ_806" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_30";
+      };
+      "OBJ_807" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_31";
+      };
+      "OBJ_808" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_33";
+      };
+      "OBJ_809" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_34";
+      };
+      "OBJ_81" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_82",
+            "OBJ_83",
+            "OBJ_84",
+            "OBJ_85",
+            "OBJ_86",
+            "OBJ_87",
+            "OBJ_88",
+            "OBJ_89",
+            "OBJ_90",
+            "OBJ_91",
+            "OBJ_92",
+            "OBJ_93",
+            "OBJ_94",
+            "OBJ_95",
+            "OBJ_96",
+            "OBJ_97",
+            "OBJ_98",
+            "OBJ_99",
+            "OBJ_100",
+            "OBJ_101",
+            "OBJ_102",
+            "OBJ_103",
+            "OBJ_104",
+            "OBJ_105",
+            "OBJ_106",
+            "OBJ_107",
+            "OBJ_108",
+            "OBJ_109",
+            "OBJ_110",
+            "OBJ_111",
+            "OBJ_112",
+            "OBJ_113",
+            "OBJ_114",
+            "OBJ_115",
+            "OBJ_116",
+            "OBJ_117",
+            "OBJ_118",
+            "OBJ_119",
+            "OBJ_120",
+            "OBJ_121",
+            "OBJ_122",
+            "OBJ_123",
+            "OBJ_124",
+            "OBJ_125",
+            "OBJ_126",
+            "OBJ_127",
+            "OBJ_128",
+            "OBJ_129",
+            "OBJ_130",
+            "OBJ_131",
+            "OBJ_132",
+            "OBJ_133",
+            "OBJ_134",
+            "OBJ_135",
+            "OBJ_136",
+            "OBJ_137",
+            "OBJ_138",
+            "OBJ_139",
+            "OBJ_140",
+            "OBJ_141",
+            "OBJ_142",
+            "OBJ_143",
+            "OBJ_144",
+            "OBJ_145",
+            "OBJ_146",
+            "OBJ_147"
+         );
+         name = "Idiomatic";
+         path = "Idiomatic";
+         sourceTree = "<group>";
+      };
+      "OBJ_810" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_35";
+      };
+      "OBJ_811" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_37";
+      };
+      "OBJ_812" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_38";
+      };
+      "OBJ_813" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_39";
+      };
+      "OBJ_814" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_40";
+      };
+      "OBJ_815" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_41";
+      };
+      "OBJ_816" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_42";
+      };
+      "OBJ_817" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_43";
+      };
+      "OBJ_818" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_44";
+      };
+      "OBJ_819" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_45";
+      };
+      "OBJ_82" = {
+         isa = "PBXFileReference";
+         path = "BlockBasedKVORule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_820" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_46";
+      };
+      "OBJ_821" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_47";
+      };
+      "OBJ_822" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_48";
+      };
+      "OBJ_823" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_49";
+      };
+      "OBJ_824" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_50";
+      };
+      "OBJ_825" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_51";
+      };
+      "OBJ_826" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_52";
+      };
+      "OBJ_827" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_53";
+      };
+      "OBJ_828" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_54";
+      };
+      "OBJ_829" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_55";
+      };
+      "OBJ_83" = {
+         isa = "PBXFileReference";
+         path = "ConvenienceTypeRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_830" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_56";
+      };
+      "OBJ_831" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_57";
+      };
+      "OBJ_832" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_58";
+      };
+      "OBJ_833" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_59";
+      };
+      "OBJ_834" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_60";
+      };
+      "OBJ_835" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_61";
+      };
+      "OBJ_836" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_63";
+      };
+      "OBJ_837" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_64";
+      };
+      "OBJ_838" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_65";
+      };
+      "OBJ_839" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_66";
+      };
+      "OBJ_84" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedObjectLiteralRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_840" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_67";
+      };
+      "OBJ_841" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_68";
+      };
+      "OBJ_842" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_70";
+      };
+      "OBJ_843" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_71";
+      };
+      "OBJ_844" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_72";
+      };
+      "OBJ_845" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_73";
+      };
+      "OBJ_846" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_74";
+      };
+      "OBJ_847" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_75";
+      };
+      "OBJ_848" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_76";
+      };
+      "OBJ_849" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_77";
+      };
+      "OBJ_85" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedOptionalBooleanRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_850" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_78";
+      };
+      "OBJ_851" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_79";
+      };
+      "OBJ_852" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_82";
+      };
+      "OBJ_853" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_83";
+      };
+      "OBJ_854" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_84";
+      };
+      "OBJ_855" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_85";
+      };
+      "OBJ_856" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_86";
+      };
+      "OBJ_857" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_87";
+      };
+      "OBJ_858" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_88";
+      };
+      "OBJ_859" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_89";
+      };
+      "OBJ_86" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedOptionalBooleanRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_860" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_90";
+      };
+      "OBJ_861" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_91";
+      };
+      "OBJ_862" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_92";
+      };
+      "OBJ_863" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_93";
+      };
+      "OBJ_864" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_94";
+      };
+      "OBJ_865" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_95";
+      };
+      "OBJ_866" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_96";
+      };
+      "OBJ_867" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_97";
+      };
+      "OBJ_868" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_98";
+      };
+      "OBJ_869" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_99";
+      };
+      "OBJ_87" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedOptionalCollectionExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_870" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_100";
+      };
+      "OBJ_871" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_101";
+      };
+      "OBJ_872" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_102";
+      };
+      "OBJ_873" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_103";
+      };
+      "OBJ_874" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_104";
+      };
+      "OBJ_875" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_105";
+      };
+      "OBJ_876" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_106";
+      };
+      "OBJ_877" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_107";
+      };
+      "OBJ_878" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_108";
+      };
+      "OBJ_879" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_109";
+      };
+      "OBJ_88" = {
+         isa = "PBXFileReference";
+         path = "DiscouragedOptionalCollectionRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_880" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_110";
+      };
+      "OBJ_881" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_111";
+      };
+      "OBJ_882" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_112";
+      };
+      "OBJ_883" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_113";
+      };
+      "OBJ_884" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_114";
+      };
+      "OBJ_885" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_115";
+      };
+      "OBJ_886" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_116";
+      };
+      "OBJ_887" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_117";
+      };
+      "OBJ_888" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_118";
+      };
+      "OBJ_889" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_119";
+      };
+      "OBJ_89" = {
+         isa = "PBXFileReference";
+         path = "DuplicateImportsRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_890" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_120";
+      };
+      "OBJ_891" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_121";
+      };
+      "OBJ_892" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_122";
+      };
+      "OBJ_893" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_123";
+      };
+      "OBJ_894" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_124";
+      };
+      "OBJ_895" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_125";
+      };
+      "OBJ_896" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_126";
+      };
+      "OBJ_897" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_127";
+      };
+      "OBJ_898" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_128";
+      };
+      "OBJ_899" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_129";
+      };
+      "OBJ_9" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_10",
+            "OBJ_11",
+            "OBJ_12",
+            "OBJ_13",
+            "OBJ_14",
+            "OBJ_15",
+            "OBJ_16",
+            "OBJ_17",
+            "OBJ_18",
+            "OBJ_19",
+            "OBJ_20",
+            "OBJ_21",
+            "OBJ_22",
+            "OBJ_23",
+            "OBJ_24",
+            "OBJ_25",
+            "OBJ_26",
+            "OBJ_27",
+            "OBJ_28",
+            "OBJ_29",
+            "OBJ_30",
+            "OBJ_31"
+         );
+         name = "Extensions";
+         path = "Extensions";
+         sourceTree = "<group>";
+      };
+      "OBJ_90" = {
+         isa = "PBXFileReference";
+         path = "DuplicateImportsRuleExamples.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_900" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_130";
+      };
+      "OBJ_901" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_131";
+      };
+      "OBJ_902" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_132";
+      };
+      "OBJ_903" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_133";
+      };
+      "OBJ_904" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_134";
+      };
+      "OBJ_905" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_135";
+      };
+      "OBJ_906" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_136";
+      };
+      "OBJ_907" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_137";
+      };
+      "OBJ_908" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_138";
+      };
+      "OBJ_909" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_139";
+      };
+      "OBJ_91" = {
+         isa = "PBXFileReference";
+         path = "ExplicitACLRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_910" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_140";
+      };
+      "OBJ_911" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_141";
+      };
+      "OBJ_912" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_142";
+      };
+      "OBJ_913" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_143";
+      };
+      "OBJ_914" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_144";
+      };
+      "OBJ_915" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_145";
+      };
+      "OBJ_916" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_146";
+      };
+      "OBJ_917" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_147";
+      };
+      "OBJ_918" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_149";
+      };
+      "OBJ_919" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_150";
+      };
+      "OBJ_92" = {
+         isa = "PBXFileReference";
+         path = "ExplicitEnumRawValueRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_920" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_151";
+      };
+      "OBJ_921" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_152";
+      };
+      "OBJ_922" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_153";
+      };
+      "OBJ_923" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_154";
+      };
+      "OBJ_924" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_155";
+      };
+      "OBJ_925" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_156";
+      };
+      "OBJ_926" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_157";
+      };
+      "OBJ_927" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_158";
+      };
+      "OBJ_928" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_159";
+      };
+      "OBJ_929" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_160";
+      };
+      "OBJ_93" = {
+         isa = "PBXFileReference";
+         path = "ExplicitInitRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_930" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_161";
+      };
+      "OBJ_931" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_162";
+      };
+      "OBJ_932" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_163";
+      };
+      "OBJ_933" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_164";
+      };
+      "OBJ_934" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_165";
+      };
+      "OBJ_935" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_166";
+      };
+      "OBJ_936" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_167";
+      };
+      "OBJ_937" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_168";
+      };
+      "OBJ_938" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_169";
+      };
+      "OBJ_939" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_170";
+      };
+      "OBJ_94" = {
+         isa = "PBXFileReference";
+         path = "ExplicitTopLevelACLRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_940" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_171";
+      };
+      "OBJ_941" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_172";
+      };
+      "OBJ_942" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_173";
+      };
+      "OBJ_943" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_174";
+      };
+      "OBJ_944" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_175";
+      };
+      "OBJ_945" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_176";
+      };
+      "OBJ_946" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_177";
+      };
+      "OBJ_947" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_178";
+      };
+      "OBJ_948" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_179";
+      };
+      "OBJ_949" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_180";
+      };
+      "OBJ_95" = {
+         isa = "PBXFileReference";
+         path = "ExplicitTypeInterfaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_950" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_181";
+      };
+      "OBJ_951" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_182";
+      };
+      "OBJ_952" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_183";
+      };
+      "OBJ_953" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_184";
+      };
+      "OBJ_954" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_185";
+      };
+      "OBJ_955" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_186";
+      };
+      "OBJ_956" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_187";
+      };
+      "OBJ_957" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_188";
+      };
+      "OBJ_958" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_189";
+      };
+      "OBJ_959" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_190";
+      };
+      "OBJ_96" = {
+         isa = "PBXFileReference";
+         path = "ExtensionAccessModifierRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_960" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_191";
+      };
+      "OBJ_961" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_192";
+      };
+      "OBJ_962" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_193";
+      };
+      "OBJ_963" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_194";
+      };
+      "OBJ_964" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_195";
+      };
+      "OBJ_965" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_196";
+      };
+      "OBJ_966" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_197";
+      };
+      "OBJ_967" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_198";
+      };
+      "OBJ_968" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_199";
+      };
+      "OBJ_969" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_200";
+      };
+      "OBJ_97" = {
+         isa = "PBXFileReference";
+         path = "FallthroughRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_970" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_202";
+      };
+      "OBJ_971" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_203";
+      };
+      "OBJ_972" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_204";
+      };
+      "OBJ_973" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_205";
+      };
+      "OBJ_974" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_206";
+      };
+      "OBJ_975" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_207";
+      };
+      "OBJ_976" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_208";
+      };
+      "OBJ_977" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_209";
+      };
+      "OBJ_978" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_210";
+      };
+      "OBJ_979" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_211";
+      };
+      "OBJ_98" = {
+         isa = "PBXFileReference";
+         path = "FatalErrorMessageRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_980" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_212";
+      };
+      "OBJ_981" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_214";
+      };
+      "OBJ_982" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_215";
+      };
+      "OBJ_983" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_216";
+      };
+      "OBJ_984" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_217";
+      };
+      "OBJ_985" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_218";
+      };
+      "OBJ_986" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_219";
+      };
+      "OBJ_987" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_220";
+      };
+      "OBJ_988" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_221";
+      };
+      "OBJ_989" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_222";
+      };
+      "OBJ_99" = {
+         isa = "PBXFileReference";
+         path = "FileNameNoSpaceRule.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_990" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_223";
+      };
+      "OBJ_991" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_224";
+      };
+      "OBJ_992" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_225";
+      };
+      "OBJ_993" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_226";
+      };
+      "OBJ_994" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_228";
+      };
+      "OBJ_995" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_229";
+      };
+      "OBJ_996" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_230";
+      };
+      "OBJ_997" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_231";
+      };
+      "OBJ_998" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_232";
+      };
+      "OBJ_999" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_233";
+      };
+      "SWXMLHash::SWXMLHash" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_690";
+         buildPhases = (
+            "OBJ_693",
+            "OBJ_697"
+         );
+         dependencies = (
+         );
+         name = "SWXMLHash";
+         productName = "SWXMLHash";
+         productReference = "SWXMLHash::SWXMLHash::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SWXMLHash::SWXMLHash::Product" = {
+         isa = "PBXFileReference";
+         path = "SWXMLHash.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SWXMLHash::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_699";
+         buildPhases = (
+            "OBJ_702"
+         );
+         dependencies = (
+         );
+         name = "SWXMLHashPackageDescription";
+         productName = "SWXMLHashPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "SourceKitten::Clang_C" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_652";
+         buildPhases = (
+            "OBJ_655",
+            "OBJ_657",
+            "OBJ_666"
+         );
+         dependencies = (
+         );
+         name = "Clang_C";
+         productName = "Clang_C";
+         productReference = "SourceKitten::Clang_C::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SourceKitten::Clang_C::Product" = {
+         isa = "PBXFileReference";
+         path = "Clang_C.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SourceKitten::SourceKit" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_705";
+         buildPhases = (
+            "OBJ_708",
+            "OBJ_710",
+            "OBJ_713"
+         );
+         dependencies = (
+         );
+         name = "SourceKit";
+         productName = "SourceKit";
+         productReference = "SourceKitten::SourceKit::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SourceKitten::SourceKit::Product" = {
+         isa = "PBXFileReference";
+         path = "SourceKit.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SourceKitten::SourceKittenFramework" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_715";
+         buildPhases = (
+            "OBJ_718",
+            "OBJ_763"
+         );
+         dependencies = (
+            "OBJ_769",
+            "OBJ_771",
+            "OBJ_772",
+            "OBJ_773",
+            "OBJ_774"
+         );
+         name = "SourceKittenFramework";
+         productName = "SourceKittenFramework";
+         productReference = "SourceKitten::SourceKittenFramework::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SourceKitten::SourceKittenFramework::Product" = {
+         isa = "PBXFileReference";
+         path = "SourceKittenFramework.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SourceKitten::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_776";
+         buildPhases = (
+            "OBJ_779"
+         );
+         dependencies = (
+         );
+         name = "SourceKittenPackageDescription";
+         productName = "SourceKittenPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftLint::SwiftLintFramework" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_782";
+         buildPhases = (
+            "OBJ_785",
+            "OBJ_1113"
+         );
+         dependencies = (
+            "OBJ_1122",
+            "OBJ_1124",
+            "OBJ_1126",
+            "OBJ_1127",
+            "OBJ_1128",
+            "OBJ_1129",
+            "OBJ_1130",
+            "OBJ_1131"
+         );
+         name = "SwiftLintFramework";
+         productName = "SwiftLintFramework";
+         productReference = "SwiftLint::SwiftLintFramework::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftLint::SwiftLintFramework::Product" = {
+         isa = "PBXFileReference";
+         path = "SwiftLintFramework.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SwiftLint::SwiftLintFrameworkTests" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1133";
+         buildPhases = (
+            "OBJ_1136",
+            "OBJ_1211"
+         );
+         dependencies = (
+            "OBJ_1221",
+            "OBJ_1222",
+            "OBJ_1223",
+            "OBJ_1224",
+            "OBJ_1225",
+            "OBJ_1226",
+            "OBJ_1227",
+            "OBJ_1228",
+            "OBJ_1229"
+         );
+         name = "SwiftLintFrameworkTests";
+         productName = "SwiftLintFrameworkTests";
+         productReference = "SwiftLint::SwiftLintFrameworkTests::Product";
+         productType = "com.apple.product-type.bundle.unit-test";
+      };
+      "SwiftLint::SwiftLintFrameworkTests::Product" = {
+         isa = "PBXFileReference";
+         path = "SwiftLintFrameworkTests.xctest";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SwiftLint::SwiftLintPackageTests::ProductTarget" = {
+         isa = "PBXAggregateTarget";
+         buildConfigurationList = "OBJ_1237";
+         buildPhases = (
+         );
+         dependencies = (
+            "OBJ_1240"
+         );
+         name = "SwiftLintPackageTests";
+         productName = "SwiftLintPackageTests";
+      };
+      "SwiftLint::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1231";
+         buildPhases = (
+            "OBJ_1234"
+         );
+         dependencies = (
+         );
+         name = "SwiftLintPackageDescription";
+         productName = "SwiftLintPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftLint::swiftlint" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1331";
+         buildPhases = (
+            "OBJ_1334",
+            "OBJ_1350"
+         );
+         dependencies = (
+            "OBJ_1362",
+            "OBJ_1363",
+            "OBJ_1364",
+            "OBJ_1365",
+            "OBJ_1366",
+            "OBJ_1367",
+            "OBJ_1368",
+            "OBJ_1369",
+            "OBJ_1370",
+            "OBJ_1371",
+            "OBJ_1372"
+         );
+         name = "swiftlint";
+         productName = "swiftlint";
+         productReference = "SwiftLint::swiftlint::Product";
+         productType = "com.apple.product-type.tool";
+      };
+      "SwiftLint::swiftlint::Product" = {
+         isa = "PBXFileReference";
+         path = "swiftlint";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SwiftSyntax::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1277";
+         buildPhases = (
+            "OBJ_1280"
+         );
+         dependencies = (
+         );
+         name = "SwiftSyntaxPackageDescription";
+         productName = "SwiftSyntaxPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftSyntax::SwiftSyntax" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1241";
+         buildPhases = (
+            "OBJ_1244",
+            "OBJ_1273"
+         );
+         dependencies = (
+            "OBJ_1275"
+         );
+         name = "SwiftSyntax";
+         productName = "SwiftSyntax";
+         productReference = "SwiftSyntax::SwiftSyntax::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftSyntax::SwiftSyntax::Product" = {
+         isa = "PBXFileReference";
+         path = "SwiftSyntax.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SwiftSyntax::_CSwiftSyntax" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1324";
+         buildPhases = (
+            "OBJ_1327",
+            "OBJ_1329"
+         );
+         dependencies = (
+         );
+         name = "_CSwiftSyntax";
+         productName = "_CSwiftSyntax";
+         productReference = "SwiftSyntax::_CSwiftSyntax::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftSyntax::_CSwiftSyntax::Product" = {
+         isa = "PBXFileReference";
+         path = "_CSwiftSyntax.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SwiftyTextTable::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1290";
+         buildPhases = (
+            "OBJ_1293"
+         );
+         dependencies = (
+         );
+         name = "SwiftyTextTablePackageDescription";
+         productName = "SwiftyTextTablePackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftyTextTable::SwiftyTextTable" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1283";
+         buildPhases = (
+            "OBJ_1286",
+            "OBJ_1288"
+         );
+         dependencies = (
+         );
+         name = "SwiftyTextTable";
+         productName = "SwiftyTextTable";
+         productReference = "SwiftyTextTable::SwiftyTextTable::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftyTextTable::SwiftyTextTable::Product" = {
+         isa = "PBXFileReference";
+         path = "SwiftyTextTable.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "Yams::CYaml" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_637";
+         buildPhases = (
+            "OBJ_640",
+            "OBJ_647",
+            "OBJ_650"
+         );
+         dependencies = (
+         );
+         name = "CYaml";
+         productName = "CYaml";
+         productReference = "Yams::CYaml::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "Yams::CYaml::Product" = {
+         isa = "PBXFileReference";
+         path = "CYaml.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "Yams::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1319";
+         buildPhases = (
+            "OBJ_1322"
+         );
+         dependencies = (
+         );
+         name = "YamsPackageDescription";
+         productName = "YamsPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "Yams::Yams" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1295";
+         buildPhases = (
+            "OBJ_1298",
+            "OBJ_1315"
+         );
+         dependencies = (
+            "OBJ_1317"
+         );
+         name = "Yams";
+         productName = "Yams";
+         productReference = "Yams::Yams::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "Yams::Yams::Product" = {
+         isa = "PBXFileReference";
+         path = "Yams.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+   };
+   rootObject = "OBJ_1";
 }

--- a/SwiftLint.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SwiftLint.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:SwiftLint.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/SwiftLint.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/SwiftLint.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+    <false/>
+</dict>
+</plist>

--- a/SwiftLint.xcodeproj/xcshareddata/xcschemes/SwiftLint-Package.xcscheme
+++ b/SwiftLint.xcodeproj/xcshareddata/xcschemes/SwiftLint-Package.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SwiftLint::swiftlint"
-               BuildableName = "swiftlint"
-               BlueprintName = "swiftlint"
+               BlueprintIdentifier = "SwiftLint::SwiftLintFramework"
+               BuildableName = "SwiftLintFramework.framework"
+               BlueprintName = "SwiftLintFramework"
                ReferencedContainer = "container:SwiftLint.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,9 +28,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SwiftLint::SwiftLintFramework"
-               BuildableName = "SwiftLintFramework.framework"
-               BlueprintName = "SwiftLintFramework"
+               BlueprintIdentifier = "SwiftLint::swiftlint"
+               BuildableName = "swiftlint"
+               BlueprintName = "swiftlint"
                ReferencedContainer = "container:SwiftLint.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/SwiftLint.xcodeproj/xcshareddata/xcschemes/SwiftLint-Package.xcscheme
+++ b/SwiftLint.xcodeproj/xcshareddata/xcschemes/SwiftLint-Package.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:SwiftLint.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftLint::SwiftLintFramework"
+               BuildableName = "SwiftLintFramework.framework"
+               BlueprintName = "SwiftLintFramework"
+               ReferencedContainer = "container:SwiftLint.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -50,16 +64,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "SwiftLint::swiftlint"
-            BuildableName = "swiftlint"
-            BlueprintName = "swiftlint"
-            ReferencedContainer = "container:SwiftLint.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SwiftLint.xcodeproj/xcshareddata/xcschemes/swiftlint.xcscheme
+++ b/SwiftLint.xcodeproj/xcshareddata/xcschemes/swiftlint.xcscheme
@@ -44,6 +44,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1223,6 +1223,12 @@ extension ReturnArrowWhitespaceRuleTests {
     ]
 }
 
+extension ReturnValueFromVoidFunctionRuleTests {
+    static var allTests: [(String, (ReturnValueFromVoidFunctionRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension RuleConfigurationTests {
     static var allTests: [(String, (RuleConfigurationTests) -> () throws -> Void)] = [
         ("testNameConfigurationSetsCorrectly", testNameConfigurationSetsCorrectly),
@@ -1775,6 +1781,7 @@ XCTMain([
     testCase(RequiredDeinitRuleTests.allTests),
     testCase(RequiredEnumCaseRuleTestCase.allTests),
     testCase(ReturnArrowWhitespaceRuleTests.allTests),
+    testCase(ReturnValueFromVoidFunctionRuleTests.allTests),
     testCase(RuleConfigurationTests.allTests),
     testCase(RuleTests.allTests),
     testCase(RulesTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -654,6 +654,12 @@ class ReturnArrowWhitespaceRuleTests: XCTestCase {
     }
 }
 
+class ReturnValueFromVoidFunctionRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(ReturnValueFromVoidFunctionRule.description)
+    }
+}
+
 class ShorthandOperatorRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ShorthandOperatorRule.description)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -88,7 +88,8 @@ extension ConfigurationTests {
         let mergedConfiguration = projectMockConfig0CustomRules.merge(with: projectMockConfig2CustomRules)
         guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
             else {
-            return XCTFail("Custom rule are expected to be present")
+                XCTFail("Custom rule are expected to be present")
+                return
         }
         XCTAssertTrue(
             mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abc" })
@@ -102,7 +103,8 @@ extension ConfigurationTests {
         let mergedConfiguration = projectMockConfig0CustomRules.merge(with: projectMockConfig2CustomRulesDisabled)
         guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
             else {
-            return XCTFail("Custom rule are expected to be present")
+                XCTFail("Custom rule are expected to be present")
+                return
         }
         XCTAssertFalse(
             mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abc" })

--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -103,6 +103,15 @@ class IntegrationTests: XCTestCase {
         // Since this test uses the `swiftlint` binary built while building `SwiftLintPackageTests`,
         // we run it only on macOS using SwiftPM.
 #if os(macOS) && SWIFT_PACKAGE
+        let keyName = "SWIFTLINT_FRAMEWORK_TEST_ENABLE_SIMULATE_HOMEBREW_TEST"
+        guard ProcessInfo.processInfo.environment[keyName] != nil else {
+            print("""
+                Skipping the opt-in test `\(#function)`.
+                Set the `\(keyName)` environment variable to test `\(#function)`.
+            """)
+            return
+        }
+
         guard let swiftlintURL = swiftlintBuiltBySwiftPM(),
             let (testSwiftURL, seatbeltURL) = prepareSandbox() else {
                 return


### PR DESCRIPTION
Used https://github.com/realm/SwiftLint/pull/2480 as a starting point

This is an example of a rule that SwiftSyntax enables us to write with not too much code and in a reliable way.

Added "DO NOT MERGE" because there are a few drawbacks of adding SwiftSyntax and we should address those separately first:

- We can't import `SwiftSyntax` via CocoaPods, so we'd have to deprecate `SwiftLintFramework.podspec`
- Apparently [there's an issue](https://forums.swift.org/t/swiftsyntax-with-swift-5-1/29051/15) with SPM + Xcode, so we can't use the regular Xcode 11 SPM support
- We'd need to move away from Carthage in favor of building SwiftLint in Xcode with SPM 
- Running `swift package generate-xcodeproj` might have changed important settings (e.g. deployment target)