### PR TITLE
Add multiline closure anonymous args rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 #### Enhancements
 
+* Add multiline closure anonymous arguments rule to require named arguments for all multiline closures
+  [namolnad](https://github.com/namolnad)
+  [#3263](https://github.com/realm/SwiftLint/pull/3263)
+
 * JUnit reporter for GitLab artifact:report:junit with better representation of
   found issues.  
   [krin-san](https://github.com/krin-san)

--- a/Source/SwiftLintFramework/Models/MasterRuleList.swift
+++ b/Source/SwiftLintFramework/Models/MasterRuleList.swift
@@ -96,6 +96,7 @@ public let masterRuleList = RuleList(rules: [
     ModifierOrderRule.self,
     MultilineArgumentsBracketsRule.self,
     MultilineArgumentsRule.self,
+    MultilineClosureAnonymousArgsRule.self,
     MultilineFunctionChainsRule.self,
     MultilineLiteralBracketsRule.self,
     MultilineParametersBracketsRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/MultilineClosureAnonymousArgsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MultilineClosureAnonymousArgsRule.swift
@@ -25,7 +25,10 @@ public struct MultilineClosureAnonymousArgsRule: ConfigurationProviderRule, OptI
     public init() {}
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return file.match(pattern: "^[^{\\n]*(\\$0)", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds).compactMap { range in
+        return file.match(
+            pattern: "^[^{\\n]*(\\$0)",
+            excludingSyntaxKinds: SyntaxKind.commentAndStringKinds
+        ).compactMap { range in
             return StyleViolation(
                 ruleDescription: Self.description,
                 severity: configuration.severity,

--- a/Source/SwiftLintFramework/Rules/Lint/MultilineClosureAnonymousArgsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MultilineClosureAnonymousArgsRule.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SourceKittenFramework
+
+public struct MultilineClosureAnonymousArgsRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public static let description = RuleDescription(
+        identifier: "multiline_closure_anonymous_args",
+        name: "Multiline Closure Anonymous Arguments",
+        description: "Multiline closures should use named argmuents.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("{ print($0 }"),
+            Example("{\nprint(array.map { $0.property }\n}"),
+            Example("// print($0)"),
+            Example("\"$0.00\"")
+        ],
+        triggeringExamples: [
+            Example("{\nprint($0)\n}"),
+            Example("$0.numberOfLines = 0\n$0.textColor = .secondaryLabel"),
+            Example("array.compactMap($0)")
+        ]
+    )
+
+    public init() {}
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        return file.match(pattern: "^[^{\\n]*(\\$0)", excludingSyntaxKinds: SyntaxKind.commentAndStringKinds).compactMap { range in
+            return StyleViolation(
+                ruleDescription: Self.description,
+                severity: configuration.severity,
+                location: Location(file: file, characterOffset: range.location)
+            )
+        }
+    }
+}

--- a/SwiftLint.xcodeproj/project.pbxproj
+++ b/SwiftLint.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1EC163521D5992D900DD2928 /* VerticalWhitespaceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */; };
 		1EF115921EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */; };
 		1F11B3CF1C252F23002E8FA8 /* ClosingBraceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */; };
+		2215A7F924BDF8C6006ED109 /* MultilineClosureAnonymousArgsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2215A7F824BDF8C6006ED109 /* MultilineClosureAnonymousArgsRule.swift */; };
 		224E7F9D235A5E800051368B /* ExpiringTodoRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */; };
 		22A36FDF235673F50037B47D /* ExpiringTodoRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */; };
 		22A36FE123578CC10037B47D /* ExpiringTodoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */; };
@@ -546,6 +547,7 @@
 		1EC163511D5992D900DD2928 /* VerticalWhitespaceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalWhitespaceRule.swift; sourceTree = "<group>"; };
 		1EF115911EB2AD5900E30140 /* ExplicitTopLevelACLRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitTopLevelACLRule.swift; sourceTree = "<group>"; };
 		1F11B3CE1C252F23002E8FA8 /* ClosingBraceRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosingBraceRule.swift; sourceTree = "<group>"; };
+		2215A7F824BDF8C6006ED109 /* MultilineClosureAnonymousArgsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineClosureAnonymousArgsRule.swift; sourceTree = "<group>"; };
 		224E7F9B235A5E4D0051368B /* ExpiringTodoRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRuleTests.swift; sourceTree = "<group>"; };
 		22A36FDE235673F50037B47D /* ExpiringTodoRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoRule.swift; sourceTree = "<group>"; };
 		22A36FE023578CC10037B47D /* ExpiringTodoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTodoConfiguration.swift; sourceTree = "<group>"; };
@@ -1194,6 +1196,7 @@
 				C26330352073DAA200D7B4FD /* LowerACLThanParentRule.swift */,
 				856651A61D6B395F005E6B29 /* MarkRule.swift */,
 				F9E691272091952E0085B53E /* MissingDocsRule.swift */,
+				2215A7F824BDF8C6006ED109 /* MultilineClosureAnonymousArgsRule.swift */,
 				D4DABFD61E2C23B1009617B6 /* NotificationCenterDetachmentRule.swift */,
 				D4DABFD81E2C59BC009617B6 /* NotificationCenterDetachmentRuleExamples.swift */,
 				D4B31ADB22A0581B000300F1 /* DuplicateEnumCasesRule.swift */,
@@ -2148,6 +2151,7 @@
 				E315B83C1DFA4BC500621B44 /* DynamicInlineRule.swift in Sources */,
 				125AAC78203AA82D0004BCE0 /* ExplicitTypeInterfaceConfiguration.swift in Sources */,
 				8FF49E0723FC9E40003AC871 /* UnusedImportRuleExamples.swift in Sources */,
+				2215A7F924BDF8C6006ED109 /* MultilineClosureAnonymousArgsRule.swift in Sources */,
 				1E18574B1EADBA51004F89F7 /* NoExtensionAccessModifierRule.swift in Sources */,
 				5BD08DCC23D254BF000B9CE6 /* ImplicitGetterRuleExamples.swift in Sources */,
 				D42D2B381E09CC0D00CD7A2E /* FirstWhereRule.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -915,6 +915,12 @@ extension MultilineArgumentsRuleTests {
     ]
 }
 
+extension MultilineClosureAnonymousArgsRuleTests {
+    static var allTests: [(String, (MultilineClosureAnonymousArgsRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension MultilineFunctionChainsRuleTests {
     static var allTests: [(String, (MultilineFunctionChainsRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1774,6 +1780,7 @@ XCTMain([
     testCase(ModifierOrderTests.allTests),
     testCase(MultilineArgumentsBracketsRuleTests.allTests),
     testCase(MultilineArgumentsRuleTests.allTests),
+    testCase(MultilineClosureAnonymousArgsRuleTests.allTests),
     testCase(MultilineFunctionChainsRuleTests.allTests),
     testCase(MultilineLiteralBracketsRuleTests.allTests),
     testCase(MultilineParametersBracketsRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -378,6 +378,12 @@ class MultilineArgumentsBracketsRuleTests: XCTestCase {
     }
 }
 
+class MultilineClosureAnonymousArgsRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(MultilineClosureAnonymousArgsRule.description)
+    }
+}
+
 class MultilineFunctionChainsRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultilineFunctionChainsRule.description)


### PR DESCRIPTION
Adds an opt-in linting rule to flag when a multiline closure uses anonymous (as opposed to named arguments) to prefer clarity over brevity. E.g. 
``` swift
let label = configure(UILabel()) {
    $0.numberOfLines = 0
    $0.textColor = .black
}
...
view.configureLayout {
    $0.configure { $0.something = true }
}
// VS
let label = configure(UILabel()) { label in
    label.numberOfLines = 0
    label.textColor = .black
}
...
view.configureLayout { layout in
    layout.configure { $0.something = true }
}
```