### PR TITLE
Add integration with pre-commit tool

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
--   id: swiftlint
-    name: SwiftLint
-    description: "Check swift files for issues with SwiftLint"
-    entry: swiftlint
-    language: swift
-    types: [swift]
-    pass_filenames: false
+- id: swiftlint
+  name: SwiftLint
+  description: "Check swift files for issues with SwiftLint"
+  entry: "swiftlint --quiet --"
+  language: swift
+  types: [swift]
+  pass_filenames: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
     entry: swiftlint
     language: swift
     types: [swift]
+    pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: swiftlint
+    name: SwiftLint
+    description: "Check swift files for issues with SwiftLint"
+    entry: swiftlint
+    language: swift
+    types: [swift]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: swiftlint
   name: SwiftLint
-  description: "Check swift files for issues with SwiftLint"
+  description: "Check Swift files for issues with SwiftLint"
   entry: "swiftlint --quiet --"
   language: swift
   types: [swift]


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) is a popular tool used for managing git precommit hooks. This PR adds a .pre-commit-hooks.yaml file to allow swiftlint to be used with pre-commit.

Note: I am not proposing to use pre-commit in this project, this allows other projects that use pre-commit to more easily use swiftlint.