### PR TITLE
Empty count configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
   a ternary operator to call `Void` functions.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#2358](https://github.com/realm/SwiftLint/issues/2358)
+* Add `only_after_dot` configuration option to `empty_count` rule. With the
+  option enabled, `empty_count` rule will ignore variables named `count`.
+  By default, this option is disabled.  
+  [Zsolt Kovács](https://github.com/lordzsolt)
+  [#827](https://github.com/realm/SwiftLint/issues/827)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -4,7 +4,7 @@ private enum ConfigurationKey: String {
 }
 
 public struct EmptyCountConfiguration: RuleConfiguration, Equatable {
-    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var severityConfiguration = SeverityConfiguration(.error)
     private(set) var onlyAfterDot: Bool = false
 
     public var consoleDescription: String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -1,0 +1,26 @@
+private enum ConfigurationKey: String {
+    case severity = "severity"
+    case onlyAfterDot = "only_after_dot"
+}
+
+public struct EmptyCountConfiguration: RuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var onlyAfterDot: Bool = false
+
+    public var consoleDescription: String {
+        return [severityConfiguration.consoleDescription,
+                "\(ConfigurationKey.onlyAfterDot.rawValue): \(onlyAfterDot)"].joined(separator: ", ")
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let severityString = configuration[ConfigurationKey.severity.rawValue] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        onlyAfterDot = configuration[ConfigurationKey.onlyAfterDot.rawValue] as? Bool ?? false
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -140,6 +140,8 @@
 		67EB4DFA1E4CC111004E9ACD /* CyclomaticComplexityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */; };
 		67EB4DFC1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB4DFB1E4CD7F5004E9ACD /* CyclomaticComplexityRuleTests.swift */; };
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
+		6A804EF323D8F6CF00976471 /* EmptyCountConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A804EF023D8F6A200976471 /* EmptyCountConfiguration.swift */; };
+		6A804EF623D8FB0D00976471 /* EmptyCountRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A804EF423D8FA7900976471 /* EmptyCountRuleTests.swift */; };
 		6BE79EB12204EC0700B5A2FE /* RequiredDeinitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE79EB02204EC0700B5A2FE /* RequiredDeinitRule.swift */; };
 		6C15818D237026AC00F582A2 /* GitHubActionsLoggingReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C15818C237026AC00F582A2 /* GitHubActionsLoggingReporter.swift */; };
 		6C15818F23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */; };
@@ -657,6 +659,8 @@
 		692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpeningBraceRule.swift; sourceTree = "<group>"; };
 		692B60AB1BD8F2E700C7AA22 /* StatementPositionRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementPositionRule.swift; sourceTree = "<group>"; };
 		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
+		6A804EF023D8F6A200976471 /* EmptyCountConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCountConfiguration.swift; sourceTree = "<group>"; };
+		6A804EF423D8FA7900976471 /* EmptyCountRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCountRuleTests.swift; sourceTree = "<group>"; };
 		6BE79EB02204EC0700B5A2FE /* RequiredDeinitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredDeinitRule.swift; sourceTree = "<group>"; };
 		6C15818C237026AC00F582A2 /* GitHubActionsLoggingReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubActionsLoggingReporter.swift; sourceTree = "<group>"; };
 		6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CannedGitHubActionsLoggingReporterOutput.txt; sourceTree = "<group>"; };
@@ -1072,6 +1076,7 @@
 				67EB4DF81E4CC101004E9ACD /* CyclomaticComplexityConfiguration.swift */,
 				62A498551F306A7700D766E4 /* DiscouragedDirectInitConfiguration.swift */,
 				D41985EA21FAB63E003BE2B7 /* DeploymentTargetConfiguration.swift */,
+				6A804EF023D8F6A200976471 /* EmptyCountConfiguration.swift */,
 				125AAC77203AA82D0004BCE0 /* ExplicitTypeInterfaceConfiguration.swift */,
 				D4C4A3511DEFBBB700E0E04C /* FileHeaderConfiguration.swift */,
 				29FFC3781F1574FD007E4825 /* FileLengthRuleConfiguration.swift */,
@@ -1568,6 +1573,7 @@
 				125CE52E20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift */,
 				12E3D4DB2042729300B3E30E /* ExplicitTypeInterfaceRuleTests.swift */,
 				02FD8AEE1BFC18D60014BFFB /* ExtendedNSStringTests.swift */,
+				6A804EF423D8FA7900976471 /* EmptyCountRuleTests.swift */,
 				D4998DE81DF194F20006E05D /* FileHeaderRuleTests.swift */,
 				29FFC37B1F157BA8007E4825 /* FileLengthRuleTests.swift */,
 				4100D7A123BEAB5A009464E0 /* FileNameNoSpaceRuleTests.swift */,
@@ -2056,6 +2062,7 @@
 				827169B51F48D712003FB9AF /* NoGroupingExtensionRule.swift in Sources */,
 				D41B57781ED8CEE0007B0470 /* ExtensionAccessModifierRule.swift in Sources */,
 				E881985C1BEA978500333A11 /* TrailingNewlineRule.swift in Sources */,
+				6A804EF323D8F6CF00976471 /* EmptyCountConfiguration.swift in Sources */,
 				D414D6AE21D22FF500960935 /* LastWhereRule.swift in Sources */,
 				D4EABD0C22CE6F5B00635667 /* VerticalParameterAlignmentRuleExamples.swift in Sources */,
 				D44037972132730000FDA77B /* ProhibitedInterfaceBuilderRule.swift in Sources */,
@@ -2440,6 +2447,7 @@
 				E86396C71BADAFE6002C9E88 /* ReporterTests.swift in Sources */,
 				BCB68283216213130078E4C3 /* CompilerProtocolInitRuleTests.swift in Sources */,
 				D43B04661E071ED3004016AF /* ColonRuleTests.swift in Sources */,
+				6A804EF623D8FB0D00976471 /* EmptyCountRuleTests.swift in Sources */,
 				D4F5851920E99B5A0085C6D8 /* PrivateOutletRuleTests.swift in Sources */,
 				3B12C9C71C3361CB000B423F /* RuleTests.swift in Sources */,
 				125CE52F20425EFD001635E5 /* ExplicitTypeInterfaceConfigurationTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -358,7 +358,8 @@ extension EmptyCollectionLiteralRuleTests {
 
 extension EmptyCountRuleTests {
     static var allTests: [(String, (EmptyCountRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testEmptyCountWithDefaultConfiguration", testEmptyCountWithDefaultConfiguration),
+        ("testEmptyCountWithOnlyAfterDot", testEmptyCountWithOnlyAfterDot)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -138,12 +138,6 @@ class EmptyCollectionLiteralRuleTests: XCTestCase {
     }
 }
 
-class EmptyCountRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(EmptyCountRule.description)
-    }
-}
-
 class EmptyEnumArgumentsRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyEnumArgumentsRule.description)

--- a/Tests/SwiftLintFrameworkTests/EmptyCountRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/EmptyCountRuleTests.swift
@@ -10,25 +10,25 @@ class EmptyCountRuleTests: XCTestCase {
     func testEmptyCountWithOnlyAfterDot() {
         // Test with `only_after_dot` set to true
         let nonTriggeringExamples = [
-            "var count = 0\n",
-            "[Int]().isEmpty\n",
-            "[Int]().count > 1\n",
-            "[Int]().count == 1\n",
-            "[Int]().count == 0xff\n",
-            "[Int]().count == 0b01\n",
-            "[Int]().count == 0o07\n",
-            "discount == 0\n",
-            "order.discount == 0\n",
-            "count == 0\n"
+            Example("var count = 0\n"),
+            Example("[Int]().isEmpty\n"),
+            Example("[Int]().count > 1\n"),
+            Example("[Int]().count == 1\n"),
+            Example("[Int]().count == 0xff\n"),
+            Example("[Int]().count == 0b01\n"),
+            Example("[Int]().count == 0o07\n"),
+            Example("discount == 0\n"),
+            Example("order.discount == 0\n"),
+            Example("count == 0\n")
         ]
         let triggeringExamples = [
-            "[Int]().↓count == 0\n",
-            "[Int]().↓count > 0\n",
-            "[Int]().↓count != 0\n",
-            "[Int]().↓count == 0x0\n",
-            "[Int]().↓count == 0x00_00\n",
-            "[Int]().↓count == 0b00\n",
-            "[Int]().↓count == 0o00\n"
+            Example("[Int]().↓count == 0\n"),
+            Example("[Int]().↓count > 0\n"),
+            Example("[Int]().↓count != 0\n"),
+            Example("[Int]().↓count == 0x0\n"),
+            Example("[Int]().↓count == 0x00_00\n"),
+            Example("[Int]().↓count == 0b00\n"),
+            Example("[Int]().↓count == 0o00\n")
         ]
 
         let description = EmptyCountRule.description

--- a/Tests/SwiftLintFrameworkTests/EmptyCountRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/EmptyCountRuleTests.swift
@@ -1,0 +1,40 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class EmptyCountRuleTests: XCTestCase {
+    func testEmptyCountWithDefaultConfiguration() {
+        // Test with default parameters
+        verifyRule(EmptyCountRule.description)
+    }
+
+    func testEmptyCountWithOnlyAfterDot() {
+        // Test with `only_after_dot` set to true
+        let nonTriggeringExamples = [
+            "var count = 0\n",
+            "[Int]().isEmpty\n",
+            "[Int]().count > 1\n",
+            "[Int]().count == 1\n",
+            "[Int]().count == 0xff\n",
+            "[Int]().count == 0b01\n",
+            "[Int]().count == 0o07\n",
+            "discount == 0\n",
+            "order.discount == 0\n",
+            "count == 0\n"
+        ]
+        let triggeringExamples = [
+            "[Int]().↓count == 0\n",
+            "[Int]().↓count > 0\n",
+            "[Int]().↓count != 0\n",
+            "[Int]().↓count == 0x0\n",
+            "[Int]().↓count == 0x00_00\n",
+            "[Int]().↓count == 0b00\n",
+            "[Int]().↓count == 0o00\n"
+        ]
+
+        let description = EmptyCountRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+
+        verifyRule(description, ruleConfiguration: ["only_after_dot": true])
+    }
+}


### PR DESCRIPTION
This PR provides an improvement for #827 

It adds a a configuration option, to ignore variables named `count`. This option is disabled by default.