### PR TITLE
Fix false negative in `explicit_acl` rule with Swift 5.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * Fix false positive uppercase enum case in `raw_value_for_camel_cased_codable_enum` rule
   [Teameh](https://github.com/teameh)
 
-* Fix false positive in `explicit_acl` rule when using `extension` with 
+* Fix false negative in `explicit_acl` rule when using `extension` with 
   Swift 5.2+.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3186](https://github.com/realm/SwiftLint/issues/3186)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
 * Fix false positive uppercase enum case in `raw_value_for_camel_cased_codable_enum` rule
   [Teameh](https://github.com/teameh)
 
+* Fix false positive in `explicit_acl` rule when using `extension` with 
+  Swift 5.2+.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3186](https://github.com/realm/SwiftLint/issues/3186)
+
 ## 0.39.2: Stay Home
 
 This is the last release to support building with Swift 5.0.x.

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -41,15 +41,25 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
             """),
             Example("internal class A { deinit {} }"),
             Example("extension A: Equatable {}"),
-            Example("extension A {}")
+            Example("extension A {}"),
+            Example("""
+            extension Foo {
+                internal func bar() {}
+            }
+            """)
         ],
         triggeringExamples: [
-            Example("enum A {}\n"),
-            Example("final class B {}\n"),
-            Example("internal struct C { let d = 5 }\n"),
-            Example("public struct C { let d = 5 }\n"),
+            Example("↓enum A {}\n"),
+            Example("final ↓class B {}\n"),
+            Example("internal struct C { ↓let d = 5 }\n"),
+            Example("public struct C { ↓let d = 5 }\n"),
             Example("func a() {}\n"),
-            Example("internal let a = 0\nfunc b() {}\n")
+            Example("internal let a = 0\n↓func b() {}\n"),
+            Example("""
+            extension Foo {
+                ↓func bar() {}
+            }
+            """)
         ]
     )
 
@@ -91,7 +101,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
     }
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let implicitAndExplicitInternalElements = internalTypeElements(in: file.structureDictionary )
+        let implicitAndExplicitInternalElements = internalTypeElements(in: file.structureDictionary)
 
         guard !implicitAndExplicitInternalElements.isEmpty else {
             return []
@@ -129,7 +139,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
             let internalTypeElementsInSubstructure = elementKind.childsAreExemptFromACL || isPrivate ? [] :
                 internalTypeElements(in: element)
 
-            if element.accessibility == .internal {
+            if element.accessibility == .internal || element.accessibility == nil {
                 return internalTypeElementsInSubstructure + [element]
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -59,6 +59,18 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
                     return result
                 }
             }
+            """),
+            Example("""
+            extension Foo {
+                private var isValid: Bool {
+                    get {
+                        return true
+                    }
+                    set(newValue) {
+                        print(newValue)
+                    }
+                }
+            }
             """)
         ],
         triggeringExamples: [
@@ -139,7 +151,8 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
 
     private func internalTypeElements(in parent: SourceKittenElement) -> [SourceKittenElement] {
         return parent.substructure.flatMap { element -> [SourceKittenElement] in
-            guard let elementKind = element.declarationKind, elementKind != .varLocal else {
+            guard let elementKind = element.declarationKind,
+                  elementKind != .varLocal, elementKind != .varParameter else {
                 return []
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -51,6 +51,14 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
             internal enum Foo {
                 case bar
             }
+            """),
+            Example("""
+            extension Foo {
+                public var isValid: Bool {
+                    let result = true
+                    return result
+                }
+            }
             """)
         ],
         triggeringExamples: [
@@ -131,7 +139,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
 
     private func internalTypeElements(in parent: SourceKittenElement) -> [SourceKittenElement] {
         return parent.substructure.flatMap { element -> [SourceKittenElement] in
-            guard let elementKind = element.declarationKind else {
+            guard let elementKind = element.declarationKind, elementKind != .varLocal else {
                 return []
             }
 


### PR DESCRIPTION
Fixes #3186