### PR TITLE
Pass moduleName instead of cursorInfo to UnusedImportRule helper function

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -175,7 +175,7 @@ private extension SwiftLintFile {
                 }
             }
 
-            appendUsedImports(cursorInfo: cursorInfo, usrFragments: &usrFragments)
+            appendUsedImports(moduleName: cursorInfo.moduleName, usrFragments: &usrFragments)
         }
 
         return (imports: imports, usrFragments: usrFragments)
@@ -218,7 +218,7 @@ private extension SwiftLintFile {
                     continue
                 }
 
-                appendUsedImports(cursorInfo: cursorInfo, usrFragments: &imports)
+                appendUsedImports(moduleName: cursorInfo.moduleName, usrFragments: &imports)
             }
         }
 
@@ -258,8 +258,8 @@ private extension SwiftLintFile {
         ].contains { kind.hasPrefix($0) }
     }
 
-    func appendUsedImports(cursorInfo: SourceKittenDictionary, usrFragments: inout Set<String>) {
-        if let rootModuleName = cursorInfo.moduleName?.split(separator: ".").first.map(String.init) {
+    func appendUsedImports(moduleName: String?, usrFragments: inout Set<String>) {
+        if let rootModuleName = moduleName?.split(separator: ".").first.map(String.init) {
             usrFragments.insert(rootModuleName)
         }
     }


### PR DESCRIPTION
Simplifies the interface of `appendUsedImports()` to take an (optional) module name, instead of a `SourceKittenDictionary` (aka cursor info). The function uses only the module name. This is a non-functional change.