### PR TITLE
Fix false positives in inclusive_language rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix false positives in `inclusive_language` rule.  
+  [Dalton Claybrook](https://github.com/daltonclaybrook)
+  [#3415](https://github.com/realm/SwiftLint/issues/3415)
 
 ## 0.41.0: World’s Cleanest Voting Booth
 

--- a/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
@@ -100,4 +100,29 @@ extension String {
             $1 == character ? $0 + 1 : $0
         })
     }
+
+    /// Return an array of strings by splitting the receiver into
+    /// its camel-case components.
+    public var componentsSeparatedByCamelCase: [String] {
+        var components: [String] = []
+        var nextComponent = ""
+        zip(indices, self).forEach { currentIndex, character in
+            guard currentIndex > startIndex && currentIndex < index(before: endIndex) else {
+                return nextComponent.append(character)
+            }
+            if character.isLowercase {
+                nextComponent.append(character)
+            } else if self[index(before: currentIndex)].isUppercase && self[index(after: currentIndex)].isUppercase {
+                // Index before and after are uppercase, so this character is part of an acronym
+                nextComponent.append(character)
+            } else {
+                components.append(nextComponent)
+                nextComponent = String(character)
+            }
+        }
+        if !nextComponent.isEmpty {
+            components.append(nextComponent)
+        }
+        return components
+    }
 }

--- a/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRule.swift
@@ -1,7 +1,11 @@
+import Foundation
 import SourceKittenFramework
 
 public struct InclusiveLanguageRule: ASTRule, ConfigurationProviderRule {
     public var configuration = InclusiveLanguageConfiguration()
+
+    private let declarationCharacterSet = CharacterSet.alphanumerics
+        .union(CharacterSet(charactersIn: "_"))
 
     public init() {}
 
@@ -24,8 +28,10 @@ public struct InclusiveLanguageRule: ASTRule, ConfigurationProviderRule {
             let nameByteRange = dictionary.nameByteRange
             else { return [] }
 
-        let lowercased = name.lowercased()
-        guard let term = configuration.allTerms.first(where: lowercased.contains) else {
+        let components = name.components(separatedBy: declarationCharacterSet.inverted)
+            .flatMap { $0.componentsSeparateByCamelOrSnakeCase }
+            .map { $0.lowercased() }
+        guard let term = configuration.allTerms.intersection(components).first else {
             return []
         }
 
@@ -37,5 +43,15 @@ public struct InclusiveLanguageRule: ASTRule, ConfigurationProviderRule {
                 reason: "Declaration \(name) contains the term \"\(term)\" which is not considered inclusive."
             )
         ]
+    }
+}
+
+private extension String {
+    var componentsSeparateByCamelOrSnakeCase: [String] {
+        if contains("_" as Character) {
+            return components(separatedBy: "_")
+        } else {
+            return componentsSeparatedByCamelCase
+        }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRuleExamples.swift
@@ -8,17 +8,25 @@ internal struct InclusiveLanguageRuleExamples {
             case foo, bar
         }
         """),
-        Example("func updateAllowList(add: String) {}")
+        Example("func updateAllowList(add: String) {}"),
+        Example("""
+        enum WalletItemType {
+            case visa
+            case mastercard
+        }
+        """),
+        Example("func chargeMastercard(_ card: Card) {}")
     ]
 
     static let triggeringExamples: [Example] = [
         Example("let ↓slave = \"abc\""),
         Example("""
-        enum ↓BlackList {
+        enum ↓Blacklist {
             case foo, bar
         }
         """),
-        Example("func ↓updateWhiteList(add: String) {}"),
+        Example("func ↓updateWhitelist(add: String) {}"),
+        Example("let ↓the_master_list = 123"),
         Example("""
         enum ListType {
             case ↓whitelist
@@ -54,18 +62,18 @@ internal struct InclusiveLanguageRuleExamples {
     static let triggeringExamplesWithConfig: [Example] = [
         Example("""
         enum Things {
-            case foo, ↓fizzBuzz
+            case foo, ↓fizzbuzzTest
         }
         """, configuration: [
             "additional_terms": ["fizzbuzz"]
         ]),
         Example("""
-        private func ↓thisIsASwiftyFunction() {}
+        private func ↓thisIsASwiftFunction() {}
         """, configuration: [
             "additional_terms": ["swift"]
         ]),
         Example("""
-        private var ↓fooBar = "abc"
+        private var ↓testFoobar = "abc"
         """, configuration: [
             "additional_terms": ["FoObAr"]
         ])

--- a/Tests/SwiftLintFrameworkTests/ExtendedStringTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtendedStringTests.swift
@@ -6,4 +6,32 @@ class ExtendedStringTests: XCTestCase {
         XCTAssertEqual("".countOccurrences(of: "a"), 0)
         XCTAssertEqual("\n\n".countOccurrences(of: "\n"), 2)
     }
+
+    func testComponentsSeparatedByCamelCase() {
+        XCTAssertEqual(
+            "camelCaseString".componentsSeparatedByCamelCase,
+            ["camel", "Case", "String"]
+        )
+        XCTAssertEqual(
+            "one".componentsSeparatedByCamelCase,
+            ["one"]
+        )
+        XCTAssertEqual(
+            "acronymAtEndABC".componentsSeparatedByCamelCase,
+            ["acronym", "At", "End", "ABC"]
+        )
+        XCTAssertEqual(
+            "acronymABCInMiddle".componentsSeparatedByCamelCase,
+            ["acronym", "ABC", "In", "Middle"]
+        )
+        XCTAssertEqual(
+            "CapitalAtStart".componentsSeparatedByCamelCase,
+            ["Capital", "At", "Start"]
+        )
+        XCTAssertEqual(
+            "stringWithASingleLetterWord".componentsSeparatedByCamelCase,
+            ["string", "With", "A", "Single", "Letter", "Word"]
+        )
+        XCTAssertEqual("".componentsSeparatedByCamelCase, [])
+    }
 }


### PR DESCRIPTION
This PR resolves #3415 

A noteworthy implication of this PR is that strings like `BlackList` and `whiteList` no longer trigger violations because these use camel case and are thus treated as separate terms.