### PR TITLE
Update regex patters to use Raw Strings to improve readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,10 @@
 
 #### Enhancements
 
-* None.
+* Update regex patters to use Raw Strings to improve readability
+  [Zsolt Kovács](https://github.com/lordzsolt)
+  [#3050](https://github.com/realm/SwiftLint/issues/3050)
+
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
@@ -60,7 +60,7 @@ extension SwiftLintFile {
         }
         let contents = stringView
         let range = range ?? stringView.range
-        let pattern = "swiftlint:(enable|disable)(:previous|:this|:next)?\\ [^\\n]+"
+        let pattern = #"swiftlint:(enable|disable)(:previous|:this|:next)?\ [^\n]+"#
         return match(pattern: pattern, range: range).filter { match in
             return Set(match.1).isSubset(of: [.comment, .commentURL])
         }.compactMap { match -> Command? in

--- a/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
+++ b/Source/SwiftLintFramework/Helpers/RegexHelpers.swift
@@ -3,16 +3,16 @@ struct RegexHelpers {
     static let varName = "[a-zA-Z_][a-zA-Z0-9_]+"
 
     /// A single variable in a group (capturable)
-    static let varNameGroup = "\\s*(\(varName))\\s*"
+    static let varNameGroup = #"\s*(\#(varName))\s*"#
 
     /// Two variables (capturables)
     static let twoVars = "\(varNameGroup),\(varNameGroup)"
 
     /// A number
-    static let number = "[\\-0-9\\.]+"
+    static let number = #"[\-0-9\.]+"#
 
     /// A variable or a number (capturable)
-    static let variableOrNumber = "\\s*(\(varName)|\(number))\\s*"
+    static let variableOrNumber = #"\s*(\#(varName)|\#(number))\s*"#
 
     /// Two 'variable or number'
     static let twoVariableOrNumber = "\(variableOrNumber),\(variableOrNumber)"

--- a/Source/SwiftLintFramework/Reporters/MarkdownReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/MarkdownReporter.swift
@@ -39,7 +39,7 @@ public struct MarkdownReporter: Reporter {
     private static func severity(for severity: ViolationSeverity) -> String {
         switch severity {
         case .error:
-            return ":stop\\_sign:"
+            return #":stop\_sign:"#
         case .warning:
             return ":warning:"
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -16,8 +16,8 @@ public struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRu
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let booleanPattern = "Bool\\?"
-        let optionalPattern = "Optional\\.some\\(\\s*(true|false)\\s*\\)"
+        let booleanPattern = #"Bool\?"#
+        let optionalPattern = #"Optional\.some\(\s*(true|false)\s*\)"#
         let pattern = "(" + [booleanPattern, optionalPattern].joined(separator: "|") + ")"
         let excludingKinds = SyntaxKind.commentAndStringKinds
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
@@ -54,7 +54,7 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
             case let byteRange = ByteRange(location: start, length: end - start),
             case let contents = file.stringView,
             let range = file.stringView.byteRangeToNSRange(byteRange),
-            let match = file.match(pattern: "->\\s*(.*?)\\{", excludingSyntaxKinds: excludingKinds, range: range).first
+            let match = file.match(pattern: #"->\s*(.*?)\{"#, excludingSyntaxKinds: excludingKinds, range: range).first
             else { return [] }
 
         return contents.substring(with: match).optionalCollectionRanges().map { _ in nameOffset }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -49,7 +49,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
 
         // Grammar of import declaration
         // attributes(optional) import import-kind(optional) import-path
-        let regex = "^(\\w\\s)?import(\\s(\(importKinds)))?\\s+[a-zA-Z0-9._]+$"
+        let regex = #"^(\w\s)?import(\s(\#(importKinds)))?\s+[a-zA-Z0-9._]+$"#
         let importRanges = file.match(pattern: regex)
             .filter { $0.1.allSatisfy { [.keyword, .identifier].contains($0) } }
             .compactMap { contents.NSRangeToByteRange(start: $0.0.location, length: $0.0.length) }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -61,7 +61,7 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
         }
     }
 
-    private let initializerWithType = regex("^[A-Z][^(]*\\.init$")
+    private let initializerWithType = regex(#"^[A-Z][^(]*\.init$"#)
 
     public func violationRanges(in file: SwiftLintFile, kind: SwiftExpressionKind,
                                 dictionary: SourceKittenDictionary) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -117,7 +117,7 @@ private extension SourceKittenDictionary {
         let contents = file.stringView
         let contentAfterName = contents.nsString.substring(from: afterNameRange.location)
         let initCallRegex =
-            regex("^\\s*=\\s*(?:try[!?]?\\s+)?\\[?\\p{Lu}[^\\(\\s<]*(?:<[^\\>]*>)?(?::\\s*[^\\(\\n]+)?\\]?\\(")
+            regex(#"^\s*=\s*(?:try[!?]?\s+)?\[?\p{Lu}[^\(\s<]*(?:<[^\>]*>)?(?::\s*[^\(\n]+)?\]?\("#)
 
         return initCallRegex.firstMatch(in: contentAfterName, options: [], range: contentAfterName.fullNSRange) != nil
     }
@@ -134,7 +134,7 @@ private extension SourceKittenDictionary {
 
         let contents = file.stringView
         let contentAfterName = contents.nsString.substring(from: afterNameRange.location)
-        let typeAssignment = regex("^\\s*=\\s*(?:\\p{Lu}[^\\(\\s<]*(?:<[^\\>]*>)?\\.)*self")
+        let typeAssignment = regex(#"^\s*=\s*(?:\p{Lu}[^\(\s<]*(?:<[^\>]*>)?\.)*self"#)
 
         return typeAssignment.firstMatch(in: contentAfterName, options: [], range: contentAfterName.fullNSRange) != nil
     }
@@ -167,7 +167,7 @@ private extension SourceKittenDictionary {
 
 private extension SwiftLintFile {
     var captureGroupByteRanges: [ByteRange] {
-        return match(pattern: "\\{\\s*\\[(\\s*\\w+\\s+\\w+,*)+\\]",
+        return match(pattern: #"\{\s*\[(\s*\w+\s+\w+,*)+\]"#,
                      excludingSyntaxKinds: SyntaxKind.commentKinds)
                 .compactMap { stringView.NSRangeToByteRange(start: $0.location, length: $0.length) }
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -19,7 +19,7 @@ public struct FileNameRule: ConfigurationProviderRule, OptInRule {
         severity: .warning,
         excluded: ["main.swift", "LinuxMain.swift"],
         prefixPattern: "",
-        suffixPattern: "\\+.*",
+        suffixPattern: #"\+.*"#,
         nestedTypeSeparator: "."
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -39,8 +39,8 @@ public struct FileNameRule: ConfigurationProviderRule, OptInRule {
             return []
         }
 
-        let prefixRegex = regex("\\A(?:\(configuration.prefixPattern))")
-        let suffixRegex = regex("(?:\(configuration.suffixPattern))\\z")
+        let prefixRegex = regex(#"\A(?:\#(configuration.prefixPattern))"#)
+        let suffixRegex = regex(#"(?:\#(configuration.suffixPattern))\z"#)
 
         var typeInFileName = fileName.bridge().deletingPathExtension
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -154,12 +154,12 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
                 return false
             }
 
-            let containsKeyword = !file.match(pattern: "\\blet|var|case\\b", with: [.keyword], range: range).isEmpty
+            let containsKeyword = !file.match(pattern: #"\blet|var|case\b"#, with: [.keyword], range: range).isEmpty
             if containsKeyword {
                 return true
             }
 
-            return !file.match(pattern: "\\|\\||&&", with: [], range: range).isEmpty
+            return !file.match(pattern: #"\|\||&&"#, with: [], range: range).isEmpty
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -65,13 +65,13 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
 
     // capture previous of "!"
     // http://userguide.icu-project.org/strings/regexp
-    private static let pattern = "([^\\s\\p{Ps}])(!+)"
+    private static let pattern = #"([^\s\p{Ps}])(!+)"#
     // Match any variable declaration
     // Has a small bug in @IBOutlet due suffix "let"
     // But that does not compromise the filtering for var declarations
-    private static let varDeclarationPattern = "\\s?(?:let|var)\\s+[^=\\v{]*!"
+    private static let varDeclarationPattern = #"\s?(?:let|var)\s+[^=\v{]*!"#
 
-    private static let functionReturnPattern = "\\)\\s*->\\s*[^\\n\\{=]*!"
+    private static let functionReturnPattern = #"\)\s*->\s*[^\n\{=]*!"#
 
     private static let regularExpression = regex(pattern)
     private static let varDeclarationRegularExpression = regex(varDeclarationPattern)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -118,11 +118,11 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
 // MARK: - Legacy Implementation
 
 extension GenericTypeNameRule {
-    private static let genericTypePattern = "<(\\s*\\w.*?)>"
+    private static let genericTypePattern = #"<(\s*\w.*?)>"#
     private static let genericTypeRegex = regex(genericTypePattern)
 
     private func validateGenericTypeAliases(in file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "typealias\\s+\\w+?\\s*" + type(of: self).genericTypePattern + "\\s*="
+        let pattern = #"typealias\s+\w+?\s*"# + type(of: self).genericTypePattern + #"\s*="#
         return file.match(pattern: pattern).flatMap { range, tokens -> [(String, ByteCount)] in
             guard tokens.first == .keyword,
                 Set(tokens.dropFirst()) == [.identifier],
@@ -231,7 +231,7 @@ private extension String {
     func trimmingWhitespaces() -> (String, NSRange) {
         let bridged = bridge()
         let range = NSRange(location: 0, length: bridged.length)
-        guard let match = regex("^\\s*(\\S*)\\s*$").firstMatch(in: self, options: [], range: range),
+        guard let match = regex(#"^\s*(\S*)\s*$"#).firstMatch(in: self, options: [], range: range),
             NSEqualRanges(range, match.range)
         else {
             return (self, range)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/IsDisjointRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/IsDisjointRule.swift
@@ -23,7 +23,7 @@ public struct IsDisjointRule: ConfigurationProviderRule, AutomaticTestableRule {
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "\\bintersection\\(\\S+\\)\\.isEmpty"
+        let pattern = #"\bintersection\(\S+\)\.isEmpty"#
         let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: type(of: self).description,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -90,7 +90,7 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
                          "CGRectIntersection", "CGRectContainsRect", "CGRectContainsPoint",
                          "CGRectIntersectsRect"]
 
-        let pattern = "\\b(" + functions.joined(separator: "|") + ")\\b"
+        let pattern = #"\b("# + functions.joined(separator: "|") + #")\b"#
 
         return file.match(pattern: pattern, with: [.identifier]).map {
             StyleViolation(ruleDescription: type(of: self).description,
@@ -104,26 +104,26 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         let twoVars = RegexHelpers.twoVars
         let twoVariableOrNumber = RegexHelpers.twoVariableOrNumber
         let patterns: [String: String] = [
-            "CGRectGetWidth\\(\(varName)\\)": "$1.width",
-            "CGRectGetHeight\\(\(varName)\\)": "$1.height",
-            "CGRectGetMinX\\(\(varName)\\)": "$1.minX",
-            "CGRectGetMidX\\(\(varName)\\)": "$1.midX",
-            "CGRectGetMaxX\\(\(varName)\\)": "$1.maxX",
-            "CGRectGetMinY\\(\(varName)\\)": "$1.minY",
-            "CGRectGetMidY\\(\(varName)\\)": "$1.midY",
-            "CGRectGetMaxY\\(\(varName)\\)": "$1.maxY",
-            "CGRectIsNull\\(\(varName)\\)": "$1.isNull",
-            "CGRectIsEmpty\\(\(varName)\\)": "$1.isEmpty",
-            "CGRectIsInfinite\\(\(varName)\\)": "$1.isInfinite",
-            "CGRectStandardize\\(\(varName)\\)": "$1.standardized",
-            "CGRectIntegral\\(\(varName)\\)": "$1.integral",
-            "CGRectInset\\(\(varName),\(twoVariableOrNumber)\\)": "$1.insetBy(dx: $2, dy: $3)",
-            "CGRectOffset\\(\(varName),\(twoVariableOrNumber)\\)": "$1.offsetBy(dx: $2, dy: $3)",
-            "CGRectUnion\\(\(twoVars)\\)": "$1.union($2)",
-            "CGRectIntersection\\(\(twoVars)\\)": "$1.intersect($2)",
-            "CGRectContainsRect\\(\(twoVars)\\)": "$1.contains($2)",
-            "CGRectContainsPoint\\(\(twoVars)\\)": "$1.contains($2)",
-            "CGRectIntersectsRect\\(\(twoVars)\\)": "$1.intersects($2)"
+            #"CGRectGetWidth\(\#(varName)\)"#: "$1.width",
+            #"CGRectGetHeight\(\#(varName)\)"#: "$1.height",
+            #"CGRectGetMinX\(\#(varName)\)"#: "$1.minX",
+            #"CGRectGetMidX\(\#(varName)\)"#: "$1.midX",
+            #"CGRectGetMaxX\(\#(varName)\)"#: "$1.maxX",
+            #"CGRectGetMinY\(\#(varName)\)"#: "$1.minY",
+            #"CGRectGetMidY\(\#(varName)\)"#: "$1.midY",
+            #"CGRectGetMaxY\(\#(varName)\)"#: "$1.maxY",
+            #"CGRectIsNull\(\#(varName)\)"#: "$1.isNull",
+            #"CGRectIsEmpty\(\#(varName)\)"#: "$1.isEmpty",
+            #"CGRectIsInfinite\(\#(varName)\)"#: "$1.isInfinite",
+            #"CGRectStandardize\(\#(varName)\)"#: "$1.standardized",
+            #"CGRectIntegral\(\#(varName)\)"#: "$1.integral",
+            #"CGRectInset\(\#(varName),\#(twoVariableOrNumber)\)"#: "$1.insetBy(dx: $2, dy: $3)",
+            #"CGRectOffset\(\#(varName),\#(twoVariableOrNumber)\)"#: "$1.offsetBy(dx: $2, dy: $3)",
+            #"CGRectUnion\(\#(twoVars)\)"#: "$1.union($2)",
+            #"CGRectIntersection\(\#(twoVars)\)"#: "$1.intersect($2)",
+            #"CGRectContainsRect\(\#(twoVars)\)"#: "$1.contains($2)",
+            #"CGRectContainsPoint\(\#(twoVars)\)"#: "$1.contains($2)",
+            #"CGRectIntersectsRect\(\#(twoVars)\)"#: "$1.intersects($2)"
         ]
         return file.correct(legacyRule: self, patterns: patterns)
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
@@ -23,7 +23,7 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule, Au
     private static let legacyPatterns = LegacyConstantRuleExamples.patterns
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "\\b" + LegacyConstantRule.legacyConstants.joined(separator: "|")
+        let pattern = #"\b"# + LegacyConstantRule.legacyConstants.joined(separator: "|")
 
         return file.match(pattern: pattern, range: nil)
             .filter { Set($0.1).isSubset(of: [.identifier]) }
@@ -38,7 +38,7 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule, Au
     public func correct(file: SwiftLintFile) -> [Correction] {
         var wordBoundPatterns: [String: String] = [:]
         LegacyConstantRule.legacyPatterns.forEach { key, value in
-            wordBoundPatterns["\\b" + key] = value
+            wordBoundPatterns[#"\b"# + key] = value
         }
 
         return file.correct(legacyRule: self, patterns: wordBoundPatterns)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRuleExamples.swift
@@ -49,7 +49,7 @@ internal struct LegacyConstantRuleExamples {
         "NSZeroRect": "NSRect.zero",
         "NSZeroSize": "NSSize.zero",
         "CGRectNull": "CGRect.null",
-        "CGFloat\\(M_PI\\)": "CGFloat.pi",
-        "Float\\(M_PI\\)": "Float.pi"
+        #"CGFloat\(M_PI\)"#: "CGFloat.pi",
+        #"Float\(M_PI\)"#: "Float.pi"
     ]
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -42,7 +42,7 @@ public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, Automati
     // MARK: - Rule
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "(?!\\b\\s*)%\(RegexHelpers.variableOrNumber)[=!]=\\s*0\\b"
+        let pattern = #"(?!\b\s*)%\#(RegexHelpers.variableOrNumber)[=!]=\s*0\b"#
         return file.match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
             .map {
                 StyleViolation(ruleDescription: type(of: self).description,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -89,7 +89,7 @@ public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
                          "NSOffsetRect", "NSUnionRect", "NSIntersectionRect",
                          "NSContainsRect", "NSPointInRect", "NSIntersectsRect"]
 
-        let pattern = "\\b(" + functions.joined(separator: "|") + ")\\b"
+        let pattern = #"\b("# + functions.joined(separator: "|") + #")\b"#
 
         return file.match(pattern: pattern, with: [.identifier]).map {
             StyleViolation(ruleDescription: type(of: self).description,
@@ -103,27 +103,27 @@ public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         let twoVars = RegexHelpers.twoVars
         let twoVariableOrNumber = RegexHelpers.twoVariableOrNumber
         let patterns: [String: String] = [
-            "NSWidth\\(\(varName)\\)": "$1.width",
-            "NSHeight\\(\(varName)\\)": "$1.height",
-            "NSMinX\\(\(varName)\\)": "$1.minX",
-            "NSMidX\\(\(varName)\\)": "$1.midX",
-            "NSMaxX\\(\(varName)\\)": "$1.maxX",
-            "NSMinY\\(\(varName)\\)": "$1.minY",
-            "NSMidY\\(\(varName)\\)": "$1.midY",
-            "NSMaxY\\(\(varName)\\)": "$1.maxY",
-            "NSEqualRects\\(\(twoVars)\\)": "$1 == $2",
-            "NSEqualSizes\\(\(twoVars)\\)": "$1 == $2",
-            "NSEqualPoints\\(\(twoVars)\\)": "$1 == $2",
-            "NSEdgeInsetsEqual\\(\(twoVars)\\)": "$1 == $2",
-            "NSIsEmptyRect\\(\(varName)\\)": "$1.isEmpty",
-            "NSIntegralRect\\(\(varName)\\)": "$1.integral",
-            "NSInsetRect\\(\(varName),\(twoVariableOrNumber)\\)": "$1.insetBy(dx: $2, dy: $3)",
-            "NSOffsetRect\\(\(varName),\(twoVariableOrNumber)\\)": "$1.offsetBy(dx: $2, dy: $3)",
-            "NSUnionRect\\(\(twoVars)\\)": "$1.union($2)",
-            "NSIntersectionRect\\(\(twoVars)\\)": "$1.intersect($2)",
-            "NSContainsRect\\(\(twoVars)\\)": "$1.contains($2)",
-            "NSPointInRect\\(\(twoVars)\\)": "$2.contains($1)", // note order of arguments
-            "NSIntersectsRect\\(\(twoVars)\\)": "$1.intersects($2)"
+            #"NSWidth\(\#(varName)\)"#: "$1.width",
+            #"NSHeight\(\#(varName)\)"#: "$1.height",
+            #"NSMinX\(\#(varName)\)"#: "$1.minX",
+            #"NSMidX\(\#(varName)\)"#: "$1.midX",
+            #"NSMaxX\(\#(varName)\)"#: "$1.maxX",
+            #"NSMinY\(\#(varName)\)"#: "$1.minY",
+            #"NSMidY\(\#(varName)\)"#: "$1.midY",
+            #"NSMaxY\(\#(varName)\)"#: "$1.maxY",
+            #"NSEqualRects\(\#(twoVars)\)"#: "$1 == $2",
+            #"NSEqualSizes\(\#(twoVars)\)"#: "$1 == $2",
+            #"NSEqualPoints\(\#(twoVars)\)"#: "$1 == $2",
+            #"NSEdgeInsetsEqual\(\#(twoVars)\)"#: "$1 == $2",
+            #"NSIsEmptyRect\(\#(varName)\)"#: "$1.isEmpty",
+            #"NSIntegralRect\(\#(varName)\)"#: "$1.integral",
+            #"NSInsetRect\(\#(varName),\#(twoVariableOrNumber)\)"#: "$1.insetBy(dx: $2, dy: $3)",
+            #"NSOffsetRect\(\#(varName),\#(twoVariableOrNumber)\)"#: "$1.offsetBy(dx: $2, dy: $3)",
+            #"NSUnionRect\(\#(twoVars)\)"#: "$1.union($2)",
+            #"NSIntersectionRect\(\#(twoVars)\)"#: "$1.intersect($2)",
+            #"NSContainsRect\(\#(twoVars)\)"#: "$1.contains($2)",
+            #"NSPointInRect\(\#(twoVars)\)"#: "$2.contains($1)", // note order of arguments
+            #"NSIntersectsRect\(\#(twoVars)\)"#: "$1.intersects($2)"
         ]
         return file.correct(legacyRule: self, patterns: patterns)
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -101,7 +101,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
     }
 
     private func violationMatchesRanges(in file: SwiftLintFile) -> [NSRange] {
-        let operandPattern = "(.(?!expect\\())+?"
+        let operandPattern = #"(.(?!expect\())+?"#
 
         let operatorsPattern = "(" + predicatesMapping.map { name, predicateDescription in
             let argumentsPattern = predicateDescription.arity.hasArguments
@@ -176,7 +176,7 @@ private extension String {
     func replace(function name: NimbleOperatorRule.MatcherFunction,
                  with predicateDescription: NimbleOperatorRule.PredicateDescription,
                  in range: NSRange) -> String? {
-        let anything = "\\s*(.*?)\\s*"
+        let anything = #"\s*(.*?)\s*"#
 
         let toPattern = ("expect\\(\(anything)\\)\\.to\\(\(name)\\(\(anything)\\)\\)", predicateDescription.to)
         let toNotPattern = ("expect\\(\(anything)\\)\\.toNot\\(\(name)\\(\(anything)\\)\\)", predicateDescription.toNot)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -108,10 +108,10 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
                 ? operandPattern
                 : ""
 
-            return "\(name)\\(\(argumentsPattern)\\)"
+            return #"\#(name)\(\#(argumentsPattern)\)"#
         }.joined(separator: "|") + ")"
 
-        let pattern = "expect\\(\(operandPattern)\\)\\.to(Not)?\\(\(operatorsPattern)\\)"
+        let pattern = #"expect\(\#(operandPattern)\)\.to(Not)?\(\#(operatorsPattern)\)"#
 
         let excludingKinds = SyntaxKind.commentKinds
 
@@ -178,8 +178,8 @@ private extension String {
                  in range: NSRange) -> String? {
         let anything = #"\s*(.*?)\s*"#
 
-        let toPattern = ("expect\\(\(anything)\\)\\.to\\(\(name)\\(\(anything)\\)\\)", predicateDescription.to)
-        let toNotPattern = ("expect\\(\(anything)\\)\\.toNot\\(\(name)\\(\(anything)\\)\\)", predicateDescription.toNot)
+        let toPattern = (#"expect\(\#(anything)\)\.to\(\#(name)\(\#(anything)\)\)"#, predicateDescription.to)
+        let toNotPattern = (#"expect\(\#(anything)\)\.toNot\(\#(name)\(\#(anything)\)\)"#, predicateDescription.toNot)
 
         for case let (pattern, operatorString?) in [toPattern, toNotPattern] {
             let expression = regex(pattern)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -29,7 +29,7 @@ public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule, Automat
 
         let caseBodyRange = NSRange(location: colonLocation,
                                     length: range.length + range.location - colonLocation)
-        let nonCommentCaseBody = file.match(pattern: "\\w+", range: caseBodyRange).filter { _, syntaxKinds in
+        let nonCommentCaseBody = file.match(pattern: #"\w+"#, range: caseBodyRange).filter { _, syntaxKinds in
             return !Set(syntaxKinds).subtracting(SyntaxKind.commentKinds).isEmpty
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -56,6 +56,6 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
             return false
         }
 
-        return !file.match(pattern: "\\bwhere\\b", with: [.keyword], range: range).isEmpty
+        return !file.match(pattern: #"\bwhere\b"#, with: [.keyword], range: range).isEmpty
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -49,8 +49,8 @@ public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, O
                 return []
             }
 
-            let letMatches = file.match(pattern: "\\blet\\b", with: [.keyword], range: caseRange)
-            let varMatches = file.match(pattern: "\\bvar\\b", with: [.keyword], range: caseRange)
+            let letMatches = file.match(pattern: #"\blet\b"#, with: [.keyword], range: caseRange)
+            let varMatches = file.match(pattern: #"\bvar\b"#, with: [.keyword], range: caseRange)
 
             if !letMatches.isEmpty && !varMatches.isEmpty {
                 return []

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -41,6 +41,6 @@ public struct RedundantNilCoalescingRule: OptInRule, SubstitutionCorrectableRule
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file.match(pattern: "\\s?\\?{2}\\s*nil\\b", with: [.keyword])
+        return file.match(pattern: #"\s?\?{2}\s*nil\b"#, with: [.keyword])
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -99,7 +99,7 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
         return corrections
     }()
 
-    private let pattern = "\\s*=\\s*nil\\b"
+    private let pattern = #"\s*=\s*nil\b"#
 
     public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
@@ -162,7 +162,7 @@ extension SourceKittenDictionary {
         guard let byteRange = byteRange,
             case let contents = file.stringView,
             let range = contents.byteRangeToNSRange(byteRange),
-            !file.match(pattern: "\\Avar\\b", with: [.keyword], range: range).isEmpty else {
+            !file.match(pattern: #"\Avar\b"#, with: [.keyword], range: range).isEmpty else {
                 return false
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -69,8 +69,8 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        let pattern = "(var|let)\\s?\\w+\(typeAnnotationPattern)\\s?=\\s?\\w+(\\(|.)"
         let typeAnnotationPattern = #":\s?\w+"#
+        let pattern = #"(var|let)\s?\w+\#(typeAnnotationPattern)\s?=\s?\w+(\(|.)"#
         let foundRanges = file.match(pattern: pattern, with: [.keyword, .identifier, .typeidentifier, .identifier])
         return foundRanges
             .filter { !isFalsePositive(in: file, range: $0) && !isIBInspectable(range: $0, file: file) }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -69,8 +69,8 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        let typeAnnotationPattern = ":\\s?\\w+"
         let pattern = "(var|let)\\s?\\w+\(typeAnnotationPattern)\\s?=\\s?\\w+(\\(|.)"
+        let typeAnnotationPattern = #":\s?\w+"#
         let foundRanges = file.match(pattern: pattern, with: [.keyword, .identifier, .typeidentifier, .identifier])
         return foundRanges
             .filter { !isFalsePositive(in: file, range: $0) && !isIBInspectable(range: $0, file: file) }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -57,7 +57,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
         ]
     )
 
-    private let pattern = "\\s*->\\s*(?:Void\\b|\\(\\s*\\))(?![?!])"
+    private let pattern = #"\s*->\s*(?:Void\b|\(\s*\))(?![?!])"#
     private let excludingKinds = SyntaxKind.allKinds.subtracting([.typeidentifier])
     private let functionKinds = SwiftDeclarationKind.functionKinds.subtracting([.functionSubscript])
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -6,8 +6,8 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
 
     private var pattern: String {
         let types = ["Optional", "ImplicitlyUnwrappedOptional", "Array", "Dictionary"]
-        let negativeLookBehind = "(?:(?<!\\.)|Swift\\.)"
-        return negativeLookBehind + "\\b(" + types.joined(separator: "|") + ")\\s*<.*?>"
+        let negativeLookBehind = #"(?:(?<!\.)|Swift\.)"#
+        return negativeLookBehind + #"\b("# + types.joined(separator: "|") + #")\s*<.*?>"#
     }
 
     public init() {}
@@ -150,7 +150,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
         // avoid triggering when referring to an associatedtype
         let start = range.location + range.length
         let restOfFileRange = NSRange(location: start, length: contents.nsString.length - start)
-        if regex("\\s*\\.").firstMatch(in: file.contents, options: [],
+        if regex(#"\s*\."#).firstMatch(in: file.contents, options: [],
                                        range: restOfFileRange)?.range.location == start {
             guard let byteOffset = contents.NSRangeToByteRange(start: range.location,
                                                                length: range.length)?.location else {
@@ -162,7 +162,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
                 return false
             }
 
-            if let (range, kinds) = file.match(pattern: "\\s*\\.(?:self|Type)", range: restOfFileRange).first,
+            if let (range, kinds) = file.match(pattern: #"\s*\.(?:self|Type)"#, range: restOfFileRange).first,
                 range.location == start, kinds == [.keyword] || kinds == [.identifier] {
                 return false
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -41,7 +41,7 @@ public struct ToggleBoolRule: SubstitutionCorrectableRule, ConfigurationProvider
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        let pattern = "(?<![\\w.])([\\w.]+) = !\\1\\b"
+        let pattern = #"(?<![\w.])([\w.]+) = !\1\b"#
         let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds)
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -37,7 +37,7 @@ public struct TrailingSemicolonRule: SubstitutionCorrectableRule, ConfigurationP
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file.match(pattern: "(;+([^\\S\\n]?)*)+;?$",
+        return file.match(pattern: #"(;+([^\S\n]?)*)+;?$"#,
                           excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -42,7 +42,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
             return []
         }
 
-        let rangesAndTokens = file.rangesAndTokens(matching: "(typealias|associatedtype)\\s+.+?\\b")
+        let rangesAndTokens = file.rangesAndTokens(matching: #"(typealias|associatedtype)\s+.+?\b"#)
         return rangesAndTokens.flatMap { _, tokens -> [StyleViolation] in
             guard tokens.count == 2,
                 let keywordToken = tokens.first,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -67,7 +67,7 @@ public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptIn
             !isFunctionUnavailable(file: file, dictionary: dictionary),
             let bodyRange = dictionary.bodyByteRange,
             let range = file.stringView.byteRangeToNSRange(bodyRange),
-            file.match(pattern: "\\breturn\\b", with: [.keyword], range: range).isEmpty else {
+            file.match(pattern: #"\breturn\b"#, with: [.keyword], range: range).isEmpty else {
                 return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -7,27 +7,27 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, Aut
     public init() {}
 
     private static let regularExpression =
-        "catch" + // The catch keyword
-        "(?:"   + // Start of the first non-capturing group
-        "\\s*"  + // Zero or multiple whitespace character
-        "\\("   + // The `(` character
-        "?"     + // Zero or one occurrence of the previous character
-        "\\s*"  + // Zero or multiple whitespace character
-        "(?:"   + // Start of the alternative non-capturing group
-        "let"   + // `let` keyword
-        "|"     + // OR
-        "var"   + // `var` keyword
-        ")"     + // End of the alternative non-capturing group
-        "\\s+"  + // At least one any type of whitespace character
-        "\\w+"  + // At least one any type of word character
-        "\\s*"  + // Zero or multiple whitespace character
-        "\\)"   + // The `)` character
-        "?"     + // Zero or one occurrence of the previous character
-        ")"     + // End of the first non-capturing group
-        "(?:"   + // Start of the second non-capturing group
-        "\\s*"  + // Zero or unlimited any whitespace character
-        ")"     + // End of the second non-capturing group
-        "\\{"     // Start scope character
+        "catch" +   // The catch keyword
+        "(?:"   +   // Start of the first non-capturing group
+        #"\s*"#  +  // Zero or multiple whitespace character
+        #"\("#   +  // The `(` character
+        "?"     +   // Zero or one occurrence of the previous character
+        #"\s*"#  +  // Zero or multiple whitespace character
+        "(?:"   +   // Start of the alternative non-capturing group
+        "let"   +   // `let` keyword
+        "|"     +   // OR
+        "var"   +   // `var` keyword
+        ")"     +   // End of the alternative non-capturing group
+        #"\s+"#  +  // At least one any type of whitespace character
+        #"\w+"#  +  // At least one any type of word character
+        #"\s*"#  +  // Zero or multiple whitespace character
+        #"\)"#   +  // The `)` character
+        "?"     +   // Zero or one occurrence of the previous character
+        ")"     +   // End of the first non-capturing group
+        "(?:"   +   // Start of the second non-capturing group
+        #"\s*"#  +  // Zero or unlimited any whitespace character
+        ")"     +   // End of the second non-capturing group
+        #"\{"#      // Start scope character
 
     public static let description = RuleDescription(
         identifier: "untyped_error_in_catch",

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -95,7 +95,7 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
             return false
         }
 
-        let pattern = regex("\\A\\s*\\(?\\s*\\{")
+        let pattern = regex(#"\A\s*\(?\s*\{"#)
         return pattern.firstMatch(in: file.contents, options: .anchored, range: nsRange) != nil
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -80,7 +80,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule, Aut
     }
 
     private func isClassProtocol(file: SwiftLintFile, range: NSRange) -> Bool {
-        return !file.match(pattern: "\\bclass\\b", with: [.keyword], range: range).isEmpty
+        return !file.match(pattern: #"\bclass\b"#, with: [.keyword], range: range).isEmpty
     }
 
     private func isDelegateProtocol(_ name: String) -> Bool {

--- a/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
@@ -48,7 +48,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
     }
 
     private func validateConditions(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "#available\\s*\\([^\\(]+\\)"
+        let pattern = #"#available\s*\([^\(]+\)"#
 
         return file.rangesAndTokens(matching: pattern).flatMap { range, tokens -> [StyleViolation] in
             guard let availabilityToken = tokens.first,
@@ -98,7 +98,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
                           byteOffsetToReport: ByteCount) -> [StyleViolation] {
         let platformToConfiguredMinVersion = self.platformToConfiguredMinVersion
         let allPlatforms = "(?:" + platformToConfiguredMinVersion.keys.joined(separator: "|") + ")"
-        let pattern = "\(allPlatforms) [\\d\\.]+"
+        let pattern = #"\#(allPlatforms) [\d\.]+"#
 
         return file.rangesAndTokens(matching: pattern, range: range).compactMap { _, tokens -> StyleViolation? in
             guard tokens.count == 2,

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -73,17 +73,17 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
                 return []
         }
 
-        if let lastMatch = regex("\\b[^\\(]+").matches(in: file.contents, options: [], range: range).last?.range,
+        if let lastMatch = regex(#"\b[^\(]+"#).matches(in: file.contents, options: [], range: range).last?.range,
             lastMatch.location == range.length - lastMatch.length - 1 {
             return []
         }
 
-        if let lastMatch = regex("\\s?=\\s*").matches(in: file.contents, options: [], range: range).last?.range,
+        if let lastMatch = regex(#"\s?=\s*"#).matches(in: file.contents, options: [], range: range).last?.range,
             lastMatch.location == range.length - lastMatch.length {
             return []
         }
 
-        if let lastMatch = file.match(pattern: "\\breturn\\s+", with: [.keyword], range: range).last,
+        if let lastMatch = file.match(pattern: #"\breturn\s+"#, with: [.keyword], range: range).last,
             lastMatch.location == range.length - lastMatch.length,
             let lastFunction = file.structureDictionary.functions(forByteOffset: offset).last,
             !lastFunction.enclosedSwiftAttributes.contains(.discardableResult) {

--- a/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
@@ -42,7 +42,7 @@ public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule, AutomaticTe
             inlineMatch.range.location != NSNotFound,
             case let attributeRange = NSRange(location: inlineMatch.range.location,
                                               length: funcOffset - inlineMatch.range.location),
-            case let alwaysInlinePattern = regex("@inline\\(\\s*__always\\s*\\)"),
+            case let alwaysInlinePattern = regex(#"@inline\(\s*__always\s*\)"#),
             alwaysInlinePattern.firstMatch(in: file.contents, options: [], range: attributeRange) != nil
         else {
             return []

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -44,7 +44,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         // swiftlint:disable:next line_length
-        let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{2,4}\\\(configuration.dateSeparator)\\d{2}\\\(configuration.dateSeparator)\\d{2,4})\\\(configuration.dateDelimiters.closing)"
+        let regex = #"\b(?:TODO|FIXME)(?::|\b)(?:.*)\\#(configuration.dateDelimiters.opening)(\d{2,4}\\#(configuration.dateSeparator)\d{2}\\#(configuration.dateSeparator)\d{2,4})\\#(configuration.dateDelimiters.closing)"#
 
         return file.matchesAndSyntaxKinds(matching: regex).compactMap { checkingResult, syntaxKinds in
             guard

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -69,7 +69,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let operators = type(of: self).operators.joined(separator: "|")
         return
-            file.matchesAndTokens(matching: "\\s(" + operators + ")\\s")
+            file.matchesAndTokens(matching: #"\s("# + operators + #")\s"#)
                 .filter { _, tokens in tokens.isEmpty }
                 .compactMap { matchResult, _ in violationRangeFrom(match: matchResult, in: file) }
                 .map { range in
@@ -201,6 +201,6 @@ private extension StringView {
         guard let betweenTokens = subStringBetweenTokens(startToken, endToken) else { return false }
 
         let range = betweenTokens.fullNSRange
-        return !regex("^\\s*\(regexString)\\s*$").matches(in: betweenTokens, options: [], range: range).isEmpty
+        return !regex(#"^\s*\#(regexString)\s*$"#).matches(in: betweenTokens, options: [], range: range).isEmpty
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
@@ -52,7 +52,7 @@ public struct InertDeferRule: ConfigurationProviderRule, AutomaticTestableRule {
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let defers = file.match(pattern: "defer\\s*\\{", with: [.keyword])
+        let defers = file.match(pattern: #"defer\s*\{"#, with: [.keyword])
 
         return defers.compactMap { range -> StyleViolation? in
             let contents = file.stringView

--- a/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
@@ -85,8 +85,8 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
     private let missingColonPattern = "(?:// ?MARK[^:])"
     // The below patterns more specifically describe some of the above pattern's failure cases for correction.
     private let oneOrMoreSpacesBeforeColonPattern = "(?:// ?MARK +:)"
-    private let nonWhitespaceBeforeColonPattern = "(?:// ?MARK\\S+:)"
-    private let nonWhitespaceNorColonBeforeSpacesPattern = "(?:// ?MARK[^\\s:]* +)"
+    private let nonWhitespaceBeforeColonPattern = #"(?:// ?MARK\S+:)"#
+    private let nonWhitespaceNorColonBeforeSpacesPattern = #"(?:// ?MARK[^\s:]* +)"#
     private let threeSlashesInsteadOfTwo = "/// MARK:?"
 
     private var pattern: String {

--- a/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
@@ -72,7 +72,7 @@ public struct TodoRule: ConfigurationProviderRule {
     }
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return file.match(pattern: "\\b(?:TODO|FIXME)(?::|\\b)").compactMap { range, syntaxKinds in
+        return file.match(pattern: #"\b(?:TODO|FIXME)(?::|\b)"#).compactMap { range, syntaxKinds in
             if syntaxKinds.contains(where: { !$0.isCommentLike }) {
                 return nil
             }

--- a/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -32,7 +32,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
         guard kind == .closure, let bodyRange = dictionary.bodyByteRange,
             case let contents = file.stringView,
             let closureRange = contents.byteRangeToNSRange(bodyRange),
-            let inTokenRange = file.match(pattern: "\\bin\\b", with: [.keyword], range: closureRange).first,
+            let inTokenRange = file.match(pattern: #"\bin\b"#, with: [.keyword], range: closureRange).first,
             let inTokenByteRange = contents.NSRangeToByteRange(start: inTokenRange.location,
                                                                length: inTokenRange.length)
         else {

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
@@ -72,7 +72,7 @@ public struct UnusedCaptureListRule: ASTRule, ConfigurationProviderRule, Automat
         ]
     )
 
-    private let captureListRegex = regex("^\\{\\s*\\[([^\\]]+)\\]")
+    private let captureListRegex = regex(#"^\{\s*\[([^\]]+)\]"#)
 
     public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -189,7 +189,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
     private func isClosure(dictionary: SourceKittenDictionary) -> Bool {
         return dictionary.name.flatMap { name -> Bool in
             let range = name.fullNSRange
-            return regex("\\A[\\s\\(]*?\\{").firstMatch(in: name, options: [], range: range) != nil
+            return regex(#"\A[\s\(]*?\{"#).firstMatch(in: name, options: [], range: range) != nil
         } ?? false
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -121,7 +121,7 @@ public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, Config
             let tokenContent = file.contents(for: firstToken),
             case let contents = file.stringView,
             let range = contents.byteRangeToNSRange(byteRange),
-            case let pattern = "(?:break|continue)\\s+\(tokenContent)\\b",
+            case let pattern = #"(?:break|continue)\s+\#(tokenContent)\b"#,
             file.match(pattern: pattern, with: [.keyword, .identifier], range: range).isEmpty,
             let violationRange = contents.byteRangeToNSRange(firstToken.range)
         else {

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -183,7 +183,7 @@ private extension SwiftLintFile {
     func rangedAndSortedUnusedImports(of unusedImports: [String], contents: NSString) -> [(String, NSRange)] {
         return unusedImports
             .compactMap { module in
-                match(pattern: "^(@[\\w_]+ +)?import +\(module)\\b.*?\n").first.map { (module, $0.0) }
+                match(pattern: #"^(@[\w_]+ +)?import +\#(module)\b.*?\n"#).first.map { (module, $0.0) }
             }
             .sorted(by: { $0.1.location < $1.1.location })
     }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -142,7 +142,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
             }
 
             let argumentName = argument?.name ?? "newValue"
-            guard file.match(pattern: "\\b\(argumentName)\\b", with: [.identifier], range: setterRange).isEmpty else {
+            guard file.match(pattern: #"\b\#(argumentName)\b"#, with: [.identifier], range: setterRange).isEmpty else {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -99,7 +99,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let setTokens = file.rangesAndTokens(matching: "\\bset\\b").keywordTokens()
+        let setTokens = file.rangesAndTokens(matching: #"\bset\b"#).keywordTokens()
 
         let violatingLocations = setTokens.compactMap { setToken -> ByteCount? in
             // the last element is the deepest structure
@@ -175,7 +175,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
 
     private func findGetToken(in range: NSRange, file: SwiftLintFile,
                               propertyStructure: SourceKittenDictionary) -> SwiftLintSyntaxToken? {
-        let getTokens = file.rangesAndTokens(matching: "\\bget\\b", range: range).keywordTokens()
+        let getTokens = file.rangesAndTokens(matching: #"\bget\b"#, range: range).keywordTokens()
         return getTokens.first(where: { token -> Bool in
             // the last element is the deepest structure
             guard let dict = declarations(forByteOffset: token.offset,

--- a/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
@@ -9,25 +9,25 @@ public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
     private static let regularExpression = regex(
         "(?<!" +                      // Starting negative lookbehind
         "(" +                         // First capturing group
-        "\\+|-|\\*|\\/|%|\\?" +       // One of the operators
+        #"\+|-|\*|\/|%|\?"# +         // One of the operators
         ")" +                         // Ending negative lookbehind
         ")" +                         // End first capturing group
-        "\\s+" +                      // Starting with whitespace
+        #"\s+"# +                     // Starting with whitespace
         "(" +                         // Second capturing group
-        "(?:\\\"[\\\"\\w\\ ]+\")" +   // Multiple words between quotes
+        #"(?:\"[\"\w\ ]+")"# +        // Multiple words between quotes
         "|" +                         // OR
-        "(?:\\d+" +                   // Number of digits
-        "(?:\\.\\d*)?)" +             // Optionally followed by a dot and any number digits
+        #"(?:\d+"# +                  // Number of digits
+        #"(?:\.\d*)?)"# +             // Optionally followed by a dot and any number digits
         "|" +                         // OR
         "(nil)" +                     // `nil` value
         ")" +                         // End second capturing group
-        "\\s+" +                      // Followed by whitespace
+        #"\s+"# +                     // Followed by whitespace
         "(" +                         // Third capturing group
         "==|!=|>|<|>=|<=" +           // One of comparison operators
         ")" +                         // End third capturing group
-        "\\s+" +                      // Followed by whitespace
+        #"\s+"# +                     // Followed by whitespace
         "(" +                         // Fourth capturing group
-        "\\w+" +                      // Number of words
+        #"\w+"# +                     // Number of words
         ")"                           // End fourth capturing group
     )
     private let observedStatements: Set<StatementKind> = [.if, .guard, .repeatWhile, .while]

--- a/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
@@ -194,7 +194,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule, AutomaticTesta
     }
 
     private func containsReturnArrow(in text: String, range: NSRange) -> Bool {
-        let arrowRegex = regex("\\A(?:\\s*throws)?\\s*->")
+        let arrowRegex = regex(#"\A(?:\s*throws)?\s*->"#)
         let start = NSMaxRange(range)
         let restOfStringRange = NSRange(location: start, length: text.bridge().length - start)
 

--- a/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
@@ -140,9 +140,9 @@ private extension String {
         // Workaround for Linux until NSDataDetector is available
         #if os(Linux)
             // Regex pattern from http://daringfireball.net/2010/07/improved_regex_for_matching_urls
-            let pattern = "(?i)\\b((?:[a-z][\\w-]+:(?:/{1,3}|[a-z0-9%])|www\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}/)" +
-                "(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*" +
-                "\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))"
+            let pattern = #"(?i)\b((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)"# +
+                #"(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*"# +
+                #"\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))"#
             let urlRegex = regex(pattern)
             return urlRegex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "")
         #else

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -31,7 +31,7 @@ public struct ContainsOverFilterCountRule: CallPairRule, OptInRule, Configuratio
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "[\\}\\)]\\s*\\.count\\s*(?:!=|==|>)\\s*0\\b"
+        let pattern = #"[\}\)]\s*\.count\s*(?:!=|==|>)\s*0\b"#
         return validate(file: file, pattern: pattern, patternSyntaxKinds: [.identifier, .number],
                         callNameSuffix: ".filter", severity: configuration.severity)
     }

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -29,7 +29,7 @@ public struct ContainsOverFilterIsEmptyRule: CallPairRule, OptInRule, Configurat
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "[\\}\\)]\\s*\\.isEmpty\\b"
+        let pattern = #"[\}\)]\s*\.isEmpty\b"#
         return validate(file: file, pattern: pattern, patternSyntaxKinds: [.identifier],
                         callNameSuffix: ".filter", severity: configuration.severity)
     }

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -31,7 +31,7 @@ public struct ContainsOverFirstNotNilRule: CallPairRule, OptInRule, Configuratio
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "[\\}\\)]\\s*(==|!=)\\s*nil"
+        let pattern = #"[\}\)]\s*(==|!=)\s*nil"#
         let firstViolations = validate(file: file, pattern: pattern, patternSyntaxKinds: [.keyword],
                                        callNameSuffix: ".first", severity: configuration.severity,
                                        reason: "Prefer `contains` over `first(where:) != nil`")

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -25,7 +25,7 @@ public struct ContainsOverRangeNilComparisonRule: CallPairRule, OptInRule, Confi
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "\\)\\s*(==|!=)\\s*nil"
+        let pattern = #"\)\s*(==|!=)\s*nil"#
         return validate(file: file, pattern: pattern, patternSyntaxKinds: [.keyword],
                         callNameSuffix: ".range", severity: configuration.severity,
                         reason: "Prefer `contains` over range(of:) comparison to nil") { expression in

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCollectionLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCollectionLiteralRule.swift
@@ -29,7 +29,7 @@ public struct EmptyCollectionLiteralRule: ConfigurationProviderRule, OptInRule, 
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "\\b\\s*(==|!=)\\s*\\[\\s*:?\\s*\\]"
+        let pattern = #"\b\s*(==|!=)\s*\[\s*:?\s*\]"#
         let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
             StyleViolation(ruleDescription: type(of: self).description,

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
@@ -23,7 +23,7 @@ public struct EmptyStringRule: ConfigurationProviderRule, OptInRule, AutomaticTe
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "\\b\\s*(==|!=)\\s*\"\""
+        let pattern = #"\b\s*(==|!=)\s*"""#
         return file.match(pattern: pattern, with: [.string]).compactMap { range in
             guard let byteRange = file.stringView.NSRangeToByteRange(NSRange(location: range.location, length: 1)),
                 case let kinds = file.syntaxMap.kinds(inByteRange: byteRange),

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -33,7 +33,7 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return validate(
             file: file,
-            pattern: "[\\}\\)]\\s*\\.first",
+            pattern: #"[\}\)]\s*\.first"#,
             patternSyntaxKinds: [.identifier],
             callNameSuffix: ".filter",
             severity: configuration.severity

--- a/Source/SwiftLintFramework/Rules/Performance/FlatMapOverMapReduceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FlatMapOverMapReduceRule.swift
@@ -20,7 +20,7 @@ public struct FlatMapOverMapReduceRule: CallPairRule, OptInRule, ConfigurationPr
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "[\\}\\)]\\s*\\.reduce\\s*\\(\\[\\s*\\],\\s*\\+\\s*\\)"
+        let pattern = #"[\}\)]\s*\.reduce\s*\(\[\s*\],\s*\+\s*\)"#
         return validate(file: file, pattern: pattern, patternSyntaxKinds: [.identifier],
                         callNameSuffix: ".map", severity: configuration.severity)
     }

--- a/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
@@ -31,7 +31,7 @@ public struct LastWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule,
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return validate(file: file,
-                        pattern: "[\\}\\)]\\s*\\.last",
+                        pattern: #"[\}\)]\s*\.last"#,
                         patternSyntaxKinds: [.identifier],
                         callNameSuffix: ".filter",
                         severity: configuration.severity) { dictionary in

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
@@ -28,7 +28,7 @@ public struct ReduceBooleanRule: Rule, ConfigurationProviderRule, AutomaticTesta
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "\\breduce\\((true|false)"
+        let pattern = #"\breduce\((true|false)"#
         return file
             .match(pattern: pattern, with: [.identifier, .keyword])
             .map { range in

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
@@ -94,8 +94,8 @@ public struct ReduceIntoRule: ASTRule, ConfigurationProviderRule, OptInRule, Aut
         ]
     )
 
-    private let reduceExpression = regex("(?<!\\w)reduce$")
-    private let initExpression = regex("^(?:\\[.+:?.*\\]|(?:Array|Dictionary)<.+>)(?:\\.init\\(|\\().*\\)$")
+    private let reduceExpression = regex(#"(?<!\w)reduce$"#)
+    private let initExpression = regex(#"^(?:\[.+:?.*\]|(?:Array|Dictionary)<.+>)(?:\.init\(|\().*\)$"#)
 
     public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
@@ -44,7 +44,7 @@ public struct SortedFirstLastRule: CallPairRule, OptInRule, ConfigurationProvide
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return validate(file: file,
-                        pattern: "[\\}\\)]\\s*\\.(first|last)(?!Index)",
+                        pattern: #"[\}\)]\s*\.(first|last)(?!Index)"#,
                         patternSyntaxKinds: [.identifier],
                         callNameSuffix: ".sorted",
                         severity: configuration.severity) { dictionary in

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -16,7 +16,7 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
     private var _forbiddenRegex: NSRegularExpression?
     private var _requiredRegex: NSRegularExpression?
 
-    private static let defaultRegex = regex("\\bCopyright\\b", options: [.caseInsensitive])
+    private static let defaultRegex = regex(#"\bCopyright\b"#, options: [.caseInsensitive])
 
     public var consoleDescription: String {
         let requiredStringDescription = requiredString ?? "None"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -14,7 +14,7 @@ public struct FileNameConfiguration: RuleConfiguration, Equatable {
     public private(set) var nestedTypeSeparator: String
 
     public init(severity: ViolationSeverity, excluded: [String] = [],
-                prefixPattern: String = "", suffixPattern: String = "\\+.*", nestedTypeSeparator: String = ".") {
+                prefixPattern: String = "", suffixPattern: String = #"\+.*"#, nestedTypeSeparator: String = ".") {
         self.severity = SeverityConfiguration(severity)
         self.excluded = Set(excluded)
         self.prefixPattern = prefixPattern

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -9,7 +9,7 @@ private enum AttributesRuleError: Error {
 public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = AttributesConfiguration()
 
-    private static let parametersPattern = "^\\s*\\(.+\\)"
+    private static let parametersPattern = #"^\s*\(.+\)"#
     private static let regularExpression = regex(parametersPattern, options: [])
 
     public init() {}
@@ -52,7 +52,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
     }
 
     private func validateTestableImport(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "@testable[\n]+\\s*import"
+        let pattern = #"@testable[\n]+\s*import"#
         return file.match(pattern: pattern).compactMap { range, kinds -> StyleViolation? in
             guard kinds == [.attributeBuiltin, .keyword] else {
                 return nil

--- a/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
@@ -34,7 +34,7 @@ public struct ClosingBraceRule: SubstitutionCorrectableRule, ConfigurationProvid
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file.match(pattern: "(\\}[ \\t]+\\))", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
+        return file.match(pattern: #"(\}[ \t]+\))"#, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
     }
 
     public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -16,7 +16,7 @@ public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderR
         corrections: ClosureEndIndentationRuleExamples.corrections
     )
 
-    fileprivate static let notWhitespace = regex("[^\\s]")
+    fileprivate static let notWhitespace = regex(#"[^\s]"#)
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violations(in: file).map { violation in
@@ -261,7 +261,7 @@ extension ClosureEndIndentationRule {
             return nil
         }
 
-        let newLineRegex = regex("\n(\\s*\\}?\\.)")
+        let newLineRegex = regex(#"\n(\s*\}?\.)"#)
         let contents = file.stringView
         guard let range = contents.byteRangeToNSRange(nameByteRange),
             let match = newLineRegex.matches(in: file.contents, options: [], range: range).last?.range(at: 1),
@@ -318,7 +318,7 @@ extension ClosureEndIndentationRule {
         return arguments.filter { argument in
             guard let bodyByteRange = argument.bodyByteRange,
                 let range = file.stringView.byteRangeToNSRange(bodyByteRange),
-                let match = regex("\\s*\\{").firstMatch(in: file.contents, options: [], range: range)?.range,
+                let match = regex(#"\s*\{"#).firstMatch(in: file.contents, options: [], range: range)?.range,
                 match.location == range.location
             else {
                 return false
@@ -339,7 +339,7 @@ extension ClosureEndIndentationRule {
             case let length = firstArgumentOffset - offset,
             case let byteRange = ByteRange(location: offset, length: length),
             let range = file.stringView.byteRangeToNSRange(byteRange),
-            let match = regex("\\(\\s*\\n\\s*").firstMatch(in: file.contents, options: [], range: range)?.range,
+            let match = regex(#"\(\s*\n\s*"#).firstMatch(in: file.contents, options: [], range: range)?.range,
             match.location == range.location
         else {
             return false

--- a/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
@@ -45,7 +45,7 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule, 
         ]
     )
 
-    private static let openBraceRegex = regex("\\{")
+    private static let openBraceRegex = regex(#"\{"#)
 
     public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -71,7 +71,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
     // returns ranges of braces `{` or `}` in the same line
     private func validBraces(in file: SwiftLintFile) -> [NSRange] {
         let nsstring = file.contents.bridge()
-        let bracePattern = regex("\\{|\\}")
+        let bracePattern = regex(#"\{|\}"#)
         let linesTokens = file.syntaxTokensByLines
         let kindsToExclude = SyntaxKind.commentAndStringKinds
 

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+Type.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+Type.swift
@@ -5,21 +5,21 @@ internal extension ColonRule {
     var pattern: String {
         // If flexible_right_spacing is true, match only 0 whitespaces.
         // If flexible_right_spacing is false or omitted, match 0 or 2+ whitespaces.
-        let spacingRegex = configuration.flexibleRightSpacing ? "(?:\\s{0})" : "(?:\\s{0}|\\s{2,})"
+        let spacingRegex = configuration.flexibleRightSpacing ? #"(?:\s{0})"# : #"(?:\s{0}|\s{2,})"#
 
-        return "(\\w)" +                // Capture an identifier.
-            "(<[\\w\\s:\\.,]+>)?" +     // Capture a generic parameter clause (optional).
+        return #"(\w)"# +               // Capture an identifier.
+            #"(<[\w\s:\.,]+>)?"# +      // Capture a generic parameter clause (optional).
             "(?:" +                     // Start group
-            "\\s+" +                    // followed by whitespace
+            #"\s+"# +                   // followed by whitespace
             ":" +                       // to the left of a colon
-            "\\s*" +                    // followed by any amount of whitespace.
+            #"\s*"# +                   // followed by any amount of whitespace.
             "|" +                       // or
             ":" +                       // immediately followed by a colon
             spacingRegex +              // followed by right spacing regex
             ")" +                       // end group
             "(" +                       // Capture a type identifier
-            "[\\[|\\(]*" +              // which may begin with a series of nested parenthesis or brackets
-            "\\S)"                      // lazily to the first non-whitespace character.
+            #"[\[|\(]*"# +              // which may begin with a series of nested parenthesis or brackets
+            #"\S)"#                     // lazily to the first non-whitespace character.
     }
 
     func typeColonViolationRanges(in file: SwiftLintFile, matching pattern: String) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -53,18 +53,18 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
 
     private static let mainPatternGroups =
         "(" +                  // start first capure
-        "\\s+" +               // followed by whitespace
+        #"\s+"# +              // followed by whitespace
         "," +                  // to the left of a comma
-        "[\\t\\p{Z}]*" +       // followed by any amount of tab or space.
+        #"[\t\p{Z}]*"# +       // followed by any amount of tab or space.
         "|" +                  // or
         "," +                  // immediately followed by a comma
-        "(?:[\\t\\p{Z}]{0}|" + // followed by 0
-        "[\\t\\p{Z}]{2,})" +   // or 2+ tab or space characters.
+        #"(?:[\t\p{Z}]{0}|"# + // followed by 0
+        #"[\t\p{Z}]{2,})"# +   // or 2+ tab or space characters.
         ")" +                  // end capture
-        "(\\S)"                // second capture is not whitespace.
+        #"(\S)"#               // second capture is not whitespace.
 
     private static let pattern =
-        "\\S\(mainPatternGroups)" + // Regexp will match if expression not begin with comma
+        #"\S\#(mainPatternGroups)"# + // Regexp will match if expression not begin with comma
         "|" +                       // or
         "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
 

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -93,9 +93,9 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
         let statementPatterns: [String] = statements.map { statement -> String in
             let isGuard = statement == "guard"
             let isSwitch = statement == "switch"
-            let elsePattern = isGuard ? "else\\s*" : ""
+            let elsePattern = isGuard ? #"else\s*"# : ""
             let clausePattern = isSwitch ? "[^,{]*" : "[^{]*"
-            return "\(statement)\\s*\\(\(clausePattern)\\)\\s*\(elsePattern)\\{"
+            return #"\#(statement)\s*\(\#(clausePattern)\)\s*\#(elsePattern)\{"#
         }
         return statementPatterns.flatMap { pattern -> [NSRange] in
             return file.match(pattern: pattern)

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -100,7 +100,7 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
                 return []
             }
 
-            let emptyArgumentRegex = regex("\\.\\S+\\s*(\\([,\\s_]*\\))")
+            let emptyArgumentRegex = regex(#"\.\S+\s*(\([,\s_]*\))"#)
             return emptyArgumentRegex.matches(in: file.contents, options: [], range: caseRange).compactMap { match in
                 let parenthesesRange = match.range(at: 1)
 

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
@@ -43,9 +43,9 @@ public struct EmptyParametersRule: ConfigurationProviderRule, SubstitutionCorrec
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        let voidPattern = "\\(Void\\)"
-        let pattern = voidPattern + "\\s*(throws\\s+)?->"
-        let excludingPattern = "->\\s*" + pattern // excludes curried functions
+        let voidPattern = #"\(Void\)"#
+        let pattern = voidPattern + #"\s*(throws\s+)?->"#
+        let excludingPattern = #"->\s*"# + pattern // excludes curried functions
 
         return file.match(pattern: pattern,
                           excludingSyntaxKinds: SyntaxKind.commentAndStringKinds,

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -48,7 +48,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
         ]
     )
 
-    private static let emptyParenthesesRegex = regex("^\\s*\\(\\s*\\)")
+    private static let emptyParenthesesRegex = regex(#"^\s*\(\s*\)"#)
 
     public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
@@ -70,7 +70,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
 
     private func findComputedPropertyToken(keyword: String, file: SwiftLintFile,
                                            range: NSRange? = nil) -> [SwiftLintSyntaxToken] {
-        let pattern = "\\{[^\\{]*?\\s+\(keyword)\\b"
+        let pattern = #"\{[^\{]*?\s+\#(keyword)\b"#
         let attributesKinds: Set<SyntaxKind> = [.attributeBuiltin, .attributeID]
         return file.rangesAndTokens(matching: pattern, range: range).compactMap { _, tokens in
             let kinds = tokens.kinds

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -29,7 +29,7 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        let pattern = "(?:\\bin|\\{)\\s+(return\\s+)"
+        let pattern = #"(?:\bin|\{)\s+(return\s+)"#
         let contents = file.stringView
 
         return file.matchesAndSyntaxKinds(matching: pattern).compactMap { result, kinds in

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -140,7 +140,7 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
                               reason: reason)
     }
 
-    fileprivate static let notWhitespace = regex("[^\\s]")
+    fileprivate static let notWhitespace = regex(#"[^\s]"#)
 }
 
 extension LiteralExpressionEndIdentationRule: CorrectableRule {

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -92,8 +92,8 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
             return []
         }
 
-        let expectedBodyBeginRegex = regex("\\A(?:[ \\t]*\\n|[^\\n]*(?:in|\\{)\\n)")
-        let expectedBodyEndRegex = regex("\\n[ \\t]*\\z")
+        let expectedBodyBeginRegex = regex(#"\A(?:[ \t]*\n|[^\n]*(?:in|\{)\n)"#)
+        let expectedBodyEndRegex = regex(#"\n[ \t]*\z"#)
 
         var violatingByteOffsets = [ByteCount]()
         if expectedBodyBeginRegex.firstMatch(in: body, options: [], range: body.fullNSRange) == nil {

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
@@ -128,7 +128,7 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
     private func isClosure(in file: SwiftLintFile) -> (Argument) -> Bool {
         return { argument in
             let contents = file.stringView
-            let closureMatcher = regex("^\\s*\\{")
+            let closureMatcher = regex(#"^\s*\{"#)
             guard let range = contents.byteRangeToNSRange(argument.bodyRange) else {
                 return false
             }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -132,7 +132,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
         return noLeadingNewlineViolations.map { $0.dotOffset }
     }
 
-    private static let whitespaceDotRegex = regex("\\s*\\.")
+    private static let whitespaceDotRegex = regex(#"\s*\."#)
 
     private func callDotOffset(file: SwiftLintFile, callRange: ByteRange) -> Int? {
         guard
@@ -144,7 +144,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
         return match.location + match.length - 1
     }
 
-    private static let newlineWhitespaceDotRegex = regex("\\n\\s*\\.")
+    private static let newlineWhitespaceDotRegex = regex(#"\n\s*\."#)
 
     private func callHasLeadingNewline(file: SwiftLintFile, callRange: ByteRange) -> Bool {
         guard

--- a/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -113,8 +113,8 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
             return []
         }
 
-        let expectedBodyBeginRegex = regex("\\A[ \\t]*\\n")
-        let expectedBodyEndRegex = regex("\\n[ \\t]*\\z")
+        let expectedBodyBeginRegex = regex(#"\A[ \t]*\n"#)
+        let expectedBodyEndRegex = regex(#"\n[ \t]*\z"#)
 
         var violatingByteOffsets = [ByteCount]()
         if expectedBodyBeginRegex.firstMatch(in: body, options: [], range: body.fullNSRange) == nil {

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -138,7 +138,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
         }
 
         let prefix = file.stringView.nsString.substring(to: firstParamRange.lowerBound)
-        let invalidRegex = regex("\\([ \\t]*\\z")
+        let invalidRegex = regex(#"\([ \t]*\z"#)
 
         guard let invalidMatch = invalidRegex.firstMatch(in: prefix, options: [], range: prefix.fullNSRange) else {
             return nil
@@ -161,7 +161,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
         }
 
         let suffix = file.stringView.nsString.substring(from: lastParamRange.upperBound)
-        let invalidRegex = regex("\\A[ \\t]*\\)")
+        let invalidRegex = regex(#"\A[ \t]*\)"#)
 
         guard let invalidMatch = invalidRegex.firstMatch(in: suffix, options: [], range: suffix.fullNSRange) else {
             return nil

--- a/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -73,7 +73,7 @@ private extension Array where Element == SourceKittenDictionary {
             return filter { argument in
                 guard let bodyByteRange = argument.bodyByteRange,
                     let range = file.stringView.byteRangeToNSRange(bodyByteRange),
-                    let match = regex("^\\s*\\{").firstMatch(in: file.contents, options: [], range: range)?.range,
+                    let match = regex(#"^\s*\{"#).firstMatch(in: file.contents, options: [], range: range)?.range,
                     match.location == range.location
                 else {
                     return false

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -5,9 +5,9 @@ private let whitespaceAndNewlineCharacterSet = CharacterSet.whitespacesAndNewlin
 
 private extension SwiftLintFile {
     func violatingOpeningBraceRanges() -> [(range: NSRange, location: Int)] {
-        return match(pattern: "(?:[^( ]|[\\s(][\\s]+)\\{",
+        return match(pattern: #"(?:[^( ]|[\s(][\s]+)\{"#,
                      excludingSyntaxKinds: SyntaxKind.commentAndStringKinds,
-                     excludingPattern: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{").compactMap {
+                     excludingPattern: #"(?:if|guard|while)\n[^\{]+?[\s\t\n]\{"#).compactMap {
             if isAnonimousClosure(range: $0) {
                 return nil
             }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorFunctionWhitespaceRule.swift
@@ -27,11 +27,11 @@ public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule, Automat
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let escapedOperators = ["/", "=", "-", "+", "!", "*", "|", "^", "~", "?", "."]
-            .map({ "\\\($0)" }).joined()
+            .map({ #"\\#($0)"# }).joined()
         let operators = "\(escapedOperators)%<>&"
-        let zeroOrManySpaces = "(\\s{0}|\\s{2,})"
-        let pattern1 = "func\\s+[\(operators)]+\(zeroOrManySpaces)(<[A-Z]+>)?\\("
-        let pattern2 = "func\(zeroOrManySpaces)[\(operators)]+\\s+(<[A-Z]+>)?\\("
+        let zeroOrManySpaces = #"(\s{0}|\s{2,})"#
+        let pattern1 = #"func\s+[\#(operators)]+\#(zeroOrManySpaces)(<[A-Z]+>)?\("#
+        let pattern2 = #"func\#(zeroOrManySpaces)[\#(operators)]+\s+(<[A-Z]+>)?\("#
         return file.match(pattern: "(\(pattern1)|\(pattern2))").filter { _, syntaxKinds in
             return syntaxKinds.first == .keyword
         }.map { range, _ in

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -79,19 +79,19 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
     }
 
     private func violationRanges(file: SwiftLintFile) -> [(NSRange, String)] {
-        let escapedOperators = ["/", "=", "-", "+", "*", "|", "^", "~"].map({ "\\\($0)" }).joined()
-        let rangePattern = "\\.\\.(?:\\.|<)" // ... or ..<
-        let notEqualsPattern = "\\!\\=\\=?" // != or !==
-        let coalescingPattern = "\\?{2}"
+        let escapedOperators = ["/", "=", "-", "+", "*", "|", "^", "~"].map({ #"\\#($0)"# }).joined()
+        let rangePattern = #"\.\.(?:\.|<)"# // ... or ..<
+        let notEqualsPattern = #"\!\=\=?"# // != or !==
+        let coalescingPattern = #"\?{2}"#
 
         let operators = "(?:[\(escapedOperators)%<>&]+|\(rangePattern)|\(coalescingPattern)|" +
             "\(notEqualsPattern))"
 
-        let oneSpace = "[^\\S\\r\\n]" // to allow lines ending with operators to be valid
+        let oneSpace = #"[^\S\r\n]"# // to allow lines ending with operators to be valid
         let zeroSpaces = oneSpace + "{0}"
         let manySpaces = oneSpace + "{2,}"
-        let leadingVariableOrNumber = "(?:\\b|\\))"
-        let trailingVariableOrNumber = "(?:\\b|\\()"
+        let leadingVariableOrNumber = #"(?:\b|\))"#
+        let trailingVariableOrNumber = #"(?:\b|\()"#
 
         let spaces = [(zeroSpaces, zeroSpaces), (oneSpace, manySpaces),
                       (manySpaces, oneSpace), (manySpaces, manySpaces)]
@@ -100,7 +100,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         }
         let pattern = "(?:\(patterns.joined(separator: "|")))"
 
-        let genericPattern = "<(?:\(oneSpace)|\\S)*>" // not using dot to avoid matching new line
+        let genericPattern = #"<(?:\#(oneSpace)|\S)*>"# // not using dot to avoid matching new line
         let validRangePattern = leadingVariableOrNumber + zeroSpaces + rangePattern +
             zeroSpaces + trailingVariableOrNumber
         let excludingPattern = "(?:\(genericPattern)|\(validRangePattern))"

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -122,7 +122,7 @@ public struct PreferSelfTypeOverTypeOfSelfRule: OptInRule, ConfigurationProvider
             return []
         }
 
-        let pattern = "((?:Swift\\s*\\.\\s*)?type\\(\\s*of\\:\\s*self\\s*\\))\\s*\\."
+        let pattern = #"((?:Swift\s*\.\s*)?type\(\s*of\:\s*self\s*\))\s*\."#
         return file.matchesAndSyntaxKinds(matching: pattern)
             .filter {
                 $0.1 == [.identifier, .identifier, .identifier, .keyword] ||

--- a/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -35,7 +35,7 @@ public struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, Sub
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file.match(pattern: "\\bset\\s*get\\b", with: [.keyword, .keyword])
+        return file.match(pattern: #"\bset\s*get\b"#, with: [.keyword, .keyword])
     }
 
     public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {

--- a/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
@@ -43,7 +43,7 @@ public struct RedundantDiscardableLetRule: SubstitutionCorrectableRule, Configur
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let contents = file.stringView
-        return file.match(pattern: "let\\s+_\\b", with: [.keyword, .keyword]).filter { range in
+        return file.match(pattern: #"let\s+_\b"#, with: [.keyword, .keyword]).filter { range in
             guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length) else {
                 return false
             }

--- a/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -87,21 +87,21 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
 
     private let pattern: String = {
         // Just horizontal spacing so that "func abc()->\n" can pass validation
-        let space = "[ \\f\\r\\t]"
+        let space = #"[ \f\r\t]"#
 
         // Either 0 space characters or 2+
         let incorrectSpace = "(\(space){0}|\(space){2,})"
 
         // The possible combinations of whitespace around the arrow
         let patterns = [
-            "(\(incorrectSpace)\\->\(space)*)",
-            "(\(space)\\->\(incorrectSpace))",
-            "\\n\(space)*\\->\(incorrectSpace)",
-            "\(incorrectSpace)\\->\\n\(space)*"
+            #"(\#(incorrectSpace)\->\#(space)*)"#,
+            #"(\#(space)\->\#(incorrectSpace))"#,
+            #"\n\#(space)*\->\#(incorrectSpace)"#,
+            #"\#(incorrectSpace)\->\n\#(space)*"#
         ]
 
         // ex: `func abc()-> Int {` & `func abc() ->Int {`
-        return "\\)(\(patterns.joined(separator: "|")))\\S+"
+        return #"\)(\#(patterns.joined(separator: "|")))\S+"#
     }()
 
     private func violationRanges(in file: SwiftLintFile, skipParentheses: Bool) -> [NSRange] {

--- a/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
@@ -46,18 +46,18 @@ public struct ShorthandOperatorRule: ConfigurationProviderRule, AutomaticTestabl
 
     private static let pattern: String = {
         let escaped = { (operators: [String]) -> String in
-            return "[\(operators.map { "\\\($0)" }.joined())]"
+            return "[\(operators.map { #"\\#($0)"# }.joined())]"
         }
 
         let escapedAll = escaped(allOperators)
         let operatorsWithoutPrecedence = escaped(["-", "+"])
         let operatorsWithPrecedence = escaped(["/", "*"])
-        let operand = "[\\w\\d\\.]+?"
-        let spaces = "[^\\S\\r\\n]*?"
+        let operand = #"[\w\d\.]+?"#
+        let spaces = #"[^\S\r\n]*?"#
 
         let pattern1 = "\(operatorsWithoutPrecedence)"
-        let pattern2 = "\(operatorsWithPrecedence)\(spaces)\\S+$"
-        return "^\(spaces)(\(operand))\(spaces)=\(spaces)(\\1)\(spaces)(\(pattern1)|\(pattern2))"
+        let pattern2 = #"\#(operatorsWithPrecedence)\#(spaces)\S+$"#
+        return #"^\#(spaces)(\#(operand))\#(spaces)=\#(spaces)(\1)\#(spaces)(\#(pattern1)|\#(pattern2))"#
     }()
 
     private static let violationRegex: NSRegularExpression = {

--- a/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
@@ -144,7 +144,7 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
     }
 
     private func importGroups(in file: SwiftLintFile, filterEnabled: Bool) -> [[Line]] {
-        var importRanges = file.match(pattern: "import\\s+\\w+", with: [.keyword, .identifier])
+        var importRanges = file.match(pattern: #"import\s+\w+"#, with: [.keyword, .identifier])
         if filterEnabled {
             importRanges = file.ruleEnabled(violatingRanges: importRanges, for: self)
         }

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -88,7 +88,7 @@ private extension StatementPositionRule {
     // match literal '}'
     // followed by 1) nothing, 2) two+ whitespace/newlines or 3) newlines or tabs
     // followed by 'else' or 'catch' literals
-    static let defaultPattern = "\\}(?:[\\s\\n\\r]{2,}|[\\n\\t\\r]+)?\\b(else|catch)\\b"
+    static let defaultPattern = #"\}(?:[\s\n\r]{2,}|[\n\t\r]+)?\b(else|catch)\b"#
 
     func defaultValidate(file: SwiftLintFile) -> [StyleViolation] {
         return defaultViolationRanges(in: file, matching: type(of: self).defaultPattern).compactMap { range in
@@ -137,7 +137,7 @@ private extension StatementPositionRule {
     // preceded by whitespace (or nothing)
     // followed by 1) nothing, 2) two+ whitespace/newlines or 3) newlines or tabs
     // followed by newline and the same amount of whitespace then 'else' or 'catch' literals
-    static let uncuddledPattern = "([ \t]*)\\}(\\n+)?([ \t]*)\\b(else|catch)\\b"
+    static let uncuddledPattern = #"([ \t]*)\}(\n+)?([ \t]*)\b(else|catch)\b"#
 
     static let uncuddledRegex = regex(uncuddledPattern, options: [])
 

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -92,7 +92,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
             case let length = totalLength + offset - start,
             case let byteRange = ByteRange(location: start, length: length),
             let range = file.stringView.byteRangeToNSRange(byteRange),
-            let match = regex("\\s*\\(\\s*\\{").firstMatch(in: file.contents, options: [], range: range)?.range,
+            let match = regex(#"\s*\(\s*\{"#).firstMatch(in: file.contents, options: [], range: range)?.range,
             match.location == range.location {
             return shouldTrigger()
         }
@@ -105,7 +105,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
         return arguments.filter { argument in
             guard let bodyByteRange = argument.bodyByteRange,
                 let range = file.stringView.byteRangeToNSRange(bodyByteRange),
-                let match = regex("\\s*\\{").firstMatch(in: file.contents, options: [], range: range)?.range,
+                let match = regex(#"\s*\{"#).firstMatch(in: file.contents, options: [], range: range)?.range,
                 match.location == range.location
             else {
                 return false
@@ -132,7 +132,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
             return false
         }
 
-        let pattern = regex("\\)\\s*\\)\\z")
+        let pattern = regex(#"\)\s*\)\z"#)
         return pattern.numberOfMatches(in: file.contents, range: range) > 0
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -69,8 +69,8 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
     }
 
     private func violationRanges(file: SwiftLintFile) -> [NSRange] {
-        let capturesPattern = "(?:\\[[^\\]]+\\])?"
-        let pattern = "\\{\\s*\(capturesPattern)\\s*(\\([^:}]+?\\))\\s*(in|->)"
+        let capturesPattern = #"(?:\[[^\]]+\])?"#
+        let pattern = #"\{\s*\#(capturesPattern)\s*(\([^:}]+?\))\s*(in|->)"#
         let contents = file.stringView
         return regex(pattern).matches(in: file).compactMap { match -> NSRange? in
             let parametersRange = match.range(at: 1)

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -70,9 +70,9 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
     private func violations(in range: NSRange, of file: SwiftLintFile, with kind: StatementKind) -> [NSRange] {
         let kinds = SyntaxKind.commentAndStringKinds
 
-        let underscorePattern = "(_\\s*[=,)]\\s*(try\\?)?)"
-        let underscoreTuplePattern = "(\\((\\s*[_,]\\s*)+\\)\\s*=\\s*(try\\?)?)"
-        let letUnderscore = "let\\s+(\(underscorePattern)|\(underscoreTuplePattern))"
+        let underscorePattern = #"(_\s*[=,)]\s*(try\?)?)"#
+        let underscoreTuplePattern = #"(\((\s*[_,]\s*)+\)\s*=\s*(try\?)?)"#
+        let letUnderscore = #"let\s+(\#(underscorePattern)|\#(underscoreTuplePattern))"#
 
         let matches = file.matchesAndSyntaxKinds(matching: letUnderscore, range: range)
 

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -113,7 +113,7 @@ public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
         """)
     ]
 
-    private let pattern = "([^\\n{][ \\t]*\\n)([ \\t]*(?:case[^\\n]+|default):[ \\t]*\\n)"
+    private let pattern = #"([^\n{][ \t]*\n)([ \t]*(?:case[^\n]+|default):[ \t]*\n)"#
 
     private func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         return file.violatingRanges(for: pattern).filter {

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -37,7 +37,7 @@ public struct VerticalWhitespaceClosingBracesRule: ConfigurationProviderRule {
             Example("class Name {\n    run(5) { x in print(x) }\n}")
     ]
 
-    private let pattern = "((?:\\n[ \\t]*)+)(\\n[ \\t]*[)}\\]])"
+    private let pattern = #"((?:\n[ \t]*)+)(\n[ \t]*[)}\]])"#
 }
 
 extension VerticalWhitespaceClosingBracesRule: OptInRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -58,7 +58,7 @@ public struct VerticalWhitespaceOpeningBracesRule: ConfigurationProviderRule {
         """)
     ]
 
-    private let pattern = "([{(\\[][ \\t]*(?:[^\\n{]+ in[ \\t]*$)?)((?:\\n[ \\t]*)+)(\\n)"
+    private let pattern = #"([{(\[][ \t]*(?:[^\n{]+ in[ \t]*$)?)((?:\n[ \t]*)+)(\n)"#
 }
 
 extension VerticalWhitespaceOpeningBracesRule: OptInRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
@@ -57,7 +57,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
     private typealias LineSection = (lastLine: Line, linesToRemove: Int)
 
     private func violatingLineSections(in file: SwiftLintFile) -> [LineSection] {
-        let nonSpaceRegex = regex("\\S", options: [])
+        let nonSpaceRegex = regex(#"\S"#, options: [])
         let filteredLines = file.lines.filter {
             nonSpaceRegex.firstMatch(in: file.contents, options: [], range: $0.range) == nil
         }

--- a/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
@@ -51,9 +51,9 @@ public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectable
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let kinds = SyntaxKind.commentAndStringKinds
-        let parensPattern = "\\(\\s*(?:Void)?\\s*\\)"
-        let pattern = "->\\s*\(parensPattern)\\s*(?!->)"
-        let excludingPattern = "(\(pattern))\\s*(throws\\s+)?->"
+        let parensPattern = #"\(\s*(?:Void)?\s*\)"#
+        let pattern = #"->\s*\#(parensPattern)\s*(?!->)"#
+        let excludingPattern = #"(\#(pattern))\s*(throws\s+)?->"#
 
         return file.match(pattern: pattern, excludingSyntaxKinds: kinds, excludingPattern: excludingPattern,
                           exclusionMapping: { $0.range(at: 1) }).compactMap {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -91,7 +91,7 @@ class CustomRulesTests: XCTestCase {
     }
 
     func testCustomRulesIncludedExcludesFile() {
-        var (regexConfig, customRules) = getCustomRules(["included": "\\.yml$"])
+        var (regexConfig, customRules) = getCustomRules(["included": #"\.yml$"#])
 
         var customRuleConfiguration = CustomRulesConfiguration()
         customRuleConfiguration.customRuleConfigurations = [regexConfig]
@@ -102,7 +102,7 @@ class CustomRulesTests: XCTestCase {
     }
 
     func testCustomRulesExcludedExcludesFile() {
-        var (regexConfig, customRules) = getCustomRules(["excluded": "\\.txt$"])
+        var (regexConfig, customRules) = getCustomRules(["excluded": #"\.txt$"#])
 
         var customRuleConfiguration = CustomRulesConfiguration()
         customRuleConfiguration.customRuleConfigurations = [regexConfig]

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -52,7 +52,7 @@ class FileHeaderRuleTests: XCTestCase {
             .with(nonTriggeringExamples: nonTriggeringExamples)
             .with(triggeringExamples: triggeringExamples)
 
-        verifyRule(description, ruleConfiguration: ["required_pattern": "\\d{4} Realm"],
+        verifyRule(description, ruleConfiguration: ["required_pattern": #"\d{4} Realm"#],
                    stringDoesntViolate: false, skipCommentTests: true,
                    testMultiByteOffsets: false)
     }
@@ -110,7 +110,7 @@ class FileHeaderRuleTests: XCTestCase {
             .with(nonTriggeringExamples: nonTriggeringExamples)
             .with(triggeringExamples: triggeringExamples)
 
-        verifyRule(description, ruleConfiguration: ["forbidden_pattern": "\\s\\w+\\.swift"],
+        verifyRule(description, ruleConfiguration: ["forbidden_pattern": #"\s\w+\.swift"#],
                    skipCommentTests: true)
     }
 
@@ -156,9 +156,9 @@ class FileHeaderRuleTests: XCTestCase {
     }
 
     func testFileHeaderWithRequiredPatternUsingFilenamePlaceholder() {
-        let configuration1 = ["required_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
+        let configuration1 = ["required_pattern": #"/ SWIFTLINT_CURRENT_FILENAME\n.*\d{4}"#]
         let configuration2 = ["required_pattern":
-            "// Copyright © \\d{4}\n// File: \"SWIFTLINT_CURRENT_FILENAME\""]
+            #"// Copyright © \d{4}\n// File: "SWIFTLINT_CURRENT_FILENAME""#]
 
         // Non triggering tests
         XCTAssert(try validate(fileName: "FileNameMatchingSimple.swift", using: configuration1).isEmpty)
@@ -171,8 +171,8 @@ class FileHeaderRuleTests: XCTestCase {
     }
 
     func testFileHeaderWithForbiddenPatternUsingFilenamePlaceholder() {
-        let configuration1 = ["forbidden_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
-        let configuration2 = ["forbidden_pattern": "//.*(\\s|\")SWIFTLINT_CURRENT_FILENAME(\\s|\").*"]
+        let configuration1 = ["forbidden_pattern": #"// SWIFTLINT_CURRENT_FILENAME\n.*\d{4}"#]
+        let configuration2 = ["forbidden_pattern": #"//.*(\s|\")SWIFTLINT_CURRENT_FILENAME(\s|").*"#]
 
         // Non triggering tests
         XCTAssert(try validate(fileName: "FileNameCaseMismatch.swift", using: configuration1).isEmpty)

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -78,7 +78,7 @@ class FileNameRuleTests: XCTestCase {
     func testCustomSuffixPattern() {
         XCTAssert(try validate(fileName: "BoolExtension.swift", suffixPattern: "Extensions?").isEmpty)
         XCTAssert(try validate(fileName: "BoolExtensions.swift", suffixPattern: "Extensions?").isEmpty)
-        XCTAssert(try validate(fileName: "BoolExtensionTests.swift", suffixPattern: "Extensions?|\\+.*").isEmpty)
+        XCTAssert(try validate(fileName: "BoolExtensionTests.swift", suffixPattern: #"Extensions?|\+.*"#).isEmpty)
     }
 
     func testCustomPrefixPattern() {
@@ -91,7 +91,7 @@ class FileNameRuleTests: XCTestCase {
             try validate(
                 fileName: "SLBoolExtension.swift",
                 prefixPattern: "SL",
-                suffixPattern: "Extensions?|\\+.*"
+                suffixPattern: #"Extensions?|\+.*"#
             ).isEmpty
         )
 
@@ -99,7 +99,7 @@ class FileNameRuleTests: XCTestCase {
             try validate(
                 fileName: "ExtensionBool+SwiftLint.swift",
                 prefixPattern: "Extensions?",
-                suffixPattern: "Extensions?|\\+.*"
+                suffixPattern: #"Extensions?|\+.*"#
             ).isEmpty
         )
     }


### PR DESCRIPTION
Implements #3050 

I split the changes into two commits, one for patterns without interpolation and one with interpolation.
In case of patterns without interpolation, they can be right away copy-pasted to regex testers, so I consider raw strings are extremely helpful.
If you prefer merging only that part, I can exclude the 2nd commit.