### PR TITLE
Fix crash on missing `#endif`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 * Fix `discarded_notification_center_observer` false positives when
   capturing observers into an array.  
   [Petteri Huusko](https://github.com/PetteriHuusko)
+* Fix crash when non-closed #if was present in file.
+  [PaulTaykalo](https://github.com/PaulTaykalo)
 
 ## 0.38.2: Machine Repair Manual
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -32,6 +32,9 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
                 return ["#if", "#endif"].contains(contents.substringWithByteRange(range))
             }
 
+        // Make sure that each #if has corresponding #endif
+        guard ranges.count % 2 == 0 else { return [] }
+
         return stride(from: 0, to: ranges.count, by: 2).reduce(into: []) { result, rangeIndex in
             result.append(ranges[rangeIndex].union(with: ranges[rangeIndex + 1]))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
@@ -9,7 +9,12 @@ internal struct DuplicateImportsRuleExamples {
             import KsApi
         #endif
         """),
-        Example("import A // module\nimport B // module")
+        Example("import A // module\nimport B // module"),
+        Example("""
+        #if TEST
+        func test() {
+        }
+        """)
     ]
 
     static let triggeringExamples: [Example] = {


### PR DESCRIPTION
Just a simple check to make sure that there is an even count of `#if`s and `#endif`s
Since the Swiftlitn is not a compiler, then there's no need to check for a valid order of those.