### PR TITLE
Add support for Xcode 11.5 and Swift 5.2.4

### DIFF
--- a/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
@@ -4,7 +4,9 @@ import XCTest
 final class SwiftVersionTests: XCTestCase {
     // swiftlint:disable:next function_body_length
     func testDetectSwiftVersion() {
-        #if compiler(>=5.2.3)
+        #if compiler(>=5.2.4)
+            let version = "5.2.4"
+        #elseif compiler(>=5.2.3)
             let version = "5.2.3"
         #elseif compiler(>=5.2.2)
             let version = "5.2.2"


### PR DESCRIPTION
This fixes the `SwiftVersionTests` when running them with Xcode 11.5 (Swift 5.2.4).