### PR TITLE
Fix some discarded_notification_center_observer false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@
   removed.  
   [JP Simard](https://github.com/jpsim)
 
+* Fix discarded_notification_center_observer false positives
+  when capturing observers into an array
+  [Petteri Huusko](https://github.com/PetteriHuusko)
+
 ## 0.38.1: Extra Shiny Pulsator Cap
 
 #### Breaking


### PR DESCRIPTION
This style of managing observers produced discarded_notification_center_observer false positives:

var tokens: [NSObjectProtocol] = [
	NotificationCenter.default.addObserver(forName: .this, object: nil, queue: .main) { _ in print("this") },
	NotificationCenter.default.addObserver(forName: .that, object: nil, queue: .main) { _ in print("that") }
]
// Later..
tokens.forEach { NotificationCenter.default.removeObserver($0) }
