### PR TITLE
Fix NSObjectPreferIsEqualRuleTests with Swift 5.2

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRuleExamples.swift
@@ -33,14 +33,6 @@ internal struct NSObjectPreferIsEqualRuleExamples {
             }
         }
         """),
-        // NSObject subclass with non-static ==
-        Example("""
-        class AClass: NSObject {
-            func ==(lhs: AClass, rhs: AClass) -> Bool {
-                return true
-            }
-        }
-        """),
         // NSObject subclass implementing == with different signature
         Example("""
         class AClass: NSObject {


### PR DESCRIPTION
This is not valid Swift code and Swift 5.2 changes the SourceKit response: https://bugs.swift.org/browse/SR-12167