### PR TITLE
[Fix] `UnusedCaptureListRule`: implicit self in @escaping closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
 
 #### Bug Fixes
 
-* None.
+* Rule `unused_capture_list` should not be triggered by self keyword.  
+  [hank121314](https://github.com/hank121314)
+  [#2367](https://github.com/realm/SwiftLint/issues/3267)
 
 ## 0.40.2: Demo Unit
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
@@ -47,6 +47,15 @@ public struct UnusedCaptureListRule: ASTRule, ConfigurationProviderRule, Automat
             [1, 2].map { [self, unowned delegate = self.delegate!] num in
                 delegate.handle(num)
             }
+            """),
+            Example("""
+            [1, 2].map {
+                [ weak
+                  delegate,
+                  self
+                ] num in
+                delegate.handle(num)
+            }
             """)
         ],
         triggeringExamples: [
@@ -134,7 +143,8 @@ public struct UnusedCaptureListRule: ASTRule, ConfigurationProviderRule, Automat
         var locationOffset = 0
         return captureList.components(separatedBy: ",")
             .reduce(into: [(String, Int)]()) { referencesAndLocations, item in
-                guard item != selfKeyword else { return }
+                let word = item.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard word != selfKeyword else { return }
                 let item = item.bridge()
                 let range = item.rangeOfCharacter(from: CharacterSet.whitespacesAndNewlines.inverted)
                 guard range.location != NSNotFound else { return }


### PR DESCRIPTION
## Summary

This pr fixes: #3267 .

Since Swift 5.3 is released. It support implicit self in @escaping closures([SE-0269](https://github.com/apple/swift-evolution/blob/master/proposals/0269-implicit-self-explicit-capture.md))

I think we should exclude self keyword from capture list rule.

## Test Plan

I have already add some test in example.

Thanks you so much for your code review!