### PR TITLE
Add deinitializer to type_contents_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 #### Enhancements
 
-* Add `deinitializer` type content to `type_contents_order` rule instead of grouping it with initializers.  
-[Steven Magdy](https://github.com/StevenMagdy)
-[#3042](https://github.com/realm/SwiftLint/issues/3042)
+* Add `deinitializer` type content to `type_contents_order` rule instead of
+  grouping it with initializers.  
+  [Steven Magdy](https://github.com/StevenMagdy)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* Add `deinitializer` type content to `type_contents_order` rule instead of grouping it with initializers.  
+[Steven Magdy](https://github.com/StevenMagdy)
+[#3042](https://github.com/realm/SwiftLint/issues/3042)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -13,6 +13,7 @@ enum TypeContent: String {
     case ibAction = "ib_action"
     case otherMethod = "other_method"
     case `subscript` = "subscript"
+    case deinitializer = "deinitializer"
 }
 
 public struct TypeContentsOrderConfiguration: RuleConfiguration, Equatable {
@@ -30,7 +31,8 @@ public struct TypeContentsOrderConfiguration: RuleConfiguration, Equatable {
         [.viewLifeCycleMethod],
         [.ibAction],
         [.otherMethod],
-        [.subscript]
+        [.subscript],
+        [.deinitializer]
     ]
 
     public var consoleDescription: String {

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -121,8 +121,10 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 "viewDidDisappear("
             ]
 
-            if typeContentStructure.name!.starts(with: "init") || typeContentStructure.name!.starts(with: "deinit") {
+            if typeContentStructure.name!.starts(with: "init") {
                 return .initializer
+            } else if typeContentStructure.name!.starts(with: "deinit") {
+                return .deinitializer
             } else if viewLifecycleMethodNames.contains(where: { typeContentStructure.name!.starts(with: $0) }) {
                 return .viewLifeCycleMethod
             } else if typeContentStructure.enclosedSwiftAttributes.contains(SwiftDeclarationAttributeKind.ibaction) {

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRuleExamples.swift
@@ -104,6 +104,11 @@ internal struct TypeContentsOrderRuleExamples {
                     log.warning("Just a test", newValue)
                 }
             }
+        """,
+        """
+            deinit {
+                log.debug("deinit")
+            }
         """
     ]
 
@@ -160,6 +165,12 @@ internal struct TypeContentsOrderRuleExamples {
         """,
         """
         class TestViewController: UIViewController {
+
+            // deinitializer
+            ↓deinit {
+                log.debug("deinit")
+            }
+
             // Initializers
             override ↓init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
                 super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)

--- a/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
@@ -65,8 +65,13 @@ class TypeContentsOrderRuleTests: XCTestCase {
                 @IBOutlet private ↓var view1: UIView!
 
                 // Initializers
-                override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+                override ↓init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
                     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+                }
+
+                // deinitializer
+                deinit {
+                    log.debug("deinit")
                 }
             }
             """,
@@ -144,6 +149,7 @@ class TypeContentsOrderRuleTests: XCTestCase {
             reversedOrderDescription,
             ruleConfiguration: [
                 "order": [
+                    "deinitializer",
                     "subscript",
                     "other_method",
                     "ib_action",
@@ -224,6 +230,11 @@ class TypeContentsOrderRuleTests: XCTestCase {
                     fatalError("init(coder:) has not been implemented")
                 }
 
+                // deinitializer
+                deinit {
+                    log.debug("deinit")
+                }
+
                 // View Life-Cycle Method
                 override func viewDidLoad() {
                     super.viewDidLoad()
@@ -279,6 +290,11 @@ class TypeContentsOrderRuleTests: XCTestCase {
                 // Instance Property
                 ↓var shouldLayoutView1: Bool!
 
+                // deinitializer
+                ↓deinit {
+                    log.debug("deinit")
+                }
+
                 // Subtype
                 class TestClass {
                     // 10 lines
@@ -327,7 +343,7 @@ class TypeContentsOrderRuleTests: XCTestCase {
                 "order": [
                     ["type_alias", "associated_type", "subtype"],
                     ["type_property", "instance_property", "ib_inspectable", "ib_outlet"],
-                    ["initializer", "type_method"],
+                    ["initializer", "type_method", "deinitializer"],
                     ["view_life_cycle_method", "ib_action", "other_method", "subscript"]
                 ]
             ]


### PR DESCRIPTION
Add `deinitializer` type content to `type_contents_order` rule instead of grouping it with initializers.
This allows the common use case of putting the deinitializer at the end of the class.