### PR TITLE
Adjust --strict to treat warnings as errors instead of only altering exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* Add new option `warnings-as-errors` to lint & analyze.  
+  [Jeehut](https://github.com/Jeehut)
+  [#3312](https://github.com/realm/SwiftLint/issues/3312)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 #### Breaking
 
-* None.
+* Changed behavior of `strict` option on `lint` and `analyze` to treat
+  all warnings as errors instead of only changing the exit code.  
+  [Jeehut](https://github.com/Jeehut)
+  [#3312](https://github.com/realm/SwiftLint/issues/3312)
 
 #### Experimental
 
@@ -10,9 +13,7 @@
 
 #### Enhancements
 
-* Add new option `warnings-as-errors` to lint & analyze.  
-  [Jeehut](https://github.com/Jeehut)
-  [#3312](https://github.com/realm/SwiftLint/issues/3312)
+* None.
 
 #### Bug Fixes
 
@@ -202,11 +203,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3225](https://github.com/realm/SwiftLint/issues/3225)
 
-* Fix some cases where the output would be incomplete when running 
+* Fix some cases where the output would be incomplete when running
   SwiftLint on Linux.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3214](https://github.com/realm/SwiftLint/issues/3214)
-  
+
 * `compiler_protocol_init` now triggers on `IndexSet(arrayLiteral:)`.  
   [Janak Shah](https://github.com/janakshah)
   [#3284](https://github.com/realm/SwiftLint/pull/3284)
@@ -246,7 +247,7 @@ This is the last release to support building with Swift 5.0.x.
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3149](https://github.com/realm/SwiftLint/issues/3149)
 
-* Fix false positives in `redundant_objc_attribute` rule in extensions when 
+* Fix false positives in `redundant_objc_attribute` rule in extensions when
   using Swift 5.2.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
@@ -373,7 +374,7 @@ This is the last release to support building with Swift 5.0.x.
 * Fix false positives when line ends with carriage return + line feed.  
   [John Mueller](https://github.com/john-mueller)
   [#3060](https://github.com/realm/SwiftLint/issues/3060)
-  
+
 * Implicit_return description now reports current config correctly.
   [John Buckley](https://github.com/nhojb)
 

--- a/Source/swiftlint/Commands/AnalyzeCommand.swift
+++ b/Source/swiftlint/Commands/AnalyzeCommand.swift
@@ -52,7 +52,7 @@ struct AnalyzeOptions: OptionsProtocol {
     let warningsAsErrors: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ paths: [String]) -> AnalyzeOptions {
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ warningsAsErrors: Bool) -> (_ paths: [String]) -> AnalyzeOptions {
         return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { warningsAsErrors in { paths in
             let allPaths: [String]
             if !path.isEmpty {

--- a/Source/swiftlint/Commands/AnalyzeCommand.swift
+++ b/Source/swiftlint/Commands/AnalyzeCommand.swift
@@ -49,20 +49,19 @@ struct AnalyzeOptions: OptionsProtocol {
     let autocorrect: Bool
     let compilerLogPath: String
     let compileCommands: String
-    let warningsAsErrors: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ warningsAsErrors: Bool) -> (_ paths: [String]) -> AnalyzeOptions {
-        return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { warningsAsErrors in { paths in
+    static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ paths: [String]) -> AnalyzeOptions {
+        return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
             } else {
                 allPaths = paths
             }
-            return self.init(paths: allPaths, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, enableAllRules: enableAllRules, autocorrect: autocorrect, compilerLogPath: compilerLogPath, compileCommands: compileCommands, warningsAsErrors: warningsAsErrors)
+            return self.init(paths: allPaths, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, enableAllRules: enableAllRules, autocorrect: autocorrect, compilerLogPath: compilerLogPath, compileCommands: compileCommands)
             // swiftlint:enable line_length
-            }}}}}}}}}}}}}}
+            }}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AnalyzeOptions, CommandantError<CommandantError<()>>> {
@@ -70,7 +69,7 @@ struct AnalyzeOptions: OptionsProtocol {
             <*> mode <| pathOption(action: "analyze")
             <*> mode <| configOption
             <*> mode <| Option(key: "strict", defaultValue: false,
-                               usage: "fail on warnings")
+                               usage: "upgrades warnings to serious violations (errors)")
             <*> mode <| Option(key: "lenient", defaultValue: false,
                                usage: "downgrades serious violations to warnings, warning threshold is disabled")
             <*> mode <| Option(key: "force-exclude", defaultValue: false,
@@ -90,8 +89,6 @@ struct AnalyzeOptions: OptionsProtocol {
                                usage: "the path of the full xcodebuild log to use when linting AnalyzerRules")
             <*> mode <| Option(key: "compile-commands", defaultValue: "",
                                usage: "the path of a compilation database to use when linting AnalyzerRules")
-            <*> mode <| Option(key: "warnings-as-errors", defaultValue: false,
-                               usage: "upgrades warnings to serious violations (errors)")
             // This should go last to avoid eating other args
             <*> mode <| pathsArgument(action: "analyze")
     }

--- a/Source/swiftlint/Commands/AnalyzeCommand.swift
+++ b/Source/swiftlint/Commands/AnalyzeCommand.swift
@@ -49,19 +49,20 @@ struct AnalyzeOptions: OptionsProtocol {
     let autocorrect: Bool
     let compilerLogPath: String
     let compileCommands: String
+    let warningsAsErrors: Bool
 
     // swiftlint:disable line_length
     static func create(_ path: String) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ enableAllRules: Bool) -> (_ autocorrect: Bool) -> (_ compilerLogPath: String) -> (_ compileCommands: String) -> (_ paths: [String]) -> AnalyzeOptions {
-        return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { paths in
+        return { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { enableAllRules in { autocorrect in { compilerLogPath in { compileCommands in { warningsAsErrors in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
             } else {
                 allPaths = paths
             }
-            return self.init(paths: allPaths, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, enableAllRules: enableAllRules, autocorrect: autocorrect, compilerLogPath: compilerLogPath, compileCommands: compileCommands)
+            return self.init(paths: allPaths, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, enableAllRules: enableAllRules, autocorrect: autocorrect, compilerLogPath: compilerLogPath, compileCommands: compileCommands, warningsAsErrors: warningsAsErrors)
             // swiftlint:enable line_length
-            }}}}}}}}}}}}}
+            }}}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<AnalyzeOptions, CommandantError<CommandantError<()>>> {
@@ -89,6 +90,8 @@ struct AnalyzeOptions: OptionsProtocol {
                                usage: "the path of the full xcodebuild log to use when linting AnalyzerRules")
             <*> mode <| Option(key: "compile-commands", defaultValue: "",
                                usage: "the path of a compilation database to use when linting AnalyzerRules")
+            <*> mode <| Option(key: "warnings-as-errors", defaultValue: false,
+                               usage: "upgrades warnings to serious violations (errors)")
             // This should go last to avoid eating other args
             <*> mode <| pathsArgument(action: "analyze")
     }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -23,20 +23,19 @@ struct LintOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let enableAllRules: Bool
-    let warningsAsErrors: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> (_ warningsAsErrors: Bool) -> (_ paths: [String]) -> LintOptions {
-        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in { warningsAsErrors in { paths in
+    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> (_ paths: [String]) -> LintOptions {
+        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
             } else {
                 allPaths = paths
             }
-            return self.init(paths: allPaths, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules, warningsAsErrors: warningsAsErrors)
+            return self.init(paths: allPaths, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
             // swiftlint:enable line_length
-        }}}}}}}}}}}}}}
+        }}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<LintOptions, CommandantError<CommandantError<()>>> {
@@ -46,7 +45,7 @@ struct LintOptions: OptionsProtocol {
                                usage: "lint standard input")
             <*> mode <| configOption
             <*> mode <| Option(key: "strict", defaultValue: false,
-                               usage: "fail on warnings")
+                               usage: "upgrades warnings to serious violations (errors)")
             <*> mode <| Option(key: "lenient", defaultValue: false,
                                usage: "downgrades serious violations to warnings, warning threshold is disabled")
             <*> mode <| Option(key: "force-exclude", defaultValue: false,
@@ -64,8 +63,6 @@ struct LintOptions: OptionsProtocol {
                                usage: "ignore cache when linting")
             <*> mode <| Option(key: "enable-all-rules", defaultValue: false,
                                usage: "run all rules, even opt-in and disabled ones, ignoring `whitelist_rules`")
-            <*> mode <| Option(key: "warnings-as-errors", defaultValue: false,
-                               usage: "upgrades warnings to serious violations (errors)")
             // This should go last to avoid eating other args
             <*> mode <| pathsArgument(action: "lint")
     }

--- a/Source/swiftlint/Commands/LintCommand.swift
+++ b/Source/swiftlint/Commands/LintCommand.swift
@@ -23,19 +23,20 @@ struct LintOptions: OptionsProtocol {
     let cachePath: String
     let ignoreCache: Bool
     let enableAllRules: Bool
+    let warningsAsErrors: Bool
 
     // swiftlint:disable line_length
-    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> (_ paths: [String]) -> LintOptions {
-        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in { paths in
+    static func create(_ path: String) -> (_ useSTDIN: Bool) -> (_ configurationFile: String) -> (_ strict: Bool) -> (_ lenient: Bool) -> (_ forceExclude: Bool) -> (_ useScriptInputFiles: Bool) -> (_ benchmark: Bool) -> (_ reporter: String) -> (_ quiet: Bool) -> (_ cachePath: String) -> (_ ignoreCache: Bool) -> (_ enableAllRules: Bool) -> (_ warningsAsErrors: Bool) -> (_ paths: [String]) -> LintOptions {
+        return { useSTDIN in { configurationFile in { strict in { lenient in { forceExclude in { useScriptInputFiles in { benchmark in { reporter in { quiet in { cachePath in { ignoreCache in { enableAllRules in { warningsAsErrors in { paths in
             let allPaths: [String]
             if !path.isEmpty {
                 allPaths = [path]
             } else {
                 allPaths = paths
             }
-            return self.init(paths: allPaths, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules)
+            return self.init(paths: allPaths, useSTDIN: useSTDIN, configurationFile: configurationFile, strict: strict, lenient: lenient, forceExclude: forceExclude, useScriptInputFiles: useScriptInputFiles, benchmark: benchmark, reporter: reporter, quiet: quiet, cachePath: cachePath, ignoreCache: ignoreCache, enableAllRules: enableAllRules, warningsAsErrors: warningsAsErrors)
             // swiftlint:enable line_length
-        }}}}}}}}}}}}}
+        }}}}}}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<LintOptions, CommandantError<CommandantError<()>>> {
@@ -63,6 +64,8 @@ struct LintOptions: OptionsProtocol {
                                usage: "ignore cache when linting")
             <*> mode <| Option(key: "enable-all-rules", defaultValue: false,
                                usage: "run all rules, even opt-in and disabled ones, ignoring `whitelist_rules`")
+            <*> mode <| Option(key: "warnings-as-errors", defaultValue: false,
+                               usage: "upgrades warnings to serious violations (errors)")
             // This should go last to avoid eating other args
             <*> mode <| pathsArgument(action: "lint")
     }

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -62,19 +62,9 @@ struct LintOrAnalyzeCommand {
                 ruleBenchmark.save()
             }
             try? cache?.save()
-            return successOrExit(numberOfSeriousViolations: numberOfSeriousViolations,
-                                 strictWithViolations: options.strict && !violations.isEmpty)
+            guard numberOfSeriousViolations == 0 else { exit(2) }
+            return .success(())
         }
-    }
-
-    private static func successOrExit(numberOfSeriousViolations: Int,
-                                      strictWithViolations: Bool) -> Result<(), CommandantError<()>> {
-        if numberOfSeriousViolations > 0 {
-            exit(2)
-        } else if strictWithViolations {
-            exit(3)
-        }
-        return .success(())
     }
 
     private static func printStatus(violations: [StyleViolation], files: [SwiftLintFile], serious: Int, verb: String) {
@@ -109,7 +99,7 @@ struct LintOrAnalyzeCommand {
     }
 
     private static func applyLeniency(options: LintOrAnalyzeOptions, violations: [StyleViolation]) -> [StyleViolation] {
-        switch (options.lenient, options.warningsAsErrors) {
+        switch (options.lenient, options.strict) {
         case (false, false):
             return violations
 
@@ -132,7 +122,7 @@ struct LintOrAnalyzeCommand {
             }
 
         case (true, true):
-            queuedFatalError("Invalid command line options: 'lenient' and 'warnings-as-errors' are mutually exclusive.")
+            queuedFatalError("Invalid command line options: 'lenient' and 'strict' are mutually exclusive.")
         }
     }
 }
@@ -155,7 +145,6 @@ struct LintOrAnalyzeOptions {
     let autocorrect: Bool
     let compilerLogPath: String
     let compileCommands: String
-    let warningsAsErrors: Bool
 
     init(_ options: LintOptions) {
         mode = .lint
@@ -175,7 +164,6 @@ struct LintOrAnalyzeOptions {
         autocorrect = false
         compilerLogPath = ""
         compileCommands = ""
-        warningsAsErrors = options.warningsAsErrors
     }
 
     init(_ options: AnalyzeOptions) {
@@ -196,7 +184,6 @@ struct LintOrAnalyzeOptions {
         autocorrect = options.autocorrect
         compilerLogPath = options.compilerLogPath
         compileCommands = options.compileCommands
-        warningsAsErrors = options.warningsAsErrors
     }
 
     var verb: String {


### PR DESCRIPTION
Implements #3312 with @jpsim's [suggested solution](https://github.com/realm/SwiftLint/issues/3312#issuecomment-702955921).

I tested that this works manually by building via `swift build -c release` and running `.build/release/swiftlint --strict` and it worked just as expected. Without that option, I had 1 warning & 1 error reported, with that options 2 errors were reported, so I can confirm it works. But I did not add any unit tests because there seem to be no unit tests for the CLI product, other options like `--lenient` seem also not to be unit tested.

Note that I did not mess with any tresholds (like `lenient` does), I think we could think about those things after seeing how people are using this new option, so I'd rather keep this simple for now.

Also note that I have decided to put the Changelog entry into the "Breaking Changes" section as some people might have been relying on the fact that using `--strict` was still making a distinction between warnings & errors when using the output of reporters directly. As this is changing this documented behavior, I feel like it would be wrong to place the change into the "Bug Fixes" section. But I can also move it there if needed, I do not have a strong opinion here.