### PR TITLE
[bug fix] expiring todo regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   with a static member (e.g. `if number == .zero`).  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3562](https://github.com/realm/SwiftLint/issues/3562)
+* Fix the regex for expiring-todos  
+  [namolnad](https://github.com/namolnad)
+  [#3597](https://github.com/realm/SwiftLint/issues/3597)
 
 ## 0.43.1: Laundroformat
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   [#3562](https://github.com/realm/SwiftLint/issues/3562)
 * Fix the regex for expiring-todos  
   [namolnad](https://github.com/namolnad)
-  [#3597](https://github.com/realm/SwiftLint/issues/3597)
+  [#3597](https://github.com/realm/SwiftLint/pull/3597)
 
 ## 0.43.1: Laundroformat
 

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -46,7 +46,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         // swiftlint:disable:next line_length
-        let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{2,4}\\\(configuration.dateSeparator)\\d{2}\\\(configuration.dateSeparator)\\d{2,4})\\\(configuration.dateDelimiters.closing)"
+        let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{1,4}\\\(configuration.dateSeparator)\\d{1,2}\\\(configuration.dateSeparator)\\d{1,4})\\\(configuration.dateDelimiters.closing)"
 
         return file.matchesAndSyntaxKinds(matching: regex).compactMap { checkingResult, syntaxKinds in
             guard

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -34,7 +34,9 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
         ],
         triggeringExamples: [
             Example("// TODO: [10/14/2019]\n"),
-            Example("// FIXME: [10/14/2019]\n")
+            Example("// FIXME: [10/14/2019]\n"),
+            Example("// FIXME: [1/14/2019]\n"),
+            Example("// FIXME: [10/4/2019]\n")
         ]
     )
 


### PR DESCRIPTION
Currently the regex for the expiring_todo rule requires zero-padded dates. (i.e. 01/01/2021 vs 1/1/2021). This loosens the regex digit searching to allow for dates which are not zero-padded.