### PR TITLE
Fix inconsistency in `operator_usage_whitespace` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@
   [JP Simard](https://github.com/jpsim)
   [#3333](https://github.com/realm/SwiftLint/issues/3333)
 
+* Fix inconsistency in `operator_usage_whitespace` rule.  
+  [Paul Taykalo](https://github.com/PaulTaykalo)
+  [#3321](https://github.com/realm/SwiftLint/issues/3321)
+
 * Fix false positives in `convenience_type` rule for types that cannot
   be converted to enums.  
   [ZevEisenberg](https://github.com/ZevEisenberg)

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -16,7 +16,7 @@ extension Configuration {
         case whitelistRules = "whitelist_rules" // deprecated in favor of onlyRules
         case indentation = "indentation"
         case analyzerRules = "analyzer_rules"
-        case allowZeroLintableFiles  = "allow_zero_lintable_files"
+        case allowZeroLintableFiles = "allow_zero_lintable_files"
     }
 
     private static let validGlobalKeys: Set<String> = {

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
@@ -144,7 +144,7 @@ internal struct QuickDiscouragedCallRuleExamples {
         """)
     ]
 
-    static let triggeringExamples: [Example]  = [
+    static let triggeringExamples: [Example] = [
         Example("""
         class TotoTests {
            override func spec() {

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -53,7 +53,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
         let allOffsets = mainTypeOffset + extensionOffsets + supportingTypeOffsets + previewProviderOffsets
         let orderedFileTypeOffsets = allOffsets.sorted { lhs, rhs in lhs.offset < rhs.offset }
 
-        var violations =  [StyleViolation]()
+        var violations = [StyleViolation]()
 
         var lastMatchingIndex = -1
         for expectedTypes in configuration.order {

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -32,7 +32,8 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             Example("let doubleValue = -9e-11\n"),
             Example("let foo = GenericType<(UIViewController) -> Void>()\n"),
             Example("let foo = Foo<Bar<T>, Baz>()\n"),
-            Example("let foo = SignalProducer<Signal<Value, Error>, Error>([ self.signal, next ]).flatten(.concat)\n")
+            Example("let foo = SignalProducer<Signal<Value, Error>, Error>([ self.signal, next ]).flatten(.concat)\n"),
+            Example("\"let foo =  1\"")
         ],
         triggeringExamples: [
             Example("let foo = 1↓+2\n"),
@@ -50,7 +51,9 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             Example("let v8 = Int8(1)↓  << 6\n"),
             Example("let v8 = 1↓ <<  (6)\n"),
             Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"),
-            Example("let foo↓  = [1]\n")
+            Example("let foo↓  = [1]\n"),
+            Example("let foo↓  = \"1\"\n"),
+            Example("let foo↓ =  \"1\"\n")
         ],
         corrections: [
             Example("let foo = 1↓+2\n"): Example("let foo = 1 + 2\n"),
@@ -67,7 +70,9 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             Example("let foo = bar↓ !==  bar2\n"): Example("let foo = bar !== bar2\n"),
             Example("let v8 = Int8(1)↓  << 6\n"): Example("let v8 = Int8(1) << 6\n"),
             Example("let v8 = 1↓ <<  (6)\n"): Example("let v8 = 1 << (6)\n"),
-            Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"): Example("let v8 = 1 << (6)\n let foo = 1 > 2\n")
+            Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"): Example("let v8 = 1 << (6)\n let foo = 1 > 2\n"),
+            Example("let foo↓  = \"1\"\n"): Example("let foo = \"1\"\n"),
+            Example("let foo↓ =  \"1\"\n"): Example("let foo = \"1\"\n")
         ]
     )
 
@@ -84,14 +89,13 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         let notEqualsPattern = "\\!\\=\\=?" // != or !==
         let coalescingPattern = "\\?{2}"
 
-        let operators = "(?:[%<>&=*+|^/~-]+|\(rangePattern)|\(coalescingPattern)|" +
-            "\(notEqualsPattern))"
+        let operators = "(?:[%<>&=*+|^/~-]+|\(rangePattern)|\(coalescingPattern)|" + "\(notEqualsPattern))"
 
         let oneSpace = "[^\\S\\r\\n]" // to allow lines ending with operators to be valid
         let zeroSpaces = oneSpace + "{0}"
         let manySpaces = oneSpace + "{2,}"
-        let leadingVariableOrNumber = "(?:\\b|\\)|\\])"
-        let trailingVariableOrNumber = "(?:\\b|\\(|\\[)"
+        let leadingVariableOrNumber = "(?:\\b|\\)|\\]|\")"
+        let trailingVariableOrNumber = "(?:\\b|\\(|\\[|\")"
 
         let spaces = [(zeroSpaces, zeroSpaces), (oneSpace, manySpaces),
                       (manySpaces, oneSpace), (manySpaces, manySpaces)]
@@ -105,7 +109,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             zeroSpaces + trailingVariableOrNumber
         let excludingPattern = "(?:\(genericPattern)|\(validRangePattern))"
 
-        let excludingKinds = SyntaxKind.commentAndStringKinds.union([.objectLiteral])
+        let excludingKinds = SyntaxKind.commentKinds.union([.objectLiteral])
 
         return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds,
                           excludingPattern: excludingPattern).compactMap { range in
@@ -120,6 +124,10 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             // if it's a range operator, the correction shouldn't have spaces
             if let matchRange = rangeRegex.firstMatch(in: file.contents, options: [], range: range)?.range {
                 let correction = operatorInRange(file: file, range: matchRange)
+                // Make sure that the match is not within the string i.e `let a = "12...123"`
+                guard kinds(in: matchRange, file: file) != [.string] else {
+                    return nil
+                }
                 return (matchRange, correction)
             }
 
@@ -128,6 +136,11 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
 
             guard let matchRange = operatorsRegex.firstMatch(in: file.contents,
                                                              options: [], range: range)?.range else {
+                return nil
+            }
+
+            // Make sure that the match is not within the string i.e `let a = "12 == 123"`
+            guard kinds(in: matchRange, file: file) != [.string] else {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -49,7 +49,8 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             Example("let foo = bar↓ !==  bar2\n"),
             Example("let v8 = Int8(1)↓  << 6\n"),
             Example("let v8 = 1↓ <<  (6)\n"),
-            Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n")
+            Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"),
+            Example("let foo↓  = [1]\n")
         ],
         corrections: [
             Example("let foo = 1↓+2\n"): Example("let foo = 1 + 2\n"),
@@ -79,19 +80,18 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
     }
 
     private func violationRanges(file: SwiftLintFile) -> [(NSRange, String)] {
-        let escapedOperators = ["/", "=", "-", "+", "*", "|", "^", "~"].map({ "\\\($0)" }).joined()
         let rangePattern = "\\.\\.(?:\\.|<)" // ... or ..<
         let notEqualsPattern = "\\!\\=\\=?" // != or !==
         let coalescingPattern = "\\?{2}"
 
-        let operators = "(?:[\(escapedOperators)%<>&]+|\(rangePattern)|\(coalescingPattern)|" +
+        let operators = "(?:[%<>&=*+|^/~-]+|\(rangePattern)|\(coalescingPattern)|" +
             "\(notEqualsPattern))"
 
         let oneSpace = "[^\\S\\r\\n]" // to allow lines ending with operators to be valid
         let zeroSpaces = oneSpace + "{0}"
         let manySpaces = oneSpace + "{2,}"
-        let leadingVariableOrNumber = "(?:\\b|\\))"
-        let trailingVariableOrNumber = "(?:\\b|\\()"
+        let leadingVariableOrNumber = "(?:\\b|\\)|\\])"
+        let trailingVariableOrNumber = "(?:\\b|\\(|\\[)"
 
         let spaces = [(zeroSpaces, zeroSpaces), (oneSpace, manySpaces),
                       (manySpaces, oneSpace), (manySpaces, manySpaces)]

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -13,7 +13,7 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
 
     public init() {}
 
-    private static let triggeringExamples: [Example] =  [
+    private static let triggeringExamples: [Example] = [
         Example("let foo = [1, 2, 3↓,]\n"),
         Example("let foo = [1, 2, 3↓, ]\n"),
         Example("let foo = [1, 2, 3   ↓,]\n"),


### PR DESCRIPTION
This Fixes case when the right part of the expression is an array or a string
Previously, strings and comments tokens were ignored.
In the current implementation, matching done first and then those are filtered if the operator is within the string token