### PR TITLE
Use indentation_width severity configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 * Rule `unused_capture_list` should not be triggered by unowned self keyword.  
   [hank121314](https://github.com/hank121314)
   [#3389](https://github.com/realm/SwiftLint/issues/3389)
+  
+* Fix severity configuration for `indentation_width`.
+  [Samasaur1](https://github.com/Samasaur1)
+  [#3346](https://github.com/realm/SwiftLint/issues/3389)
 
 ## 0.40.3: Greased Up Drum Bearings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@
   [hank121314](https://github.com/hank121314)
   [#3389](https://github.com/realm/SwiftLint/issues/3389)
   
-* Fix severity configuration for `indentation_width`.
-  [Samasaur1](https://github.com/Samasaur1)
+* Fix severity configuration for `indentation_width`.  
+  [Samasaur1](https://github.com/Samasaur1), issue 
   [#3346](https://github.com/realm/SwiftLint/issues/3389)
 
 ## 0.40.3: Greased Up Drum Bearings

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -73,7 +73,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
                 violations.append(
                     StyleViolation(
                         ruleDescription: IndentationWidthRule.description,
-                        severity: .warning,
+                        severity: configuration.severityConfiguration.severity,
                         location: Location(file: file, characterOffset: line.range.location),
                         reason: "Code should be indented with tabs or " +
                         "\(configuration.indentationWidth) spaces, but not both in the same line."
@@ -97,7 +97,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
                     violations.append(
                         StyleViolation(
                             ruleDescription: IndentationWidthRule.description,
-                            severity: .warning,
+                            severity: configuration.severityConfiguration.severity,
                             location: Location(file: file, characterOffset: line.range.location),
                             reason: "The first line shall not be indented."
                         )
@@ -122,7 +122,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
                 violations.append(
                     StyleViolation(
                         ruleDescription: IndentationWidthRule.description,
-                        severity: .warning,
+                        severity: configuration.severityConfiguration.severity,
                         location: Location(file: file, characterOffset: line.range.location),
                         reason: isIndentation ?
                             "Code should be indented using one tab or \(indentWidth) spaces." :


### PR DESCRIPTION
Fixes #3346 
It was previously using a hardcoded value for the severity when reporting violations.