### PR TITLE
Fix type_contents_order rule treats methods starting with init like initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,8 @@ Improve documentation for multiple configuration files.
 
 #### Bug Fixes
 
-* None.
+* Fix methods starting `init` are treated like initializers.  
+  [rabbitinspace](https://github.com/rabbitinspace)
 
 ## 0.41.0: World’s Cleanest Voting Booth
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,8 @@ Improve documentation for multiple configuration files.
 
 #### Bug Fixes
 
-* Fix methods starting `init` are treated like initializers.  
+* Fix methods starting with `init` are always treated like initializers
+  (`type_contents_order`).  
   [rabbitinspace](https://github.com/rabbitinspace)
 
 ## 0.41.0: World’s Cleanest Voting Booth

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -121,7 +121,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 "viewDidDisappear("
             ]
 
-            if typeContentStructure.name!.starts(with: "init") {
+            if typeContentStructure.name!.starts(with: "init(") {
                 return .initializer
             } else if typeContentStructure.name!.starts(with: "deinit") {
                 return .deinitializer

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -121,14 +121,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 "viewDidDisappear("
             ]
 
-            let initMethodNames = [
-                "init(",
-                "init<",
-                "init?",
-                "init!"
-            ]
-
-            if initMethodNames.contains(where: { typeContentStructure.name!.starts(with: $0) }) {
+            if isInitializer(typeContentStructure.name!) {
                 return .initializer
             } else if typeContentStructure.name!.starts(with: "deinit") {
                 return .deinitializer
@@ -146,5 +139,14 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
         default:
             return nil
         }
+    }
+
+    private func isInitializer(_ name: String) -> Bool {
+        guard name.starts(with: "init") && name.count > 4 else {
+            return false
+        }
+
+        let next = name[name.index(name.startIndex, offsetBy: 4)]
+        return next == "(" || next == "<" || next == "?" || next == "!" || next.isWhitespace
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -147,6 +147,6 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
         }
 
         let next = name[name.index(name.startIndex, offsetBy: 4)]
-        return next == "(" || next == "<" || next == "?" || next == "!" || next.isWhitespace
+        return next == "(" || next == "<" || next == "?" || next == "!"
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -121,7 +121,14 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 "viewDidDisappear("
             ]
 
-            if typeContentStructure.name!.starts(with: "init(") {
+            let initMethodNames = [
+                "init(",
+                "init<",
+                "init?",
+                "init!"
+            ]
+
+            if initMethodNames.contains(where: { typeContentStructure.name!.starts(with: $0) }) {
                 return .initializer
             } else if typeContentStructure.name!.starts(with: "deinit") {
                 return .deinitializer

--- a/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintFramework
 import XCTest
 
-// swiftlint:disable function_body_length type_body_length
+// swiftlint:disable function_body_length type_body_length file_length
 class TypeContentsOrderRuleTests: XCTestCase {
     func testTypeContentsOrderWithDefaultConfiguration() {
         verifyRule(TypeContentsOrderRule.description)
@@ -362,6 +362,39 @@ class TypeContentsOrderRuleTests: XCTestCase {
 
                 func initSelf() { }
             }
+            """),
+            Example("""
+            class TestClass {
+                init?() { return nil }
+
+                static func make() -> Self {
+                    return TestClass()
+                }
+
+                func initSelf() { }
+            }
+            """),
+            Example("""
+            class TestClass {
+                init!() { return nil }
+
+                static func make() -> Self {
+                    return TestClass()
+                }
+
+                func initSelf() { }
+            }
+            """),
+            Example("""
+            class TestClass {
+                init<T: Hashable>(t: T) { print(t.hashValue) }
+
+                static func make() -> Self {
+                    return TestClass()
+                }
+
+                func initSelf() { }
+            }
             """)
         ]
 
@@ -370,11 +403,38 @@ class TypeContentsOrderRuleTests: XCTestCase {
             class TestClass {
                 init() {}
 
-                func initSelf() { }
+                ↓func initSelf() { }
 
                 static func make() -> Self {
                     return TestClass()
                 }
+            }
+            """),
+            Example("""
+            class TestClass {
+                init() {}
+
+                ↓func initSelf() { }
+
+                init?() { return nil }
+            }
+            """),
+            Example("""
+            class TestClass {
+                init() {}
+
+                ↓func initSelf() { }
+
+                init!() { return nil }
+            }
+            """),
+            Example("""
+            class TestClass {
+                init() {}
+
+                ↓func initSelf() { }
+
+                init<T: Hashable>(t: T) { print(t.hashValue) }
             }
             """)
         ]

--- a/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
@@ -349,4 +349,49 @@ class TypeContentsOrderRuleTests: XCTestCase {
             ]
         )
     }
+
+    func testTypeContentsOrderInitDetection() {
+        let nonTriggeringExamples = [
+            Example("""
+            class TestClass {
+                init() {}
+
+                static func make() -> Self {
+                    return TestClass()
+                }
+
+                func initSelf() { }
+            }
+            """)
+        ]
+
+        let triggeringExamples = [
+            Example("""
+            class TestClass {
+                init() {}
+
+                func initSelf() { }
+
+                static func make() -> Self {
+                    return TestClass()
+                }
+            }
+            """)
+        ]
+
+        let groupedOrderDescription = TypeContentsOrderRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+
+        verifyRule(
+            groupedOrderDescription,
+            ruleConfiguration: [
+                "order": [
+                    ["initializer", "deinitializer"],
+                    ["type_method"],
+                    ["other_method"]
+                ]
+            ]
+        )
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
@@ -436,6 +436,15 @@ class TypeContentsOrderRuleTests: XCTestCase {
 
                 init<T: Hashable>(t: T) { print(t.hashValue) }
             }
+            """),
+            Example("""
+            class TestClass {
+                init() {}
+
+                ↓func initSelf() { }
+
+                init    () {}
+            }
             """)
         ]
 


### PR DESCRIPTION
When `type_contents_order` rule sees a method like `init.+(...)` it thinks that it's a `TypeContent.initializer` instead of `TypeContent.otherMethod` because of the `starts(with: "init")` check. Instead, we need to compare it with one of the following strings: `"init("`, `"init<"`, `"init?"` or `"init!"`, as per [language reference](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_initializer-declaration) to make the correct decision. 

I think there's the same issue with the `deinit` check, but I didn't touch it in this PR. 