### PR TITLE
Tweak the auto-correction result console output for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 * Add opt-in rule `private_subject` rule which warns against
   public Combine subjects.  
   [Otavio Cordeiro](https://github.com/otaviocc)
+* Tweak the auto-correction result console output for clarity.  
+  [mokagio](https://github.com/mokagio)
+  [#3522](https://github.com/realm/SwiftLint/issues/3522)
 
 #### Bug Fixes
 

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -152,7 +152,7 @@ struct LintOrAnalyzeCommand {
                 let pluralSuffix = { (collection: [Any]) -> String in
                     return collection.count != 1 ? "s" : ""
                 }
-                queuedPrintError("Done correcting \(files.count) file\(pluralSuffix(files))!")
+                queuedPrintError("Done inspecting \(files.count) file\(pluralSuffix(files)) for auto-correction!")
             }
             return .success(())
         }


### PR DESCRIPTION
Hello dear SwiftLint maintainers 👋 

A colleague was confused by the output of `swiftlint autocorrect`, she couldn't understand why SwiftLint told her it corrected thousands of files when she only touched one.

The `Done correcting \(files.count)...` output made her think that a change was made on each of the `files`, when really they had only been inspected.

A good solution would be to adopt a similar approach as the `lint` command does.

Not being familiar with the codebase, I though a good first step could have been to tweak the message a bit, making it clearer that the count printed to the console is the inspected files.

If the idea resonates and you'd rather implement a more refined solution, feel free to take over the branch or close this PR. I don't have the time to dive in and see if I can get it to work myself right now, but loop me in the conversation and let me know if there's anything you need from me to help. 

Thanks for maintaining this great tool 🙇‍♂️ 