### PR TITLE
Add opt-in rule balanced_xctest_lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
 * Add opt-in rule `private_subject` rule which warns against
   public Combine subjects.  
   [Otavio Cordeiro](https://github.com/otaviocc)
+* Adds `required_xctest_teardown` opt-in rule to enforce `tearDown` when 
+  `setUp` is implemented in a test class.  
+  [Otavio Cordeiro](https://github.com/otaviocc)
+  [#3452](https://github.com/realm/SwiftLint/issues/3452)
 
 * Tweak the auto-correction result console output for clarity.  
   [mokagio](https://github.com/mokagio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
   by setting the `SWIFTLINT_LOG_MODULE_USAGE=<module-name>` environment
   variable when running analyze.  
   [jpsim](https://github.com/jpsim)
+
 * Add opt-in rule `private_subject` rule which warns against
   public Combine subjects.  
   [Otavio Cordeiro](https://github.com/otaviocc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,6 @@
   `assert(false)`.  
   [Otavio Cordeiro](https://github.com/otaviocc)
 
-* Add opt-in rule `private_subject` rule which warns against
-  public Combine subjects.  
-  [Otavio Cordeiro](https://github.com/otaviocc)
 * Adds `required_xctest_teardown` opt-in rule to enforce `tearDown` when 
   `setUp` is implemented in a test class.  
   [Otavio Cordeiro](https://github.com/otaviocc)
@@ -94,6 +91,9 @@
   by setting the `SWIFTLINT_LOG_MODULE_USAGE=<module-name>` environment
   variable when running analyze.  
   [jpsim](https://github.com/jpsim)
+* Add opt-in rule `private_subject` rule which warns against
+  public Combine subjects.  
+  [Otavio Cordeiro](https://github.com/otaviocc)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@
   `assert(false)`.  
   [Otavio Cordeiro](https://github.com/otaviocc)
 
-* Adds `required_xctest_teardown` opt-in rule to enforce `tearDown` when 
-  `setUp` is implemented in a test class.  
+* Adds `balanced_xctest_lifecycle` opt-in rule to enforce balanced `setUp`
+  and `tearDown` methods in a test class.  
   [Otavio Cordeiro](https://github.com/otaviocc)
   [#3452](https://github.com/realm/SwiftLint/issues/3452)
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -155,7 +155,7 @@ public let primaryRuleList = RuleList(rules: [
     RedundantVoidReturnRule.self,
     RequiredDeinitRule.self,
     RequiredEnumCaseRule.self,
-    RequiredXCTestTearDownRule.self,
+    BalancedXCTestLifecycleRule.self,
     ReturnArrowWhitespaceRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -155,6 +155,7 @@ public let primaryRuleList = RuleList(rules: [
     RedundantVoidReturnRule.self,
     RequiredDeinitRule.self,
     RequiredEnumCaseRule.self,
+    RequiredXCTestTearDownRule.self,
     ReturnArrowWhitespaceRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -1,14 +1,14 @@
 import SourceKittenFramework
 
-public struct RequiredXCTestTearDownRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct BalancedXCTestLifecycleRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
     // MARK: - Properties
 
     public var configuration = SeverityConfiguration(.warning)
 
     public static let description = RuleDescription(
-        identifier: "required_xctest_teardown",
-        name: "Required XCTest Tear Down",
-        description: "Test classes must implement tearDown when setUp is provided.",
+        identifier: "balanced_xctest_lifecycle",
+        name: "Balanced XCTest life-cycle",
+        description: "Test classes must implement balanced setUp and tearDown methods.",
         kind: .lint,
         nonTriggeringExamples: [
             Example(#"""

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredXCTestTearDownRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredXCTestTearDownRule.swift
@@ -49,6 +49,12 @@ public struct RequiredXCTestTearDownRule: Rule, OptInRule, ConfigurationProvider
             final class FooTests: XCTestCase {
                 override func setUpAlLExamples() {}
             }
+            """#),
+            Example(#"""
+            final class FooTests: XCTestCase {
+                class func setUp() {}
+                class func tearDown() {}
+            }
             """#)
         ],
         triggeringExamples: [
@@ -69,6 +75,11 @@ public struct RequiredXCTestTearDownRule: Rule, OptInRule, ConfigurationProvider
             }
             final class ↓BarTests: XCTestCase {
                 override func setUpWithError() throws {}
+            }
+            """#),
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                class func setUp() {}
             }
             """#)
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredXCTestTearDownRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredXCTestTearDownRule.swift
@@ -1,6 +1,8 @@
 import SourceKittenFramework
 
 public struct RequiredXCTestTearDownRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    // MARK: - Properties
+
     public var configuration = SeverityConfiguration(.warning)
 
     public static let description = RuleDescription(
@@ -85,11 +87,17 @@ public struct RequiredXCTestTearDownRule: Rule, OptInRule, ConfigurationProvider
         ]
     )
 
+    // MARK: - Life cycle
+
     public init() {}
+
+    // MARK: - Public
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         testClasses(in: file).compactMap { violations(in: file, for: $0) }
     }
+
+    // MARK: - Private
 
     private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
         file.structureDictionary.substructure.filter { dictionary in

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredXCTestTearDownRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredXCTestTearDownRule.swift
@@ -81,7 +81,26 @@ public struct RequiredXCTestTearDownRule: Rule, OptInRule, ConfigurationProvider
             """#),
             Example(#"""
             final class ↓FooTests: XCTestCase {
-                class func setUp() {}
+                class func tearDown() {}
+            }
+            """#),
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                override func tearDown() {}
+            }
+            """#),
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                override func tearDownWithError() throws {}
+            }
+            """#),
+            Example(#"""
+            final class FooTests: XCTestCase {
+                override func setUp() {}
+                override func tearDownWithError() throws {}
+            }
+            final class ↓BarTests: XCTestCase {
+                override func tearDownWithError() throws {}
             }
             """#)
         ]
@@ -112,8 +131,7 @@ public struct RequiredXCTestTearDownRule: Rule, OptInRule, ConfigurationProvider
             .compactMap { XCTMethod($0.name) }
 
         guard
-            methods.contains(.setUp) == true,
-            methods.contains(.tearDown) == false,
+            methods.contains(.setUp) != methods.contains(.tearDown),
             let offset = dictionary.nameOffset
         else {
             return nil

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredXCTestTearDownRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredXCTestTearDownRule.swift
@@ -1,0 +1,122 @@
+import SourceKittenFramework
+
+public struct RequiredXCTestTearDownRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public static let description = RuleDescription(
+        identifier: "required_xctest_teardown",
+        name: "Required XCTest Tear Down",
+        description: "Test classes must implement tearDown when setUp is provided.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example(#"""
+            final class FooTests: XCTestCase {
+                override func setUp() {}
+                override func tearDown() {}
+            }
+            """#),
+            Example(#"""
+            final class FooTests: XCTestCase {
+                override func setUpWithError() throws {}
+                override func tearDown() {}
+            }
+            """#),
+            Example(#"""
+            final class FooTests: XCTestCase {
+                override func setUp() {}
+                override func tearDownWithError() throws {}
+            }
+            """#),
+            Example(#"""
+            final class FooTests: XCTestCase {
+                override func setUpWithError() throws {}
+                override func tearDownWithError() throws {}
+            }
+            final class BarTests: XCTestCase {
+                override func setUpWithError() throws {}
+                override func tearDownWithError() throws {}
+            }
+            """#),
+            Example(#"""
+            struct FooTests {
+                override func setUp() {}
+            }
+            class BarTests {
+                override func setUpWithError() throws {}
+            }
+            """#),
+            Example(#"""
+            final class FooTests: XCTestCase {
+                override func setUpAlLExamples() {}
+            }
+            """#)
+        ],
+        triggeringExamples: [
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                override func setUp() {}
+            }
+            """#),
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                override func setUpWithError() throws {}
+            }
+            """#),
+            Example(#"""
+            final class FooTests: XCTestCase {
+                override func setUp() {}
+                override func tearDownWithError() throws {}
+            }
+            final class ↓BarTests: XCTestCase {
+                override func setUpWithError() throws {}
+            }
+            """#)
+        ]
+    )
+
+    public init() {}
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        testClasses(in: file).compactMap { violations(in: file, for: $0) }
+    }
+
+    private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
+        file.structureDictionary.substructure.filter { dictionary in
+            guard dictionary.declarationKind == .class else { return false }
+            return dictionary.inheritedTypes.contains("XCTestCase")
+        }
+    }
+
+    private func violations(in file: SwiftLintFile,
+                            for dictionary: SourceKittenDictionary) -> StyleViolation? {
+        let methods = dictionary.substructure
+            .compactMap { XCTMethod($0.name) }
+
+        guard
+            methods.contains(.setUp) == true,
+            methods.contains(.tearDown) == false,
+            let offset = dictionary.nameOffset
+        else {
+            return nil
+        }
+
+        return StyleViolation(ruleDescription: Self.description,
+                              severity: configuration.severity,
+                              location: Location(file: file, byteOffset: offset))
+    }
+}
+
+// MARK: - Private
+
+private enum XCTMethod {
+    case setUp
+    case tearDown
+
+    init?(_ name: String?) {
+        switch name {
+        case "setUp()", "setUpWithError()": self = .setUp
+        case "tearDown()", "tearDownWithError()": self = .tearDown
+        default: return nil
+        }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 1.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.2.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 @testable import SwiftLintFrameworkTests
 import XCTest
 
@@ -31,6 +30,12 @@ extension AttributesRuleTests {
         ("testAttributesWithAlwaysOnSameLine", testAttributesWithAlwaysOnSameLine),
         ("testAttributesWithAlwaysOnLineAbove", testAttributesWithAlwaysOnLineAbove),
         ("testAttributesWithAttributesOnLineAboveButOnOtherDeclaration", testAttributesWithAttributesOnLineAboveButOnOtherDeclaration)
+    ]
+}
+
+extension BalancedXCTestLifecycleRuleTests {
+    static var allTests: [(String, (BalancedXCTestLifecycleRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]
 }
 
@@ -185,12 +190,15 @@ extension ConfigurationTests {
         ("testInitWithRelativePathAndRootPath", testInitWithRelativePathAndRootPath),
         ("testEnableAllRulesConfiguration", testEnableAllRulesConfiguration),
         ("testOnlyRules", testOnlyRules),
+        ("testOnlyRulesWithCustomRules", testOnlyRulesWithCustomRules),
         ("testWarningThreshold_value", testWarningThreshold_value),
         ("testWarningThreshold_nil", testWarningThreshold_nil),
         ("testOtherRuleConfigurationsAlongsideOnlyRules", testOtherRuleConfigurationsAlongsideOnlyRules),
         ("testDisabledRules", testDisabledRules),
         ("testDisabledRulesWithUnknownRule", testDisabledRulesWithUnknownRule),
         ("testDuplicatedRules", testDuplicatedRules),
+        ("testIncludedExcludedRelativeLocationLevel1", testIncludedExcludedRelativeLocationLevel1),
+        ("testIncludedExcludedRelativeLocationLevel0", testIncludedExcludedRelativeLocationLevel0),
         ("testExcludedPaths", testExcludedPaths),
         ("testForceExcludesFile", testForceExcludesFile),
         ("testForceExcludesFileNotPresentInExcluded", testForceExcludesFileNotPresentInExcluded),
@@ -220,6 +228,9 @@ extension ConfigurationTests {
         ("testOnlyRulesMerging", testOnlyRulesMerging),
         ("testCustomRulesMerging", testCustomRulesMerging),
         ("testMergingAllowsDisablingParentsCustomRules", testMergingAllowsDisablingParentsCustomRules),
+        ("testCustomRulesMergingWithOnlyRulesCase1", testCustomRulesMergingWithOnlyRulesCase1),
+        ("testCustomRulesMergingWithOnlyRulesCase2", testCustomRulesMergingWithOnlyRulesCase2),
+        ("testCustomRulesReconfiguration", testCustomRulesReconfiguration),
         ("testLevel0", testLevel0),
         ("testLevel1", testLevel1),
         ("testLevel2", testLevel2),
@@ -1361,12 +1372,6 @@ extension RequiredEnumCaseRuleTestCase {
     ]
 }
 
-extension RequiredXCTestTearDownRuleTests {
-    static var allTests: [(String, (RequiredXCTestTearDownRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
-    ]
-}
-
 extension ReturnArrowWhitespaceRuleTests {
     static var allTests: [(String, (ReturnArrowWhitespaceRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1791,6 +1796,7 @@ XCTMain([
     testCase(AnyObjectProtocolRuleTests.allTests),
     testCase(ArrayInitRuleTests.allTests),
     testCase(AttributesRuleTests.allTests),
+    testCase(BalancedXCTestLifecycleRuleTests.allTests),
     testCase(BlockBasedKVORuleTests.allTests),
     testCase(ClassDelegateProtocolRuleTests.allTests),
     testCase(ClosingBraceRuleTests.allTests),
@@ -1959,7 +1965,6 @@ XCTMain([
     testCase(ReporterTests.allTests),
     testCase(RequiredDeinitRuleTests.allTests),
     testCase(RequiredEnumCaseRuleTestCase.allTests),
-    testCase(RequiredXCTestTearDownRuleTests.allTests),
     testCase(ReturnArrowWhitespaceRuleTests.allTests),
     testCase(RuleConfigurationTests.allTests),
     testCase(RuleTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1361,6 +1361,12 @@ extension RequiredEnumCaseRuleTestCase {
     ]
 }
 
+extension RequiredXCTestTearDownRuleTests {
+    static var allTests: [(String, (RequiredXCTestTearDownRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension ReturnArrowWhitespaceRuleTests {
     static var allTests: [(String, (ReturnArrowWhitespaceRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1953,6 +1959,7 @@ XCTMain([
     testCase(ReporterTests.allTests),
     testCase(RequiredDeinitRuleTests.allTests),
     testCase(RequiredEnumCaseRuleTestCase.allTests),
+    testCase(RequiredXCTestTearDownRuleTests.allTests),
     testCase(ReturnArrowWhitespaceRuleTests.allTests),
     testCase(RuleConfigurationTests.allTests),
     testCase(RuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -666,6 +666,12 @@ class RequiredDeinitRuleTests: XCTestCase {
     }
 }
 
+class RequiredXCTestTearDownRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RequiredXCTestTearDownRule.description)
+    }
+}
+
 class ReturnArrowWhitespaceRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReturnArrowWhitespaceRule.description)

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 1.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.2.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 import SwiftLintFramework
 import XCTest
 
@@ -15,6 +14,12 @@ class AnyObjectProtocolRuleTests: XCTestCase {
 class ArrayInitRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ArrayInitRule.description)
+    }
+}
+
+class BalancedXCTestLifecycleRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(BalancedXCTestLifecycleRule.description)
     }
 }
 
@@ -663,12 +668,6 @@ class RedundantVoidReturnRuleTests: XCTestCase {
 class RequiredDeinitRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RequiredDeinitRule.description)
-    }
-}
-
-class RequiredXCTestTearDownRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(RequiredXCTestTearDownRule.description)
     }
 }
 


### PR DESCRIPTION
This PR implements `balanced_xctest_lifecycle`, requested in #3452. This rule enforces test classes to have balanced set-up and tear-down methods.

Triggering examples:

```swift
final class FooTests: XCTestCase {
    override func setUp() { /* ... */ }
}

final class FooTests: XCTestCase {
    override func setUpWithError() throws { /* ... */ }
}
```

Non-triggering examples:

```swift
final class FooTests: XCTestCase {
    override func setUp() { /* ... */ }
    override func tearDown() { /* ... */ }
}

final class FooTests: XCTestCase {
    override func setUpWithError() throws { /* ... */ }
    override func tearDown() { /* ... */ }
}

final class FooTests: XCTestCase {
    override func setUp() { /* ... */ }
    override func tearDownWithError() throws { /* ... */ }
}

final class FooTests: XCTestCase {
    override func setUpWithError() throws { /* ... */ }
    override func tearDownWithError() throws { /* ... */ }
}
```