### PR TITLE
NameConfiguration excluded_pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 #### Enhancements
 
+* Add `excluded_pattern` property to `NameConfiguration`.  
+  [Arnaud Dorgans](https://github.com/arnauddorgans)
+  [#3676](https://github.com/realm/SwiftLint/pull/3676) 
+  
 * Make `test_case_accessibility` rule identify invalid test functions
   with parameters.  
   [Keith Smiley](https://github.com/keith)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -81,7 +81,7 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
     }
 
     private func validate(name: String, file: SwiftLintFile, offset: ByteCount) -> [StyleViolation] {
-        guard !configuration.excluded.contains(name) else {
+        guard !shouldExcludeName(name) else {
             return []
         }
 
@@ -112,6 +112,18 @@ public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         return []
+    }
+
+    private func shouldExcludeName(_ name: String) -> Bool {
+        guard !configuration.excluded.contains(name) else {
+            return true
+        }
+        if !configuration.excludedPattern.isEmpty,
+           let match = regex(configuration.excludedPattern).firstMatch(in: name, options: [], range: name.fullNSRange),
+           name.nsrangeToIndexRange(match.range) != nil {
+            return true
+        }
+        return false
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -62,7 +62,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
 
     private func validate(name: String, dictionary: SourceKittenDictionary = SourceKittenDictionary([:]),
                           file: SwiftLintFile, offset: ByteCount) -> [StyleViolation] {
-        guard !configuration.excluded.contains(name) else {
+        guard !shouldExcludeName(name) else {
             return []
         }
 
@@ -90,6 +90,18 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         return []
+    }
+
+    private func shouldExcludeName(_ name: String) -> Bool {
+        guard !configuration.excluded.contains(name) else {
+            return true
+        }
+        if !configuration.excludedPattern.isEmpty,
+           let match = regex(configuration.excludedPattern).firstMatch(in: name, options: [], range: name.fullNSRange),
+           name.nsrangeToIndexRange(match.range) != nil {
+            return true
+        }
+        return false
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -5,6 +5,7 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
         return "(min_length) \(minLength.shortConsoleDescription), " +
             "(max_length) \(maxLength.shortConsoleDescription), " +
             "excluded: \(excluded.sorted()), " +
+            "excluded_pattern: \(excludedPattern)," +
             "allowed_symbols: \(allowedSymbolsSet.sorted()), " +
             "validates_start_with_lowercase: \(validatesStartWithLowercase)"
     }
@@ -12,6 +13,7 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
     var minLength: SeverityLevelsConfiguration
     var maxLength: SeverityLevelsConfiguration
     var excluded: Set<String>
+    var excludedPattern: String
     private var allowedSymbolsSet: Set<String>
     var validatesStartWithLowercase: Bool
 
@@ -32,11 +34,13 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
                 maxLengthWarning: Int,
                 maxLengthError: Int,
                 excluded: [String] = [],
+                excludedPattern: String = "",
                 allowedSymbols: [String] = [],
                 validatesStartWithLowercase: Bool = true) {
         minLength = SeverityLevelsConfiguration(warning: minLengthWarning, error: minLengthError)
         maxLength = SeverityLevelsConfiguration(warning: maxLengthWarning, error: maxLengthError)
         self.excluded = Set(excluded)
+        self.excludedPattern = excludedPattern
         self.allowedSymbolsSet = Set(allowedSymbols)
         self.validatesStartWithLowercase = validatesStartWithLowercase
     }
@@ -54,6 +58,9 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
         }
         if let excluded = [String].array(of: configurationDict["excluded"]) {
             self.excluded = Set(excluded)
+        }
+        if let excludedPattern = configurationDict["excluded_pattern"] as? String {
+            self.excludedPattern = excludedPattern
         }
         if let allowedSymbols = [String].array(of: configurationDict["allowed_symbols"]) {
             self.allowedSymbolsSet = Set(allowedSymbols)

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -30,7 +30,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         return validateName(dictionary: dictionary, kind: kind).map { name, offset in
-            guard !configuration.excluded.contains(name), let firstCharacter = name.first else {
+            guard !shouldExcludeName(name), let firstCharacter = name.first else {
                 return []
             }
 
@@ -82,6 +82,18 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
 
             return []
         } ?? []
+    }
+
+    private func shouldExcludeName(_ name: String) -> Bool {
+        guard !configuration.excluded.contains(name) else {
+            return true
+        }
+        if !configuration.excludedPattern.isEmpty,
+           let match = regex(configuration.excludedPattern).firstMatch(in: name, options: [], range: name.fullNSRange),
+           name.nsrangeToIndexRange(match.range) != nil {
+            return true
+        }
+        return false
     }
 
     private func validateName(dictionary: SourceKittenDictionary,

--- a/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
@@ -48,4 +48,17 @@ class GenericTypeNameRuleTests: XCTestCase {
                                          .with(triggeringExamples: triggeringExamples)
         verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": false])
     }
+
+    func testGenericTypeNameWithExcludedPattern() {
+        let baseDescription = GenericTypeNameRule.description
+        let triggeringExamples = [
+            Example("func foo<T_$_>() {}\n")
+        ]
+        let nonTriggeringExamples = [
+            Example("func foo<T_$>() {}\n")
+        ]
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
+                                         .with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["excluded_pattern": #".*_\$$"#])
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -56,4 +56,17 @@ class IdentifierNameRuleTests: XCTestCase {
         let description = baseDescription.with(triggeringExamples: triggeringExamples)
         verifyRule(description, ruleConfiguration: ["allowed_symbols": ["$", "%"]])
     }
+
+    func testIdentifierNameWithExcludedPattern() {
+        let baseDescription = IdentifierNameRule.description
+        let nonTriggeringExamples = [
+            Example("let my_Let$ = 0")
+        ]
+        let triggeringExamples = [
+            Example("let my_Let$_ = 0")
+        ]
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
+                                         .with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["excluded_pattern": #"Let\$$"#])
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -9,6 +9,7 @@ class RuleConfigurationTests: XCTestCase {
         let config = [ "min_length": ["warning": 17, "error": 7],
                        "max_length": ["warning": 170, "error": 700],
                        "excluded": "id",
+                       "excluded_pattern": "X",
                        "allowed_symbols": ["$"],
                        "validates_start_with_lowercase": false] as [String: Any]
         var nameConfig = NameConfiguration(minLengthWarning: 0,
@@ -20,6 +21,7 @@ class RuleConfigurationTests: XCTestCase {
                                      maxLengthWarning: 170,
                                      maxLengthError: 700,
                                      excluded: ["id"],
+                                     excludedPattern: "X",
                                      allowedSymbols: ["$"],
                                      validatesStartWithLowercase: false)
         do {

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -48,4 +48,17 @@ class TypeNameRuleTests: XCTestCase {
 
         verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": false])
     }
+
+    func testTypeNameWithExcludedPattern() {
+        let baseDescription = TypeNameRule.description
+        let nonTriggeringExamples = [
+            Example("enum MyType$")
+        ]
+        let triggeringExamples = [
+            Example("enum MyTypee$")
+        ]
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
+                                         .with(triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["excluded_pattern": #".*Type\$$"#])
+    }
 }


### PR DESCRIPTION
## What is the purpose of this PR?
The goal of this PR is to answer this issue https://github.com/realm/SwiftLint/issues/2156.
It allows us to exclude regex pattern for `generic_type_name`, `type_name` and `identifier_name` rules.

## How?
I added a new property to `NameConfiguration` named `excluded_pattern`

## Testing?
Ran the three test commands stated in CONTRIBUTING.md file and all of them have passed locally.