### PR TITLE
fix unused_import false positive

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule, AutomaticTestableRule {
+public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
     public var configuration = UnusedImportConfiguration(severity: .warning, requireExplicitImports: false,
                                                          allowedTransitiveImports: [])
 
@@ -114,6 +114,17 @@ private extension SwiftLintFile {
                     arguments: compilerArguments,
                     processedTokenOffsets: Set(syntaxMap.tokens.map { $0.offset })
                 )
+            )
+        }
+
+        if !unusedImports.isEmpty {
+            unusedImports.subtract(
+                usrFragments
+                    .flatMap { module in
+                        return configuration.allowedTransitiveImports
+                            .filter { $0.transitivelyImportedModules.contains(module) }
+                            .map { $0.importedModule }
+                    }
             )
         }
 

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */; };
 		1EF115921EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */; };
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
+		20FDA48C2456DDA100521D8A /* UnusedImportRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20FDA48B2456DDA100521D8A /* UnusedImportRuleTests.swift */; };
 		224E7F9D235A5E800051368B /* ExpiringTodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */; };
 		22A36FDF235673F50037B47D /* ExpiringTodoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */; };
 		22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */; };
@@ -545,6 +546,7 @@
 		1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRule.swift; sourceTree = "<group>"; };
 		1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTopLevelACLRule.swift; sourceTree = "<group>"; };
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
+		20FDA48B2456DDA100521D8A /* UnusedImportRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedImportRuleTests.swift; sourceTree = "<group>"; };
 		224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRuleTests.swift; sourceTree = "<group>"; };
 		22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRule.swift; sourceTree = "<group>"; };
 		22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoConfiguration.swift; sourceTree = "<group>"; };
@@ -1616,6 +1618,7 @@
 				820F451B2107292500AA056A /* TypeContentsOrderRuleTests.swift */,
 				3B20CD0B1EB699C20069EF2E /* TypeNameRuleTests.swift */,
 				D4470D5A1EB76F44008A1B2E /* UnusedOptionalBindingRuleTests.swift */,
+				20FDA48B2456DDA100521D8A /* UnusedImportRuleTests.swift */,
 				006204DD1E1E4E0A00FFFBE1 /* VerticalWhitespaceRuleTests.swift */,
 				F480DC801F2609AB00099465 /* XCTestCase+BundlePath.swift */,
 				627C7A312004F9290053C79D /* XCTSpecificMatcherRuleTests.swift */,
@@ -2416,6 +2419,7 @@
 				D41985EF21FAD5E8003BE2B7 /* DeploymentTargetRuleTests.swift in Sources */,
 				6C7045441C6ADA450003F15A /* SourceKitCrashTests.swift in Sources */,
 				820F451E21073D7200AA056A /* ConditionalReturnsOnNewlineRuleTests.swift in Sources */,
+				20FDA48C2456DDA100521D8A /* UnusedImportRuleTests.swift in Sources */,
 				D4246D6F1F30DB260097E658 /* PrivateOverFilePrivateRuleTests.swift in Sources */,
 				B25DCD101F7EF6DC0028A199 /* MultilineArgumentsRuleTests.swift in Sources */,
 				3BB47D871C51DE6E00AE6A10 /* CustomRulesTests.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1225,6 +1225,7 @@ extension ReporterTests {
         ("testXcodeReporter", testXcodeReporter),
         ("testEmojiReporter", testEmojiReporter),
         ("testGitHubActionsLoggingReporter", testGitHubActionsLoggingReporter),
+        ("testGitLabJUnitReporter", testGitLabJUnitReporter),
         ("testJSONReporter", testJSONReporter),
         ("testCSVReporter", testCSVReporter),
         ("testCheckstyleReporter", testCheckstyleReporter),
@@ -1532,7 +1533,8 @@ extension UnusedEnumeratedRuleTests {
 
 extension UnusedImportRuleTests {
     static var allTests: [(String, (UnusedImportRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration),
+        ("testWithAllowedTransitiveImports", testWithAllowedTransitiveImports)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -774,12 +774,6 @@ class UnusedEnumeratedRuleTests: XCTestCase {
     }
 }
 
-class UnusedImportRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(UnusedImportRule.description)
-    }
-}
-
 class UnusedSetterValueRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedSetterValueRule.description)

--- a/Tests/SwiftLintFrameworkTests/RuleDescription+Examples.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleDescription+Examples.swift
@@ -10,7 +10,8 @@ extension RuleDescription {
                                nonTriggeringExamples: nonTriggeringExamples,
                                triggeringExamples: triggeringExamples,
                                corrections: corrections,
-                               deprecatedAliases: deprecatedAliases)
+                               deprecatedAliases: deprecatedAliases,
+                               requiresFileOnDisk: requiresFileOnDisk)
     }
 
     func with(nonTriggeringExamples: [Example]) -> RuleDescription {
@@ -31,6 +32,7 @@ extension RuleDescription {
                                nonTriggeringExamples: nonTriggeringExamples,
                                triggeringExamples: triggeringExamples,
                                corrections: corrections,
-                               deprecatedAliases: deprecatedAliases)
+                               deprecatedAliases: deprecatedAliases,
+                               requiresFileOnDisk: requiresFileOnDisk)
     }
 }

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -390,6 +390,10 @@ extension XCTestCase {
                                 line callSiteLine: UInt = #line) {
         // Non-triggering examples don't violate
         for nonTrigger in nonTriggers {
+            #if os(Linux)
+            guard nonTrigger.testOnLinux else { continue }
+            #endif
+
             let unexpectedViolations = violations(nonTrigger, config: config,
                                                   requiresFileOnDisk: requiresFileOnDisk)
             if unexpectedViolations.isEmpty { continue }
@@ -402,6 +406,10 @@ extension XCTestCase {
 
         // Triggering examples violate
         for trigger in triggers {
+            #if os(Linux)
+            guard trigger.testOnLinux else { continue }
+            #endif
+
             let triggerViolations = violations(trigger, config: config,
                                                requiresFileOnDisk: requiresFileOnDisk)
 

--- a/Tests/SwiftLintFrameworkTests/UnusedImportRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedImportRuleTests.swift
@@ -1,0 +1,48 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class UnusedImportRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnusedImportRule.description)
+    }
+
+    func testWithAllowedTransitiveImports() {
+        let nonTriggeringExamples = [
+            Example("""
+            import Foundation
+            typealias Foo = CFData
+            """, testOnLinux: false),
+            Example("""
+            import Foundation
+            typealias Foo = CFData
+            @objc
+            class A {}
+            """, testOnLinux: false)
+        ]
+
+        let triggeringExamples = [
+            Example("""
+            import Foundation
+            typealias Foo = UIView
+            """, testOnLinux: false)
+        ]
+
+        let description = UnusedImportRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: [:])
+
+        verifyRule(
+            description,
+            ruleConfiguration: [
+                "require_explicit_imports": true,
+                "allowed_transitive_imports": [
+                    [
+                        "module": "Foundation",
+                        "allowed_transitive_imports": ["CoreFoundation"]
+                    ]
+                ]
+            ]
+        )
+    }
+}


### PR DESCRIPTION
Fix unused_import rule false positive in this example:
Configuration:
```yml
unused_import:
    require_explicit_imports: true
    allowed_transitive_imports:
        - module: Foundation
          allowed_transitive_imports:
            - CoreFoundation
```
```swift
import Foundation

typealias Baz = CFData
```

Current master build corrects this code which leads to compilation errors.
```swift

typealias Baz = CFData
```