### PR TITLE
Fix logging linting the current working directory

### DIFF
--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -211,7 +211,7 @@ extension Configuration {
         }
         if !visitor.quiet {
             let filesInfo: String
-            if visitor.paths.isEmpty {
+            if visitor.paths.isEmpty || visitor.paths.first == "" {
                 filesInfo = "in current working directory"
             } else {
                 filesInfo = "at paths \(visitor.paths.joined(separator: ", "))"

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -211,7 +211,7 @@ extension Configuration {
         }
         if !visitor.quiet {
             let filesInfo: String
-            if visitor.paths.isEmpty || visitor.paths.first == "" {
+            if visitor.paths.isEmpty || visitor.paths[0].isEmpty {
                 filesInfo = "in current working directory"
             } else {
                 filesInfo = "at paths \(visitor.paths.joined(separator: ", "))"

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -211,7 +211,7 @@ extension Configuration {
         }
         if !visitor.quiet {
             let filesInfo: String
-            if visitor.paths.isEmpty || visitor.paths[0].isEmpty {
+            if visitor.paths.isEmpty || visitor.paths == [""] {
                 filesInfo = "in current working directory"
             } else {
                 filesInfo = "at paths \(visitor.paths.joined(separator: ", "))"


### PR DESCRIPTION
Fixes log messages saying `Linting files at path ''` that should have said `Linting files in current working directory`.