### PR TITLE
Integrate OS Signposts to help profile SwiftLint performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@
   rule.  
   [Thomas Goyne](https://github.com/tgoyne)
 
+* [Internal] Integrate OS Signposts to help profile SwiftLint
+  performance.  
+  [jpsim](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Fix typos in configuration options for `file_name` rule.  

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -32,56 +32,65 @@ struct LintOrAnalyzeCommand {
     }
 
     private static func lintOrAnalyze(_ options: LintOrAnalyzeOptions) -> Result<(), SwiftLintError> {
-        var fileBenchmark = Benchmark(name: "files")
-        var ruleBenchmark = Benchmark(name: "rules")
-        var violations = [StyleViolation]()
-        let storage = RuleStorage()
-        let configuration = Signposts.record(name: "LintOrAnalyzeCommand.ParseConfiguration") {
-            Configuration(options: options)
-        }
-        let reporter = reporterFrom(optionsReporter: options.reporter, configuration: configuration)
-        let cache = options.ignoreCache ? nil : LinterCache(configuration: configuration)
+        let builder = LintOrAnalyzeResultBuilder(options)
+        return collectViolations(builder: builder)
+            .flatMap { postProcessViolations(files: $0, builder: builder) }
+    }
+
+    private static func collectViolations(builder: LintOrAnalyzeResultBuilder)
+        -> Result<[SwiftLintFile], SwiftLintError> {
+        let options = builder.options
         let visitorMutationQueue = DispatchQueue(label: "io.realm.swiftlint.lintVisitorMutation")
-        return configuration.visitLintableFiles(options: options, cache: cache, storage: storage) { linter in
+        return builder.configuration.visitLintableFiles(options: options, cache: builder.cache,
+                                                        storage: builder.storage) { linter in
             let currentViolations: [StyleViolation]
             if options.benchmark {
                 let start = Date()
-                let (violationsBeforeLeniency, currentRuleTimes) = linter.styleViolationsAndRuleTimes(using: storage)
+                let (violationsBeforeLeniency, currentRuleTimes) = linter
+                    .styleViolationsAndRuleTimes(using: builder.storage)
                 currentViolations = applyLeniency(options: options, violations: violationsBeforeLeniency)
                 visitorMutationQueue.sync {
-                    fileBenchmark.record(file: linter.file, from: start)
-                    currentRuleTimes.forEach { ruleBenchmark.record(id: $0, time: $1) }
-                    violations += currentViolations
+                    builder.fileBenchmark.record(file: linter.file, from: start)
+                    currentRuleTimes.forEach { builder.ruleBenchmark.record(id: $0, time: $1) }
+                    builder.violations += currentViolations
                 }
             } else {
-                currentViolations = applyLeniency(options: options, violations: linter.styleViolations(using: storage))
+                currentViolations = applyLeniency(options: options,
+                                                  violations: linter.styleViolations(using: builder.storage))
                 visitorMutationQueue.sync {
-                    violations += currentViolations
+                    builder.violations += currentViolations
                 }
             }
             linter.file.invalidateCache()
-            reporter.report(violations: currentViolations, realtimeCondition: true)
-        }.flatMap { files in
-            Signposts.record(name: "LintOrAnalyzeCommand.PostProcessViolations") {
-                if isWarningThresholdBroken(configuration: configuration, violations: violations)
-                    && !options.lenient {
-                    violations.append(createThresholdViolation(threshold: configuration.warningThreshold!))
-                    reporter.report(violations: [violations.last!], realtimeCondition: true)
-                }
-                reporter.report(violations: violations, realtimeCondition: false)
-                let numberOfSeriousViolations = violations.filter({ $0.severity == .error }).count
-                if !options.quiet {
-                    printStatus(violations: violations, files: files, serious: numberOfSeriousViolations,
-                                verb: options.verb)
-                }
-                if options.benchmark {
-                    fileBenchmark.save()
-                    ruleBenchmark.save()
-                }
-                try? cache?.save()
-                guard numberOfSeriousViolations == 0 else { exit(2) }
-                return .success(())
+            builder.reporter.report(violations: currentViolations, realtimeCondition: true)
+        }
+    }
+
+    private static func postProcessViolations(files: [SwiftLintFile], builder: LintOrAnalyzeResultBuilder)
+        -> Result<(), SwiftLintError> {
+        return Signposts.record(name: "LintOrAnalyzeCommand.PostProcessViolations") {
+            let options = builder.options
+            let configuration = builder.configuration
+            if isWarningThresholdBroken(configuration: configuration, violations: builder.violations)
+                && !options.lenient {
+                builder.violations.append(
+                    createThresholdViolation(threshold: configuration.warningThreshold!)
+                )
+                builder.reporter.report(violations: [builder.violations.last!], realtimeCondition: true)
             }
+            builder.reporter.report(violations: builder.violations, realtimeCondition: false)
+            let numberOfSeriousViolations = builder.violations.filter({ $0.severity == .error }).count
+            if !options.quiet {
+                printStatus(violations: builder.violations, files: files, serious: numberOfSeriousViolations,
+                            verb: options.verb)
+            }
+            if options.benchmark {
+                builder.fileBenchmark.save()
+                builder.ruleBenchmark.save()
+            }
+            try? builder.cache?.save()
+            guard numberOfSeriousViolations == 0 else { exit(2) }
+            return .success(())
         }
     }
 
@@ -191,5 +200,26 @@ struct LintOrAnalyzeOptions {
         } else {
             return mode.verb
         }
+    }
+}
+
+private class LintOrAnalyzeResultBuilder {
+    var fileBenchmark = Benchmark(name: "files")
+    var ruleBenchmark = Benchmark(name: "rules")
+    var violations = [StyleViolation]()
+    let storage = RuleStorage()
+    let configuration: Configuration
+    let reporter: Reporter.Type
+    let cache: LinterCache?
+    let options: LintOrAnalyzeOptions
+
+    init(_ options: LintOrAnalyzeOptions) {
+        let config = Signposts.record(name: "LintOrAnalyzeCommand.ParseConfiguration") {
+            Configuration(options: options)
+        }
+        configuration = config
+        reporter = reporterFrom(optionsReporter: options.reporter, configuration: config)
+        cache = options.ignoreCache ? nil : LinterCache(configuration: config)
+        self.options = options
     }
 }

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -97,27 +97,29 @@ struct LintableFilesVisitor {
                        allowZeroLintableFiles: Bool,
                        block: @escaping (CollectedLinter) -> Void)
         -> Result<LintableFilesVisitor, SwiftLintError> {
-        let compilerInvocations: CompilerInvocations?
-        if options.mode == .lint {
-            compilerInvocations = nil
-        } else {
-            switch loadCompilerInvocations(options) {
-            case let .success(invocations):
-                compilerInvocations = invocations
-            case let .failure(error):
-                return .failure(error)
+        Signposts.record(name: "LintableFilesVisitor.Create") {
+            let compilerInvocations: CompilerInvocations?
+            if options.mode == .lint {
+                compilerInvocations = nil
+            } else {
+                switch loadCompilerInvocations(options) {
+                case let .success(invocations):
+                    compilerInvocations = invocations
+                case let .failure(error):
+                    return .failure(error)
+                }
             }
-        }
 
-        let visitor = LintableFilesVisitor(paths: options.paths, action: options.verb.bridge().capitalized,
-                                           useSTDIN: options.useSTDIN, quiet: options.quiet,
-                                           useScriptInputFiles: options.useScriptInputFiles,
-                                           forceExclude: options.forceExclude,
-                                           useExcludingByPrefix: options.useExcludingByPrefix,
-                                           cache: cache,
-                                           compilerInvocations: compilerInvocations,
-                                           allowZeroLintableFiles: allowZeroLintableFiles, block: block)
-        return .success(visitor)
+            let visitor = LintableFilesVisitor(paths: options.paths, action: options.verb.bridge().capitalized,
+                                               useSTDIN: options.useSTDIN, quiet: options.quiet,
+                                               useScriptInputFiles: options.useScriptInputFiles,
+                                               forceExclude: options.forceExclude,
+                                               useExcludingByPrefix: options.useExcludingByPrefix,
+                                               cache: cache,
+                                               compilerInvocations: compilerInvocations,
+                                               allowZeroLintableFiles: allowZeroLintableFiles, block: block)
+            return .success(visitor)
+        }
     }
 
     func shouldSkipFile(atPath path: String?) -> Bool {

--- a/Source/swiftlint/Helpers/Signposts.swift
+++ b/Source/swiftlint/Helpers/Signposts.swift
@@ -10,6 +10,7 @@ struct Signposts {
     }
 
     static func record<R>(name: StaticString, span: Span = .timeline, body: () -> R) -> R {
+#if canImport(os)
         if #available(OSX 10.14, *) {
             let log: OSLog
             let description: String?
@@ -35,8 +36,8 @@ struct Signposts {
                 os_signpost(.end, log: log, name: name, signpostID: signpostID)
             }
             return result
-        } else {
-            return body()
         }
+#endif
+        return body()
     }
 }

--- a/Source/swiftlint/Helpers/Signposts.swift
+++ b/Source/swiftlint/Helpers/Signposts.swift
@@ -1,0 +1,42 @@
+#if canImport(os)
+import os.signpost
+private let timelineLog = OSLog(subsystem: "io.realm.swiftlint", category: "Timeline")
+private let fileLog = OSLog(subsystem: "io.realm.swiftlint", category: "File")
+#endif
+
+struct Signposts {
+    enum Span {
+        case timeline, file(String)
+    }
+
+    static func record<R>(name: StaticString, span: Span = .timeline, body: () -> R) -> R {
+        if #available(OSX 10.14, *) {
+            let log: OSLog
+            let description: String?
+            switch span {
+            case .timeline:
+                log = timelineLog
+                description = nil
+            case .file(let file):
+                log = fileLog
+                description = file
+            }
+            let signpostID = OSSignpostID(log: log)
+            if let description = description {
+                os_signpost(.begin, log: log, name: name, signpostID: signpostID, "%{public}s", description)
+            } else {
+                os_signpost(.begin, log: log, name: name, signpostID: signpostID)
+            }
+
+            let result = body()
+            if let description = description {
+                os_signpost(.end, log: log, name: name, signpostID: signpostID, "%{public}s", description)
+            } else {
+                os_signpost(.end, log: log, name: name, signpostID: signpostID)
+            }
+            return result
+        } else {
+            return body()
+        }
+    }
+}


### PR DESCRIPTION
In the process, split `LintOrAnalyzeCommand.lintOrAnalyze(_:)` into two functions using a builder reference type to share common mutable state.

Run with Instruments and the OS Signposts instrument to see results. Helped identify a performance regression in https://github.com/realm/SwiftLint/pull/3534

![image](https://user-images.githubusercontent.com/474794/109038062-34e13d00-7680-11eb-89b4-4af270adcf18.png)

![image](https://user-images.githubusercontent.com/474794/109038077-3874c400-7680-11eb-9ec3-f7009aa27fa8.png)
