### PR TITLE
Update README files to include complete list of reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ identifier_name:
     - id
     - URL
     - GlobalAPIKey
-reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit, html, emoji, sonarqube, markdown)
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit, html, emoji, sonarqube, markdown, github-actions-logging)
 ```
 
 You can also use environment variables in your configuration file,

--- a/README_CN.md
+++ b/README_CN.md
@@ -283,7 +283,7 @@ identifier_name:
     - id
     - URL
     - GlobalAPIKey
-reporter: "xcode" # 报告类型 (xcode, json, csv, checkstyle, junit, html, emoji)
+reporter: "xcode" # 报告类型 (xcode, json, csv, checkstyle, junit, html, emoji, sonarqube, markdown, github-actions-logging)
 ```
 
 #### 定义自定义规则

--- a/README_KR.md
+++ b/README_KR.md
@@ -258,7 +258,7 @@ identifier_name:
     - id
     - URL
     - GlobalAPIKey
-reporter: "xcode" # 보고 유형 (xcode, json, csv, checkstyle, junit, html, emoji, markdown)
+reporter: "xcode" # 보고 유형 (xcode, json, csv, checkstyle, junit, html, emoji, sonarqube, markdown, github-actions-logging)
 ```
 
 #### 커스텀 룰 정의


### PR DESCRIPTION
👋 

I didn't realise that Realm supported formatting the report to support GitHub Actions and it wasn't until I dug into the source code (and later on when I realised that the docs listed it [here](https://realm.github.io/SwiftLint/Structs/GitHubActionsLoggingReporter.html)) that I realised support was already there.

I thought this because I thought the list included in the README.md was complete but it looks like the English one had been missing `github-actions-logging` and the translations had also been missing a couple of the more recent additions. 

Thought I'd add them to help anybody else in the future 👍 