### PR TITLE
Add CommentSpacingRule (#3233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@
   `unused_import` rule.  
   [Keith Smiley](https://github.com/keith)
 
+* Add `comment_spacing` rule.
+  [Noah Gilmore](https://github.com/noahsark769)
+  [#3233](https://github.com/realm/SwiftLint/issues/3233)
+
 #### Bug Fixes
 
 * None.
@@ -452,9 +456,7 @@ This is the last release to support building with Swift 5.0.x.
 
 #### Enhancements
 
-* Add `comment_spacing` rule.  
-  [Noah Gilmore](https://github.com/noahsark769)
-  [#3233](https://github.com/realm/SwiftLint/issues/3233)
+* None.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
   `unused_import` rule.  
   [Keith Smiley](https://github.com/keith)
 
-* Add `comment_spacing` rule.
+* Add `comment_spacing` rule.  
   [Noah Gilmore](https://github.com/noahsark769)
   [#3233](https://github.com/realm/SwiftLint/issues/3233)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,7 +452,9 @@ This is the last release to support building with Swift 5.0.x.
 
 #### Enhancements
 
-* None.
+* Add `comment_spacing` rule.  
+  [Noah Gilmore](https://github.com/noahsark769)
+  [#3233](https://github.com/realm/SwiftLint/issues/3233)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Regex.swift
@@ -191,7 +191,6 @@ extension SwiftLintFile {
         return tokens.map { $0.kinds }
     }
 
-    //Added by S2dent
     /**
      This function returns only matches that are not contained in a syntax kind
      specified.

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -16,6 +16,7 @@ public let primaryRuleList = RuleList(rules: [
     CollectionAlignmentRule.self,
     ColonRule.self,
     CommaRule.self,
+    CommentSpacingRule.self,
     CompilerProtocolInitRule.self,
     ComputedAccessorsOrderRule.self,
     ConditionalReturnsOnNewlineRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct CommentSpacingRule: OptInRule,
-                                  ConfigurationProviderRule,
+public struct CommentSpacingRule: ConfigurationProviderRule,
                                   SubstitutionCorrectableRule,
                                   AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -98,7 +98,7 @@ public struct CommentSpacingRule: OptInRule, ConfigurationProviderRule, Substitu
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         // Find all comment tokens in the file and regex search them for violations
-        let commentTokens = file.syntaxMap.tokens.filter { [.comment, .docComment].contains($0.kind) }
+        let commentTokens = file.syntaxMap.tokens.filter { SyntaxKind.commentKinds.contains($0.kind) }
         return commentTokens.compactMap { (token: SwiftLintSyntaxToken) -> [NSRange]? in
             guard let commentBody = file.stringView.substringWithByteRange(token.range).map(StringView.init) else {
                 return nil

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -105,7 +105,7 @@ public struct CommentSpacingRule: OptInRule, ConfigurationProviderRule, Substitu
             }
             // Look for 2-3 slash characters followed immediately by a non-whitespace, non-slash
             // character (this is a violation)
-            return regex("^(\\/){2,3}[^\\s\\/]").matches(in: commentBody, options: .anchored)
+            return regex(#"^(\/){2,3}[^\s\/]"#).matches(in: commentBody, options: .anchored)
                 .compactMap { result in
                     // Set the location to be directly before the first non-slash,
                     // non-whitespace character which was matched

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -1,0 +1,138 @@
+import Foundation
+import SourceKittenFramework
+
+public struct CommentSpacingRule: OptInRule, ConfigurationProviderRule, SubstitutionCorrectableRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "comment_spacing",
+        name: "Comment Spacing",
+        description: "Prefer at least one space after slashes for comments.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+            // This is a comment
+            """),
+            Example("""
+            /// Triple slash comment
+            """),
+            Example("""
+            // Multiline double-slash
+            // comment
+            """),
+            Example("""
+            /// Multiline triple-slash
+            /// comment
+            """),
+            Example("""
+            /// Multiline triple-slash
+            ///   - This is indented
+            """),
+            Example("""
+            // - MARK: Mark comment
+            """),
+            Example("""
+            /* Asterisk comment */
+            """),
+            Example("""
+            /*
+                Multiline asterisk comment
+            */
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+            //↓Something
+            """),
+            Example("""
+            //↓MARK
+            """),
+            Example("""
+            //↓👨‍👨‍👦‍👦Something
+            """),
+            Example("""
+            func a() {
+                //↓This needs refactoring
+                print("Something")
+            }
+            //↓We should improve above function
+            """),
+            Example("""
+            ///↓This is a comment
+            """),
+            Example("""
+            /// Multiline triple-slash
+            ///↓This line is incorrect, though
+            """),
+            Example("""
+            //↓- MARK: Mark comment
+            """)
+        ],
+        corrections: [
+            Example("//↓Something"): Example("// Something"),
+            Example("//↓- MARK: Mark comment"): Example("// - MARK: Mark comment"),
+            Example("""
+            /// Multiline triple-slash
+            ///↓This line is incorrect, though
+            """): Example("""
+            /// Multiline triple-slash
+            /// This line is incorrect, though
+            """),
+            Example("""
+            func a() {
+                //↓This needs refactoring
+                print("Something")
+            }
+            //↓We should improve above function
+            """): Example("""
+            func a() {
+                // This needs refactoring
+                print("Something")
+            }
+            // We should improve above function
+            """)
+        ]
+    )
+
+    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+        let commentTokens = file.syntaxMap.tokens.filter { [.comment, .docComment].contains($0.kind) }
+        return commentTokens.compactMap { (token: SwiftLintSyntaxToken) -> [NSRange]? in
+            guard let commentBody = file.stringView.substringWithByteRange(token.range).map(StringView.init) else {
+                return nil
+            }
+            return regex("^(\\/){2,3}[^\\s\\/]").matches(in: commentBody, options: .anchored)
+                .compactMap { result in
+                    // Set the location to be directly before the first non-slash,
+                    // non-whitespace character which was matched
+                    guard let characterRange = file.stringView.byteRangeToNSRange(
+                        ByteRange(
+                            location: ByteCount(
+                                token.range.lowerBound.value + result.range.upperBound - 1
+                            ),
+                            length: ByteCount(1)
+                        )
+                    ) else {
+                        return nil
+                    }
+                    return characterRange
+                }
+        }.flatMap { $0 }
+    }
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        return violationRanges(in: file).map { range in
+            StyleViolation(
+                ruleDescription: Self.description,
+                severity: configuration.severity,
+                location: Location(file: file, characterOffset: range.location)
+            )
+        }
+    }
+
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+        let violationCharacters = file.stringView.substring(with: violationRange)
+        return (violationRange, " \(violationCharacters)")
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -1,7 +1,10 @@
 import Foundation
 import SourceKittenFramework
 
-public struct CommentSpacingRule: OptInRule, ConfigurationProviderRule, SubstitutionCorrectableRule, AutomaticTestableRule {
+public struct CommentSpacingRule: OptInRule,
+                                  ConfigurationProviderRule,
+                                  SubstitutionCorrectableRule,
+                                  AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -98,28 +101,32 @@ public struct CommentSpacingRule: OptInRule, ConfigurationProviderRule, Substitu
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         // Find all comment tokens in the file and regex search them for violations
-        let commentTokens = file.syntaxMap.tokens.filter { SyntaxKind.commentKinds.contains($0.kind) }
+        let commentTokens = file.syntaxMap.tokens.filter {
+            guard let kind = $0.kind else { return false }
+            return SyntaxKind.commentKinds.contains(kind)
+        }
         return commentTokens.compactMap { (token: SwiftLintSyntaxToken) -> [NSRange]? in
-            guard let commentBody = file.stringView.substringWithByteRange(token.range).map(StringView.init) else {
-                return nil
-            }
-            // Look for 2-3 slash characters followed immediately by a non-whitespace, non-slash
-            // character (this is a violation)
-            return regex(#"^(\/){2,3}[^\s\/]"#).matches(in: commentBody, options: .anchored)
-                .compactMap { result in
-                    // Set the location to be directly before the first non-slash,
-                    // non-whitespace character which was matched
-                    guard let characterRange = file.stringView.byteRangeToNSRange(
-                        ByteRange(
-                            location: ByteCount(
-                                token.range.lowerBound.value + result.range.upperBound - 1
-                            ),
-                            length: ByteCount(1)
-                        )
-                    ) else {
-                        return nil
-                    }
-                    return characterRange
+            return file.stringView
+                .substringWithByteRange(token.range)
+                .map(StringView.init).map { commentBody in
+                    // Look for 2-3 slash characters followed immediately by a non-whitespace, non-slash
+                    // character (this is a violation)
+                    return regex(#"^(\/){2,3}[^\s\/]"#).matches(in: commentBody, options: .anchored)
+                        .compactMap { result in
+                            // Set the location to be directly before the first non-slash,
+                            // non-whitespace character which was matched
+                            guard let characterRange = file.stringView.byteRangeToNSRange(
+                                ByteRange(
+                                    location: ByteCount(
+                                        token.range.lowerBound.value + result.range.upperBound - 1
+                                    ),
+                                    length: ByteCount(1)
+                                )
+                            ) else {
+                                return nil
+                            }
+                            return characterRange
+                        }
                 }
         }.flatMap { $0 }
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverridenSuperCallConfiguration.swift
@@ -1,16 +1,16 @@
 public struct OverridenSuperCallConfiguration: RuleConfiguration, Equatable {
     private let defaultIncluded = [
-        //NSObject
+        // NSObject
         "awakeFromNib()",
         "prepareForInterfaceBuilder()",
-        //UICollectionViewLayout
+        // UICollectionViewLayout
         "invalidateLayout()",
         "invalidateLayout(with:)",
         "invalidateLayoutWithContext(_:)",
-        //UIView
+        // UIView
         "prepareForReuse()",
         "updateConstraints()",
-        //UIViewController
+        // UIViewController
         "addChildViewController(_:)",
         "decodeRestorableState(with:)",
         "decodeRestorableStateWithCoder(_:)",
@@ -27,7 +27,7 @@ public struct OverridenSuperCallConfiguration: RuleConfiguration, Equatable {
         "viewDidLoad()",
         "viewWillAppear(_:)",
         "viewWillDisappear(_:)",
-        //XCTestCase
+        // XCTestCase
         "setUp()",
         "setUpWithError()",
         "tearDown()",

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -37,7 +37,7 @@ private extension SwiftLintFile {
             return false
         }
 
-        //First non-whitespace character should be "(" - otherwise it is not an anonymous closure
+        // First non-whitespace character should be "(" - otherwise it is not an anonymous closure
         let afterBracketCode = closureCode.substring(from: closingBracketPosition + 1)
                                             .trimmingCharacters(in: .whitespaces)
         return afterBracketCode.first == "("

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
@@ -134,7 +134,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
                 let description = Self.description
                 let location = Location(file: file, characterOffset: currentLine.range.location)
 
-                //reports every line that is being deleted
+                // reports every line that is being deleted
                 corrections.append(Correction(ruleDescription: description, location: location))
                 continue // skips line
             }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -136,6 +136,12 @@ extension CommandTests {
     ]
 }
 
+extension CommentSpacingRuleTests {
+    static var allTests: [(String, (CommentSpacingRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension CompilerProtocolInitRuleTests {
     static var allTests: [(String, (CompilerProtocolInitRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration),
@@ -1756,6 +1762,7 @@ XCTMain([
     testCase(ColonRuleTests.allTests),
     testCase(CommaRuleTests.allTests),
     testCase(CommandTests.allTests),
+    testCase(CommentSpacingRuleTests.allTests),
     testCase(CompilerProtocolInitRuleTests.allTests),
     testCase(ComputedAccessorsOrderRuleTests.allTests),
     testCase(ConditionalReturnsOnNewlineRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -66,6 +66,12 @@ class CommaRuleTests: XCTestCase {
     }
 }
 
+class CommentSpacingRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(CommentSpacingRule.description)
+    }
+}
+
 class ContainsOverFilterCountRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ContainsOverFilterCountRule.description)

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -257,22 +257,22 @@ class CommandTests: XCTestCase {
     func testDisableAllOverridesSuperfluousDisableCommand() {
         XCTAssert(
             violations(
-                Example("//swiftlint:disable all\n// swiftlint:disable nesting\nprint(123)\n")
+                Example("// swiftlint:disable all\n// swiftlint:disable nesting\nprint(123)\n")
             ).isEmpty
         )
         XCTAssert(
             violations(
-                Example("//swiftlint:disable all\n// swiftlint:disable:next nesting\nprint(123)\n")
+                Example("// swiftlint:disable all\n// swiftlint:disable:next nesting\nprint(123)\n")
             ).isEmpty
         )
         XCTAssert(
             violations(
-                Example("//swiftlint:disable all\n// swiftlint:disable:this nesting\nprint(123)\n")
+                Example("// swiftlint:disable all\n// swiftlint:disable:this nesting\nprint(123)\n")
             ).isEmpty
         )
         XCTAssert(
             violations(
-                Example("//swiftlint:disable all\n// swiftlint:disable:previous nesting\nprint(123)\n")
+                Example("// swiftlint:disable all\n// swiftlint:disable:previous nesting\nprint(123)\n")
             ).isEmpty
         )
     }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -149,7 +149,7 @@ class ExplicitTypeInterfaceRuleTests: XCTestCase {
         verifyRule(description)
     }
 
-    //swiftlint:disable function_body_length
+    // swiftlint:disable function_body_length
     func testSwitchCaseDeclarations() {
         guard SwiftVersion.current >= .fourDotOne else {
             return

--- a/Tests/SwiftLintFrameworkTests/LineEndingTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineEndingTests.swift
@@ -5,7 +5,7 @@ class LineEndingTests: XCTestCase {
     func testCarriageReturnDoesNotCauseError() {
         XCTAssert(
             violations(
-                Example("//swiftlint:disable all\r\nprint(123)\r\n")
+                Example("// swiftlint:disable all\r\nprint(123)\r\n")
             ).isEmpty
         )
     }

--- a/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
@@ -78,7 +78,7 @@ class ModifierOrderTests: XCTestCase {
                                                                     "override"]])
     }
 
-    //swiftlint:disable function_body_length
+    // swiftlint:disable function_body_length
     func testAtPrefixedGroup() {
         let descriptionOverride = RuleDescription(
             identifier: "modifier_order",

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -350,6 +350,7 @@ extension XCTestCase {
             XCTAssertEqual(
                 triggers.flatMap({ makeViolations($0.with(code: "/*\n  " + $0.code + "\n */")) }).count,
                 commentDoesntViolate ? 0 : triggers.count,
+                "Violation(s) still triggered when code was nested inside comment",
                 file: (file), line: line
             )
         }
@@ -433,7 +434,7 @@ extension XCTestCase {
             let violationsAtUnexpectedLocation = triggerViolations
                 .filter { !expectedLocations.contains($0.location) }
             if !violationsAtUnexpectedLocation.isEmpty {
-                XCTFail("triggeringExample violate at unexpected location: \n" +
+                XCTFail("triggeringExample violated at unexpected location: \n" +
                     "\(render(violations: violationsAtUnexpectedLocation, in: trigger.code))",
                     file: trigger.file,
                     line: trigger.line)


### PR DESCRIPTION
This PR adds the rule requested in #3233, a rule which enforces double-slash and triple-slash style comments to have at least one space after the slashes. This rule is opt in for now, but is autocorrectable!

I tried to make this an `ASTRule`, but it turns out the `SwiftLintFile`'s `structureDictionary` that is passed to `ASTRule` does not include comment tokens, so I opted to enumerate the comment tokens manually using the `syntaxMap`. Let me know if this isn't the best way to go about this, happy to change it.

I also made a couple of small updates to the messages I encountered during testing to make them more specific/actionable.