### PR TITLE
Improve visibility of whitelist_rules option

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,14 +325,19 @@ Rule inclusion:
   only configurable rule list (there is no disabled/whitelist equivalent).
 
 ```yaml
-disabled_rules: # rule identifiers to exclude from running
+# By default, SwiftLint uses a set of sensible default rules you can adjust:
+disabled_rules: # rule identifiers turned on by default to exclude from running
   - colon
   - comma
   - control_statement
-opt_in_rules: # some rules are only opt-in
-  - empty_count
-  # Find all the available rules by running:
-  # swiftlint rules
+opt_in_rules: # some rules are turned off by default, so you need to opt-in
+  - empty_count # Find all the available rules by running: `swiftlint rules`
+
+# Alternatively, specify all rules explicitly by uncommenting this option:
+# whitelist_rules: # delete `disabled_rules` & `opt_in_rules` if using this
+#   - empty_parameters
+#   - vertical_whitespace
+
 included: # paths to include during linting. `--path` is ignored if present.
   - Source
 excluded: # paths to ignore during linting. Takes precedence over `included`.


### PR DESCRIPTION
Related to https://github.com/realm/SwiftLint/issues/1451 and https://github.com/realm/SwiftLint/issues/1118.

Implements the comment https://github.com/realm/SwiftLint/issues/1118#issuecomment-271536394 which was also approved by @jpsim as a good idea.