### PR TITLE
Use `-static-stdlib` on building Linux binary for release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ portable_zip: installables
 
 zip_linux:
 	$(eval TMP_FOLDER := $(shell mktemp -d))
-	docker run -v `pwd`:`pwd` -w `pwd` --rm swift:latest swift build -c release
+	docker run -v `pwd`:`pwd` -w `pwd` --rm swift:latest sh -c 'apt-get update && apt-get install -y libxml2-dev && swift build -c release -Xswiftc -static-stdlib'
 	mv .build/release/swiftlint "$(TMP_FOLDER)"
 	cp -f "$(LICENSE_PATH)" "$(TMP_FOLDER)"
 	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "LICENSE") > "./swiftlint_linux.zip"


### PR DESCRIPTION
This change prevents `swiftlint` from having links to shared libraries belonging to `/usr/lib/swift`.
```
$ docker run -v$PWD:$PWD -w$PWD --rm swift sh -c 'ldd $(swift build -c release --show-bin-path)/swiftlint'
	linux-vdso.so.1 (0x00007ffee8bb8000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f75e750b000)
	libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007f75e7308000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f75e7104000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f75e6d66000)
	libxml2.so.2 => /usr/lib/x86_64-linux-gnu/libxml2.so.2 (0x00007f75e69a5000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f75e661c000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f75e6404000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f75e6013000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f75ea7bf000)
	libicuuc.so.60 => /usr/lib/x86_64-linux-gnu/libicuuc.so.60 (0x00007f75e5c5b000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f75e5a3e000)
	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007f75e5818000)
	libicudata.so.60 => /usr/lib/x86_64-linux-gnu/libicudata.so.60 (0x00007f75e3c6f000)
```
I confirmed that `swiftlint` produced by `make zip_linux` works with following docker images:
- swift:5.3.1-xenial
- swift:5.3.1-bionic
- swift:5.3.1-focal
- swift:5.3.1-centos8
- swift:5.3.1-amazonlinux2
- norionomura/swift:5.3.1
- norionomura/swift:5.3.0
- norionomura/swift:5.2.5
- norionomura/swift:5.1.5
- norionomura/swift:5.0.3