### PR TITLE
Fix discarded_notification_center_observer false positive on arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@
   removed.  
   [JP Simard](https://github.com/jpsim)
 
+* Fix discarded_notification_center_observer false positives
+  when capturing observers into an array
+  [Petteri Huusko](https://github.com/PetteriHuusko)
+
 ## 0.38.1: Extra Shiny Pulsator Cap
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -27,7 +27,13 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
             "func foo(_ notif: Any) {\n" +
             "   obs.append(notif)\n" +
             "}\n" +
-            "foo(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n"
+            "foo(nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }))\n",
+            """
+            var obs: [NSObjectProtocol] = [
+               nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil, using: { }),
+               nc.addObserver(forName: .CKAccountChanged, object: nil, queue: nil, using: { })
+            ]
+            """
         ],
         triggeringExamples: [
             "↓nc.addObserver(forName: .NSSystemTimeZoneDidChange, object: nil, queue: nil) { }\n",
@@ -75,6 +81,11 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
             lastMatch.location == range.length - lastMatch.length,
             let lastFunction = file.structureDictionary.functions(forByteOffset: offset).last,
             !lastFunction.enclosedSwiftAttributes.contains(.discardableResult) {
+            return []
+        }
+
+        let kinds = file.structureDictionary.kinds(forByteOffset: offset)
+        if kinds.count >= 2 && SwiftExpressionKind(rawValue: kinds[kinds.count - 2].0) == .array {
             return []
         }
 


### PR DESCRIPTION
This style of managing observers produces discarded_notification_center_observer false positives:
```
var tokens: [NSObjectProtocol] = [
  NotificationCenter.default.addObserver(forName: Notification.Name.this, object: nil, queue: .main) { _ in print("this") },
  NotificationCenter.default.addObserver(forName: Notification.Name.that, object: nil, queue: .main) { _ in print("that") }
]
```
// Later..
```
tokens.forEach { NotificationCenter.default.removeObserver($0) }
```