### PR TITLE
Fix typos in configuration options for file_name rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 
 #### Experimental
 
-* None.
+* Fix typos in configuration options for `file_name` rule.  
+  [advantis](https://github.com/advantis)
 
 #### Enhancements
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -2,9 +2,9 @@ public struct FileNameConfiguration: RuleConfiguration, Equatable {
     public var consoleDescription: String {
         return "(severity) \(severity.consoleDescription), " +
             "excluded: \(excluded.sorted()), " +
-            "prefixPattern: \(prefixPattern), " +
-            "suffixPattern: \(suffixPattern), " +
-            "nestedTypeSeparator: \(nestedTypeSeparator)"
+            "prefix_pattern: \(prefixPattern), " +
+            "suffix_pattern: \(suffixPattern), " +
+            "nested_type_separator: \(nestedTypeSeparator)"
     }
 
     public private(set) var severity: SeverityConfiguration


### PR DESCRIPTION
I was wondering why it doesn't work. It turns out that the configuration options in the documentation were listed in camel case, where they should be in snake case.