### PR TITLE
"Colon Spacing" rule name update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
   Only applied with `--fix`/`--autocorrect`.  
   [JP Simard](https://github.com/jpsim)
   [#3571](https://github.com/realm/SwiftLint/issues/3571)
+  
+* Fix the rule name from "Colon" to "Colon Spacing" to improve phrasing.
+  [Radu](https://github.com/raduciobanu002)
 
 ## 0.43.0: Clothes Line Interface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
   
 * Fix the rule name from "Colon" to "Colon Spacing" to improve phrasing.
   [Radu](https://github.com/raduciobanu002)
+  [#3587](https://github.com/realm/SwiftLint/issues/3587)
 
 ## 0.43.0: Clothes Line Interface
 

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -14,7 +14,7 @@ public struct ColonRule: CorrectableRule, ConfigurationProviderRule {
 
     public static let description = RuleDescription(
         identifier: "colon",
-        name: "Colon",
+        name: "Colon Spacing",
         description: "Colons should be next to the identifier when specifying a type " +
                      "and next to the key in dictionary literals.",
         kind: .style,

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedCSVReporterOutput.csv
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedCSVReporterOutput.csv
@@ -2,4 +2,4 @@ file,line,character,severity,type,reason,rule_id
 filename,1,2,Warning,Line Length,Violation Reason.,line_length
 filename,1,2,Error,Line Length,Violation Reason.,line_length
 filename,1,2,Error,Syntactic Sugar,"Shorthand syntactic sugar should be used, i.e. [Int] instead of Array<Int>.",syntactic_sugar
-,,,Error,Colon,Colons should be next to the identifier when specifying a type and next to the key in dictionary literals.,colon
+,,,Error,Colon Spacing,Colons should be next to the identifier when specifying a type and next to the key in dictionary literals.,colon

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedCodeClimateReporterOutput.json
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedCodeClimateReporterOutput.json
@@ -45,7 +45,7 @@
     "type" : "issue"
   },
   {
-    "check_name" : "Colon",
+    "check_name" : "Colon Spacing",
     "description" : "Colons should be next to the identifier when specifying a type and next to the key in dictionary literals.",
     "engine_name" : "SwiftLint",
     "fingerprint" : "1f9389145aa6d7e89a582fce5ae54659",

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedJSONReporterOutput.json
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedJSONReporterOutput.json
@@ -33,6 +33,6 @@
     "rule_id" : "colon",
     "line" : null,
     "severity" : "Error",
-    "type" : "Colon"
+    "type" : "Colon Spacing"
   }
 ]

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedMarkdownReporterOutput.md
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedMarkdownReporterOutput.md
@@ -3,4 +3,4 @@ file | line | severity | reason | rule_id
 filename | 1 | :warning: | Line Length: Violation Reason. | line_length
 filename | 1 | :stop\_sign: | Line Length: Violation Reason. | line_length
 filename | 1 | :stop\_sign: | Syntactic Sugar: Shorthand syntactic sugar should be used, i.e. [Int] instead of Array<Int>. | syntactic_sugar
- |  | :stop\_sign: | Colon: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. | colon
+ |  | :stop\_sign: | Colon Spacing: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. | colon

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedXcodeReporterOutput.txt
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedXcodeReporterOutput.txt
@@ -1,4 +1,4 @@
 filename:1:2: warning: Line Length Violation: Violation Reason. (line_length)
 filename:1:2: error: Line Length Violation: Violation Reason. (line_length)
 filename:1:2: error: Syntactic Sugar Violation: Shorthand syntactic sugar should be used, i.e. [Int] instead of Array<Int>. (syntactic_sugar)
-<nopath>:1:1: error: Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)
+<nopath>:1:1: error: Colon Spacing Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)


### PR DESCRIPTION
**Why?**

The way `SwiftLint` was assembling some strings resulted in phrasing that... wasn't great:
![image](https://user-images.githubusercontent.com/79847218/112626010-8b7c9b00-8e27-11eb-98c7-24e0f3cb754f.png)

**How?**

* Changed the rule name from "Colon" to "Colon Spacing"
* Updated tests