### PR TITLE
Add 'always_keep_imports' to UnusedImportRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   found issues.  
   [krin-san](https://github.com/krin-san)
   [#3177](https://github.com/realm/SwiftLint/pull/3177)
+* Add 'always_keep_imports' UnusedImportRule exception.  
+  [Keith Smiley](https://github.com/keith)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule, AutomaticTestableRule {
     public var configuration = UnusedImportConfiguration(severity: .warning, requireExplicitImports: false,
-                                                         allowedTransitiveImports: [])
+                                                         allowedTransitiveImports: [], alwaysKeepImports: [])
 
     public init() {}
 
@@ -102,7 +102,7 @@ private extension SwiftLintFile {
 
         // Always disallow 'import Swift' because it's available without importing.
         usrFragments.remove("Swift")
-        var unusedImports = imports.subtracting(usrFragments)
+        var unusedImports = imports.subtracting(usrFragments).subtracting(configuration.alwaysKeepImports)
         // Certain Swift attributes requires importing Foundation.
         if unusedImports.contains("Foundation") && containsAttributesRequiringFoundation() {
             unusedImports.remove("Foundation")

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRuleExamples.swift
@@ -210,6 +210,16 @@ struct UnusedImportRuleExamples {
             typealias Bar = CFData
             @objc
             class A {}
-            """)
+            """),
+        Example("""
+        import Foundation
+        func bar() {}
+        """, configuration: [
+            "always_keep_imports": ["Foundation"]
+        ]):
+            Example("""
+            import Foundation
+            func bar() {}
+            """),
     ]
 }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRuleExamples.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable type_body_length
 struct UnusedImportRuleExamples {
     static let nonTriggeringExamples = [
         Example("""
@@ -220,6 +221,6 @@ struct UnusedImportRuleExamples {
             Example("""
             import Foundation
             func bar() {}
-            """),
+            """)
     ]
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -24,19 +24,24 @@ public struct UnusedImportConfiguration: RuleConfiguration, Equatable {
         return [
             "severity: \(severity.consoleDescription)",
             "require_explicit_imports: \(requireExplicitImports)",
-            "allowed_transitive_imports: \(allowedTransitiveImports)"
+            "allowed_transitive_imports: \(allowedTransitiveImports)",
+            "always_keep_imports: \(alwaysKeepImports)"
         ].joined(separator: ", ")
     }
 
     public private(set) var severity: SeverityConfiguration
     public private(set) var requireExplicitImports: Bool
     public private(set) var allowedTransitiveImports: [TransitiveModuleConfiguration]
+    /// A set of modules to never remove the imports of.
+    public private(set) var alwaysKeepImports: [String]
 
     public init(severity: ViolationSeverity, requireExplicitImports: Bool,
-                allowedTransitiveImports: [TransitiveModuleConfiguration]) {
+                allowedTransitiveImports: [TransitiveModuleConfiguration],
+                alwaysKeepImports: [String]) {
         self.severity = SeverityConfiguration(severity)
         self.requireExplicitImports = requireExplicitImports
         self.allowedTransitiveImports = allowedTransitiveImports
+        self.alwaysKeepImports = alwaysKeepImports
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -52,6 +57,9 @@ public struct UnusedImportConfiguration: RuleConfiguration, Equatable {
         }
         if let allowedTransitiveImports = configurationDict["allowed_transitive_imports"] as? [Any] {
             self.allowedTransitiveImports = try allowedTransitiveImports.map(TransitiveModuleConfiguration.init)
+        }
+        if let alwaysKeepImports = configurationDict["always_keep_imports"] as? [String] {
+            self.alwaysKeepImports = alwaysKeepImports
         }
     }
 }


### PR DESCRIPTION
Sometimes we hit issues with SourceKit that cause this rule to produce
false positives of some imports. While we would prefer to fix all of
these cases whenever possible, this gives us a temporary escape hatch to
tell the rule never to remove imports of specific modules until the
fixes land in SwiftLint or Swift itself.

Currently this is for us to opt out of https://bugs.swift.org/browse/SR-13120