### PR TITLE
Re-add --format flag to reformat Swift files using SourceKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   [onato](https://github.com/onato)
   [#3560](https://github.com/realm/SwiftLint/issues/3560)
 
+* Re-add `--format` flag to reformat Swift files using SourceKit.
+  Only applied with `--fix`/`--autocorrect`.  
+  [JP Simard](https://github.com/jpsim)
+  [#3571](https://github.com/realm/SwiftLint/issues/3571)
+
 ## 0.43.0: Clothes Line Interface
 
 #### Breaking

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -43,6 +43,7 @@ extension SwiftLint {
                 ignoreCache: true,
                 enableAllRules: false,
                 autocorrect: common.fix,
+                format: common.format,
                 compilerLogPath: compilerLogPath,
                 compileCommands: compileCommands
             )

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -47,6 +47,7 @@ extension SwiftLint {
                 ignoreCache: noCache,
                 enableAllRules: enableAllRules,
                 autocorrect: common.fix,
+                format: common.format,
                 compilerLogPath: nil,
                 compileCommands: nil
             )

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -20,6 +20,11 @@ struct LintOrAnalyzeArguments: ParsableArguments {
     var config = [String]()
     @Flag(name: [.long, .customLong("autocorrect")], help: "Correct violations whenever possible.")
     var fix = false
+    @Flag(help: """
+        Should reformat the Swift files using the same mechanism used by Xcode (via SourceKit).
+        Only applied with `--fix`/`--autocorrect`.
+        """)
+    var format = false
     @Flag(help: "Use an alternative algorithm to exclude paths for `excluded`, which may be faster in some cases.")
     var useAlternativeExcluding = false
     @Flag(help: "Read SCRIPT_INPUT_FILE* environment variables as files.")

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -157,6 +157,15 @@ struct LintOrAnalyzeCommand {
         let storage = RuleStorage()
         let configuration = Configuration(options: options)
         return configuration.visitLintableFiles(options: options, cache: nil, storage: storage) { linter in
+            if options.format {
+                switch configuration.indentation {
+                case .tabs:
+                    linter.format(useTabs: true, indentWidth: 4)
+                case .spaces(let count):
+                    linter.format(useTabs: false, indentWidth: count)
+                }
+            }
+
             let corrections = linter.correct(using: storage)
             if !corrections.isEmpty && !options.quiet {
                 let correctionLogs = corrections.map({ $0.consoleDescription })
@@ -191,6 +200,7 @@ struct LintOrAnalyzeOptions {
     let ignoreCache: Bool
     let enableAllRules: Bool
     let autocorrect: Bool
+    let format: Bool
     let compilerLogPath: String?
     let compileCommands: String?
 


### PR DESCRIPTION
Missed during the migration from Commandant to swift-argument-parser in https://github.com/realm/SwiftLint/pull/3465.

Fixes https://github.com/realm/SwiftLint/issues/3571.