### PR TITLE
Update `nslocalizedstring_key` to validate all NSLocalizedString parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@
 
 * SwiftLint now requires Swift 5.4 or higher to build.  
   [JP Simard](https://github.com/jpsim)
+  
+* Deprecated the `nslocalizedstring_key` rule name in favor of new and
+  more accurate `nslocalizedstring_requires_staticstring_arguments`
+  behavior.
+
+  [Josh Asbury](http://github.com/theoriginalbit)
 
 #### Experimental
 
@@ -77,6 +83,12 @@
   instance with `self` or use `MyClass.self` if you really want to reference 
   the method.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+* Improve ``nslocalizedstring_key`` to validate the tableName and value
+  arguments in addition to the existing key and comment arguments. Also
+  renamed to `nslocalizedstring_requires_staticstring_arguments`
+  to better match new behavior.
+  [Josh Asbury](http://github.com/theoriginalbit)
+  [#3729](https://github.com/realm/SwiftLint/pull/3729)
 
 * Exclude `id` from `identifier_name` by default.  
   [Artem Garmash](https://github.com/agarmash)

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [
@@ -111,8 +111,8 @@ public let primaryRuleList = RuleList(rules: [
     MultilineParametersBracketsRule.self,
     MultilineParametersRule.self,
     MultipleClosuresWithTrailingClosureRule.self,
-    NSLocalizedStringKeyRule.self,
     NSLocalizedStringRequireBundleRule.self,
+    NSLocalizedStringRequiresStaticStringArgumentsRule.self,
     NSObjectPreferIsEqualRule.self,
     NestingRule.self,
     NimbleOperatorRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequiresStaticStringArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequiresStaticStringArgumentsRule.swift
@@ -1,15 +1,14 @@
 import SourceKittenFramework
 
-public struct NSLocalizedStringKeyRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NSLocalizedStringRequiresStaticStringArgumentsRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
 
     public static let description = RuleDescription(
-        identifier: "nslocalizedstring_key",
-        name: "NSLocalizedString Key",
-        description: "Static strings should be used as key/comment" +
-            " in NSLocalizedString in order for genstrings to work.",
+        identifier: "nslocalizedstring_requires_staticstring_arguments",
+        name: "NSLocalizedString Requires StaticString Arguments",
+        description: "All NSLocalizedString parameters (except bundle) should be static strings in order for genstrings to work.",
         kind: .lint,
         nonTriggeringExamples: [
             // Key validation
@@ -112,6 +111,9 @@ public struct NSLocalizedStringKeyRule: ASTRule, OptInRule, ConfigurationProvide
             Example(#"NSLocalizedString(↓"key_\(param)", comment: ↓method())"#),
             Example(#"NSLocalizedString(↓"key_\(param)", comment: ↓variable)"#),
         ],
+        deprecatedAliases: [
+            "nslocalizedstring_key"
+        ]
     )
 
     public func validate(file: SwiftLintFile,

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequiresStaticStringArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequiresStaticStringArgumentsRule.swift
@@ -8,7 +8,8 @@ public struct NSLocalizedStringRequiresStaticStringArgumentsRule: ASTRule, OptIn
     public static let description = RuleDescription(
         identifier: "nslocalizedstring_requires_staticstring_arguments",
         name: "NSLocalizedString Requires StaticString Arguments",
-        description: "All NSLocalizedString parameters (except bundle) should be static strings in order for genstrings to work.",
+        description: "All NSLocalizedString parameters (except bundle) should be static strings in order for " +
+        "genstrings to work.",
         kind: .lint,
         nonTriggeringExamples: [
             // Key validation
@@ -62,8 +63,8 @@ public struct NSLocalizedStringRequiresStaticStringArgumentsRule: ASTRule, OptIn
             """, comment: "")
             """#),
             Example("""
-            let format = NSLocalizedString("%@, %@.", value: "%@, %@.", comment: "Accessibility label for a post in the post list." +
-            " The parameters are the title, and date respectively." +
+            let format = NSLocalizedString("%@, %@.", value: "%@, %@.", comment: "Accessibility label for a post in" +
+            " the post list. The parameters are the title, and date respectively." +
             " For example, "Let it Go, 1 hour ago.")
             """),
             Example(#"""
@@ -87,7 +88,7 @@ public struct NSLocalizedStringRequiresStaticStringArgumentsRule: ASTRule, OptIn
             """)
             """#),
             // All parameters
-            Example(#"NSLocalizedString("key", tableName: "Table", value: "Value", comment: "Comment")"#),
+            Example(#"NSLocalizedString("key", tableName: "Table", value: "Value", comment: "Comment")"#)
         ],
         triggeringExamples: [
             // Key validation
@@ -109,7 +110,7 @@ public struct NSLocalizedStringRequiresStaticStringArgumentsRule: ASTRule, OptIn
             Example(#"NSLocalizedString("key", comment: ↓"comment with \(param)")"#),
             Example(#"NSLocalizedString("key", comment: ↓"comment with \(param)")"#),
             Example(#"NSLocalizedString(↓"key_\(param)", comment: ↓method())"#),
-            Example(#"NSLocalizedString(↓"key_\(param)", comment: ↓variable)"#),
+            Example(#"NSLocalizedString(↓"key_\(param)", comment: ↓variable)"#)
         ],
         deprecatedAliases: [
             "nslocalizedstring_key"
@@ -125,12 +126,12 @@ public struct NSLocalizedStringRequiresStaticStringArgumentsRule: ASTRule, OptIn
             getViolationForArgument(nil /* key */, file: file, dictionary: dictionary),
             getViolationForArgument("tableName", file: file, dictionary: dictionary),
             getViolationForArgument("value", file: file, dictionary: dictionary),
-            getViolationForArgument("comment", file: file, dictionary: dictionary),
+            getViolationForArgument("comment", file: file, dictionary: dictionary)
         ].compactMap { $0 }
     }
 
     // MARK: - Private helpers
-    
+
     private func getViolationForArgument(_ name: String?,
                                          file: SwiftLintFile,
                                          dictionary: SourceKittenDictionary) -> StyleViolation? {
@@ -146,7 +147,7 @@ public struct NSLocalizedStringRequiresStaticStringArgumentsRule: ASTRule, OptIn
             // All tokens are string literals
             return nil
         }
-        
+
         return StyleViolation(ruleDescription: Self.description,
                               severity: configuration.severity,
                               location: Location(file: file, byteOffset: bodyByteRange.location))

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @testable import SwiftLintFrameworkTests
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import SwiftLintFramework
 import XCTest
@@ -457,7 +457,7 @@ class MultipleClosuresWithTrailingClosureRuleTests: XCTestCase {
 
 class NSLocalizedStringKeyRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
-        verifyRule(NSLocalizedStringKeyRule.description)
+        verifyRule(NSLocalizedStringRequiresStaticStringArgumentsRule.description)
     }
 }
 


### PR DESCRIPTION
Also rename the rule to `nslocalizedstring_requires_staticstring_arguments` to better match what it is now doing.

This furthers the work done in #3373 and validates all parameters when provided in the call. After this change it will validate the `key`, `tableName`, `value`, and `comment` arguments and ensure they are static strings.