### PR TITLE
Improving excluding paths algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* Speed up excluding paths process.  
+  [JohnReeze](https://github.com/JohnReeze)
+  [#3304](https://github.com/realm/SwiftLint/issues/3304)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -31,41 +31,20 @@ extension Configuration {
         let includedPaths = included.parallelFlatMap {
             fileManager.filesToLint(inPath: $0, rootDirectory: self.rootPath)
         }
-        return filterExcludedPaths(fileManager: fileManager, in: pathsForPath, includedPaths)
+        return filterExcludedPaths(in: pathsForPath, includedPaths)
     }
 
     /// Returns an array of file paths after removing the excluded paths as defined by this configuration.
     ///
-    /// - parameter fileManager: The lintable file manager to use to expand the excluded paths into all matching paths.
     /// - parameter paths:       The input paths to filter.
     ///
     /// - returns: The input paths after removing the excluded paths.
-    public func filterExcludedPaths(fileManager: LintableFileManager = FileManager.default,
-                                    in paths: [String]...) -> [String] {
+    public func filterExcludedPaths(in paths: [String]...) -> [String] {
         let allPaths = paths.flatMap { $0 }
-#if os(Linux)
-        let result = NSMutableOrderedSet(capacity: allPaths.count)
-        result.addObjects(from: allPaths)
-#else
-        let result = NSMutableOrderedSet(array: allPaths)
-#endif
-        let excludedPaths = self.excludedPaths(fileManager: fileManager)
-        result.minusSet(Set(excludedPaths))
-        // swiftlint:disable:next force_cast
-        return result.map { $0 as! String }
-    }
+        let excludedPaths = excluded.flatMap(Glob.resolveGlob).map { $0.absolutePathStandardized() }
 
-    /// Returns the file paths that are excluded by this configuration after expanding them using the specified file
-    /// manager.
-    ///
-    /// - parameter fileManager: The file manager to get child paths in a given parent location.
-    ///
-    /// - returns: The expanded excluded file paths.
-    internal func excludedPaths(fileManager: LintableFileManager) -> [String] {
-        return excluded
-            .flatMap(Glob.resolveGlob)
-            .parallelFlatMap {
-                fileManager.filesToLint(inPath: $0, rootDirectory: self.rootPath)
-            }
+        return allPaths.filter { path in
+            !excludedPaths.contains { path.hasPrefix($0) }
+        }
     }
 }


### PR DESCRIPTION
Resolves #3304

As I described in #3304 current excluding process is quiet inefficient. I changed it to more strait algorithm and got better results. 

In my case hardware: MacBook Pro 6-Core Intel Core i7, 16gb 
And for my quite big project for current algorithm which collects all lintable files in excluded directories (Pods, third party, etc)  the excluding method (`filterExcludedPaths`) takes  about 4.5-5.5 seconds, and for new algorithm for same conditions it takes about 1-1.6 seconds to do the same thing. 

