### PR TITLE
Remove @IBOutlet and @IBInspectable from UnusedDeclarationRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,9 @@
 
 #### Bug Fixes
 
-* None.
+* Remove `@IBOutlet` and `@IBInspectable` from UnusedDeclarationRule.  
+  [Keith Smiley](https://github.com/keith)
+  [#3184](https://github.com/realm/SwiftLint/issues/3184)
 
 ## 0.41.0: World’s Cleanest Voting Booth
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -268,8 +268,6 @@ private let declarationKindsToSkip: Set<SwiftDeclarationKind> = [
 
 private let declarationAttributesToSkip: Set<SwiftDeclarationAttributeKind> = [
     .ibaction,
-    .ibinspectable,
-    .iboutlet,
     .main,
     .nsApplicationMain,
     .override,

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -123,6 +123,20 @@ struct UnusedDeclarationRuleExamples {
             func applicationWillFinishLaunching(_ notification: Notification) {}
             func applicationWillBecomeActive(_ notification: Notification) {}
         }
+        """),
+        Example("""
+        import Foundation
+
+        public final class Foo: NSObject {
+            @IBAction private func foo() {}
+        }
+        """),
+        Example("""
+        import Foundation
+
+        public final class Foo: NSObject {
+            @objc func foo() {}
+        }
         """)
     ]
 
@@ -142,6 +156,20 @@ struct UnusedDeclarationRuleExamples {
         final class ↓AppDelegate: NSObject, NSApplicationDelegate {
             func applicationWillFinishLaunching(_ notification: Notification) {}
             func applicationWillBecomeActive(_ notification: Notification) {}
+        }
+        """),
+        Example("""
+        import Foundation
+
+        public final class Foo: NSObject {
+            @IBOutlet var ↓bar: NSObject!
+        }
+        """),
+        Example("""
+        import Foundation
+
+        public final class Foo: NSObject {
+            @IBInspectable var ↓bar: String!
         }
         """)
     ]


### PR DESCRIPTION
The original implementation wasn't tested so it regressed.

https://github.com/realm/SwiftLint/pull/3184