### PR TITLE
Extend empty_enum_arguments rule to support `if case` and `guard case`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3158](https://github.com/realm/SwiftLint/issues/3158)
 
+* Extend `empty_enum_arguments` rule to support `if case` and `guard case`.  
+  [Zsolt Kovács](https://github.com/lordzsolt)
+  [#3103](https://github.com/realm/SwiftLint/issues/3103)
+
 #### Bug Fixes
 
 * Fix UnusedImportRule breaking transitive imports.  

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -42,21 +42,27 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
             wrapInSwitch("case \"bar\".uppercased()"),
             wrapInSwitch(variable: "(foo, bar)", "case (_, _) where !something"),
             wrapInSwitch("case (let f as () -> String)?"),
-            wrapInSwitch("default")
+            wrapInSwitch("default"),
+            Example("if case .bar = foo {\n}"),
+            Example("guard case .bar = foo else {\n}")
         ],
         triggeringExamples: [
             wrapInSwitch("case .bar↓(_)"),
             wrapInSwitch("case .bar↓()"),
             wrapInSwitch("case .bar↓(_), .bar2↓(_)"),
             wrapInSwitch("case .bar↓() where method() > 2"),
-            wrapInFunc("case .bar↓(_)")
+            wrapInFunc("case .bar↓(_)"),
+            Example("if case .bar↓(_) = foo {\n}"),
+            Example("guard case .bar↓(_) = foo else {\n}")
         ],
         corrections: [
             wrapInSwitch("case .bar↓(_)"): wrapInSwitch("case .bar"),
             wrapInSwitch("case .bar↓()"): wrapInSwitch("case .bar"),
             wrapInSwitch("case .bar↓(_), .bar2↓(_)"): wrapInSwitch("case .bar, .bar2"),
             wrapInSwitch("case .bar↓() where method() > 2"): wrapInSwitch("case .bar where method() > 2"),
-            wrapInFunc("case .bar↓(_)"): wrapInFunc("case .bar")
+            wrapInFunc("case .bar↓(_)"): wrapInFunc("case .bar"),
+            Example("if case .bar↓(_) = foo {"): Example("if case .bar = foo {"),
+            Example("guard case .bar↓(_) = foo else {"): Example("guard case .bar = foo else {")
         ]
     )
 
@@ -75,7 +81,7 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
 
     public func violationRanges(in file: SwiftLintFile, kind: StatementKind,
                                 dictionary: SourceKittenDictionary) -> [NSRange] {
-        guard kind == .case else {
+        guard kind == .case || kind == .if || kind == .guard else {
             return []
         }
 
@@ -93,14 +99,15 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
         }
 
         return dictionary.elements.flatMap { subDictionary -> [NSRange] in
-            guard subDictionary.kind == "source.lang.swift.structure.elem.pattern",
+            guard (subDictionary.kind == "source.lang.swift.structure.elem.pattern" ||
+                subDictionary.kind == "source.lang.swift.structure.elem.condition_expr"),
                 let byteRange = subDictionary.byteRange,
                 let caseRange = contents.byteRangeToNSRange(byteRange)
             else {
                 return []
             }
 
-            let emptyArgumentRegex = regex("\\.\\S+\\s*(\\([,\\s_]*\\))")
+            let emptyArgumentRegex = regex(#"\.\S+\s*(\([,\s_]*\))"#)
             return emptyArgumentRegex.matches(in: file.contents, options: [], range: caseRange).compactMap { match in
                 let parenthesesRange = match.range(at: 1)
 


### PR DESCRIPTION
Fixes #3103 