### PR TITLE
Add document comments to Reporter+CommandLine.swift file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 * Add document comments to `Reporter+CommandLine.swift` file.
   [Anh Pham](https://github.com/Taenerys)
-  [??](??)  
+  [#3673](https://github.com/realm/SwiftLint/pull/3673)  
   
 * Make `test_case_accessibility` rule identify invalid test functions
   with parameters.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 #### Enhancements
 
+* Add document comments to `Reporter+CommandLine.swift` file.
+  [Anh Pham](https://github.com/Taenerys)
+  [??](??)  
+  
 * Make `test_case_accessibility` rule identify invalid test functions
   with parameters.  
   [Keith Smiley](https://github.com/keith)

--- a/Source/swiftlint/Extensions/Reporter+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Reporter+CommandLine.swift
@@ -2,7 +2,7 @@ import SwiftLintFramework
 
 extension Reporter {
     /**
-     Optionally reports violations as they are found.
+        Optionally reports violations as they are found.
              
         - Parameters:
             - violations: An array of `StyleViolation` to report.

--- a/Source/swiftlint/Extensions/Reporter+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Reporter+CommandLine.swift
@@ -1,6 +1,13 @@
 import SwiftLintFramework
 
 extension Reporter {
+    /**
+     Optionally reports violations as they are found.
+             
+        - Parameters:
+            - violations: An array of `StyleViolation` to report.
+            - realtimeCondition: When enabled, output the report as violations are found.
+    */
     static func report(violations: [StyleViolation], realtimeCondition: Bool) {
         if isRealtime == realtimeCondition {
             let report = generateReport(violations)
@@ -11,6 +18,14 @@ extension Reporter {
     }
 }
 
+/**
+    Returns a reporter that corresponds with a defined identifier.
+ 
+    - Parameters:
+        - optionsReporter: An optional string that identifies the options.
+        - configuration: A `Configuration` value.
+    - Returns: A `Reporter` for the options, `Configuration` otherwise.
+ */
 func reporterFrom(optionsReporter: String?, configuration: Configuration) -> Reporter.Type {
     return reporterFrom(identifier: optionsReporter ?? configuration.reporter)
 }


### PR DESCRIPTION
## What does this PR include?

This PR includes adding document comments to the method `report` and the function `reporterFrom` in the file `Reporter+CommandLine.swift` file.

## What is the purpose of this PR?

The goal of this PR is to improve the documentation of these above method and function.

## How?

- I added Markdown Markup to make document comments before the method and function.
- I added a summary of my proposed changes, my name (with my Github link) and the PR number and link in the `CHANGELOG.md` file.

## Testing?

Ran the three test commands stated in [`CONTRIBUTING.md`](https://github.com/realm/SwiftLint/blob/master/CONTRIBUTING.md#tests) file and all of them have passed locally.  

Thank you! This is my first Pull Request to SwiftLint so I would really appreciate any suggestions and feedbacks!