### PR TITLE
Improve compilation times

### DIFF
--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
@@ -14,6 +14,37 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
 
     public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        guard let input = RuleInput(file: file, kind: kind, dictionary: dictionary) else {
+            return []
+        }
+
+        for parameter in configuration.params {
+            let (exceeds, lineCount) = file.exceedsLineCountExcludingCommentsAndWhitespace(
+                input.startLine, input.endLine, parameter.value
+            )
+            guard exceeds else { continue }
+            return [
+                StyleViolation(
+                    ruleDescription: Self.description, severity: parameter.severity,
+                    location: Location(file: file, byteOffset: input.offset),
+                    reason: """
+                        Function body should span \(configuration.warning) lines or less excluding comments and \
+                        whitespace: currently spans \(lineCount) lines
+                        """
+                )
+            ]
+        }
+
+        return []
+    }
+}
+
+private struct RuleInput {
+    let offset: ByteCount
+    let startLine: Int
+    let endLine: Int
+
+    init?(file: SwiftLintFile, kind: SwiftDeclarationKind, dictionary: SourceKittenDictionary) {
         guard SwiftDeclarationKind.functionKinds.contains(kind),
             let offset = dictionary.offset,
             let bodyOffset = dictionary.bodyOffset,
@@ -22,20 +53,11 @@ public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
             let startLine = contentsNSString.lineAndCharacter(forByteOffset: bodyOffset)?.line,
             let endLine = contentsNSString.lineAndCharacter(forByteOffset: bodyOffset + bodyLength)?.line
         else {
-            return []
+            return nil
         }
-        for parameter in configuration.params {
-            let (exceeds, lineCount) = file.exceedsLineCountExcludingCommentsAndWhitespace(
-                startLine, endLine, parameter.value
-            )
-            guard exceeds else { continue }
-            return [StyleViolation(ruleDescription: Self.description,
-                                   severity: parameter.severity,
-                                   location: Location(file: file, byteOffset: offset),
-                                   reason: "Function body should span \(configuration.warning) lines or less " +
-                                           "excluding comments and whitespace: currently spans \(lineCount) " +
-                                           "lines")]
-        }
-        return []
+
+        self.offset = offset
+        self.startLine = startLine
+        self.endLine = endLine
     }
 }

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -29,9 +29,9 @@ enum LintOrAnalyzeModeWithCompilerArguments {
 }
 
 private func resolveParamsFiles(args: [String]) -> [String] {
-    return args.reduce(into: []) { allArgs, arg in
+    return args.reduce(into: []) { (allArgs: inout [String], arg: String) -> Void in
         if arg.hasPrefix("@"), let contents = try? String(contentsOfFile: String(arg.dropFirst())) {
-            allArgs += resolveParamsFiles(args: contents.split(separator: "\n").map(String.init))
+            allArgs.append(contentsOf: resolveParamsFiles(args: contents.split(separator: "\n").map(String.init)))
         } else {
             allArgs.append(arg)
         }

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -147,7 +147,11 @@ private func render(violations: [StyleViolation], in contents: String) -> String
             contents.insert(message, at: line)
         }
     }
-    return (["```"] + contents + ["```"]).joined(separator: "\n")
+    return """
+        ```
+        \(contents)
+        ```
+        """
 }
 
 private func render(locations: [Location], in contents: String) -> String {
@@ -158,7 +162,11 @@ private func render(locations: [Location], in contents: String) -> String {
         content.insert("↓", at: character - 1)
         contents[line - 1] = content.bridge()
     }
-    return (["```"] + contents + ["```"]).joined(separator: "\n")
+    return """
+        ```
+        \(contents)
+        ```
+        """
 }
 
 private extension Configuration {


### PR DESCRIPTION
By speeding up a handful of the longest expressions to compile.

Here are some quick unscientific measurements reported by `make display_compilation_time`:

| Declaration                                                    | Before   | After    | Speedup |
| -------------------------------------------------------------- | -------- | -------- | ------- |
| `NimbleOperatorRule.swift/violationMatchesRanges(in:)`         | 244.53ms | 5.08ms   | 48x     |
| `LintableFilesVisitor.swift/resolveParamsFiles(args:)`         | 251.44ms | 106.95ms | 2.4x    |
| `TestHelpers.swift/render(violations:in:)`                     | 295.11ms | 125.02ms | 2.4x    |
| `FunctionBodyLengthRule.swift/validate(file:kind:dictionary:)` | 312.87ms | 186.87ms | 1.7x    |
| `InertDeferRule.swift/validate(file:)`                         | 315.05ms | 198.54ms | 1.6x    |