### PR TITLE
add configuration for missing_docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@
 
 #### Enhancements
 
-* Add configurations to  `missing_docs` rule.
-[Ben Fox](https://github.com/bdfox325)
+* Add configuration options to  `missing_docs` rule:
+  * `excludes_extensions` defaults to `true` to skip reporting violations
+     for extensions with missing documentation comments.
+  * `excludes_inherited_types` defaults to `true` to skip reporting
+     violations for inherited declarations, like subclass overrides.  
+  [Ben Fox](https://github.com/bdfox325)
 
 * Fix false negative on `redundant_optional_initialization` rule when variable
   has observers.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 #### Enhancements
 
+* Add configurations to  `missing_docs` rule.
+[Ben Fox](https://github.com/bdfox325)
+
 * Fix false negative on `redundant_optional_initialization` rule when variable
   has observers.  
   [Isaac Ressler](https://github.com/iressler)

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -10,7 +10,12 @@ private extension SwiftLintFile {
             return []
         }
         let substructureOffsets = dictionary.substructure.flatMap {
-            missingDocOffsets(in: $0, acls: acls, excludesExtensions: excludesExtensions, excludesInheritedTypes: excludesInheritedTypes)
+            missingDocOffsets(
+                in: $0,
+                acls: acls,
+                excludesExtensions: excludesExtensions,
+                excludesInheritedTypes: excludesInheritedTypes
+            )
         }
         let extensionKinds: Set<SwiftDeclarationKind> = [.extension, .extensionEnum, .extensionClass,
                                                          .extensionStruct, .extensionProtocol]

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -20,13 +20,13 @@ private extension SwiftLintFile {
         let extensionKinds: Set<SwiftDeclarationKind> = [.extension, .extensionEnum, .extensionClass,
                                                          .extensionStruct, .extensionProtocol]
         guard let kind = dictionary.declarationKind,
-              (!extensionKinds.contains(kind) || !excludesExtensions),
-              case let isDeinit = kind == .functionMethodInstance && dictionary.name == "deinit",
-              !isDeinit,
-              let offset = dictionary.offset,
-              let acl = dictionary.accessibility,
-              acls.contains(acl) else {
-            return substructureOffsets
+            (!extensionKinds.contains(kind) || !excludesExtensions),
+            case let isDeinit = kind == .functionMethodInstance && dictionary.name == "deinit",
+            !isDeinit,
+            let offset = dictionary.offset,
+            let acl = dictionary.accessibility,
+            acls.contains(acl) else {
+                return substructureOffsets
         }
         if dictionary.docLength != nil {
             return substructureOffsets

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -4,9 +4,15 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
     private(set) var excludesInheritedTypes = true
 
     public var consoleDescription: String {
-        return parameters.group { $0.severity }.sorted { $0.key.rawValue < $1.key.rawValue }.map {
+        let parametersDescription = parameters.group { $0.severity }.sorted { $0.key.rawValue < $1.key.rawValue }.map {
             "\($0.rawValue): \($1.map { $0.value.description }.sorted(by: <).joined(separator: ", "))"
-        }.joined(separator: ", ") + ", excludes_extensions: \(excludesExtensions)"
+        }.joined(separator: ", ")
+
+        if parametersDescription.isEmpty {
+            return "excludes_extensions: \(excludesExtensions), excludes_inherited_types: \(excludesInheritedTypes)"
+        } else {
+            return "\(parametersDescription), excludes_extensions: \(excludesExtensions), excludes_inherited_types: \(excludesInheritedTypes)"
+        }
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -21,7 +27,7 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
 
         for (key, value) in dict {
             guard let severity = ViolationSeverity(rawValue: key) else {
-                continue
+                throw ConfigurationError.unknownConfiguration
             }
 
             if let array = [String].array(of: value) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -9,9 +9,18 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
         }.joined(separator: ", ")
 
         if parametersDescription.isEmpty {
-            return "excludes_extensions: \(excludesExtensions), excludes_inherited_types: \(excludesInheritedTypes)"
+            return [
+                "excludes_extensions: \(excludesExtensions)",
+                "excludes_inherited_types: \(excludesInheritedTypes)"
+            ]
+            .joined(separator: ", ")
         } else {
-            return "\(parametersDescription), excludes_extensions: \(excludesExtensions), excludes_inherited_types: \(excludesInheritedTypes)"
+            return [
+                parametersDescription,
+                "excludes_extensions: \(excludesExtensions)",
+                "excludes_inherited_types: \(excludesInheritedTypes)"
+            ]
+            .joined(separator: ", ")
         }
     }
 
@@ -31,12 +40,13 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
             }
 
             if let array = [String].array(of: value) {
-                let rules: [RuleParameter<AccessControlLevel>] = try array.map { val -> RuleParameter<AccessControlLevel> in
-                    guard let acl = AccessControlLevel(description: val) else {
-                        throw ConfigurationError.unknownConfiguration
+                let rules: [RuleParameter<AccessControlLevel>] = try array
+                    .map { val -> RuleParameter<AccessControlLevel> in
+                        guard let acl = AccessControlLevel(description: val) else {
+                            throw ConfigurationError.unknownConfiguration
+                        }
+                        return RuleParameter<AccessControlLevel>(severity: severity, value: acl)
                     }
-                    return RuleParameter<AccessControlLevel>(severity: severity, value: acl)
-                }
 
                 parameters.append(contentsOf: rules)
             } else if let string = value as? String, let acl = AccessControlLevel(description: string) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -1,35 +1,49 @@
 public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
     private(set) var parameters = [RuleParameter<AccessControlLevel>]()
+    private(set) var excludesExtensions = true
+    private(set) var excludesInheritedTypes = true
 
     public var consoleDescription: String {
         return parameters.group { $0.severity }.sorted { $0.key.rawValue < $1.key.rawValue }.map {
             "\($0.rawValue): \($1.map { $0.value.description }.sorted(by: <).joined(separator: ", "))"
-        }.joined(separator: ", ")
+        }.joined(separator: ", ") + ", excludes_extensions: \(excludesExtensions)"
     }
 
     public mutating func apply(configuration: Any) throws {
         guard let dict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }
-        let parameters = try dict.flatMap { (key: String, value: Any) -> [RuleParameter<AccessControlLevel>] in
+
+        excludesExtensions = dict["excludes_extensions"] as? Bool ?? true
+        excludesInheritedTypes = dict["excludes_inherited_types"] as? Bool ?? true
+
+        var parameters: [RuleParameter<AccessControlLevel>] = []
+
+        for (key, value) in dict {
             guard let severity = ViolationSeverity(rawValue: key) else {
-                throw ConfigurationError.unknownConfiguration
+                continue
             }
+
             if let array = [String].array(of: value) {
-                return try array.map {
-                    guard let acl = AccessControlLevel(description: $0) else {
+                let rules: [RuleParameter<AccessControlLevel>] = try array.map { val -> RuleParameter<AccessControlLevel> in
+                    guard let acl = AccessControlLevel(description: val) else {
                         throw ConfigurationError.unknownConfiguration
                     }
                     return RuleParameter<AccessControlLevel>(severity: severity, value: acl)
                 }
+
+                parameters.append(contentsOf: rules)
             } else if let string = value as? String, let acl = AccessControlLevel(description: string) {
-                return [RuleParameter<AccessControlLevel>(severity: severity, value: acl)]
+                let rule = RuleParameter<AccessControlLevel>(severity: severity, value: acl)
+
+                parameters.append(rule)
             }
-            throw ConfigurationError.unknownConfiguration
         }
+
         guard parameters.count == parameters.map({ $0.value }).unique.count else {
             throw ConfigurationError.unknownConfiguration
         }
+
         self.parameters = parameters
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -29,8 +29,13 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
             throw ConfigurationError.unknownConfiguration
         }
 
-        excludesExtensions = dict["excludes_extensions"] as? Bool ?? true
-        excludesInheritedTypes = dict["excludes_inherited_types"] as? Bool ?? true
+        if let shouldExcludeExtensions = dict["excludes_extensions"] as? Bool {
+            excludesExtensions = shouldExcludeExtensions
+        }
+
+        if let shouldExcludeInheritedTypes = dict["excludes_inherited_types"] as? Bool {
+            excludesExtensions = shouldExcludeInheritedTypes
+        }
 
         var parameters: [RuleParameter<AccessControlLevel>] = []
 

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
@@ -4,27 +4,32 @@ import XCTest
 class MissingDocsRuleConfigurationTests: XCTestCase {
     func testDescriptionEmpty() {
         let configuration = MissingDocsRuleConfiguration()
-        XCTAssertEqual(configuration.consoleDescription, "")
+        XCTAssertEqual(configuration.consoleDescription, "excludes_extensions: true, excludes_inherited_types: true")
+    }
+
+    func testDescriptionExcludesFalse() {
+        let configuration = MissingDocsRuleConfiguration(excludesExtensions: false, excludesInheritedTypes: false)
+        XCTAssertEqual(configuration.consoleDescription, "excludes_extensions: false, excludes_inherited_types: false")
     }
 
     func testDescriptionSingleServety() {
         let configuration = MissingDocsRuleConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
-        XCTAssertEqual(configuration.consoleDescription, "error: open")
+        XCTAssertEqual(configuration.consoleDescription, "error: open, excludes_extensions: true, excludes_inherited_types: true")
     }
 
     func testDescriptionMultipleSeverities() {
         let configuration = MissingDocsRuleConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open),
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
-        XCTAssertEqual(configuration.consoleDescription, "error: open, warning: public")
+        XCTAssertEqual(configuration.consoleDescription, "error: open, warning: public, excludes_extensions: true, excludes_inherited_types: true")
     }
 
     func testDescriptionMultipleAcls() {
         let configuration = MissingDocsRuleConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
-        XCTAssertEqual(configuration.consoleDescription, "warning: open, public")
+        XCTAssertEqual(configuration.consoleDescription, "warning: open, public, excludes_extensions: true, excludes_inherited_types: true")
     }
 
     func testParsingSingleServety() {

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleConfigurationTests.swift
@@ -4,54 +4,76 @@ import XCTest
 class MissingDocsRuleConfigurationTests: XCTestCase {
     func testDescriptionEmpty() {
         let configuration = MissingDocsRuleConfiguration()
-        XCTAssertEqual(configuration.consoleDescription, "excludes_extensions: true, excludes_inherited_types: true")
+        XCTAssertEqual(
+            configuration.consoleDescription,
+            "excludes_extensions: true, excludes_inherited_types: true"
+        )
     }
 
     func testDescriptionExcludesFalse() {
         let configuration = MissingDocsRuleConfiguration(excludesExtensions: false, excludesInheritedTypes: false)
-        XCTAssertEqual(configuration.consoleDescription, "excludes_extensions: false, excludes_inherited_types: false")
+        XCTAssertEqual(
+            configuration.consoleDescription,
+            "excludes_extensions: false, excludes_inherited_types: false"
+        )
     }
 
     func testDescriptionSingleServety() {
         let configuration = MissingDocsRuleConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
-        XCTAssertEqual(configuration.consoleDescription, "error: open, excludes_extensions: true, excludes_inherited_types: true")
+        XCTAssertEqual(
+            configuration.consoleDescription,
+            "error: open, excludes_extensions: true, excludes_inherited_types: true"
+        )
     }
 
     func testDescriptionMultipleSeverities() {
         let configuration = MissingDocsRuleConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open),
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
-        XCTAssertEqual(configuration.consoleDescription, "error: open, warning: public, excludes_extensions: true, excludes_inherited_types: true")
+        XCTAssertEqual(
+            configuration.consoleDescription,
+            "error: open, warning: public, excludes_extensions: true, excludes_inherited_types: true"
+        )
     }
 
     func testDescriptionMultipleAcls() {
         let configuration = MissingDocsRuleConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
-        XCTAssertEqual(configuration.consoleDescription, "warning: open, public, excludes_extensions: true, excludes_inherited_types: true")
+        XCTAssertEqual(
+            configuration.consoleDescription,
+            "warning: open, public, excludes_extensions: true, excludes_inherited_types: true"
+        )
     }
 
     func testParsingSingleServety() {
         var configuration = MissingDocsRuleConfiguration()
         try? configuration.apply(configuration: ["warning": "open"])
-        XCTAssertEqual(configuration.parameters, [RuleParameter<AccessControlLevel>(severity: .warning, value: .open)])
+        XCTAssertEqual(
+            configuration.parameters,
+            [RuleParameter<AccessControlLevel>(severity: .warning, value: .open)]
+        )
     }
 
     func testParsingMultipleSeverities() {
         var configuration = MissingDocsRuleConfiguration()
         try? configuration.apply(configuration: ["warning": "public", "error": "open"])
-        XCTAssertEqual(configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
-                       [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
-                        RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
+        XCTAssertEqual(
+            configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
+            [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+             RuleParameter<AccessControlLevel>(severity: .error, value: .open)]
+        )
     }
 
     func testParsingMultipleAcls() {
         var configuration = MissingDocsRuleConfiguration()
         try? configuration.apply(configuration: ["warning": ["public", "open"]])
-        XCTAssertEqual(configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
-                       [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
-                        RuleParameter<AccessControlLevel>(severity: .warning, value: .open)])
+        XCTAssertEqual(
+            configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
+            [RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+             RuleParameter<AccessControlLevel>(severity: .warning, value: .open)]
+        )
     }
 
     func testInvalidServety() {


### PR DESCRIPTION
Add the configuration `excludes_extensions` and `excludes_inherited_types` for missing_docs.