### PR TITLE
[UnusedDeclarationRule] Allow configuring related USRs to skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@
   public Combine subjects.  
   [Otavio Cordeiro](https://github.com/otaviocc)
 
+* Allow configuring related USRs to skip in UnusedDeclarationRule by
+  specifying a list of USRs in the `related_usrs_to_skip` key.
+  For example you might have custom source tooling that does something
+  with types conforming to a procotol even if that type is never
+  explicitly referenced by other code.  
+  [JP Simard](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Fix typos in configuration options for `file_name` rule.  

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -1,20 +1,24 @@
 private enum ConfigurationKey: String {
     case severity = "severity"
     case includePublicAndOpen = "include_public_and_open"
+    case relatedUSRsToSkip = "related_usrs_to_skip"
 }
 
 public struct UnusedDeclarationConfiguration: RuleConfiguration, Equatable {
     private(set) var includePublicAndOpen: Bool
     private(set) var severity: ViolationSeverity
+    private(set) var relatedUSRsToSkip: Set<String>
 
     public var consoleDescription: String {
         return "\(ConfigurationKey.severity.rawValue): \(severity.rawValue), " +
-            "\(ConfigurationKey.includePublicAndOpen.rawValue): \(includePublicAndOpen)"
+            "\(ConfigurationKey.includePublicAndOpen.rawValue): \(includePublicAndOpen), " +
+            "\(ConfigurationKey.relatedUSRsToSkip.rawValue): \(relatedUSRsToSkip.sorted())"
     }
 
-    public init(severity: ViolationSeverity, includePublicAndOpen: Bool) {
+    public init(severity: ViolationSeverity, includePublicAndOpen: Bool, relatedUSRsToSkip: Set<String>) {
         self.includePublicAndOpen = includePublicAndOpen
         self.severity = severity
+        self.relatedUSRsToSkip = relatedUSRsToSkip
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -35,6 +39,12 @@ public struct UnusedDeclarationConfiguration: RuleConfiguration, Equatable {
                 }
             case (.includePublicAndOpen, let boolValue as Bool):
                 includePublicAndOpen = boolValue
+            case (.relatedUSRsToSkip, let value):
+                if let usrs = [String].array(of: value) {
+                    relatedUSRsToSkip.formUnion(usrs)
+                } else {
+                    throw ConfigurationError.unknownConfiguration
+                }
             default:
                 throw ConfigurationError.unknownConfiguration
             }


### PR DESCRIPTION
For example you might have custom source tooling that does something with types conforming to a procotol even if that type is never explicitly referenced by other code.