### PR TITLE
Address false positive in the redundant_optional_initialization rule when variable has observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 #### Enhancements
 
+* Fix false negative on `redundant_optional_initialization` rule when variable
+has observers.  
+[Isaac Ressler](https://github.com/iressler)
+[#3621](https://github.com/realm/SwiftLint/issues/3621)
+
 * Make `test_case_accessibility` rule identify invalid test functions
   with parameters.  
   [Keith Smiley](https://github.com/keith)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -57,7 +57,12 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
             Example("var myVar: Int?↓ = nil\n"),
             Example("var myVar: Optional<Int>↓ = nil\n"),
             Example("var myVar: Int?↓=nil\n"),
-            Example("var myVar: Optional<Int>↓=nil\n)")
+            Example("var myVar: Optional<Int>↓=nil\n)"),
+            Example("""
+              var myVar: String?↓ = nil {
+                didSet { print("didSet") }
+              }
+              """)
         ]
 
         guard SwiftVersion.current >= .fourDotOne else {
@@ -99,7 +104,7 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
         return corrections
     }()
 
-    private let pattern = "\\s*=\\s*nil\\b"
+    private let pattern = "\\s*=\\s*nil\\b\\s*\\{?"
 
     public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {


### PR DESCRIPTION
This change addresses #3621 where the redundant_optional_initialization rule fails when the variable has observers.

I couldn't find any way to determine that the property had any observers, although I may have missed something. So I came up with a change to the regex used to (I assume) verify the match is at the end of the checked range. The change adds a check for any number of spaces and an optional `{`:

`"\\s*=\\s*nil\\b"` -> `"\\s*=\\s*nil\\b\\s*\\{?"`