### PR TITLE
Add support for testing Examples with configuration

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -93,6 +93,9 @@ struct UnusedDeclarationRuleExamples {
         }
         """),
         Example("""
+        public func ↓foo() {}
+        """, configuration: ["include_public_and_open": true]),
+        Example("""
         protocol Foo {
             func ↓bar1()
         }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRuleExamples.swift
@@ -56,13 +56,7 @@ struct UnusedImportRuleExamples {
         ↓import Foundation
         import UnknownModule
         func foo(error: Swift.Error) {}
-        """),
-        Example("""
-        ↓import Foundation
-        typealias Foo = CFData
-        """, configuration: [
-            "require_explicit_imports": true
-        ])
+        """)
     ]
 
     static let corrections = [

--- a/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -17,6 +17,7 @@ public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationPro
             Example("public let kFoo = false"),
             Example("internal let kFoo = \"Foo\""),
             Example("let kFoo = true"),
+            Example("let Foo = true", configuration: ["only_private": true]),
             Example("struct Foo {\n" +
             "   let bar = 20.0\n" +
             "}"),

--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -41,9 +41,21 @@ extension String {
 
 let allRuleIdentifiers = Array(primaryRuleList.list.keys)
 
-func violations(_ example: Example, config: Configuration = Configuration()!,
+extension Configuration {
+    func applyingConfiguration(from example: Example) -> Configuration {
+        guard let exampleConfiguration = example.configuration,
+           case let .only(onlyRules) = self.rulesMode,
+           let firstRule = onlyRules.first,
+           case let configDict = ["only_rules": onlyRules, firstRule: exampleConfiguration],
+           let typedConfiguration = Configuration(dict: configDict) else { return self }
+        return merge(with: typedConfiguration)
+    }
+}
+
+func violations(_ example: Example, config inputConfig: Configuration = Configuration()!,
                 requiresFileOnDisk: Bool = false) -> [StyleViolation] {
     SwiftLintFile.clearCaches()
+    let config = inputConfig.applyingConfiguration(from: example)
     let stringStrippingMarkers = example.removingViolationMarkers()
     guard requiresFileOnDisk else {
         let file = SwiftLintFile(contents: stringStrippingMarkers.code)


### PR DESCRIPTION
This was extracting from another change that no longer needed it. It
should be helpful for anyone testing custom configuration with their
non-analyzer rules.

I added a random example of something that wasn't previously tested as
an example.