### PR TITLE
Include IndexSet in compiler_protocol_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@
   SwiftLint on Linux.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3214](https://github.com/realm/SwiftLint/issues/3214)
+  
+* `compiler_protocol_init` now triggers on `IndexSet(arrayLiteral:`.  
+  [Janak Shah](https://github.com/janakshah)
+  [#3284](https://github.com/realm/SwiftLint/pull/3284)
 
 ## 0.39.2: Stay Home
 

--- a/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
@@ -99,7 +99,8 @@ private struct ExpressibleByCompiler {
             "NSOrderedSet",
             "NSSet",
             "SBElementArray",
-            "Set"
+            "Set",
+            "IndexSet"
         ]
         return ExpressibleByCompiler(protocolName: "ExpressibleByArrayLiteral",
                                      types: types, arguments: [["arrayLiteral"]])


### PR DESCRIPTION
The collection:
```    private static let byArrayLiteral: ExpressibleByCompiler = {
        let types: Set = [
            "Array",
            "ArraySlice",
            "ContiguousArray",
            "IndexPath",
            "NSArray",
            "NSCountedSet",
            "NSMutableArray",
            "NSMutableOrderedSet",
            "NSMutableSet",
            "NSOrderedSet",
            "NSSet",
            "SBElementArray",
            "Set"
        ]
```
Should include "IndexSet" which would result in this line triggering the rule:
`let set = IndexSet(arrayLiteral: 1, 2)`
Currently this would not trigger `compiler_protocol_init`.
