### PR TITLE
Update test `testDetectSwiftVersion` for Swift 5.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3150](https://github.com/realm/SwiftLint/issues/3150)
 
+* Fix test `testDetectSwiftVersion` for Swift 5.2.5
+  [cfiken](https://github.com/cfiken)
+  [#3299](https://github.com/realm/SwiftLint/pull/3299)
+
 ## 0.39.2: Stay Home
 
 This is the last release to support building with Swift 5.0.x.

--- a/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
@@ -6,6 +6,8 @@ final class SwiftVersionTests: XCTestCase {
     func testDetectSwiftVersion() {
         #if compiler(>=5.3.0)
             let version = "5.3.0"
+        #elseif compiler(>=5.2.5)
+            let version = "5.2.5"
         #elseif compiler(>=5.2.4)
             let version = "5.2.4"
         #elseif compiler(>=5.2.3)


### PR DESCRIPTION
Swift 5.2.5 is released. https://swift.org/download/

Now CI `realm.SwiftLint (linux swift52)` failed [like this](https://dev.azure.com/jpsim/SwiftLint/_build/results?buildId=2220&view=logs&j=4f8fa21d-d991-5a18-87c9-c27fd1f9664a&t=3d14e094-cca2-59d1-b01e-ac4a347eefa3).
It is probably due to the [swift5.2 container image update](https://github.com/apple/swift-docker/blob/master/5.2/ubuntu/20.04/Dockerfile#L31). 
This PR supports Swift 5.2.5 in the test `testDetectSwiftVersion`.