### PR TITLE
ImplicitReturnConfiguration description now reports current config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 * Fix false positives when line ends with carriage return + line feed.  
   [John Mueller](https://github.com/john-mueller)
   [#3060](https://github.com/realm/SwiftLint/issues/3060)
+  
+* Implicit_return description now reports current config correctly.
+  [John Buckley](https://github.com/nhojb)
+  
 
 ## 0.38.2: Machine Repair Manual
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -8,11 +8,13 @@ public struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
     public static let defaultIncludedKinds = Set(ReturnKind.allCases)
 
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
+
     private(set) var includedKinds = ImplicitReturnConfiguration.defaultIncludedKinds
 
     public var consoleDescription: String {
+        let includedKinds = self.includedKinds.map { $0.rawValue }
         return severityConfiguration.consoleDescription +
-            ", included: \(ImplicitReturnConfiguration.defaultIncludedKinds)"
+            ", included: [\(includedKinds.joined(separator: ", "))]"
     }
 
     public init(includedKinds: Set<ReturnKind> = ImplicitReturnConfiguration.defaultIncludedKinds) {


### PR DESCRIPTION
Previously only the default config was reported by `swiftlint rules`

Assuming only "function" is disabled by current config:

Old output:
`implicit_return ... | warning, included: [SwiftLintFramework.ImplicitReturnConfiguration.ReturnKind.function, SwiftLintFramework.ImplicitReturnConfiguration.ReturnKind.closure, SwiftLintFramework.ImplicitReturnConfiguration.ReturnKind.getter`

New output:
`implicit_return ... | warning, included: [closure, getter]`

