### PR TITLE
Fix the File Length rule name. #3560

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 #### Bug Fixes
 
-* Fix the File Length rule name.
+* Fix the File Length rule name.  
   [onato](https://github.com/onato)
   [#3560](https://github.com/realm/SwiftLint/issues/3560)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix the File Length rule name.
+  [onato](https://github.com/onato)
+  [#3560](https://github.com/realm/SwiftLint/issues/3560)
 
 ## 0.43.0: Clothes Line Interface
 

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -7,7 +7,7 @@ public struct FileLengthRule: ConfigurationProviderRule {
 
     public static let description = RuleDescription(
         identifier: "file_length",
-        name: "File Line Length",
+        name: "File Length",
         description: "Files should not span too many lines.",
         kind: .metrics,
         nonTriggeringExamples: [


### PR DESCRIPTION
Issue https://github.com/realm/SwiftLint/issues/3560

I couldn’t see where the `oss-check` reference results are stored.