### PR TITLE
Fix @IBInspectable unused declarations with get/set

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -138,8 +138,15 @@ private extension SwiftLintFile {
         if indexEntity.shouldSkipIndexEntityToWorkAroundSR11985() ||
             indexEntity.isIndexEntitySwiftUIProvider() ||
             indexEntity.enclosedSwiftAttributes.contains(where: declarationAttributesToSkip.contains) ||
-            indexEntity.value["key.is_implicit"] as? Bool == true ||
+            indexEntity.isImplicit ||
             indexEntity.value["key.is_test_candidate"] as? Bool == true {
+            return nil
+        }
+
+        if indexEntity.enclosedSwiftAttributes.contains(.ibinspectable),
+           let getter = indexEntity.entities.first(where: { $0.declarationKind == .functionAccessorGetter }),
+           let setter = indexEntity.entities.first(where: { $0.declarationKind == .functionAccessorSetter }),
+           !getter.isImplicit, !setter.isImplicit {
             return nil
         }
 
@@ -205,6 +212,10 @@ private extension SourceKittenDictionary {
 
     var annotatedDeclaration: String? {
         return value["key.annotated_decl"] as? String
+    }
+
+    var isImplicit: Bool {
+        return value["key.is_implicit"] as? Bool == true
     }
 
     func aclAtOffset(_ offset: ByteCount) -> AccessControlLevel? {

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -140,6 +140,16 @@ struct UnusedDeclarationRuleExamples {
         public final class Foo: NSObject {
             @objc func foo() {}
         }
+        """),
+        Example("""
+        import Foundation
+
+        public final class Foo: NSObject {
+            @IBInspectable private var innerPaddingWidth: Int {
+                set { self.backgroundView.innerPaddingWidth = newValue }
+                get { return self.backgroundView.innerPaddingWidth }
+            }
+        }
         """)
     ]
 


### PR DESCRIPTION
This fixes an issue where `@IBInspectables` that have both a custom
getter and setter were marked as dead if they weren't referenced in code
even though in that case they can still have behavior if they are used
from IB.