### PR TITLE
Improve `file_length` warnings when excluding comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   [Kane Cheshire](https://github.com/kanecheshire)
   [#3624](https://github.com/realm/SwiftLint/issues/3624)
 
+* Improve language and positioning of `file_length` warnings when
+  `ignore_comment_only_lines: true`.  
+  [Steven Grosmark](https://github.com/g-mark)
+  [#3654](https://github.com/realm/SwiftLint/pull/3654)
+
 #### Bug Fixes
 
 * Fix false positives in `empty_enum_arguments` rule when comparing values

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -40,7 +40,7 @@ public struct FileLengthRule: ConfigurationProviderRule {
 
         for parameter in configuration.severityConfiguration.params where lineCount > parameter.value {
             let reason = "File should contain \(configuration.severityConfiguration.warning) lines or less" +
-                         (configuration.ignoreCommentOnlyLines ? " excluding comments and whitespace" : "") +
+                         (configuration.ignoreCommentOnlyLines ? " excluding comments and whitespaces" : "") +
                          ": currently contains \(lineCount)"
             return [StyleViolation(ruleDescription: Self.description,
                                    severity: parameter.severity,

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -15,7 +15,8 @@ public struct FileLengthRule: ConfigurationProviderRule {
         ],
         triggeringExamples: [
             Example(repeatElement("print(\"swiftlint\")\n", count: 401).joined()),
-            Example((repeatElement("print(\"swiftlint\")\n", count: 400) + ["//\n"]).joined())
+            Example((repeatElement("print(\"swiftlint\")\n", count: 400) + ["//\n"]).joined()),
+            Example(repeatElement("print(\"swiftlint\")\n\n", count: 201).joined())
         ]
     )
 
@@ -38,11 +39,12 @@ public struct FileLengthRule: ConfigurationProviderRule {
         }
 
         for parameter in configuration.severityConfiguration.params where lineCount > parameter.value {
-            let reason = "File should contain \(configuration.severityConfiguration.warning) lines or less: " +
-                         "currently contains \(lineCount)"
+            let reason = "File should contain \(configuration.severityConfiguration.warning) lines or less" +
+                         (configuration.ignoreCommentOnlyLines ? " excluding comments and whitespace" : "") +
+                         ": currently contains \(lineCount)"
             return [StyleViolation(ruleDescription: Self.description,
                                    severity: parameter.severity,
-                                   location: Location(file: file.path, line: lineCount),
+                                   location: Location(file: file.path, line: file.lines.count),
                                    reason: reason)]
         }
 

--- a/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
@@ -13,7 +13,8 @@ class FileLengthRuleTests: XCTestCase {
         ]
         let nonTriggeringExamples = [
             Example((repeatElement("print(\"swiftlint\")\n", count: 400) + ["//\n"]).joined()),
-            Example(repeatElement("print(\"swiftlint\")\n", count: 400).joined())
+            Example(repeatElement("print(\"swiftlint\")\n", count: 400).joined()),
+            Example(repeatElement("print(\"swiftlint\")\n\n", count: 201).joined())
         ]
 
         let description = FileLengthRule.description


### PR DESCRIPTION
This PR adds two minor tweaks to how `file_length` warnings are reported when `ignore_comment_only_lines: true`:
- Move warnings to the bottom of the file, rather than at the line corresponding to the abridged line count
- Adds "excluding comments and whitespace" to the warning when appropriate
  Old: _"File Length Violation: File should contain 400 lines or less: currently contains 401 (file_length)"_ 
  New: _"File Length Violation: File should contain 400 lines or less excluding comments and whitespace: currently contains 401 (file_length)"_

`file_length` warnings remain unchanged when `ignore_comment_only_lines: false`