### PR TITLE
Fix UnusedImportRule breaking transitive imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@
 
 #### Enhancements
 
+* Fix UnusedImportRule breaking transitive imports.  
+  [keith](https://github.com/keith)
 * JUnit reporter for GitLab artifact:report:junit with better representation of
   found issues.  
   [krin-san](https://github.com/krin-san)
   [#3177](https://github.com/realm/SwiftLint/pull/3177)
+
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@
 
 #### Enhancements
 
-* Fix UnusedImportRule breaking transitive imports.  
-  [keith](https://github.com/keith)
 * JUnit reporter for GitLab artifact:report:junit with better representation of
   found issues.  
   [krin-san](https://github.com/krin-san)
@@ -25,7 +23,8 @@
 
 #### Bug Fixes
 
-* None.
+* Fix UnusedImportRule breaking transitive imports.  
+  [keith](https://github.com/keith)
 
 ## 0.39.2: Stay Home
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
   [krin-san](https://github.com/krin-san)
   [#3177](https://github.com/realm/SwiftLint/pull/3177)
 
-
 #### Bug Fixes
 
 * Fix UnusedImportRule breaking transitive imports.  

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -132,6 +132,7 @@ private extension SwiftLintFile {
             .subtracting(imports + [currentModule].compactMap({ $0 }))
             .filter { module in
                 let modulesAllowedToImportCurrentModule = configuration.allowedTransitiveImports
+                    .filter { !unusedImports.contains($0.importedModule) }
                     .filter { $0.transitivelyImportedModules.contains(module) }
                     .map { $0.importedModule }
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRuleExamples.swift
@@ -152,6 +152,22 @@ struct UnusedImportRuleExamples {
             """),
         Example("""
         ↓↓import Foundation
+        typealias Foo = CGPoint
+        """, configuration: [
+            "require_explicit_imports": true,
+            "allowed_transitive_imports": [
+                [
+                    "module": "Foundation",
+                    "allowed_transitive_imports": ["CoreGraphics"]
+                ]
+            ]
+        ], testMultiByteOffsets: false, testOnLinux: false):
+            Example("""
+            import CoreGraphics
+            typealias Foo = CGPoint
+            """),
+        Example("""
+        ↓↓import Foundation
         typealias Foo = CFData
         """, configuration: [
             "require_explicit_imports": true


### PR DESCRIPTION
Previously in the case a unused import was allowed to transitively
pollute another module, when that unused import was removed, this rule
would not insert the previously transitively included module, leading
the code to fail to compile. Now unused imports, that will be removed,
are no longer considered for which imports can be implicit.