### PR TITLE
Fix finding the nested config when a single file path is passed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,9 @@
   [Jumhyn](https://github.com/jumhyn)
   [#3295](https://github.com/realm/SwiftLint/issues/3295)
 
+* Fix finding a nested config when a single file path is passed.  
+  [Seth Friedman](https://github.com/sethfri)
+
 ## 0.40.2: Demo Unit
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@
   [ZevEisenberg](https://github.com/ZevEisenberg)
   [#3033](https://github.com/realm/SwiftLint/issues/3033)
 
+* Fix finding a nested config when a single file path is passed.  
+  [Seth Friedman](https://github.com/sethfri)
+
 ## 0.40.3: Greased Up Drum Bearings
 
 #### Breaking
@@ -140,9 +143,6 @@
   5.3's 'multiple trailing closures' feature is used.
   [Jumhyn](https://github.com/jumhyn)
   [#3295](https://github.com/realm/SwiftLint/issues/3295)
-
-* Fix finding a nested config when a single file path is passed.  
-  [Seth Friedman](https://github.com/sethfri)
 
 ## 0.40.2: Demo Unit
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -16,7 +16,9 @@ extension Configuration {
     }
 
     private func configuration(forPath path: String) -> Configuration {
-        if path == rootDirectory {
+        let rootConfigurationDirectory = configurationPath?.bridge().deletingLastPathComponent
+        // We're linting a file in the same directory as the root configuration we've already loaded
+        if path == rootConfigurationDirectory {
             return self
         }
 
@@ -47,23 +49,6 @@ extension Configuration {
 
         // If nothing else, return self
         return self
-    }
-
-    private var rootDirectory: String? {
-        guard let rootPath = rootPath else {
-            return nil
-        }
-
-        var isDirectoryObjC: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: rootPath, isDirectory: &isDirectoryObjC) else {
-            return nil
-        }
-
-        if isDirectoryObjC.boolValue {
-            return rootPath
-        } else {
-            return rootPath.bridge().deletingLastPathComponent
-        }
     }
 
     private struct HashableRule: Hashable {

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -67,9 +67,11 @@ extension Configuration {
 
         var groupedFiles = [Configuration: [SwiftLintFile]]()
         for file in files {
-            // Files whose configuration specifies they should be excluded will be skipped
-            let fileConfiguration = configuration(for: file)
+            // If config was specified as a command line argument, always use it as an override. Otherwise, look for
+            // configs as normal, merging as necessary
+            let fileConfiguration = configurationSpecified() ? self : configuration(for: file)
             let fileConfigurationRootPath = (fileConfiguration.rootPath ?? "").bridge()
+            // Files whose configuration specifies they should be excluded will be skipped
             let shouldSkip = fileConfiguration.excluded.contains { excludedRelativePath in
                 let excludedPath = fileConfigurationRootPath.appendingPathComponent(excludedRelativePath)
                 let filePathComponents = file.path?.bridge().pathComponents ?? []
@@ -267,6 +269,10 @@ extension Configuration {
 
 private func isConfigOptional() -> Bool {
     return !CommandLine.arguments.contains("--config")
+}
+
+private func configurationSpecified() -> Bool {
+    return CommandLine.arguments.contains("--config")
 }
 
 private struct DuplicateCollector {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import SwiftLintFrameworkTests
@@ -214,6 +214,7 @@ extension ConfigurationTests {
         ("testLevel2", testLevel2),
         ("testLevel3", testLevel3),
         ("testNestedConfigurationWithCustomRootPath", testNestedConfigurationWithCustomRootPath),
+        ("testNestedConfigurationForOnePathPassedIn", testNestedConfigurationForOnePathPassedIn),
         ("testMergedWarningThreshold", testMergedWarningThreshold),
         ("testNestedOnlyRules", testNestedOnlyRules),
         ("testNestedConfigurationsWithCustomRulesMerge", testNestedConfigurationsWithCustomRulesMerge),

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Nested.swift
@@ -45,6 +45,14 @@ extension ConfigurationTests {
         XCTAssertEqual(projectMockConfig0.merge(with: projectMockConfig3).rootPath, projectMockConfig3.rootPath)
     }
 
+    func testNestedConfigurationForOnePathPassedIn() {
+        let config = Configuration(path: projectMockYAML0, rootPath: projectMockSwift3)
+        XCTAssertEqual(
+            config.configuration(for: SwiftLintFile(path: projectMockSwift3)!),
+            config.merge(with: projectMockConfig3)
+        )
+    }
+
     func testMergedWarningThreshold() {
         func configuration(forWarningThreshold warningThreshold: Int?) -> Configuration {
             return Configuration(warningThreshold: warningThreshold,


### PR DESCRIPTION
This was previously attempted in #3342, but produced a bug in the case where `--config` is used to specify a config from outside of the source tree. The `--config` argument wasn't always being used as an override, and was being merged with the config in the source tree. This has now been addressed and reverts the revert done in #3362. 

Fixes #3341