### PR TITLE
Use Ray Wenderlich’s Swift Style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # SwiftLint
 
-A tool to enforce Swift style and conventions, loosely based on
-[GitHub's Swift Style Guide](https://github.com/github/swift-style-guide).
+A tool to enforce Swift style and conventions, loosely based on the now archived [GitHub Swift Style Guide](https://github.com/github/swift-style-guide). SwiftLint enforces the style guide rules that are generally accepted by the Swift community. These rules are well described in popular style guides like [Ray Wenderlich's Swift Style Guide](https://github.com/raywenderlich/swift-style-guide).
 
 SwiftLint hooks into [Clang](http://clang.llvm.org) and
 [SourceKit](http://www.jpsim.com/uncovering-sourcekit) to use the

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,6 @@
 # SwiftLint
 
-SwiftLint 是一个用于强制检查 Swift 代码风格和规定的一个工具，基本上以 [GitHub's Swift 代码风格指南](https://github.com/github/swift-style-guide)为基础。
+SwiftLint 是一个用于强制检查 Swift 代码风格和规定的一个工具，基本上以 [Ray Wenderlich's Swift 代码风格指南](https://github.com/raywenderlich/swift-style-guide)为基础。
 
 SwiftLint Hook 了 [Clang](http://clang.llvm.org) 和 [SourceKit](http://www.jpsim.com/uncovering-sourcekit) 从而能够使用 [AST](http://clang.llvm.org/docs/IntroductionToTheClangAST.html) 来表示源代码文件的更多精确结果。
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -1,6 +1,6 @@
 # SwiftLint
 
-SwiftLint는 스위프트 스타일 및 컨벤션을 강제하기 위한 도구로, [GitHub 스위프트 스타일 가이드](https://github.com/github/swift-style-guide)에 대략적인 기반을 두고 있습니다.
+SwiftLint는 스위프트 스타일 및 컨벤션을 강제하기 위한 도구로, [Ray Wenderlich 스위프트 스타일 가이드](https://github.com/raywenderlich/swift-style-guide)에 대략적인 기반을 두고 있습니다.
 
 SwiftLint는 좀 더 정확한 결과를 위해 [Clang](http://clang.llvm.org)과 [SourceKit](http://www.jpsim.com/uncovering-sourcekit)에 연결하여 소스 파일의 [AST](http://clang.llvm.org/docs/IntroductionToTheClangAST.html) 표현을 사용합니다.
 


### PR DESCRIPTION
GitHub has archived their current style guide.
The style guide from Wenderlich closely follows the existing rules, and is still being maintained.
Closes #3200 