### PR TITLE
Add `scope_depth` rule to validate that scopes aren't nested more than `N` levels deep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@
   named arguments are used in closures that span multiple lines.  
   [Marcelo Fabri](https://github.com/marcelofabri)
 
+* Add `scope_depth` rule to validate that scopes aren't nested more than `N`
+  levels deep. `N` defaults to 10 but is configurable.  
+  [Dale Myers](https://github.com/dalemyers)
+  [#?](https://github.com/realm/SwiftLint/pull/?)
+
 #### Bug Fixes
 
 * Fix false positives in `empty_enum_arguments` rule when comparing values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * Add `scope_depth` rule to validate that scopes aren't nested more than `N`
   levels deep. `N` defaults to 10 but is configurable.  
   [Dale Myers](https://github.com/dalemyers)
-  [#?](https://github.com/realm/SwiftLint/pull/?)
+  [#3695](https://github.com/realm/SwiftLint/pull/3695)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -160,6 +160,7 @@ public let primaryRuleList = RuleList(rules: [
     RequiredDeinitRule.self,
     RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,
+    ScopeDepthRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,
     SortedFirstLastRule.self,

--- a/Source/SwiftLintFramework/Rules/Metrics/ScopeDepthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/ScopeDepthRule.swift
@@ -1,0 +1,209 @@
+import SourceKittenFramework
+
+public struct ScopeDepthRule: ConfigurationProviderRule {
+    public var configuration = ScopeDepthConfiguration(warningDepth: 7, errorDepth: 10)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "scope_depth",
+        name: "Scope Depth",
+        description: "Code should not be more than 10 scope levels deep",
+        kind: .metrics,
+        nonTriggeringExamples: [
+            Example("struct F0 { }"),
+            Example("struct F0 { struct F1 {}}"),
+            Example("struct F0 { struct F1 { struct F2 { Struct F3 { struct F4 {}}}}}"),
+            Example("struct F0 { struct F1 { struct F2 { Struct F3 { struct F4 { struct F5 { struct F6 { struct F7 {}}}}}}}}"), // swiftlint:disable:this line_length
+            Example("""
+                class One {
+                  class Two {
+                    class Three {
+                      func whatever() {}
+                      func four() {
+                        if 5 == 5 {
+                          print("Irrelevant")
+                          repeat {
+                            if 7 == 7 {
+                              print("Safe")
+                            }
+                          } while 6 == 6
+                        } else {
+                          print("Safe")
+                        }
+                      }
+                    }
+                  }
+                }
+                """)
+        ],
+        triggeringExamples: [
+            Example("struct F0 { struct F1 { struct F2 { Struct F3 { struct F4 { struct F5 { struct F6 { struct F7 { ↓struct F8 { ↓struct F9 { ↓struct F10 { ↓struct F11 {}}}}}}}}}}}}"), // swiftlint:disable:this line_length
+            Example("struct F0 { struct F1 { struct F2 { Struct F3 { struct F4 { struct F5 { struct F6 { struct F7 { ↓struct F8 { ↓struct F9 { ↓struct F10 { ↓struct F11 { struct F12 {}}}}}}}}}}}}}"), // swiftlint:disable:this line_length
+            Example("""
+                class Zero {
+                  class One {
+                    class Two {
+                      func safeFunc() { print("Safe") }
+                      func three() {
+                        if 4 == 4 {
+                          repeat {
+                            guard 7 == 7 else {
+                              break
+                            }
+                            if 6 != 6 {
+                              print("Safe")
+                            }
+                            if 6 == 6 {
+                              print("Pre-call")
+                              callFunc() {
+                                ↓print("Eight")
+                                ↓if 8 == 8 ↓{
+                                  ↓print("Nine")
+                                  ↓if 9 == 9 ↓{
+                                    ↓if 10 == 10 ↓{
+                                      ↓{
+                                        print("Bad")
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          } while 5 == 5
+                        } else {
+                          print("Safe")
+                        }
+                      }
+                    }
+                  }
+                }
+                """),
+            Example("""
+                class Zero {
+                  class One {
+                    class Two {
+                      func three() {
+                        switch 4 {
+                        case 4:
+                          for i in x {
+                            for var i = 0; i < 10; i++ {
+                              ↓callFunc() ↓↓{
+                                ↓while true ↓{
+                                  ↓if 1 == 2 ↓{
+                                    ↓{
+                                      print("Bad")
+                                    }
+                                  }
+                                }
+                                ↓print("Ten")
+                              }
+                              ↓print("Post-call")
+                            }
+                          }
+                        default:
+                          break
+                      }
+                      func safeFunc1() { let x = [1,2,3] }
+                      func safeFunc2(a: Int) { let x = [1: "One", 2: "Two", 3: "Three", a: "Unknown"] }
+                      func safeFunc3() { let x = (1, 2) }
+                      func safeFunc4() { let x = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) }
+                    }
+                  }
+                }
+                """)
+        ]
+    )
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        let substructure = file.structureDictionary.substructure
+
+        var violations = [StyleViolation]()
+
+        for structure in substructure {
+            // This will give all structures and depths in the file, so we filter
+            // down to just the ones we care about
+            for (depth, structureReference) in determineStructureDepths(structure) {
+                guard depth > self.configuration.warningDepth else {
+                    continue
+                }
+
+                violations.append(
+                    StyleViolation(
+                        ruleDescription: Self.description,
+                        severity: depth > self.configuration.errorDepth ? .error : .warning,
+                        location: Location(file: file, byteOffset: structureReference.offset ?? 0),
+                        reason: "Exceeds configured scope depth: \(configuration.consoleDescription)"
+                    )
+                )
+            }
+        }
+        return violations
+    }
+
+    private func determineStructureDepths(
+        _ structure: SwiftLintFramework.SourceKittenDictionary, depth: Int = 0
+    ) -> [(Int, SourceKittenDictionary)] {
+        var results = [(Int, SourceKittenDictionary)]()
+
+        results.append((depth, structure))
+
+        guard !structure.substructure.isEmpty else {
+            return results
+        }
+
+        // There's no point going deeper than we have to. If somthing is too
+        // deep, then obviously everything deeper will also need to be corrected.
+        guard depth <= configuration.errorDepth else {
+            return results
+        }
+
+        // Determine if we should increase the scope level or not
+        let shouldIncreaseScope: Bool = {
+            // If it was an expression it doesn't change the depth
+            if structure.expressionKind != nil {
+                return false
+            }
+
+            // If it was a declaration, it depends on the type of declaration
+            if let declarationKind: SwiftDeclarationKind = structure.declarationKind {
+                switch declarationKind {
+                case .`associatedtype`, .enumcase, .enumelement, .genericTypeParam,
+                     .module, .`typealias`, .varClass, .varGlobal, .varInstance,
+                     .varLocal, .varParameter, .varStatic:
+                  return false
+                case .`class`, .`enum`, .`extension`, .extensionClass, .extensionEnum,
+                     .extensionProtocol, .extensionStruct, .functionAccessorAddress,
+                     .functionAccessorDidset, .functionAccessorGetter, .functionAccessorModify,
+                     .functionAccessorMutableaddress, .functionAccessorRead, .functionAccessorSetter,
+                     .functionAccessorWillset, .functionConstructor, .functionDestructor,
+                     .functionFree, .functionMethodClass, .functionMethodInstance,
+                     .functionMethodStatic, .functionOperator, .functionOperatorInfix,
+                     .functionOperatorPostfix, .functionOperatorPrefix, .functionSubscript,
+                     .opaqueType, .precedenceGroup, .`protocol`, .`struct`:
+                  return true
+                }
+            }
+
+            // Statements usually increase scope/depth. For anything with a
+            // brace block though we just let the braces handle it (since they
+            // are separate from the statement).
+            if let statementKind = structure.statementKind {
+                switch statementKind {
+                case .brace, .`switch`, .`case`:
+                    return true
+                case .forEach, .`if`, .repeatWhile, .`guard`, .`while`, .`for`:
+                    return false
+                }
+            }
+
+            return false
+        }()
+
+        for substructure in structure.substructure {
+            let newDepth = shouldIncreaseScope ? depth + 1 : depth
+            results.append(contentsOf: determineStructureDepths(substructure, depth: newDepth))
+        }
+        return results
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ScopeDepthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ScopeDepthConfiguration.swift
@@ -1,0 +1,34 @@
+public struct ScopeDepthConfiguration: RuleConfiguration, Equatable {
+    private(set) var warningDepth: Int
+    private(set) var errorDepth: Int
+
+    public var consoleDescription: String {
+        return "warningDepth: \(warningDepth), errorDepth: \(errorDepth)"
+    }
+
+    public init(warningDepth: Int, errorDepth: Int) {
+        self.warningDepth = warningDepth
+        self.errorDepth = errorDepth
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configurationData = configuration as? [String: Int] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        guard let warningDepthValue = configurationData["warning"] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        guard let errorDepthValue = configurationData["error"] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        guard warningDepthValue <= errorDepthValue else {
+            throw ConfigurationError.generic("warning depth should be less than or equal to the error depth")
+        }
+
+        warningDepth = warningDepthValue
+        errorDepth = errorDepthValue
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/ScopeDepthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ScopeDepthRuleTests.swift
@@ -1,0 +1,8 @@
+import SwiftLintFramework
+import XCTest
+
+class ScopeDepthRuleTests: XCTestCase {
+    func testScopeDepthWithDefaultConfiguration() {
+        verifyRule(ScopeDepthRule.description)
+    }
+}


### PR DESCRIPTION
`N` defaults to 10 for warnings and 7 for errors, but is configurable.

Why do we want/need this rule? Swift relies heavily on closures and it's very easy to end up in a [pyramid of doom](https://en.wikipedia.org/wiki/Pyramid_of_doom_(programming)). By enforcing a max depth, developers are forced to re-evaluate and refactor their code so that it does not end up in this state. 

Some non-triggering examples:

```swift
struct F0 { }
```

```swift
struct F0 { struct F1 { struct F2 { Struct F3 { struct F4 { struct F5 { struct F6 { struct F7 {}}}}}}}}
```

A couple of triggering examples (these can be quite large):

```swift
struct F0 { struct F1 { struct F2 { Struct F3 { struct F4 { struct F5 { struct F6 { struct F7 { ↓struct F8 { ↓struct F9 { ↓struct F10 { ↓struct F11 {}}}}}}}}}}}}"
```
Triggers warning on F8, F9 and F10, and errors on F11.

```swift
class Zero {
  class One {
    class Two {
      func three() {
        if 4 == 4 {
          repeat {
            if 6 == 6 {
              callFunc() {
                ↓print("Eight")
                ↓if 8 == 8 ↓{
                  ↓print("Nine")
                  ↓if 9 == 9 ↓{
                    ↓if 10 == 10 ↓{
                      ↓{
                        print("Bad")
                      }
                    }
                  }
                }
              }
            }
          } while 5 == 5
        }
      }
    }
  }
}
``` 

Once the error level is reached, anything deeper is ignored to avoid excessive noise. 

I'm not entirely happy with the naming, so definitely open to changes there. 

This is my first real PR for SwiftLint, so there's probably a lot I've missed or misunderstood. 
