### PR TITLE
Rename OverridenSuperCallConfiguration to fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   Defaults to `true`.  
   [Skoti](https://github.com/Skoti)
 
+* Renamed `OverridenSuperCallConfiguration` to
+  `OverriddenSuperCallConfiguration`.  
+  [Bryan Ricker](https://github.com/bricker)
+  [#3426](https://github.com/realm/SwiftLint/pull/3426)
+
 #### Experimental
 
 * None.

--- a/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 
 public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptInRule, AutomaticTestableRule {
-    public var configuration = OverridenSuperCallConfiguration()
+    public var configuration = OverriddenSuperCallConfiguration()
 
     public init() {}
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -1,4 +1,4 @@
-public struct OverridenSuperCallConfiguration: RuleConfiguration, Equatable {
+public struct OverriddenSuperCallConfiguration: RuleConfiguration, Equatable {
     private let defaultIncluded = [
         // NSObject
         "awakeFromNib()",

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -46,8 +46,8 @@ public struct OverriddenSuperCallConfiguration: RuleConfiguration, Equatable {
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription +
-            ", excluded: [\(excluded)]" +
-            ", included: [\(included)]"
+            ", excluded: \(excluded)" +
+            ", included: \(included)"
     }
 
     public mutating func apply(configuration: Any) throws {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1362,7 +1362,7 @@ extension RuleConfigurationTests {
         ("testTrailingWhitespaceConfigurationApplyConfigurationSetsIgnoresComments", testTrailingWhitespaceConfigurationApplyConfigurationSetsIgnoresComments),
         ("testTrailingWhitespaceConfigurationCompares", testTrailingWhitespaceConfigurationCompares),
         ("testTrailingWhitespaceConfigurationApplyConfigurationUpdatesSeverityConfiguration", testTrailingWhitespaceConfigurationApplyConfigurationUpdatesSeverityConfiguration),
-        ("testOverridenSuperCallConfigurationFromDictionary", testOverridenSuperCallConfigurationFromDictionary),
+        ("testOverriddenSuperCallConfigurationFromDictionary", testOverriddenSuperCallConfigurationFromDictionary),
         ("testModifierOrderConfigurationFromDictionary", testModifierOrderConfigurationFromDictionary),
         ("testModifierOrderConfigurationThrowsOnUnrecognizedModifierGroup", testModifierOrderConfigurationThrowsOnUnrecognizedModifierGroup),
         ("testModifierOrderConfigurationThrowsOnNonModifiableGroup", testModifierOrderConfigurationThrowsOnNonModifiableGroup),

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -274,8 +274,8 @@ class RuleConfigurationTests: XCTestCase {
         }
     }
 
-    func testOverridenSuperCallConfigurationFromDictionary() {
-        var configuration = OverridenSuperCallConfiguration()
+    func testOverriddenSuperCallConfigurationFromDictionary() {
+        var configuration = OverriddenSuperCallConfiguration()
         XCTAssertTrue(configuration.resolvedMethodNames.contains("viewWillAppear(_:)"))
 
         let conf1 = ["severity": "error", "excluded": "viewWillAppear(_:)"]


### PR DESCRIPTION
Renames `OverridenSuperCallConfiguration` to
`OverriddenSuperCallConfiguration`

BREAKING CHANGE: As `OverridenSuperCallConfiguration` is a
publicly-exposed struct, this rename should be considered breaking.