### PR TITLE
[WIP] New rule: Redundant Bool comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
   [Noah Gilmore](https://github.com/noahsark769)
   [#3233](https://github.com/realm/SwiftLint/issues/3233)
 
+* Add `redundant_bool_comparison` rule.  
+  [Artem Garmash](https://github.com/agarmash)
+  [#3420](https://github.com/realm/SwiftLint/issues/3420)
+
 #### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -142,6 +142,7 @@ public let primaryRuleList = RuleList(rules: [
     RawValueForCamelCasedCodableEnumRule.self,
     ReduceBooleanRule.self,
     ReduceIntoRule.self,
+    RedundantBoolComparisonRule.self,
     RedundantDiscardableLetRule.self,
     RedundantNilCoalescingRule.self,
     RedundantObjcAttributeRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -138,8 +138,8 @@ private extension SwiftLintFile {
         if indexEntity.shouldSkipIndexEntityToWorkAroundSR11985() ||
             indexEntity.isIndexEntitySwiftUIProvider() ||
             indexEntity.enclosedSwiftAttributes.contains(where: declarationAttributesToSkip.contains) ||
-            indexEntity.value["key.is_implicit"] as? Bool == true ||
-            indexEntity.value["key.is_test_candidate"] as? Bool == true {
+            indexEntity.value["key.is_implicit"] as? Bool ?? false ||
+            indexEntity.value["key.is_test_candidate"] as? Bool ?? false {
             return nil
         }
 

--- a/Source/SwiftLintFramework/Rules/Performance/RedundantBoolComparisonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/RedundantBoolComparisonRule.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SourceKittenFramework
+
+public struct RedundantBoolComparisonRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public init() {}
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public static let description = RuleDescription(
+        identifier: "redundant_bool_comparison",
+        name: "Redundant Bool Comparison",
+        description: """
+            The usage of `==` or `!=` operators for checking if the Bool value is `true` or `false` \
+            is discouraged in favor of using the Bool value itself or the one with negation operator
+            """,
+        kind: .performance,
+        nonTriggeringExamples: [
+            Example("""
+            var isEnabled = true
+            if isEnabled { /* do stuff */ }
+            """),
+            Example("""
+            let value = "true"
+            if value == "true" { /* do stuff */ }
+            """),
+            Example("""
+            var isEnabled = true
+            // check if isEnabled == true
+            if isEnabled { /* do stuff */ }
+            """),
+            Example("""
+            enum Success {
+                case `true`
+                case `false`
+            }
+
+            let success: Success = .true
+            if success == .true { /* do stuff */ }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+            var isEnabled = true
+            if isEnabled ↓== true { /* do stuff */ }
+            """),
+            Example("""
+            // don't forget the Yoda notation:
+            var isEnabled = true
+            if ↓true == isEnabled, isEnabled ↓== true { /* do stuff */ }
+            """),
+            Example("""
+            var isEnabled = true
+            if  ↓!true != isEnabled { /* do stuff */ }
+            """),
+            Example("""
+            var isEnabled = true
+            if isEnabled↓!=false { /* do stuff */ }
+            """),
+            Example("""
+            var isEnabled = true
+            if isEnabled ↓==       true { /* do stuff */ }
+            """),
+            Example("""
+            var isEnabled = true
+            if isEnabled ↓==
+
+
+                true { /* do stuff */ }
+            """),
+            Example("""
+            if ↓true == true { /* do stuff */ }
+            """)
+        ])
+
+    private let conditionExpressionKind = "source.lang.swift.structure.elem.condition_expr"
+
+    private let pattern =
+        "(=|!)=" +          // equal or not equal operator
+        "\\s*" +            // any number of whitespace characters
+        "!?(true|false)" +  // true or false with possible negating operator
+        "|" +               // and the same in reverse order, Yoda notation to cover
+        "!?(true|false)" +
+        "\\s*" +
+        "(=|!)="
+
+    public func validate(
+        file: SwiftLintFile,
+        kind: StatementKind,
+        dictionary: SourceKittenDictionary
+    ) -> [StyleViolation] {
+        guard kind == .if else { return [] }
+
+        let conditionExpressions = dictionary.elements.filter { $0.kind == conditionExpressionKind }
+
+        let totalViolations = conditionExpressions.flatMap { expression -> [StyleViolation] in
+            guard
+                let offset = expression.offset,
+                let lenght = expression.length
+            else {
+                return []
+            }
+
+            let byteRange = ByteRange(location: offset, length: lenght)
+            let range = file.stringView.byteRangeToNSRange(byteRange)
+            let matches = file.match(pattern: pattern, with: [.keyword], range: range)
+            let violations: [StyleViolation] = matches.map { match in
+                StyleViolation(
+                    ruleDescription: Self.description,
+                    severity: configuration.severity,
+                    location: Location(file: file, characterOffset: match.location))
+            }
+
+            return violations
+        }
+
+        return totalViolations
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -132,7 +132,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
                 )
             }
 
-            if linesValidationResult.first == true {
+            if let isFirstLineValid = linesValidationResult.first, isFirstLineValid {
                 // Reset previousLineIndentations to this line only
                 // if this line's indentation matches the last valid line's indentation (first in the array)
                 previousLineIndentations = [indentation]

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1233,6 +1233,12 @@ extension ReduceIntoRuleTests {
     ]
 }
 
+extension RedundantBoolComparisonRuleTests {
+    static var allTests: [(String, (RedundantBoolComparisonRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension RedundantDiscardableLetRuleTests {
     static var allTests: [(String, (RedundantDiscardableLetRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1903,6 +1909,7 @@ XCTMain([
     testCase(RawValueForCamelCasedCodableEnumRuleTests.allTests),
     testCase(ReduceBooleanRuleTests.allTests),
     testCase(ReduceIntoRuleTests.allTests),
+    testCase(RedundantBoolComparisonRuleTests.allTests),
     testCase(RedundantDiscardableLetRuleTests.allTests),
     testCase(RedundantNilCoalescingRuleTests.allTests),
     testCase(RedundantObjcAttributeRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -594,6 +594,12 @@ class ReduceIntoRuleTests: XCTestCase {
     }
 }
 
+class RedundantBoolComparisonRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RedundantBoolComparisonRule.description)
+    }
+}
+
 class RedundantDiscardableLetRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantDiscardableLetRule.description)


### PR DESCRIPTION
Implements the rule described in #3420.
I decided not to check if the value in the condition expression is optional Bool for the following reasons:
* the optional Bool case is already covered in `discouraged_optional_boolean`;
* it's not possible to easily check types of operands in the expression, so I decided that it doesn't worth additional time and effort.

Resolves #3420