### PR TITLE
Fix compiler warnings on Linux

### DIFF
--- a/Source/swiftlint/Commands/ShowDocsCommand.swift
+++ b/Source/swiftlint/Commands/ShowDocsCommand.swift
@@ -15,15 +15,16 @@ struct ShowDocsCommand: CommandProtocol {
 private extension ShowDocsCommand {
     func open(_ url: URL) {
         let process = Process()
-        process.launchPath = "/usr/bin/env"
-        let command: String = {
-            #if os(Linux)
-            return "xdg-open"
-            #else
-            return "open"
-            #endif
-        }()
-        process.arguments = [command, url.absoluteString]
+        let envPath = "/usr/bin/env"
+
+#if os(macOS)
+        process.launchPath = envPath
+        process.arguments = ["open", url.absoluteString]
         process.launch()
+#else
+        process.executableURL = URL(fileURLWithPath: envPath)
+        process.arguments = ["xdg-open", url.absoluteString]
+        process.run()
+#endif
     }
 }


### PR DESCRIPTION
Before:

```
Source/swiftlint/Commands/ShowDocsCommand.swift:18:17: note: use 'executableURL' instead
    process.launchPath = "/usr/bin/env"
            ^~~~~~~~~~
            executableURL
Source/swiftlint/Commands/ShowDocsCommand.swift:27:17: note: use 'run' instead
    process.launch()
            ^~~~~~
            run
```