### PR TITLE
[SwiftLintFile] Remove lock in favor of UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   enable it to detect more occurrences of unused declarations.  
   [JP Simard](https://github.com/jpsim)
 
+* Remove unneeded internal locking overhead, leading to increased
+  performance in multithreaded operations.  
+  [JP Simard](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-private typealias FileCacheKey = Int
+private typealias FileCacheKey = UUID
 private var responseCache = Cache({ file -> [String: SourceKitRepresentable]? in
     do {
         return try Request.editorOpen(file: file.file).sendIfNotDisabled()

--- a/Source/SwiftLintFramework/Models/SwiftLintFile.swift
+++ b/Source/SwiftLintFramework/Models/SwiftLintFile.swift
@@ -3,25 +3,15 @@ import SourceKittenFramework
 
 /// A unit of Swift source code, either on disk or in memory.
 public final class SwiftLintFile {
-    private static var id = 0
-    private static var lock = NSLock()
-
-    private static func nextID () -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-        id += 1
-        return id
-    }
-
     let file: File
-    let id: Int
+    let id: UUID
 
     /// Creates a `SwiftLintFile` with a SourceKitten `File`.
     ///
     /// - parameter file: A file from SourceKitten.
     public init(file: File) {
         self.file = file
-        self.id = SwiftLintFile.nextID()
+        self.id = UUID()
     }
 
     /// Creates a `SwiftLintFile` by specifying its path on disk.


### PR DESCRIPTION
We were using this lock to guarantee a new ID for every file, but we can get that benefit by using values that are guaranteed to be unique without the need for locks, such as a UUID.