### PR TITLE
[AttributesRule] Fix parameterized attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@
   [JP Simard](https://github.com/jpsim)
   [#3306](https://github.com/realm/SwiftLint/issues/3306)
 
+* Fix false positives with parameterized attributes in `attributes`.  
+  [JP Simard](https://github.com/jpsim)
+  [#3316](https://github.com/realm/SwiftLint/issues/3316)
+
 ## 0.40.3: Greased Up Drum Bearings
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -96,7 +96,13 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         let tokens = file.syntaxMap.tokens(inByteRange: line.byteRange)
         let attributesTokensWithRanges = tokens.compactMap { attributeName(token: $0, file: file) }
 
-        let attributesTokens = Set(attributesTokensWithRanges.map { $0.0 })
+        let attributesTokens = Set(
+            attributesTokensWithRanges.map { tokenString, _ in
+                // Some attributes are parameterized, such as `@objc(name)`, so discard anything from an opening
+                // parenthesis onward.
+                String(tokenString.prefix(while: { $0 != "(" }))
+            }
+        )
 
         do {
             let previousAttributesWithParameters = try attributesFromPreviousLines(lineNumber: lineNumber - 1,

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRuleExamples.swift
@@ -85,7 +85,6 @@ internal struct AttributesRuleExamples {
         Example("@IBDesignable ↓class MyCustomView: UIView {}"),
         Example("@testable\n↓import SourceKittenFramework"),
         Example("@testable\n\n\n↓import SourceKittenFramework"),
-        Example("@objc(foo_x) ↓var x: String"),
         Example("@available(iOS 9.0, *) @objc(abc_stackView)\n ↓let stackView: UIStackView"),
         Example("@objc(abc_addSomeObject:) @NSManaged\n ↓func addSomeObject(book: SomeObject)"),
         Example("@objc(abc_addSomeObject:)\n @NSManaged\n ↓func addSomeObject(book: SomeObject)"),

--- a/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
@@ -18,6 +18,9 @@ class AttributesRuleTests: XCTestCase {
                 @objc private var object: RLMWeakObjectHandle?
                 @objc private var property: RLMProperty?
             }
+            """),
+            Example("""
+            @objc(XYZFoo) class Foo: NSObject {}
             """)
         ]
         let triggeringExamples = [


### PR DESCRIPTION
Some attributes are parameterized, such as `@objc(name)`. Previously these reported `attributes` violations because their contents weren't included in the configuration, which would just have `@objc`.

Fixes #3316