### PR TITLE
Reduce overhead when creating unique IDs for SwiftLintFile instances

### DIFF
--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-private typealias FileCacheKey = Int
+private typealias FileCacheKey = ObjectIdentifier
 private var responseCache = Cache({ file -> [String: SourceKitRepresentable]? in
     do {
         return try Request.editorOpen(file: file.file).sendIfNotDisabled()

--- a/Source/SwiftLintFramework/Models/SwiftLintFile.swift
+++ b/Source/SwiftLintFramework/Models/SwiftLintFile.swift
@@ -3,25 +3,14 @@ import SourceKittenFramework
 
 /// A unit of Swift source code, either on disk or in memory.
 public final class SwiftLintFile {
-    private static var id = 0
-    private static var lock = NSLock()
-
-    private static func nextID () -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-        id += 1
-        return id
-    }
-
     let file: File
-    let id: Int
+    var id: ObjectIdentifier { return ObjectIdentifier(self) }
 
     /// Creates a `SwiftLintFile` with a SourceKitten `File`.
     ///
     /// - parameter file: A file from SourceKitten.
     public init(file: File) {
         self.file = file
-        self.id = SwiftLintFile.nextID()
     }
 
     /// Creates a `SwiftLintFile` by specifying its path on disk.


### PR DESCRIPTION
Generating a globally unique integer ID for each class instance should be functionally equivalent to using that class's `ObjectIdentifier`, without the overhead of locking or storing that property in memory.