### PR TITLE
Add NonPrivateXCTestMembersRule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -33,14 +33,15 @@ opt_in_rules:
   - flatmap_over_map_reduce
   - identical_operands
   - joined_default_parameter
-  - legacy_random
-  - let_var_whitespace
   - last_where
   - legacy_multiple
+  - legacy_random
+  - let_var_whitespace
   - literal_expression_end_indentation
   - lower_acl_than_parent
   - modifier_order
   - nimble_operator
+  - non_private_xctest_member
   - nslocalizedstring_key
   - number_separator
   - object_literal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
   format. Could be used for GitLab Code Quality MR Widget.  
   [jkroepke](https://github.com/jkroepke)
   [#3424](https://github.com/realm/SwiftLint/issues/3424)
+* Add `non_private_xctest_member` rule.  
+  [Keith Smiley](https://github.com/keith)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
   format. Could be used for GitLab Code Quality MR Widget.  
   [jkroepke](https://github.com/jkroepke)
   [#3424](https://github.com/realm/SwiftLint/issues/3424)
+
 * Add `non_private_xctest_member` rule.  
   [Keith Smiley](https://github.com/keith)
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -114,6 +114,7 @@ public let primaryRuleList = RuleList(rules: [
     NoFallthroughOnlyRule.self,
     NoGroupingExtensionRule.self,
     NoSpaceInMethodCallRule.self,
+    NonPrivateXCTestMembersRule.self,
     NotificationCenterDetachmentRule.self,
     NumberSeparatorRule.self,
     ObjectLiteralRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/NonPrivateXCTestMembersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NonPrivateXCTestMembersRule.swift
@@ -1,0 +1,48 @@
+import SourceKittenFramework
+
+public struct NonPrivateXCTestMembersRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "non_private_xctest_member",
+        name: "Non-private XCTest member",
+        description: "All non-test XCTest members should be private.",
+        kind: .lint,
+        nonTriggeringExamples: NonPrivateXCTestMembersRuleExamples.nonTriggeringExamples,
+        triggeringExamples: NonPrivateXCTestMembersRuleExamples.triggeringExamples
+    )
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        return testClasses(in: file).flatMap { violations(in: file, for: $0) }
+    }
+
+    // MARK: - Private
+
+    private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
+        let dict = file.structureDictionary
+        return dict.substructure.filter { dictionary in
+            guard dictionary.declarationKind == .class else { return false }
+            return dictionary.inheritedTypes.contains("XCTestCase")
+        }
+    }
+
+    private func violations(in file: SwiftLintFile,
+                            for dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        return dictionary.substructure.compactMap { subDictionary -> StyleViolation? in
+            guard
+                let name = subDictionary.name, !isXCTestMethod(name),
+                let acl = subDictionary.accessibility, acl != .fileprivate && acl != .private,
+                let offset = subDictionary.offset else { return nil }
+
+            return StyleViolation(ruleDescription: Self.description,
+                                  severity: configuration.severity,
+                                  location: Location(file: file, byteOffset: offset))
+        }
+    }
+
+    private func isXCTestMethod(_ method: String) -> Bool {
+        return method.hasPrefix("test") || method == "setUp()" || method == "tearDown()"
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/NonPrivateXCTestMembersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NonPrivateXCTestMembersRuleExamples.swift
@@ -1,0 +1,59 @@
+internal struct NonPrivateXCTestMembersRuleExamples {
+    static let nonTriggeringExamples = [
+        // Valid XCTestCase class
+
+        Example("""
+        class TotoTests: XCTestCase {
+            private var foo: Bar?
+            fileprivate func baz() {}
+
+            override class func setUp() {}
+            override static func tearDown() {}
+
+            override func setUp() {
+                super.setUp()
+            }
+
+            override func tearDown() {}
+
+            func testFoo() {}
+
+            func testBar() {}
+        }
+        """),
+
+        // Not an XCTestCase class
+
+        Example("""
+        class Foobar {
+            var foo: Bar?
+
+            func setUp() {}
+
+            func tearDown() {}
+
+            func testFoo() {}
+        }
+        """)
+    ]
+
+    static let triggeringExamples = [
+        Example("""
+        class TotoTests: XCTestCase {
+            ↓var foo: Bar?
+
+            ↓struct Baz {}
+
+            override func setUp() {}
+
+            override func tearDown() {}
+
+            func testFoo() {}
+
+            func testBar() {}
+
+            ↓func helperFunction() {}
+        }
+        """)
+    ]
+}

--- a/Source/SwiftLintFramework/Rules/Lint/NonPrivateXCTestMembersRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NonPrivateXCTestMembersRuleExamples.swift
@@ -56,4 +56,41 @@ internal struct NonPrivateXCTestMembersRuleExamples {
         }
         """)
     ]
+
+    static let corrections = [
+        Example("""
+        class TotoTests: XCTestCase {
+            ↓var foo: Bar?
+
+            ↓struct Baz {}
+
+            override func setUp() {}
+
+            override func tearDown() {}
+
+            func testFoo() {}
+
+            func testBar() {}
+
+            ↓func helperFunction() {}
+        }
+        """):
+        Example("""
+        class TotoTests: XCTestCase {
+            private var foo: Bar?
+
+            private struct Baz {}
+
+            override func setUp() {}
+
+            override func tearDown() {}
+
+            func testFoo() {}
+
+            func testBar() {}
+
+            private func helperFunction() {}
+        }
+        """)
+    ]
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1053,6 +1053,12 @@ extension NoSpaceInMethodCallRuleTests {
     ]
 }
 
+extension NonPrivateXCTestMembersRuleTests {
+    static var allTests: [(String, (NonPrivateXCTestMembersRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension NotificationCenterDetachmentRuleTests {
     static var allTests: [(String, (NotificationCenterDetachmentRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1876,6 +1882,7 @@ XCTMain([
     testCase(NoFallthroughOnlyRuleTests.allTests),
     testCase(NoGroupingExtensionRuleTests.allTests),
     testCase(NoSpaceInMethodCallRuleTests.allTests),
+    testCase(NonPrivateXCTestMembersRuleTests.allTests),
     testCase(NotificationCenterDetachmentRuleTests.allTests),
     testCase(NumberSeparatorRuleTests.allTests),
     testCase(ObjectLiteralRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -468,6 +468,12 @@ class NoSpaceInMethodCallRuleTests: XCTestCase {
     }
 }
 
+class NonPrivateXCTestMembersRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NonPrivateXCTestMembersRule.description)
+    }
+}
+
 class NotificationCenterDetachmentRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NotificationCenterDetachmentRule.description)

--- a/Tests/SwiftLintFrameworkTests/DeploymentTargetConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeploymentTargetConfigurationTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 class DeploymentTargetConfigurationTests: XCTestCase {
-    typealias Version = DeploymentTargetConfiguration.Version
+    private typealias Version = DeploymentTargetConfiguration.Version
 
     func testAppliesConfigurationFromDictionary() throws {
         var configuration = DeploymentTargetConfiguration()

--- a/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleTests.swift
@@ -2,7 +2,7 @@ import SwiftLintFramework
 import XCTest
 
 class DiscouragedDirectInitRuleTests: XCTestCase {
-    let baseDescription = DiscouragedDirectInitRule.description
+    private let baseDescription = DiscouragedDirectInitRule.description
 
     func testDiscouragedDirectInitWithDefaultConfiguration() {
         verifyRule(baseDescription)

--- a/Tests/SwiftLintFrameworkTests/RequiredEnumCaseRuleTestCase.swift
+++ b/Tests/SwiftLintFrameworkTests/RequiredEnumCaseRuleTestCase.swift
@@ -2,17 +2,17 @@
 import XCTest
 
 class RequiredEnumCaseRuleTestCase: XCTestCase {
-    typealias RuleConfiguration = RequiredEnumCaseRuleConfiguration
-    typealias RequiredCase = RuleConfiguration.RequiredCase
+    private typealias RuleConfiguration = RequiredEnumCaseRuleConfiguration
+    private typealias RequiredCase = RuleConfiguration.RequiredCase
 
-    let protocol1 = "RequiredProtocol"
-    let protocol2 = "NetworkResults"
-    let protocol3 = "RequiredProtocolWithSeverity"
-    let rule1 = RuleConfiguration.RequiredCase(name: "success", severity: .warning)
-    let rule2 = RuleConfiguration.RequiredCase(name: "error", severity: .warning)
-    let rule3 = RuleConfiguration.RequiredCase(name: "success", severity: .error)
+    private let protocol1 = "RequiredProtocol"
+    private let protocol2 = "NetworkResults"
+    private let protocol3 = "RequiredProtocolWithSeverity"
+    private let rule1 = RuleConfiguration.RequiredCase(name: "success", severity: .warning)
+    private let rule2 = RuleConfiguration.RequiredCase(name: "error", severity: .warning)
+    private let rule3 = RuleConfiguration.RequiredCase(name: "success", severity: .error)
 
-    var config: RuleConfiguration!
+    private var config: RuleConfiguration!
 
     override func setUp() {
         super.setUp()
@@ -66,7 +66,7 @@ class RequiredEnumCaseRuleTestCase: XCTestCase {
         XCTAssertEqual(config.consoleDescription, expected)
     }
 
-    func validateRulesExistForProtocol1() {
+    private func validateRulesExistForProtocol1() {
         XCTAssertTrue(self.config.protocols[protocol1]?.contains(self.rule1) ?? false)
         XCTAssertTrue(self.config.protocols[protocol1]?.contains(self.rule2) ?? false)
     }
@@ -76,7 +76,7 @@ class RequiredEnumCaseRuleTestCase: XCTestCase {
         validateRulesExistForProtocol3()
     }
 
-    func validateRulesExistForProtocol3() {
+    private func validateRulesExistForProtocol3() {
         XCTAssertTrue(self.config.protocols[protocol3]?.contains(self.rule3) ?? false)
         XCTAssertTrue(self.config.protocols[protocol3]?.contains(self.rule2) ?? false)
     }


### PR DESCRIPTION
This rule lints against any members of XCTestCase subclasses that aren't
implementing XCTestCase methods, or prefixed with `test`. This can help
encourage reducing ACLs on these classes, and potentially find
mis-spelled test functions.