### PR TITLE
Remove @IBOutlet and @IBInspectable from UnusedDeclarationRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [mknabbe](https://github.com/mknabbe)
   [#1280](https://github.com/realm/SwiftLint/issues/1280)
 
+* Remove `@IBOutlet` and `@IBInspectable` from UnusedDeclarationRule  
+  [Keith Smiley](https://github.com/keith)
+  [#3184](https://github.com/realm/SwiftLint/issues/3184)
+
 #### Bug Fixes
 
 * Fix parsing of Xcode 12 compiler logs for analyzer rules.  

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -171,7 +171,7 @@ private extension SwiftLintFile {
         let cursorInfo = self.cursorInfo(at: nameOffset, compilerArguments: compilerArguments)
 
         if let annotatedDecl = cursorInfo?.annotatedDeclaration,
-            ["@IBOutlet", "@IBAction", "@objc", "@IBInspectable"].contains(where: annotatedDecl.contains) {
+            ["@IBAction", "@objc"].contains(where: annotatedDecl.contains) {
             return nil
         }
 


### PR DESCRIPTION
This list was intended to be things that could have side effects from
being in IB, or just being dynamic, and therefore we cannot tell if they
are used or not. In the case of the 2 attributes I'm removing, they
could be used in IB, but if they aren't used in code, they should still
be considered dead.