### PR TITLE
Add parameter max_declarations to pattern_matching_keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@
 
 #### Enhancements
 
-* None.
+* Add `max_declarations` configuration option to `pattern_matching_keywords` 
+  rule to set number of declarations allowed inside tuples in a `switch`.  
+  [Marcin Podeszwa](https://github.com/mpodeszwa)
+  [#3566](https://github.com/realm/SwiftLint/pull/3566)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PatternMatchingKeywordsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PatternMatchingKeywordsRuleConfiguration.swift
@@ -1,0 +1,24 @@
+public struct PatternMatchingKeywordsRuleConfiguration: RuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.warning)
+    var maxDeclarations = 1
+
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription + ", max_declarations: \(maxDeclarations)"
+    }
+
+    public init(maxDeclarations: Int) {
+        self.maxDeclarations = maxDeclarations
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        maxDeclarations = configuration["max_declarations"] as? Int ?? 1
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1162,7 +1162,8 @@ extension ParserDiagnosticsTests {
 
 extension PatternMatchingKeywordsRuleTests {
     static var allTests: [(String, (PatternMatchingKeywordsRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration),
+        ("testWithZeroMaxDeclarations", testWithZeroMaxDeclarations)
     ]
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -527,12 +527,6 @@ class OverrideInExtensionRuleTests: XCTestCase {
     }
 }
 
-class PatternMatchingKeywordsRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(PatternMatchingKeywordsRule.description)
-    }
-}
-
 class PreferNimbleRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferNimbleRule.description)

--- a/Tests/SwiftLintFrameworkTests/PatternMatchingKeywordsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/PatternMatchingKeywordsRuleTests.swift
@@ -1,0 +1,50 @@
+import SwiftLintFramework
+import XCTest
+
+class PatternMatchingKeywordsRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PatternMatchingKeywordsRule.description)
+    }
+
+    func testWithZeroMaxDeclarations() {
+        let nonTriggeringExamples = [
+            Example("default"),
+            Example("case 1"),
+            Example("case bar"),
+            Example("case let (x)"),
+            Example("case let (x, y)"),
+            Example("case let .foo(x, y)"),
+            Example("case .foo(let x, var y)"),
+            Example("case var (x, y)"),
+            Example("case var .foo(x, y)")
+        ].map(wrapInSwitch)
+        let triggeringExamples = [
+            Example("case .foo(↓let x)"),
+            Example("case .foo(↓let x), .bar(↓let x)"),
+            Example("case .foo(↓let x), let .bar(x)"),
+            Example("case .foo(↓var x)"),
+            Example("case .foo(↓let x, (↓let y, ↓let z))"),
+            Example("case .foo(↓let x, ↓let (y, z))"),
+            Example("case (↓let x,  ↓let y)"),
+            Example("case .foo(↓let x, ↓let y)"),
+            Example("case (.yamlParsing(↓let x), .yamlParsing(↓let y))"),
+            Example("case (↓var x,  ↓var y)"),
+            Example("case .foo(↓var x, ↓var y)"),
+            Example("case (.yamlParsing(↓var x), .yamlParsing(↓var y))"),
+            Example("case (↓let .yamlParsing(x), ↓let .yamlParsing(y))")
+        ].map(wrapInSwitch)
+
+        let description = PatternMatchingKeywordsRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["max_declarations": 0])
+    }
+}
+
+private func wrapInSwitch(_ example: Example) -> Example {
+    return example.with(code: """
+        switch foo {
+            \(example.code): break
+        }
+        """)
+}


### PR DESCRIPTION
This change adds additional configuration for `pattern_matching_keyword` rule (purely for styling).

Consider following enum:

```
enum Foo {
    case single(Int)
    case double(Int, Int)
    case triple(Int, Int, Int)

    var sum: Int {
        switch self {
        case .single(let x):
            return x
        case .double(let x, let y):
            return x + y
        case .triple(let x, let y, let z):
            return x + y + z
        }
    }
}
```

Enabling `pattern_matching_keyword` would enforce following code:

```
enum Foo {
    case single(Int)
    case double(Int, Int)
    case triple(Int, Int, Int)

    var sum: Int {
        switch self {
        case .single(let x):
            return x
        case let .double(x, y):
            return x + y
        case let .triple(x, y, z):
            return x + y + z
        }
    }
}
```

However, in this case `let`s are not in the same place. `let` is either before or after identifier depending on number of parameters. 

This PR allows you to specify in `.swiftlint.yml`:

```
pattern_matching_keyword:
  max_declarations: 0
```

and then example code will look like this:

```
enum Foo {
    case single(Int)
    case double(Int, Int)
    case triple(Int, Int, Int)

    var sum: Int {
        switch self {
        case let .single(x):
            return x
        case let .double(x, y):
            return x + y
        case let .triple(x, y, z):
            return x + y + z
        }
    }
}
```
