### PR TITLE
Add support for params files for file path arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 #### Enhancements
 
-* None.
+* Add support for params files for file paths.  
+  [keith](https://github.com/keith)
 
 #### Bug Fixes
 


### PR DESCRIPTION
This allows you to pass `@path/to/file` which will be read line by line
for the list of files to lint / analyze. This is useful if you want to
pass a massive list of files which will either exceed arg max, or
break most unix tools if you use script input files + env vars.