### PR TITLE
JUnit reporter for GitLab artifact:report:junit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* JUnit reporter for GitLab artifact:report:junit with better representation of found issues.  
+  [krin-san](https://github.com/krin-san)
+  [#3177](https://github.com/realm/SwiftLint/pull/3177)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -43,6 +43,8 @@ public func reporterFrom(identifier: String) -> Reporter.Type { // swiftlint:dis
         return MarkdownReporter.self
     case GitHubActionsLoggingReporter.identifier:
         return GitHubActionsLoggingReporter.self
+    case GitLabJUnitReporter.identifier:
+        return GitLabJUnitReporter.self
     default:
         queuedFatalError("no reporter with identifier '\(identifier)' available.")
     }

--- a/Source/SwiftLintFramework/Reporters/GitLabJUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/GitLabJUnitReporter.swift
@@ -1,0 +1,41 @@
+/// Reports violations as JUnit XML supported by GitLab.
+public struct GitLabJUnitReporter: Reporter {
+    // MARK: - Reporter Conformance
+
+    public static let identifier = "gitlab"
+    public static let isRealtime = false
+
+    public var description: String {
+        return "Reports violations as JUnit XML supported by GitLab."
+    }
+
+    public static func generateReport(_ violations: [StyleViolation]) -> String {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +
+            violations.map({ violation -> String in
+                let fileName = (violation.location.relativeFile ?? "<nopath>").escapedForXML()
+                let line = violation.location.line.map(String.init)
+                let column = violation.location.character.map(String.init)
+
+                let severity = violation.severity.rawValue
+                let rule = violation.ruleIdentifier
+                let reason = violation.reason.escapedForXML()
+
+                let location = [fileName, line].compactMap { $0 }.joined(separator: ":")
+                let message = "\(severity): \(rule) in \(location)"
+                let body = """
+                Severity: \(severity)
+                Rule: \(rule)
+                Reason: \(reason)
+
+                File: \(fileName)
+                Line: \(line ?? "nil")
+                Column: \(column ?? "nil")
+                """
+                return [
+                    "\n\t<testcase name='\(message)\'>\n",
+                    "\t\t<failure>\(body)\n\t\t</failure>\n",
+                    "\t</testcase>"
+                ].joined()
+            }).joined() + "\n</testsuite></testsuites>\n"
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -213,6 +213,8 @@
 		A1A6F3F21EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */; };
 		A3184D56215BCEFF00621EA2 /* LegacyRandomRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3184D55215BCEFF00621EA2 /* LegacyRandomRule.swift */; };
 		A73469421FB121BA009B57C7 /* CallPairRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73469401FB12149009B57C7 /* CallPairRule.swift */; };
+		B0270FAE242E486D00A43E8B /* GitLabJUnitReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0270FAD242E486D00A43E8B /* GitLabJUnitReporter.swift */; };
+		B0270FB0242E48D600A43E8B /* CannedGitLabJUnitReporterOutput.xml in Resources */ = {isa = PBXBuildFile; fileRef = B0270FAF242E48CF00A43E8B /* CannedGitLabJUnitReporterOutput.xml */; };
 		B1FD3AB9238877F200CE121E /* ImplicitReturnConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD3AB8238877F200CE121E /* ImplicitReturnConfiguration.swift */; };
 		B1FD3ABB238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD3ABA238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift */; };
 		B1FD3ABD238BC5FB00CE121E /* ImplicitReturnRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD3ABC238BC5FB00CE121E /* ImplicitReturnRuleTests.swift */; };
@@ -724,6 +726,8 @@
 		A1A6F3F11EE319ED00A9F9E2 /* ObjectLiteralConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectLiteralConfiguration.swift; sourceTree = "<group>"; };
 		A3184D55215BCEFF00621EA2 /* LegacyRandomRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyRandomRule.swift; sourceTree = "<group>"; };
 		A73469401FB12149009B57C7 /* CallPairRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallPairRule.swift; sourceTree = "<group>"; };
+		B0270FAD242E486D00A43E8B /* GitLabJUnitReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabJUnitReporter.swift; sourceTree = "<group>"; };
+		B0270FAF242E48CF00A43E8B /* CannedGitLabJUnitReporterOutput.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = CannedGitLabJUnitReporterOutput.xml; sourceTree = "<group>"; };
 		B1FD3AB8238877F200CE121E /* ImplicitReturnConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitReturnConfiguration.swift; sourceTree = "<group>"; };
 		B1FD3ABA238BC5BC00CE121E /* ImplicitReturnConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitReturnConfigurationTests.swift; sourceTree = "<group>"; };
 		B1FD3ABC238BC5FB00CE121E /* ImplicitReturnRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImplicitReturnRuleTests.swift; sourceTree = "<group>"; };
@@ -1049,6 +1053,7 @@
 				6C15818E23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt */,
 				B39352E4EA2A06BE66BD661A /* CannedXcodeReporterOutput.txt */,
 				B3935001033261E5A70CE101 /* CannedEmojiReporterOutput.txt */,
+				B0270FAF242E48CF00A43E8B /* CannedGitLabJUnitReporterOutput.xml */,
 				B39350463894A3FC1338E0AF /* CannedJSONReporterOutput.json */,
 				584B0D3B2112E8FB002F7E25 /* CannedSonarQubeReporterOutput.json */,
 				341FDB1E21AD66550022E8E9 /* CannedMarkdownReporterOutput.md */,
@@ -1661,6 +1666,7 @@
 				E86396CA1BADB519002C9E88 /* CSVReporter.swift */,
 				2E336D191DF08AF200CCFE77 /* EmojiReporter.swift */,
 				6C15818C237026AC00F582A2 /* GitHubActionsLoggingReporter.swift */,
+				B0270FAD242E486D00A43E8B /* GitLabJUnitReporter.swift */,
 				4A9A3A391DC1D75F00DF5183 /* HTMLReporter.swift */,
 				E86396C81BADB2B9002C9E88 /* JSONReporter.swift */,
 				57ED82791CF65183002B3513 /* JUnitReporter.swift */,
@@ -1908,6 +1914,7 @@
 				B3935A1C3BCA03A6B902E7AF /* CannedJSONReporterOutput.json in Resources */,
 				6C15818F23702DCE00F582A2 /* CannedGitHubActionsLoggingReporterOutput.txt in Resources */,
 				D495B1A221165DAA00E2CD7B /* FileNameRuleFixtures in Resources */,
+				B0270FB0242E48D600A43E8B /* CannedGitLabJUnitReporterOutput.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2178,6 +2185,7 @@
 				756B585D2138ECD300D1A4E9 /* CollectionAlignmentRule.swift in Sources */,
 				621C8EA420CBC7A10007DA74 /* RedundantTypeAnnotationRule.swift in Sources */,
 				62DADC481FFF0423002B6319 /* PrefixedTopLevelConstantRule.swift in Sources */,
+				B0270FAE242E486D00A43E8B /* GitLabJUnitReporter.swift in Sources */,
 				D4BED5F82278AECC00D86BCE /* UnownedVariableCaptureRule.swift in Sources */,
 				D4130D991E16CC1300242361 /* TypeNameRuleExamples.swift in Sources */,
 				24E17F721B14BB3F008195BE /* SwiftLintFile+Cache.swift in Sources */,

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -15,7 +15,8 @@ class ReporterTests: XCTestCase {
             EmojiReporter.self,
             SonarQubeReporter.self,
             MarkdownReporter.self,
-            GitHubActionsLoggingReporter.self
+            GitHubActionsLoggingReporter.self,
+            GitLabJUnitReporter.self
         ]
         for reporter in reporters {
             XCTAssertEqual(reporter.identifier, reporterFrom(identifier: reporter.identifier).identifier)
@@ -63,6 +64,12 @@ class ReporterTests: XCTestCase {
     func testGitHubActionsLoggingReporter() {
         let expectedOutput = stringFromFile("CannedGitHubActionsLoggingReporterOutput.txt")
         let result = GitHubActionsLoggingReporter.generateReport(generateViolations())
+        XCTAssertEqual(result, expectedOutput)
+    }
+
+    func testGitLabJUnitReporter() {
+        let expectedOutput = stringFromFile("CannedGitLabJUnitReporterOutput.xml")
+        let result = GitLabJUnitReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedGitLabJUnitReporterOutput.xml
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedGitLabJUnitReporterOutput.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites><testsuite>
+	<testcase name='warning: line_length in filename:1'>
+		<failure>Severity: warning
+Rule: line_length
+Reason: Violation Reason.
+
+File: filename
+Line: 1
+Column: 2
+		</failure>
+	</testcase>
+	<testcase name='error: line_length in filename:1'>
+		<failure>Severity: error
+Rule: line_length
+Reason: Violation Reason.
+
+File: filename
+Line: 1
+Column: 2
+		</failure>
+	</testcase>
+	<testcase name='error: syntactic_sugar in filename:1'>
+		<failure>Severity: error
+Rule: syntactic_sugar
+Reason: Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;.
+
+File: filename
+Line: 1
+Column: 2
+		</failure>
+	</testcase>
+	<testcase name='error: colon in &lt;nopath&gt;'>
+		<failure>Severity: error
+Rule: colon
+Reason: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals.
+
+File: &lt;nopath&gt;
+Line: nil
+Column: nil
+		</failure>
+	</testcase>
+</testsuite></testsuites>


### PR DESCRIPTION
When I found out that GitLab provides a nice representation of JUnit reports and SwiftLint can generate JUnit report, I tried to use that but the result _(for 7 failures)_ looked like that:
- [Failures list](https://user-images.githubusercontent.com/2318002/78876962-6f35f180-7a50-11ea-988e-9ca1266759d7.png)
- [Failure details](https://user-images.githubusercontent.com/2318002/78877446-26326d00-7a51-11ea-8c88-d83d100e3f3b.png)

Not only it joined 7 issues into 1 because `classname` & `name` combination [is not unique](https://gitlab.com/gitlab-org/gitlab/-/issues/26251), but it don't give much details on why and where this issue is.

So I created a new JUnit formatter which would give much better result:
- [Failures list](https://user-images.githubusercontent.com/2318002/78877125-a7d5cb00-7a50-11ea-8853-6834d482baa6.png)
- [Failure details](https://user-images.githubusercontent.com/2318002/78877514-4104e180-7a51-11ea-8bd8-3316d479923b.png)

I decided to create a new reporter instead of existing one because JUnit format GitLab supports is not compliant with JUnit format specifications and might break already configured CI set-ups with, for example, Jenkins.

Test file: https://gitlab.com/krin-san/swiftlint-gitlabreporter/-/blob/master/main.swift
JUnit reporter results: https://gitlab.com/krin-san/swiftlint-gitlabreporter/-/merge_requests/2
GitLab reporter results: https://gitlab.com/krin-san/swiftlint-gitlabreporter/-/merge_requests/3

---

I plan to improve that reporter even more, when GitLab release new update related to junit artifacts. E.g.:
- Link from Widget to failed test file: https://gitlab.com/gitlab-org/gitlab/-/issues/22336