### PR TITLE
Fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   [Frederick Pietschmann](https://github.com/fredpi)
   [JP Simard](https://github.com/jpsim)
 
-* The `discarded_notification_center_observer` is not opt-in due to some
+* The `discarded_notification_center_observer` is now opt-in due to some
   difficult to resolve false positives, such as
   [#3498](https://github.com/realm/SwiftLint/issues/3498).  
   [JP Simard](https://github.com/jpsim)


### PR DESCRIPTION
This fixes a small typo that changed the entire meaning of the changelog entry ;)