### PR TITLE
Fix severity level configuration for duplicate_imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 * Fix UnusedImportRule breaking transitive imports.  
   [keith](https://github.com/keith)
+* Fix severity level configuration for `duplicate_imports`.
+  [Yusuke Goto](https://github.com/yusukegoto)
 
 ## 0.39.2: Stay Home
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -84,7 +84,9 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
                 }()
 
                 let location = Location(file: file, characterOffset: lineWithDuplicatedImport.range.location)
-                let violation = StyleViolation(ruleDescription: type(of: self).description, location: location)
+                let violation = StyleViolation(ruleDescription: type(of: self).description,
+                                               severity: configuration.severity,
+                                               location: location)
                 violations.append(violation)
             }
         }


### PR DESCRIPTION
Couldn't overwrite the severity configuration of `duplicate_imports` .
There seems be no other similar case inside the Idiomatic rules at lease I see.