### PR TITLE
Require Swift 5.3 or higher to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 #### Breaking
 
-* None.
+* SwiftLint now requires Swift 5.3 or higher to build.  
+  [JP Simard](https://github.com/jpsim)
 
 #### Experimental
 

--- a/README.md
+++ b/README.md
@@ -60,19 +60,7 @@ running it.
 ### Installing from source:
 
 You can also build and install from source by cloning this project and running
-`make install` (Xcode 11.4 or later).
-
-### Known Installation Issues On MacOS Before 10.14.4
-
-Starting with [SwiftLint 0.32.0](https://github.com/realm/SwiftLint/releases/tag/0.32.0), if you get
-an error similar to `dyld: Symbol not found: _$s11SubSequenceSlTl` when running SwiftLint,
-you'll need to install the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/kb/DL1998).
-
-Alternatively, you can:
-
-* Update to macOS 10.14.4 or later
-* Install Xcode 11.4 or later at `/Applications/Xcode.app`
-* Rebuild SwiftLint from source using Xcode 11.4 or later
+`make install` (Xcode 12 or later).
 
 ## Usage
 
@@ -241,7 +229,8 @@ Here's a reference of which SwiftLint version to use for a given Swift version.
 | Swift 3.x       | SwiftLint 0.25.1                 |
 | Swift 4.0-4.1.x | SwiftLint 0.28.2                 |
 | Swift 4.2.x     | SwiftLint 0.35.0                 |
-| Swift 5.x       | Latest                           |
+| Swift 5.0-5.2.x | SwiftLint 0.43.0                 |
+| Swift 5.3+      | Latest                           |
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -218,20 +218,6 @@ On Linux, SourceKit is expected to be located in
 `/usr/lib/libsourcekitdInProc.so` or specified by the `LINUX_SOURCEKIT_LIB_PATH`
 environment variable.
 
-### Swift Version Support
-
-Here's a reference of which SwiftLint version to use for a given Swift version.
-
-| Swift version   | Last supported SwiftLint release |
-|:----------------|:---------------------------------|
-| Swift 1.x       | SwiftLint 0.1.2                  |
-| Swift 2.x       | SwiftLint 0.18.1                 |
-| Swift 3.x       | SwiftLint 0.25.1                 |
-| Swift 4.0-4.1.x | SwiftLint 0.28.2                 |
-| Swift 4.2.x     | SwiftLint 0.35.0                 |
-| Swift 5.0-5.2.x | SwiftLint 0.43.0                 |
-| Swift 5.3+      | Latest                           |
-
 ## Rules
 
 Over 100 rules are included in SwiftLint and the Swift community (that's you!)

--- a/README_CN.md
+++ b/README_CN.md
@@ -161,19 +161,6 @@ $ TOOLCHAINS=com.apple.dt.toolchain.Swift_2_3 swiftlint autocorrect
 
 在 Linux 上，SourceKit 默认需要位于 `/usr/lib/libsourcekitdInProc.so` 或者通过 `LINUX_SOURCEKIT_LIB_PATH` 环境变量进行指定。
 
-### Swift Version Support
-
-这里有一份 SwiftLint 版本和对应该 Swift 版本的对照表作为参考。
-
-| Swift 版本      | 最后一个 SwiftLint 支持版本 |
-|:----------------|:----------------------------|
-| Swift 1.x       | SwiftLint 0.1.2             |
-| Swift 2.x       | SwiftLint 0.18.1            |
-| Swift 3.x       | SwiftLint 0.25.1            |
-| Swift 4.0-4.1.x | SwiftLint 0.28.2            |
-| Swift 4.2.x     | SwiftLint 0.35.0            |
-| Swift 5.x       | 最新的                      |
-
 ## 规则
 
 SwiftLint 已经包含了超过 75 条规则，并且我们希望 Swift 社区（就是你！）会在以后有更多的贡献，我们鼓励提交 [Pull Requests](CONTRIBUTING.md)。

--- a/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
@@ -23,19 +23,3 @@ class CompilerProtocolInitRuleTests: XCTestCase {
         )
     }
 }
-
-// https://bugs.swift.org/browse/SR-11501
-#if SWIFT_PACKAGE && os(macOS) && compiler(<5.2)
-private enum UnwrapError: Error {
-    case missingValue
-}
-
-private func XCTUnwrap<T>(_ expression: @autoclosure () throws -> T?,
-                          _ message: @autoclosure () -> String = "") throws -> T {
-    if let value = try expression() {
-        return value
-    } else {
-        throw UnwrapError.missingValue
-    }
-}
-#endif

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,8 +8,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      swift52:
-        containerImage: swift:5.2
       swift53:
         containerImage: swift:5.3
   container: $[ variables['containerImage'] ]
@@ -23,14 +21,10 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      xcode114:
-        DEVELOPER_DIR: /Applications/Xcode_11.4.app
-      xcode115:
-        DEVELOPER_DIR: /Applications/Xcode_11.5.app
-      xcode116:
-        DEVELOPER_DIR: /Applications/Xcode_11.6.app
       xcode12:
         DEVELOPER_DIR: /Applications/Xcode_12.app
+      xcode124:
+        DEVELOPER_DIR: /Applications/Xcode_12.4.app
   steps:
     - script: |
         sw_vers
@@ -55,14 +49,10 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      xcode114:
-        DEVELOPER_DIR: /Applications/Xcode_11.4.app
-      xcode115:
-        DEVELOPER_DIR: /Applications/Xcode_11.5.app
-      xcode116:
-        DEVELOPER_DIR: /Applications/Xcode_11.6.app
       xcode12:
         DEVELOPER_DIR: /Applications/Xcode_12.app
+      xcode124:
+        DEVELOPER_DIR: /Applications/Xcode_12.4.app
   steps:
     - script: |
         sw_vers
@@ -77,7 +67,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.15'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_12.app
+    DEVELOPER_DIR: /Applications/Xcode_12.4.app
   steps:
     - script: bundle install --path vendor/bundle
       displayName: bundle install
@@ -90,7 +80,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.15'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_12.app
+    DEVELOPER_DIR: /Applications/Xcode_12.4.app
   steps:
     - script: make analyze
       displayName: Run SwiftLint Analyze
@@ -99,7 +89,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.15'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_12.app
+    DEVELOPER_DIR: /Applications/Xcode_12.4.app
   steps:
     - script: swift run --sanitize=thread swiftlint lint --lenient
       displayName: Pre-cache SwiftLint Run
@@ -112,7 +102,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.15'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_12.app
+    DEVELOPER_DIR: /Applications/Xcode_12.4.app
   steps:
     - script: swift run swiftlint generate-docs
       displayName: Run swiftlint generate-docs


### PR DESCRIPTION
Swift 5.3 has been available for close to 6 months now, seems like a good time to require it.