### PR TITLE
Add option warnings-as-errors to lint & analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* Add new option `warnings-as-errors` to lint & analyze.  
+  [Jeehut](https://github.com/Jeehut)
+  [#3312](https://github.com/realm/SwiftLint/issues/3312)
 
 #### Bug Fixes
 

--- a/Source/swiftlint/Commands/AnalyzeCommand.swift
+++ b/Source/swiftlint/Commands/AnalyzeCommand.swift
@@ -52,7 +52,7 @@ struct AnalyzeOptions: OptionsProtocol {
     let warningsAsErrors: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ paths: [String]) -> AnalyzeOptions {
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ warningsAsErrors: Bool) -> (_ paths: [String]) -> AnalyzeOptions {
         return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { warningsAsErrors in { paths in
             let allPaths: [String]
             if !path.isEmpty {

--- a/Source/swiftlint/Commands/AnalyzeCommand.swift
+++ b/Source/swiftlint/Commands/AnalyzeCommand.swift
@@ -49,19 +49,20 @@ struct AnalyzeOptions: OptionsProtocol {
     let autocorrect: Bool
     let compilerLogPath: String
     let compileCommands: String
+    let warningsAsErrors: Bool
 
     // swiftlint:disable line_length
     static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ paths: [String]) -> AnalyzeOptions {
-        return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { paths in
+        return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { warningsAsErrors in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
             } else {
                 allPaths = paths
             }
-            return self.init(paths: allPaths, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, enableAllRules: enableAllRules, autocorrect: autocorrect, compilerLogPath: compilerLogPath, compileCommands: compileCommands)
+            return self.init(paths: allPaths, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, enableAllRules: enableAllRules, autocorrect: autocorrect, compilerLogPath: compilerLogPath, compileCommands: compileCommands, warningsAsErrors: warningsAsErrors)
             // swiftlint:enable line_length
-            }}}}}}}}}}}}}
+            }}}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AnalyzeOptions, CommandantError<CommandantError<()>>> {
@@ -89,6 +90,8 @@ struct AnalyzeOptions: OptionsProtocol {
                                usage: "the path of the full xcodebuild log to use when linting AnalyzerRules")
             <*> mode <| Option(key: "compile-commands", defaultValue: "",
                                usage: "the path of a compilation database to use when linting AnalyzerRules")
+            <*> mode <| Option(key: "warnings-as-errors", defaultValue: false,
+                               usage: "upgrades warnings to serious violations (errors)")
             // This should go last to avoid eating other args
             <*> mode <| pathsArgument(action: "analyze")
     }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -23,19 +23,20 @@ struct LintOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let enableAllRules: Bool
+    let warningsAsErrors: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> (_ paths: [String]) -> LintOptions {
-        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in { paths in
+    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> (_ warningsAsErrors: Bool) -> (_ paths: [String]) -> LintOptions {
+        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in { warningsAsErrors in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
             } else {
                 allPaths = paths
             }
-            return self.init(paths: allPaths, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
+            return self.init(paths: allPaths, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules, warningsAsErrors: warningsAsErrors)
             // swiftlint:enable line_length
-        }}}}}}}}}}}}}
+        }}}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<LintOptions, CommandantError<CommandantError<()>>> {
@@ -63,6 +64,8 @@ struct LintOptions: OptionsProtocol {
                                usage: "ignore cache when linting")
             <*> mode <| Option(key: "enable-all-rules", defaultValue: false,
                                usage: "run all rules, even opt-in and disabled ones, ignoring `whitelist_rules`")
+            <*> mode <| Option(key: "warnings-as-errors", defaultValue: false,
+                               usage: "upgrades warnings to serious violations (errors)")
             // This should go last to avoid eating other args
             <*> mode <| pathsArgument(action: "lint")
     }


### PR DESCRIPTION
Implementes #3312.

I tested that this works manually by building via `swift build -c release` and running `.build/release/swiftlint --warnings-as-errors` and it worked just as expected. Without that option, I had 1 warning & 1 error reported, with that options 2 errors were reported, so I can confirm it works. But I did not add any unit tests because there seem to be no unit tests for the CLI product, other options like `--lenient` seem also not to be unit tested.

Note that I did not mess with any tresholds (like `lenient` does), I think we could think about those things after seeing how people are using this new option, so I'd rather keep this simple for now.