### PR TITLE
Add opt-in rule: uiimage_require_bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@
   by setting the `SWIFTLINT_LOG_MODULE_USAGE=<module-name>` environment
   variable when running analyze.  
   [jpsim](https://github.com/jpsim)
+* Add `uiimage_require_bundle` rule.  
+  [Dwayne Coussement](https://github.com/DwayneCoussement)
 
 * Add opt-in rule `private_subject` rule which warns against
   public Combine subjects.  

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -180,6 +180,7 @@ public let primaryRuleList = RuleList(rules: [
     TypeBodyLengthRule.self,
     TypeContentsOrderRule.self,
     TypeNameRule.self,
+    UIImageRequireBundleRule.self,
     UnavailableFunctionRule.self,
     UnneededBreakInSwitchRule.self,
     UnneededParenthesesInClosureArgumentRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/UIImageRequireBundleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UIImageRequireBundleRule.swift
@@ -1,0 +1,58 @@
+public struct UIImageRequireBundleRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "uiimage_require_bundle",
+        name: "UIImage Require Bundle",
+        description: "Calls to UIImage(named:) should specify the bundle which contains the strings file.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+			UIImage(named: "someImage", in: .main, compatibleWith: nil)
+			"""),
+            Example("""
+			UIImage(named: "someImage",
+					in: .main,
+					compatibleWith: nil)
+			"""),
+            Example("""
+			UIImage(contentsOfFile: filePath)
+			"""),
+            Example("""
+			UIImage()
+			"""),
+            Example("""
+			UIImage.init()
+			""")
+        ],
+        triggeringExamples: [
+            Example("""
+			↓UIImage(named: "someImage")
+			"""),
+            Example("""
+			↓UIImage.init(named: "someImage")
+			""")
+        ]
+    )
+
+    public func validate(file: SwiftLintFile,
+                         kind: SwiftExpressionKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        let isNamedArgument: (SourceKittenDictionary) -> Bool = { $0.name == "named" }
+        let isBundleArgument: (SourceKittenDictionary) -> Bool = { $0.name == "in" }
+        guard kind == .call,
+			  dictionary.name == "UIImage" || dictionary.name == "UIImage.init",
+              let offset = dictionary.offset,
+              !dictionary.enclosedArguments.contains(where: isBundleArgument),
+              dictionary.enclosedArguments.contains(where: isNamedArgument) else {
+            return []
+        }
+        return [
+            StyleViolation(ruleDescription: Self.description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: offset))
+        ]
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1609,6 +1609,12 @@ extension TypeNameRuleTests {
     ]
 }
 
+extension UIImageRequireBundleRuleTests {
+    static var allTests: [(String, (UIImageRequireBundleRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension UnavailableFunctionRuleTests {
     static var allTests: [(String, (UnavailableFunctionRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -2001,6 +2007,7 @@ XCTMain([
     testCase(TypeBodyLengthRuleTests.allTests),
     testCase(TypeContentsOrderRuleTests.allTests),
     testCase(TypeNameRuleTests.allTests),
+    testCase(UIImageRequireBundleRuleTests.allTests),
     testCase(UnavailableFunctionRuleTests.allTests),
     testCase(UnneededBreakInSwitchRuleTests.allTests),
     testCase(UnneededParenthesesInClosureArgumentRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -761,6 +761,12 @@ class TypeBodyLengthRuleTests: XCTestCase {
     }
 }
 
+class UIImageRequireBundleRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UIImageRequireBundleRule.description)
+    }
+}
+
 class UnavailableFunctionRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnavailableFunctionRule.description)


### PR DESCRIPTION
This PR adds the opt-in rule uiimage_require_bundle to be sure a specific Bundle is passed to UIImage initialization.

Triggering example:

```
UIImage(named: "someImage")
```

Non triggering example:
```
UIImage(named: "folder", in: Bundle.main, compatibleWith: nil)
```