### PR TITLE
Fix some false positives in rule `explicit_self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   [JP Simard](https://github.com/jpsim)
   [#3365](https://github.com/realm/SwiftLint/issues/3365)
 
+* Fix some false positives in rule `explicit_self`.  
+  [Sven Münnich](https://github.com/svenmuennich)
+
 ## 0.40.3: Greased Up Drum Bearings
 
 #### Breaking


### PR DESCRIPTION
Some accesses to instance properties attributed with a property wrapper resulted in false positives for rule `explicit_self`. This was caused by only checking the character directly preceding the member access to be a `.`. Hence accesses to a projected value of a wrapped property (e.g. `self.$foo`) or the property wrapper itself (e.g. `self._foo`) failed the test.