### PR TITLE
Add SWIFTLINT_LOG_MODULE_USAGE environment variable for UnusedImportRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@
   [Artem Garmash](https://github.com/agarmash)
   [#3423](https://github.com/realm/SwiftLint/issues/3423)
 
+* Log references to a specified module when running the `unused_import`
+  by setting the `SWIFTLINT_LOG_MODULE_USAGE=<module-name>` environment
+  variable when running analyze.  
+  [jpsim](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Fix typos in configuration options for `file_name` rule.  

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -1,6 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
+private let moduleToLog = ProcessInfo.processInfo.environment["SWIFTLINT_LOG_MODULE_USAGE"]
+
 public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule, AutomaticTestableRule {
     public var configuration = UnusedImportConfiguration(severity: .warning, requireExplicitImports: false,
                                                          allowedTransitiveImports: [], alwaysKeepImports: [])
@@ -261,6 +263,11 @@ private extension SwiftLintFile {
     func appendUsedImports(cursorInfo: SourceKittenDictionary, usrFragments: inout Set<String>) {
         if let rootModuleName = cursorInfo.moduleName?.split(separator: ".").first.map(String.init) {
             usrFragments.insert(rootModuleName)
+            if rootModuleName == moduleToLog, let filePath = path, let usr = cursorInfo.value["key.usr"] as? String {
+                queuedPrintError(
+                    "[SWIFTLINT_LOG_MODULE_USAGE] \(rootModuleName) referenced by USR '\(usr)' in file '\(filePath)'"
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
That's because it can currently be difficult to know why a module is referenced in a file.

To use, run SwiftLint with the environment variable set to the module whose references you want to log to `stderr`:

    SWIFTLINT_LOG_MODULE_USAGE=MyModule swiftlint analyze ...