### PR TITLE
Fix false positives in inclusive_language rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,11 +72,14 @@
 * Add `non_private_xctest_member` rule.  
   [Keith Smiley](https://github.com/keith)
 
-#### Bug Fixes
-
-* Fix false positives in `inclusive_language` rule.  
+* Add an `override_allowed_terms` configuration parameter to the
+  `inclusive_language` rule, with a default value of `mastercard`.  
   [Dalton Claybrook](https://github.com/daltonclaybrook)
   [#3415](https://github.com/realm/SwiftLint/issues/3415)
+
+#### Bug Fixes
+
+* None.
 
 ## 0.41.0: World’s Cleanest Voting Booth
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix false positives in `inclusive_language` rule.  
+  [Dalton Claybrook](https://github.com/daltonclaybrook)
+  [#3415](https://github.com/realm/SwiftLint/issues/3415)
 
 ## 0.41.0: World’s Cleanest Voting Booth
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -2,18 +2,22 @@ private enum ConfigurationKey: String {
     case severity
     case additionalTerms = "additional_terms"
     case overrideTerms = "override_terms"
+    case overrideAllowedTerms = "override_allowed_terms"
 }
 
 public struct InclusiveLanguageConfiguration: RuleConfiguration, Equatable {
     public var severityConfiguration = SeverityConfiguration(.warning)
     public var additionalTerms: Set<String>?
     public var overrideTerms: Set<String>?
+    public var overrideAllowedTerms: Set<String>?
     public var allTerms: Set<String>
+    public var allAllowedTerms: Set<String>
 
     public var consoleDescription: String {
         severityConfiguration.consoleDescription
             + ", additional_terms: \(additionalTerms?.sorted() ?? [])"
             + ", override_terms: \(overrideTerms?.sorted() ?? [])"
+            + ", override_allowed_terms: \(overrideAllowedTerms?.sorted() ?? [])"
     }
 
     public var severity: ViolationSeverity {
@@ -27,8 +31,13 @@ public struct InclusiveLanguageConfiguration: RuleConfiguration, Equatable {
         "slave"
     ]
 
+    private let defaultAllowedTerms: Set<String> = [
+        "mastercard"
+    ]
+
     public init() {
         self.allTerms = defaultTerms
+        self.allAllowedTerms = defaultAllowedTerms
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -42,9 +51,11 @@ public struct InclusiveLanguageConfiguration: RuleConfiguration, Equatable {
 
         additionalTerms = lowercasedSet(for: .additionalTerms, from: configuration)
         overrideTerms = lowercasedSet(for: .overrideTerms, from: configuration)
+        overrideAllowedTerms = lowercasedSet(for: .overrideAllowedTerms, from: configuration)
 
         allTerms = overrideTerms ?? defaultTerms
         allTerms.formUnion(additionalTerms ?? [])
+        allAllowedTerms = overrideAllowedTerms ?? defaultAllowedTerms
     }
 
     private func lowercasedSet(for key: ConfigurationKey, from config: [String: Any]) -> Set<String>? {

--- a/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRule.swift
@@ -25,7 +25,16 @@ public struct InclusiveLanguageRule: ASTRule, ConfigurationProviderRule {
             else { return [] }
 
         let lowercased = name.lowercased()
-        guard let term = configuration.allTerms.first(where: lowercased.contains) else {
+        let violationTerm = configuration.allTerms.first { term in
+            guard let range = lowercased.range(of: term) else { return false }
+            let overlapsAllowedTerm = configuration.allAllowedTerms.contains { allowedTerm in
+                guard let allowedRange = lowercased.range(of: allowedTerm) else { return false }
+                return range.overlaps(allowedRange)
+            }
+            return !overlapsAllowedTerm
+        }
+
+        guard let term = violationTerm else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRuleExamples.swift
@@ -8,7 +8,14 @@ internal struct InclusiveLanguageRuleExamples {
             case foo, bar
         }
         """),
-        Example("func updateAllowList(add: String) {}")
+        Example("func updateAllowList(add: String) {}"),
+        Example("""
+        enum WalletItemType {
+            case visa
+            case mastercard
+        }
+        """),
+        Example("func chargeMasterCard(_ card: Card) {}")
     ]
 
     static let triggeringExamples: [Example] = [


### PR DESCRIPTION
This PR resolves #3415 by adding "allowed terms" to the rule configuration. If a disallowed term is found to overlap with an allowed term, the allowed term "wins." The only default allowed term at the moment is "mastercard"