### PR TITLE
Update CodeClimateReporter to produce relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@
   performance.  
   [jpsim](https://github.com/jpsim)
 
+* Update CodeClimateReporter to produce relative paths.  
+  [bmwalters](https://github.com/bmwalters)
+
 #### Bug Fixes
 
 * Fix typos in configuration options for `file_name` rule.  

--- a/Source/SwiftLintFramework/Reporters/CodeClimateReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CodeClimateReporter.swift
@@ -29,7 +29,7 @@ public struct CodeClimateReporter: Reporter {
             "engine_name": "SwiftLint",
             "fingerprint": generateFingerprint(violation),
             "location": [
-                "path": violation.location.file ?? NSNull() as Any,
+                "path": violation.location.relativeFile ?? NSNull() as Any,
                 "lines": [
                     "begin": violation.location.line ?? NSNull() as Any,
                     "end": violation.location.line ?? NSNull() as Any


### PR DESCRIPTION
GitLab and the CodeClimate spec both expect these paths to be relative.

https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool
https://github.com/codeclimate/platform/blob/690633cb2a08839a5bfa350ed925ddb6de55bbdc/spec/analyzers/SPEC.md#locations

<details>

<summary>Before/After</summary>

Before:
```json
[
  {
    "check_name" : "Todo",
    "description" : "TODOs should be resolved (foo).",
    "engine_name" : "SwiftLint",
    "fingerprint" : "xxx",
    "location" : {
      "lines" : {
        "begin" : 329,
        "end" : 329
      },
      "path" : "/Users/myuser/projects/mylibrary/MyLibrary/Client.swift"
    },
    "severity" : "MINOR",
    "type" : "issue"
  }
]
```

After:
```json
[
  {
    "check_name" : "Todo",
    "description" : "TODOs should be resolved (foo).",
    "engine_name" : "SwiftLint",
    "fingerprint" : "xxx",
    "location" : {
      "lines" : {
        "begin" : 329,
        "end" : 329
      },
      "path" : "MyLibrary/Client.swift"
    },
    "severity" : "MINOR",
    "type" : "issue"
  }
]
```

</details>