### PR TITLE
Add `isNotEmpty` extension

### DIFF
--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -28,11 +28,11 @@ struct RuleDocumentation {
     var fileContents: String {
         let description = ruleType.description
         var content = [h1(description.name), description.description, detailsSummary(ruleType.init())]
-        if !description.nonTriggeringExamples.isEmpty {
+        if description.nonTriggeringExamples.isNotEmpty {
             content += [h2("Non Triggering Examples")]
             content += description.nonTriggeringExamples.map(formattedCode)
         }
-        if !description.triggeringExamples.isEmpty {
+        if description.triggeringExamples.isNotEmpty {
             content += [h2("Triggering Examples")]
             content += description.triggeringExamples.map(formattedCode)
         }

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -56,3 +56,9 @@ extension Array {
         }
     }
 }
+
+extension Collection {
+    var isNotEmpty: Bool {
+        return !isEmpty
+    }
+}

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -133,8 +133,8 @@ extension Configuration {
         let rulesMode: RulesMode
         if enableAllRules {
             rulesMode = .allEnabled
-        } else if !whitelistRules.isEmpty {
-            if !disabledRules.isEmpty || !optInRules.isEmpty {
+        } else if whitelistRules.isNotEmpty {
+            if disabledRules.isNotEmpty || optInRules.isNotEmpty {
                 queuedPrintError("'\(Key.disabledRules.rawValue)' or " +
                     "'\(Key.optInRules.rawValue)' cannot be used in combination " +
                     "with '\(Key.whitelistRules.rawValue)'")
@@ -200,7 +200,7 @@ extension Configuration {
     private static func warnAboutInvalidKeys(configurationDictionary dict: [String: Any], ruleList: RuleList) {
         // Log an error when supplying invalid keys in the configuration dictionary
         let invalidKeys = Set(dict.keys).subtracting(self.validKeys(ruleList: ruleList))
-        if !invalidKeys.isEmpty {
+        if invalidKeys.isNotEmpty {
             queuedPrintError("Configuration contains invalid keys:\n\(invalidKeys)")
         }
     }

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
@@ -306,7 +306,7 @@ extension SwiftLintFile {
             }.map { ($0.0, pattern, template) }
         }).sorted { $0.0.location > $1.0.location } // reversed
 
-        guard !matches.isEmpty else { return [] }
+        guard matches.isNotEmpty else { return [] }
 
         let description = type(of: legacyRule).description
         var corrections = [Correction]()

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -126,7 +126,7 @@ public struct Command: Equatable {
         }
         let ruleTexts = rawRuleTexts.components(separatedBy: .whitespacesAndNewlines).filter {
             let component = $0.trimmingCharacters(in: .whitespaces)
-            return !component.isEmpty && component != "*/"
+            return component.isNotEmpty && component != "*/"
         }
 
         ruleIdentifiers = Set(ruleTexts.map(RuleIdentifier.init(_:)))

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -243,7 +243,7 @@ public struct Configuration: Hashable {
 private func validateRuleIdentifiers(ruleIdentifiers: [String], validRuleIdentifiers: [String]) -> [String] {
     // Validate that all rule identifiers map to a defined rule
     let invalidRuleIdentifiers = ruleIdentifiers.filter { !validRuleIdentifiers.contains($0) }
-    if !invalidRuleIdentifiers.isEmpty {
+    if invalidRuleIdentifiers.isNotEmpty {
         for invalidRuleIdentifier in invalidRuleIdentifiers {
             queuedPrintError("configuration error: '\(invalidRuleIdentifier)' is not a valid rule identifier")
         }

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -11,7 +11,7 @@ private extension Rule {
     static func superfluousDisableCommandViolations(regions: [Region],
                                                     superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
                                                     allViolations: [StyleViolation]) -> [StyleViolation] {
-        guard !regions.isEmpty, let superfluousDisableCommandRule = superfluousDisableCommandRule else {
+        guard regions.isNotEmpty, let superfluousDisableCommandRule = superfluousDisableCommandRule else {
             return []
         }
 
@@ -279,7 +279,7 @@ public struct CollectedLinter {
         for rule in rules.compactMap({ $0 as? CorrectableRule }) {
             let newCorrections = rule.correct(file: file, using: storage, compilerArguments: compilerArguments)
             corrections += newCorrections
-            if !newCorrections.isEmpty {
+            if newCorrections.isNotEmpty {
                 file.invalidateCache()
             }
         }
@@ -303,7 +303,7 @@ public struct CollectedLinter {
                                                        configuration: Configuration,
                                                        superfluousDisableCommandRule: SuperfluousDisableCommandRule?
         ) -> [StyleViolation] {
-        guard !regions.isEmpty, let superfluousDisableCommandRule = superfluousDisableCommandRule else {
+        guard regions.isNotEmpty, let superfluousDisableCommandRule = superfluousDisableCommandRule else {
             return []
         }
         let allCustomIdentifiers = configuration.customRuleIdentifiers.map { RuleIdentifier($0) }

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -96,7 +96,7 @@ public final class LinterCache {
         defer {
             writeCacheLock.unlock()
         }
-        guard !writeCache.isEmpty else {
+        guard writeCache.isNotEmpty else {
             return
         }
 
@@ -105,7 +105,7 @@ public final class LinterCache {
         readCacheLock.unlock()
 
         let encoder = Encoder()
-        for (description, writeFileCache) in writeCache where !writeFileCache.entries.isEmpty {
+        for (description, writeFileCache) in writeCache where writeFileCache.entries.isNotEmpty {
             let fileCacheEntries = readCache[description]?.entries.merging(writeFileCache.entries) { _, write in write }
             let fileCache = fileCacheEntries.map(FileCache.init) ?? writeFileCache
             let data = try encoder.encode(fileCache)

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -162,7 +162,7 @@ public protocol SubstitutionCorrectableRule: CorrectableRule {
 public extension SubstitutionCorrectableRule {
     func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
-        guard !violatingRanges.isEmpty else { return [] }
+        guard violatingRanges.isNotEmpty else { return [] }
 
         let description = Self.description
         var corrections = [Correction]()

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -62,7 +62,7 @@ public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule
         guard let offset = dictionary.offset,
             [.class, .struct].contains(kind),
             dictionary.inheritedTypes.isEmpty,
-            !dictionary.substructure.isEmpty else {
+            dictionary.substructure.isNotEmpty else {
                 return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -128,7 +128,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTe
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let implicitAndExplicitInternalElements = internalTypeElements(in: file.structureDictionary)
 
-        guard !implicitAndExplicitInternalElements.isEmpty else {
+        guard implicitAndExplicitInternalElements.isNotEmpty else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -51,7 +51,7 @@ public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, Aut
             return nil
         }
 
-        guard !internalTypesOffsets.isEmpty else {
+        guard internalTypesOffsets.isNotEmpty else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -62,7 +62,7 @@ public struct FileNameRule: ConfigurationProviderRule, OptInRule {
             $0.replacingOccurrences(of: ".", with: configuration.nestedTypeSeparator)
         }
 
-        guard !allDeclaredTypeNames.isEmpty, !allDeclaredTypeNames.contains(typeInFileName) else {
+        guard allDeclaredTypeNames.isNotEmpty, !allDeclaredTypeNames.contains(typeInFileName) else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -154,12 +154,12 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
                 return false
             }
 
-            let containsKeyword = !file.match(pattern: "\\blet|var|case\\b", with: [.keyword], range: range).isEmpty
+            let containsKeyword = file.match(pattern: "\\blet|var|case\\b", with: [.keyword], range: range).isNotEmpty
             if containsKeyword {
                 return true
             }
 
-            return !file.match(pattern: "\\|\\||&&", with: [], range: range).isEmpty
+            return file.match(pattern: "\\|\\||&&", with: [], range: range).isNotEmpty
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -64,13 +64,13 @@ public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderR
                 return paramOffset < bodyOffset
             }
 
-        guard !params.isEmpty else {
+        guard params.isNotEmpty else {
             return []
         }
 
         let containsDefaultValue = { self.isDefaultParameter(file: file, dictionary: $0) }
         let defaultParams = params.filter(containsDefaultValue)
-        guard !defaultParams.isEmpty else {
+        guard defaultParams.isNotEmpty else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -139,8 +139,8 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
 
     public func correct(file: SwiftLintFile) -> [Correction] {
         let matches = violationMatchesRanges(in: file)
-            .filter { !file.ruleEnabled(violatingRanges: [$0], for: self).isEmpty }
-        guard !matches.isEmpty else { return [] }
+            .filter { file.ruleEnabled(violatingRanges: [$0], for: self).isNotEmpty }
+        guard matches.isNotEmpty else { return [] }
 
         let description = Self.description
         var corrections: [Correction] = []
@@ -186,7 +186,7 @@ private extension String {
 
         for case let (pattern, operatorString?) in [toPattern, toNotPattern] {
             let expression = regex(pattern)
-            guard !expression.matches(in: self, options: [], range: range).isEmpty else {
+            guard expression.matches(in: self, options: [], range: range).isNotEmpty else {
                 continue
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -56,6 +56,6 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, Aut
             return false
         }
 
-        return !file.match(pattern: "\\bwhere\\b", with: [.keyword], range: range).isEmpty
+        return file.match(pattern: "\\bwhere\\b", with: [.keyword], range: range).isNotEmpty
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -52,7 +52,7 @@ public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, O
             let letMatches = file.match(pattern: "\\blet\\b", with: [.keyword], range: caseRange)
             let varMatches = file.match(pattern: "\\bvar\\b", with: [.keyword], range: caseRange)
 
-            if !letMatches.isEmpty && !varMatches.isEmpty {
+            if letMatches.isNotEmpty && varMatches.isNotEmpty {
                 return []
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -162,7 +162,7 @@ extension SourceKittenDictionary {
         guard let byteRange = byteRange,
             case let contents = file.stringView,
             let range = contents.byteRangeToNSRange(byteRange),
-            !file.match(pattern: "\\Avar\\b", with: [.keyword], range: range).isEmpty else {
+            file.match(pattern: "\\Avar\\b", with: [.keyword], range: range).isNotEmpty else {
                 return false
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -108,7 +108,7 @@ public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, 
 
     private func enumElementsCount(dictionary: SourceKittenDictionary) -> Int {
         return children(of: dictionary, matching: .enumelement).filter({ element in
-            return !filterEnumInits(dictionary: element).isEmpty
+            return filterEnumInits(dictionary: element).isNotEmpty
         }).count
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -48,7 +48,7 @@ public struct ToggleBoolRule: SubstitutionCorrectableRule, ConfigurationProvider
 
     public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         let violationString = file.stringView.substring(with: violationRange)
-        let identifier = violationString.components(separatedBy: .whitespaces).first { !$0.isEmpty }
+        let identifier = violationString.components(separatedBy: .whitespaces).first { $0.isNotEmpty }
         return (violationRange, identifier! + ".toggle()")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -152,7 +152,7 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
                 .trimmingCharacters(in: CharacterSet(charactersIn: "{}"))
                 .trimmingCharacters(in: .whitespacesAndNewlines)
 
-            if !processedSubstring.isEmpty {
+            if processedSubstring.isNotEmpty {
                 stop.pointee = true
                 containsContent = true
             }

--- a/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -80,7 +80,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule, Aut
     }
 
     private func isClassProtocol(file: SwiftLintFile, range: NSRange) -> Bool {
-        return !file.match(pattern: "\\bclass\\b", with: [.keyword], range: range).isEmpty
+        return file.match(pattern: "\\bclass\\b", with: [.keyword], range: range).isNotEmpty
     }
 
     private func isDelegateProtocol(_ name: String) -> Bool {

--- a/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
@@ -77,7 +77,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule {
         let attributes = dictionary.swiftAttributes.filter {
             $0.attribute.flatMap(SwiftDeclarationAttributeKind.init) == .available
         }
-        guard !attributes.isEmpty else {
+        guard attributes.isNotEmpty else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -193,7 +193,7 @@ private extension StringView {
                                    _ endToken: SwiftLintSyntaxToken) -> Bool {
         guard let betweenTokens = subStringBetweenTokens(startToken, endToken) else { return false }
         let range = betweenTokens.fullNSRange
-        return !regex(#"^[\s\(,]*$"#).matches(in: betweenTokens, options: [], range: range).isEmpty
+        return regex(#"^[\s\(,]*$"#).matches(in: betweenTokens, options: [], range: range).isNotEmpty
     }
 
     func isRegexBetweenTokens(_ startToken: SwiftLintSyntaxToken, _ regexString: String,
@@ -201,6 +201,6 @@ private extension StringView {
         guard let betweenTokens = subStringBetweenTokens(startToken, endToken) else { return false }
 
         let range = betweenTokens.fullNSRange
-        return !regex("^\\s*\(regexString)\\s*$").matches(in: betweenTokens, options: [], range: range).isEmpty
+        return regex("^\\s*\(regexString)\\s*$").matches(in: betweenTokens, options: [], range: range).isNotEmpty
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
@@ -187,7 +187,7 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
             guard let syntaxKind = syntaxTokens.first?.kind else {
                 return false
             }
-            return !syntaxTokens.isEmpty && SyntaxKind.commentKinds.contains(syntaxKind)
+            return syntaxTokens.isNotEmpty && SyntaxKind.commentKinds.contains(syntaxKind)
         }.compactMap { range, syntaxTokens in
             let byteRange = ByteRange(location: syntaxTokens[0].offset, length: 0)
             let identifierRange = file.stringView.byteRangeToNSRange(byteRange)

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -4,7 +4,7 @@ private extension SwiftLintFile {
     func missingDocOffsets(in dictionary: SourceKittenDictionary,
                            acls: [AccessControlLevel]) -> [(ByteCount, AccessControlLevel)] {
         if dictionary.enclosedSwiftAttributes.contains(.override) ||
-            !dictionary.inheritedTypes.isEmpty {
+            dictionary.inheritedTypes.isNotEmpty {
             return []
         }
         let substructureOffsets = dictionary.substructure.flatMap {

--- a/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
@@ -70,7 +70,7 @@ public struct OrphanedDocCommentRule: ConfigurationProviderRule {
                         return false
                 }
 
-                return !contents.trimmingCharacters(in: Self.characterSet).isEmpty
+                return contents.trimmingCharacters(in: Self.characterSet).isNotEmpty
             }.map { token in
                 return StyleViolation(ruleDescription: Self.description,
                                       severity: configuration.severity,

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
@@ -152,7 +152,7 @@ public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDesc
             return false
         }
         let range = superclass.fullNSRange
-        return !regex.matches(in: superclass, options: [], range: range).isEmpty
+        return regex.matches(in: superclass, options: [], range: range).isNotEmpty
     }
 
     private func validateFunction(file: SwiftLintFile,

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
@@ -79,7 +79,7 @@ public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule
             kind == .functionMethodInstance,
             configuration.resolvedMethodNames.contains(name),
             dictionary.enclosedSwiftAttributes.contains(.override),
-            !dictionary.extractCallsToSuper(methodName: name).isEmpty
+            dictionary.extractCallsToSuper(methodName: name).isNotEmpty
             else { return [] }
 
         return [StyleViolation(ruleDescription: Self.description,

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -31,7 +31,7 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
     )
 
     public func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> UnusedDeclarationRule.FileUSRs {
-        guard !compilerArguments.isEmpty else {
+        guard compilerArguments.isNotEmpty else {
             queuedPrintError("""
                 Attempted to lint file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule without any compiler arguments.
@@ -39,7 +39,7 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
             return .empty
         }
 
-        guard let index = file.index(compilerArguments: compilerArguments), !index.value.isEmpty else {
+        guard let index = file.index(compilerArguments: compilerArguments), index.value.isNotEmpty else {
             queuedPrintError("""
                 Could not index file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule.

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -40,7 +40,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
             corrections.append(Correction(ruleDescription: description, location: location))
         }
 
-        if !corrections.isEmpty {
+        if corrections.isNotEmpty {
             file.write(contents.bridge())
         }
 
@@ -57,7 +57,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
             }
         }
 
-        guard !missingImports.isEmpty else {
+        guard missingImports.isNotEmpty else {
             return corrections
         }
 
@@ -84,7 +84,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
     }
 
     private func importUsage(in file: SwiftLintFile, compilerArguments: [String]) -> [ImportUsage] {
-        guard !compilerArguments.isEmpty else {
+        guard compilerArguments.isNotEmpty else {
             queuedPrintError("""
                 Attempted to lint file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule without any compiler arguments.
@@ -108,7 +108,7 @@ private extension SwiftLintFile {
             unusedImports.remove("Foundation")
         }
 
-        if !unusedImports.isEmpty {
+        if unusedImports.isNotEmpty {
             unusedImports.subtract(
                 operatorImports(
                     arguments: compilerArguments,

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -66,7 +66,7 @@ public struct WeakDelegateRule: ASTRule, SubstitutionCorrectableASTRule, Configu
 
         // if the declaration is inside a protocol
         if let offset = dictionary.offset,
-            !protocolDeclarations(forByteOffset: offset, structureDictionary: file.structureDictionary).isEmpty {
+            protocolDeclarations(forByteOffset: offset, structureDictionary: file.structureDictionary).isNotEmpty {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -39,7 +39,7 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
             severity: configuration.severity
         ) { dictionary in
             if
-                !dictionary.substructure.isEmpty &&
+                dictionary.substructure.isNotEmpty &&
                 dictionary.substructure.last?.expressionKind != .argument &&
                 dictionary.substructure.last?.name != "NSPredicate"
             {

--- a/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
@@ -35,7 +35,7 @@ public struct LastWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule,
                         patternSyntaxKinds: [.identifier],
                         callNameSuffix: ".filter",
                         severity: configuration.severity) { dictionary in
-            if !dictionary.substructure.isEmpty {
+            if dictionary.substructure.isNotEmpty {
                 return true // has a substructure, like a closure
             }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -48,11 +48,11 @@ public struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
 
     public mutating func apply(configuration: Any) throws {
         if let configurationArray = [Int].array(of: configuration),
-            !configurationArray.isEmpty {
+            configurationArray.isNotEmpty {
             let warning = configurationArray[0]
             let error = (configurationArray.count > 1) ? configurationArray[1] : nil
             length = SeverityLevelsConfiguration(warning: warning, error: error)
-        } else if let configDict = configuration as? [String: Any], !configDict.isEmpty {
+        } else if let configDict = configuration as? [String: Any], configDict.isNotEmpty {
             for (string, value) in configDict {
                 guard let key = ConfigurationKey(rawValue: string) else {
                     throw ConfigurationError.unknownConfiguration

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
@@ -20,11 +20,11 @@ public struct FileLengthRuleConfiguration: RuleConfiguration, Equatable {
 
     public mutating func apply(configuration: Any) throws {
         if let configurationArray = [Int].array(of: configuration),
-            !configurationArray.isEmpty {
+            configurationArray.isNotEmpty {
             let warning = configurationArray[0]
             let error = (configurationArray.count > 1) ? configurationArray[1] : nil
             severityConfiguration = SeverityLevelsConfiguration(warning: warning, error: error)
-        } else if let configDict = configuration as? [String: Any], !configDict.isEmpty {
+        } else if let configDict = configuration as? [String: Any], configDict.isNotEmpty {
             for (string, value) in configDict {
                 guard let key = ConfigurationKey(rawValue: string) else {
                     throw ConfigurationError.unknownConfiguration

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -38,7 +38,7 @@ public struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
             }
         }
 
-        if !customOrder.isEmpty {
+        if customOrder.isNotEmpty {
             self.order = customOrder
         }
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -20,11 +20,11 @@ public struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable 
 
     public mutating func apply(configuration: Any) throws {
         if let configurationArray = [Int].array(of: configuration),
-            !configurationArray.isEmpty {
+            configurationArray.isNotEmpty {
             let warning = configurationArray[0]
             let error = (configurationArray.count > 1) ? configurationArray[1] : nil
             severityConfiguration = SeverityLevelsConfiguration(warning: warning, error: error)
-        } else if let configDict = configuration as? [String: Any], !configDict.isEmpty {
+        } else if let configDict = configuration as? [String: Any], configDict.isNotEmpty {
             for (string, value) in configDict {
                 guard let key = ConfigurationKey(rawValue: string) else {
                     throw ConfigurationError.unknownConfiguration

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -66,7 +66,7 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
     /// - returns: True if the configuration was successfuly applied.
     private mutating func applyArray(configuration: Any) -> Bool {
         guard let configurationArray = [Int].array(of: configuration),
-            !configurationArray.isEmpty else {
+            configurationArray.isNotEmpty else {
             return false
         }
 
@@ -84,7 +84,7 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
     private mutating func applyDictionary(configuration: Any) throws {
         let error = ConfigurationError.unknownConfiguration
         guard let configDict = configuration as? [String: Any],
-            !configDict.isEmpty else {
+            configDict.isNotEmpty else {
             throw error
         }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -28,11 +28,11 @@ public struct SeverityLevelsConfiguration: RuleConfiguration, Equatable {
     }
 
     public mutating func apply(configuration: Any) throws {
-        if let configurationArray = [Int].array(of: configuration), !configurationArray.isEmpty {
+        if let configurationArray = [Int].array(of: configuration), configurationArray.isNotEmpty {
             warning = configurationArray[0]
             error = (configurationArray.count > 1) ? configurationArray[1] : nil
         } else if let configDict = configuration as? [String: Int?],
-            !configDict.isEmpty, Set(configDict.keys).isSubset(of: ["warning", "error"]) {
+            configDict.isNotEmpty, Set(configDict.keys).isSubset(of: ["warning", "error"]) {
             warning = (configDict["warning"] as? Int) ?? warning
             error = configDict["error"] as? Int
         } else {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -59,7 +59,7 @@ public struct TypeContentsOrderConfiguration: RuleConfiguration, Equatable {
             }
         }
 
-        if !customOrder.isEmpty {
+        if customOrder.isNotEmpty {
             self.order = customOrder
         }
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -18,7 +18,7 @@ public struct UnusedDeclarationConfiguration: RuleConfiguration, Equatable {
     }
 
     public mutating func apply(configuration: Any) throws {
-        guard let configDict = configuration as? [String: Any], !configDict.isEmpty else {
+        guard let configDict = configuration as? [String: Any], configDict.isNotEmpty else {
             throw ConfigurationError.unknownConfiguration
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -74,7 +74,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
                               dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let attributes = parseAttributes(dictionary: dictionary)
 
-        guard !attributes.isEmpty,
+        guard attributes.isNotEmpty,
             let offset = dictionary.offset,
             let (line, _) = file.stringView.lineAndCharacter(forByteOffset: offset) else {
             return []

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -43,10 +43,10 @@ extension ClosureEndIndentationRule: CorrectableRule {
                 return false
             }
 
-            return !file.ruleEnabled(violatingRanges: [nsRange], for: self).isEmpty
+            return file.ruleEnabled(violatingRanges: [nsRange], for: self).isNotEmpty
         }
 
-        guard !allViolations.isEmpty else {
+        guard allViolations.isNotEmpty else {
             return []
         }
 
@@ -201,7 +201,7 @@ extension ClosureEndIndentationRule {
 
         var closureArguments = filterClosureArguments(dictionary.enclosedArguments, file: file)
 
-        if hasTrailingClosure(in: file, dictionary: dictionary), !closureArguments.isEmpty {
+        if hasTrailingClosure(in: file, dictionary: dictionary), closureArguments.isNotEmpty {
             closureArguments.removeLast()
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -153,9 +153,9 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
 
     public func correct(file: SwiftLintFile) -> [Correction] {
         var matches = removeNested(findViolations(file: file)).filter {
-            !file.ruleEnabled(violatingRanges: [$0], for: self).isEmpty
+            file.ruleEnabled(violatingRanges: [$0], for: self).isNotEmpty
         }
-        guard !matches.isEmpty else { return [] }
+        guard matches.isNotEmpty else { return [] }
 
         // `matches` should be sorted by location from `findViolations`.
         let start = NSRange(location: 0, length: 0)
@@ -174,7 +174,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
             let next = nextMatch.location
             let length = next - current
             let nonViolationContent = file.contents.substring(from: current, length: length)
-            if !nonViolationContent.isEmpty {
+            if nonViolationContent.isNotEmpty {
                 fixedSections.append(nonViolationContent)
             }
             // selects violation ranges and fixes them before adding back in

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -43,10 +43,10 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
     public func correct(file: SwiftLintFile) -> [Correction] {
         let violations = correctionRanges(in: file)
         let matches = violations.filter {
-            !file.ruleEnabled(violatingRanges: [$0.range], for: self).isEmpty
+            file.ruleEnabled(violatingRanges: [$0.range], for: self).isNotEmpty
         }
 
-        guard !matches.isEmpty else { return [] }
+        guard matches.isNotEmpty else { return [] }
         let regularExpression = regex(pattern)
         let description = Self.description
         var corrections = [Correction]()

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -62,7 +62,7 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         var configurations = configuration.customRuleConfigurations
 
-        guard !configurations.isEmpty else {
+        guard configurations.isNotEmpty else {
             return []
         }
 
@@ -71,7 +71,7 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
             configurations = configurations.filter { config in
                 let included: Bool
                 if let includedRegex = config.included {
-                    included = !includedRegex.matches(in: path, options: [], range: pathRange).isEmpty
+                    included = includedRegex.matches(in: path, options: [], range: pathRange).isNotEmpty
                 } else {
                     included = true
                 }

--- a/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
@@ -185,7 +185,7 @@ public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, Anal
     }
 
     private func violationRanges(in file: SwiftLintFile, compilerArguments: [String]) -> [NSRange] {
-        guard !compilerArguments.isEmpty else {
+        guard compilerArguments.isNotEmpty else {
             queuedPrintError("""
                 Attempted to lint file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule without any compiler arguments.
@@ -208,7 +208,7 @@ public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, Anal
             return kindsToFind.contains(kindString)
         }
 
-        guard !cursorsMissingExplicitSelf.isEmpty else {
+        guard cursorsMissingExplicitSelf.isNotEmpty else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
@@ -95,7 +95,7 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
             return false
         }
 
-        return !file.commands(in: range).isEmpty
+        return file.commands(in: range).isNotEmpty
     }
 
     private func makeViolation(at location: Location) -> StyleViolation {

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -58,7 +58,8 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
             if !configuration.includeComments {
                 // Skip line if it's part of a comment
                 let syntaxKindsInLine = Set(file.syntaxMap.tokens(inByteRange: line.byteRange).kinds)
-                if !syntaxKindsInLine.isEmpty && SyntaxKind.commentKinds.isSuperset(of: syntaxKindsInLine) { continue }
+                if syntaxKindsInLine.isNotEmpty &&
+                    SyntaxKind.commentKinds.isSuperset(of: syntaxKindsInLine) { continue }
             }
 
             // Get space and tab count in prefix
@@ -89,7 +90,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
             }
 
             // Catch indented first line
-            guard !previousLineIndentations.isEmpty else {
+            guard previousLineIndentations.isNotEmpty else {
                 previousLineIndentations = [indentation]
 
                 if indentation != .spaces(0) {

--- a/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
@@ -36,7 +36,7 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
         let spaceCount = file.contents.countOfLeadingCharacters(in: whitespaceAndNewline)
         guard spaceCount > 0,
             let firstLineRange = file.lines.first?.range,
-            !file.ruleEnabled(violatingRanges: [firstLineRange], for: self).isEmpty else {
+            file.ruleEnabled(violatingRanges: [firstLineRange], for: self).isNotEmpty else {
                 return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -63,7 +63,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
             }
 
             let trimmed = line.content.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.isEmpty else {
+            guard trimmed.isNotEmpty else {
                 continue
             }
 
@@ -178,7 +178,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
 
             let substructure = statement.substructure
 
-            if !substructure.isEmpty {
+            if substructure.isNotEmpty {
                 varLetLineNumbers(file: file,
                                   structure: substructure,
                                   attributeLines: &attributeLines,

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -150,10 +150,10 @@ extension LiteralExpressionEndIdentationRule: CorrectableRule {
                 return false
             }
 
-            return !file.ruleEnabled(violatingRanges: [nsRange], for: self).isEmpty
+            return file.ruleEnabled(violatingRanges: [nsRange], for: self).isNotEmpty
         }
 
-        guard !allViolations.isEmpty else {
+        guard allViolations.isNotEmpty else {
             return []
         }
 
@@ -232,7 +232,7 @@ extension LiteralExpressionEndIdentationRule {
         let elements = dictionary.elements.filter { $0.kind == "source.lang.swift.structure.elem.expr" }
 
         let contents = file.stringView
-        guard !elements.isEmpty,
+        guard elements.isNotEmpty,
             let offset = dictionary.offset,
             let length = dictionary.length,
             let (startLine, _) = contents.lineAndCharacter(forByteOffset: offset),

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -119,7 +119,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
             let declarationNewlineCount = functionName.countOccurrences(of: "\n")
             let isMultiline = declarationNewlineCount > parametersNewlineCount
 
-            if isMultiline && !parameters.isEmpty {
+            if isMultiline && parameters.isNotEmpty {
                 if let openingBracketViolation = openingBracketViolation(parameters: parameters, file: file) {
                     violations.append(openingBracketViolation)
                 }

--- a/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -44,7 +44,7 @@ public struct MultipleClosuresWithTrailingClosureRule: ASTRule, ConfigurationPro
             case let arguments = dictionary.enclosedArguments,
             case let closureArguments = arguments.filterClosures(file: file),
             // Any violations must have at least one closure argument.
-            closureArguments.isEmpty == false,
+            closureArguments.isNotEmpty,
             // If there is no closing paren (e.g. `foo { ... }`), there is no violation.
             let closingParenOffset = dictionary.closingParenLocation(file: file),
             // Find all trailing closures.
@@ -52,7 +52,7 @@ public struct MultipleClosuresWithTrailingClosureRule: ASTRule, ConfigurationPro
                 isTrailingClosure(argument: $0, closingParenOffset: closingParenOffset)
             }),
             // If there are no trailing closures, there is no violation.
-            trailingClosureArguments.isEmpty == false,
+            trailingClosureArguments.isNotEmpty,
             // If all closure arguments are trailing closures, there is no violation
             trailingClosureArguments.count != closureArguments.count,
             let firstTrailingClosureOffset = trailingClosureArguments.first?.offset else {
@@ -81,7 +81,7 @@ private extension SourceKittenDictionary {
     func closingParenLocation(file: SwiftLintFile) -> ByteCount? {
         guard self.expressionKind == .call,
               case let arguments = self.enclosedArguments,
-              arguments.isEmpty == false else {
+              arguments.isNotEmpty else {
             return nil
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -173,7 +173,7 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
     public func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.violatingOpeningBraceRanges(allowMultilineFunc: configuration.allowMultilineFunc)
             .filter {
-                !file.ruleEnabled(violatingRanges: [$0.range], for: self).isEmpty
+                file.ruleEnabled(violatingRanges: [$0.range], for: self).isNotEmpty
             }
         var correctedContents = file.contents
         var adjustedLocations = [Location]()

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -153,7 +153,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
 
     public func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = violationRanges(file: file).filter { range, _ in
-            return !file.ruleEnabled(violatingRanges: [range], for: self).isEmpty
+            return file.ruleEnabled(violatingRanges: [range], for: self).isNotEmpty
         }
 
         var correctedContents = file.contents

--- a/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
@@ -183,7 +183,7 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
             return Correction(ruleDescription: Self.description, location: location)
         }
 
-        guard !corrections.isEmpty else {
+        guard corrections.isNotEmpty else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -193,7 +193,7 @@ private extension StatementPositionRule {
         let filterRanges = Self.uncuddledMatchFilter(contents: file.stringView, syntaxMap: syntaxMap)
 
         let validMatches = matches.compactMap(validator).filter(filterRanges)
-                  .filter { !file.ruleEnabled(violatingRanges: [$0.range], for: self).isEmpty }
+                  .filter { file.ruleEnabled(violatingRanges: [$0.range], for: self).isNotEmpty }
         if validMatches.isEmpty { return [] }
         let description = Self.uncuddledDescription
         var corrections = [Correction]()

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -75,7 +75,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
         let arguments = dictionary.enclosedArguments
 
         // check if last parameter should be trailing closure
-        if !configuration.onlySingleMutedParameter, !arguments.isEmpty,
+        if !configuration.onlySingleMutedParameter, arguments.isNotEmpty,
             case let closureArguments = filterClosureArguments(arguments, file: file),
             closureArguments.count == 1,
             closureArguments.last?.offset == arguments.last?.offset {

--- a/Source/SwiftLintFramework/Rules/Style/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingWhitespaceRule.swift
@@ -38,7 +38,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
 
             return !configuration.ignoresEmptyLines ||
                     // If configured, ignore lines that contain nothing but whitespace (empty lines)
-                    !$0.content.trimmingCharacters(in: .whitespaces).isEmpty
+                    $0.content.trimmingCharacters(in: .whitespaces).isNotEmpty
         }
 
         return filteredLines.map {
@@ -86,7 +86,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
             }
             correctedLines.append(correctedLine)
         }
-        if !corrections.isEmpty {
+        if corrections.isNotEmpty {
             // join and re-add trailing newline
             file.write(correctedLines.joined(separator: "\n") + "\n")
             return corrections

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -88,6 +88,6 @@ public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
         }
 
         let matches = file.match(pattern: "try?", with: [.keyword], range: range)
-        return !matches.isEmpty
+        return matches.isNotEmpty
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -172,7 +172,7 @@ extension VerticalWhitespaceBetweenCasesRule: OptInRule, AutomaticTestableRule {
 extension VerticalWhitespaceBetweenCasesRule: CorrectableRule {
     public func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
-        guard !violatingRanges.isEmpty else { return [] }
+        guard violatingRanges.isNotEmpty else { return [] }
 
         let patternRegex = regex(pattern)
         let replacementTemplate = "$1\n$2"

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -143,7 +143,7 @@ extension VerticalWhitespaceClosingBracesRule: OptInRule, AutomaticTestableRule 
 extension VerticalWhitespaceClosingBracesRule: CorrectableRule {
     public func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.ruleEnabled(violatingRanges: file.violatingRanges(for: pattern), for: self)
-        guard !violatingRanges.isEmpty else { return [] }
+        guard violatingRanges.isNotEmpty else { return [] }
 
         let patternRegex: NSRegularExpression = regex(pattern)
         let replacementTemplate = "$2"

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -179,7 +179,7 @@ extension VerticalWhitespaceOpeningBracesRule: OptInRule, AutomaticTestableRule 
 extension VerticalWhitespaceOpeningBracesRule: CorrectableRule {
     public func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.ruleEnabled(violatingRanges: file.violatingRanges(for: pattern), for: self)
-        guard !violatingRanges.isEmpty else { return [] }
+        guard violatingRanges.isNotEmpty else { return [] }
 
         let patternRegex: NSRegularExpression = regex(pattern)
         let replacementTemplate = "$1$3"

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
@@ -40,7 +40,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let linesSections = violatingLineSections(in: file)
-        guard !linesSections.isEmpty else {
+        guard linesSections.isNotEmpty else {
             return []
         }
 
@@ -62,7 +62,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
             nonSpaceRegex.firstMatch(in: file.contents, options: [], range: $0.range) == nil
         }
 
-        guard !filteredLines.isEmpty else {
+        guard filteredLines.isNotEmpty else {
             return []
         }
 
@@ -95,13 +95,13 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
             let previousLine: Line = lines[previousIndex]
             if previousLine.index + 1 == line.index {
                 lineSection.append(line)
-            } else if !lineSection.isEmpty {
+            } else if lineSection.isNotEmpty {
                 blankLinesSections.append(lineSection)
                 lineSection.removeAll()
             }
             previousIndex = index
         }
-        if !lineSection.isEmpty {
+        if lineSection.isNotEmpty {
             blankLinesSections.append(lineSection)
         }
 
@@ -143,7 +143,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
             correctedLines.append(currentLine.content)
         }
         // converts lines back to file and adds trailing line
-        if !corrections.isEmpty {
+        if corrections.isNotEmpty {
             file.write(correctedLines.joined(separator: "\n") + "\n")
             return corrections
         }


### PR DESCRIPTION
From one point of view, this is a simple sugar-like extension.

**Pros**:
 - Some expressions that are using `isEmpty` calls will look like a natural language
 - No going back and forth when parsing some complex conditional expressions

**Cons**:
  - Some linting rules for the framework itself can break
  - There's no lining rule that will force this usage later.
