### PR TITLE
Fix issues with analyzer rules, Xcode 12 & SwiftUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
 
 * None.
 
+#### Bug Fixes
+
+* Fix parsing of Xcode 12 compiler logs for analyzer rules.  
+  [JP Simard](https://github.com/jpsim)
+  [#3365](https://github.com/realm/SwiftLint/issues/3365)
+
+* Fix some SwiftUI unused declaration rule false positives.  
+  [JP Simard](https://github.com/jpsim)
+  [#3365](https://github.com/realm/SwiftLint/issues/3365)
+
 ## 0.40.3: Greased Up Drum Bearings
 
 #### Breaking

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -35,6 +35,8 @@ struct CompilerArgumentsExtractor {
      */
     static func filterCompilerArguments(_ args: [String]) -> [String] {
         var args = args
+        // https://github.com/realm/SwiftLint/issues/3365
+        args = args.map { $0.replacingOccurrences(of: "\\=", with: "=") }
         args.append(contentsOf: ["-D", "DEBUG"])
         var shouldContinueToFilterArguments = true
         while shouldContinueToFilterArguments {


### PR DESCRIPTION
We weren't properly handling some new Xcode 12 compiler logs.

We also were marking declarations used by SwiftUI as unused (`@main` and preview providers).

Fixes https://github.com/realm/SwiftLint/issues/3365