### PR TITLE
Invalid Autocorrect behaviour for LiteralExpressionEndIdentationRule [WIP]

### DIFF
--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -119,6 +119,16 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
                3,
                4
             ]
+            """),
+            Example("""
+            let x = [
+               Test(keyA: valueA,
+                    keyB: valueB)]
+            """): Example("""
+                let x = [
+                Test(keyA: valueA,
+                keyB: valueB)
+                ]
             """)
         ]
     )
@@ -131,8 +141,8 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
 
     private func styleViolation(for violation: Violation, in file: SwiftLintFile) -> StyleViolation {
         let reason = "\(LiteralExpressionEndIdentationRule.description.description) " +
-                     "Expected \(violation.indentationRanges.expected.length), " +
-                     "got \(violation.indentationRanges.actual.length)."
+            "Expected \(violation.indentationRanges.expected.length), " +
+        "got \(violation.indentationRanges.actual.length)."
 
         return StyleViolation(ruleDescription: type(of: self).description,
                               severity: configuration.severity,
@@ -244,8 +254,8 @@ extension LiteralExpressionEndIdentationRule {
             case let endOffset = offset + length - 1,
             let (endLine, endPosition) = contents.lineAndCharacter(forByteOffset: endOffset),
             lastParamLine != endLine
-        else {
-            return nil
+            else {
+                return nil
         }
 
         let range = file.lines[startLine - 1].range
@@ -254,8 +264,8 @@ extension LiteralExpressionEndIdentationRule {
         guard let match = regex.firstMatch(in: file.contents, options: [], range: range)?.range,
             case let expected = match.location - range.location,
             expected != actual
-        else {
-            return nil
+            else {
+                return nil
         }
 
         var expectedRange = range

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -69,6 +69,11 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
             let x = [
                key: value
                ↓]
+            """),
+            Example("""
+            let x = [
+               Test(keyA: valueA,
+                    keyB: valueB)↓]
             """)
         ],
         corrections: [
@@ -123,12 +128,12 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
             Example("""
             let x = [
                Test(keyA: valueA,
-                    keyB: valueB)]
+                    keyB: valueB)↓]
             """): Example("""
-                let x = [
-                Test(keyA: valueA,
-                keyB: valueB)
-                ]
+            let x = [
+               Test(keyA: valueA,
+                    keyB: valueB)
+            ]
             """)
         ]
     )


### PR DESCRIPTION
I've identified a destructive autocorrect behaviour within SwiftLint 0.39.2 relating to the LiteralExpressionEndIdentationRule.

I'm completely new to the codebase, so I'm happy to attempt to fix the issue, but wanted to created a PR that reproduced the issue with a failing test and wanted to make sure I was along the right lines before diving in.

Input:

```
let array = [
    Bug(first: "a",
        second: "b")]
```

Expected Behaviour after running `swiftlint autocorrect`

```
let array = [
    Bug(first: "a",
        second: "b")
]
```

Actual behaviour after running `swiftlint autocorrect`

```
let array = [
    Bug(first: "a",
]
```

Is this the correct way to reproduce an autocorrect issue with a test case?