### PR TITLE
[IdentifierNameRule] Allow "allowed symbols" as first character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
   [Keith Smiley](https://github.com/keith)
   [#3402](https://github.com/realm/SwiftLint/issues/3402)
 
+* Allow "allowed symbols" as first character in `identifier_name`.  
+  [JP Simard](https://github.com/jpsim)
+  [#3306](https://github.com/realm/SwiftLint/issues/3306)
+
 ## 0.40.3: Greased Up Drum Bearings
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -64,7 +64,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             }
 
             let firstCharacterIsAllowed = configuration.allowedSymbols
-                .isSuperset(of: CharacterSet(firstCharacter.unicodeScalars))
+                .isSuperset(of: CharacterSet(charactersIn: String(firstCharacter)))
             guard !firstCharacterIsAllowed else {
                 return []
             }

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -30,7 +30,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         return validateName(dictionary: dictionary, kind: kind).map { name, offset in
-            guard !configuration.excluded.contains(name) else {
+            guard !configuration.excluded.contains(name), let firstCharacter = name.first else {
                 return []
             }
 
@@ -63,6 +63,11 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
                 }
             }
 
+            let firstCharacterIsAllowed = configuration.allowedSymbols
+                .isSuperset(of: CharacterSet(firstCharacter.unicodeScalars))
+            guard !firstCharacterIsAllowed else {
+                return []
+            }
             let requiresCaseCheck = configuration.validatesStartWithLowercase || isFunction
             if requiresCaseCheck &&
                 kind != .varStatic && name.isViolatingCase && !name.isOperator {

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -11,11 +11,13 @@ class IdentifierNameRuleTests: XCTestCase {
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
             Example("let myLet$ = 0"),
             Example("let myLet% = 0"),
-            Example("let myLet$% = 0")
+            Example("let myLet$% = 0"),
+            Example("let _myLet = 0"),
         ]
-
-        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
-        verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%"]])
+        let triggeringExamples = baseDescription.triggeringExamples.filter { !$0.code.contains("_") }
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples,
+                                               triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%", "_"]])
     }
 
     func testIdentifierNameWithAllowedSymbolsAndViolation() {

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -12,7 +12,7 @@ class IdentifierNameRuleTests: XCTestCase {
             Example("let myLet$ = 0"),
             Example("let myLet% = 0"),
             Example("let myLet$% = 0"),
-            Example("let _myLet = 0"),
+            Example("let _myLet = 0")
         ]
         let triggeringExamples = baseDescription.triggeringExamples.filter { !$0.code.contains("_") }
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples,


### PR DESCRIPTION
This means that if `allowed_symbols` contains `_`, you can now write identifiers like `let _myLet`.

Fixes https://github.com/realm/SwiftLint/issues/3306