### PR TITLE
Allow opening brace on newline in case of multiline function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
   [Keith Smiley](https://github.com/keith)
   [#3184](https://github.com/realm/SwiftLint/issues/3184)
 
+* Add `allow_multiline_func` configuration option to `opening_brace`
+  rule, to allow placing `{` on new line in case of multiline function.
+  Defaults to `false`.  
+  [Zsolt Kovács](https://github.com/lordzsolt)
+  [#1921](https://github.com/realm/SwiftLint/issues/1921)
+
 #### Bug Fixes
 
 * Fix parsing of Xcode 12 compiler logs for analyzer rules.  

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -1,0 +1,26 @@
+private enum ConfigurationKey: String {
+    case severity = "severity"
+    case allowMultilineFunc = "allow_multiline_func"
+}
+
+public struct OpeningBraceConfiguration: RuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var allowMultilineFunc: Bool = false
+
+    public var consoleDescription: String {
+        return [severityConfiguration.consoleDescription,
+                "\(ConfigurationKey.allowMultilineFunc): \(allowMultilineFunc)"].joined(separator: ", ")
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let severityString = configuration[ConfigurationKey.severity.rawValue] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        allowMultilineFunc = configuration[ConfigurationKey.allowMultilineFunc.rawValue] as? Bool ?? false
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -143,6 +143,8 @@
 		69F88BF71BDA38A6005E7CAE /* OpeningBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692B1EB11BD7E00F00EAABFF /* OpeningBraceRule.swift */; };
 		6A804EF323D8F6CF00976471 /* EmptyCountConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A804EF023D8F6A200976471 /* EmptyCountConfiguration.swift */; };
 		6A804EF623D8FB0D00976471 /* EmptyCountRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A804EF423D8FA7900976471 /* EmptyCountRuleTests.swift */; };
+		6A14DB9323E7296700C17847 /* OpeningBraceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A14DB9123E7292000C17847 /* OpeningBraceConfiguration.swift */; };
+		6A84A3ED23E79420004ECB7F /* OpeningBraceRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A14DB9423E75ACF00C17847 /* OpeningBraceRuleTests.swift */; };
 		6BE79EB12204EC0700B5A2FE /* RequiredDeinitRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE79EB02204EC0700B5A2FE /* RequiredDeinitRule.swift */; };
 		6C15818D237026AC00F582A2 /* GitHubActionsLoggingReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C15818C237026AC00F582A2 /* GitHubActionsLoggingReporter.swift */; };
 		6C15818F23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */; };
@@ -676,6 +678,8 @@
 		695BE9CE1BDFD92B0071E985 /* CommaRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommaRule.swift; sourceTree = "<group>"; };
 		6A804EF023D8F6A200976471 /* EmptyCountConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCountConfiguration.swift; sourceTree = "<group>"; };
 		6A804EF423D8FA7900976471 /* EmptyCountRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCountRuleTests.swift; sourceTree = "<group>"; };
+		6A14DB9123E7292000C17847 /* OpeningBraceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningBraceConfiguration.swift; sourceTree = "<group>"; };
+		6A14DB9423E75ACF00C17847 /* OpeningBraceRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningBraceRuleTests.swift; sourceTree = "<group>"; };
 		6BE79EB02204EC0700B5A2FE /* RequiredDeinitRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredDeinitRule.swift; sourceTree = "<group>"; };
 		6C15818C237026AC00F582A2 /* GitHubActionsLoggingReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubActionsLoggingReporter.swift; sourceTree = "<group>"; };
 		6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CannedGitHubActionsLoggingReporterOutput.txt; sourceTree = "<group>"; };
@@ -1124,6 +1128,7 @@
 				D93DA3CF1E699E4E00809827 /* NestingConfiguration.swift */,
 				D4DA1DFD1E1A10DB0037413D /* NumberSeparatorConfiguration.swift */,
 				A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */,
+				6A14DB9123E7292000C17847 /* OpeningBraceConfiguration.swift */,
 				78F032471D7D614300BE709A /* OverridenSuperCallConfiguration.swift */,
 				C28B2B3B2106DF210009A0FE /* PrefixedConstantRuleConfiguration.swift */,
 				DAD3BE491D6ECD9500660239 /* PrivateOutletRuleConfiguration.swift */,
@@ -1637,6 +1642,7 @@
 				B25DCD0F1F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift */,
 				D4CA758E1E2DEEA500A40E8A /* NumberSeparatorRuleTests.swift */,
 				825F19D01EEFF19700969EF1 /* ObjectLiteralRuleTests.swift */,
+				6A14DB9423E75ACF00C17847 /* OpeningBraceRuleTests.swift */,
 				8FAD90A92513FA5B004653BA /* ParserDiagnosticsTests.swift */,
 				C25EBBDD210787B200E27603 /* PrefixedTopLevelConstantRuleTests.swift */,
 				D4F5851820E99B5A0085C6D8 /* PrivateOutletRuleTests.swift */,
@@ -2303,6 +2309,7 @@
 				E88DEA6F1B09843F00A66CB0 /* Location.swift in Sources */,
 				D43B046B1E075905004016AF /* ClosureEndIndentationRule.swift in Sources */,
 				D47EF4821F69E34D0012C4CA /* ColonRule+Dictionary.swift in Sources */,
+				6A14DB9323E7296700C17847 /* OpeningBraceConfiguration.swift in Sources */,
 				D93DA3D11E699E6300809827 /* NestingConfiguration.swift in Sources */,
 				CC26ED07204DEB510013BBBC /* RuleIdentifier.swift in Sources */,
 				C328A2F71E6759AE00A9E4D7 /* ExplicitTypeInterfaceRule.swift in Sources */,
@@ -2526,6 +2533,7 @@
 				8FAD90AA2513FA5B004653BA /* ParserDiagnosticsTests.swift in Sources */,
 				8F2CC1CD20A6A189006ED34F /* FileNameRuleTests.swift in Sources */,
 				4100D7A323BEAB69009464E0 /* FileNameNoSpaceRuleTests.swift in Sources */,
+				6A84A3ED23E79420004ECB7F /* OpeningBraceRuleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1063,7 +1063,8 @@ extension ObjectLiteralRuleTests {
 
 extension OpeningBraceRuleTests {
     static var allTests: [(String, (OpeningBraceRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testOpeningBraceWithDefaultConfiguration", testOpeningBraceWithDefaultConfiguration),
+        ("testWithAllowMultilineTrue", testWithAllowMultilineTrue)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -474,12 +474,6 @@ class NotificationCenterDetachmentRuleTests: XCTestCase {
     }
 }
 
-class OpeningBraceRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(OpeningBraceRule.description)
-    }
-}
-
 class OperatorFunctionWhitespaceRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OperatorFunctionWhitespaceRule.description)

--- a/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
@@ -1,0 +1,97 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class OpeningBraceRuleTests: XCTestCase {
+    func testOpeningBraceWithDefaultConfiguration() {
+        verifyRule(OpeningBraceRule.description)
+    }
+
+    // swiftlint:disable function_body_length
+    func testWithAllowMultilineTrue() {
+        // Test with `same_line` set to false
+
+        let nonTriggeringExamples = [
+            Example("func abc() {\n}"),
+            Example("func abc(a: A\n\tb: B)\n{"),
+            Example("[].map() { $0 }"),
+            Example("[].map({ })"),
+            Example("if let a = b { }"),
+            Example("while a == b { }"),
+            Example("guard let a = b else { }"),
+            Example("if\n\tlet a = b,\n\tlet c = d\n\twhere a == c\n{ }"),
+            Example("while\n\tlet a = b,\n\tlet c = d\n\twhere a == c\n{ }"),
+            Example("guard\n\tlet a = b,\n\tlet c = d\n\twhere a == c else\n{ }"),
+            Example("struct Rule {}\n"),
+            Example("struct Parent {\n\tstruct Child {\n\t\tlet foo: Int\n\t}\n}\n"),
+            Example("""
+            func f(rect: CGRect) {
+               {
+                  let centre = CGPoint(x: rect.midX, y: rect.midY)
+                  print(centre)
+               }()
+            }
+            """),
+            Example("""
+            // Get the current thread's TLS pointer. On first call for a given thread,
+            // creates and initializes a new one.
+            internal static func getPointer()
+              -> UnsafeMutablePointer<_ThreadLocalStorage>
+            {
+              return _swift_stdlib_threadLocalStorageGet().assumingMemoryBound(
+                to: _ThreadLocalStorage.self)
+            }
+            """)
+        ]
+        let triggeringExamples = [
+            Example("func abc()↓{\n}"),
+            Example("func abc()\n\t↓{ }"),
+            Example("[].map()↓{ $0 }"),
+            Example("[].map( ↓{ } )"),
+            Example("if let a = b↓{ }"),
+            Example("while a == b↓{ }"),
+            Example("guard let a = b else↓{ }"),
+            Example("if\n\tlet a = b,\n\tlet c = d\n\twhere a == c↓{ }"),
+            Example("while\n\tlet a = b,\n\tlet c = d\n\twhere a == c↓{ }"),
+            Example("guard\n\tlet a = b,\n\tlet c = d\n\twhere a == c else↓{ }"),
+            Example("struct Rule↓{}\n"),
+            Example("struct Rule\n↓{\n}\n"),
+            Example("struct Rule\n\n\t↓{\n}\n"),
+            Example("struct Parent {\n\tstruct Child\n\t↓{\n\t\tlet foo: Int\n\t}\n}\n"),
+            Example("""
+            func run_Array_method1x(_ N: Int) {
+              let existentialArray = array!
+              for _ in 0 ..< N * 100 {
+                for elt in existentialArray {
+                  if !elt.doIt()  {
+                    fatalError("expected true")
+                  }
+                }
+              }
+            }
+
+            func run_Array_method2x(_ N: Int) {
+
+            }
+            """)
+        ]
+
+        let corrections = [
+            Example("struct Rule↓{}\n"): Example("struct Rule {}\n"),
+            Example("struct Rule\n↓{\n}\n"): Example("struct Rule {\n}\n"),
+            Example("struct Rule\n\n\t↓{\n}\n"): Example("struct Rule {\n}\n"),
+            Example("struct Parent {\n\tstruct Child\n\t↓{\n\t\tlet foo: Int\n\t}\n}\n"):
+                Example("struct Parent {\n\tstruct Child {\n\t\tlet foo: Int\n\t}\n}\n"),
+            Example("[].map()↓{ $0 }\n"): Example("[].map() { $0 }\n"),
+            Example("[].map( ↓{ })\n"): Example("[].map({ })\n"),
+            Example("if a == b↓{ }\n"): Example("if a == b { }\n"),
+            Example("if\n\tlet a = b,\n\tlet c = d↓{ }\n"): Example("if\n\tlet a = b,\n\tlet c = d { }\n")
+        ]
+
+        let description = OpeningBraceRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(corrections: corrections)
+
+        verifyRule(description, ruleConfiguration: ["allow_multiline_func": true])
+    }
+}


### PR DESCRIPTION
Implements #1921 

I kept the option disabled, to keep the old behavior.

Note: Indentation is not validated, similar to the old `if`, `guard` and `while` behavior.