### PR TITLE
Updated README to mach swift-argument-parser's array parsing strategy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ while the last one is treated as the highest-priority child.
 
 A simple example including just two configuration files looks like this:
 
-`swiftlint --config ".swiftlint.yml .swiftlint_child.yml"`
+`swiftlint --config .swiftlint.yml --config .swiftlint_child.yml`
 
 ### Nested Configurations
 


### PR DESCRIPTION
Currently the [README's command line section](https://github.com/realm/SwiftLint#command-line-1) has a misleading example. The one I provide matches [swift-argument-parser's documentation](https://github.com/apple/swift-argument-parser/blob/main/Documentation/02%20Arguments%2C%20Options%2C%20and%20Flags.md#alternative-array-parsing-strategies).

Related #3652