### PR TITLE
#3167: Fixes false positives for multiline_parameters_brackets and multiline_arguments_brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 
 * Fix UnusedImportRule breaking transitive imports.  
   [keith](https://github.com/keith)
+* #3167: Fixes false positives for multiline_parameters_brackets and multiline_arguments_brackets.  
+  [Noah Gilmore](https://github.com/noahsark769)
+  [#3167](https://github.com/realm/SwiftLint/issues/3167)
 
 ## 0.39.2: Stay Home
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 * Fix UnusedImportRule breaking transitive imports.  
   [keith](https://github.com/keith)
-* #3167: Fixes false positives for multiline_parameters_brackets and multiline_arguments_brackets.  
+* Fixes false positives for multiline_parameters_brackets and multiline_arguments_brackets.  
   [Noah Gilmore](https://github.com/noahsark769)
   [#3167](https://github.com/realm/SwiftLint/issues/3167)
 

--- a/Source/SwiftLintFramework/Extensions/SourceKittenDictionary+Swiftlint.swift
+++ b/Source/SwiftLintFramework/Extensions/SourceKittenDictionary+Swiftlint.swift
@@ -41,4 +41,19 @@ extension SourceKittenDictionary {
         parse(self)
         return results
     }
+
+    /// Return the string content of this structure in the given file.
+    /// - Parameter file: File this structure occurs in
+    /// - Returns: The content of the file which this `SourceKittenDictionary` structure represents
+    func content(in file: SwiftLintFile) -> String? {
+        guard
+            let byteRange = self.byteRange,
+            let range = file.stringView.byteRangeToNSRange(byteRange)
+        else {
+            return nil
+        }
+
+        let body = file.stringView.nsString.substring(with: range)
+        return String(body)
+    }
 }

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -91,4 +91,13 @@ extension String {
         }
         return false
     }
+
+    /// Count the number of occurrences of the given character in `self`
+    /// - Parameter character: Character to count
+    /// - Returns: Number of times `character` occurs in `self`
+    public func countOccurrences(of character: Character) -> Int {
+        return self.reduce(0, {
+            $1 == character ? $0 + 1 : $0
+        })
+    }
 }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -44,7 +44,30 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
             AlertViewModel.AlertAction(title: "some title", style: .default) {
                 AlertManager.shared.presentNextDebugAlert()
             }
-            """)
+            """),
+            Example("""
+            public final class Logger {
+                public static let shared = Logger(outputs: [
+                    OSLoggerOutput(),
+                    ErrorLoggerOutput()
+                ])
+            }
+            """),
+            Example("""
+            let errors = try self.download([
+                (description: description, priority: priority),
+            ])
+            """),
+            Example("""
+            return SignalProducer({ observer, _ in
+                observer.sendCompleted()
+            }).onMainQueue()
+            """),
+            Example("""
+            SomeType(a: [
+                1, 2, 3
+            ], b: [1, 2])
+            """),
         ],
         triggeringExamples: [
             Example("""
@@ -71,6 +94,12 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
                     x: 5,
                     y: 7
             )↓)
+            """),
+            Example("""
+            SomeOtherType(↓a: [
+                    1, 2, 3
+                ],
+                b: "two"↓)
             """)
         ]
     )
@@ -86,8 +115,19 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
             return []
         }
 
-        let body = file.contents.substring(from: range.location, length: range.length)
-        let isMultiline = body.contains("\n")
+        let callBody = file.contents.substring(from: range.location, length: range.length)
+
+        let parameters = dictionary.substructure.filter {
+            // Argument expression types that can contain newlines
+            [.argument, .array, .dictionary, .closure].contains($0.expressionKind)
+        }
+        let parameterBodies = parameters.compactMap { $0.content(in: file) }
+        let parametersNewlineCount = parameterBodies.map { body in
+            return body.countOccurrences(of: "\n")
+        }.reduce(0, +)
+        let callNewlineCount = callBody.countOccurrences(of: "\n")
+        let isMultiline = callNewlineCount > parametersNewlineCount
+
         guard isMultiline else {
             return []
         }
@@ -96,11 +136,11 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
         let expectedBodyEndRegex = regex("\\n[ \\t]*\\z")
 
         var violatingByteOffsets = [ByteCount]()
-        if expectedBodyBeginRegex.firstMatch(in: body, options: [], range: body.fullNSRange) == nil {
+        if expectedBodyBeginRegex.firstMatch(in: callBody, options: [], range: callBody.fullNSRange) == nil {
             violatingByteOffsets.append(bodyRange.location)
         }
 
-        if expectedBodyEndRegex.firstMatch(in: body, options: [], range: body.fullNSRange) == nil {
+        if expectedBodyEndRegex.firstMatch(in: callBody, options: [], range: callBody.fullNSRange) == nil {
             violatingByteOffsets.append(bodyRange.upperBound)
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -67,7 +67,7 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
             SomeType(a: [
                 1, 2, 3
             ], b: [1, 2])
-            """),
+            """)
         ],
         triggeringExamples: [
             Example("""

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -50,6 +50,11 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
             """),
             Example("""
             func foo<T>(param1: T, param2: String, param3: String) -> T { /* some code */ }
+            """),
+            Example("""
+                func foo(a: [Int] = [
+                    1
+                ])
             """)
         ],
         triggeringExamples: [
@@ -106,9 +111,14 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
                 return []
             }
 
-            let isMultiline = functionName.contains("\n")
-
             let parameters = substructure.substructure.filter { $0.declarationKind == .varParameter }
+            let parameterBodies = parameters.compactMap { $0.content(in: file) }
+            let parametersNewlineCount = parameterBodies.map { body in
+                return body.countOccurrences(of: "\n")
+            }.reduce(0, +)
+            let declarationNewlineCount = functionName.countOccurrences(of: "\n")
+            let isMultiline = declarationNewlineCount > parametersNewlineCount
+
             if isMultiline && !parameters.isEmpty {
                 if let openingBracketViolation = openingBracketViolation(parameters: parameters, file: file) {
                     violations.append(openingBracketViolation)

--- a/Tests/SwiftLintFrameworkTests/ExtendedStringTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtendedStringTests.swift
@@ -1,10 +1,3 @@
-//
-//  ExtendedStringTests.swift
-//  SwiftLintFrameworkTests
-//
-//  Created by Noah Gilmore on 4/5/20.
-//
-
 import XCTest
 
 class ExtendedStringTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/ExtendedStringTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtendedStringTests.swift
@@ -1,0 +1,16 @@
+//
+//  ExtendedStringTests.swift
+//  SwiftLintFrameworkTests
+//
+//  Created by Noah Gilmore on 4/5/20.
+//
+
+import XCTest
+
+class ExtendedStringTests: XCTestCase {
+    func testCountOccurrences() {
+        XCTAssertEqual("aabbabaaba".countOccurrences(of: "a"), 6)
+        XCTAssertEqual("".countOccurrences(of: "a"), 0)
+        XCTAssertEqual("\n\n".countOccurrences(of: "\n"), 2)
+    }
+}


### PR DESCRIPTION
As documented in #3167, the `multiline_parameters_brackets` and `multiline_arguments_brackets` verification code assumes that the definition/call body is multiline if there's a newline in the body, but this creates false positives when the argument itself contains newlines (e.g. an array or closure) or when the parameter has a default value which contains newlines (e.g. array or dictionary).

This PR fixes the false positives by calculating whether a definition/call is multiline based on whether there are more newlines in the definition/call body than in the sum of the parameter bodies.

I added a couple of utils (+ tests) to enable this code and added a few triggering/nontriggering examples that would have caught this issue.

This is my first PR to SwiftLint, so happy to take advice from the maintainers on any part of this code. Thanks for maintaining SwiftLint, and can't wait to see these fixes applied so we can enable `multiline_parameters_brackets` in our app!