### PR TITLE
Capture non-constant variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,11 @@
 * Add Bool violation reporting in `redundant_type_annotation`.  
   [Artem Garmash](https://github.com/agarmash)
   [#3423](https://github.com/realm/SwiftLint/issues/3423)
-* Add opt-in rule `capture_variable` to warn about listing a non-constant
-  (`var`) variable in a closure's capture list. This captures the variable's
-  value at closure creation time instead of closure call time, which may be
-  unexpected.
+
+* Add a new `capture_variable` analyzer rule to warn about listing a
+  non-constant (`var`) variable in a closure's capture list. This
+  captures the variable's value at closure creation time instead of
+  closure call time, which may be unexpected.  
   [Laszlo Kustra](https://github.com/kustra)
 
 #### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@
 * Add Bool violation reporting in `redundant_type_annotation`.  
   [Artem Garmash](https://github.com/agarmash)
   [#3423](https://github.com/realm/SwiftLint/issues/3423)
+* Add opt-in rule `capture_variable` to warn about listing a non-constant
+  (`var`) variable in a closure's capture list. This captures the variable's
+  value at closure creation time instead of closure call time, which may be
+  unexpected.
+  [Laszlo Kustra](https://github.com/kustra)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -273,6 +273,29 @@ extension SourceKittenDictionary {
             subDict.traverseDepthFirst(collectingValuesInto: &array, traverseBlock: traverseBlock)
         }
     }
+
+    /// Traversing all entities of the dictionary hierarchically, calling `traverseBlock` on each node.
+    /// Traversing using depth first strategy, so deepest substructures will be passed to `traverseBlock` first.
+    ///
+    /// - parameter traverseBlock: block that will be called for each entity in the dictionary.
+    ///
+    /// - returns: The list of entity dictionaries with updated values from the traverse block.
+    func traverseEntitiesDepthFirst<T>(traverseBlock: (SourceKittenDictionary) -> T?) -> [T] {
+        var result: [T] = []
+        traverseEntitiesDepthFirst(collectingValuesInto: &result, traverseBlock: traverseBlock)
+        return result
+    }
+
+    private func traverseEntitiesDepthFirst<T>(collectingValuesInto array: inout [T],
+                                               traverseBlock: (SourceKittenDictionary) -> T?) {
+        entities.forEach { subDict in
+            subDict.traverseEntitiesDepthFirst(collectingValuesInto: &array, traverseBlock: traverseBlock)
+
+            if let collectedValue = traverseBlock(subDict) {
+                array.append(collectedValue)
+            }
+        }
+    }
 }
 
 extension Dictionary where Key == Example {

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -7,6 +7,7 @@ public let primaryRuleList = RuleList(rules: [
     ArrayInitRule.self,
     AttributesRule.self,
     BlockBasedKVORule.self,
+    CaptureVariableRule.self,
     ClassDelegateProtocolRule.self,
     ClosingBraceRule.self,
     ClosureBodyLengthRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CaptureVariableRule.swift
@@ -1,7 +1,6 @@
 import SourceKittenFramework
 
-public struct CaptureVariableRule: AutomaticTestableRule, ConfigurationProviderRule, AnalyzerRule, CollectingRule,
-    OptInRule {
+public struct CaptureVariableRule: AutomaticTestableRule, ConfigurationProviderRule, AnalyzerRule, CollectingRule {
     public struct Variable: Hashable {
         let usr: String
         let offset: ByteCount

--- a/Source/SwiftLintFramework/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CaptureVariableRule.swift
@@ -1,0 +1,278 @@
+import SourceKittenFramework
+
+public struct CaptureVariableRule: AutomaticTestableRule, ConfigurationProviderRule, AnalyzerRule, CollectingRule,
+    OptInRule {
+    public struct Variable: Hashable {
+        let usr: String
+        let offset: ByteCount
+    }
+
+    public typealias USR = String
+    public typealias FileInfo = Set<USR>
+
+    public static let description = RuleDescription(
+        identifier: "capture_variable",
+        name: "Capture Variable",
+        description: "Non-constant variables should not be captured.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+            class C {
+                let i: Int
+                init(_ i: Int) { self.i = i }
+            }
+
+            let j: Int = 0
+            let c = C(1)
+
+            let closure: () -> Void = { [j, c] in
+                print(c.i, j)
+            }
+
+            closure()
+            """),
+            Example("""
+            let iGlobal: Int = 0
+
+            class C {
+                class var iClass: Int { 0 }
+                static let iStatic: Int = 0
+                let iInstance: Int = 0
+
+                func callTest() {
+                    var iLocal: Int = 0
+                    test { [unowned self, iGlobal, iInstance, iLocal, iClass=C.iClass, iStatic=C.iStatic] j in
+                        print(iGlobal, iClass, iStatic, iInstance, iLocal, j)
+                    }
+                }
+
+                func test(_ completionHandler: @escaping (Int) -> Void) {
+                }
+            }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+            var j: Int = 0
+
+            let closure: () -> Void = { [j] in
+                print(j)
+            }
+
+            closure()
+            j = 1
+            closure()
+            """),
+            Example("""
+            class C {
+                let i: Int
+                init(_ i: Int) { self.i = i }
+            }
+
+            var c = C(0)
+            let closure: () -> Void = { [c] in
+                print(c.i)
+            }
+
+            closure()
+            c = C(1)
+            closure()
+            """),
+            Example("""
+            var iGlobal: Int = 0
+
+            class C {
+                func callTest() {
+                    test { [iGlobal] j in
+                        print(iGlobal, j)
+                    }
+                }
+
+                func test(_ completionHandler: @escaping (Int) -> Void) {
+                }
+            }
+            """),
+            Example("""
+            class C {
+                class var iClass: Int {
+                    get { iStatic }
+                    set { iStatic = newValue }
+                }
+                static var iStatic: Int = 0
+
+                func callTest() {
+                    test { [iClass=C.iClass] j in
+                        print(iClass, j)
+                    }
+                }
+
+                func test(_ completionHandler: @escaping (Int) -> Void) {
+                }
+            }
+            """),
+            Example("""
+            class C {
+                static var iStatic: Int = 0
+
+                static func callTest() {
+                    test { [iStatic] j in
+                        print(iStatic, j)
+                    }
+                }
+
+                static func test(_ completionHandler: @escaping (Int) -> Void) {
+                    completionHandler(2)
+                    C.iStatic = 1
+                    completionHandler(3)
+                }
+            }
+
+            C.callTest()
+            """),
+            Example("""
+            class C {
+                var iInstance: Int = 0
+
+                func callTest() {
+                    test { [iInstance] j in
+                        print(iInstance, j)
+                    }
+                }
+
+                func test(_ completionHandler: @escaping (Int) -> Void) {
+                }
+            }
+            """)
+        ],
+        requiresFileOnDisk: true
+    )
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> CaptureVariableRule.FileInfo {
+        file.declaredVariables(compilerArguments: compilerArguments)
+    }
+
+    public func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: CaptureVariableRule.FileInfo],
+                         compilerArguments: [String]) -> [StyleViolation] {
+        file.captureListVariables(compilerArguments: compilerArguments)
+            .filter { capturedVariable in collectedInfo.values.contains { $0.contains(capturedVariable.usr) } }
+            .map {
+                StyleViolation(ruleDescription: Self.description,
+                               severity: configuration.severity,
+                               location: Location(file: file, byteOffset: $0.offset))
+            }
+    }
+}
+
+private extension SwiftLintFile {
+    static var checkedDeclarationKinds: [SwiftDeclarationKind] {
+        [.varClass, .varGlobal, .varInstance, .varStatic]
+    }
+
+    func captureListVariableOffsets() -> Set<ByteCount> {
+        Self.captureListVariableOffsets(parentEntity: structureDictionary)
+    }
+
+    static func captureListVariableOffsets(parentEntity: SourceKittenDictionary) -> Set<ByteCount> {
+        parentEntity.substructure
+            .reversed()
+            .reduce(into: (foundOffsets: Set<ByteCount>(), afterClosure: nil as ByteCount?)) { acc, entity in
+                guard let offset = entity.offset else { return }
+
+                if entity.expressionKind == .closure {
+                    acc.afterClosure = offset
+                } else if let closureOffset = acc.afterClosure,
+                          closureOffset < offset,
+                          let length = entity.length,
+                          let nameLength = entity.nameLength,
+                          entity.declarationKind == .varLocal {
+                    acc.foundOffsets.insert(offset + length - nameLength)
+                } else {
+                    acc.afterClosure = nil
+                }
+
+                acc.foundOffsets.formUnion(captureListVariableOffsets(parentEntity: entity))
+            }
+            .foundOffsets
+    }
+
+    func captureListVariables(compilerArguments: [String]) -> Set<CaptureVariableRule.Variable> {
+        let offsets = self.captureListVariableOffsets()
+        guard !offsets.isEmpty, let indexEntities = index(compilerArguments: compilerArguments) else { return Set() }
+
+        return Set(indexEntities.traverseEntitiesDepthFirst {
+            guard
+                let kind = $0.kind,
+                kind.hasPrefix("source.lang.swift.ref.var."),
+                let usr = $0.usr,
+                let line = $0.line,
+                let column = $0.column
+            else { return nil }
+            let offset = stringView.byteOffset(forLine: Int(line), column: Int(column))
+            return offsets.contains(offset) ? CaptureVariableRule.Variable(usr: usr, offset: offset) : nil
+        })
+    }
+
+    func declaredVariableOffsets() -> Set<ByteCount> {
+        Self.declaredVariableOffsets(parentStructure: structureDictionary)
+    }
+
+    static func declaredVariableOffsets(parentStructure: SourceKittenDictionary) -> Set<ByteCount> {
+        Set(
+            parentStructure.traverseDepthFirst {
+                guard
+                    let declarationKind = $0.declarationKind,
+                    checkedDeclarationKinds.contains(declarationKind),
+                    $0.setterAccessibility != nil,
+                    let nameOffset = $0.nameOffset
+                else { return [] }
+                return [nameOffset]
+            }
+        )
+    }
+
+    func declaredVariables(compilerArguments: [String]) -> Set<CaptureVariableRule.USR> {
+        let offsets = self.declaredVariableOffsets()
+        guard !offsets.isEmpty, let indexEntities = index(compilerArguments: compilerArguments) else { return Set() }
+
+        return Set(indexEntities.traverseEntitiesDepthFirst {
+            guard
+                let declarationKind = $0.declarationKind,
+                Self.checkedDeclarationKinds.contains(declarationKind),
+                let line = $0.line,
+                let column = $0.column,
+                offsets.contains(stringView.byteOffset(forLine: Int(line), column: Int(column)))
+            else { return nil }
+            return $0.usr
+        })
+    }
+
+    func index(compilerArguments: [String]) -> SourceKittenDictionary? {
+        guard
+            let path = self.path,
+            let response = try? Request.index(file: path, arguments: compilerArguments).sendIfNotDisabled()
+        else {
+            queuedPrintError("""
+                Could not index file at path '\(self.path ?? "...")' with the \
+                \(CaptureVariableRule.description.identifier) rule.
+                """)
+            return nil
+        }
+
+        return SourceKittenDictionary(response)
+    }
+}
+
+private extension SourceKittenDictionary {
+    var usr: String? { value["key.usr"] as? String }
+}
+
+private extension StringView {
+    func byteOffset(forLine line: Int, column: Int) -> ByteCount {
+        guard line > 0 else { return ByteCount(column - 1) }
+        return lines[line - 1].byteRange.location + ByteCount(column - 1)
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -119,7 +119,7 @@ private extension SwiftLintFile {
     func declaredUSRs(index: SourceKittenDictionary, editorOpen: SourceKittenDictionary,
                       compilerArguments: [String], configuration: UnusedDeclarationConfiguration)
     -> Set<UnusedDeclarationRule.DeclaredUSR> {
-        return Set(index.traverseEntities { indexEntity in
+        return Set(index.traverseEntitiesDepthFirst { indexEntity in
             self.declaredUSR(indexEntity: indexEntity, editorOpen: editorOpen, compilerArguments: compilerArguments,
                              configuration: configuration)
         })

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -40,6 +40,12 @@ extension BlockBasedKVORuleTests {
     ]
 }
 
+extension CaptureVariableRuleTests {
+    static var allTests: [(String, (CaptureVariableRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension ClassDelegateProtocolRuleTests {
     static var allTests: [(String, (ClassDelegateProtocolRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1786,6 +1792,7 @@ XCTMain([
     testCase(ArrayInitRuleTests.allTests),
     testCase(AttributesRuleTests.allTests),
     testCase(BlockBasedKVORuleTests.allTests),
+    testCase(CaptureVariableRuleTests.allTests),
     testCase(ClassDelegateProtocolRuleTests.allTests),
     testCase(ClosingBraceRuleTests.allTests),
     testCase(ClosureBodyLengthRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -24,6 +24,12 @@ class BlockBasedKVORuleTests: XCTestCase {
     }
 }
 
+class CaptureVariableRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(CaptureVariableRule.description)
+    }
+}
+
 class ClassDelegateProtocolRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ClassDelegateProtocolRule.description)


### PR DESCRIPTION
Created a new analyzer rule that shows a warning if items listed in a closure's capture list are `var` variables, meaning that their value is captured at the time the closure is created, not at the time it's called.

This is useful when a former `let` constant is changed to `var`, so the developer doesn't have to remember to look for closures capturing it. Or the developer simply forgets this part of the capture semantics.

I think this rule should exclude `lazy var`s and implicitly unwrapped optionals from checking, but this is not implemented yet. I'll probably add it this Friday. Until then, I just posted the PR to get initial feedback.