### PR TITLE
Rule Modification: Don't trigger `unavailable_function` for a function that returns `Never`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@
 
 #### Enhancements
 
-* None.
+* Rule Modification: Don't trigger `unavailable_function`for a function
+  that returns `Never`.
+  [Artem Garmash](https://github.com/agarmash)
+  [#3286](https://github.com/realm/SwiftLint/issues/3286)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
+++ b/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
@@ -49,7 +49,6 @@ public func queuedPrintError(_ string: String) {
  the source path from the compiled binary.
  */
 public func queuedFatalError(_ string: String, file: StaticString = #file, line: UInt = #line) -> Never {
-    // swiftlint:disable:previous unavailable_function
     outputQueue.sync {
         fflush(stdout)
         let file = "\(file)".bridge().lastPathComponent


### PR DESCRIPTION
Implements the change suggested in #3286.
Doesn't add any additional configuration parameters.

Resolves #3286