### PR TITLE
Don't log a warning if no configuration files were explicitly specified

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "138cf1b701cf825233b92ceac919152d5aba8a3f",
-          "version": "4.0.1"
+          "revision": "88caa2e6fffdbef2e91c2022d038576062042907",
+          "version": "4.0.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "88caa2e6fffdbef2e91c2022d038576062042907",
-          "version": "4.0.0"
+          "revision": "138cf1b701cf825233b92ceac919152d5aba8a3f",
+          "version": "4.0.1"
         }
       }
     ]

--- a/Source/SwiftLintFramework/Extensions/Configuration+FileGraph.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+FileGraph.swift
@@ -117,7 +117,8 @@ internal extension Configuration {
                 : Configuration.Key.parentConfig.rawValue
 
             if let reference = vertix.configurationDict[key] as? String {
-                let referencedVertix = Vertix(string: reference, rootDirectory: vertix.rootDirectory, isInitialVertix: false)
+                let referencedVertix = Vertix(string: reference, rootDirectory: vertix.rootDirectory,
+                                              isInitialVertix: false)
 
                 // Local vertices are allowed to have local / remote references
                 // Remote vertices are only allowed to have remote references

--- a/Source/SwiftLintFramework/Extensions/Configuration+FileGraph.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+FileGraph.swift
@@ -17,7 +17,9 @@ internal extension Configuration {
 
         // MARK: - Initializers
         internal init(commandLineChildConfigs: [String], rootDirectory: String, ignoreParentAndChildConfigs: Bool) {
-            let verticesArray = commandLineChildConfigs.map { Vertix(string: $0, rootDirectory: rootDirectory) }
+            let verticesArray = commandLineChildConfigs.map { config in
+                Vertix(string: config, rootDirectory: rootDirectory, isInitialVertix: true)
+            }
             vertices = Set(verticesArray)
             edges = Set(zip(verticesArray, verticesArray.dropFirst()).map { Edge(parent: $0.0, child: $0.1) })
 
@@ -115,7 +117,7 @@ internal extension Configuration {
                 : Configuration.Key.parentConfig.rawValue
 
             if let reference = vertix.configurationDict[key] as? String {
-                let referencedVertix = Vertix(string: reference, rootDirectory: vertix.rootDirectory)
+                let referencedVertix = Vertix(string: reference, rootDirectory: vertix.rootDirectory, isInitialVertix: false)
 
                 // Local vertices are allowed to have local / remote references
                 // Remote vertices are only allowed to have remote references

--- a/Source/SwiftLintFramework/Extensions/Configuration+FileGraphSubtypes.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+FileGraphSubtypes.swift
@@ -72,7 +72,7 @@ internal extension Configuration.FileGraph {
 
         private func read(at path: String) throws -> String {
             guard !path.isEmpty && FileManager.default.fileExists(atPath: path) else {
-                throw ConfigurationError.fileNotFound(path: path)
+                throw ConfigurationError.generic("File \(path) can't be found.")
             }
 
             return try String(contentsOfFile: path, encoding: .utf8)

--- a/Source/SwiftLintFramework/Extensions/Configuration+FileGraphSubtypes.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+FileGraphSubtypes.swift
@@ -72,7 +72,7 @@ internal extension Configuration.FileGraph {
 
         private func read(at path: String) throws -> String {
             guard !path.isEmpty && FileManager.default.fileExists(atPath: path) else {
-                throw ConfigurationError.generic("File \(path) can't be found.")
+                throw ConfigurationError.fileNotFound(path: path)
             }
 
             return try String(contentsOfFile: path, encoding: .utf8)

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -274,7 +274,7 @@ extension Configuration: CustomStringConvertible {
             + "- Indentation Style: \(indentation)\n"
             + "- Included Paths: \(includedPaths)\n"
             + "- Excluded Paths: \(excludedPaths)\n"
-            + "- Warning Treshold: \(warningThreshold as Optional)\n"
+            + "- Warning Threshold: \(warningThreshold as Optional)\n"
             + "- Root Directory: \(rootDirectory as Optional)\n"
             + "- Reporter: \(reporter)\n"
             + "- Cache Path: \(cachePath as Optional)\n"

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -219,7 +219,7 @@ public struct Configuration {
             )
             switch initializationResult {
             case .initialImplicitFileNotFound:
-                // Silently back to default
+                // Silently fall back to default
                 self.init(rulesMode: rulesMode, cachePath: cachePath)
                 return
             case .error(let message):

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -215,12 +215,19 @@ public struct Configuration {
         } catch {
             let errorString: String
             switch error {
+            case let ConfigurationError.fileNotFound(path: path):
+                if hasCustomConfigurationFiles {
+                    errorString = "Configuration file not found at path: \(path)"
+                } else {
+                    // Not an error, the user didn't specify a configuration file and none was found at the
+                    // default location. Use default configuration.
+                    self.init(rulesMode: rulesMode, cachePath: cachePath)
+                    return
+                }
             case let ConfigurationError.generic(message):
                 errorString = "SwiftLint Configuration Error: \(message)"
-
             case let YamlParserError.yamlParsing(message):
                 errorString = "YML Parsing Error: \(message)"
-
             default:
                 errorString = "Unknown Error"
             }

--- a/Source/SwiftLintFramework/Models/ConfigurationError.swift
+++ b/Source/SwiftLintFramework/Models/ConfigurationError.swift
@@ -8,7 +8,4 @@ public enum ConfigurationError: Error, Equatable {
 
     /// A generic configuration error specified by a string.
     case generic(String)
-
-    /// An error for a configuration file that was not found on disk.
-    case fileNotFound(path: String)
 }

--- a/Source/SwiftLintFramework/Models/ConfigurationError.swift
+++ b/Source/SwiftLintFramework/Models/ConfigurationError.swift
@@ -8,4 +8,7 @@ public enum ConfigurationError: Error, Equatable {
 
     /// A generic configuration error specified by a string.
     case generic(String)
+
+    /// The initial configuration file was not found.
+    case initialFileNotFound(path: String)
 }

--- a/Source/SwiftLintFramework/Models/ConfigurationError.swift
+++ b/Source/SwiftLintFramework/Models/ConfigurationError.swift
@@ -8,4 +8,7 @@ public enum ConfigurationError: Error, Equatable {
 
     /// A generic configuration error specified by a string.
     case generic(String)
+
+    /// An error for a configuration file that was not found on disk.
+    case fileNotFound(path: String)
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -203,7 +203,7 @@ extension ConfigurationTests {
 
             // If the cycle is properly detected, the config should equal the default config.
             XCTAssertEqual(
-                Configuration(configurationFiles: []), // not specifiying a file means the .swiftlint.yml will be used
+                Configuration(configurationFiles: []), // not specifying a file means the .swiftlint.yml will be used
                 Configuration()
             )
         }


### PR DESCRIPTION
And none was found at the default location of `.swiftlint.yml`.