### PR TITLE
Fix false positive in `attributes` with Swift 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3057](https://github.com/realm/SwiftLint/issues/3057)
 
+* Fix false positive in `attributes` rule with `@escaping` parameters when
+  using Swift 5.2.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3079](https://github.com/realm/SwiftLint/issues/3079)
+
 ## 0.38.2: Machine Repair Manual
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -274,6 +274,10 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
     }
 
     private func isAttribute(_ name: String) -> Bool {
+        if name == "@escaping" {
+            return false
+        }
+
         // all attributes *should* start with @
         if name.hasPrefix("@") {
             return true

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRuleExamples.swift
@@ -45,6 +45,10 @@ internal struct AttributesRuleExamples {
         @available (iOS 11.0, *)
         class DeleteMeTests: XCTestCase {
         }
+        """),
+        Example("""
+        @objc
+        internal func foo(identifier: String, completion: @escaping (() -> Void)) {}
         """)
     ]
 


### PR DESCRIPTION
Fixes #3079