### PR TITLE
Fix unused_import rule reported locations and corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## Master
+
+#### Breaking
+
+* None.
+
+#### Experimental
+
+* None.
+
+#### Enhancements
+
+* None.
+
+#### Bug Fixes
+
+* Fix unused_import rule reported locations and corrections when
+  multiple `@testable` imports are involved.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.39.0: A Visitor in the Laundromat
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -135,6 +135,17 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
             @testable import Foundation
             @objc
             class A {}
+            """),
+            Example("""
+            @testable import Foundation
+            ↓@testable import Dispatch
+            @objc
+            class A {}
+            """):
+            Example("""
+            @testable import Foundation
+            @objc
+            class A {}
             """)
         ],
         requiresFileOnDisk: true
@@ -239,7 +250,7 @@ private extension SwiftLintFile {
     func rangedAndSortedUnusedImports(of unusedImports: [String], contents: NSString) -> [(String, NSRange)] {
         return unusedImports
             .compactMap { module in
-                self.match(pattern: "^(@.+ +)?import +\(module)\\b.*?\n").first.map { (module, $0.0) }
+                self.match(pattern: "^(@[\\w_]+ +)?import +\(module)\\b.*?\n").first.map { (module, $0.0) }
             }
             .sorted(by: { $0.1.location < $1.1.location })
     }


### PR DESCRIPTION
When multiple `@testable` imports are involved.

Because we use the `.dotMatchesLineSeparators` regular expression option, the dot was matching across lines when the intention was for it to just match `\w_` characters.