### PR TITLE
Add option to configure SortedImportsRule to sort @testable imports on the top or on the bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@
 
 #### Experimental
 
-* None.
+* Add option to configure SortedImportsRule to sort `@testable` imports on
+  the top or on the bottom of the imports.  
+  [MaxHaertwig](https://github.com/maxhaertwig)
 
 #### Enhancements
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -1,0 +1,27 @@
+public struct SortedImportsConfiguration: RuleConfiguration, Equatable {
+    enum TestableImportsConfiguration: String {
+        case `default`, top, bottom
+    }
+
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var testableImportsConfiguration = TestableImportsConfiguration.default
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription + ", testable_imports: \(testableImportsConfiguration.rawValue)"
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let testableImportsConfigString = configuration["testable_imports"] as? String,
+            let testableImportsConfig = TestableImportsConfiguration(rawValue: testableImportsConfigString) {
+            testableImportsConfiguration = testableImportsConfig
+        }
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1433,7 +1433,9 @@ extension SortedFirstLastRuleTests {
 
 extension SortedImportsRuleTests {
     static var allTests: [(String, (SortedImportsRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration),
+        ("testWithTestableImportsTop", testWithTestableImportsTop),
+        ("testWithTestableImportsBottom", testWithTestableImportsBottom)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -678,12 +678,6 @@ class SortedFirstLastRuleTests: XCTestCase {
     }
 }
 
-class SortedImportsRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(SortedImportsRule.description)
-    }
-}
-
 class StaticOperatorRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StaticOperatorRule.description)

--- a/Tests/SwiftLintFrameworkTests/SortedImportsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SortedImportsRuleTests.swift
@@ -1,0 +1,59 @@
+import SwiftLintFramework
+import XCTest
+
+class SortedImportsRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(SortedImportsRule.description, commentDoesntViolate: true,
+                   testMultiByteOffsets: false, testShebang: false)
+    }
+
+    func testWithTestableImportsTop() {
+        let triggeringExamples = [
+            Example("import AAA\nimport BBB\n@testable import CCC\nimport DDD"),
+            Example("@testable import BBB\n@testable import AAA\nimport CCC\nimport DDD")
+        ]
+        let nonTriggeringExamples = [
+            Example("@testable import CCC\nimport AAA\nimport BBB\nimport DDD"),
+            Example("@testable import AAA\n@testable import BBB\nimport CCC\nimport DDD")
+        ]
+        let corrections = [
+            Example("import AAA\nimport BBB\n@testable import CCC\nimport DDD"):
+                Example("@testable import CCC\nimport AAA\nimport BBB\nimport DDD"),
+            Example("@testable import BBB\n@testable import AAA\nimport CCC\nimport DDD"):
+                Example("@testable import AAA\n@testable import BBB\nimport CCC\nimport DDD")
+        ]
+
+        let description = SortedImportsRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: corrections)
+
+        verifyRule(description, ruleConfiguration: ["testable_imports": "top"],
+                   testMultiByteOffsets: false, testShebang: false)
+    }
+
+    func testWithTestableImportsBottom() {
+        let triggeringExamples = [
+            Example("import AAA\nimport BBB\n@testable import CCC\nimport DDD"),
+            Example("import CCC\nimport DDD\n@testable import BBB\n@testable import AAA")
+        ]
+        let nonTriggeringExamples = [
+            Example("import AAA\nimport BBB\nimport DDD\n@testable import CCC"),
+            Example("import CCC\nimport DDD\n@testable import AAA\n@testable import BBB")
+        ]
+        let corrections = [
+            Example("import AAA\nimport BBB\n@testable import CCC\nimport DDD"):
+                Example("import AAA\nimport BBB\nimport DDD\n@testable import CCC"),
+            Example("import CCC\nimport DDD\n@testable import BBB\n@testable import AAA"):
+                Example("import CCC\nimport DDD\n@testable import AAA\n@testable import BBB")
+        ]
+
+        let description = SortedImportsRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: corrections)
+
+        verifyRule(description, ruleConfiguration: ["testable_imports": "bottom"],
+                   testMultiByteOffsets: false, testShebang: false)
+    }
+}


### PR DESCRIPTION
Hi :)

What do you think about this configuration option? I'm open to rename the options `top` and `bottom` to `first` and `last`.