### PR TITLE
Fix improper handling of `\ ` in Xcode build logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@
   [p-x9](https://github.com/p-x9)
   [#3633](https://github.com/realm/SwiftLint/issues/3633)
 
+* Fix Xcode build logs with spaces in paths preventing `analyze` from running.  
+  [adamawolf](https://github.com/adamawolf)
+  [#3677](https://github.com/realm/SwiftLint/pull/3677)
+
 ## 0.43.1: Laundroformat
 
 #### Breaking

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -104,6 +104,7 @@ extension Array where Element == String {
 
         // https://github.com/realm/SwiftLint/issues/3365
         args = args.map { $0.replacingOccurrences(of: "\\=", with: "=") }
+        args = args.map { $0.replacingOccurrences(of: "\\ ", with: " ") }
         args.append(contentsOf: ["-D", "DEBUG"])
         var shouldContinueToFilterArguments = true
         while shouldContinueToFilterArguments {


### PR DESCRIPTION
When running an `analyze` using `--compiler-log-path`, `CompilerArgumentsExtractor.allCompilerInvocations` returns argument lists with entries like `Users/wolf/src/App/App\\ Modules/AModule/Sources/File.swift`.

This causes [the comparison here to fail](https://github.com/realm/SwiftLint/blob/master/Source/swiftlint/Helpers/LintableFilesVisitor.swift#L16) to find any files for a given analysis target path, and in-turn, for the file to not be analyzed if it belongs to a module with a space anywhere in it's path.