### PR TITLE
Add unused_import config option to require imports for each module used

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 
 public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule, AutomaticTestableRule {
-    public var configuration = SeverityConfiguration(.warning)
+    public var configuration = UnusedImportConfiguration(severity: .warning, requireExplicitImports: false)
 
     public init() {}
 
@@ -154,7 +154,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
     public func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
         return violationRanges(in: file, compilerArguments: compilerArguments).map {
             StyleViolation(ruleDescription: type(of: self).description,
-                           severity: configuration.severity,
+                           severity: configuration.severity.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
     }
@@ -244,6 +244,18 @@ private extension SwiftLintFile {
             )
         }
 
+        // TODO: Only add missing imports when correcting
+        // TODO: Be smarter about where imports are added
+        // TODO: Make a best effort to keep imports sorted
+        let missingImports = usrFragments.subtracting(imports)
+        if !missingImports.isEmpty {
+            let missingImportStatements = missingImports
+                .sorted()
+                .map { "import \($0)" }
+                .joined(separator: "\n")
+            self.write(missingImportStatements + "\n" + self.contents)
+        }
+
         return rangedAndSortedUnusedImports(of: Array(unusedImports), contents: contentsNSString)
     }
 
@@ -325,8 +337,8 @@ private extension SwiftLintFile {
     }
 
     func appendUsedImports(cursorInfo: SourceKittenDictionary, usrFragments: inout Set<String>) {
-        if let usr = cursorInfo.moduleName {
-            usrFragments.formUnion(usr.split(separator: ".").map(String.init))
+        if let rootModuleName = cursorInfo.moduleName?.split(separator: ".").first.map(String.init) {
+            usrFragments.insert(rootModuleName)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -248,6 +248,7 @@ private extension SwiftLintFile {
         // TODO: Be smarter about where imports are added
         // TODO: Make a best effort to keep imports sorted
         // TODO: Move modulesAllowedToBeTransitivelyImported to UnusedImportConfiguration
+        // TODO: Don't add current module
         let modulesAllowedToBeTransitivelyImported = [
             "UIKit": [
                 "CoreFoundation",
@@ -260,7 +261,8 @@ private extension SwiftLintFile {
             ],
             "Foundation": [
                 "CoreFoundation",
-                "Darwin"
+                "Darwin",
+                "ObjectiveC"
             ]
         ]
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -247,7 +247,34 @@ private extension SwiftLintFile {
         // TODO: Only add missing imports when correcting
         // TODO: Be smarter about where imports are added
         // TODO: Make a best effort to keep imports sorted
-        let missingImports = usrFragments.subtracting(imports)
+        // TODO: Move modulesAllowedToBeTransitivelyImported to UnusedImportConfiguration
+        let modulesAllowedToBeTransitivelyImported = [
+            "UIKit": [
+                "CoreFoundation",
+                "CoreGraphics",
+                "CoreText",
+                "Darwin",
+                "Foundation",
+                "ObjectiveC",
+                "QuartzCore"
+            ],
+            "Foundation": [
+                "CoreFoundation",
+                "Darwin"
+            ]
+        ]
+
+        let missingImports = usrFragments
+            .subtracting(imports)
+            .filter { module in
+                let modulesAllowedToTransitivelyImportCurrentModule = modulesAllowedToBeTransitivelyImported
+                    .filter { $0.value.contains(module) }
+                    .keys
+
+                return modulesAllowedToTransitivelyImportCurrentModule.isEmpty ||
+                    imports.isDisjoint(with: modulesAllowedToTransitivelyImportCurrentModule)
+            }
+
         if !missingImports.isEmpty {
             let missingImportStatements = missingImports
                 .sorted()

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -1,0 +1,29 @@
+public struct UnusedImportConfiguration: RuleConfiguration, Equatable {
+    public var consoleDescription: String {
+        return [
+            "severity: \(severity.consoleDescription)",
+            "require_explicit_imports: \(requireExplicitImports)"
+        ].joined(separator: ", ")
+    }
+
+    public private(set) var severity: SeverityConfiguration
+    public private(set) var requireExplicitImports: Bool
+
+    public init(severity: ViolationSeverity, requireExplicitImports: Bool) {
+        self.severity = SeverityConfiguration(severity)
+        self.requireExplicitImports = requireExplicitImports
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configurationDict = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let severityConfiguration = configurationDict["severity"] {
+            try severity.apply(configuration: severityConfiguration)
+        }
+        if let requireExplicitImports = configurationDict["require_explicit_imports"] as? Bool {
+            self.requireExplicitImports = requireExplicitImports
+        }
+    }
+}


### PR DESCRIPTION
*This is a proof of concept, see TODOs for what would need to be cleaned up*

For example, if `CGFloat` is used in a file where only `UIKit` is imported but not `CoreGraphics`, this will be a violation even if the file previously compiled.

This is because Swift allows referencing some declarations that are only transitively imported.

Enabling the `require_explicit_imports` configuration option will require that the module of every declaration referenced in a source file be explicitly imported.

This will add significant noise to the imports list, but has a few advantages:

1. It will be easier to understand all the dependencies explicitly referenced in a source file.
2. Correcting the `unused_import` rule will no longer introduce compilation errors in files that compiled prior to the correction.

Missing imports will always be added to the top of the file, which may cause `sorted_imports` violations. You may run SwiftLint autocorrect with the `sorted_imports` rule enabled to re-sort those import statements afterwards.