### PR TITLE
Fix Autocorrect on no space between the tuple and "in" in unneeded_parentheses_in_closure_argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 
 * Fix `type_contents_order` initializer detection.  
   [StevenMagdy](https://github.com/StevenMagdy)
+  
+* Fix Autocorrect on no space between the tuple and "in" in unneeded_parentheses_in_closure_argument.  
+  [p-x9](https://github.com/p-x9)
+  [#3633](https://github.com/realm/SwiftLint/issues/3633)
 
 ## 0.43.1: Laundroformat
 

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -112,6 +112,12 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
             if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange),
                 let updatedRange = correctedContents.nsrangeToIndexRange(correctingRange) {
                 let updatedArguments = correctedContents[updatedRange]
+                if let whiteSpaceIndex = correctedContents.index(correctedContents.startIndex,
+                                                              offsetBy: violatingRange.location + violatingRange.length,
+                                                              limitedBy: correctedContents.endIndex),
+                   !String(correctedContents[whiteSpaceIndex]).hasTrailingWhitespace() {
+                    correctedContents.insert(" ", at: whiteSpaceIndex)
+                }
                 correctedContents = correctedContents.replacingCharacters(in: indexRange,
                                                                           with: String(updatedArguments))
                 adjustedLocations.insert(violatingRange.location, at: 0)

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -113,8 +113,8 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
                 let updatedRange = correctedContents.nsrangeToIndexRange(correctingRange) {
                 let updatedArguments = correctedContents[updatedRange]
                 if let whiteSpaceIndex = correctedContents.index(correctedContents.startIndex,
-                                                              offsetBy: violatingRange.location + violatingRange.length,
-                                                              limitedBy: correctedContents.endIndex),
+                                                                 offsetBy: violatingRange.location + violatingRange.length,
+                                                                 limitedBy: correctedContents.endIndex),
                    !String(correctedContents[whiteSpaceIndex]).hasTrailingWhitespace() {
                     correctedContents.insert(" ", at: whiteSpaceIndex)
                 }

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -112,8 +112,9 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
             if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange),
                 let updatedRange = correctedContents.nsrangeToIndexRange(correctingRange) {
                 let updatedArguments = correctedContents[updatedRange]
+                let whiteSpaceOffset = violatingRange.location + violatingRange.length
                 if let whiteSpaceIndex = correctedContents.index(correctedContents.startIndex,
-                                                                 offsetBy: violatingRange.location + violatingRange.length,
+                                                                 offsetBy: whiteSpaceOffset,
                                                                  limitedBy: correctedContents.endIndex),
                    !String(correctedContents[whiteSpaceIndex]).hasTrailingWhitespace() {
                     correctedContents.insert(" ", at: whiteSpaceIndex)

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -111,13 +111,12 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
                                           length: violatingRange.length - 2)
             if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange),
                 let updatedRange = correctedContents.nsrangeToIndexRange(correctingRange) {
-                let updatedArguments = correctedContents[updatedRange]
-                let whiteSpaceOffset = violatingRange.location + violatingRange.length
-                if let whiteSpaceIndex = correctedContents.index(correctedContents.startIndex,
-                                                                 offsetBy: whiteSpaceOffset,
+                var updatedArguments = correctedContents[updatedRange]
+                if let whiteSpaceIndex = correctedContents.index(indexRange.upperBound,
+                                                                 offsetBy: 0,
                                                                  limitedBy: correctedContents.endIndex),
                    !String(correctedContents[whiteSpaceIndex]).hasTrailingWhitespace() {
-                    correctedContents.insert(" ", at: whiteSpaceIndex)
+                    updatedArguments += " "
                 }
                 correctedContents = correctedContents.replacingCharacters(in: indexRange,
                                                                           with: String(updatedArguments))

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -52,6 +52,7 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
         corrections: [
             Example("call(arg: { ↓(bar) in })\n"): Example("call(arg: { bar in })\n"),
             Example("call(arg: { ↓(bar, _) in })\n"): Example("call(arg: { bar, _ in })\n"),
+            Example("call(arg: { ↓(bar, _)in })\n"): Example("call(arg: { bar, _ in })\n"),
             Example("let foo = { ↓(bar) -> Bool in return true }\n"):
                 Example("let foo = { bar -> Bool in return true }\n"),
             Example("method { ↓(foo, bar) in }\n"): Example("method { foo, bar in }\n"),


### PR DESCRIPTION
Fix Autocorrect on no space between the tuple and "in" in unneeded_parentheses_in_closure_argument.
Related to #3633