### PR TITLE
Add opt-in rule discouraged_assert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
   rules.  
   [JP Simard](https://github.com/jpsim)
 
+* Add opt-in rule `discouraged_assert` to encourage the use of
+  `assertionFailure()` and/or `preconditionFailure()` over
+  `assert(false)`.  
+  [Otavio Cordeiro](https://github.com/otaviocc)
+
 #### Bug Fixes
 
 * Fix typos in configuration options for `file_name` rule.  

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 /// The rule list containing all available rules built into SwiftLint.
@@ -30,6 +30,7 @@ public let primaryRuleList = RuleList(rules: [
     CyclomaticComplexityRule.self,
     DeploymentTargetRule.self,
     DiscardedNotificationCenterObserverRule.self,
+    DiscouragedAssertRule.self,
     DiscouragedDirectInitRule.self,
     DiscouragedObjectLiteralRule.self,
     DiscouragedOptionalBooleanRule.self,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 public struct DiscouragedAssertRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -1,0 +1,124 @@
+import Foundation
+import SourceKittenFramework
+
+public struct DiscouragedAssertRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    // MARK: - Properties
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public static let description = RuleDescription(
+        identifier: "discouraged_assert",
+        name: "Discouraged Assert",
+        description: "Prefer `assertionFailure()` and/or `preconditionFailure()` over `assert(false)`",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            Example(#"assert(true)"#),
+            Example(#"assert(true, "foobar")"#),
+            Example(#"assert(true, "foobar", file: "toto", line: 42)"#)
+        ],
+        triggeringExamples: [
+            Example(#"↓assert(false)"#),
+            Example(#"↓assert(false, "foobar")"#),
+            Example(#"↓assert(false, "foobar", file: "toto", line: 42)"#),
+            Example(#"↓assert(   false    , "foobar")"#)
+        ]
+    )
+
+    // MARK: - Nested types
+
+    private enum DiscouragedAssertError: Error {
+        case missingArgument
+        case missingArguments
+    }
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+    // MARK: - Public
+
+    public func validate(file: SwiftLintFile,
+                         kind: SwiftExpressionKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        guard
+            kind == .call,
+            let offset = dictionary.offset,
+            dictionary.name == "assert"
+        else {
+            return []
+        }
+
+        let isSingleFalse = try? isSingleArgumentFalse(dictionary: dictionary, file: file)
+        let isFirstOfMultiplesFalse = try? isFirstOfMultipleArgumentsFalse(dictionary: dictionary, file: file)
+
+        guard isSingleFalse == true || isFirstOfMultiplesFalse == true else {
+            return []
+        }
+
+        return [
+            StyleViolation(ruleDescription: Self.description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: offset))
+        ]
+    }
+
+    // MARK: - Private
+
+    /// Check if the single argument is `false`.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// assert(false)
+    /// ```
+    ///
+    /// - Returns: A boolean indicating if the single argument is `false`.
+    private func isSingleArgumentFalse(dictionary: SourceKittenDictionary,
+                                       file: SwiftLintFile) throws -> Bool {
+        guard
+            let bodyOffset = dictionary.bodyOffset,
+            let bodyLength = dictionary.bodyLength,
+            case let byteRange = ByteRange(location: bodyOffset, length: bodyLength),
+            let argument = file.stringView.substringWithByteRange(byteRange)
+        else {
+            throw DiscouragedAssertError.missingArgument
+        }
+
+        return argument == "false"
+    }
+
+    /// Check if the first of multiples arguments is `false`
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// assert(false, "foobar")
+    /// assert(false, "foobar", file: "toto")
+    /// assert(false, "foobar", file: "toto", line: 42)
+    /// ```
+    ///
+    /// - Returns: A boolean indicating if the first argument is `false`.
+    private func isFirstOfMultipleArgumentsFalse(dictionary: SourceKittenDictionary,
+                                                 file: SwiftLintFile) throws -> Bool {
+        let firstArgument = dictionary.substructure
+            .filter { $0.offset != nil }
+            .sorted { arg1, arg2 -> Bool in
+                guard
+                    let firstOffset = arg1.offset,
+                    let secondOffset = arg2.offset else { return false }
+
+                return firstOffset < secondOffset
+            }
+            .prefix(1)
+            .compactMap {
+                $0.byteRange.flatMap(file.stringView.substringWithByteRange)
+            }
+            .first
+
+        guard let argument = firstArgument else {
+            throw DiscouragedAssertError.missingArguments
+        }
+
+        return argument == "false"
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -13,7 +13,9 @@ public struct DiscouragedAssertRule: ASTRule, OptInRule, ConfigurationProviderRu
         nonTriggeringExamples: [
             Example(#"assert(true)"#),
             Example(#"assert(true, "foobar")"#),
-            Example(#"assert(true, "foobar", file: "toto", line: 42)"#)
+            Example(#"assert(true, "foobar", file: "toto", line: 42)"#),
+            Example(#"assert(false || true)"#),
+            Example(#"XCTAssert(false)"#)
         ],
         triggeringExamples: [
             Example(#"↓assert(false)"#),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -346,6 +346,12 @@ extension DiscardedNotificationCenterObserverRuleTests {
     ]
 }
 
+extension DiscouragedAssertRuleTests {
+    static var allTests: [(String, (DiscouragedAssertRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension DiscouragedDirectInitRuleTests {
     static var allTests: [(String, (DiscouragedDirectInitRuleTests) -> () throws -> Void)] = [
         ("testDiscouragedDirectInitWithDefaultConfiguration", testDiscouragedDirectInitWithDefaultConfiguration),
@@ -1798,6 +1804,7 @@ XCTMain([
     testCase(DeploymentTargetRuleTests.allTests),
     testCase(DisableAllTests.allTests),
     testCase(DiscardedNotificationCenterObserverRuleTests.allTests),
+    testCase(DiscouragedAssertRuleTests.allTests),
     testCase(DiscouragedDirectInitRuleTests.allTests),
     testCase(DiscouragedObjectLiteralRuleTests.allTests),
     testCase(DiscouragedOptionalBooleanRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -108,6 +108,12 @@ class DiscardedNotificationCenterObserverRuleTests: XCTestCase {
     }
 }
 
+class DiscouragedAssertRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(DiscouragedAssertRule.description)
+    }
+}
+
 class DiscouragedOptionalBooleanRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedOptionalBooleanRule.description)


### PR DESCRIPTION
Implements #2288, which I promised  [here](https://github.com/realm/SwiftLint/issues/2288#issuecomment-404435600) but never implemented.

Example:

```swift
if someCondition {
    assert(false)
}

if someCondition {
    assert(false, "Error message goes here")
}
```

Structure:

```json
﻿﻿{
  "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
  "key.length" : 109,
  "key.offset" : 0,
  "key.substructure" : [
    {
      "key.elements" : [
        {
          "key.kind" : "source.lang.swift.structure.elem.condition_expr",
          "key.length" : 15,
          "key.offset" : 3
        }
      ],
      "key.kind" : "source.lang.swift.stmt.if",
      "key.length" : 40,
      "key.namelength" : 0,
      "key.nameoffset" : 0,
      "key.offset" : 0,
      "key.substructure" : [
        {
          "key.bodylength" : 19,
          "key.bodyoffset" : 20,
          "key.kind" : "source.lang.swift.stmt.brace",
          "key.length" : 21,
          "key.namelength" : 0,
          "key.nameoffset" : 0,
          "key.offset" : 19,
          "key.substructure" : [
            {
              "key.bodylength" : 5,
              "key.bodyoffset" : 32,
              "key.kind" : "source.lang.swift.expr.call",
              "key.length" : 13,
              "key.name" : "assert",
              "key.namelength" : 6,
              "key.nameoffset" : 25,
              "key.offset" : 25
            }
          ]
        }
      ]
    },
    {
      "key.elements" : [
        {
          "key.kind" : "source.lang.swift.structure.elem.condition_expr",
          "key.length" : 15,
          "key.offset" : 45
        }
      ],
      "key.kind" : "source.lang.swift.stmt.if",
      "key.length" : 67,
      "key.namelength" : 0,
      "key.nameoffset" : 0,
      "key.offset" : 42,
      "key.substructure" : [
        {
          "key.bodylength" : 46,
          "key.bodyoffset" : 62,
          "key.kind" : "source.lang.swift.stmt.brace",
          "key.length" : 48,
          "key.namelength" : 0,
          "key.nameoffset" : 0,
          "key.offset" : 61,
          "key.substructure" : [
            {
              "key.bodylength" : 32,
              "key.bodyoffset" : 74,
              "key.kind" : "source.lang.swift.expr.call",
              "key.length" : 40,
              "key.name" : "assert",
              "key.namelength" : 6,
              "key.nameoffset" : 67,
              "key.offset" : 67,
              "key.substructure" : [
                {
                  "key.bodylength" : 5,
                  "key.bodyoffset" : 74,
                  "key.kind" : "source.lang.swift.expr.argument",
                  "key.length" : 5,
                  "key.namelength" : 0,
                  "key.nameoffset" : 0,
                  "key.offset" : 74
                },
                {
                  "key.bodylength" : 25,
                  "key.bodyoffset" : 81,
                  "key.kind" : "source.lang.swift.expr.argument",
                  "key.length" : 25,
                  "key.namelength" : 0,
                  "key.nameoffset" : 0,
                  "key.offset" : 81
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```