### PR TITLE
Add "stable git revision" to configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,4 @@
+stable_git_revision: origin/master
 included:
   - Source
   - Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@
   performance.  
   [jpsim](https://github.com/jpsim)
 
+* Add "stable git revision" to configuration. This allows specifying a
+  git revision or "commit-ish" that is considered stable. If specified,
+  SwifLint will attempt to query the git repository index for files
+  changed since that revision, using only those files as input as
+  opposed to traversing the file system to collect lintable files.  
+  [jpsim](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Fix typos in configuration options for `file_name` rule.  

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -12,8 +12,10 @@ extension Configuration {
     ///
     /// - returns: Files to lint.
     public func lintableFiles(inPath path: String, forceExclude: Bool,
+                              fileManager: LintableFileManager,
                               excludeByPrefix: Bool = false) -> [SwiftLintFile] {
-        return lintablePaths(inPath: path, forceExclude: forceExclude, excludeByPrefix: excludeByPrefix)
+        return lintablePaths(inPath: path, forceExclude: forceExclude, excludeByPrefix: excludeByPrefix,
+                             fileManager: fileManager)
             .compactMap(SwiftLintFile.init(pathDeferringReading:))
     }
 
@@ -31,7 +33,7 @@ extension Configuration {
         inPath path: String,
         forceExclude: Bool,
         excludeByPrefix: Bool = false,
-        fileManager: LintableFileManager = FileManager.default
+        fileManager: LintableFileManager
     ) -> [String] {
         // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
         if path.isFile && !forceExclude { return [path] }
@@ -53,7 +55,7 @@ extension Configuration {
     ///
     /// - returns: The input paths after removing the excluded paths.
     public func filterExcludedPaths(
-        fileManager: LintableFileManager = FileManager.default,
+        fileManager: LintableFileManager,
         in paths: [String]...
     ) -> [String] {
         let allPaths = paths.flatMap { $0 }

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -25,7 +25,8 @@ extension Configuration {
             warningThreshold: mergedWarningTreshold(with: childConfiguration),
             reporter: reporter,
             cachePath: cachePath,
-            allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles
+            allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles,
+            stableGitRevision: stableGitRevision
         )
     }
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -22,6 +22,7 @@ extension Configuration {
         case parentConfig = "parent_config"
         case remoteConfigTimeout = "remote_timeout"
         case remoteConfigTimeoutIfCached = "remote_timeout_if_cached"
+        case stableGitRevision = "stable_git_revision"
     }
 
     // MARK: - Properties
@@ -92,7 +93,8 @@ extension Configuration {
             reporter: dict[Key.reporter.rawValue] as? String ?? XcodeReporter.identifier,
             cachePath: cachePath ?? dict[Key.cachePath.rawValue] as? String,
             pinnedVersion: dict[Key.swiftlintVersion.rawValue].map { ($0 as? String) ?? String(describing: $0) },
-            allowZeroLintableFiles: dict[Key.allowZeroLintableFiles.rawValue] as? Bool ?? false
+            allowZeroLintableFiles: dict[Key.allowZeroLintableFiles.rawValue] as? Bool ?? false,
+            stableGitRevision: dict[Key.stableGitRevision.rawValue] as? String
         )
     }
 

--- a/Source/SwiftLintFramework/Helpers/Exec.swift
+++ b/Source/SwiftLintFramework/Helpers/Exec.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Namespace for utilities to execute a child process.
+enum Exec {
+    /// How to handle stderr output from the child process.
+    enum Stderr {
+        /// Treat stderr same as parent process.
+        case inherit
+        /// Send stderr to /dev/null.
+        case discard
+        /// Merge stderr with stdout.
+        case merge
+    }
+
+    /// The result of running the child process.
+    struct Results {
+        /// The process's exit status.
+        let terminationStatus: Int32
+        /// The data from stdout and optionally stderr.
+        let data: Data
+        /// The `data` reinterpreted as a string with whitespace trimmed; `nil` for the empty string.
+        var string: String? {
+            let encoded = String(data: data, encoding: .utf8) ?? ""
+            let trimmed = encoded.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    /**
+    Run a command with arguments and return its output and exit status.
+
+    - parameter command: Absolute path of the command to run.
+    - parameter arguments: Arguments to pass to the command.
+    - parameter currentDirectory: Current directory for the command.  By default
+                                  the parent process's current directory.
+    - parameter stderr: What to do with stderr output from the command.  By default
+                        whatever the parent process does.
+    */
+    static func run(_ command: String,
+                    _ arguments: String...,
+                    currentDirectory: String = FileManager.default.currentDirectoryPath,
+                    stderr: Stderr = .inherit) -> Results {
+        return run(command, arguments, currentDirectory: currentDirectory, stderr: stderr)
+    }
+
+    /**
+     Run a command with arguments and return its output and exit status.
+
+     - parameter command: Absolute path of the command to run.
+     - parameter arguments: Arguments to pass to the command.
+     - parameter currentDirectory: Current directory for the command.  By default
+                                   the parent process's current directory.
+     - parameter stderr: What to do with stderr output from the command.  By default
+                         whatever the parent process does.
+     */
+     static func run(_ command: String,
+                     _ arguments: [String] = [],
+                     currentDirectory: String = FileManager.default.currentDirectoryPath,
+                     stderr: Stderr = .inherit) -> Results {
+        let process = Process()
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        switch stderr {
+        case .discard:
+            // FileHandle.nullDevice does not work here, as it consists of an invalid file descriptor,
+            // causing process.launch() to abort with an EBADF.
+            process.standardError = FileHandle(forWritingAtPath: "/dev/null")!
+        case .merge:
+            process.standardError = pipe
+        case .inherit:
+            break
+        }
+
+        do {
+#if canImport(Darwin)
+            if #available(macOS 10.13, *) {
+                process.executableURL = URL(fileURLWithPath: command)
+                process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+                try process.run()
+            } else {
+                process.launchPath = command
+                process.currentDirectoryPath = currentDirectory
+                process.launch()
+            }
+#else
+            process.executableURL = URL(fileURLWithPath: command)
+            process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+            try process.run()
+#endif
+        } catch {
+            return Results(terminationStatus: -1, data: Data())
+        }
+
+        let file = pipe.fileHandleForReading
+        let data = file.readDataToEndOfFile()
+        process.waitUntilExit()
+        return Results(terminationStatus: process.terminationStatus, data: data)
+    }
+}

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -40,6 +40,11 @@ public struct Configuration {
     /// was used to explicitly specify the default `.swiftlint.yml` as the configuration file
     public private(set) var basedOnCustomConfigurationFiles: Bool = false
 
+    /// A git revision or "commit-ish" that is considered stable. If specified, SwifLint will attempt to query the git
+    /// repository index for files changed since that revision, using only those files as input as opposed to traversing
+    /// the file system to collect lintable files.
+    public let stableGitRevision: String?
+
     // MARK: Public Computed
     /// All rules enabled in this configuration
     public var rules: [Rule] { rulesWrapper.resultingRules }
@@ -69,7 +74,8 @@ public struct Configuration {
         warningThreshold: Int?,
         reporter: String,
         cachePath: String?,
-        allowZeroLintableFiles: Bool
+        allowZeroLintableFiles: Bool,
+        stableGitRevision: String?
     ) {
         self.rulesWrapper = rulesWrapper
         self.fileGraph = fileGraph
@@ -80,11 +86,12 @@ public struct Configuration {
         self.reporter = reporter
         self.cachePath = cachePath
         self.allowZeroLintableFiles = allowZeroLintableFiles
+        self.stableGitRevision = stableGitRevision
     }
 
     /// Creates a Configuration by copying an existing configuration.
     ///
-    /// - parameter copying:    The existing configuration to copy.
+    /// - parameter copying: The existing configuration to copy.
     internal init(copying configuration: Configuration) {
         rulesWrapper = configuration.rulesWrapper
         fileGraph = configuration.fileGraph
@@ -96,6 +103,7 @@ public struct Configuration {
         basedOnCustomConfigurationFiles = configuration.basedOnCustomConfigurationFiles
         cachePath = configuration.cachePath
         allowZeroLintableFiles = configuration.allowZeroLintableFiles
+        stableGitRevision = configuration.stableGitRevision
     }
 
     /// Creates a `Configuration` by specifying its properties directly,
@@ -117,6 +125,10 @@ public struct Configuration {
     /// - parameter cachePath:              The location of the persisted cache to use whith this configuration.
     /// - parameter pinnedVersion:          The SwiftLint version defined in this configuration.
     /// - parameter allowZeroLintableFiles: Allow SwiftLint to exit successfully when passed ignored or unlintable files
+    /// - parameter stableGitRevision:      A git revision or "commit-ish" that is considered stable. If specified,
+    ///                                     SwifLint will attempt to query the git repository index for files changed
+    ///                                     since that revision, using only those files as input as opposed to
+    ///                                     traversing the file system to collect lintable files.
     internal init(
         rulesMode: RulesMode = .default(disabled: [], optIn: []),
         allRulesWrapped: [ConfigurationRuleWrapper]? = nil,
@@ -129,7 +141,8 @@ public struct Configuration {
         reporter: String = XcodeReporter.identifier,
         cachePath: String? = nil,
         pinnedVersion: String? = nil,
-        allowZeroLintableFiles: Bool = false
+        allowZeroLintableFiles: Bool = false,
+        stableGitRevision: String? = nil
     ) {
         if let pinnedVersion = pinnedVersion, pinnedVersion != Version.current.value {
             queuedPrintError(
@@ -154,7 +167,8 @@ public struct Configuration {
             warningThreshold: warningThreshold,
             reporter: reporter,
             cachePath: cachePath,
-            allowZeroLintableFiles: allowZeroLintableFiles
+            allowZeroLintableFiles: allowZeroLintableFiles,
+            stableGitRevision: stableGitRevision
         )
     }
 

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -41,8 +41,9 @@ struct LintOrAnalyzeCommand {
         -> Result<[SwiftLintFile], SwiftLintError> {
         let options = builder.options
         let visitorMutationQueue = DispatchQueue(label: "io.realm.swiftlint.lintVisitorMutation")
-        return builder.configuration.visitLintableFiles(options: options, cache: builder.cache,
-                                                        storage: builder.storage) { linter in
+        let configuration = builder.configuration
+        return configuration.visitLintableFiles(options: options, cache: builder.cache, storage: builder.storage,
+                                                stableGitRevision: configuration.stableGitRevision) { linter in
             let currentViolations: [StyleViolation]
             if options.benchmark {
                 let start = Date()
@@ -156,7 +157,8 @@ struct LintOrAnalyzeCommand {
     private static func autocorrect(_ options: LintOrAnalyzeOptions) -> Result<(), SwiftLintError> {
         let storage = RuleStorage()
         let configuration = Configuration(options: options)
-        return configuration.visitLintableFiles(options: options, cache: nil, storage: storage) { linter in
+        return configuration.visitLintableFiles(options: options, cache: nil, storage: storage,
+                                                stableGitRevision: configuration.stableGitRevision) { linter in
             let corrections = linter.correct(using: storage)
             if !corrections.isEmpty && !options.quiet {
                 let correctionLogs = corrections.map({ $0.consoleDescription })

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -49,13 +49,14 @@ struct LintableFilesVisitor {
     let cache: LinterCache?
     let parallel: Bool
     let allowZeroLintableFiles: Bool
+    let stableGitRevision: String?
     let mode: LintOrAnalyzeModeWithCompilerArguments
     let block: (CollectedLinter) -> Void
 
     init(paths: [String], action: String, useSTDIN: Bool,
          quiet: Bool, useScriptInputFiles: Bool, forceExclude: Bool, useExcludingByPrefix: Bool,
          cache: LinterCache?, parallel: Bool,
-         allowZeroLintableFiles: Bool, block: @escaping (CollectedLinter) -> Void) {
+         allowZeroLintableFiles: Bool, stableGitRevision: String?, block: @escaping (CollectedLinter) -> Void) {
         self.paths = resolveParamsFiles(args: paths)
         self.action = action
         self.useSTDIN = useSTDIN
@@ -67,13 +68,14 @@ struct LintableFilesVisitor {
         self.parallel = parallel
         self.mode = .lint
         self.allowZeroLintableFiles = allowZeroLintableFiles
+        self.stableGitRevision = stableGitRevision
         self.block = block
     }
 
     private init(paths: [String], action: String, useSTDIN: Bool, quiet: Bool,
                  useScriptInputFiles: Bool, forceExclude: Bool, useExcludingByPrefix: Bool,
                  cache: LinterCache?, compilerInvocations: CompilerInvocations?,
-                 allowZeroLintableFiles: Bool, block: @escaping (CollectedLinter) -> Void) {
+                 allowZeroLintableFiles: Bool, stableGitRevision: String?, block: @escaping (CollectedLinter) -> Void) {
         self.paths = resolveParamsFiles(args: paths)
         self.action = action
         self.useSTDIN = useSTDIN
@@ -90,11 +92,13 @@ struct LintableFilesVisitor {
         }
         self.block = block
         self.allowZeroLintableFiles = allowZeroLintableFiles
+        self.stableGitRevision = stableGitRevision
     }
 
     static func create(_ options: LintOrAnalyzeOptions,
                        cache: LinterCache?,
                        allowZeroLintableFiles: Bool,
+                       stableGitRevision: String?,
                        block: @escaping (CollectedLinter) -> Void)
         -> Result<LintableFilesVisitor, SwiftLintError> {
         Signposts.record(name: "LintableFilesVisitor.Create") {
@@ -117,7 +121,9 @@ struct LintableFilesVisitor {
                                                useExcludingByPrefix: options.useExcludingByPrefix,
                                                cache: cache,
                                                compilerInvocations: compilerInvocations,
-                                               allowZeroLintableFiles: allowZeroLintableFiles, block: block)
+                                               allowZeroLintableFiles: allowZeroLintableFiles,
+                                               stableGitRevision: stableGitRevision,
+                                               block: block)
             return .success(visitor)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -260,7 +260,8 @@ class ConfigurationTests: XCTestCase {
     }
 
     func testLintablePaths() {
-        let paths = Configuration.default.lintablePaths(inPath: Mock.Dir.level0, forceExclude: false)
+        let paths = Configuration.default.lintablePaths(inPath: Mock.Dir.level0, forceExclude: false,
+                                                        fileManager: FileManager.default)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         let expectedFilenames = [
             "DirectoryLevel1.swift",
@@ -277,7 +278,8 @@ class ConfigurationTests: XCTestCase {
             excludedPaths: [Mock.Dir.level3.stringByAppendingPathComponent("*.swift")]
         )
 
-        XCTAssertEqual(configuration.lintablePaths(inPath: "", forceExclude: false), [])
+        XCTAssertEqual(configuration.lintablePaths(inPath: "", forceExclude: false, fileManager: FileManager.default),
+                       [])
     }
 
     // MARK: - Testing Configuration Equality
@@ -365,7 +367,8 @@ extension ConfigurationTests {
                                                           "Level1/Level2/Level3"])
         let paths = configuration.lintablePaths(inPath: Mock.Dir.level0,
                                                 forceExclude: false,
-                                                excludeByPrefix: true)
+                                                excludeByPrefix: true,
+                                                fileManager: FileManager.default)
         let filenames = paths.map { $0.bridge().lastPathComponent }
         XCTAssertEqual(filenames, ["Level2.swift"])
     }
@@ -375,7 +378,8 @@ extension ConfigurationTests {
         let configuration = Configuration(excludedPaths: ["Level1/Level2/Level3/Level3.swift"])
         let paths = configuration.lintablePaths(inPath: "Level1/Level2/Level3/Level3.swift",
                                                 forceExclude: true,
-                                                excludeByPrefix: true)
+                                                excludeByPrefix: true,
+                                                fileManager: FileManager.default)
         XCTAssertEqual([], paths)
     }
 
@@ -385,7 +389,8 @@ extension ConfigurationTests {
                                           excludedPaths: ["Level1/Level1.swift"])
         let paths = configuration.lintablePaths(inPath: "Level1",
                                                 forceExclude: true,
-                                                excludeByPrefix: true)
+                                                excludeByPrefix: true,
+                                                fileManager: FileManager.default)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         XCTAssertEqual(["Level2.swift", "Level3.swift"], filenames)
     }
@@ -399,7 +404,8 @@ extension ConfigurationTests {
         )
         let paths = configuration.lintablePaths(inPath: ".",
                                                 forceExclude: true,
-                                                excludeByPrefix: true)
+                                                excludeByPrefix: true,
+                                                fileManager: FileManager.default)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         XCTAssertEqual(["Level0.swift", "Level1.swift"], filenames)
     }
@@ -413,7 +419,8 @@ extension ConfigurationTests {
         )
         let paths = configuration.lintablePaths(inPath: ".",
                                                 forceExclude: true,
-                                                excludeByPrefix: true)
+                                                excludeByPrefix: true,
+                                                fileManager: FileManager.default)
         let filenames = paths.map { $0.bridge().lastPathComponent }
         XCTAssertEqual(["Level0.swift"], filenames)
     }
@@ -425,7 +432,8 @@ extension ConfigurationTests {
             excludedPaths: ["Level1/**/*.swift", "Level1/**/**/*.swift"])
         let paths = configuration.lintablePaths(inPath: "Level1",
                                                 forceExclude: false,
-                                                excludeByPrefix: true)
+                                                excludeByPrefix: true,
+                                                fileManager: FileManager.default)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         XCTAssertEqual(filenames, ["Level1.swift"])
     }

--- a/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IntegrationTests.swift
@@ -15,7 +15,7 @@ private let config: Configuration = {
 class IntegrationTests: XCTestCase {
     func testSwiftLintLints() {
         // This is as close as we're ever going to get to a self-hosting linter.
-        let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false)
+        let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false, fileManager: FileManager.default)
         XCTAssert(swiftFiles.contains(where: { #file == $0.path }), "current file should be included")
 
         let storage = RuleStorage()
@@ -30,7 +30,7 @@ class IntegrationTests: XCTestCase {
     }
 
     func testSwiftLintAutoCorrects() {
-        let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false)
+        let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false, fileManager: FileManager.default)
         let storage = RuleStorage()
         let corrections = swiftFiles.parallelFlatMap {
             Linter(file: $0, configuration: config).collect(into: storage).correct(using: storage)


### PR DESCRIPTION
This allows specifying a git revision or "commit-ish" that is considered stable. If specified, SwifLint will attempt to query the git repository index for files changed since that revision, using only those files as input as opposed to traversing the file system to collect lintable files.