### PR TITLE
[UnusedDeclarationRule] Speed up and detect more dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* Make the `unused_declaration` rule run 3-5 times faster, and
+  enable it to detect more occurrences of unused declarations.  
+  [JP Simard](https://github.com/jpsim)
 
 #### Bug Fixes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,30 @@
         }
       },
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "7cd2f8cacc4d22f21bc0b2309c3b18acf7957b66",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c228db5d2ad1b01ebc84435e823e6cca4e3db98b",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "2b1809051b4a65c1d7f5233331daa24572cd7fca",
-          "version": "8.1.1"
+          "revision": "b02b00b30b6353632aa4a5fb6124f8147f7140c0",
+          "version": "8.0.5"
         }
       },
       {
@@ -24,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "09b3becb37cb2163919a3842a4c5fa6ec7130792",
-          "version": "2.2.1"
+          "revision": "33682c2f6230c60614861dfc61df267e11a1602f",
+          "version": "2.2.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,30 +11,12 @@
         }
       },
       {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "7cd2f8cacc4d22f21bc0b2309c3b18acf7957b66",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "c228db5d2ad1b01ebc84435e823e6cca4e3db98b",
-          "version": "1.2.0"
-        }
-      },
-      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "b02b00b30b6353632aa4a5fb6124f8147f7140c0",
-          "version": "8.0.5"
+          "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
+          "version": "8.1.2"
         }
       },
       {
@@ -42,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "33682c2f6230c60614861dfc61df267e11a1602f",
-          "version": "2.2.0"
+          "revision": "09b3becb37cb2163919a3842a4c5fa6ec7130792",
+          "version": "2.2.1"
         }
       },
       {

--- a/Source/SwiftLintFramework/Models/RuleStorage.swift
+++ b/Source/SwiftLintFramework/Models/RuleStorage.swift
@@ -1,9 +1,13 @@
 import Dispatch
 
 /// A storage mechanism for aggregating the results of `CollectingRule`s.
-public class RuleStorage {
+public class RuleStorage: CustomStringConvertible {
     private var storage: [ObjectIdentifier: [SwiftLintFile: Any]]
     private let access = DispatchQueue(label: "io.realm.swiftlint.ruleStorageAccess", attributes: .concurrent)
+
+    public var description: String {
+        storage.description
+    }
 
     /// Creates a `RuleStorage` with no initial stored data.
     public init() {

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -208,9 +208,3 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
         }
     }
 }
-
-private extension Array where Element == SyntaxKind {
-    static func ~= (array: [SyntaxKind], value: [SyntaxKind]) -> Bool {
-        return array == value
-    }
-}

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -2,10 +2,16 @@ import Foundation
 import SourceKittenFramework
 
 public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProviderRule, AnalyzerRule, CollectingRule {
-    public struct FileUSRs {
+    public struct FileUSRs: Hashable {
+        struct DeclaredUSR: Hashable {
+            let usr: String
+            let nameOffset: ByteCount
+        }
+
         var referenced: Set<String>
-        var declared: [(usr: String, nameOffset: ByteCount)]
-        var testCaseUSRs: Set<String>
+        var declared: Set<DeclaredUSR>
+
+        fileprivate static var empty: FileUSRs { FileUSRs(referenced: [], declared: []) }
     }
 
     public typealias FileInfo = FileUSRs
@@ -63,6 +69,9 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
                 }
             }
             _ = ResponseModel()
+            """),
+            Example("""
+            public func foo() {}
             """)
         ],
         triggeringExamples: [
@@ -95,24 +104,40 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
                 Attempted to lint file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule without any compiler arguments.
                 """)
-            return FileUSRs(referenced: [], declared: [], testCaseUSRs: [])
+            return .empty
         }
 
-        let allCursorInfo = file.allCursorInfo(compilerArguments: compilerArguments)
-        return FileUSRs(referenced: Set(SwiftLintFile.referencedUSRs(allCursorInfo: allCursorInfo)),
-                        declared: SwiftLintFile.declaredUSRs(allCursorInfo: allCursorInfo,
-                                                             includePublicAndOpen: configuration.includePublicAndOpen),
-                        testCaseUSRs: SwiftLintFile.testCaseUSRs(allCursorInfo: allCursorInfo))
+        guard let index = file.index(compilerArguments: compilerArguments) else {
+            queuedPrintError("""
+                Could not index file at path '\(file.path ?? "...")' with the \
+                \(Self.description.identifier) rule.
+                """)
+            return .empty
+        }
+
+        guard let editorOpen = (try? Request.editorOpen(file: file.file).sendIfNotDisabled())
+                .map(SourceKittenDictionary.init) else {
+            queuedPrintError("""
+                Could not open file at path '\(file.path ?? "...")' with the \
+                \(Self.description.identifier) rule.
+                """)
+            return .empty
+        }
+
+        return FileUSRs(
+            referenced: file.referencedUSRs(index: index),
+            declared: file.declaredUSRs(index: index,
+                                        editorOpen: editorOpen,
+                                        compilerArguments: compilerArguments,
+                                        includePublicAndOpen: configuration.includePublicAndOpen)
+        )
     }
 
     public func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: UnusedDeclarationRule.FileUSRs],
                          compilerArguments: [String]) -> [StyleViolation] {
         let allReferencedUSRs = collectedInfo.values.reduce(into: Set()) { $0.formUnion($1.referenced) }
-        let allTestCaseUSRs = collectedInfo.values.reduce(into: Set()) { $0.formUnion($1.testCaseUSRs) }
-        return violationOffsets(in: file, compilerArguments: compilerArguments,
-                                declaredUSRs: collectedInfo[file]?.declared ?? [],
-                                allReferencedUSRs: allReferencedUSRs,
-                                allTestCaseUSRs: allTestCaseUSRs)
+        return violationOffsets(declaredUSRs: collectedInfo[file]?.declared ?? [],
+                                allReferencedUSRs: allReferencedUSRs)
             .map {
                 StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
@@ -120,154 +145,141 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
             }
     }
 
-    private func violationOffsets(in file: SwiftLintFile, compilerArguments: [String],
-                                  declaredUSRs: [(usr: String, nameOffset: ByteCount)],
-                                  allReferencedUSRs: Set<String>,
-                                  allTestCaseUSRs: Set<String>) -> [ByteCount] {
+    private func violationOffsets(declaredUSRs: Set<FileUSRs.DeclaredUSR>,
+                                  allReferencedUSRs: Set<String>) -> [ByteCount] {
         // Unused declarations are:
         // 1. all declarations
         // 2. minus all references
-        // 3. minus all XCTestCase subclasses
-        // 4. minus all XCTest test functions
-        let unusedDeclarations = declaredUSRs
+        return declaredUSRs
             .filter { !allReferencedUSRs.contains($0.usr) }
-            .filter { !allTestCaseUSRs.contains($0.usr) }
-            .filter { declaredUSR in
-                return !allTestCaseUSRs.contains(where: { testCaseUSR in
-                    return declaredUSR.usr.hasPrefix(testCaseUSR + "(im)test") ||
-                        declaredUSR.usr.hasPrefix(
-                            testCaseUSR.replacingOccurrences(of: "@M@", with: "@CM@") + "(im)test"
-                        )
-                })
-            }
-        return unusedDeclarations.map { $0.nameOffset }
+            .map { $0.nameOffset }
+            .sorted()
     }
 }
 
 // MARK: - File Extensions
 
 private extension SwiftLintFile {
-    func allCursorInfo(compilerArguments: [String]) -> [SourceKittenDictionary] {
-        guard let path = path,
-            let editorOpen = (try? Request.editorOpen(file: self.file).sendIfNotDisabled())
-                .map(SourceKittenDictionary.init) else {
-            return []
-        }
-
-        return syntaxMap.tokens
-            .compactMap { token in
-                guard let kind = token.kind, !syntaxKindsToSkip.contains(kind) else {
-                    return nil
-                }
-
-                let offset = token.offset
-                let request = Request.cursorInfo(file: path, offset: offset, arguments: compilerArguments)
-                guard var cursorInfo = try? request.sendIfNotDisabled() else {
-                    return nil
-                }
-
-                if let acl = editorOpen.aclAtOffset(offset) {
-                    cursorInfo["key.accessibility"] = acl.rawValue
-                }
-                cursorInfo["swiftlint.offset"] = Int64(offset.value)
-                return cursorInfo
+    func index(compilerArguments: [String]) -> SourceKittenDictionary? {
+        return path
+            .flatMap { path in
+                try? Request.index(file: path, arguments: compilerArguments)
+                            .send()
             }
             .map(SourceKittenDictionary.init)
     }
 
-    static func declaredUSRs(allCursorInfo: [SourceKittenDictionary], includePublicAndOpen: Bool)
-        -> [(usr: String, nameOffset: ByteCount)] {
-        return allCursorInfo.compactMap { cursorInfo in
-            return declaredUSRAndOffset(cursorInfo: cursorInfo, includePublicAndOpen: includePublicAndOpen)
-        }
+    func referencedUSRs(index: SourceKittenDictionary) -> Set<String> {
+        return Set(index.traverseEntities { entity -> String? in
+            if let usr = entity.usr,
+                let kind = entity.kind,
+                kind.starts(with: "source.lang.swift.ref")
+            {
+                return usr
+            }
+
+            return nil
+        })
     }
 
-    static func referencedUSRs(allCursorInfo: [SourceKittenDictionary]) -> [String] {
-        return allCursorInfo.compactMap(referencedUSR)
-    }
-
-    static func testCaseUSRs(allCursorInfo: [SourceKittenDictionary]) -> Set<String> {
-        return Set(allCursorInfo.compactMap(testCaseUSR))
-    }
-
-    private static func declaredUSRAndOffset(cursorInfo: SourceKittenDictionary, includePublicAndOpen: Bool)
-        -> (usr: String, nameOffset: ByteCount)? {
-        if let offset = cursorInfo.swiftlintOffset,
-            let usr = cursorInfo.usr,
-            let kind = cursorInfo.declarationKind,
-            !declarationKindsToSkip.contains(kind),
-            let acl = cursorInfo.accessibility,
-            includePublicAndOpen || [.internal, .private, .fileprivate].contains(acl) {
-            // Skip declarations marked as @IBOutlet, @IBAction or @objc
-            // since those might not be referenced in code, but only dynamically (e.g. Interface Builder)
-            if let annotatedDecl = cursorInfo.annotatedDeclaration,
-                ["@IBOutlet", "@IBAction", "@objc", "@IBInspectable"].contains(where: annotatedDecl.contains) {
+    func declaredUSRs(index: SourceKittenDictionary, editorOpen: SourceKittenDictionary,
+                     compilerArguments: [String], includePublicAndOpen: Bool)
+        -> Set<UnusedDeclarationRule.FileUSRs.DeclaredUSR>
+    {
+        return Set(index.traverseEntities { entity -> UnusedDeclarationRule.FileUSRs.DeclaredUSR? in
+            guard let stringKind = entity.kind,
+                  stringKind.starts(with: "source.lang.swift.decl."),
+                  !stringKind.contains(".accessor."),
+                  let usr = entity.value["key.usr"] as? String,
+                  let line = entity.line.map(Int.init),
+                  let column = entity.column.map(Int.init),
+                  let kind = entity.declarationKind,
+                  !declarationKindsToSkip.contains(kind)
+            else {
                 return nil
             }
 
-            // Classes marked as @UIApplicationMain are used by the operating system as the entry point into the app.
-            if let annotatedDecl = cursorInfo.annotatedDeclaration,
-                annotatedDecl.contains("@UIApplicationMain") {
+            let swiftAttributesToSkip: [SwiftDeclarationAttributeKind] = [
+                .ibaction,
+                .ibinspectable,
+                .iboutlet,
+                .override
+            ]
+
+            let enclosedSwiftAttributes = entity.enclosedSwiftAttributes
+            if enclosedSwiftAttributes.contains(where: swiftAttributesToSkip.contains) {
                 return nil
             }
 
-            // Skip declarations that override another. This works for both subclass overrides &
-            // protocol extension overrides.
-            if cursorInfo.value["key.overrides"] != nil {
+            if entity.value["key.is_implicit"] as? Bool == true {
+                return nil
+            }
+
+            if entity.value["key.is_test_candidate"] as? Bool == true {
+                return nil
+            }
+
+            let nameOffset = stringView.byteOffset(forLine: line, column: column)
+
+            if !includePublicAndOpen,
+                [.public, .open].contains(editorOpen.aclAtOffset(nameOffset))
+            {
+                return nil
+            }
+
+            // Skip CodingKeys as they are used for Codable generation
+            if kind == .enum,
+                entity.name == "CodingKeys",
+                case let allRelatedUSRs = entity.traverseEntities(traverseBlock: { $0.usr }),
+                allRelatedUSRs.contains("s:s9CodingKeyP")
+            {
+                return nil
+            }
+
+            // Skip `static var allTests` members since those are used for Linux test discovery.
+            if kind == .varStatic, entity.name == "allTests" {
+                let allTestCandidates = entity.traverseEntities { subEntity -> Bool in
+                    subEntity.value["key.is_test_candidate"] as? Bool == true
+                }
+
+                if allTestCandidates.contains(true) {
+                    return nil
+                }
+            }
+
+            let cursorInfo = self.cursorInfo(at: nameOffset, compilerArguments: compilerArguments)
+
+            if let annotatedDecl = cursorInfo?.annotatedDeclaration,
+                ["@IBOutlet", "@IBAction", "@objc", "@IBInspectable"].contains(where: annotatedDecl.contains)
+            {
+                return nil
+            }
+
+            // This works for both subclass overrides & protocol extension overrides.
+            if cursorInfo?.value["key.overrides"] != nil {
                 return nil
             }
 
             // Sometimes default protocol implementations don't have `key.overrides` set but they do have
-            // `key.related_decls`.
-            if cursorInfo.value["key.related_decls"] != nil {
+            // `key.related_decls`. The apparent exception is that related declarations also includes declarations
+            // with "related names", which appears to be similarly named declarations (i.e. overloads) that are
+            // programmatically unrelated to the current cursor-info declaration. Those similarly named declarations
+            // aren't in `key.related` so confirm that that one is also populated.
+            if cursorInfo?.value["key.related_decls"] != nil && entity.value["key.related"] != nil {
                 return nil
             }
 
-            // Skip CodingKeys as they are used
-            if kind == .enum,
-                cursorInfo.name == "CodingKeys",
-                let annotatedDecl = cursorInfo.annotatedDeclaration,
-                annotatedDecl.contains("usr=\"s:s9CodingKeyP\">CodingKey<") {
-                return nil
-            }
-
-            return (usr, ByteCount(offset))
-        }
-
-        return nil
+            return .init(usr: usr, nameOffset: nameOffset)
+        })
     }
 
-    private static func referencedUSR(cursorInfo: SourceKittenDictionary) -> String? {
-        if let usr = cursorInfo.usr,
-            let kind = cursorInfo.kind,
-            kind.starts(with: "source.lang.swift.ref") {
-            if let synthesizedLocation = usr.range(of: "::SYNTHESIZED::")?.lowerBound {
-                return String(usr.prefix(upTo: synthesizedLocation))
-            }
-            return usr
-        }
-
-        return nil
-    }
-
-    private static func testCaseUSR(cursorInfo: SourceKittenDictionary) -> String? {
-        if let kind = cursorInfo.declarationKind,
-            kind == .class,
-            let annotatedDecl = cursorInfo.annotatedDeclaration,
-            annotatedDecl.contains("<Type usr=\"c:objc(cs)XCTestCase\">XCTestCase</Type>"),
-            let usr = cursorInfo.usr {
-            return usr
-        }
-
-        return nil
+    func cursorInfo(at byteOffset: ByteCount, compilerArguments: [String]) -> SourceKittenDictionary? {
+        let request = Request.cursorInfo(file: path!, offset: byteOffset, arguments: compilerArguments)
+        return (try? request.sendIfNotDisabled()).map(SourceKittenDictionary.init)
     }
 }
 
 private extension SourceKittenDictionary {
-    var swiftlintOffset: Int64? {
-        return value["swiftlint.offset"] as? Int64
-    }
-
     var usr: String? {
         return value["key.usr"] as? String
     }
@@ -293,25 +305,40 @@ private extension SourceKittenDictionary {
 
 // Skip initializers, deinit, enum cases and subscripts since we can't reliably detect if they're used.
 private let declarationKindsToSkip: Set<SwiftDeclarationKind> = [
+    .enumelement,
+    .extensionProtocol,
+    .extension,
+    .extensionEnum,
+    .extensionClass,
+    .extensionStruct,
     .functionConstructor,
     .functionDestructor,
-    .enumelement,
-    .functionSubscript
+    .functionSubscript,
+    .genericTypeParam
 ]
 
-/// Skip syntax kinds that won't respond to cursor info requests.
-private let syntaxKindsToSkip: Set<SyntaxKind> = [
-    .attributeBuiltin,
-    .attributeID,
-    .comment,
-    .commentMark,
-    .commentURL,
-    .buildconfigID,
-    .buildconfigKeyword,
-    .docComment,
-    .docCommentField,
-    .keyword,
-    .number,
-    .string,
-    .stringInterpolationAnchor
-]
+private extension SourceKittenDictionary {
+    func traverseEntities<T>(traverseBlock: (SourceKittenDictionary) -> T?) -> [T] {
+        var result: [T] = []
+        traverseEntitiesDepthFirst(collectingValuesInto: &result, traverseBlock: traverseBlock)
+        return result
+    }
+
+    private func traverseEntitiesDepthFirst<T>(collectingValuesInto array: inout [T],
+                                       traverseBlock: (SourceKittenDictionary) -> T?) {
+        entities.forEach { subDict in
+            subDict.traverseEntitiesDepthFirst(collectingValuesInto: &array, traverseBlock: traverseBlock)
+
+            if let collectedValue = traverseBlock(subDict) {
+                array.append(collectedValue)
+            }
+        }
+    }
+}
+
+private extension StringView {
+    func byteOffset(forLine line: Int, column: Int) -> ByteCount {
+        guard line > 0 else { return ByteCount(column - 1) }
+        return lines[line - 1].byteRange.location + ByteCount(column - 1)
+    }
+}


### PR DESCRIPTION
By using SourceKit's `index` request to index the entire source file, we can avoid having to make `cursor-info` requests for every candidate token in the file, which scales linearly with the number of candidate tokens.

For the Yams project, this approach improved the total SwiftLint run time by 4.6x: 7.9 down from 36.8s.

![image](https://user-images.githubusercontent.com/474794/93044146-d0b64980-f608-11ea-8b48-72861f1205cd.png)

The SourceKit index response doesn't have everything we need to identify declarations, so we still need to make some `cursor-info` requests, mostly to detect overrides: protocol conformances and parent class overrides.

This approach ends up finding more unused declarations because the index contains more declared USRs than can be found by calling `cursor-info` on candidate tokens in a file.