### PR TITLE
Include Linux zip in list of GitHub release binaries

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -10,7 +10,8 @@ For SwiftLint contributors, follow these steps to cut a release:
 2. Push new version: `make push_version "0.2.0: Tumble Dry"`
 3. Make sure you have the latest stable Xcode version installed and
   `xcode-select`ed.
-4. Create the pkg installer, framework zip, and portable zip: `make release`
+4. Create the pkg installer, framework zip, portable zip, and Linux zip:
+   `make release`
 5. Create a GitHub release: https://github.com/realm/SwiftLint/releases/new
     * Specify the tag you just pushed from the dropdown.
     * Set the release title to the new version number & release name.

--- a/Releasing.md
+++ b/Releasing.md
@@ -15,7 +15,7 @@ For SwiftLint contributors, follow these steps to cut a release:
     * Specify the tag you just pushed from the dropdown.
     * Set the release title to the new version number & release name.
     * Add the changelog section to the release description text box.
-    * Upload the pkg installer, framework zip, and portable zip you just built
+    * Upload the pkg installer, framework zip, portable zip, and Linux zip you just built
       to the GitHub release binaries.
     * Click "Publish release".
 6. Publish to Homebrew and CocoaPods trunk: `make publish`

--- a/Releasing.md
+++ b/Releasing.md
@@ -7,17 +7,17 @@ For SwiftLint contributors, follow these steps to cut a release:
     * FabricSoftenerRule
     * Top Loading
     * Fresh Out Of The Dryer
-2. Push new version: `make push_version "0.2.0: Tumble Dry"`
-3. Make sure you have the latest stable Xcode version installed and
+1. Push new version: `make push_version "0.2.0: Tumble Dry"`
+1. Make sure you have the latest stable Xcode version installed and
   `xcode-select`ed.
-4. Create the pkg installer, framework zip, portable zip, and Linux zip:
+1. Create the pkg installer, framework zip, portable zip, and Linux zip:
    `make release`
-5. Create a GitHub release: https://github.com/realm/SwiftLint/releases/new
+1. Create a GitHub release: https://github.com/realm/SwiftLint/releases/new
     * Specify the tag you just pushed from the dropdown.
     * Set the release title to the new version number & release name.
     * Add the changelog section to the release description text box.
     * Upload the pkg installer, framework zip, portable zip, and Linux zip you just built
       to the GitHub release binaries.
     * Click "Publish release".
-6. Publish to Homebrew and CocoaPods trunk: `make publish`
-7. Celebrate. :tada:
+1. Publish to Homebrew and CocoaPods trunk: `make publish`
+1. Celebrate. :tada:


### PR DESCRIPTION
Including the Linux zip to match what has been included in recent releases. 

I also took the liberty of renumbering the numbered list to all 1s to make it easier to maintain in the future. One can add/remove steps in the list without needing to renumber everything.