### PR TITLE
Update swiftlint Build phase code snippet to work on M1 Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ target, and go to Build Phases. Click the + and select "New Run Script Phase".
 Insert the following as the script:
 
 ```bash
+# Support for M1 Macs: Homebrew is installed on /opt/homebrew/ by default
+PATH=/opt/homebrew/bin/:$PATH
+
 if which swiftlint >/dev/null; then
   swiftlint
 else


### PR DESCRIPTION
The code snippet in the README should also work out of the box on M1 Macs where homebrew is installed in `/opt/homebrew` by default; swiftlint will not be in the default $PATH then and the shell configuration files like '.bashrc' don't change the environment for Xcode.