### PR TITLE
Fix UnownedVariableCaptureRuleTests in Swift 5.2

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -52,7 +52,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
 
                 return contents.substringWithByteRange(attributeByteRange) == "unowned"
             }?.offset
-        }
+        }.unique
 
         return unownedVariableOffsets.map { offset in
             return StyleViolation(ruleDescription: type(of: self).description,


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-12168