### PR TITLE
Replace non_private_xctest_member with test_case_accessibility

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -41,7 +41,6 @@ opt_in_rules:
   - lower_acl_than_parent
   - modifier_order
   - nimble_operator
-  - non_private_xctest_member
   - nslocalizedstring_key
   - number_separator
   - object_literal
@@ -65,6 +64,7 @@ opt_in_rules:
   - sorted_imports
   - static_operator
   - strong_iboutlet
+  - test_case_accessibility
   - toggle_bool
   - unavailable_function
   - unneeded_parentheses_in_closure_argument

--- a/Tests/SwiftLintFrameworkTests/ConfigurationAliasesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationAliasesTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class ConfigurationAliasesTests: XCTestCase {
-    let testRuleList = RuleList(rules: RuleWithLevelsMock.self)
+    private let testRuleList = RuleList(rules: RuleWithLevelsMock.self)
 
     func testConfiguresCorrectlyFromDeprecatedAlias() throws {
         let ruleConfiguration = [1, 2]

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -298,7 +298,7 @@ class ConfigurationTests: XCTestCase {
 
     // MARK: - Testing Rules from config dictionary
 
-    let testRuleList = RuleList(rules: RuleWithLevelsMock.self)
+    private let testRuleList = RuleList(rules: RuleWithLevelsMock.self)
 
     func testConfiguresCorrectlyFromDict() throws {
         let ruleConfiguration = [1, 2]


### PR DESCRIPTION
in `.swiftlint.yml`.