### PR TITLE
Add Linux binary to release artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ SwiftLint.pkg
 SwiftLintFramework.framework.zip
 benchmark_*
 portable_swiftlint.zip
+swiftlint_linux.zip
 osscheck/
 docs/
 rule_docs/

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,13 @@ portable_zip: installables
 	cp -f "$(LICENSE_PATH)" "$(TEMPORARY_FOLDER)"
 	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "swiftlint" "LICENSE") > "./portable_swiftlint.zip"
 
+zip_linux:
+	$(eval TMP_FOLDER := $(shell mktemp -d))
+	docker run -v `pwd`:`pwd` -w `pwd` --rm swift:latest swift build -c release
+	mv .build/release/swiftlint "$(TMP_FOLDER)"
+	cp -f "$(LICENSE_PATH)" "$(TMP_FOLDER)"
+	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "LICENSE") > "./swiftlint_linux.zip"
+
 package: installables
 	pkgbuild \
 		--identifier "io.realm.swiftlint" \
@@ -119,7 +126,7 @@ archive:
 	carthage build --no-skip-current --platform mac
 	carthage archive SwiftLintFramework
 
-release: package archive portable_zip
+release: package archive portable_zip zip_linux
 
 docker_test:
 	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm norionomura/swift:5.2.4 swift test --parallel


### PR DESCRIPTION
There are a lot of libraries dynamically linked, so it's unlikely to work in most places other than the same Docker image used to build the binary (latest official Swift Docker image).

It might still be useful if you can guarantee that you'll use this from that image.

    ldd .build/release/swiftlint
      linux-vdso.so.1 (0x00007fff38db5000)
      libswiftCore.so => /usr/lib/swift/linux/libswiftCore.so (0x00007f11503cd000)
      libFoundation.so => /usr/lib/swift/linux/libFoundation.so (0x00007f114fba6000)
      libswiftGlibc.so => /usr/lib/swift/linux/libswiftGlibc.so (0x00007f1151264000)
      libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f114f987000)
      libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007f114f784000)
      libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f114f580000)
      libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f114f1e2000)
      libswiftDispatch.so => /usr/lib/swift/linux/libswiftDispatch.so (0x00007f115122b000)
      libdispatch.so => /usr/lib/swift/linux/libdispatch.so (0x00007f114ef82000)
      libBlocksRuntime.so => /usr/lib/swift/linux/libBlocksRuntime.so (0x00007f114ed7f000)
      libFoundationXML.so => /usr/lib/swift/linux/libFoundationXML.so (0x00007f11511d2000)
      libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f114e98e000)
      libicui18nswift.so.65 => /usr/lib/swift/linux/libicui18nswift.so.65 (0x00007f114e463000)
      libicuucswift.so.65 => /usr/lib/swift/linux/libicuucswift.so.65 (0x00007f114e062000)
      libicudataswift.so.65 => /usr/lib/swift/linux/libicudataswift.so.65 (0x00007f114c3b3000)
      libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f114c02a000)
      libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f114be12000)
      /lib64/ld-linux-x86-64.so.2 (0x00007f1151053000)
      librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f114bc0a000)
      libxml2.so.2 => /usr/lib/x86_64-linux-gnu/libxml2.so.2 (0x00007f114b849000)
      libicuuc.so.60 => /usr/lib/x86_64-linux-gnu/libicuuc.so.60 (0x00007f114b491000)
      libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f114b274000)
      liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007f114b04e000)
      libicudata.so.60 => /usr/lib/x86_64-linux-gnu/libicudata.so.60 (0x00007f11494a5000)