### PR TITLE
Fix cache directory resolution when using remote config file

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Configuration+Remote.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Remote.swift
@@ -203,8 +203,8 @@ internal extension Configuration.FileGraph.FilePath {
         // Create directory if needed
         let directory = "\(Configuration.FileGraph.FilePath.remoteCachePath)/"
             + "\(Configuration.FileGraph.FilePath.remoteCacheVersionNumber)/"
-            .bridge().absolutePathRepresentation(rootDirectory: rootDirectory)
-        if !FileManager.default.fileExists(atPath: directory) {
+        let absoluteDirectory = directory.bridge().absolutePathRepresentation(rootDirectory: rootDirectory)
+        if !FileManager.default.fileExists(atPath: absoluteDirectory) {
             try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
         }
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Remote.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Remote.swift
@@ -12,6 +12,11 @@ internal extension Configuration.FileGraph.FilePath {
     /// If the format of the caching is changed in the future, change this version number
     private static let remoteCacheVersionNumber: String = "v1"
 
+    /// Use this to get the path to the cache directory for the current cache format
+    private static var versionedRemoteCachePath: String {
+        "\(remoteCachePath)/\(remoteCacheVersionNumber)"
+    }
+
     // MARK: - Methods: Resolving
     mutating func resolve(
         remoteConfigTimeout: Double,
@@ -194,17 +199,15 @@ internal extension Configuration.FileGraph.FilePath {
 
     private func filePath(for urlString: String, rootDirectory: String) -> String {
         let adjustedUrlString = urlString.replacingOccurrences(of: "/", with: "_")
-        let path = "\(Configuration.FileGraph.FilePath.remoteCachePath)/"
-            + "\(Configuration.FileGraph.FilePath.remoteCacheVersionNumber)/\(adjustedUrlString).yml"
+        let path = "\(Configuration.FileGraph.FilePath.versionedRemoteCachePath)" + "/\(adjustedUrlString).yml"
         return path.bridge().absolutePathRepresentation(rootDirectory: rootDirectory)
     }
 
     private func maintainRemoteConfigCache(rootDirectory: String) throws {
         // Create directory if needed
-        let directory = "\(Configuration.FileGraph.FilePath.remoteCachePath)/"
-            + "\(Configuration.FileGraph.FilePath.remoteCacheVersionNumber)/"
-        let absoluteDirectory = directory.bridge().absolutePathRepresentation(rootDirectory: rootDirectory)
-        if !FileManager.default.fileExists(atPath: absoluteDirectory) {
+        let directory = Configuration.FileGraph.FilePath.versionedRemoteCachePath
+            .bridge().absolutePathRepresentation(rootDirectory: rootDirectory)
+        if !FileManager.default.fileExists(atPath: directory) {
             try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
         }
 


### PR DESCRIPTION
I'm spiking using a [centralized SwiftLint configuration](https://github.com/Automattic/swiftlint-config) across the Automattic's Swift repositories, as we have quite a few.

I used https://github.com/realm/SwiftLint/pull/3058 but it wasn't working. After a bit of digging around, I discovered the issue had to do with how the cache directory path was build, or to be precise resolved as an absolute path.

You can see the SwiftLint build failing [here](https://github.com/wordpress-mobile/WordPress-iOS-Shared/runs/756641590?check_suite_focus=true#step:7:7) (although the message is a bit misleading) and succeeding [here](https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/262/checks?check_run_id=756740142), with [the only change](https://github.com/wordpress-mobile/WordPress-iOS-Shared/compare/39b9e33...3c8dcc8) being that the former uses https://github.com/realm/SwiftLint/pull/3058 as the source for SwiftLint and the latter this PR.

I would have liked to add tests for this fix, but the only way I could see would have been to add an abstraction on `FileManager` in order to provide a test double for it in the test. That seemed like a lot of work as well as a substantial change in the design of this code, which is not on `master` yet. I opted for simply fixing the production code, instead. If you can think of a quick way to add tests which would fit in the context of this PR, I'd love to make that happen.

Thank you for working on this @fredpi. It's super useful, I really love this feature.

