### PR TITLE
Fix false positives when line ends with carriage return + line feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
   capturing observers into an array.  
   [Petteri Huusko](https://github.com/PetteriHuusko)
 
+* Fix false positives when line ends with carriage return + line feed
+  [John Mueller](https://github.com/john-mueller)
+  [#3060](https://github.com/realm/SwiftLint/issues/3060)
+
 ## 0.38.2: Machine Repair Manual
 
 #### Breaking

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -124,7 +124,7 @@ public struct Command: Equatable {
             let startOfCommentPastDelimiter = scanner.scanLocation + Command.commentDelimiter.count
             trailingComment = scanner.string.bridge().substring(from: startOfCommentPastDelimiter)
         }
-        let ruleTexts = rawRuleTexts.components(separatedBy: .whitespaces).filter {
+        let ruleTexts = rawRuleTexts.components(separatedBy: .whitespacesAndNewlines).filter {
             let component = $0.trimmingCharacters(in: .whitespaces)
             return !component.isEmpty && component != "*/"
         }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -787,6 +787,12 @@ extension LetVarWhitespaceRuleTests {
     ]
 }
 
+extension LineEndingTests {
+    static var allTests: [(String, (LineEndingTests) -> () throws -> Void)] = [
+        ("testCarriageReturnDoesNotCauseError", testCarriageReturnDoesNotCauseError)
+    ]
+}
+
 extension LineLengthConfigurationTests {
     static var allTests: [(String, (LineLengthConfigurationTests) -> () throws -> Void)] = [
         ("testLineLengthConfigurationInitializerSetsLength", testLineLengthConfigurationInitializerSetsLength),
@@ -1735,6 +1741,7 @@ XCTMain([
     testCase(LegacyNSGeometryFunctionsRuleTests.allTests),
     testCase(LegacyRandomRuleTests.allTests),
     testCase(LetVarWhitespaceRuleTests.allTests),
+    testCase(LineEndingTests.allTests),
     testCase(LineLengthConfigurationTests.allTests),
     testCase(LineLengthRuleTests.allTests),
     testCase(LinterCacheTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/LineEndingTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineEndingTests.swift
@@ -1,0 +1,12 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class LineEndingTests: XCTestCase {
+    func testCarriageReturnDoesNotCauseError() {
+        XCTAssert(
+            violations(
+                "//swiftlint:disable all\r\nprint(123)\r\n"
+            ).isEmpty
+        )
+    }
+}


### PR DESCRIPTION
Fixes: #3060

I wasn't exactly sure where the test should go, so I added it in its own file. If there's a better place for it, I'm happy to move it.