### PR TITLE
Revert "Fix finding the nested config when a single file path is passed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@
   [hank121314](https://github.com/hank121314)
   [#2367](https://github.com/realm/SwiftLint/issues/3267)
 
-* Fix finding a nested config when a single file path is passed.  
-  [Seth Friedman](https://github.com/sethfri)
-
 ## 0.40.2: Demo Unit
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -16,9 +16,7 @@ extension Configuration {
     }
 
     private func configuration(forPath path: String) -> Configuration {
-        let rootConfigurationDirectory = configurationPath?.bridge().deletingLastPathComponent
-        // We're linting a file in the same directory as the root configuration we've already loaded
-        if path == rootConfigurationDirectory {
+        if path == rootDirectory {
             return self
         }
 
@@ -49,6 +47,23 @@ extension Configuration {
 
         // If nothing else, return self
         return self
+    }
+
+    private var rootDirectory: String? {
+        guard let rootPath = rootPath else {
+            return nil
+        }
+
+        var isDirectoryObjC: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: rootPath, isDirectory: &isDirectoryObjC) else {
+            return nil
+        }
+
+        if isDirectoryObjC.boolValue {
+            return rootPath
+        } else {
+            return rootPath.bridge().deletingLastPathComponent
+        }
     }
 
     private struct HashableRule: Hashable {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -208,7 +208,6 @@ extension ConfigurationTests {
         ("testLevel2", testLevel2),
         ("testLevel3", testLevel3),
         ("testNestedConfigurationWithCustomRootPath", testNestedConfigurationWithCustomRootPath),
-        ("testNestedConfigurationForOnePathPassedIn", testNestedConfigurationForOnePathPassedIn),
         ("testMergedWarningThreshold", testMergedWarningThreshold),
         ("testNestedWhitelistedRules", testNestedWhitelistedRules),
         ("testNestedConfigurationsWithCustomRulesMerge", testNestedConfigurationsWithCustomRulesMerge),

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -45,14 +45,6 @@ extension ConfigurationTests {
         XCTAssertEqual(projectMockConfig0.merge(with: projectMockConfig3).rootPath, projectMockConfig3.rootPath)
     }
 
-    func testNestedConfigurationForOnePathPassedIn() {
-        let config = Configuration(path: projectMockYAML0, rootPath: projectMockSwift3)
-        XCTAssertEqual(
-            config.configuration(for: SwiftLintFile(path: projectMockSwift3)!),
-            config.merge(with: projectMockConfig3)
-        )
-    }
-
     func testMergedWarningThreshold() {
         func configuration(forWarningThreshold warningThreshold: Int?) -> Configuration {
             return Configuration(warningThreshold: warningThreshold,


### PR DESCRIPTION
Reverts realm/SwiftLint#3342

This caused a regression in one of my projects. cc @sethfri 

It's a closed source project so it'll take some time for me to craft a repro case.