### PR TITLE
Fix expiring_todo configuration key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3562](https://github.com/realm/SwiftLint/issues/3562)
 
+* Fix incorrect expiring_todo configuration key.  
+  [Dan Loman](https://github.com/namolnad)
+  [#3590](https://github.com/realm/SwiftLint/issues/3590)
+
 ## 0.43.1: Laundroformat
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -13,7 +13,7 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
 
     public var consoleDescription: String {
         return "(approaching_expiry_severity) \(approachingExpirySeverity.consoleDescription), " +
-        "(reached_or_passed_expiry_severity) \(expiredSeverity.consoleDescription)"
+        "(expired_severity) \(expiredSeverity.consoleDescription)"
     }
 
     private(set) var approachingExpirySeverity: SeverityConfiguration

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -53,7 +53,7 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         if let approachingExpiryConfiguration = configurationDict["approaching_expiry_severity"] {
             try approachingExpirySeverity.apply(configuration: approachingExpiryConfiguration)
         }
-        if let expiredConfiguration = configurationDict["expired_severity"] {
+        if let expiredConfiguration = configurationDict["expired_severity"] ?? configurationDict["reached_or_passed_expiry_severity"] {
             try expiredSeverity.apply(configuration: expiredConfiguration)
         }
         if let approachingExpiryThreshold = configurationDict["approaching_expiry_threshold"] as? Int {

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -78,14 +78,14 @@ class ExpiringTodoRuleTests: XCTestCase {
     }
 
     func testAlternativeConfigSyntax() {
-        XCTAssertEqual(makeConfig(nil, ExpiringTodoRule.description.identifier)!.ruleConfiguration.expiredSeverity, .init(.error))
+        let defaultConfig = makeConfig(nil, ExpiringTodoRule.description.identifier)!
+        XCTAssertEqual(defaultConfig.ruleConfiguration.expiredSeverity, .init(.error))
 
         let serializedConfig: [String: Any] = [
             "reached_or_passed_expiry_severity": "warning"
         ]
 
         let config = makeConfig(serializedConfig, ExpiringTodoRule.description.identifier)!
-
         XCTAssertEqual(config.ruleConfiguration.expiredSeverity, .init(.warning))
     }
 

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -77,6 +77,18 @@ class ExpiringTodoRuleTests: XCTestCase {
         XCTAssertEqual(violations.first!.reason, "TODO/FIXME has expired and must be resolved.")
     }
 
+    func testAlternativeConfigSyntax() {
+        XCTAssertEqual(makeConfig(nil, ExpiringTodoRule.description.identifier)!.ruleConfiguration.expiredSeverity, .init(.error))
+
+        let serializedConfig: [String: Any] = [
+            "reached_or_passed_expiry_severity": "warning"
+        ]
+
+        let config = makeConfig(serializedConfig, ExpiringTodoRule.description.identifier)!
+
+        XCTAssertEqual(config.ruleConfiguration.expiredSeverity, .init(.warning))
+    }
+
     private func violations(_ example: Example) -> [StyleViolation] {
         return SwiftLintFrameworkTests.violations(example, config: config)
     }


### PR DESCRIPTION
Addresses expiring_todo severity configuration https://github.com/realm/SwiftLint/issues/3590:

- Updates documentation to reflect intended configuration key for `expiring_todo` rule
- Adds alternative config syntax handling
- Adds unit test for alternative config key