### PR TITLE
Make discarded_notification_center_observer opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   works and we'll attempt to add a bridge to help with its transition.  
   [JP Simard](https://github.com/jpsim)
 
+* The `discarded_notification_center_observer` is not opt-in due to some
+  difficult to resolve false positives, such as
+  [#3498](https://github.com/realm/SwiftLint/issues/3498).  
+  [JP Simard](https://github.com/jpsim)
+
 #### Experimental
 
 * None.

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule,
+    OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}


### PR DESCRIPTION
It's very common for this rule to produce false positives, and there's no easy way to address them.

See these issues:
  * https://github.com/realm/SwiftLint/issues/1398
  * https://github.com/realm/SwiftLint/issues/3498