### PR TITLE
[Fix] `UnusedCaptureListRule`: unowned self in @escaping closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 * Fix incorrect autocorrection in `prefer_zero_over_explicit_init` rule.  
   [Paul Taykalo](https://github.com/PaulTaykalo)
 
+* Rule `unused_capture_list` should not be triggered by unowned self keyword.  
+  [hank121314](https://github.com/hank121314)
+  [#3389](https://github.com/realm/SwiftLint/issues/3389)
+
 ## 0.40.3: Greased Up Drum Bearings
 
 #### Breaking


### PR DESCRIPTION
## Summary

This pr fixes: #3389  .

It seems that we also need to prevent [unowned self] from triggering this rule.

## Test Plan

I have already add some test in example.

Thanks you so much for your code review! 😄 