### PR TITLE
Fix skipped files when target names contain spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3100](https://github.com/realm/SwiftLint/issues/3100)
 
+  * Fix skipped files when target names contain spaces.  
+  [Erik Kerber](https://github.com/eskerber)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
+
 ## 0.38.2: Machine Repair Manual
 
 #### Breaking


### PR DESCRIPTION
Resolves #3076 

SwiftLint determines the files to lint based on build output. Specifically, it peeks inside of a `.SwiftFileList` file:

```bash
export SWIFT_RESPONSE_FILE_PATH_normal_x86_64="/Users/erik/Library/Developer/Xcode/DerivedData/Flagship-cxvakyfeadqmyecwvirxgmrbkpoa/Build/Intermediates.noindex/Flagship.build/Debug-iphonesimulator/Experiences - CartCheckout.build/Objects-normal/x86_64/CartCheckout.SwiftFileList"
```

These build output lines are split on spaces. If the line that contains the file list has a split - then the path itself will be split:

```
Debug-iphonesimulator/Experiences\ 
-\ 
CartCheckout.build/Objects-normal/x86_64/CartCheckout.SwiftFileList
```

No file list will be found, and no Swift files will be added to the list of files to lint.

### Fix

Adding onto the space-escaping pattern used in [CompilerArgumentsExtractor.swift ](https://github.com/realm/SwiftLint/blob/master/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift#L86), convert escaped spaces immediately into Unicode "null", allowing code that requires splitting on spaces to be able to rely simply on `components(separatedBy: " ")`.

When needed, unescape these strings just-in-time.


> **Note:** I just pulled the code today so I'm not familiar (yet) with the layout of the tests, but at first glance I didn't recognize any test fixtures/fake build files that tested the parsing and loading of build output. If there's something there, happy to add to it.
