### PR TITLE
Add opt-in rule discouraged_default_switch_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 * Add opt-in rule `private_subject` rule which warns against
   public Combine subjects.  
+* Add opt-in rule `discouraged_default_switch_case` to discourage
+  default switch case for enums.  
   [Otavio Cordeiro](https://github.com/otaviocc)
 
 #### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 * Add opt-in rule `private_subject` rule which warns against
   public Combine subjects.  
+  [Otavio Cordeiro](https://github.com/otaviocc)
+
 * Add opt-in rule `discouraged_default_switch_case` to discourage
   default switch case for enums.  
   [Otavio Cordeiro](https://github.com/otaviocc)

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -31,6 +31,7 @@ public let primaryRuleList = RuleList(rules: [
     DeploymentTargetRule.self,
     DiscardedNotificationCenterObserverRule.self,
     DiscouragedAssertRule.self,
+    DiscouragedDefaultSwitchCaseRule.self,
     DiscouragedDirectInitRule.self,
     DiscouragedObjectLiteralRule.self,
     DiscouragedOptionalBooleanRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDefaultSwitchCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDefaultSwitchCaseRule.swift
@@ -115,7 +115,7 @@ public struct DiscouragedDefaultSwitchCaseRule: ASTRule, OptInRule, Configuratio
 
     // MARK: - Nested type
 
-    private typealias EnumSwitchCase = (offset: ByteCount, content: String)
+    private typealias SwitchCase = (offset: ByteCount, content: String)
 
     // MARK: - Life cycle
 
@@ -123,6 +123,10 @@ public struct DiscouragedDefaultSwitchCaseRule: ASTRule, OptInRule, Configuratio
 
     // MARK: - Public
 
+    /// Checks if all the elements from cases in a `switch` are from an enum and
+    /// include `default`.
+    ///
+    /// - Returns: Violations in case `default` is found in a `switch` of enums.
     public func validate(file: SwiftLintFile,
                          kind: StatementKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
@@ -147,14 +151,29 @@ public struct DiscouragedDefaultSwitchCaseRule: ASTRule, OptInRule, Configuratio
 
     // MARK: - Private
 
+    /// Array of all elements in a `switch`, including multiple elements from
+    /// a `switch` case.
+    ///
+    /// E.g.,
+    ///
+    /// ```
+    /// switch foo {
+    ///     case "a", "b": doSomething()
+    ///     case "c": doSomethingElse()
+    /// }
+    /// ```
+    ///
+    /// generates "a", "b", and "c" (and their offsets)
+    ///
+    /// - Returns: An array with all elements in a `switch`,
     private func allSwitchCases(in switchDictionary: SourceKittenDictionary,
-                                file: SwiftLintFile) -> [EnumSwitchCase] {
+                                file: SwiftLintFile) -> [SwitchCase] {
         switchDictionary.substructure
             .filter { element in
                 element.kind == StatementKind.case.rawValue
             }
             .flatMap { caseStatement in
-                caseStatement.elements.compactMap { caseElement -> EnumSwitchCase? in
+                caseStatement.elements.compactMap { caseElement -> SwitchCase? in
                     guard
                         let offset = caseElement.offset,
                         let length = caseElement.length,

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDefaultSwitchCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDefaultSwitchCaseRule.swift
@@ -133,7 +133,7 @@ public struct DiscouragedDefaultSwitchCaseRule: ASTRule, OptInRule, Configuratio
             case let defaultCase = allCases.filter({ $0.content == "default" }),
             defaultCase.count == 1,
             enumCases.count == allCases.count - 1,
-            let offSet = defaultCase.first?.offset
+            let offset = defaultCase.first?.offset
         else {
             return []
         }
@@ -141,7 +141,7 @@ public struct DiscouragedDefaultSwitchCaseRule: ASTRule, OptInRule, Configuratio
         return [
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
-                           location: Location(file: file, byteOffset: offSet))
+                           location: Location(file: file, byteOffset: offset))
         ]
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDefaultSwitchCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDefaultSwitchCaseRule.swift
@@ -1,0 +1,171 @@
+import SourceKittenFramework
+
+public struct DiscouragedDefaultSwitchCaseRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    // MARK: - Properties
+
+    public var configuration = SeverityConfiguration(.error)
+
+    public static let description = RuleDescription(
+        identifier: "discouraged_default_switch_case",
+        name: "Discouraged Default Switch Case",
+        description: "Discouraged default switch case for enums.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example(
+                #"""
+                enum StateOfMatter {
+                    case liquid
+                    case solid
+                    case gas
+                    case plasm
+
+                    var description: String {
+                        switch self {
+                            case .liquid: return "Liquid"
+                            case .solid: return "Solid"
+                            case .gas: return "Gas"
+                            case .plasm: return "Plasm"
+                        }
+                    }
+                }
+                """#
+            ),
+            Example(
+                #"""
+                switch number {
+                    case 1...4: return "Number is less than 5"
+                    case 5: return "Number is 5"
+                    default: return "Number is greater than 5"
+                }
+                """#
+            ),
+            Example(
+                #"""
+                switch text {
+                    case "Welcome": return true
+                    case "Goodbye": return false
+                    default: return nil
+                }
+                """#
+            ),
+            Example(
+                #"""
+                switch value {
+                    case .one: return "One"
+                    case .two: return "Two"
+                    case .default: return "Default"
+                }
+                """#
+            ),
+            Example(
+                #"""
+                switch result {
+                    case .success(let value): print(value)
+                    case .failure(let error): print(error)
+                }
+                """#
+            ),
+            Example(
+                #"""
+                switch (status, value) {
+                    case (.on, .green): return true
+                    default: return false
+                }
+                """#
+            )
+        ],
+        triggeringExamples: [
+            Example(
+                #"""
+                enum StateOfMatter {
+                    case liquid
+                    case solid
+                    case gas
+                    case plasm
+
+                    var description: String {
+                        switch self {
+                            case .liquid: return "Liquid"
+                            case .solid: return "Solid"
+                            ↓default: return "Other stuff"
+                        }
+                    }
+                }
+                """#
+            ),
+            Example(
+                #"""
+                switch CLLocationManager.authorizationStatus() {
+                    case .authorizedAlways, .authorizedWhenInUse, .notDetermined: return "authorized"
+                    case .denied, .restricted: return "denied"
+                    @unknown ↓default: fatalError("Unhandled case!")
+                }
+                """#
+            ),
+            Example(
+                #"""
+                switch result {
+                    case .success(let value): print(value)
+                    ↓default: print("Unhandled case!")
+                }
+                """#
+            )
+        ]
+    )
+
+    // MARK: - Nested type
+
+    private typealias EnumSwitchCase = (offset: ByteCount, content: String)
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+    // MARK: - Public
+
+    public func validate(file: SwiftLintFile,
+                         kind: StatementKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        guard
+            kind == .switch,
+            case let allCases = allSwitchCases(in: dictionary, file: file),
+            case let enumCases = allCases.filter({ $0.content.hasPrefix(".") }),
+            case let defaultCase = allCases.filter({ $0.content == "default" }),
+            defaultCase.count == 1,
+            enumCases.count == allCases.count - 1,
+            let offSet = defaultCase.first?.offset
+        else {
+            return []
+        }
+
+        return [
+            StyleViolation(ruleDescription: Self.description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: offSet))
+        ]
+    }
+
+    // MARK: - Private
+
+    private func allSwitchCases(in switchDictionary: SourceKittenDictionary,
+                                file: SwiftLintFile) -> [EnumSwitchCase] {
+        switchDictionary.substructure
+            .filter { element in
+                element.kind == StatementKind.case.rawValue
+            }
+            .flatMap { caseStatement in
+                caseStatement.elements.compactMap { caseElement -> EnumSwitchCase? in
+                    guard
+                        let offset = caseElement.offset,
+                        let length = caseElement.length,
+                        case let byteRange = ByteRange(location: offset, length: length),
+                        let string = file.stringView.substringWithByteRange(byteRange)
+                    else {
+                        return nil
+                    }
+
+                    return (offset, string)
+                }
+            }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -352,6 +352,12 @@ extension DiscouragedAssertRuleTests {
     ]
 }
 
+extension DiscouragedDefaultSwitchCaseRuleTests {
+    static var allTests: [(String, (DiscouragedDefaultSwitchCaseRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension DiscouragedDirectInitRuleTests {
     static var allTests: [(String, (DiscouragedDirectInitRuleTests) -> () throws -> Void)] = [
         ("testDiscouragedDirectInitWithDefaultConfiguration", testDiscouragedDirectInitWithDefaultConfiguration),
@@ -1811,6 +1817,7 @@ XCTMain([
     testCase(DisableAllTests.allTests),
     testCase(DiscardedNotificationCenterObserverRuleTests.allTests),
     testCase(DiscouragedAssertRuleTests.allTests),
+    testCase(DiscouragedDefaultSwitchCaseRuleTests.allTests),
     testCase(DiscouragedDirectInitRuleTests.allTests),
     testCase(DiscouragedObjectLiteralRuleTests.allTests),
     testCase(DiscouragedOptionalBooleanRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -114,6 +114,12 @@ class DiscouragedAssertRuleTests: XCTestCase {
     }
 }
 
+class DiscouragedDefaultSwitchCaseRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(DiscouragedDefaultSwitchCaseRule.description)
+    }
+}
+
 class DiscouragedOptionalBooleanRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedOptionalBooleanRule.description)


### PR DESCRIPTION
This PR adds the opt-in rule `discouraged_default_switch_case` to discourage `default` in a switch of enum cases.

Triggering example:

```swift
enum StateOfMatter {
    case liquid
    case solid
    case gas
    case plasm

    var description: String {
        switch self {
            case .liquid: return "Liquid"
            case .solid: return "Solid"
            default: return "Other stuff"
        }
    }
}
```

Non-triggering examples:

```swift
switch self {
    case .liquid: return "Liquid"
    case .solid: return "Solid"
    case .gas: return "Gas"
    case .plasm: return "Plasm"
}
```

```swift
switch result {
    case .success(let value): print(value)
    case .failure(let error): print(error)
}
```

```swift
switch number {
    case 1...4: return "Number is less than 5"
    case 5: return "Number is 5"
    default: return "Number is greater than 5"
}
```

```swift
switch (status, value) {
    case (.on, .green): return true
    default: return false
}
```

```swift
switch value {
    case .one: return "One"
    case .two: return "Two"
    case .default: return "Default"
}
```