### PR TITLE
Support Swift Playground control comments in the comment spacing rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
 
 #### Enhancements
 
-* None.
+* Support Swift Playground control comments in the `comment_spacing` rule.  
+  [Thomas Goyne](https://github.com/tgoyne)
+  [#3490](https://github.com/realm/SwiftLint/pull/3490)
 
 #### Bug Fixes
 


### PR DESCRIPTION
Swift Playgrounds use `//:` to mark prose sections and `//:#` for embedded content like images and localized prose, so those shouldn't violate the space-after-comment rule.