### PR TITLE
Fix typo in ExplicitTopLevelACLRule.swift

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -35,7 +35,7 @@ public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, Aut
         let extensionKinds: Set<SwiftDeclarationKind> = [.extension, .extensionClass, .extensionEnum,
                                                          .extensionProtocol, .extensionStruct]
 
-        // find all top-level types marked as internal (either explictly or implictly)
+        // find all top-level types marked as internal (either explicitly or implictly)
         let dictionary = file.structureDictionary
         let internalTypesOffsets = dictionary.substructure.compactMap { element -> ByteCount? in
             // ignore extensions


### PR DESCRIPTION
## Overview

Hi.

I found a typo again, and so fixed.