### PR TITLE
Add stale probot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had any
+  recent activity. Please comment to prevent this issue from being closed. Thank
+  you for your contributions!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
I think it would be a nice addition to SwiftLint to add Probot's [Stale app](https://probot.github.io/apps/stale/). SwiftLint currently has 398 issues and 72 pull requests, many of which date back to 2015 and 2016 respectively. Automatically closing stale issues and pull requests will make things less overwhelming for maintainers and prospective contributors. It will be especially helpful for guiding prospective contributors toward the most actionable issues where they can have immediate impact, and it will also help in searching for existing active issues before making your own.

**NOTE:** You will need to [install Probot's Stale app](https://github.com/apps/stale/installations/new) into the repo before merging, as I do not have permission to do this