### PR TITLE
Enable legacy_multiple and prefer_self_type_over_type_of_self in our codebase

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,6 +36,7 @@ opt_in_rules:
   - legacy_random
   - let_var_whitespace
   - last_where
+  - legacy_multiple
   - literal_expression_end_indentation
   - lower_acl_than_parent
   - modifier_order
@@ -47,6 +48,7 @@ opt_in_rules:
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
   - private_action
   - private_outlet
   - prohibited_interface_builder

--- a/Source/SwiftLintFramework/Protocols/CallPairRule.swift
+++ b/Source/SwiftLintFramework/Protocols/CallPairRule.swift
@@ -56,7 +56,7 @@ extension CallPairRule {
         }
 
         return violatingLocations.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: severity,
                            location: Location(file: file, byteOffset: $0),
                            reason: reason)

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -74,7 +74,7 @@ extension Rule {
     }
 
     public func isEqualTo(_ rule: Rule) -> Bool {
-        return type(of: self).description == type(of: rule).description
+        return Self.description == type(of: rule).description
     }
 
     public func collectInfo(for file: SwiftLintFile, into storage: RuleStorage, compilerArguments: [String]) {
@@ -164,7 +164,7 @@ public extension SubstitutionCorrectableRule {
         let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
         guard !violatingRanges.isEmpty else { return [] }
 
-        let description = type(of: self).description
+        let description = Self.description
         var corrections = [Correction]()
         var contents = file.contents
         for range in violatingRanges.sorted(by: { $0.location > $1.location }) {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -47,7 +47,7 @@ public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule, AutomaticTe
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -88,7 +88,7 @@ public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -35,7 +35,7 @@ public struct DiscouragedObjectLiteralRule: ASTRule, OptInRule, ConfigurationPro
             return []
         }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severityConfiguration.severity,
                                location: Location(file: file, byteOffset: offset))]
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -22,7 +22,7 @@ public struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRu
         let excludingKinds = SyntaxKind.commentAndStringKinds
 
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
@@ -21,7 +21,7 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
             functionViolations(file: file, kind: kind, dictionary: dictionary)
 
         return offsets.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -33,7 +33,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
             }
 
         // Make sure that each #if has corresponding #endif
-        guard ranges.count % 2 == 0 else { return [] }
+        guard ranges.count.isMultiple(of: 2) else { return [] }
 
         return stride(from: 0, to: ranges.count, by: 2).reduce(into: []) { result, rangeIndex in
             result.append(ranges[rangeIndex].union(with: ranges[rangeIndex + 1]))
@@ -84,7 +84,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
                 }()
 
                 let location = Location(file: file, characterOffset: lineWithDuplicatedImport.range.location)
-                let violation = StyleViolation(ruleDescription: type(of: self).description,
+                let violation = StyleViolation(ruleDescription: Self.description,
                                                severity: configuration.severity,
                                                location: location)
                 violations.append(violation)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -138,7 +138,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
                                           thatAreNotInRanges: explicitInternalRanges)
 
         return violations.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -94,7 +94,7 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
 
         let violations = violatingOffsetsForEnum(dictionary: dictionary)
         return violations.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -55,7 +55,7 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
     public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -79,7 +79,7 @@ public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, Aut
         }
 
         return violationOffsets.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -92,7 +92,7 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -111,7 +111,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]
@@ -148,7 +148,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
         }
 
         return violationOffsets.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
@@ -32,7 +32,7 @@ public struct FallthroughRule: ConfigurationProviderRule, OptInRule, AutomaticTe
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.match(pattern: "fallthrough", with: [.keyword]).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -46,7 +46,7 @@ public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRu
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameNoSpaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameNoSpaceRule.swift
@@ -24,7 +24,7 @@ public struct FileNameNoSpaceRule: ConfigurationProviderRule, OptInRule {
             return []
         }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity.severity,
                                location: Location(file: filePath, line: 1))]
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -66,7 +66,7 @@ public struct FileNameRule: ConfigurationProviderRule, OptInRule {
             return []
         }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity.severity,
                                location: Location(file: filePath, line: 1))]
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -101,7 +101,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceCastRule.swift
@@ -18,7 +18,7 @@ public struct ForceCastRule: ConfigurationProviderRule, AutomaticTestableRule {
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.match(pattern: "as!", with: [.keyword]).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
@@ -28,7 +28,7 @@ public struct ForceTryRule: ConfigurationProviderRule, AutomaticTestableRule {
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.match(pattern: "try!", with: [.keyword]).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -57,7 +57,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -82,7 +82,7 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -88,7 +88,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
         let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
         if !allowedSymbols.isSuperset(of: CharacterSet(charactersIn: name)) {
             return [
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: .error,
                                location: Location(file: file, byteOffset: offset),
                                reason: "Generic type name should only contain alphanumeric characters: '\(name)'")
@@ -96,14 +96,14 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
         } else if configuration.validatesStartWithLowercase &&
             !String(name[name.startIndex]).isUppercase() {
             return [
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: .error,
                                location: Location(file: file, byteOffset: offset),
                                reason: "Generic type name should start with an uppercase character: '\(name)'")
             ]
         } else if let severity = severity(forLength: name.count) {
             return [
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: severity,
                                location: Location(file: file, byteOffset: offset),
                                reason: "Generic type name should be between \(configuration.minLengthThreshold) and " +
@@ -122,12 +122,12 @@ extension GenericTypeNameRule {
     private static let genericTypeRegex = regex(genericTypePattern)
 
     private func validateGenericTypeAliases(in file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "typealias\\s+\\w+?\\s*" + type(of: self).genericTypePattern + "\\s*="
+        let pattern = "typealias\\s+\\w+?\\s*" + Self.genericTypePattern + "\\s*="
         return file.match(pattern: pattern).flatMap { range, tokens -> [(String, ByteCount)] in
             guard tokens.first == .keyword,
                 Set(tokens.dropFirst()) == [.identifier],
-                let match = type(of: self).genericTypeRegex.firstMatch(in: file.contents, options: [],
-                                                                       range: range)?.range(at: 1) else {
+                let match = Self.genericTypeRegex.firstMatch(in: file.contents, options: [],
+                                                             range: range)?.range(at: 1) else {
                     return []
             }
 
@@ -147,8 +147,8 @@ extension GenericTypeNameRule {
             case let length = bodyOffset - start,
             case let byteRange = ByteRange(location: start, length: length),
             let range = file.stringView.byteRangeToNSRange(byteRange),
-            let match = type(of: self).genericTypeRegex.firstMatch(in: file.contents, options: [],
-                                                                   range: range)?.range(at: 1) else {
+            let match = Self.genericTypeRegex.firstMatch(in: file.contents, options: [],
+                                                         range: range)?.range(at: 1) else {
                 return []
         }
 
@@ -164,8 +164,8 @@ extension GenericTypeNameRule {
             case let contents = file.stringView,
             case let byteRange = ByteRange(location: offset, length: length),
             let range = contents.byteRangeToNSRange(byteRange),
-            let match = type(of: self).genericTypeRegex.firstMatch(in: file.contents,
-                                                                   options: [], range: range)?.range(at: 1),
+            let match = Self.genericTypeRegex.firstMatch(in: file.contents,
+                                                         options: [], range: range)?.range(at: 1),
             match.location < minParameterOffset(parameters: dictionary.enclosedVarParameters, file: file)
         else {
             return []

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -61,7 +61,7 @@ public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRul
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity.severity,
                            location: location)
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/IsDisjointRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/IsDisjointRule.swift
@@ -26,7 +26,7 @@ public struct IsDisjointRule: ConfigurationProviderRule, AutomaticTestableRule {
         let pattern = "\\bintersection\\(\\S+\\)\\.isEmpty"
         let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -46,7 +46,7 @@ public struct JoinedDefaultParameterRule: SubstitutionCorrectableASTRule, Config
                          kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -93,7 +93,7 @@ public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         let pattern = "\\b(" + functions.joined(separator: "|") + ")\\b"
 
         return file.match(pattern: pattern, with: [.identifier]).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
@@ -29,7 +29,7 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule, Au
             .filter { Set($0.1).isSubset(of: [.identifier]) }
             .map { $0.0 }
             .map {
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location))
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -133,7 +133,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]
@@ -153,7 +153,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
         guard kind == .call,
             let name = dictionary.name,
             dictionary.offset != nil,
-            let expectedArguments = type(of: self).constructorsToArguments[name],
+            let expectedArguments = Self.constructorsToArguments[name],
             dictionary.enclosedArguments.count == expectedArguments.count else {
                 return false
         }
@@ -184,10 +184,10 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
             guard let byteRange = dictionary.byteRange,
                 let range = file.stringView.byteRangeToNSRange(byteRange),
                 let name = dictionary.name,
-                let correctedName = type(of: self).constructorsToCorrectedNames[name],
+                let correctedName = Self.constructorsToCorrectedNames[name],
                 file.ruleEnabled(violatingRanges: [range], for: self) == [range],
                 case let arguments = argumentsContents(file: file, arguments: dictionary.enclosedArguments),
-                let expectedArguments = type(of: self).constructorsToArguments[name],
+                let expectedArguments = Self.constructorsToArguments[name],
                 arguments.count == expectedArguments.count else {
                     continue
             }
@@ -201,7 +201,7 @@ public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProv
         }
 
         let corrections = adjustedLocations.map {
-            Correction(ruleDescription: type(of: self).description,
+            Correction(ruleDescription: Self.description,
                        location: Location(file: file, characterOffset: $0))
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
@@ -89,7 +89,7 @@ public struct LegacyHashingRule: ASTRule, ConfigurationProviderRule, AutomaticTe
                 return []
         }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: offset))]
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -45,7 +45,7 @@ public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, Automati
         let pattern = "(?!\\b\\s*)%\(RegexHelpers.variableOrNumber)[=!]=\\s*0\\b"
         return file.match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
             .map {
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location))
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -92,7 +92,7 @@ public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProvi
         let pattern = "\\b(" + functions.joined(separator: "|") + ")\\b"
 
         return file.match(pattern: pattern, with: [.identifier]).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
@@ -39,7 +39,7 @@ public struct LegacyRandomRule: ASTRule, OptInRule, ConfigurationProviderRule, A
 
         let location = Location(file: file, byteOffset: offset)
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: location)
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -94,7 +94,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let matches = violationMatchesRanges(in: file)
         return matches.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
@@ -139,7 +139,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
             .filter { !file.ruleEnabled(violatingRanges: [$0], for: self).isEmpty }
         guard !matches.isEmpty else { return [] }
 
-        let description = type(of: self).description
+        let description = Self.description
         var corrections: [Correction] = []
         var contents = file.contents
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -36,7 +36,7 @@ public struct NoExtensionAccessModifierRule: ASTRule, OptInRule, ConfigurationPr
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: aclToken.offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -40,7 +40,7 @@ public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule, Automat
         let nsRange = nonCommentCaseBody[0].0
         if contents.substring(with: nsRange) == "fallthrough" && nonCommentCaseBody[0].1 == [.keyword] &&
             !isNextTokenUnknownAttribute(afterOffset: byteRange.upperBound, file: file) {
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: configuration.severity,
                                    location: Location(file: file, characterOffset: nsRange.location))]
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -38,7 +38,7 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
                 return nil
             }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: element.offset))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -43,7 +43,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -61,7 +61,7 @@ public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, O
             }
 
             return (letMatches + varMatches).map {
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location))
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -57,7 +57,7 @@ public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, Substitutio
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -30,7 +30,7 @@ public struct RedundantNilCoalescingRule: OptInRule, SubstitutionCorrectableRule
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -22,7 +22,7 @@ public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, Configura
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -104,7 +104,7 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
     public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -98,7 +98,7 @@ public struct RedundantSetAccessControlRule: ConfigurationProviderRule, Automati
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -84,7 +84,7 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
 
         let violations = violatingOffsetsForEnum(dictionary: dictionary, file: file)
         return violations.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -57,7 +57,7 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map { range in
             StyleViolation(
-                ruleDescription: type(of: self).description,
+                ruleDescription: Self.description,
                 severity: configuration.severity,
                 location: Location(file: file, characterOffset: range.location)
             )

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -64,7 +64,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
     public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
@@ -93,7 +93,7 @@ public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, OptInRule,
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -62,7 +62,7 @@ public struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, Autom
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         // Mark all fileprivate occurences as a violation
         return file.match(pattern: "fileprivate", with: [.attributeBuiltin]).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -72,7 +72,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
         let contents = file.stringView
         return violationResults(in: file).map {
             let typeString = contents.substring(with: $0.range(at: 1))
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: $0.range.location),
                                   reason: message(for: typeString))
@@ -189,7 +189,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
             typeString = "Dictionary<String, Int>"
             sugaredType = "[String: Int]"
         default:
-            return type(of: self).description.description
+            return Self.description.description
         }
 
         return "Shorthand syntactic sugar should be used, i.e. \(sugaredType) instead of \(typeString)."

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -30,7 +30,7 @@ public struct TrailingSemicolonRule: SubstitutionCorrectableRule, ConfigurationP
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -71,18 +71,18 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
             .nameStrippingTrailingSwiftUIPreviewProvider(dictionary)
         let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
         if !allowedSymbols.isSuperset(of: CharacterSet(charactersIn: name)) {
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: .error,
                                    location: Location(file: file, byteOffset: offset),
                                    reason: "Type name should only contain alphanumeric characters: '\(name)'")]
         } else if configuration.validatesStartWithLowercase &&
             !String(name[name.startIndex]).isUppercase() {
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: .error,
                                    location: Location(file: file, byteOffset: offset),
                                    reason: "Type name should start with an uppercase character: '\(name)'")]
         } else if let severity = severity(forLength: name.count) {
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: severity,
                                    location: Location(file: file, byteOffset: offset),
                                    reason: "Type name should be between \(configuration.minLengthThreshold) and " +

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -72,7 +72,7 @@ public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptIn
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -70,7 +70,7 @@ public struct UnneededBreakInSwitchRule: ConfigurationProviderRule, AutomaticTes
                     return nil
             }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: range.location))
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -104,7 +104,7 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, Aut
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: $0.location),
                                   reason: configuration.consoleDescription)
@@ -112,7 +112,7 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, Aut
     }
 
     fileprivate func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file.match(pattern: type(of: self).regularExpression,
+        return file.match(pattern: Self.regularExpression,
                           with: [.keyword, .keyword, .identifier])
     }
 }
@@ -124,7 +124,7 @@ extension UntypedErrorInCatchRule: CorrectableRule {
         if matches.isEmpty { return [] }
 
         var contents = file.contents.bridge()
-        let description = type(of: self).description
+        let description = Self.description
         var corrections = [Correction]()
 
         for range in matches.reversed() where contents.substring(with: range).contains("let error") {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -54,7 +54,7 @@ public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule, Automati
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset),
                            reason: reason)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -48,7 +48,7 @@ public struct XCTFailMessageRule: ASTRule, ConfigurationProviderRule, AutomaticT
                 return []
         }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: offset))]
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -73,7 +73,7 @@ public struct XCTSpecificMatcherRule: ASTRule, OptInRule, ConfigurationProviderR
             else { return [] }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset),
                            reason: "Prefer the specific matcher '\(suggestedMatcher)' instead.")

--- a/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
@@ -42,7 +42,7 @@ public struct AnyObjectProtocolRule: SubstitutionCorrectableASTRule, OptInRule,
                          kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -77,7 +77,7 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -73,7 +73,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule, Aut
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
@@ -34,10 +34,10 @@ public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             let (violation, range) = $0
             return StyleViolation(
-                ruleDescription: type(of: self).description,
+                ruleDescription: Self.description,
                 severity: configuration.severity,
                 location: Location(file: file, characterOffset: range.location),
-                reason: type(of: self).violationReason(protocolName: violation.protocolName, isPlural: false)
+                reason: Self.violationReason(protocolName: violation.protocolName, isPlural: false)
             )
         }
     }

--- a/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
@@ -118,7 +118,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
             Availability \(violationType) is using a version (\(versionString)) that is \
             satisfied by the deployment target (\(minVersion.stringValue)) for platform \(platform).
             """
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severityConfiguration.severity,
                                   location: Location(file: file, byteOffset: byteOffsetToReport),
                                   reason: reason)

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -53,7 +53,7 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
     public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationOffsets(in: file, dictionary: dictionary, kind: kind).map { location in
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: location))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -43,7 +43,7 @@ public struct DiscouragedDirectInitRule: ASTRule, ConfigurationProviderRule {
                 return []
         }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: offset))]
     }

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -62,7 +62,7 @@ public struct DuplicateEnumCasesRule: ConfigurationProviderRule, ASTRule, Automa
         return elementsByName.filter { $0.value.count > 1 }
             .flatMap { $0.value }
             .map {
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: $0))
             }

--- a/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
@@ -47,7 +47,7 @@ public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule, AutomaticTe
         else {
             return []
         }
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: funcOffset))]
     }

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -39,7 +39,7 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule,
                 subDictionary.enclosedVarParameters.isEmpty,
                 subDictionary.substructure.isEmpty else { return nil }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: offset))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -58,7 +58,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
             }
 
             return StyleViolation(
-                ruleDescription: type(of: self).description,
+                ruleDescription: Self.description,
                 severity: severity,
                 location: Location(file: file, characterOffset: range.location),
                 reason: violationLevel.reason

--- a/Source/SwiftLintFramework/Rules/Lint/IBInspectableInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IBInspectableInExtensionRule.swift
@@ -44,7 +44,7 @@ public struct IBInspectableInExtensionRule: ConfigurationProviderRule, OptInRule
                 }
             }
             .map {
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: $0))
             }

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -67,13 +67,13 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, Autom
     }
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let operators = type(of: self).operators.joined(separator: "|")
+        let operators = Self.operators.joined(separator: "|")
         return
             file.matchesAndTokens(matching: "\\s(" + operators + ")\\s")
                 .filter { _, tokens in tokens.isEmpty }
                 .compactMap { matchResult, _ in violationRangeFrom(match: matchResult, in: file) }
                 .map { range in
-                    return StyleViolation(ruleDescription: type(of: self).description,
+                    return StyleViolation(ruleDescription: Self.description,
                                           severity: configuration.severity,
                                           location: Location(file: file, characterOffset: range.location))
                 }

--- a/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
@@ -69,7 +69,7 @@ public struct InertDeferRule: ConfigurationProviderRule, AutomaticTestableRule {
                     return nil
             }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: range.location))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -34,7 +34,7 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Auto
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return validateACL(isHigherThan: .open, in: file.structureDictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
@@ -102,7 +102,7 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file, matching: pattern).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
@@ -168,7 +168,7 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
         if matches.isEmpty { return [] }
 
         var nsstring = file.contents.bridge()
-        let description = type(of: self).description
+        let description = Self.description
         var corrections = [Correction]()
         for var range in matches.reversed() {
             if keepLastChar {

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -99,7 +99,7 @@ public struct MissingDocsRule: OptInRule, ConfigurationProviderRule, AutomaticTe
         let acls = configuration.parameters.map { $0.value }
         let dict = file.structureDictionary
         return file.missingDocOffsets(in: dict, acls: acls).map { offset, acl in
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.parameters.first { $0.value == acl }?.severity ?? .warning,
                            location: Location(file: file, byteOffset: offset),
                            reason: "\(acl.description) declarations should be documented.")

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringKeyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringKeyRule.swift
@@ -34,7 +34,7 @@ public struct NSLocalizedStringKeyRule: ASTRule, OptInRule, ConfigurationProvide
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: byteRange.location))
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -52,7 +52,7 @@ public struct NSLocalizedStringRequireBundleRule: ASTRule, OptInRule, Configurat
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -40,7 +40,7 @@ public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, Automa
                 isDoubleEqualsMethod(subDictionary, onType: typeName),
                 let offset = subDictionary.offset
             else { return nil }
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: offset))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
@@ -21,7 +21,7 @@ public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRu
         }
 
         return violationOffsets(file: file, dictionary: dictionary).map { offset in
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
@@ -70,9 +70,9 @@ public struct OrphanedDocCommentRule: ConfigurationProviderRule {
                         return false
                 }
 
-                return !contents.trimmingCharacters(in: type(of: self).characterSet).isEmpty
+                return !contents.trimmingCharacters(in: Self.characterSet).isEmpty
             }.map { token in
-                return StyleViolation(ruleDescription: type(of: self).description,
+                return StyleViolation(ruleDescription: Self.description,
                                       severity: configuration.severity,
                                       location: Location(file: file, byteOffset: token.offset))
             }

--- a/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
@@ -88,12 +88,12 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptIn
         let callsToSuper = dictionary.extractCallsToSuper(methodName: name)
 
         if callsToSuper.isEmpty {
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: configuration.severity,
                                    location: Location(file: file, byteOffset: offset),
                                    reason: "Method '\(name)' should call to super function")]
         } else if callsToSuper.count > 1 {
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: configuration.severity,
                                    location: Location(file: file, byteOffset: offset),
                                    reason: "Method '\(name)' should call to super only once")]

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -56,7 +56,7 @@ public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, Aut
                 }
             }
             .map {
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: $0))
             }

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
@@ -46,7 +46,7 @@ public struct PrivateActionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -50,7 +50,7 @@ public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: location)
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
@@ -172,7 +172,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDesc
             !dictionary.enclosedSwiftAttributes.contains(.objc)
             else { return [] }
         let offset = dictionary.offset ?? 0
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severityConfiguration.severity,
                                location: Location(file: file, byteOffset: offset),
                                reason: configuration.message)]

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -27,7 +27,7 @@ public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, ASTRule
         }
 
         func makeViolation() -> StyleViolation {
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: offset))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
@@ -82,7 +82,7 @@ public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule
             !dictionary.extractCallsToSuper(methodName: name).isEmpty
             else { return [] }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: offset),
                                reason: "Method '\(name)' should not call to super function")]

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -53,7 +53,7 @@ public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule, Au
             else { return [] }
 
         return violationOffsets(in: dictionary.enclosedArguments).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0),
                            reason: "Discouraged call inside a '\(name)' block.")

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -50,7 +50,7 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
             let offset = dictionary.offset,
             QuickFocusedCallKind(rawValue: name) != nil else { return [] }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: offset))]
     }

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -50,7 +50,7 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
             let offset = dictionary.offset,
             QuickPendingCallKind(rawValue: name) != nil else { return [] }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: offset))]
     }

--- a/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -109,7 +109,7 @@ public struct RawValueForCamelCasedCodableEnumRule: ASTRule, OptInRule, Configur
 
         let violations = violatingOffsetsForEnum(dictionary: dictionary)
         return violations.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredDeinitRule.swift
@@ -88,7 +88,7 @@ public struct RequiredDeinitRule: ASTRule, OptInRule, ConfigurationProviderRule,
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -211,7 +211,7 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
                         for protocolName: String,
                         missing requiredCase: RequiredCase) -> StyleViolation {
         return StyleViolation(
-            ruleDescription: type(of: self).description,
+            ruleDescription: Self.description,
             severity: requiredCase.severity,
             location: parsed.location,
             reason: "Enums conforming to \"\(protocolName)\" must have a \"\(requiredCase.name)\" case")

--- a/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
@@ -33,7 +33,7 @@ public struct StrongIBOutletRule: ConfigurationProviderRule, ASTRule, OptInRule,
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: offset))
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
@@ -35,7 +35,7 @@ public struct TodoRule: ConfigurationProviderRule {
     )
 
     private func customMessage(file: SwiftLintFile, range: NSRange) -> String {
-        var reason = type(of: self).description.description
+        var reason = Self.description.description
         let offset = NSMaxRange(range)
 
         guard let (lineNumber, _) = file.stringView.lineAndCharacter(forCharacterOffset: offset) else {
@@ -78,7 +78,7 @@ public struct TodoRule: ConfigurationProviderRule {
             }
             let reason = customMessage(file: file, range: range)
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: range.location),
                                   reason: reason)

--- a/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -55,7 +55,7 @@ public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProvi
         }.unique
 
         return unownedVariableOffsets.map { offset in
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: offset))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
@@ -150,7 +150,7 @@ public struct UnusedCaptureListRule: ASTRule, ConfigurationProviderRule, Automat
             let offset = captureListRange.location + location
             let reason = "Unused reference \(reference) in a capture list should be removed."
             return StyleViolation(
-                ruleDescription: type(of: self).description,
+                ruleDescription: Self.description,
                 severity: configuration.severity,
                 location: Location(file: file, characterOffset: offset),
                 reason: reason

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -102,7 +102,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, dictionary: dictionary, kind: kind).map { range, name in
             let reason = "Unused parameter \"\(name)\" in a closure should be replaced with _."
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: range.location),
                                   reason: reason)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -92,7 +92,7 @@ public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, Config
     public func validate(file: SwiftLintFile, kind: StatementKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return self.violationRanges(in: file, kind: kind, dictionary: dictionary).map { range in
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: range.location))
         }
@@ -113,7 +113,7 @@ public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, Config
 
     public func violationRanges(in file: SwiftLintFile, kind: StatementKind,
                                 dictionary: SourceKittenDictionary) -> [NSRange] {
-        guard type(of: self).kinds.contains(kind),
+        guard Self.kinds.contains(kind),
             let byteRange = dictionary.byteRange,
             case let tokens = file.syntaxMap.tokens(inByteRange: byteRange),
             let firstToken = tokens.first,

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -93,7 +93,7 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
         guard !compilerArguments.isEmpty else {
             queuedPrintError("""
                 Attempted to lint file at path '\(file.path ?? "...")' with the \
-                \(type(of: self).description.identifier) rule without any compiler arguments.
+                \(Self.description.identifier) rule without any compiler arguments.
                 """)
             return FileUSRs(referenced: [], declared: [], testCaseUSRs: [])
         }
@@ -114,7 +114,7 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
                                 allReferencedUSRs: allReferencedUSRs,
                                 allTestCaseUSRs: allTestCaseUSRs)
             .map {
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: $0))
             }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -20,7 +20,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
 
     public func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
         return importUsage(in: file, compilerArguments: compilerArguments).map { importUsage in
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity.severity,
                            location: Location(file: file, characterOffset: importUsage.violationRange?.location ?? 1),
                            reason: importUsage.violationReason)
@@ -32,7 +32,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
         let matches = file.ruleEnabled(violatingRanges: importUsages.compactMap({ $0.violationRange }), for: self)
 
         var contents = file.stringView.nsString
-        let description = type(of: self).description
+        let description = Self.description
         var corrections = [Correction]()
         for range in matches.reversed() {
             contents = contents.replacingCharacters(in: range, with: "").bridge()
@@ -87,7 +87,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
         guard !compilerArguments.isEmpty else {
             queuedPrintError("""
                 Attempted to lint file at path '\(file.path ?? "...")' with the \
-                \(type(of: self).description.identifier) rule without any compiler arguments.
+                \(Self.description.identifier) rule without any compiler arguments.
                 """)
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -150,7 +150,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestabl
         }
 
         return violatingLocations.map { offset in
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: offset))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
@@ -150,7 +150,7 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule, Automa
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: location)
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -42,7 +42,7 @@ public struct WeakDelegateRule: ASTRule, SubstitutionCorrectableASTRule, Configu
     public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
@@ -72,7 +72,7 @@ public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         }
 
         return matches.map { _ -> StyleViolation in
-            return StyleViolation(ruleDescription: type(of: self).description, severity: configuration.severity,
+            return StyleViolation(ruleDescription: Self.description, severity: configuration.severity,
                                   location: Location(file: file, byteOffset: offset))
         }
     }

--- a/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -41,7 +41,7 @@ public struct ClosureBodyLengthRule: OptInRule, ASTRule, ConfigurationProviderRu
             let reason = "Closure body should span \(configuration.warning) lines or less "
                 + "excluding comments and whitespace: currently spans \(lineCount) lines"
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: parameter.severity,
                                   location: Location(file: file, byteOffset: offset),
                                   reason: reason)

--- a/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
@@ -84,7 +84,7 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
             let offset = dictionary.offset ?? 0
             let reason = "Function should have complexity \(configuration.length.warning) or less: " +
                          "currently complexity equals \(complexity)"
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: parameter.severity,
                                    location: Location(file: file, byteOffset: offset),
                                    reason: reason)]

--- a/Source/SwiftLintFramework/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -69,7 +69,7 @@ public struct EnumCaseAssociatedValuesLengthRule: ASTRule, OptInRule, Configurat
                 + "currently contains \(enumCaseAssociatedValueCount)"
             violations.append(
                 StyleViolation(
-                    ruleDescription: type(of: self).description,
+                    ruleDescription: Self.description,
                     severity: violationSeverity,
                     location: Location(file: file, byteOffset: keyOffset),
                     reason: reason

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -40,7 +40,7 @@ public struct FileLengthRule: ConfigurationProviderRule {
         for parameter in configuration.severityConfiguration.params where lineCount > parameter.value {
             let reason = "File should contain \(configuration.severityConfiguration.warning) lines or less: " +
                          "currently contains \(lineCount)"
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: parameter.severity,
                                    location: Location(file: file.path, line: lineCount),
                                    reason: reason)]

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
@@ -29,7 +29,7 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
                 startLine, endLine, parameter.value
             )
             guard exceeds else { continue }
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: parameter.severity,
                                    location: Location(file: file, byteOffset: offset),
                                    reason: "Function body should span \(configuration.warning) lines or less " +

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
@@ -70,7 +70,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
             let offset = dictionary.offset ?? 0
             let reason = "Function should have \(configuration.severityConfiguration.warning) parameters or less: " +
                          "it currently has \(parameterCount)"
-            return [StyleViolation(ruleDescription: type(of: self).description,
+            return [StyleViolation(ruleDescription: Self.description,
                                    severity: parameter.severity,
                                    location: Location(file: file, byteOffset: offset),
                                    reason: reason)]

--- a/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
@@ -62,7 +62,7 @@ public struct LargeTupleRule: ASTRule, ConfigurationProviderRule, AutomaticTesta
         return offsets.compactMap { location, size in
             for parameter in configuration.params where size > parameter.value {
                 let reason = "Tuples should have at most \(configuration.warning) members."
-                return StyleViolation(ruleDescription: type(of: self).description,
+                return StyleViolation(ruleDescription: Self.description,
                                       severity: parameter.severity,
                                       location: Location(file: file, byteOffset: location),
                                       reason: reason)

--- a/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
@@ -78,7 +78,7 @@ public struct LineLengthRule: ConfigurationProviderRule {
             for param in configuration.params where length > param.value {
                 let reason = "Line should be \(configuration.length.warning) characters or less: " +
                              "currently \(length) characters"
-                return StyleViolation(ruleDescription: type(of: self).description,
+                return StyleViolation(ruleDescription: Self.description,
                                       severity: param.severity,
                                       location: Location(file: file.path, line: line.index),
                                       reason: reason)

--- a/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
@@ -71,7 +71,7 @@ public struct NestingRule: ASTRule, ConfigurationProviderRule, AutomaticTestable
                 let threshold = configuration.threshold(with: targetLevel, for: severity)
                 let pluralSuffix = threshold > 1 ? "s" : ""
                 violations.append(StyleViolation(
-                    ruleDescription: type(of: self).description,
+                    ruleDescription: Self.description,
                     severity: severity,
                     location: Location(file: file, byteOffset: offset),
                     reason: "\(targetName) should be nested at most \(threshold) level\(pluralSuffix) deep"))

--- a/Source/SwiftLintFramework/Rules/Metrics/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/TypeBodyLengthRule.swift
@@ -55,7 +55,7 @@ public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule, AutomaticT
                     if exceeds {
                         let reason = "Type body should span \(configuration.warning) lines or less " +
                             "excluding comments and whitespace: currently spans \(lineCount) lines"
-                        return [StyleViolation(ruleDescription: type(of: self).description,
+                        return [StyleViolation(ruleDescription: Self.description,
                                                severity: parameter.severity,
                                                location: Location(file: file, byteOffset: offset),
                                                reason: reason)]

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCollectionLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCollectionLiteralRule.swift
@@ -32,7 +32,7 @@ public struct EmptyCollectionLiteralRule: ConfigurationProviderRule, OptInRule, 
         let pattern = "\\b\\s*(==|!=)\\s*\\[\\s*:?\\s*\\]"
         let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
@@ -44,7 +44,7 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
 
         let excludingKinds = SyntaxKind.commentAndStringKinds
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, characterOffset: $0.location + offset))
         }

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
@@ -31,7 +31,7 @@ public struct EmptyStringRule: ConfigurationProviderRule, OptInRule, AutomaticTe
                     return nil
             }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: range.location))
         }

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
@@ -40,7 +40,7 @@ public struct ReduceBooleanRule: Rule, ConfigurationProviderRule, AutomaticTesta
                 }
 
                 return StyleViolation(
-                    ruleDescription: type(of: self).description,
+                    ruleDescription: Self.description,
                     severity: configuration.severity,
                     location: Location(file: file, characterOffset: range.location),
                     reason: reason

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
@@ -117,7 +117,7 @@ public struct ReduceIntoRule: ASTRule, ConfigurationProviderRule, OptInRule, Aut
             characterOffset: match.range.location
         )
         let violation = StyleViolation(
-            ruleDescription: type(of: self).description,
+            ruleDescription: Self.description,
             severity: configuration.severity,
             location: location
         )

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -42,7 +42,7 @@ public struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
 
     public init(warning: Int, error: Int?, ignoresCaseStatements: Bool = false) {
         self.length = SeverityLevelsConfiguration(warning: warning, error: error)
-        self.complexityStatements = type(of: self).defaultComplexityStatements
+        self.complexityStatements = Self.defaultComplexityStatements
         self.ignoresCaseStatements = ignoresCaseStatements
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -63,7 +63,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
             let idx = match.lastIndex(of: "import") ?? 0
             let location = idx + range.location
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severityConfiguration.severity,
                                   location: Location(file: file, characterOffset: location))
         }
@@ -172,7 +172,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: location)
         ]

--- a/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
@@ -27,7 +27,7 @@ public struct ClosingBraceRule: SubstitutionCorrectableRule, ConfigurationProvid
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -29,7 +29,7 @@ public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderR
                      "Expected \(violation.indentationRanges.expected.length), " +
                      "got \(violation.indentationRanges.actual.length)."
 
-        return StyleViolation(ruleDescription: type(of: self).description,
+        return StyleViolation(ruleDescription: Self.description,
                               severity: configuration.severity,
                               location: Location(file: file, byteOffset: violation.endOffset),
                               reason: reason)
@@ -64,7 +64,7 @@ extension ClosureEndIndentationRule: CorrectableRule {
         }
 
         var corrections = correctedLocations.map {
-            return Correction(ruleDescription: type(of: self).description,
+            return Correction(ruleDescription: Self.description,
                               location: Location(file: file, characterOffset: $0))
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
@@ -87,7 +87,7 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule, 
                 return nil
             }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: paramOffset))
         }

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -138,7 +138,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return findViolations(file: file).compactMap {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
@@ -199,7 +199,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
         file.write(fixedSections.joined())
 
         return matches.map {
-            Correction(ruleDescription: type(of: self).description,
+            Correction(ruleDescription: Self.description,
                        location: Location(file: file, characterOffset: $0.location))
         }
     }

--- a/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
@@ -45,7 +45,7 @@ public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule, OptIn
             }
 
         return violationLocations.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: $0)
         }
@@ -63,7 +63,7 @@ public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule, OptIn
         var values: [SourceKittenDictionary] = []
         dictionary.elements.enumerated().forEach { index, element in
             // in a dictionary, the even elements are keys, and the odd elements are values
-            if index % 2 == 0 {
+            if index.isMultiple(of: 2) {
                 keys.append(element)
             } else {
                 values.append(element)

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+Dictionary.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+Dictionary.swift
@@ -39,7 +39,7 @@ extension ColonRule {
 
     private func dictionaryColonRanges(dictionary: SourceKittenDictionary) -> [ByteRange]? {
         let elements = dictionary.elements
-        guard elements.count % 2 == 0 else {
+        guard elements.count.isMultiple(of: 2) else {
             return nil
         }
 
@@ -52,8 +52,8 @@ extension ColonRule {
             return subDict.byteRange
         }
 
-        let even = ranges.enumerated().compactMap { $0 % 2 == 0 ? $1 : nil }
-        let odd = ranges.enumerated().compactMap { $0 % 2 != 0 ? $1 : nil }
+        let even = ranges.enumerated().compactMap { $0.isMultiple(of: 2) ? $1 : nil }
+        let odd = ranges.enumerated().compactMap { $0.isMultiple(of: 2) ? nil : $1 }
 
         return zip(even, odd).map { evenRange, oddRange -> ByteRange in
             let location = evenRange.upperBound

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -25,7 +25,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let violations = typeColonViolationRanges(in: file, matching: pattern).compactMap { range in
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severityConfiguration.severity,
                                   location: Location(file: file, characterOffset: range.location))
         }
@@ -48,7 +48,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
 
         guard !matches.isEmpty else { return [] }
         let regularExpression = regex(pattern)
-        let description = type(of: self).description
+        let description = Self.description
         var corrections = [Correction]()
         var contents = file.contents
         for (range, kind) in matches.reversed() {
@@ -106,7 +106,7 @@ extension ColonRule: ASTRule {
             functionCallColonViolationRanges(in: file, kind: kind, dictionary: dictionary)
 
         return ranges.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, byteOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -38,7 +38,7 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/ComputedAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ComputedAccessorsOrderRule.swift
@@ -71,7 +71,7 @@ public struct ComputedAccessorsOrderRule: ConfigurationProviderRule {
                 return "Computed \(kindString) should declare first the \(orderString)."
             }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severityConfiguration.severity,
                                   location: Location(file: file, byteOffset: offset),
                                   reason: reason)

--- a/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -42,7 +42,7 @@ public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, Rule, 
             return searchTokens.contains(file.contents(for: firstToken) ?? "") &&
                 file.contents(for: lastToken) == "return"
         }.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, characterOffset: $0.0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -82,7 +82,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestable
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map { match -> StyleViolation in
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: match.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -63,7 +63,7 @@ public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, Configurat
     public func validate(file: SwiftLintFile, kind: StatementKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
@@ -36,7 +36,7 @@ public struct EmptyParametersRule: ConfigurationProviderRule, SubstitutionCorrec
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -53,7 +53,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
     public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
@@ -86,7 +86,7 @@ public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, Anal
 
     public func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
         return violationRanges(in: file, compilerArguments: compilerArguments).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
@@ -98,7 +98,7 @@ public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, Anal
         if matches.isEmpty { return [] }
 
         var contents = file.contents.bridge()
-        let description = type(of: self).description
+        let description = Self.description
         var corrections = [Correction]()
         for range in matches.reversed() {
             contents = contents.replacingCharacters(in: range, with: "self.").bridge()
@@ -113,7 +113,7 @@ public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, Anal
         guard !compilerArguments.isEmpty else {
             queuedPrintError("""
                 Attempted to lint file at path '\(file.path ?? "...")' with the \
-                \(type(of: self).description.identifier) rule without any compiler arguments.
+                \(Self.description.identifier) rule without any compiler arguments.
                 """)
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
@@ -99,10 +99,10 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
     }
 
     private func makeViolation(at location: Location) -> StyleViolation {
-        return StyleViolation(ruleDescription: type(of: self).description,
+        return StyleViolation(ruleDescription: Self.description,
                               severity: configuration.severityConfiguration.severity,
                               location: location,
-                              reason: type(of: self).reason)
+                              reason: Self.reason)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -78,7 +78,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
                 let article = ["a", "e", "i", "o", "u"].contains(fileType.substring(from: 0, length: 1)) ? "An" : "A"
 
                 let styleViolation = StyleViolation(
-                    ruleDescription: type(of: self).description,
+                    ruleDescription: Self.description,
                     severity: configuration.severityConfiguration.severity,
                     location: Location(file: file, byteOffset: fileTypeOffset.offset),
                     reason: "\(article) '\(fileType)' should not be placed amongst the file type(s) '\(expected)'."

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -35,7 +35,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             }
 
             let isFunction = SwiftDeclarationKind.functionKinds.contains(kind)
-            let description = Swift.type(of: self).description
+            let description = Self.description
 
             let type = self.type(for: kind)
             if !isFunction {
@@ -55,7 +55,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
                         "\(configuration.minLengthThreshold) and " +
                         "\(configuration.maxLengthThreshold) characters long: '\(name)'"
                     return [
-                        StyleViolation(ruleDescription: Swift.type(of: self).description,
+                        StyleViolation(ruleDescription: Self.description,
                                        severity: severity,
                                        location: Location(file: file, byteOffset: offset),
                                        reason: reason)

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
@@ -61,7 +61,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRu
                 return "Computed read-only \(kindString) should avoid using the get keyword."
             }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: offset),
                                   reason: reason)

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -18,7 +18,7 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).compactMap {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
@@ -25,7 +25,7 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
         let reason = "File shouldn't start with whitespace: " +
                      "currently starts with \(countOfLeadingWhitespace) whitespace characters"
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file.path, line: 1),
                                reason: reason)]
@@ -46,6 +46,6 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
             limitedBy: file.contents.endIndex) ?? file.contents.endIndex
         file.write(String(file.contents[indexEnd...]))
         let location = Location(file: file.path, line: max(file.lines.count, 1))
-        return [Correction(ruleDescription: type(of: self).description, location: location)]
+        return [Correction(ruleDescription: Self.description, location: location)]
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -134,7 +134,7 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
                      "Expected \(violation.indentationRanges.expected.length), " +
                      "got \(violation.indentationRanges.actual.length)."
 
-        return StyleViolation(ruleDescription: type(of: self).description,
+        return StyleViolation(ruleDescription: Self.description,
                               severity: configuration.severity,
                               location: Location(file: file, byteOffset: violation.endOffset),
                               reason: reason)
@@ -171,7 +171,7 @@ extension LiteralExpressionEndIdentationRule: CorrectableRule {
         }
 
         var corrections = correctedLocations.map {
-            return Correction(ruleDescription: type(of: self).description,
+            return Correction(ruleDescription: Self.description,
                               location: Location(file: file, characterOffset: $0))
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -45,7 +45,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
             let reason = "\(preferredModifier.keyword) modifier should be before \(declaredModifier.keyword)."
             return [
                 StyleViolation(
-                    ruleDescription: type(of: self).description,
+                    ruleDescription: Self.description,
                     severity: configuration.severityConfiguration.severity,
                     location: Location(file: file, byteOffset: offset),
                     reason: reason
@@ -100,7 +100,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
 
             corrections = [
                 Correction(
-                    ruleDescription: type(of: self).description,
+                    ruleDescription: Self.description,
                     location: Location(
                         file: file,
                         byteOffset: offset

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -146,7 +146,7 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
 
         return violatingByteOffsets.map { byteOffset in
             StyleViolation(
-                ruleDescription: type(of: self).description, severity: configuration.severity,
+                ruleDescription: Self.description, severity: configuration.severity,
                 location: Location(file: file, byteOffset: byteOffset)
             )
         }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
@@ -43,7 +43,7 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
         }
 
         return violatingArguments.map {
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: self.configuration.severityConfiguration.severity,
                                   location: Location(file: file, byteOffset: $0.offset))
         }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -98,7 +98,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
                          kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violatingOffsets(file: file, kind: kind, dictionary: dictionary).map { offset in
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: offset))
         }
@@ -137,7 +137,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
     private func callDotOffset(file: SwiftLintFile, callRange: ByteRange) -> Int? {
         guard
             let range = file.stringView.byteRangeToNSRange(callRange),
-            case let regex = type(of: self).whitespaceDotRegex,
+            case let regex = Self.whitespaceDotRegex,
             let match = regex.matches(in: file.contents, options: [], range: range).last?.range else {
                 return nil
         }
@@ -149,7 +149,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
     private func callHasLeadingNewline(file: SwiftLintFile, callRange: ByteRange) -> Bool {
         guard
             let range = file.stringView.byteRangeToNSRange(callRange),
-            case let regex = type(of: self).newlineWhitespaceDotRegex,
+            case let regex = Self.newlineWhitespaceDotRegex,
             regex.firstMatch(in: file.contents, options: [], range: range) != nil else {
                 return false
         }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -127,7 +127,7 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
 
         return violatingByteOffsets.map { byteOffset in
             StyleViolation(
-                ruleDescription: type(of: self).description, severity: configuration.severity,
+                ruleDescription: Self.description, severity: configuration.severity,
                 location: Location(file: file, byteOffset: byteOffset)
             )
         }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -155,7 +155,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
         }
 
         return StyleViolation(
-            ruleDescription: type(of: self).description,
+            ruleDescription: Self.description,
             severity: configuration.severity,
             location: Location(file: file, characterOffset: invalidMatch.range.location + 1)
         )
@@ -179,7 +179,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
 
         let characterOffset = lastParamRange.upperBound + invalidMatch.range.upperBound - 1
         return StyleViolation(
-            ruleDescription: type(of: self).description,
+            ruleDescription: Self.description,
             severity: configuration.severity,
             location: Location(file: file, characterOffset: characterOffset)
         )

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
@@ -55,7 +55,7 @@ public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProvider
             return []
         }
 
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file, byteOffset: nameRange.location))]
     }

--- a/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -48,7 +48,7 @@ public struct MultipleClosuresWithTrailingClosureRule: ASTRule, ConfigurationPro
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: trailingClosureOffset))
         ]

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -67,7 +67,7 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
                          kind: SwiftExpressionKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -22,7 +22,7 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violatingRanges(in: file).map { range, _ in
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severityConfiguration.severity,
                                   location: Location(file: file, characterOffset: range.location))
         }
@@ -103,7 +103,7 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
         file.write(correctedContents)
 
         return adjustedLocations.map {
-            Correction(ruleDescription: type(of: self).description,
+            Correction(ruleDescription: Self.description,
                        location: Location(file: file, characterOffset: $0))
         }
     }
@@ -142,7 +142,7 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
             defer { correctComponents.append(String(char)) }
             guard char.unicodeScalars.allSatisfy(CharacterSet.decimalDigits.contains) else { continue }
 
-            if numerals % 3 == 0 && numerals > 0 && shouldAddSeparators {
+            if numerals.isMultiple(of: 3) && numerals > 0 && shouldAddSeparators {
                 correctComponents.append("_")
             }
             numerals += 1

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -157,7 +157,7 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule, Auto
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.violatingOpeningBraceRanges().map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
@@ -178,7 +178,7 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule, Auto
         file.write(correctedContents)
 
         return adjustedLocations.map {
-            Correction(ruleDescription: type(of: self).description,
+            Correction(ruleDescription: Self.description,
                        location: $0)
         }
     }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorFunctionWhitespaceRule.swift
@@ -35,7 +35,7 @@ public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule, Automat
         return file.match(pattern: "(\(pattern1)|\(pattern2))").filter { _, syntaxKinds in
             return syntaxKinds.first == .keyword
         }.map { range, _ in
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, characterOffset: range.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -72,7 +72,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(file: file).map { range, _ in
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: range.location))
         }
@@ -170,7 +170,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         file.write(correctedContents)
 
         return adjustedLocations.map {
-            Correction(ruleDescription: type(of: self).description,
+            Correction(ruleDescription: Self.description,
                        location: Location(file: file, characterOffset: $0))
         }
     }

--- a/Source/SwiftLintFramework/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -152,7 +152,7 @@ public struct OptionalEnumCaseMatchingRule: SubstitutionCorrectableASTRule, Conf
                          kind: StatementKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
@@ -167,7 +167,7 @@ public struct OptionalEnumCaseMatchingRule: SubstitutionCorrectableASTRule, Conf
     public func violationRanges(in file: SwiftLintFile,
                                 kind: StatementKind,
                                 dictionary: SourceKittenDictionary) -> [NSRange] {
-        guard SwiftVersion.current >= type(of: self).description.minSwiftVersion, kind == .case else {
+        guard SwiftVersion.current >= Self.description.minSwiftVersion, kind == .case else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -111,14 +111,14 @@ public struct PreferSelfTypeOverTypeOfSelfRule: OptInRule, ConfigurationProvider
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        guard SwiftVersion.current >= type(of: self).description.minSwiftVersion else {
+        guard SwiftVersion.current >= Self.description.minSwiftVersion else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -69,7 +69,7 @@ public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationPro
         }
 
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, byteOffset: nameOffset))
         ]

--- a/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -28,7 +28,7 @@ public struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, Sub
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
@@ -31,7 +31,7 @@ public struct RedundantDiscardableLetRule: SubstitutionCorrectableRule, Configur
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -44,7 +44,7 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file, skipParentheses: true).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
@@ -55,7 +55,7 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
         let matches = file.ruleEnabled(violatingRanges: violationsRanges, for: self)
         if matches.isEmpty { return [] }
         let regularExpression = regex(pattern)
-        let description = type(of: self).description
+        let description = Self.description
         var corrections = [Correction]()
         var contents = file.contents
 

--- a/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
@@ -92,7 +92,7 @@ public struct ShorthandOperatorRule: ConfigurationProviderRule, AutomaticTestabl
                     return nil
             }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: byteRange.location))
         }

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -56,7 +56,7 @@ public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule, A
         return classes.compactMap { dictionary in
             guard let offset = dictionary.offset else { return nil }
 
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: Location(file: file, byteOffset: offset),
                                   reason: "\(classes.count) test classes found in this file.")

--- a/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
@@ -137,7 +137,7 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
         let groups = importGroups(in: file, filterEnabled: false)
         return violatingOffsets(inGroups: groups).map { index -> StyleViolation in
             let location = Location(file: file, characterOffset: index)
-            return StyleViolation(ruleDescription: type(of: self).description,
+            return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
                                   location: location)
         }
@@ -180,7 +180,7 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
 
         let corrections = violatingOffsets(inGroups: groups).map { characterOffset -> Correction in
             let location = Location(file: file, characterOffset: characterOffset)
-            return Correction(ruleDescription: type(of: self).description, location: location)
+            return Correction(ruleDescription: Self.description, location: location)
         }
 
         guard !corrections.isEmpty else {

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -91,8 +91,8 @@ private extension StatementPositionRule {
     static let defaultPattern = "\\}(?:[\\s\\n\\r]{2,}|[\\n\\t\\r]+)?\\b(else|catch)\\b"
 
     func defaultValidate(file: SwiftLintFile) -> [StyleViolation] {
-        return defaultViolationRanges(in: file, matching: type(of: self).defaultPattern).compactMap { range in
-            StyleViolation(ruleDescription: type(of: self).description,
+        return defaultViolationRanges(in: file, matching: Self.defaultPattern).compactMap { range in
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity.severity,
                            location: Location(file: file, characterOffset: range.location))
         }
@@ -105,11 +105,11 @@ private extension StatementPositionRule {
     }
 
     func defaultCorrect(file: SwiftLintFile) -> [Correction] {
-        let violations = defaultViolationRanges(in: file, matching: type(of: self).defaultPattern)
+        let violations = defaultViolationRanges(in: file, matching: Self.defaultPattern)
         let matches = file.ruleEnabled(violatingRanges: violations, for: self)
         if matches.isEmpty { return [] }
-        let regularExpression = regex(type(of: self).defaultPattern)
-        let description = type(of: self).description
+        let regularExpression = regex(Self.defaultPattern)
+        let description = Self.description
         var corrections = [Correction]()
         var contents = file.contents
         for range in matches.reversed() {
@@ -127,7 +127,7 @@ private extension StatementPositionRule {
 private extension StatementPositionRule {
     func uncuddledValidate(file: SwiftLintFile) -> [StyleViolation] {
         return uncuddledViolationRanges(in: file).compactMap { range in
-            StyleViolation(ruleDescription: type(of: self).uncuddledDescription,
+            StyleViolation(ruleDescription: Self.uncuddledDescription,
                            severity: configuration.severity.severity,
                            location: Location(file: file, characterOffset: range.location))
         }
@@ -177,8 +177,8 @@ private extension StatementPositionRule {
         let contents = file.stringView
         let syntaxMap = file.syntaxMap
         let matches = StatementPositionRule.uncuddledRegex.matches(in: file)
-        let validator = type(of: self).uncuddledMatchValidator(contents: contents)
-        let filterMatches = type(of: self).uncuddledMatchFilter(contents: contents, syntaxMap: syntaxMap)
+        let validator = Self.uncuddledMatchValidator(contents: contents)
+        let filterMatches = Self.uncuddledMatchFilter(contents: contents, syntaxMap: syntaxMap)
 
         let validMatches = matches.compactMap(validator).filter(filterMatches).map({ $0.range })
 
@@ -189,13 +189,13 @@ private extension StatementPositionRule {
         var contents = file.contents
         let syntaxMap = file.syntaxMap
         let matches = StatementPositionRule.uncuddledRegex.matches(in: file)
-        let validator = type(of: self).uncuddledMatchValidator(contents: file.stringView)
-        let filterRanges = type(of: self).uncuddledMatchFilter(contents: file.stringView, syntaxMap: syntaxMap)
+        let validator = Self.uncuddledMatchValidator(contents: file.stringView)
+        let filterRanges = Self.uncuddledMatchFilter(contents: file.stringView, syntaxMap: syntaxMap)
 
         let validMatches = matches.compactMap(validator).filter(filterRanges)
                   .filter { !file.ruleEnabled(violatingRanges: [$0.range], for: self).isEmpty }
         if validMatches.isEmpty { return [] }
-        let description = type(of: self).uncuddledDescription
+        let description = Self.uncuddledDescription
         var corrections = [Correction]()
 
         for match in validMatches.reversed() {

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -90,7 +90,7 @@ public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptIn
             return nil
         }
 
-        return StyleViolation(ruleDescription: type(of: self).description,
+        return StyleViolation(ruleDescription: Self.description,
                               severity: configuration.severity,
                               location: Location(file: file, byteOffset: offset))
     }

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -33,7 +33,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let dict = file.structureDictionary
         return violationOffsets(for: dict, file: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -133,7 +133,7 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
 
     private func violations(file: SwiftLintFile, byteOffset: ByteCount, reason: String) -> [StyleViolation] {
         return [
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, byteOffset: byteOffset),
                            reason: reason)

--- a/Source/SwiftLintFramework/Rules/Style/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingNewlineRule.swift
@@ -46,7 +46,7 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, S
         if file.contents.trailingNewlineCount() == 1 {
             return []
         }
-        return [StyleViolation(ruleDescription: type(of: self).description,
+        return [StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
                                location: Location(file: file.path, line: max(file.lines.count, 1)))]
     }
@@ -68,6 +68,6 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, S
             file.write(file.contents[..<index])
         }
         let location = Location(file: file.path, line: max(file.lines.count, 1))
-        return [Correction(ruleDescription: type(of: self).description, location: location)]
+        return [Correction(ruleDescription: Self.description, location: location)]
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingWhitespaceRule.swift
@@ -42,7 +42,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         }
 
         return filteredLines.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file.path, line: $0.index))
         }
@@ -80,7 +80,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
             }
 
             if line.content != correctedLine {
-                let description = type(of: self).description
+                let description = Self.description
                 let location = Location(file: file.path, line: line.index)
                 corrections.append(Correction(ruleDescription: description, location: location))
             }

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -57,7 +57,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 let article = ["a", "e", "i", "o", "u"].contains(content.substring(from: 0, length: 1)) ? "An" : "A"
 
                 let styleViolation = StyleViolation(
-                    ruleDescription: type(of: self).description,
+                    ruleDescription: Self.description,
                     severity: configuration.severityConfiguration.severity,
                     location: Location(file: file, byteOffset: typeContentOffset.offset),
                     reason: "\(article) '\(content)' should not be placed amongst the type content(s) '\(expected)'."

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -62,7 +62,7 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(file: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }
@@ -121,7 +121,7 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
         file.write(correctedContents)
 
         return adjustedLocations.map {
-            Correction(ruleDescription: type(of: self).description,
+            Correction(ruleDescription: Self.description,
                        location: Location(file: file, characterOffset: $0))
         }
     }

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -60,7 +60,7 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
             }
 
             return violations(in: range, of: file, with: kind).map {
-                StyleViolation(ruleDescription: type(of: self).description,
+                StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severityConfiguration.severity,
                                location: Location(file: file, characterOffset: $0.location))
             }

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -150,7 +150,7 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
         }
 
         return violatingOffsets.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0))
         }

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -66,7 +66,7 @@ public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule
         }
 
         return violationLocations.map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: $0)
         }

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -161,7 +161,7 @@ extension VerticalWhitespaceBetweenCasesRule: OptInRule, AutomaticTestableRule {
             let characterOffset = violationRange.location + violatingSubrange.location
 
             return StyleViolation(
-                ruleDescription: type(of: self).description,
+                ruleDescription: Self.description,
                 severity: configuration.severity,
                 location: Location(file: file, characterOffset: characterOffset)
             )
@@ -176,7 +176,7 @@ extension VerticalWhitespaceBetweenCasesRule: CorrectableRule {
 
         let patternRegex = regex(pattern)
         let replacementTemplate = "$1\n$2"
-        let description = type(of: self).description
+        let description = Self.description
 
         var corrections = [Correction]()
         var fileContents = file.contents

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -65,7 +65,7 @@ extension VerticalWhitespaceClosingBracesRule: OptInRule, AutomaticTestableRule 
             let characterOffset = violationRange.location + violatingSubrange.location + 1
 
             return StyleViolation(
-                ruleDescription: type(of: self).description,
+                ruleDescription: Self.description,
                 severity: configuration.severity,
                 location: Location(file: file, characterOffset: characterOffset)
             )
@@ -80,7 +80,7 @@ extension VerticalWhitespaceClosingBracesRule: CorrectableRule {
 
         let patternRegex: NSRegularExpression = regex(pattern)
         let replacementTemplate = "$2"
-        let description = type(of: self).description
+        let description = Self.description
 
         var corrections = [Correction]()
         var fileContents = file.contents

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -87,7 +87,7 @@ extension VerticalWhitespaceOpeningBracesRule: OptInRule, AutomaticTestableRule 
             let characterOffset = violationRange.location + violatingSubrange.location + 1
 
             return StyleViolation(
-                ruleDescription: type(of: self).description,
+                ruleDescription: Self.description,
                 severity: configuration.severity,
                 location: Location(file: file, characterOffset: characterOffset)
             )
@@ -102,7 +102,7 @@ extension VerticalWhitespaceOpeningBracesRule: CorrectableRule {
 
         let patternRegex: NSRegularExpression = regex(pattern)
         let replacementTemplate = "$1$3"
-        let description = type(of: self).description
+        let description = Self.description
 
         var corrections = [Correction]()
         var fileContents = file.contents

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
@@ -46,7 +46,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
 
         return linesSections.map { eachLastLine, eachSectionCount in
             return StyleViolation(
-                ruleDescription: type(of: self).description,
+                ruleDescription: Self.description,
                 severity: configuration.severityConfiguration.severity,
                 location: Location(file: file.path, line: eachLastLine.index),
                 reason: configuredDescriptionReason + " Currently \(eachSectionCount + 1)."
@@ -131,7 +131,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
 
             // removes lines by skipping them from correctedLines
             if Set(indexOfLinesToDelete).contains(currentLine.index) {
-                let description = type(of: self).description
+                let description = Self.description
                 let location = Location(file: file, characterOffset: currentLine.range.location)
 
                 //reports every line that is being deleted

--- a/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
@@ -43,7 +43,7 @@ public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectable
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: type(of: self).description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
         }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -231,7 +231,7 @@ extension Configuration {
 
     init(options: LintOrAnalyzeOptions) {
         let cachePath = options.cachePath.isEmpty ? nil : options.cachePath
-        self.init(path: options.configurationFile, rootPath: type(of: self).rootPath(from: options.paths),
+        self.init(path: options.configurationFile, rootPath: Self.rootPath(from: options.paths),
                   optional: isConfigOptional(), quiet: options.quiet, enableAllRules: options.enableAllRules,
                   cachePath: cachePath)
     }
@@ -251,7 +251,7 @@ extension Configuration {
 
     init(options: AutoCorrectOptions) {
         let cachePath = options.cachePath.isEmpty ? nil : options.cachePath
-        self.init(path: options.configurationFile, rootPath: type(of: self).rootPath(from: options.paths),
+        self.init(path: options.configurationFile, rootPath: Self.rootPath(from: options.paths),
                   optional: isConfigOptional(), quiet: options.quiet, cachePath: cachePath)
     }
 


### PR DESCRIPTION
Since we now require Swift 5.1+