### PR TITLE
Fix #3034: Allow opening brace directly after another opening brace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * Fixes false positives for multiline_parameters_brackets and multiline_arguments_brackets.  
   [Noah Gilmore](https://github.com/noahsark769)
   [#3167](https://github.com/realm/SwiftLint/issues/3167)
+* Fix conflict of 'opening_brace' with 'implicit_return' for functions
+  implicitly returning a closure.
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3034](https://github.com/realm/SwiftLint/issues/3034)
 
 ## 0.39.2: Stay Home
 

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -7,7 +7,7 @@ private extension SwiftLintFile {
     func violatingOpeningBraceRanges() -> [(range: NSRange, location: Int)] {
         return match(pattern: "(?:[^( ]|[\\s(][\\s]+)\\{",
                      excludingSyntaxKinds: SyntaxKind.commentAndStringKinds,
-                     excludingPattern: "(?:if|guard|while)\\n[^\\{]+?[\\s\\t\\n]\\{").compactMap {
+                     excludingPattern: "(?:(?:if|guard|while)\\n[^\\{]+?\\s|\\{\\s*)\\{").compactMap {
             if isAnonimousClosure(range: $0) {
                 return nil
             }
@@ -79,13 +79,26 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule, Auto
             Example("struct Rule {}\n"),
             Example("struct Parent {\n\tstruct Child {\n\t\tlet foo: Int\n\t}\n}\n"),
             Example("""
-            func f(rect: CGRect) {
-               {
-                  let centre = CGPoint(x: rect.midX, y: rect.midY)
-                  print(centre)
-               }()
-            }
-            """)
+                    func f(rect: CGRect) {
+                        {
+                            let centre = CGPoint(x: rect.midX, y: rect.midY)
+                            print(centre)
+                        }()
+                    }
+                    """),
+            Example("""
+                    func f(rect: CGRect) -> () -> Void {
+                        {
+                            let centre = CGPoint(x: rect.midX, y: rect.midY)
+                            print(centre)
+                        }
+                    }
+                    """),
+            Example("""
+                    func f() -> () -> Void {
+                        {}
+                    }
+                    """)
         ],
         triggeringExamples: [
             Example("func abc()↓{\n}"),


### PR DESCRIPTION
This special case occurs in functions implicitly returning closures.