### PR TITLE
Fix `type_contents_order` initializer detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3562](https://github.com/realm/SwiftLint/issues/3562)
 
+* Fix `type_contents_order` initializer detection.  
+  [StevenMagdy](https://github.com/StevenMagdy)
+
 ## 0.43.1: Laundroformat
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -121,7 +121,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 "viewDidDisappear("
             ]
 
-            if typeContentStructure.name!.starts(with: "init") {
+            if typeContentStructure.name!.starts(with: "init(") {
                 return .initializer
             } else if typeContentStructure.name!.starts(with: "deinit") {
                 return .deinitializer

--- a/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
@@ -247,6 +247,9 @@ class TypeContentsOrderRuleTests: XCTestCase {
                 // Other Method
                 func goToInfoVc() { /* TODO */ }
 
+                // Other Method
+                func initInfoVc () { /* TODO */ }
+
                 // IBAction
                 @IBAction func goNextButtonPressed() {
                     goToNextVc()


### PR DESCRIPTION
Fix where `type_contents_order` would detect functions that start with `init` as initializers.