### PR TITLE
Use working directory as root path instead of trying to calculate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,11 @@
 * Fix finding a nested config when a single file path is passed.  
   [Seth Friedman](https://github.com/sethfri)
 
+* Fix incorrect calculation of the root path when a directory in the
+  tree is passed in as a path argument.  
+  [Seth Friedman](https://github.com/sethfri)
+  [#3383](https://github.com/realm/SwiftLint/issues/3383)
+
 ## 0.40.3: Greased Up Drum Bearings
 
 #### Breaking

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -227,16 +227,12 @@ extension Configuration {
         })
     }
 
-    private static func rootPath(from paths: [String]) -> String? {
-        // We don't know the root when more than one path is passed (i.e. not useful if the root of 2 paths is ~)
-        return paths.count == 1 ? paths.first?.absolutePathStandardized() : nil
-    }
-
     // MARK: LintOrAnalyze Command
 
     init(options: LintOrAnalyzeOptions) {
         let cachePath = options.cachePath.isEmpty ? nil : options.cachePath
-        self.init(path: options.configurationFile, rootPath: Self.rootPath(from: options.paths),
+        self.init(path: options.configurationFile,
+                  rootPath: FileManager.default.currentDirectoryPath.bridge().absolutePathStandardized(),
                   optional: isConfigOptional(), quiet: options.quiet, enableAllRules: options.enableAllRules,
                   cachePath: cachePath)
     }
@@ -256,7 +252,8 @@ extension Configuration {
 
     init(options: AutoCorrectOptions) {
         let cachePath = options.cachePath.isEmpty ? nil : options.cachePath
-        self.init(path: options.configurationFile, rootPath: Self.rootPath(from: options.paths),
+        self.init(path: options.configurationFile,
+                  rootPath: FileManager.default.currentDirectoryPath.bridge().absolutePathStandardized(),
                   optional: isConfigOptional(), quiet: options.quiet, cachePath: cachePath)
     }
 


### PR DESCRIPTION
We currently try to derive the root path by using the path passed in. However, this doesn't allow us to actually get the root, just the containing directory of the path passed in. We also don't currently have a heuristic to use for deriving the root path for multiple paths passed in.

The fix (which fixes #3383) is to remove our root path calculation and just use the current working directory as the root instead.