### PR TITLE
Add `excluded_match_kinds` custom rule config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 * Improves description for  `empty_enum_arguments` 
   [Lukas Schmidt](https://github.com/lightsprint09)
-* Adds support for `excluded_match_kinds` custom rule config parameter
+
+* Add support for `excluded_match_kinds` custom rule config parameter.  
   [Ryan Demo](https://github.com/ryandemo)
 
 #### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Improves description for  `empty_enum_arguments` 
   [Lukas Schmidt](https://github.com/lightsprint09)
+* Adds support for `excluded_match_kinds` custom rule config parameter
+  [Ryan Demo](https://github.com/ryandemo)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/ConfigurationError.swift
+++ b/Source/SwiftLintFramework/Models/ConfigurationError.swift
@@ -2,4 +2,6 @@
 public enum ConfigurationError: Error {
     /// The configuration didn't match internal expectations.
     case unknownConfiguration
+    /// The configuration had both `match_kind` and `excluded_match_kind` parameters.
+    case ambiguousMatchKindParameters
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -29,7 +29,7 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
             included?.pattern ?? "",
             excluded?.pattern ?? "",
             SyntaxKind.allKinds.subtracting(excludedMatchKinds)
-                .map({ $0.rawValue }).sorted(by: <).joined(separator: ","),
+                .map(\.rawValue).sorted(by: <).joined(separator: ","),
             severityConfiguration.consoleDescription
         ]
         if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -29,7 +29,7 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
             included?.pattern ?? "",
             excluded?.pattern ?? "",
             SyntaxKind.allKinds.subtracting(excludedMatchKinds)
-                .map(\.rawValue).sorted(by: <).joined(separator: ","),
+                .map({ $0.rawValue }).sorted(by: <).joined(separator: ","),
             severityConfiguration.consoleDescription
         ]
         if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SourceKittenFramework
 
 private extension Region {
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -89,7 +89,7 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
         return configurations.flatMap { configuration -> [StyleViolation] in
             let pattern = configuration.regex.pattern
             let captureGroup = configuration.captureGroup
-            let excludingKinds = SyntaxKind.allKinds.subtracting(configuration.matchKinds)
+            let excludingKinds = configuration.excludedMatchKinds
             return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds, captureGroup: captureGroup).map({
                 StyleViolation(ruleDescription: configuration.description,
                                severity: configuration.severity,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -255,10 +255,8 @@ extension ConvenienceTypeRuleTests {
 
 extension CustomRulesTests {
     static var allTests: [(String, (CustomRulesTests) -> () throws -> Void)] = [
-        ("testCustomRuleConfigurationSetsCorrectlyWithMatchKinds",
-         testCustomRuleConfigurationSetsCorrectlyWithMatchKinds),
-        ("testCustomRuleConfigurationSetsCorrectlyWithExcludedMatchKinds",
-         testCustomRuleConfigurationSetsCorrectlyWithExcludedMatchKinds),
+        ("testCustomRuleConfigurationSetsCorrectlyWithMatchKinds", testCustomRuleConfigurationSetsCorrectlyWithMatchKinds),
+        ("testCustomRuleConfigurationSetsCorrectlyWithExcludedMatchKinds", testCustomRuleConfigurationSetsCorrectlyWithExcludedMatchKinds),
         ("testCustomRuleConfigurationThrows", testCustomRuleConfigurationThrows),
         ("testCustomRuleConfigurationMatchKindAmbiguity", testCustomRuleConfigurationMatchKindAmbiguity),
         ("testCustomRuleConfigurationIgnoreInvalidRules", testCustomRuleConfigurationIgnoreInvalidRules),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -255,8 +255,12 @@ extension ConvenienceTypeRuleTests {
 
 extension CustomRulesTests {
     static var allTests: [(String, (CustomRulesTests) -> () throws -> Void)] = [
-        ("testCustomRuleConfigurationSetsCorrectly", testCustomRuleConfigurationSetsCorrectly),
+        ("testCustomRuleConfigurationSetsCorrectlyWithMatchKinds",
+         testCustomRuleConfigurationSetsCorrectlyWithMatchKinds),
+        ("testCustomRuleConfigurationSetsCorrectlyWithExcludedMatchKinds",
+         testCustomRuleConfigurationSetsCorrectlyWithExcludedMatchKinds),
         ("testCustomRuleConfigurationThrows", testCustomRuleConfigurationThrows),
+        ("testCustomRuleConfigurationMatchKindAmbiguity", testCustomRuleConfigurationMatchKindAmbiguity),
         ("testCustomRuleConfigurationIgnoreInvalidRules", testCustomRuleConfigurationIgnoreInvalidRules),
         ("testCustomRules", testCustomRules),
         ("testLocalDisableCustomRule", testLocalDisableCustomRule),

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 import XCTest
 
 class CustomRulesTests: XCTestCase {
-    func testCustomRuleConfigurationSetsCorrectly() {
+    func testCustomRuleConfigurationSetsCorrectlyWithMatchKinds() {
         let configDict = [
             "my_custom_rule": [
                 "name": "MyCustomRule",
@@ -18,7 +18,34 @@ class CustomRulesTests: XCTestCase {
         comp.message = "Message"
         comp.regex = regex("regex")
         comp.severityConfiguration = SeverityConfiguration(.error)
-        comp.matchKinds = Set([SyntaxKind.comment])
+        comp.excludedMatchKinds = SyntaxKind.allKinds.subtracting([.comment])
+        var compRules = CustomRulesConfiguration()
+        compRules.customRuleConfigurations = [comp]
+        do {
+            var configuration = CustomRulesConfiguration()
+            try configuration.apply(configuration: configDict)
+            XCTAssertEqual(configuration, compRules)
+        } catch {
+            XCTFail("Did not configure correctly")
+        }
+    }
+
+    func testCustomRuleConfigurationSetsCorrectlyWithExcludedMatchKinds() {
+        let configDict = [
+            "my_custom_rule": [
+                "name": "MyCustomRule",
+                "message": "Message",
+                "regex": "regex",
+                "excluded_match_kinds": "comment",
+                "severity": "error"
+            ]
+        ]
+        var comp = RegexConfiguration(identifier: "my_custom_rule")
+        comp.name = "MyCustomRule"
+        comp.message = "Message"
+        comp.regex = regex("regex")
+        comp.severityConfiguration = SeverityConfiguration(.error)
+        comp.excludedMatchKinds = Set<SyntaxKind>([.comment])
         var compRules = CustomRulesConfiguration()
         compRules.customRuleConfigurations = [comp]
         do {
@@ -35,6 +62,22 @@ class CustomRulesTests: XCTestCase {
         var customRulesConfig = CustomRulesConfiguration()
         checkError(ConfigurationError.unknownConfiguration) {
             try customRulesConfig.apply(configuration: config)
+        }
+    }
+
+    func testCustomRuleConfigurationMatchKindUniqueness() {
+        let configDict = [
+            "name": "MyCustomRule",
+            "message": "Message",
+            "regex": "regex",
+            "match_kinds": "comment",
+            "excluded_match_kinds": "argument",
+            "severity": "error"
+        ]
+
+        var configuration = RegexConfiguration(identifier: "my_custom_rule")
+        checkError(ConfigurationError.ambiguousMatchKindParameters) {
+            try configuration.apply(configuration: configDict)
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -65,7 +65,7 @@ class CustomRulesTests: XCTestCase {
         }
     }
 
-    func testCustomRuleConfigurationMatchKindUniqueness() {
+    func testCustomRuleConfigurationMatchKindAmbiguity() {
         let configDict = [
             "name": "MyCustomRule",
             "message": "Message",


### PR DESCRIPTION
This allows custom rules to define an `excluded_match_kinds` array instead of listing out all but one or a few of the `SyntaxKind`s in `match_kinds`. Rules that include both `match_kinds` and `excluded_match_kinds` will be invalid, since there's not an obvious way to resolve the two without an arbitrary priority between them.