### PR TITLE
Add test functions with parameters to TestCaseAccessibilityRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@
 
 #### Enhancements
 
-* None.
+* Make `test_case_accessibility` rule identify invalid test functions
+  with parameters.  
+  [Keith Smiley](https://github.com/keith)
+  [#3612](https://github.com/realm/SwiftLint/pull/3612)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Helpers/XCTestHelpers.swift
+++ b/Source/SwiftLintFramework/Helpers/XCTestHelpers.swift
@@ -4,11 +4,24 @@ private let testVariableNames: Set = [
     "allTests"
 ]
 
+private func hasParameters(dictionary: SourceKittenDictionary) -> Bool {
+    let nameRange = ByteRange(location: dictionary.nameOffset ?? 0, length: dictionary.nameLength ?? 0)
+    for subDictionary in dictionary.substructure {
+        if subDictionary.declarationKind == .varParameter,
+            let parameterOffset = subDictionary.offset,
+            nameRange.contains(parameterOffset) {
+            return true
+        }
+    }
+
+    return false
+}
+
 enum XCTestHelpers {
     static func isXCTestMember(kind: SwiftDeclarationKind, name: String,
-                               attributes: [SwiftDeclarationAttributeKind]) -> Bool {
-        return attributes.contains(.override)
-            || (kind == .functionMethodInstance && name.hasPrefix("test"))
+                               dictionary: SourceKittenDictionary) -> Bool {
+        return dictionary.enclosedSwiftAttributes.contains(.override)
+            || (kind == .functionMethodInstance && name.hasPrefix("test") && !hasParameters(dictionary: dictionary))
             || ([.varStatic, .varClass].contains(kind) && testVariableNames.contains(name))
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -34,8 +34,7 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule,
             guard
                 let kind = subDictionary.declarationKind,
                 let name = subDictionary.name,
-                XCTestHelpers.isXCTestMember(kind: kind, name: name,
-                                             attributes: subDictionary.enclosedSwiftAttributes),
+                XCTestHelpers.isXCTestMember(kind: kind, name: name, dictionary: subDictionary),
                 let offset = subDictionary.offset,
                 subDictionary.enclosedVarParameters.isEmpty,
                 subDictionary.substructure.isEmpty else { return nil }

--- a/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -52,7 +52,7 @@ public struct TestCaseAccessibilityRule: Rule, OptInRule, ConfigurationProviderR
                 let kind = subDictionary.declarationKind,
                 kind != .varLocal,
                 let name = subDictionary.name,
-                !isXCTestMember(kind: kind, name: name, attributes: subDictionary.enclosedSwiftAttributes),
+                !isXCTestMember(kind: kind, name: name, dictionary: subDictionary),
                 let offset = subDictionary.offset,
                 subDictionary.accessibility?.isPrivate != true else { return nil }
 
@@ -61,8 +61,8 @@ public struct TestCaseAccessibilityRule: Rule, OptInRule, ConfigurationProviderR
     }
 
     private func isXCTestMember(kind: SwiftDeclarationKind, name: String,
-                                attributes: [SwiftDeclarationAttributeKind]) -> Bool {
-        return XCTestHelpers.isXCTestMember(kind: kind, name: name, attributes: attributes)
+                                dictionary: SourceKittenDictionary) -> Bool {
+        return XCTestHelpers.isXCTestMember(kind: kind, name: name, dictionary: dictionary)
             || configuration.allowedPrefixes.contains(where: name.hasPrefix)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRuleExamples.swift
@@ -44,6 +44,12 @@ internal struct TestCaseAccessibilityRuleExamples {
             func testFoo() {
                 XCTAssertTrue(true)
             }
+
+            func testBar() {
+                func nestedFunc() {}
+            }
+
+            private someFunc(hasParam: Bool) {}
         }
         """),
 
@@ -85,6 +91,8 @@ internal struct TestCaseAccessibilityRuleExamples {
             ↓static func testFoo() {}
 
             ↓static func allTests() {}
+
+            ↓func testFoo(hasParam: Bool) {}
         }
 
         final class BarTests: XCTestCase {


### PR DESCRIPTION
If a function starts with `test` but takes some parameters, it is not
actually a test.