### PR TITLE
Multiple fixes for custom rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,21 @@
 
 #### Bug Fixes
 
+* Fix `custom_rules` merging when the parent configuration is based on
+  `only_rules`.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#3468](https://github.com/realm/SwiftLint/issues/3468)
+
+* Fix misleading warnings about rules defined in the `custom_rules` not
+  being available (when using multiple configurations).  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#3472](https://github.com/realm/SwiftLint/issues/3472)
+  
+* Fix bug that prevented the reconfiguration of a custom rule in a child
+  config.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [#3477](https://github.com/realm/SwiftLint/issues/3477)
+  
 * Fix typos in configuration options for `file_name` rule.  
   [advantis](https://github.com/advantis)
   

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -5,7 +5,6 @@ import SourceKittenFramework
 /// and is preferred in case of conflicts!
 
 extension Configuration {
-    // MARK: - Subtypes
     // MARK: - Methods: Merging
     internal func merged(
         withChild childConfiguration: Configuration,

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
@@ -64,5 +64,19 @@ public extension Configuration {
                 return .allEnabled
             }
         }
+
+        internal func activateCustomRuleIdentifiers(allRulesWrapped: [ConfigurationRuleWrapper]) -> RulesMode {
+            // In the only mode, if the custom rules rule is enabled, all custom rules are also enabled implicitly
+            // This method makes the implicity explicit
+            switch self {
+            case let .only(onlyRules) where onlyRules.contains { $0 == CustomRules.description.identifier }:
+                let customRulesRule = (allRulesWrapped.first { $0.rule is CustomRules })?.rule as? CustomRules
+                let customRuleIdentifiers = customRulesRule?.configuration.customRuleConfigurations.map(\.identifier)
+                return .only(onlyRules.union(Set(customRuleIdentifiers ?? [])))
+
+            default:
+                return self
+            }
+        }
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
@@ -38,10 +38,15 @@ internal extension ConfigurationTests {
             static var _0: String { Dir.level0.stringByAppendingPathComponent(Configuration.defaultFileName) }
             static var _0Custom: String { Dir.level0.stringByAppendingPathComponent("custom.yml") }
             static var _0CustomRules: String { Dir.level0.stringByAppendingPathComponent("custom_rules.yml") }
+            static var _0CustomRulesOnly: String { Dir.level0.stringByAppendingPathComponent("custom_rules_only.yml") }
             static var _2: String { Dir.level2.stringByAppendingPathComponent(Configuration.defaultFileName) }
             static var _2CustomRules: String { Dir.level2.stringByAppendingPathComponent("custom_rules.yml") }
+            static var _2CustomRulesOnly: String { Dir.level2.stringByAppendingPathComponent("custom_rules_only.yml") }
             static var _2CustomRulesDisabled: String {
                 Dir.level2.stringByAppendingPathComponent("custom_rules_disabled.yml")
+            }
+            static var _2CustomRulesReconfig: String {
+                Dir.level2.stringByAppendingPathComponent("custom_rules_reconfig.yml")
             }
             static var _3: String { Dir.level3.stringByAppendingPathComponent(Configuration.defaultFileName) }
             static var nested: String { Dir.nested.stringByAppendingPathComponent(Configuration.defaultFileName) }
@@ -61,10 +66,15 @@ internal extension ConfigurationTests {
             static var _0: Configuration { Configuration(configurationFiles: []) }
             static var _0Custom: Configuration { Configuration(configurationFiles: [Yml._0Custom]) }
             static var _0CustomRules: Configuration { Configuration(configurationFiles: [Yml._0CustomRules]) }
+            static var _0CustomRulesOnly: Configuration { Configuration(configurationFiles: [Yml._0CustomRulesOnly]) }
             static var _2: Configuration { Configuration(configurationFiles: [Yml._2]) }
             static var _2CustomRules: Configuration { Configuration(configurationFiles: [Yml._2CustomRules]) }
+            static var _2CustomRulesOnly: Configuration { Configuration(configurationFiles: [Yml._2CustomRulesOnly]) }
             static var _2CustomRulesDisabled: Configuration {
                 Configuration(configurationFiles: [Yml._2CustomRulesDisabled])
+            }
+            static var _2CustomRulesReconfig: Configuration {
+                Configuration(configurationFiles: [Yml._2CustomRulesReconfig])
             }
             static var _3: Configuration { Configuration(configurationFiles: [Yml._3]) }
             static var nested: Configuration { Configuration(configurationFiles: [Yml.nested]) }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -103,7 +103,31 @@ extension ConfigurationTests {
         )
     }
 
-    func testCustomRulesMergingWithOnlyRules() {
+    func testCustomRulesMergingWithOnlyRulesCase1() {
+        // The base configuration is in only rules mode
+        // The child configuration is in the default rules mode
+        // => all custom rules should be considered
+        let mergedConfiguration = Mock.Config._0CustomRulesOnly.merged(
+            withChild: Mock.Config._2CustomRules,
+            rootDirectory: ""
+        )
+        guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
+            else {
+            return XCTFail("Custom rules are expected to be present")
+        }
+        XCTAssertTrue(
+            mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abc" }
+        )
+        XCTAssertTrue(
+            mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abcd" }
+        )
+    }
+
+    func testCustomRulesMergingWithOnlyRulesCase2() {
+        // The base configuration is in only rules mode
+        // The child configuration is in the only rules mode
+        // => only the custom rules from the child configuration should be considered
+        // (because custom rules from base configuration would require explicit mention as one of the `only_rules`)
         let mergedConfiguration = Mock.Config._0CustomRulesOnly.merged(
             withChild: Mock.Config._2CustomRulesOnly,
             rootDirectory: ""
@@ -112,7 +136,7 @@ extension ConfigurationTests {
             else {
             return XCTFail("Custom rules are expected to be present")
         }
-        XCTAssertTrue(
+        XCTAssertFalse(
             mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abc" }
         )
         XCTAssertTrue(

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -76,13 +76,13 @@ extension ConfigurationTests {
         )
         guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
             else {
-            return XCTFail("Custom rule are expected to be present")
+            return XCTFail("Custom rules are expected to be present")
         }
         XCTAssertTrue(
-            mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abc" })
+            mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abc" }
         )
         XCTAssertTrue(
-            mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abcd" })
+            mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abcd" }
         )
     }
 
@@ -93,14 +93,52 @@ extension ConfigurationTests {
         )
         guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
             else {
-            return XCTFail("Custom rule are expected to be present")
+            return XCTFail("Custom rules are expected to be present")
         }
         XCTAssertFalse(
-            mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abc" })
+            mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abc" }
         )
         XCTAssertTrue(
-            mergedCustomRules.configuration.customRuleConfigurations.contains(where: { $0.identifier == "no_abcd" })
+            mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abcd" }
         )
+    }
+
+    func testCustomRulesMergingWithOnlyRules() {
+        let mergedConfiguration = Mock.Config._0CustomRulesOnly.merged(
+            withChild: Mock.Config._2CustomRulesOnly,
+            rootDirectory: ""
+        )
+        guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
+            else {
+            return XCTFail("Custom rules are expected to be present")
+        }
+        XCTAssertTrue(
+            mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abc" }
+        )
+        XCTAssertTrue(
+            mergedCustomRules.configuration.customRuleConfigurations.contains { $0.identifier == "no_abcd" }
+        )
+    }
+
+    func testCustomRulesReconfiguration() {
+        // Custom Rule severity gets reconfigured to "error"
+        let mergedConfiguration = Mock.Config._0CustomRulesOnly.merged(
+            withChild: Mock.Config._2CustomRulesReconfig,
+            rootDirectory: ""
+        )
+        guard let mergedCustomRules = mergedConfiguration.rules.first(where: { $0 is CustomRules }) as? CustomRules
+            else {
+            return XCTFail("Custom rules are expected to be present")
+        }
+        XCTAssertEqual(
+            mergedCustomRules.configuration.customRuleConfigurations.filter { $0.identifier == "no_abc" }.count, 1
+        )
+        guard let customRule = (mergedCustomRules.configuration.customRuleConfigurations.first {
+            $0.identifier == "no_abc"
+        }) else {
+            return XCTFail("Custom rule is expected to be present")
+        }
+        XCTAssertEqual(customRule.severityConfiguration.severity, .error)
     }
 
     // MARK: - Nested Configurations

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -88,6 +88,26 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(only, configuredIdentifiers)
     }
 
+    func testOnlyRulesWithCustomRules() {
+        // All custom rules from a config file should be active if the `custom_rules` is included in the `only_rules`
+        // As the behavior is different for custom rules from parent configs, this test is helpful
+        let only = ["custom_rules"]
+        let customRuleIdentifier = "my_custom_rule"
+        let customRules = [customRuleIdentifier: ["name": "A name for this custom rule", "regex": "this is illegal"]]
+
+        // swiftlint:disable:next force_try
+        let config = try! Configuration(dict: ["only_rules": only, "custom_rules": customRules])
+        guard let resultingCustomRules = config.rules.first(where: { $0 is CustomRules }) as? CustomRules
+            else {
+            return XCTFail("Custom rules are expected to be present")
+        }
+        XCTAssertTrue(
+            resultingCustomRules.configuration.customRuleConfigurations.contains {
+                $0.identifier == customRuleIdentifier
+            }
+        )
+    }
+
     func testWarningThreshold_value() {
         // swiftlint:disable:next force_try
         let config = try! Configuration(dict: ["warning_threshold": 5])

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules_only.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules_only.yml
@@ -1,0 +1,4 @@
+custom_rules:
+  no_abcd:
+    name: "Don't use abcd"
+    regex: 'abcd'

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules_only.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules_only.yml
@@ -1,3 +1,6 @@
+only_rules:
+  - custom_rules
+
 custom_rules:
   no_abcd:
     name: "Don't use abcd"

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules_reconfig.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/Level1/Level2/custom_rules_reconfig.yml
@@ -1,0 +1,5 @@
+custom_rules:
+  no_abc:
+    name: "Don't use abc"
+    regex: 'abc'
+    severity: 'error'

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/custom_rules_only.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/custom_rules_only.yml
@@ -1,0 +1,7 @@
+only_rules:
+  - custom_rules
+
+custom_rules:
+  no_abc:
+    name: "Don't use abc"
+    regex: 'abc'


### PR DESCRIPTION
This is the next attempt of https://github.com/realm/SwiftLint/pull/3473 which was reverted in https://github.com/realm/SwiftLint/pull/3503.

It builds upon https://github.com/realm/SwiftLint/pull/3473 and adds new tests for + fixes the issue that caused the need for temporary reverting as described in https://github.com/realm/SwiftLint/pull/3503.

The reason for the issue was that a mechanism that implicitly marks all custom rules as active in an `only_rules` mode scenario (iff the `custom_rules` rule is active) was only happening when merging configuration files, not for single configuration file scenarios.