### PR TITLE
File false negatives in unused_declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@
 * Fix false positives with result builders in `unused_declaration`.  
   [JP Simard](https://github.com/jpsim)
 
+* Find more unused declarations in `unused_declaration`.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.42.0: He Chutes, He Scores
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -171,8 +171,7 @@ private extension SwiftLintFile {
 
         let cursorInfo = self.cursorInfo(at: nameOffset, compilerArguments: compilerArguments)
 
-        if let annotatedDecl = cursorInfo?.annotatedDeclaration,
-            ["@IBAction", "@objc"].contains(where: annotatedDecl.contains) {
+        if cursorInfo?.annotatedDeclaration?.contains("@objc ") == true {
             return nil
         }
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -261,6 +261,14 @@ struct UnusedDeclarationRuleExamples {
         public final class Foo: NSObject {
             @IBInspectable var ↓bar: String!
         }
+        """),
+        Example("""
+        import Foundation
+
+        final class Foo: NSObject {}
+        final class ↓Bar {
+            var ↓foo = Foo()
+        }
         """)
     ]
 #else


### PR DESCRIPTION
When a declaration refers to an Objective-C type but doesn't have an explicit `@objc` attribute.

It would have the string `@objc` embedded in its USR. So add a space so we only trigger this condition when there's an explicit `@objc` attribute in the declaration source code.

The triggering example added here didn't trigger before this change.