### PR TITLE
Add duplicated_key_in_dictionary_literal rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   [Keith Smiley](https://github.com/keith)
   [#3612](https://github.com/realm/SwiftLint/pull/3612)
 
+* Add `duplicated_key_in_dictionary_literal` rule to warn against duplicated
+  keys in dictionary literals.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 #### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -38,6 +38,7 @@ public let primaryRuleList = RuleList(rules: [
     DiscouragedOptionalCollectionRule.self,
     DuplicateEnumCasesRule.self,
     DuplicateImportsRule.self,
+    DuplicatedKeyInDictionaryLiteralRule.self,
     DynamicInlineRule.self,
     EmptyCollectionLiteralRule.self,
     EmptyCountRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
@@ -1,0 +1,124 @@
+import SourceKittenFramework
+
+public struct DuplicatedKeyInDictionaryLiteralRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static var description = RuleDescription(
+        identifier: "duplicated_key_in_dictionary_literal",
+        name: "Duplicated Key in Dictionary Literal",
+        description: "Dictionary literals with duplicated keys will crash in runtime.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+                [
+                    1: "1",
+                    2: "2"
+                ]
+            """),
+            Example("""
+                [
+                    "1": 1,
+                    "2": 2
+                ]
+            """),
+            Example("""
+                [
+                    foo: "1",
+                    bar: "2"
+                ]
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                [
+                    1: "1",
+                    2: "2",
+                    ↓1: "one"
+                ]
+            """),
+            Example("""
+                [
+                    "1": 1,
+                    "2": 2,
+                    ↓"2": 2
+                ]
+            """),
+            Example("""
+                [
+                    foo: "1",
+                    bar: "2",
+                    baz: "3",
+                    ↓foo: "4",
+                    zaz: "5"
+                ]
+            """),
+            Example("""
+                [
+                    .one: "1",
+                    .two: "2",
+                    .three: "3",
+                    ↓.one: "1",
+                    .four: "4",
+                    .five: "5"
+                ]
+            """)
+        ]
+    )
+
+    public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        guard kind == .dictionary else {
+            return []
+        }
+
+        let keys = dictionaryKeys(with: file, dictionary: dictionary)
+        guard keys.count >= 2 else {
+            return []
+        }
+
+        var existingKeys: [String: DictionaryKey] = [:]
+        return keys
+            .filter { key in
+                guard let existingKey = existingKeys[key.content] else {
+                    existingKeys[key.content] = key
+                    return false
+                }
+
+                let existingKeyKinds = file.syntaxMap.kinds(inByteRange: existingKey.byteRange)
+                let keyKinds = file.syntaxMap.kinds(inByteRange: key.byteRange)
+                return keyKinds == existingKeyKinds
+            }.map { key in
+                StyleViolation(ruleDescription: Self.description,
+                               severity: configuration.severity,
+                               location: Location(file: file, byteOffset: key.byteRange.location))
+            }
+    }
+
+    private func dictionaryKeys(with file: SwiftLintFile,
+                                dictionary: SourceKittenDictionary) -> [DictionaryKey] {
+        let keys = dictionary.elements.enumerated().compactMap { index, element -> SourceKittenDictionary? in
+            // in a dictionary, the even elements are keys, and the odd elements are values
+            if index.isMultiple(of: 2) {
+                return element
+            }
+            return nil
+        }
+
+        let contents = file.stringView
+        return keys.compactMap { key -> DictionaryKey? in
+            guard let range = key.byteRange,
+                  let substring = contents.substringWithByteRange(range) else {
+                return nil
+            }
+
+            return DictionaryKey(byteRange: range, content: substring)
+        }
+    }
+
+    private struct DictionaryKey {
+        let byteRange: ByteRange
+        let content: String
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -410,6 +410,12 @@ extension DuplicateImportsRuleTests {
     ]
 }
 
+extension DuplicatedKeyInDictionaryLiteralRuleTests {
+    static var allTests: [(String, (DuplicatedKeyInDictionaryLiteralRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension DynamicInlineRuleTests {
     static var allTests: [(String, (DynamicInlineRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1842,6 +1848,7 @@ XCTMain([
     testCase(DiscouragedOptionalCollectionRuleTests.allTests),
     testCase(DuplicateEnumCasesRuleTests.allTests),
     testCase(DuplicateImportsRuleTests.allTests),
+    testCase(DuplicatedKeyInDictionaryLiteralRuleTests.allTests),
     testCase(DynamicInlineRuleTests.allTests),
     testCase(EmptyCollectionLiteralRuleTests.allTests),
     testCase(EmptyCountRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -149,6 +149,12 @@ class DuplicateImportsRuleTests: XCTestCase {
     }
 }
 
+class DuplicatedKeyInDictionaryLiteralRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(DuplicatedKeyInDictionaryLiteralRule.description)
+    }
+}
+
 class DynamicInlineRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DynamicInlineRule.description)


### PR DESCRIPTION
Based on https://twitter.com/fcbunn/status/1386991646777163778

Note that the implementation is not perfect and will yield false negatives in some cases (like if you use `Enum.value` and `.value` as keys), but at least this should not give us false positives, so I think the rule would be useful even as is.