### PR TITLE
Fix CHANGELOG bad merge from colon violation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 * Add `duplicated_key_in_dictionary_literal` rule to warn against duplicated
   keys in dictionary literals.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  
+* Fix the rule name from "Colon" to "Colon Spacing" to improve phrasing.
+  [Radu](https://github.com/raduciobanu002)
+  [#3587](https://github.com/realm/SwiftLint/issues/3587)
 
 #### Bug Fixes
 
@@ -57,10 +61,6 @@
   Only applied with `--fix`/`--autocorrect`.  
   [JP Simard](https://github.com/jpsim)
   [#3571](https://github.com/realm/SwiftLint/issues/3571)
-  
-* Fix the rule name from "Colon" to "Colon Spacing" to improve phrasing.
-  [Radu](https://github.com/raduciobanu002)
-  [#3587](https://github.com/realm/SwiftLint/issues/3587)
 
 ## 0.43.0: Clothes Line Interface
 


### PR DESCRIPTION
The PR for this change was really old, so when it was merged in it was put under 0.43.1.
In actuality, it's a master change.