### PR TITLE
Add `legacy_objc_type` Opt In Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ This is the last release to support building with Swift 5.0.x.
   [JP Simard](https://github.com/jpsim)
   [#3116](https://github.com/realm/SwiftLint/issues/3116)
 
+* Add `legacy_objc_type` opt-in rule to warn against using
+  bridged Objective-C reference types instead of Swift value types.  
+  [Blake](https://github.com/72A12F4E)
+  [#2758](https://github.com/realm/SwiftLint/issues/2758)
+
 #### Bug Fixes
 
 * Fix more false positives in `implicit_getter` rule in extensions when using

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -86,6 +86,7 @@ public let masterRuleList = RuleList(rules: [
     LegacyHashingRule.self,
     LegacyMultipleRule.self,
     LegacyNSGeometryFunctionsRule.self,
+    LegacyObjcTypeRule.self,
     LegacyRandomRule.self,
     LetVarWhitespaceRule.self,
     LineLengthRule.self,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -1,0 +1,65 @@
+import Foundation
+import SourceKittenFramework
+
+private let legacyObjcTypes = [
+    "NSAffineTransform",
+    "NSArray",
+    "NSCalendar",
+    "NSCharacterSet",
+    "NSData",
+    "NSDateComponents",
+    "NSDateInterval",
+    "NSDate",
+    "NSDecimalNumber",
+    "NSDictionary",
+    "NSIndexPath",
+    "NSIndexSet",
+    "NSLocale",
+    "NSMeasurement",
+    "NSNotification",
+    "NSNumber",
+    "NSPersonNameComponents",
+    "NSSet",
+    "NSString",
+    "NSTimeZone",
+    "NSURL",
+    "NSURLComponents",
+    "NSURLQueryItem",
+    "NSURLRequest",
+    "NSUUID"
+]
+
+public struct LegacyObjcTypeRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "legacy_objc_type",
+        name: "Legacy Objective-C Reference Type",
+        description: "Prefer Swift value types to bridged Objective-C reference types",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            Example("var array = Array<Int>()\n"),
+            Example("var calendar: Calendar? = nil")
+        ],
+        triggeringExamples: [
+            Example("var array = NSArray()"),
+            Example("var calendar: NSCalendar? = nil")
+        ]
+    )
+
+    private let pattern = legacyObjcTypes.joined(separator: "|")
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        return file.match(pattern: pattern)
+            .filter {
+                $0.1.contains(.typeidentifier) || $0.1.contains(.identifier)
+            }.map { $0.0 }
+            .map {
+                StyleViolation(ruleDescription: type(of: self).description,
+                               severity: configuration.severity,
+                               location: Location(file: file, characterOffset: $0.location))
+            }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */; };
 		24B4DF0D1D6DFDE90097803B /* RedundantNilCoalescingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */; };
 		24E17F721B14BB3F008195BE /* SwiftLintFile+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E17F701B1481FF008195BE /* SwiftLintFile+Cache.swift */; };
+		2529ECDD24383AAD0039E259 /* LegacyObjcTypeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2529ECDB24383A770039E259 /* LegacyObjcTypeRule.swift */; };
 		260F66A0225C5B6D00407CF5 /* CollectingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260F669F225C5B6D00407CF5 /* CollectingRuleTests.swift */; };
 		264E080F2248BA2800ADC4C5 /* RuleStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264E080E2248BA2800ADC4C5 /* RuleStorage.swift */; };
 		26CE462D228532CD00264485 /* Array+SwiftLint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CE462C228532CD00264485 /* Array+SwiftLint.swift */; };
@@ -548,6 +549,7 @@
 		22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoConfiguration.swift; sourceTree = "<group>"; };
 		24B4DF0B1D6DFA370097803B /* RedundantNilCoalescingRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilCoalescingRule.swift; sourceTree = "<group>"; };
 		24E17F701B1481FF008195BE /* SwiftLintFile+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftLintFile+Cache.swift"; sourceTree = "<group>"; };
+		2529ECDB24383A770039E259 /* LegacyObjcTypeRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyObjcTypeRule.swift; sourceTree = "<group>"; };
 		260F669F225C5B6D00407CF5 /* CollectingRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectingRuleTests.swift; sourceTree = "<group>"; };
 		264E080E2248BA2800ADC4C5 /* RuleStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleStorage.swift; sourceTree = "<group>"; };
 		26CE462C228532CD00264485 /* Array+SwiftLint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Array+SwiftLint.swift"; path = "../../SwiftLintFramework/Extensions/Array+SwiftLint.swift"; sourceTree = "<group>"; };
@@ -1352,6 +1354,7 @@
 				C3EF547521B5A2190009262F /* LegacyHashingRule.swift */,
 				D4F10615229A331200FDE319 /* LegacyMultipleRule.swift */,
 				F22314AE1D4F7C77009AD165 /* LegacyNSGeometryFunctionsRule.swift */,
+				2529ECDB24383A770039E259 /* LegacyObjcTypeRule.swift */,
 				A3184D55215BCEFF00621EA2 /* LegacyRandomRule.swift */,
 				D4DAE8BB1DE14E8F00B0AE7A /* NimbleOperatorRule.swift */,
 				1E18574A1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift */,
@@ -2306,6 +2309,7 @@
 				6264015520155556005B9C4A /* DiscouragedOptionalBooleanRuleExamples.swift in Sources */,
 				5B3BEC3A23CCCC5D00DE5BEE /* Example.swift in Sources */,
 				8F8050821FFE0CBB006F5B93 /* Configuration+IndentationStyle.swift in Sources */,
+				2529ECDD24383AAD0039E259 /* LegacyObjcTypeRule.swift in Sources */,
 				E88DEA6B1B0983FE00A66CB0 /* StyleViolation.swift in Sources */,
 				62622F6B1F2F2E3500D5D099 /* DiscouragedDirectInitRule.swift in Sources */,
 				B89F3BCD1FD5EDFB00931E59 /* RequiredEnumCaseRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -790,6 +790,12 @@ extension LegacyNSGeometryFunctionsRuleTests {
     ]
 }
 
+extension LegacyObjcTypeRuleTests {
+    static var allTests: [(String, (LegacyObjcTypeRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension LegacyRandomRuleTests {
     static var allTests: [(String, (LegacyRandomRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1755,6 +1761,7 @@ XCTMain([
     testCase(LegacyHashingRuleTests.allTests),
     testCase(LegacyMultipleRuleTests.allTests),
     testCase(LegacyNSGeometryFunctionsRuleTests.allTests),
+    testCase(LegacyObjcTypeRuleTests.allTests),
     testCase(LegacyRandomRuleTests.allTests),
     testCase(LetVarWhitespaceRuleTests.allTests),
     testCase(LineEndingTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -342,6 +342,12 @@ class LegacyNSGeometryFunctionsRuleTests: XCTestCase {
     }
 }
 
+class LegacyObjcTypeRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(LegacyObjcTypeRule.description)
+    }
+}
+
 class LegacyRandomRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyRandomRule.description)


### PR DESCRIPTION
This change implements #2758

I was getting some unexpected behavior when I tried using SwiftLintFile.match(pattern:with:range:) to match the expected areas of code that I wanted, so I just filtered the matches manually.

I expected SwiftLintFile.match(pattern:with:range:) to return if any of the SyntaxKinds in the array I passed in were a match, but in the implementation its checking to see if the parameter has a match on every SyntaxKind passed in. It's like an AND instead of an OR?

New to the codebase, so I'm not sure if there is a better method for doing what I wanted.