### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!Source
+!Tests
+!Package.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Explicitly specify `bionic` because `swift:latest` does not use `ubuntu:latest`.
+ARG BUILDER_IMAGE=swift:bionic
+ARG RUNTIME_IMAGE=ubuntu:bionic
+
+# builder image
+FROM ${BUILDER_IMAGE} AS builder
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+    libxml2-dev \
+ && rm -r /var/lib/apt/lists/*
+WORKDIR /workdir/
+COPY Source Source/
+COPY Tests Tests/
+COPY Package.* ./
+
+ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib"
+RUN swift build $SWIFT_FLAGS
+RUN mkdir -p /executables
+RUN for executable in $(swift package completion-tool list-executables); do \
+        install -v `swift build $SWIFT_FLAGS --show-bin-path`/$executable /executables; \
+    done
+
+# runtime image
+FROM ${RUNTIME_IMAGE}
+LABEL org.opencontainers.image.source https://github.com/realm/SwiftLint
+RUN apt-get update && apt-get install -y \
+    libcurl4 \
+    libxml2 \
+ && rm -r /var/lib/apt/lists/*
+COPY --from=builder /usr/lib/libsourcekitdInProc.so /usr/lib
+COPY --from=builder /usr/lib/swift/linux/libBlocksRuntime.so /usr/lib
+COPY --from=builder /usr/lib/swift/linux/libdispatch.so /usr/lib
+COPY --from=builder /executables/* /usr/bin
+
+RUN swiftlint version
+
+CMD ["swiftlint"]

--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,10 @@ portable_zip: installables
 	cp -f "$(LICENSE_PATH)" "$(TEMPORARY_FOLDER)"
 	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "swiftlint" "LICENSE") > "./portable_swiftlint.zip"
 
-zip_linux:
+zip_linux: docker_image
 	$(eval TMP_FOLDER := $(shell mktemp -d))
-	docker run -v `pwd`:`pwd` -w `pwd` --rm swift:latest sh -c 'apt-get update && apt-get install -y libxml2-dev && swift build -c release -Xswiftc -static-stdlib'
-	mv .build/release/swiftlint "$(TMP_FOLDER)"
+	docker run swiftlint cat /usr/bin/swiftlint > "$(TMP_FOLDER)/swiftlint"
+	chmod +x "$(TMP_FOLDER)/swiftlint"
 	cp -f "$(LICENSE_PATH)" "$(TMP_FOLDER)"
 	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "LICENSE") > "./swiftlint_linux.zip"
 
@@ -121,6 +121,9 @@ package: installables
 		"$(OUTPUT_PACKAGE)"
 
 release: package portable_zip zip_linux
+
+docker_image:
+	docker build --force-rm --tag swiftlint .
 
 docker_test:
 	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm swift:5.3 swift test --parallel


### PR DESCRIPTION
- providing a runtime environment on ubuntu that does not include the Swift toolchain.
- supportintg `docker build https://github.com/realm/SwiftLint.git`
- adding `libcurl4-openssl-dev` as build time dependency that introduced by #3058
- move the build-time dependency information from `Makefile` to `Dockerfile`.