### PR TITLE
Fix attributes rule false positive with Swift 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
   using Swift 5.2.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
+* Fix false positives in `attributes` rule when using `rethrows` using
+  Swift 5.2.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.39.1: The Laundromat has a Rotating Door
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -293,28 +293,29 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
     private func parseAttributes(dictionary: SourceKittenDictionary) -> [SwiftDeclarationAttributeKind] {
         let attributes = dictionary.enclosedSwiftAttributes
         let blacklist: Set<SwiftDeclarationAttributeKind> = [
-            .mutating,
-            .nonmutating,
-            .lazy,
             .dynamic,
+            .fileprivate,
             .final,
             .infix,
+            .internal,
+            .lazy,
+            .mutating,
+            .nonmutating,
+            .open,
             .optional,
             .override,
             .postfix,
             .prefix,
-            .required,
-            .weak,
             .private,
-            .fileprivate,
-            .internal,
             .public,
-            .open,
-            .setterPrivate,
+            .required,
+            .rethrows,
             .setterFilePrivate,
             .setterInternal,
+            .setterOpen,
+            .setterPrivate,
             .setterPublic,
-            .setterOpen
+            .weak
         ]
         return attributes.filter { !blacklist.contains($0) }
     }

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRuleExamples.swift
@@ -49,6 +49,11 @@ internal struct AttributesRuleExamples {
         Example("""
         @objc
         internal func foo(identifier: String, completion: @escaping (() -> Void)) {}
+        """),
+        Example("""
+        func printBoolOrTrue(_ expression: @autoclosure () throws -> Bool?) rethrows {
+          try print(expression() ?? true)
+        }
         """)
     ]
 


### PR DESCRIPTION
The following was triggering:

```swift
func printBoolOrTrue(_ expression: @autoclosure () throws -> Bool?) rethrows {
  try print(expression() ?? true)
}
```

Fix by adding the `rethrows` attribute kind to the rule's blacklist.