### PR TITLE
Add `key_path_expression_as_function` opt-in rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -33,6 +33,7 @@ opt_in_rules:
   - flatmap_over_map_reduce
   - identical_operands
   - joined_default_parameter
+  - key_path_expression_as_function
   - legacy_random
   - let_var_whitespace
   - last_where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * Add `comment_spacing` rule.  
   [Noah Gilmore](https://github.com/noahsark769)
   [#3233](https://github.com/realm/SwiftLint/issues/3233)
+
 * Add `key_path_expression_as_function` opt-in rule to validate that key paths
   are used instead of closures in function calls whenever possible when using
   Swift 5.2+. Take a look at [SE-0249](https://git.io/JkfBZ) for more details.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@
 * Add `comment_spacing` rule.  
   [Noah Gilmore](https://github.com/noahsark769)
   [#3233](https://github.com/realm/SwiftLint/issues/3233)
+* Add `key_path_expression_as_function` opt-in rule to validate that key paths
+  are used instead of closures in function calls whenever possible when using
+  Swift 5.2+. Take a look at [SE-0249](https://git.io/JkfBZ) for more details.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3082](https://github.com/realm/SwiftLint/issues/3082)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension Array where Element: NSTextCheckingResult {
     func ranges() -> [NSRange] {
-        return map { $0.range }
+        return map(\.range)
     }
 }
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -30,7 +30,7 @@ extension Configuration {
             FileManager.default.fileExists(atPath: configurationSearchPath) {
             let fullPath = pathNSString.absolutePathRepresentation()
             let customRuleIdentifiers = (rules.first(where: { $0 is CustomRules }) as? CustomRules)?
-                .configuration.customRuleConfigurations.map { $0.identifier }
+                .configuration.customRuleConfigurations.map(\.identifier)
             let config = Configuration.getCached(atPath: fullPath) ??
                 Configuration(
                     path: configurationSearchPath,
@@ -103,7 +103,7 @@ extension Configuration {
             // (always use the nested rule first if it exists)
             regularMergedRules = Set(configuration.rules.map(HashableRule.init))
                 .union(rules.map(HashableRule.init))
-                .map { $0.rule }
+                .map(\.rule)
                 .filter { rule in
                     return onlyRules.contains(type(of: rule).description.identifier)
                 }
@@ -123,7 +123,7 @@ extension Configuration {
                         return !disabled.contains(type(of: rule).description.identifier)
                     }.map(HashableRule.init)
                 )
-                .map { $0.rule }
+                .map(\.rule)
         }
         return mergeCustomRules(mergedRules: regularMergedRules, configuration: configuration)
     }

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -36,7 +36,7 @@ extension Configuration {
             .indentation,
             .analyzerRules,
             .allowZeroLintableFiles
-        ].map({ $0.rawValue }))
+        ].map(\.rawValue))
     }()
 
     private static func validKeys(ruleList: RuleList) -> Set<String> {

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -135,7 +135,7 @@ public struct SourceKittenDictionary {
 
     /// The `SwiftDeclarationAttributeKind` values associated with this dictionary.
     var enclosedSwiftAttributes: [SwiftDeclarationAttributeKind] {
-        return swiftAttributes.compactMap { $0.attribute }
+        return swiftAttributes.compactMap(\.attribute)
             .compactMap(SwiftDeclarationAttributeKind.init(rawValue:))
     }
 

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
@@ -188,7 +188,7 @@ extension SwiftLintFile {
             return nil
         }
 
-        return tokens.map { $0.kinds }
+        return tokens.map(\.kinds)
     }
 
     /**

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -58,7 +58,7 @@ public struct Configuration: Hashable {
 
     internal var customRuleIdentifiers: [String] {
         let customRule = rules.first(where: { $0 is CustomRules }) as? CustomRules
-        return customRule?.configuration.customRuleConfigurations.map { $0.identifier } ?? []
+        return customRule?.configuration.customRuleConfigurations.map(\.identifier) ?? []
     }
 
     // MARK: Rules Properties
@@ -275,7 +275,7 @@ private func enabledRules(from configuredRules: [Rule],
                           customRulesIdentifiers: [String]) -> [Rule]? {
     let regularRuleIdentifiers = configuredRules.map { type(of: $0).description.identifier }
     let configurationCustomRulesIdentifiers = (configuredRules.first(where: { $0 is CustomRules }) as? CustomRules)?
-        .configuration.customRuleConfigurations.map { $0.identifier } ?? []
+        .configuration.customRuleConfigurations.map(\.identifier) ?? []
     let validRuleIdentifiers = regularRuleIdentifiers + configurationCustomRulesIdentifiers + customRulesIdentifiers
 
     switch mode {

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -217,10 +217,10 @@ public struct CollectedLinter {
             regions: regions, configuration: configuration,
             superfluousDisableCommandRule: superfluousDisableCommandRule)
 
-        let violations = validationResults.flatMap { $0.violations } + undefinedSuperfluousCommandViolations
-        let ruleTimes = validationResults.compactMap { $0.ruleTime }
+        let violations = validationResults.flatMap(\.violations) + undefinedSuperfluousCommandViolations
+        let ruleTimes = validationResults.compactMap(\.ruleTime)
         var deprecatedToValidIdentifier = [String: String]()
-        for (key, value) in validationResults.flatMap({ $0.deprecatedToValidIDPairs }) {
+        for (key, value) in validationResults.flatMap(\.deprecatedToValidIDPairs) {
             deprecatedToValidIdentifier[key] = value
         }
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -81,6 +81,7 @@ public let primaryRuleList = RuleList(rules: [
     InertDeferRule.self,
     IsDisjointRule.self,
     JoinedDefaultParameterRule.self,
+    KeyPathExpressionAsFunctionRule.self,
     LargeTupleRule.self,
     LastWhereRule.self,
     LeadingWhitespaceRule.self,

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -49,7 +49,7 @@ public struct Region: Equatable {
         }
 
         let identifiersToCheck = type(of: rule).description.allIdentifiers
-        let regionIdentifiers = Set(disabledRuleIdentifiers.map { $0.stringRepresentation })
+        let regionIdentifiers = Set(disabledRuleIdentifiers.map(\.stringRepresentation))
         return !regionIdentifiers.isDisjoint(with: identifiersToCheck)
     }
 
@@ -61,6 +61,6 @@ public struct Region: Equatable {
     /// - returns: Deprecated rule aliases.
     public func deprecatedAliasesDisabling(rule: Rule) -> Set<String> {
         let identifiers = type(of: rule).description.deprecatedAliases
-        return Set(disabledRuleIdentifiers.map { $0.stringRepresentation }).intersection(identifiers)
+        return Set(disabledRuleIdentifiers.map(\.stringRepresentation)).intersection(identifiers)
     }
 }

--- a/Source/SwiftLintFramework/Models/SwiftLintSyntaxMap.swift
+++ b/Source/SwiftLintFramework/Models/SwiftLintSyntaxMap.swift
@@ -49,6 +49,6 @@ public struct SwiftLintSyntaxMap {
     ///
     /// - returns: The syntax kinds in the specified byte range.
     internal func kinds(inByteRange byteRange: ByteRange) -> [SyntaxKind] {
-        return tokens(inByteRange: byteRange).compactMap { $0.kind }
+        return tokens(inByteRange: byteRange).compactMap(\.kind)
     }
 }

--- a/Source/SwiftLintFramework/Models/SwiftLintSyntaxToken.swift
+++ b/Source/SwiftLintFramework/Models/SwiftLintSyntaxToken.swift
@@ -34,6 +34,6 @@ public struct SwiftLintSyntaxToken {
 
 extension Array where Element == SwiftLintSyntaxToken {
     var kinds: [SyntaxKind] {
-        return compactMap { $0.kind }
+        return compactMap(\.kind)
     }
 }

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -61,7 +61,7 @@ public extension SwiftVersion {
 
         if !Request.disableSourceKit,
             case let dynamicCallableFile = SwiftLintFile(contents: "@dynamicCallable"),
-            dynamicCallableFile.syntaxMap.tokens.compactMap({ $0.kind }) == [.attributeID] {
+            dynamicCallableFile.syntaxMap.tokens.compactMap(\.kind) == [.attributeID] {
             return .five
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -27,7 +27,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
 
         let ranges = file.syntaxMap.tokens
             .filter { $0.kind == .buildconfigKeyword }
-            .map { $0.range }
+            .map(\.range)
             .filter { range in
                 return ["#if", "#endif"].contains(contents.substringWithByteRange(range))
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -104,7 +104,7 @@ public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProvide
         let locs = substructureElements(of: dictionary, matching: .enumcase)
             .compactMap { substructureElements(of: $0, matching: .enumelement) }
             .flatMap(enumElementsMissingInitExpr)
-            .compactMap { $0.offset }
+            .compactMap(\.offset)
 
         return locs
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -161,7 +161,7 @@ private extension SourceKittenDictionary {
 
         return elements
             .filter { elementKind == $0.kind }
-            .compactMap { $0.byteRange }
+            .compactMap(\.byteRange)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -111,7 +111,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
                 return (acl: entry.accessibility ?? .internal, offset: offset)
             }
 
-        let declarationsACLs = declarations.map { $0.acl }.unique
+        let declarationsACLs = declarations.map(\.acl).unique
         let allowedACLs: Set<AccessControlLevel> = [.internal, .private, .open]
         guard declarationsACLs.count == 1, !allowedACLs.contains(declarationsACLs[0]) else {
             return []
@@ -121,7 +121,7 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
         let parts = syntaxTokens.partitioned { offset <= $0.offset }
         if let aclToken = parts.first.last, file.isACL(token: aclToken) {
             return declarationsViolations(file: file, acl: declarationsACLs[0],
-                                          declarationOffsets: declarations.map { $0.offset },
+                                          declarationOffsets: declarations.map(\.offset),
                                           dictionary: dictionary)
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
@@ -1,0 +1,103 @@
+import Foundation
+import SourceKittenFramework
+
+public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "key_path_expression_as_function",
+        name: "Key Path Expression as Function",
+        description: "Prefer using key paths instead of closures when possible.",
+        kind: .idiomatic,
+        minSwiftVersion: .fiveDotTwo,
+        nonTriggeringExamples: [
+            Example("let emails = users.map(\\.email)"),
+            Example("let admins = users.filter(\\.isAdmin)"),
+            Example("let all = users.filter { _ in true }"),
+            Example("let emails = users.map { $0.email() }"),
+            Example("""
+            let violatingRanges = violatingRanges.filter { range in
+                let region = fileRegions.first {
+                    $0.contains(Location(file: self, characterOffset: range.location))
+                }
+                return region?.isRuleEnabled(rule) ?? true
+            }
+            """),
+            Example("let ones = values.filter { $0 == 1 }")
+        ],
+        triggeringExamples: [
+            Example("let emails = users.map ↓{ $0.email }"),
+            Example("let emails = users.map(↓{ $0.email })"),
+            Example("let admins = users.filter(where: ↓{ $0.isAdmin })")
+        ]
+    )
+
+    // MARK: - ASTRule
+
+    public func validate(file: SwiftLintFile,
+                         kind: SwiftExpressionKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        guard SwiftVersion.current >= Self.description.minSwiftVersion else {
+            return []
+        }
+
+        return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
+            StyleViolation(ruleDescription: Self.description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: $0))
+        }
+    }
+
+    private func violationRanges(in file: SwiftLintFile,
+                                 kind: SwiftExpressionKind,
+                                 dictionary: SourceKittenDictionary) -> [ByteCount] {
+        guard kind == .call else {
+            return []
+        }
+
+        let closures = dictionary.substructure.compactMap { dictionary -> SourceKittenDictionary? in
+            if dictionary.isClosure {
+                return dictionary
+            }
+
+            if dictionary.isClosureArgument {
+                return dictionary.substructure.first
+            }
+
+            return nil
+        }
+
+        return closures.compactMap { dictionary -> ByteCount? in
+            guard let offset = dictionary.offset,
+                  let bodyOffset = dictionary.bodyOffset,
+                  let bodyLength = dictionary.bodyLength,
+                  bodyLength > 0,
+                  case let byteRange = ByteRange(location: bodyOffset, length: bodyLength),
+                  let range = file.stringView.byteRangeToNSRange(byteRange) else {
+                return nil
+            }
+
+            // Right now, this rule only catches cases where $0 is used (instead of named parameters) for simplicity
+            guard !file.match(pattern: #"\A\s*\$0\.\w+\b\s*\z"#, with: [.identifier, .identifier],
+                              range: range).isEmpty else {
+                return nil
+            }
+
+            return offset
+        }
+    }
+}
+
+private extension SourceKittenDictionary {
+    var isClosure: Bool {
+        return kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .closure
+    }
+
+    var isClosureArgument: Bool {
+        return kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .argument &&
+            substructure.count == 1 &&
+            substructure.allSatisfy { $0.isClosure }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
@@ -96,6 +96,6 @@ private extension SourceKittenDictionary {
     var isClosureArgument: Bool {
         return kind.flatMap(SwiftExpressionKind.init(rawValue:)) == .argument &&
             substructure.count == 1 &&
-            substructure.allSatisfy { $0.isClosure }
+            substructure.allSatisfy(\.isClosure)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
@@ -70,12 +70,10 @@ public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, Configuration
         }
 
         return closures.compactMap { dictionary -> ByteCount? in
-            guard let offset = dictionary.offset,
-                  let bodyOffset = dictionary.bodyOffset,
-                  let bodyLength = dictionary.bodyLength,
-                  bodyLength > 0,
-                  case let byteRange = ByteRange(location: bodyOffset, length: bodyLength),
-                  let range = file.stringView.byteRangeToNSRange(byteRange) else {
+            guard dictionary.enclosedVarParameters.isEmpty,
+                  let bodyRange = dictionary.bodyByteRange,
+                  bodyRange.length > 0,
+                  let range = file.stringView.byteRangeToNSRange(bodyRange) else {
                 return nil
             }
 
@@ -85,7 +83,7 @@ public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, Configuration
                 return nil
             }
 
-            return offset
+            return dictionary.offset
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/KeyPathExpressionAsFunctionRule.swift
@@ -1,6 +1,8 @@
+import Foundation
 import SourceKittenFramework
 
-public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct KeyPathExpressionAsFunctionRule: ASTRule, CorrectableRule, OptInRule,
+                                               ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -12,8 +14,8 @@ public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, Configuration
         kind: .idiomatic,
         minSwiftVersion: .fiveDotTwo,
         nonTriggeringExamples: [
-            Example("let emails = users.map(\\.email)"),
-            Example("let admins = users.filter(\\.isAdmin)"),
+            Example(#"let emails = users.map(\.email)"#),
+            Example(#"let admins = users.filter(\.isAdmin)"#),
             Example("let all = users.filter { _ in true }"),
             Example("let emails = users.map { $0.email() }"),
             Example("""
@@ -30,6 +32,12 @@ public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, Configuration
             Example("let emails = users.map ↓{ $0.email }"),
             Example("let emails = users.map(↓{ $0.email })"),
             Example("let admins = users.filter(where: ↓{ $0.isAdmin })")
+        ],
+        corrections: [
+            Example("let emails = users.map(↓{ $0.email })"):
+                Example(#"let emails = users.map(\.email)"#),
+            Example("let admins = users.filter(where: ↓{ $0.isAdmin })"):
+                Example(#"let admins = users.filter(where: \.isAdmin)"#)
         ]
     )
 
@@ -42,16 +50,55 @@ public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, Configuration
             return []
         }
 
-        return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
+        return violations(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
-                           location: Location(file: file, byteOffset: $0))
+                           location: Location(file: file, byteOffset: $0.offset))
         }
     }
 
-    private func violationRanges(in file: SwiftLintFile,
-                                 kind: SwiftExpressionKind,
-                                 dictionary: SourceKittenDictionary) -> [ByteCount] {
+    public func correct(file: SwiftLintFile) -> [Correction] {
+        guard SwiftVersion.current >= Self.description.minSwiftVersion else {
+            return []
+        }
+
+        let violations = file.structureDictionary
+            .traverseDepthFirst { subDict -> [ViolationInfo] in
+                guard let kind = self.kind(from: subDict) else { return [] }
+                return self.violations(in: file, kind: kind, dictionary: subDict)
+            }.filter { info in
+                guard let range = info.rangeToReplace else {
+                    return false
+                }
+                return !file.ruleEnabled(violatingRanges: [range], for: self).isEmpty
+            }
+
+        var correctedContents = file.contents
+        var adjustedLocations = [Int]()
+
+        for violation in violations.reversed() {
+            guard let rangeToReplace = violation.rangeToReplace else {
+                continue
+            }
+
+            if let indexRange = correctedContents.nsrangeToIndexRange(rangeToReplace) {
+                let correction = "\\" + violation.keyPathContent
+                correctedContents = correctedContents.replacingCharacters(in: indexRange, with: correction)
+                adjustedLocations.insert(rangeToReplace.location, at: 0)
+            }
+        }
+
+        file.write(correctedContents)
+
+        return adjustedLocations.map {
+            Correction(ruleDescription: Self.description,
+                       location: Location(file: file, characterOffset: $0))
+        }
+    }
+
+    private func violations(in file: SwiftLintFile,
+                            kind: SwiftExpressionKind,
+                            dictionary: SourceKittenDictionary) -> [ViolationInfo] {
         guard kind == .call else {
             return []
         }
@@ -68,22 +115,52 @@ public struct KeyPathExpressionAsFunctionRule: ASTRule, OptInRule, Configuration
             return nil
         }
 
-        return closures.compactMap { dictionary -> ByteCount? in
-            guard dictionary.enclosedVarParameters.isEmpty,
-                  let bodyRange = dictionary.bodyByteRange,
+        let isTrailingClosure = isTrailingClosureCall(dictionary: dictionary, file: file)
+
+        return closures.compactMap { closureDictionary -> ViolationInfo? in
+            guard closureDictionary.enclosedVarParameters.isEmpty,
+                  let bodyRange = closureDictionary.bodyByteRange,
                   bodyRange.length > 0,
-                  let range = file.stringView.byteRangeToNSRange(bodyRange) else {
+                  let offset = closureDictionary.offset,
+                  let byteRange = closureDictionary.byteRange,
+                  let searchRange = file.stringView.byteRangeToNSRange(bodyRange) else {
                 return nil
             }
 
             // Right now, this rule only catches cases where $0 is used (instead of named parameters) for simplicity
-            guard !file.match(pattern: #"\A\s*\$0\.\w+\b\s*\z"#, with: [.identifier, .identifier],
-                              range: range).isEmpty else {
-                return nil
-            }
+            let pattern =  #"\A\s*\$0(\.\w+)\b\s*\z"#
+            return file
+                .matchesAndSyntaxKinds(matching: pattern, range: searchRange)
+                .compactMap { textCheckingResult, syntaxKinds in
+                    guard syntaxKinds == [.identifier, .identifier] else {
+                        return nil
+                    }
 
-            return dictionary.offset
+                    let keyPathContent = file.stringView.substring(with: textCheckingResult.range(at: 1))
+                    let rangeToReplace = isTrailingClosure ? nil : file.stringView.byteRangeToNSRange(byteRange)
+                    return ViolationInfo(offset: offset, rangeToReplace: rangeToReplace, keyPathContent: keyPathContent)
+                }
+                .first
         }
+    }
+
+    private func isTrailingClosureCall(dictionary: SourceKittenDictionary, file: SwiftLintFile) -> Bool {
+        guard let offset = dictionary.offset,
+            let length = dictionary.length,
+            case let start = min(offset, offset + length - 1),
+            case let byteRange = ByteRange(location: start, length: length),
+            let text = file.stringView.substringWithByteRange(byteRange)
+        else {
+            return false
+        }
+
+        return !text.hasSuffix(")")
+    }
+
+    private struct ViolationInfo {
+        let offset: ByteCount
+        let rangeToReplace: NSRange?
+        let keyPathContent: String
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -53,7 +53,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         guard let name = dictionary.name,
             inits(forClasses: ["UIImage", "NSImage"]).contains(name),
             case let arguments = dictionary.enclosedArguments,
-            arguments.compactMap({ $0.name }) == ["named"],
+            arguments.compactMap(\.name) == ["named"],
             let argument = arguments.first,
             case let kinds = kinds(forArgument: argument, file: file),
             kinds == [.string] else {
@@ -67,7 +67,7 @@ public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
         guard let name = dictionary.name,
             inits(forClasses: ["UIColor", "NSColor"]).contains(name),
             case let arguments = dictionary.enclosedArguments,
-            case let argumentsNames = arguments.compactMap({ $0.name }),
+            case let argumentsNames = arguments.compactMap(\.name),
             argumentsNames == ["red", "green", "blue", "alpha"] || argumentsNames == ["white", "alpha"],
             validateColorKinds(arguments: arguments, file: file) else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -80,7 +80,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return violationResults(in: file).map { $0.range }
+        return violationResults(in: file).map(\.range)
     }
 
     public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
@@ -157,7 +157,7 @@ public struct SyntacticSugarRule: SubstitutionCorrectableRule, ConfigurationProv
                 return false
             }
 
-            let kinds = file.structureDictionary.structures(forByteOffset: byteOffset).compactMap { $0.expressionKind }
+            let kinds = file.structureDictionary.structures(forByteOffset: byteOffset).compactMap(\.expressionKind)
             guard kinds.contains(.call) else {
                 return false
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -49,7 +49,7 @@ public struct ToggleBoolRule: SubstitutionCorrectableRule, ConfigurationProvider
 
     public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         let violationString = file.stringView.substring(with: violationRange)
-        let identifier = violationString.components(separatedBy: .whitespaces).first { $0.isNotEmpty }
+        let identifier = violationString.components(separatedBy: .whitespaces).first(where: \.isNotEmpty)
         return (violationRange, identifier! + ".toggle()")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
@@ -50,7 +50,7 @@ public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
 
         for compilerProtocol in ExpressibleByCompiler.allProtocols {
             guard compilerProtocol.initCallNames.contains(name),
-                case let arguments = dictionary.enclosedArguments.compactMap({ $0.name }),
+                case let arguments = dictionary.enclosedArguments.compactMap(\.name),
                 compilerProtocol.match(arguments: arguments),
                 let range = dictionary.byteRange.flatMap(file.stringView.byteRangeToNSRange)
             else {

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -65,7 +65,7 @@ public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationPro
             let name = dictionary.name,
             name.hasSuffix(".addObserver"),
             case let arguments = dictionary.enclosedArguments,
-            case let argumentsNames = arguments.compactMap({ $0.name }),
+            case let argumentsNames = arguments.compactMap(\.name),
             argumentsNames == ["forName", "object", "queue"] ||
                 argumentsNames == ["forName", "object", "queue", "using"],
             let offset = dictionary.offset,

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -60,7 +60,7 @@ public struct DuplicateEnumCasesRule: ConfigurationProviderRule, ASTRule, Automa
         }
 
         return elementsByName.filter { $0.value.count > 1 }
-            .flatMap { $0.value }
+            .flatMap(\.value)
             .map {
                 StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -48,7 +48,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
 
         return file.matchesAndSyntaxKinds(matching: regex).compactMap { checkingResult, syntaxKinds in
             guard
-                syntaxKinds.allSatisfy({ $0.isCommentLike }),
+                syntaxKinds.allSatisfy(\.isCommentLike),
                 checkingResult.numberOfRanges > 1,
                 case let range = checkingResult.range(at: 1),
                 let date = expiryDate(file: file, range: range),

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -96,7 +96,7 @@ public struct MissingDocsRule: OptInRule, ConfigurationProviderRule, AutomaticTe
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let acls = configuration.parameters.map { $0.value }
+        let acls = configuration.parameters.map(\.value)
         let dict = file.structureDictionary
         return file.missingDocOffsets(in: dict, acls: acls).map { offset, acl in
             StyleViolation(ruleDescription: Self.description,

--- a/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -119,7 +119,7 @@ public struct RawValueForCamelCasedCodableEnumRule: ASTRule, OptInRule, Configur
         return substructureElements(of: dictionary, matching: .enumcase)
             .compactMap { substructureElements(of: $0, matching: .enumelement) }
             .flatMap(camelCasedEnumCasesMissingRawValue)
-            .compactMap { $0.offset }
+            .compactMap(\.offset)
     }
 
     private func substructureElements(of dict: SourceKittenDictionary,

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -99,9 +99,9 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
         static func cases(from dictionary: SourceKittenDictionary) -> [String] {
             let caseSubstructures = dictionary.substructure.filter { dict in
                 return dict.declarationKind == .enumcase
-            }.flatMap { $0.substructure }
+            }.flatMap(\.substructure)
 
-            return caseSubstructures.compactMap { $0.name }.map { name in
+            return caseSubstructures.compactMap(\.name).map { name in
                 if SwiftVersion.current > .fourDotOne,
                     let parenIndex = name.firstIndex(of: "("),
                     parenIndex > name.startIndex {

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -142,7 +142,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
 
     public func violationRanges(in file: SwiftLintFile, kind: SwiftExpressionKind,
                                 dictionary: SourceKittenDictionary) -> [NSRange] {
-        return violationRanges(in: file, dictionary: dictionary, kind: kind).map { $0.range }
+        return violationRanges(in: file, dictionary: dictionary, kind: kind).map(\.range)
     }
 
     public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -83,7 +83,7 @@ public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProvide
         // 2. minus all references
         return declaredUSRs
             .filter { !allReferencedUSRs.contains($0.usr) }
-            .map { $0.nameOffset }
+            .map(\.nameOffset)
             .sorted()
     }
 }
@@ -152,7 +152,7 @@ private extension SwiftLintFile {
         // Skip CodingKeys as they are used for Codable generation
         if kind == .enum,
             indexEntity.name == "CodingKeys",
-            case let allRelatedUSRs = indexEntity.traverseEntities(traverseBlock: { $0.usr }),
+            case let allRelatedUSRs = indexEntity.traverseEntities(traverseBlock: \.usr),
             allRelatedUSRs.contains("s:s9CodingKeyP") {
             return nil
         }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -29,7 +29,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
 
     public func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
         let importUsages = importUsage(in: file, compilerArguments: compilerArguments)
-        let matches = file.ruleEnabled(violatingRanges: importUsages.compactMap({ $0.violationRange }), for: self)
+        let matches = file.ruleEnabled(violatingRanges: importUsages.compactMap(\.violationRange), for: self)
 
         var contents = file.stringView.nsString
         let description = Self.description
@@ -112,7 +112,7 @@ private extension SwiftLintFile {
             unusedImports.subtract(
                 operatorImports(
                     arguments: compilerArguments,
-                    processedTokenOffsets: Set(syntaxMap.tokens.map { $0.offset })
+                    processedTokenOffsets: Set(syntaxMap.tokens.map(\.offset))
                 )
             )
         }
@@ -134,7 +134,7 @@ private extension SwiftLintFile {
                 let modulesAllowedToImportCurrentModule = configuration.allowedTransitiveImports
                     .filter { !unusedImports.contains($0.importedModule) }
                     .filter { $0.transitivelyImportedModules.contains(module) }
-                    .map { $0.importedModule }
+                    .map(\.importedModule)
 
                 return modulesAllowedToImportCurrentModule.isEmpty ||
                     imports.isDisjoint(with: modulesAllowedToImportCurrentModule)

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
@@ -53,7 +53,7 @@ public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
             return []
         }
 
-        let minThreshold = configuration.severityConfiguration.params.map({ $0.value }).min(by: <)
+        let minThreshold = configuration.severityConfiguration.params.map(\.value).min(by: <)
 
         let allParameterCount = allFunctionParameterCount(structure: dictionary.substructure, range: nameRange)
         if allParameterCount < minThreshold! {

--- a/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
@@ -28,7 +28,7 @@ public struct LineLengthRule: ConfigurationProviderRule {
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let minValue = configuration.params.map({ $0.value }).min() ?? .max
+        let minValue = configuration.params.map(\.value).min() ?? .max
         let swiftDeclarationKindsByLine = Lazy(file.swiftDeclarationKindsByLine() ?? [])
         let syntaxKindsByLine = Lazy(file.syntaxKindsByLine() ?? [])
 

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -29,7 +29,7 @@ public struct ContainsOverRangeNilComparisonRule: CallPairRule, OptInRule, Confi
         return validate(file: file, pattern: pattern, patternSyntaxKinds: [.keyword],
                         callNameSuffix: ".range", severity: configuration.severity,
                         reason: "Prefer `contains` over range(of:) comparison to nil") { expression in
-                            return expression.enclosedArguments.map { $0.name } == ["of"]
+            return expression.enclosedArguments.map(\.name) == ["of"]
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
@@ -48,7 +48,7 @@ public struct SortedFirstLastRule: CallPairRule, OptInRule, ConfigurationProvide
                         patternSyntaxKinds: [.identifier],
                         callNameSuffix: ".sorted",
                         severity: configuration.severity) { dictionary in
-            let arguments = dictionary.enclosedArguments.compactMap { $0.name }
+            let arguments = dictionary.enclosedArguments.compactMap(\.name)
             return arguments.isEmpty || arguments == ["by"]
         }
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -12,7 +12,7 @@ public struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
     private(set) var includedKinds = ImplicitReturnConfiguration.defaultIncludedKinds
 
     public var consoleDescription: String {
-        let includedKinds = self.includedKinds.map { $0.rawValue }
+        let includedKinds = self.includedKinds.map(\.rawValue)
         return severityConfiguration.consoleDescription +
             ", included: [\(includedKinds.joined(separator: ", "))]"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -2,7 +2,7 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
     private(set) var parameters = [RuleParameter<AccessControlLevel>]()
 
     public var consoleDescription: String {
-        return parameters.group { $0.severity }.sorted { $0.key.rawValue < $1.key.rawValue }.map {
+        return parameters.group(by: \.severity).sorted { $0.key.rawValue < $1.key.rawValue }.map {
             "\($0.rawValue): \($1.map { $0.value.description }.sorted(by: <).joined(separator: ", "))"
         }.joined(separator: ", ")
     }
@@ -27,7 +27,7 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
             }
             throw ConfigurationError.unknownConfiguration
         }
-        guard parameters.count == parameters.map({ $0.value }).unique.count else {
+        guard parameters.count == parameters.map(\.value).unique.count else {
             throw ConfigurationError.unknownConfiguration
         }
         self.parameters = parameters

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -29,7 +29,7 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
             included?.pattern ?? "",
             excluded?.pattern ?? "",
             SyntaxKind.allKinds.subtracting(excludedMatchKinds)
-                .map({ $0.rawValue }).sorted(by: <).joined(separator: ","),
+                .map(\.rawValue).sorted(by: <).joined(separator: ","),
             severityConfiguration.consoleDescription
         ]
         if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -83,7 +83,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
             }
 
             let braces = bracePattern.matches(in: file.contents, options: [],
-                                              range: nsrange).map { $0.range }
+                                              range: nsrange).map(\.range)
             // filter out braces in comments and strings
             let tokens = linesTokens[eachLine.index].filter {
                 guard let tokenKind = $0.kind else { return false }

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -13,7 +13,7 @@ public struct CustomRulesConfiguration: RuleConfiguration, Equatable, CacheDescr
     internal var cacheDescription: String {
         return customRuleConfigurations
             .sorted { $0.identifier < $1.identifier }
-            .map { $0.cacheDescription }
+            .map(\.cacheDescription)
             .joined(separator: "\n")
     }
     public var customRuleConfigurations = [RegexConfiguration]()

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -74,7 +74,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
                 let fileTypeOffset = orderedFileTypeOffsets[index]
 
                 let fileType = fileTypeOffset.fileType.rawValue
-                let expected = expectedTypes.map { $0.rawValue }.joined(separator: ",")
+                let expected = expectedTypes.map(\.rawValue).joined(separator: ",")
                 let article = ["a", "e", "i", "o", "u"].contains(fileType.substring(from: 0, length: 1)) ? "An" : "A"
 
                 let styleViolation = StyleViolation(

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -139,7 +139,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         let prioritizedModifiers = self.prioritizedModifiers(violatableModifiers: violatableModifiers)
         let sortedByPriorityModifiers = prioritizedModifiers
             .sorted { $0.priority < $1.priority }
-            .map { $0.modifier }
+            .map(\.modifier)
 
         return zip(sortedByPriorityModifiers, violatableModifiers).filter { $0 != $1 }
     }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -118,7 +118,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
             return (dotLine: line, dotOffset: offset, range: range)
         }
 
-        let uniqueLines = calls.map { $0.dotLine }.unique
+        let uniqueLines = calls.map(\.dotLine).unique
 
         if uniqueLines.count == 1 { return [] }
 
@@ -129,7 +129,7 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
                 !callHasLeadingNewline(file: file, callRange: line.range)
             }
 
-        return noLeadingNewlineViolations.map { $0.dotOffset }
+        return noLeadingNewlineViolations.map(\.dotOffset)
     }
 
     private static let whitespaceDotRegex = regex("\\s*\\.")

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -97,7 +97,7 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
         }
 
         // Don't trigger if it's a single parameter trailing closure without parens
-        if let closureBodyOffset = dictionary.substructure.lazy.compactMap({ $0.closureBodyOffset }).first,
+        if let closureBodyOffset = dictionary.substructure.lazy.compactMap(\.closureBodyOffset).first,
             closureBodyOffset == bodyOffset {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
@@ -192,7 +192,7 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
             guard let first = group.first?.contentRange else {
                 continue
             }
-            let result = group.map { $0.content }.joined(separator: "\n")
+            let result = group.map(\.content).joined(separator: "\n")
             let union = group.dropFirst().reduce(first) { result, line in
                 return NSUnionRange(result, line.contentRange)
             }

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -180,7 +180,7 @@ private extension StatementPositionRule {
         let validator = Self.uncuddledMatchValidator(contents: contents)
         let filterMatches = Self.uncuddledMatchFilter(contents: contents, syntaxMap: syntaxMap)
 
-        let validMatches = matches.compactMap(validator).filter(filterMatches).map({ $0.range })
+        let validMatches = matches.compactMap(validator).filter(filterMatches).map(\.range)
 
         return validMatches
     }

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -144,7 +144,7 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
         // skip commas in comments
         return TrailingCommaRule.commaRegex
             .matches(in: contents, options: [], range: contents.fullNSRange)
-            .map { $0.range }
+            .map(\.range)
             .last { nsRange in
                 let offsetCharacter = file.stringView.location(fromByteOffset: offset)
                 let offsetNSRange = NSRange(location: nsRange.location + offsetCharacter, length: nsRange.length)

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -53,7 +53,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 let typeContentOffset = orderedTypeContentOffsets[index]
 
                 let content = typeContentOffset.typeContent.rawValue
-                let expected = expectedTypesContents.map { $0.rawValue }.joined(separator: ",")
+                let expected = expectedTypesContents.map(\.rawValue).joined(separator: ",")
                 let article = ["a", "e", "i", "o", "u"].contains(content.substring(from: 0, length: 1)) ? "An" : "A"
 
                 let styleViolation = StyleViolation(

--- a/Source/swiftlint/Commands/AnalyzeCommand.swift
+++ b/Source/swiftlint/Commands/AnalyzeCommand.swift
@@ -20,7 +20,7 @@ struct AnalyzeCommand: CommandProtocol {
         return configuration.visitLintableFiles(options: options, cache: nil, storage: storage) { linter in
             let corrections = linter.correct(using: storage)
             if !corrections.isEmpty && !options.quiet {
-                let correctionLogs = corrections.map({ $0.consoleDescription })
+                let correctionLogs = corrections.map(\.consoleDescription)
                 queuedPrint(correctionLogs.joined(separator: "\n"))
             }
         }.flatMap { files in

--- a/Source/swiftlint/Commands/AutoCorrectCommand.swift
+++ b/Source/swiftlint/Commands/AutoCorrectCommand.swift
@@ -83,7 +83,7 @@ struct AutoCorrectOptions: OptionsProtocol {
             }
             let corrections = linter.correct(using: storage)
             if !corrections.isEmpty && !self.quiet {
-                let correctionLogs = corrections.map({ $0.consoleDescription })
+                let correctionLogs = corrections.map(\.consoleDescription)
                 queuedPrint(correctionLogs.joined(separator: "\n"))
             }
         }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -125,7 +125,7 @@ extension Configuration {
                          storage: RuleStorage,
                          duplicateFileNames: Set<String>) -> ([CollectedLinter], Set<String>) {
         var collected = 0
-        let total = linters.filter({ $0.isCollecting }).count
+        let total = linters.filter(\.isCollecting).count
         let collect = { (linter: Linter) -> CollectedLinter? in
             let skipFile = visitor.shouldSkipFile(atPath: linter.file.path)
             if !visitor.quiet, linter.isCollecting, let filePath = linter.file.path {
@@ -204,7 +204,7 @@ extension Configuration {
                         return files
                     }
 
-                    let scriptInputPaths = files.compactMap { $0.path }
+                    let scriptInputPaths = files.compactMap(\.path)
                     let filesToLint = visitor.useExcludingByPrefix
                                       ? filterExcludedPathsByPrefix(in: scriptInputPaths)
                                       : filterExcludedPaths(in: scriptInputPaths)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -794,6 +794,12 @@ extension JoinedDefaultParameterRuleTests {
     ]
 }
 
+extension KeyPathExpressionAsFunctionRuleTests {
+    static var allTests: [(String, (KeyPathExpressionAsFunctionRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension LargeTupleRuleTests {
     static var allTests: [(String, (LargeTupleRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1840,6 +1846,7 @@ XCTMain([
     testCase(IntegrationTests.allTests),
     testCase(IsDisjointRuleTests.allTests),
     testCase(JoinedDefaultParameterRuleTests.allTests),
+    testCase(KeyPathExpressionAsFunctionRuleTests.allTests),
     testCase(LargeTupleRuleTests.allTests),
     testCase(LastWhereRuleTests.allTests),
     testCase(LegacyCGGeometryFunctionsRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -306,6 +306,12 @@ class JoinedDefaultParameterRuleTests: XCTestCase {
     }
 }
 
+class KeyPathExpressionAsFunctionRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(KeyPathExpressionAsFunctionRule.description)
+    }
+}
+
 class LargeTupleRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LargeTupleRule.description)

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -131,7 +131,7 @@ private func cleanedContentsAndMarkerOffsets(from contents: String) -> (String, 
 }
 
 private func render(violations: [StyleViolation], in contents: String) -> String {
-    var contents = StringView(contents).lines.map { $0.content }
+    var contents = StringView(contents).lines.map(\.content)
     for violation in violations.sorted(by: { $0.location > $1.location }) {
         guard let line = violation.location.line,
             let character = violation.location.character else { continue }
@@ -155,7 +155,7 @@ private func render(violations: [StyleViolation], in contents: String) -> String
 }
 
 private func render(locations: [Location], in contents: String) -> String {
-    var contents = StringView(contents).lines.map { $0.content }
+    var contents = StringView(contents).lines.map(\.content)
     for location in locations.sorted(by: > ) {
         guard let line = location.line, let character = location.character else { continue }
         let content = NSMutableString(string: contents[line - 1])
@@ -441,7 +441,7 @@ extension XCTestCase {
             }
 
             // Assert locations missing violation
-            let violatedLocations = triggerViolations.map { $0.location }
+            let violatedLocations = triggerViolations.map(\.location)
             let locationsWithoutViolation = expectedLocations
                 .filter { !violatedLocations.contains($0) }
             if !locationsWithoutViolation.isEmpty {


### PR DESCRIPTION
Fixes #3082

This only catches expressions using `$0`, but I think this is a great start and should cover a lot of cases in existing codebases. 