### PR TITLE
Error on bad expiring todo date formats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
   [JP Simard](https://github.com/jpsim)
   [#3920](https://github.com/realm/SwiftLint/issues/3920)
 
+* Error by default on bad expiring todo date formatting.  
+  [Christopher Hale](https://github.com/chrispomeroyhale)
+  [#3636](https://github.com/realm/SwiftLint/pull/3626)
+
 ## 0.47.0: Smart Appliance
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -12,13 +12,23 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
     }
 
     public var consoleDescription: String {
-        return "(approaching_expiry_severity) \(approachingExpirySeverity.consoleDescription), " +
-        "(reached_or_passed_expiry_severity) \(expiredSeverity.consoleDescription)"
+        let descriptions = [
+            "approaching_expiry_severity: \(approachingExpirySeverity.consoleDescription)",
+            "expired_severity: \(expiredSeverity.consoleDescription)",
+            "bad_formatting_severity: \(badFormattingSeverity.consoleDescription)",
+            "approaching_expiry_threshold: \(approachingExpiryThreshold)",
+            "date_format: \(dateFormat)",
+            "date_delimiters: { opening: \(dateDelimiters.opening)", "closing: \(dateDelimiters.closing) }",
+            "date_separator: \(dateSeparator)"
+        ]
+        return descriptions.joined(separator: ", ")
     }
 
     private(set) var approachingExpirySeverity: SeverityConfiguration
 
     private(set) var expiredSeverity: SeverityConfiguration
+
+    private(set) var badFormattingSeverity: SeverityConfiguration
 
     // swiftlint:disable:next todo
     /// The number of days prior to expiry before the TODO emits a violation
@@ -33,12 +43,14 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
     public init(
         approachingExpirySeverity: SeverityConfiguration = .init(.warning),
         expiredSeverity: SeverityConfiguration = .init(.error),
+        badFormattingSeverity: SeverityConfiguration = .init(.error),
         approachingExpiryThreshold: Int = 15,
         dateFormat: String = "MM/dd/yyyy",
         dateDelimiters: DelimiterConfiguration = .default,
         dateSeparator: String = "/") {
         self.approachingExpirySeverity = approachingExpirySeverity
         self.expiredSeverity = expiredSeverity
+        self.badFormattingSeverity = badFormattingSeverity
         self.approachingExpiryThreshold = approachingExpiryThreshold
         self.dateDelimiters = dateDelimiters
         self.dateFormat = dateFormat
@@ -55,6 +67,9 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         }
         if let expiredConfiguration = configurationDict["expired_severity"] {
             try expiredSeverity.apply(configuration: expiredConfiguration)
+        }
+        if let badFormattingConfiguration = configurationDict["bad_formatting_severity"] {
+            try badFormattingSeverity.apply(configuration: badFormattingConfiguration)
         }
         if let approachingExpiryThreshold = configurationDict["approaching_expiry_threshold"] as? Int {
             self.approachingExpiryThreshold = approachingExpiryThreshold

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -134,6 +134,18 @@ class ExpiringTodoRuleTests: XCTestCase {
         XCTAssertEqual(violations[0].location.line, 2)
     }
 
+    func testBadExpiryTodoFormat() throws {
+        let ruleConfig: ExpiringTodoConfiguration = .init(
+            dateFormat: "dd/yyyy/MM"
+        )
+        config = makeConfiguration(with: ruleConfig)
+
+        let example = Example("fatalError() // TODO: [31/01/2020] Implement")
+        let violations = self.violations(example)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first?.reason, "Expiring TODO/FIXME is incorrectly formatted.")
+    }
+
     private func violations(_ example: Example) -> [StyleViolation] {
         return SwiftLintFrameworkTests.violations(example, config: config)
     }
@@ -155,7 +167,7 @@ class ExpiringTodoRuleTests: XCTestCase {
             daysToAdvance = ruleConfiguration.approachingExpiryThreshold
         case .expired?:
             daysToAdvance = 0
-        case nil:
+        case .badFormatting?, nil:
             daysToAdvance = ruleConfiguration.approachingExpiryThreshold + 1
         }
 
@@ -174,6 +186,7 @@ class ExpiringTodoRuleTests: XCTestCase {
             serializedConfig = [
                 "expired_severity": config.expiredSeverity.severity.rawValue,
                 "approaching_expiry_severity": config.approachingExpirySeverity.severity.rawValue,
+                "bad_formatting_severity": config.badFormattingSeverity.severity.rawValue,
                 "approaching_expiry_threshold": config.approachingExpiryThreshold,
                 "date_format": config.dateFormat,
                 "date_delimiters": [


### PR DESCRIPTION
## Motivation
For expiring todos, there is currently a lack of documentation on the default date format. This currently requires a deep dive into SwiftLint to figure out what it is. This is a detractor of this tool in a team setting. Unfortunately, the default is an American date format which is a little surprising. Although it may be too late to change the default to be in line with ISO 8601, we can reject badly formatted dates which otherwise never expire or unexpectedly expire.

## What Changed
1. A bad TODO date format throws an error by default. This can be configured
2. To alleviate the lack of documentation, `consoleDescription` has been updated to correct and include all the latest properties
3. Updated the regex to accept any 1-4 letter date format in any position. In the future we might consider matching anything within the delimiters to the `date_format` and remove `date_separator`