### PR TITLE
Add an Hashable specialized version of unique extension we can improve time complexity

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -28,6 +28,15 @@ extension Array where Element: Hashable {
         }
         return nil
     }
+
+    var unique: [Element] {
+        var uniqueValues = [Element]()
+        var added = Set<Element>()
+        for item in self where added.insert(item).inserted {
+            uniqueValues.append(item)
+        }
+        return uniqueValues
+    }
 }
 
 extension Array {


### PR DESCRIPTION
This is a very simple change just adding a `Hashable` specialized version of `unique` to improve time complexity since the compiler can pick either one based on element (Hashable is more specialized than Equatable) so there is no ambiguity and it can take advantage of a linear time complexity where it can choose the specialized one.

Few notes
* Didn't add tests because it is tested indirectly, but if you think it makes sense I can add :) 
* Also didn't know if there is a way to run benchmarks to know how much of an improvement this is

Let me know if this makes sense on the context of this project =] 