### PR TITLE
Add XCTestCase examples to unused declaration rule

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -110,7 +110,7 @@ struct UnusedDeclarationRuleExamples {
         class ↓MyTests: NSObject {
             func ↓testExample() {}
         }
-        """),
+        """)
     ] + platformSpecificTriggeringExamples
 
 #if os(macOS)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -56,6 +56,19 @@ struct UnusedDeclarationRuleExamples {
 
         struct MyStruct: Foo {}
         MyStruct().bar()
+        """),
+        Example("""
+        import XCTest
+        class MyTests: XCTestCase {
+            func testExample() {}
+        }
+        """),
+        Example("""
+        import XCTest
+        open class BestTestCase: XCTestCase {}
+        class MyTests: BestTestCase {
+            func testExample() {}
+        }
         """)
     ] + platformSpecificNonTriggeringExamples
 
@@ -91,7 +104,13 @@ struct UnusedDeclarationRuleExamples {
 
         struct MyStruct: Foo {}
         _ = MyStruct()
-        """)
+        """),
+        Example("""
+        import XCTest
+        class ↓MyTests: NSObject {
+            func ↓testExample() {}
+        }
+        """),
     ] + platformSpecificTriggeringExamples
 
 #if os(macOS)

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -17,7 +17,19 @@ private extension SwiftLintFile {
     }
 
     func makeCompilerArguments() -> [String] {
-        return ["-sdk", sdkPath(), "-j4", path!]
+        let sdk = sdkPath()
+        let frameworks = URL(fileURLWithPath: sdk)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Frameworks")
+            .path
+        return [
+            "-F",
+            frameworks,
+            "-sdk", sdk,
+            "-j4", path!
+        ]
     }
 }
 


### PR DESCRIPTION
This rule correctly handles subclasses of XCTestCase being used, this adds some tests validating this behavior.