### PR TITLE
Fix redundant_optional_initialization autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 #### Bug Fixes
 
 * Fixes a bug with the `missing_docs` rule where `excludes_inherited_types` would not be set.
+* Fix redundant_optional_initialization autocorrect broken
+  in case observer's brace exists.
+  [Naruki Chigira](https://github.com/naru-jpn)
+  [#3718](https://github.com/realm/SwiftLint/issues/3718)
 
 * Fix a false positive in the `unneeded_break_in_switch` rule when
   using `do/catch`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 #### Bug Fixes
 
 * Fixes a bug with the `missing_docs` rule where `excludes_inherited_types` would not be set.
+
 * Fix redundant_optional_initialization autocorrect broken
   in case observer's brace exists.
   [Naruki Chigira](https://github.com/naru-jpn)


### PR DESCRIPTION
Fix redundant_optional_initialization autocorrect broken in case observer's brace exists.

| Input | Expected Autocorrect Result | Actual Autocorrect Result |
|:---:|:---:|:---:|
| `var myVar: Int? = nil {` | `var myVar: Int? {` | `var myVar: Int?` |

Closes #3718.
Related to #3671.