### PR TITLE
Fix some missed cases in rule `unavailable_function`. (realm#3374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
   [JP Simard](https://github.com/jpsim)
   [#3316](https://github.com/realm/SwiftLint/issues/3316)
 
+* Fix some missed cases in rule `unavailable_function`.  
+  [Quinn Taylor](https://github.com/quinntaylor)
+  [#3374](https://github.com/realm/SwiftLint/issues/3374)
+
 ## 0.40.3: Greased Up Drum Bearings
 
 #### Breaking

--- a/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
+++ b/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
@@ -49,6 +49,7 @@ public func queuedPrintError(_ string: String) {
  the source path from the compiled binary.
  */
 public func queuedFatalError(_ string: String, file: StaticString = #file, line: UInt = #line) -> Never {
+    // swiftlint:disable:previous unavailable_function
     outputQueue.sync {
         fflush(stdout)
         let file = "\(file)".bridge().lastPathComponent


### PR DESCRIPTION
Enhanced to detect `abort()` and `preconditionFailure()` calls, in addition to `fatalError()`.