### PR TITLE
Fix false positive uppercase enum case in raw_value_for_camel_cased_codable_enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   statements when using Swift 5.3.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3253](https://github.com/realm/SwiftLint/issues/3253)
+* Fix false positive uppercase enum case in `raw_value_for_camel_cased_codable_enum` rule
+  [Teameh](https://github.com/teameh)
 
 ## 0.39.2: Stay Home
 

--- a/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -37,6 +37,17 @@ public struct RawValueForCamelCasedCodableEnumRule: ASTRule, OptInRule, Configur
             }
             """),
             Example("""
+            enum Status: String, Codable {
+                case OK, ACCEPTABLE
+            }
+            """),
+            Example("""
+            enum Status: String, Codable {
+                case ok
+                case maybeAcceptable = "maybe_acceptable"
+            }
+            """),
+            Example("""
             enum Status: String {
                 case ok
                 case notAcceptable
@@ -120,7 +131,7 @@ public struct RawValueForCamelCasedCodableEnumRule: ASTRule, OptInRule, Configur
         _ enumElements: [SourceKittenDictionary]) -> [SourceKittenDictionary] {
         return enumElements
             .filter { substructure in
-                guard let name = substructure.name, !name.isLowercase() else { return false }
+                guard let name = substructure.name, !name.isLowercase(), !name.isUppercase() else { return false }
                 return !substructure.elements.contains { $0.kind == "source.lang.swift.structure.elem.init_expr" }
             }
     }


### PR DESCRIPTION
Added this one to show false positive: 
```
Example("""
    enum Status: String, Codable {
        case OK, ACCEPTABLE
    }
""")
```

Added this one because this example is not yet present:
```
Example("""
    enum Status: String, Codable {
        case ok
        case maybeAcceptable = "maybe_acceptable"
    }
"""),
```

