### PR TITLE
Add optional prefer_self_in_static_references rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,6 +48,7 @@ opt_in_rules:
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
+  - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self
   - private_action
   - private_outlet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update Rule list documentation to distinguish between opt-in and
   on-by-default rules.  
   [Benny Wong](https://github.com/bdotdub)
+
 * Add opt-in `prefer_self_in_static_references` rule to warn if the
   type name is used to reference static members the same type.
   Prefer using `Self` instead which is not affected by renamings.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Update Rule list documentation to distinguish between opt-in and
   on-by-default rules.  
   [Benny Wong](https://github.com/bdotdub)
+* Add opt-in `prefer_self_in_static_references` rule to warn if the
+  type name is used to reference static members the same type.
+  Prefer using `Self` instead which is not affected by renamings.  
+  [SimplyDanny](https://github.com/simplydanny)
 
 #### Bug Fixes
 
@@ -61,10 +65,6 @@
 * Speed up analyzer rules.  
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#3747](https://github.com/realm/SwiftLint/issues/3747)
-* Add optional `prefer_self_in_static_references` rule to warn if the class/struct/enum name
-  is used to reference static variables/functions in the class/struct/enum. The advice is to
-  use `Self` instead which is not effected by renamings.  
-  [SimplyDanny](https://github.com/simplydanny)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@
 * Speed up analyzer rules.  
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#3747](https://github.com/realm/SwiftLint/issues/3747)
+* Add optional `prefer_self_in_static_references` rule to warn if the class/struct/enum name
+  is used to reference static variables/functions in the class/struct/enum. The advice is to
+  use `Self` instead which is not effected by renamings.  
+  [SimplyDanny](https://github.com/simplydanny)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -9,9 +9,9 @@ extension Configuration {
     private static var cachedConfigurationsByIdentifierLock = NSLock()
 
     internal func setCached(forIdentifier identifier: String) {
-        Configuration.cachedConfigurationsByIdentifierLock.lock()
-        Configuration.cachedConfigurationsByIdentifier[identifier] = self
-        Configuration.cachedConfigurationsByIdentifierLock.unlock()
+        Self.cachedConfigurationsByIdentifierLock.lock()
+        Self.cachedConfigurationsByIdentifier[identifier] = self
+        Self.cachedConfigurationsByIdentifierLock.unlock()
     }
 
     internal static func getCached(forIdentifier identifier: String) -> Configuration? {
@@ -35,15 +35,15 @@ extension Configuration {
     private static var nestedConfigIsSelfByIdentifierLock = NSLock()
 
     internal static func setIsNestedConfigurationSelf(forIdentifier identifier: String, value: Bool) {
-        Configuration.nestedConfigIsSelfByIdentifierLock.lock()
-        Configuration.nestedConfigIsSelfByIdentifier[identifier] = value
-        Configuration.nestedConfigIsSelfByIdentifierLock.unlock()
+        Self.nestedConfigIsSelfByIdentifierLock.lock()
+        Self.nestedConfigIsSelfByIdentifier[identifier] = value
+        Self.nestedConfigIsSelfByIdentifierLock.unlock()
     }
 
     internal static func getIsNestedConfigurationSelf(forIdentifier identifier: String) -> Bool? {
-        Configuration.nestedConfigIsSelfByIdentifierLock.lock()
-        defer { Configuration.nestedConfigIsSelfByIdentifierLock.unlock() }
-        return Configuration.nestedConfigIsSelfByIdentifier[identifier]
+        Self.nestedConfigIsSelfByIdentifierLock.lock()
+        defer { Self.nestedConfigIsSelfByIdentifierLock.unlock() }
+        return Self.nestedConfigIsSelfByIdentifier[identifier]
     }
 
     // MARK: SwiftLint Cache (On-Disk)

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -90,12 +90,12 @@ extension Configuration {
         guard !basedOnCustomConfigurationFiles else { return self }
 
         let directoryNSString = directory.bridge()
-        let configurationSearchPath = directoryNSString.appendingPathComponent(Configuration.defaultFileName)
+        let configurationSearchPath = directoryNSString.appendingPathComponent(Self.defaultFileName)
         let cacheIdentifier = "nestedPath" + rootDirectory + configurationSearchPath
 
-        if Configuration.getIsNestedConfigurationSelf(forIdentifier: cacheIdentifier) == true {
+        if Self.getIsNestedConfigurationSelf(forIdentifier: cacheIdentifier) == true {
             return self
-        } else if let cached = Configuration.getCached(forIdentifier: cacheIdentifier) {
+        } else if let cached = Self.getCached(forIdentifier: cacheIdentifier) {
             return cached
         } else {
             var config: Configuration
@@ -130,7 +130,7 @@ extension Configuration {
 
             if config == self {
                 // Cache that for this path, the config equals self
-                Configuration.setIsNestedConfigurationSelf(forIdentifier: cacheIdentifier, value: true)
+                Self.setIsNestedConfigurationSelf(forIdentifier: cacheIdentifier, value: true)
             }
 
             return config

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -52,8 +52,8 @@ extension Configuration {
         let onlyRules = defaultStringArray(dict[Key.onlyRules.rawValue] ?? dict[Key.whitelistRules.rawValue])
         let analyzerRules = defaultStringArray(dict[Key.analyzerRules.rawValue])
 
-        Configuration.warnAboutInvalidKeys(configurationDictionary: dict, ruleList: ruleList)
-        Configuration.warnAboutDeprecations(
+        Self.warnAboutInvalidKeys(configurationDictionary: dict, ruleList: ruleList)
+        Self.warnAboutDeprecations(
             configurationDictionary: dict, disabledRules: disabledRules,
             optInRules: optInRules, onlyRules: onlyRules, ruleList: ruleList
         )
@@ -77,7 +77,7 @@ extension Configuration {
             analyzerRules: analyzerRules
         )
 
-        Configuration.validateConfiguredRulesAreEnabled(
+        Self.validateConfiguredRulesAreEnabled(
             configurationDictionary: dict, ruleList: ruleList, rulesMode: rulesMode
         )
 
@@ -87,7 +87,7 @@ extension Configuration {
             ruleList: ruleList,
             includedPaths: defaultStringArray(dict[Key.included.rawValue]),
             excludedPaths: defaultStringArray(dict[Key.excluded.rawValue]),
-            indentation: Configuration.getIndentationLogIfInvalid(from: dict),
+            indentation: Self.getIndentationLogIfInvalid(from: dict),
             warningThreshold: dict[Key.warningThreshold.rawValue] as? Int,
             reporter: dict[Key.reporter.rawValue] as? String ?? XcodeReporter.identifier,
             cachePath: cachePath ?? dict[Key.cachePath.rawValue] as? String,
@@ -103,7 +103,7 @@ extension Configuration {
 
     private static func getIndentationLogIfInvalid(from dict: [String: Any]) -> IndentationStyle {
         if let rawIndentation = dict[Key.indentation.rawValue] {
-            if let indentationStyle = Configuration.IndentationStyle(rawIndentation) {
+            if let indentationStyle = Self.IndentationStyle(rawIndentation) {
                 return indentationStyle
             }
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesWrapper.swift
@@ -284,13 +284,13 @@ internal extension Configuration {
         private func isOptInRule(
             _ identifier: String, allRulesWrapped: [ConfigurationRuleWrapper]
         ) -> Bool? {
-            if let cachedIsOptInRule = RulesWrapper.isOptInRuleCache[identifier] {
+            if let cachedIsOptInRule = Self.isOptInRuleCache[identifier] {
                 return cachedIsOptInRule
             }
 
             let isOptInRule = allRulesWrapped
                 .first { type(of: $0.rule).description.identifier == identifier }?.rule is OptInRule
-            RulesWrapper.isOptInRuleCache[identifier] = isOptInRule
+            Self.isOptInRuleCache[identifier] = isOptInRule
             return isOptInRule
         }
     }

--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -26,7 +26,7 @@ public struct SourceKittenDictionary {
 
         let substructure = value["key.substructure"] as? [SourceKitRepresentable] ?? []
         self.substructure = substructure.compactMap { $0 as? [String: SourceKitRepresentable] }
-            .map(SourceKittenDictionary.init)
+            .map(Self.init)
 
         let stringKind = value["key.kind"] as? String
         self.expressionKind = stringKind.flatMap(SwiftExpressionKind.init)
@@ -143,20 +143,20 @@ public struct SourceKittenDictionary {
     var swiftAttributes: [SourceKittenDictionary] {
         let array = value["key.attributes"] as? [SourceKitRepresentable] ?? []
         let dictionaries = array.compactMap { $0 as? [String: SourceKitRepresentable] }
-            .map(SourceKittenDictionary.init)
+            .map(Self.init)
         return dictionaries
     }
 
     var elements: [SourceKittenDictionary] {
         let elements = value["key.elements"] as? [SourceKitRepresentable] ?? []
         return elements.compactMap { $0 as? [String: SourceKitRepresentable] }
-        .map(SourceKittenDictionary.init)
+        .map(Self.init)
     }
 
     var entities: [SourceKittenDictionary] {
         let entities = value["key.entities"] as? [SourceKitRepresentable] ?? []
         return entities.compactMap { $0 as? [String: SourceKitRepresentable] }
-            .map(SourceKittenDictionary.init)
+            .map(Self.init)
     }
 
     var enclosedVarParameters: [SourceKittenDictionary] {

--- a/Source/SwiftLintFramework/Extensions/Request+DisableSourceKit.swift
+++ b/Source/SwiftLintFramework/Extensions/Request+DisableSourceKit.swift
@@ -5,8 +5,8 @@ extension Request {
     static let disableSourceKit = ProcessInfo.processInfo.environment["SWIFTLINT_DISABLE_SOURCEKIT"] != nil
 
     func sendIfNotDisabled() throws -> [String: SourceKitRepresentable] {
-        guard !Request.disableSourceKit else {
-            throw Request.Error.connectionInterrupted("SourceKit is disabled by `SWIFTLINT_DISABLE_SOURCEKIT`.")
+        guard !Self.disableSourceKit else {
+            throw Self.Error.connectionInterrupted("SourceKit is disabled by `SWIFTLINT_DISABLE_SOURCEKIT`.")
         }
         return try send()
     }

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -115,13 +115,13 @@ public struct Command: Equatable {
         self.line = line
         self.character = character
 
-        let rawRuleTexts = scanner.scanUpToString(Command.commentDelimiter) ?? ""
+        let rawRuleTexts = scanner.scanUpToString(Self.commentDelimiter) ?? ""
         if scanner.isAtEnd {
             trailingComment = nil
         } else {
             // Store any text after the comment delimiter as the trailingComment.
             // The addition to scanLocation is to move past the delimiter
-            let startOfCommentPastDelimiter = scanner.scanLocation + Command.commentDelimiter.count
+            let startOfCommentPastDelimiter = scanner.scanLocation + Self.commentDelimiter.count
             trailingComment = scanner.string.bridge().substring(from: startOfCommentPastDelimiter)
         }
         let ruleTexts = rawRuleTexts.components(separatedBy: .whitespacesAndNewlines).filter {

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -179,16 +179,16 @@ public struct Configuration {
         useDefaultConfigOnFailure: Bool? = nil
     ) {
         // Handle mocked network results if needed
-        Configuration.FileGraph.FilePath.mockedNetworkResults = mockedNetworkResults
+        Self.FileGraph.FilePath.mockedNetworkResults = mockedNetworkResults
         defer {
             if !mockedNetworkResults.isEmpty {
-                Configuration.FileGraph.FilePath.deleteGitignoreAndSwiftlintCache()
+                Self.FileGraph.FilePath.deleteGitignoreAndSwiftlintCache()
             }
         }
 
         // Store whether there are custom configuration files; use default config file name if there are none
         let hasCustomConfigurationFiles: Bool = configurationFiles.isNotEmpty
-        let configurationFiles = configurationFiles.isEmpty ? [Configuration.defaultFileName] : configurationFiles
+        let configurationFiles = configurationFiles.isEmpty ? [Self.defaultFileName] : configurationFiles
         defer { basedOnCustomConfigurationFiles = hasCustomConfigurationFiles }
 
         let currentWorkingDirectory = FileManager.default.currentDirectoryPath.bridge().absolutePathStandardized()
@@ -196,7 +196,7 @@ public struct Configuration {
 
         // Try obtaining cached config
         let cacheIdentifier = "\(currentWorkingDirectory) - \(configurationFiles)"
-        if let cachedConfig = Configuration.getCached(forIdentifier: cacheIdentifier) {
+        if let cachedConfig = Self.getCached(forIdentifier: cacheIdentifier) {
             self.init(copying: cachedConfig)
             return
         }

--- a/Source/SwiftLintFramework/Models/LinterCache.swift
+++ b/Source/SwiftLintFramework/Models/LinterCache.swift
@@ -109,7 +109,7 @@ public final class LinterCache {
             let fileCacheEntries = readCache[description]?.entries.merging(writeFileCache.entries) { _, write in write }
             let fileCache = fileCacheEntries.map(FileCache.init) ?? writeFileCache
             let data = try encoder.encode(fileCache)
-            let file = url.appendingPathComponent(description).appendingPathExtension(LinterCache.fileExtension)
+            let file = url.appendingPathComponent(description).appendingPathExtension(Self.fileExtension)
             try data.write(to: file, options: .atomic)
         }
     }
@@ -133,7 +133,7 @@ public final class LinterCache {
             return .empty
         }
 
-        let file = location.appendingPathComponent(cacheDescription).appendingPathExtension(LinterCache.fileExtension)
+        let file = location.appendingPathComponent(cacheDescription).appendingPathExtension(Self.fileExtension)
         let data = try? Data(contentsOf: file)
         let fileCache = data.flatMap { try? Decoder().decode(FileCache.self, from: $0) } ?? .empty
         lazyReadCache[cacheDescription] = fileCache

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -160,6 +160,7 @@ public let primaryRuleList = RuleList(rules: [
     RequiredDeinitRule.self,
     RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,
+    PreferSelfInStaticReferencesRule.self,
     SelfInPropertyInitializationRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,

--- a/Source/SwiftLintFramework/Models/RuleIdentifier.swift
+++ b/Source/SwiftLintFramework/Models/RuleIdentifier.swift
@@ -18,7 +18,7 @@ public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral {
     public var stringRepresentation: String {
         switch self {
         case .all:
-            return RuleIdentifier.allStringRepresentation
+            return Self.allStringRepresentation
 
         case .single(let identifier):
             return identifier
@@ -31,7 +31,7 @@ public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral {
     ///
     /// - parameter value: The string representation.
     public init(_ value: String) {
-        self = value == RuleIdentifier.allStringRepresentation ? .all : .single(identifier: value)
+        self = value == Self.allStringRepresentation ? .all : .single(identifier: value)
     }
 
     // MARK: - ExpressibleByStringLiteral Conformance

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -45,7 +45,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestable
 
         let ignoredRanges = self.rangesInConditionalCompilation(file: file)
 
-        let importKinds = DuplicateImportsRule.importKinds.joined(separator: "|")
+        let importKinds = Self.importKinds.joined(separator: "|")
 
         // Grammar of import declaration
         // attributes(optional) import import-kind(optional) import-path

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -139,7 +139,7 @@ public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestabl
             file.syntaxMap.kinds(inByteRange: afterIfRange)
 
         let doesntContainComments = !allKinds.contains { kind in
-            !ForWhereRule.commentKinds.contains(kind)
+            !Self.commentKinds.contains(kind)
         }
 
         return doesntContainComments

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -82,19 +82,19 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
     private func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let syntaxMap = file.syntaxMap
 
-        let varDeclarationRanges = ForceUnwrappingRule.varDeclarationRegularExpression
+        let varDeclarationRanges = Self.varDeclarationRegularExpression
             .matches(in: file)
             .compactMap { match -> NSRange? in
                 return match.range
             }
 
-        let functionDeclarationRanges = regex(ForceUnwrappingRule.functionReturnPattern)
+        let functionDeclarationRanges = regex(Self.functionReturnPattern)
             .matches(in: file)
             .compactMap { match -> NSRange? in
                 return match.range
             }
 
-        return ForceUnwrappingRule.regularExpression
+        return Self.regularExpression
             .matches(in: file)
             .compactMap { match -> NSRange? in
                 if match.range.intersects(varDeclarationRanges) || match.range.intersects(functionDeclarationRanges) {
@@ -141,7 +141,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
             // check second capture '!'
             let kindsInSecondRange = syntaxMap.kinds(inByteRange: matchByteSecondRange)
             let forceUnwrapNotInCommentOrString = !kindsInSecondRange
-                .contains(where: ForceUnwrappingRule.excludingSyntaxKindsForSecondCapture.contains)
+                .contains(where: Self.excludingSyntaxKindsForSecondCapture.contains)
             if forceUnwrapNotInCommentOrString &&
                 !isTypeAnnotation(in: file, byteRange: matchByteFirstRange) {
                 return violationRange
@@ -157,7 +157,7 @@ public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, Automat
         let tokens = syntaxMap.tokens(inByteRange: byteRange)
         return tokens.contains { token in
             guard let kind = token.kind,
-                ForceUnwrappingRule.excludingSyntaxKindsForFirstCapture.contains(kind)
+                Self.excludingSyntaxKindsForFirstCapture.contains(kind)
                 else { return false }
             // check for `self
             guard kind == .keyword else { return true }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
@@ -17,13 +17,13 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule, Au
     )
 
     private static let legacyConstants: [String] = {
-        return Array(LegacyConstantRule.legacyPatterns.keys)
+        return Array(Self.legacyPatterns.keys)
     }()
 
     private static let legacyPatterns = LegacyConstantRuleExamples.patterns
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "\\b" + LegacyConstantRule.legacyConstants.joined(separator: "|")
+        let pattern = "\\b" + Self.legacyConstants.joined(separator: "|")
 
         return file.match(pattern: pattern, range: nil)
             .filter { Set($0.1).isSubset(of: [.identifier]) }
@@ -37,7 +37,7 @@ public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule, Au
 
     public func correct(file: SwiftLintFile) -> [Correction] {
         var wordBoundPatterns: [String: String] = [:]
-        LegacyConstantRule.legacyPatterns.forEach { key, value in
+        Self.legacyPatterns.forEach { key, value in
             wordBoundPatterns["\\b" + key] = value
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -34,7 +34,7 @@ public struct ToggleBoolRule: SubstitutionCorrectableRule, ConfigurationProvider
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
-            StyleViolation(ruleDescription: ToggleBoolRule.description,
+            StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location)
             )

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -88,7 +88,7 @@ public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptIn
 
         let containsTerminatingCall = dictionary.substructure.contains { dict -> Bool in
             return dict.expressionKind == .call && (dict.name.map { name in
-                UnavailableFunctionRule.terminatingFunctions.contains(name)
+                Self.terminatingFunctions.contains(name)
             } ?? false)
         }
 

--- a/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
@@ -9,7 +9,7 @@ public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
     public static let description = RuleDescription(
         identifier: "compiler_protocol_init",
         name: "Compiler Protocol Init",
-        description: CompilerProtocolInitRule.violationReason(
+        description: Self.violationReason(
             protocolName: "such as `ExpressibleByArrayLiteral`",
             isPlural: true
         ),

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -77,9 +77,9 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
         let cases: [String]
 
         init(from dictionary: SourceKittenDictionary, in file: SwiftLintFile) {
-            location = Enum.location(from: dictionary, in: file)
+            location = Self.location(from: dictionary, in: file)
             inheritedTypes = dictionary.inheritedTypes
-            cases = Enum.cases(from: dictionary)
+            cases = Self.cases(from: dictionary)
         }
 
         /// Determines the location of where the enum declaration starts.

--- a/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
@@ -4,7 +4,7 @@ import SourceKittenFramework
 public extension SyntaxKind {
     /// Returns if the syntax kind is comment-like.
     var isCommentLike: Bool {
-        return SyntaxKind.commentKinds.contains(self)
+        return Self.commentKinds.contains(self)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
@@ -4,7 +4,7 @@ import SourceKittenFramework
 public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
-    private static let supportedTypes = ValidIBInspectableRule.createSupportedTypes()
+    private static let supportedTypes = Self.createSupportedTypes()
 
     public init() {}
 
@@ -130,7 +130,7 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule, Automa
         if !file.isMutableProperty(dictionary) {
             shouldMakeViolation = true
         } else if let type = dictionary.typeName,
-            ValidIBInspectableRule.supportedTypes.contains(type) {
+            Self.supportedTypes.contains(type) {
             shouldMakeViolation = false
         } else {
             // Variable should have explicit type or IB won't recognize it

--- a/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
@@ -67,7 +67,7 @@ public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule, 
 
         let matches = file.lines.filter({ $0.byteRange.contains(offset) }).reduce(into: []) { matches, line in
             let range = line.content.fullNSRange
-            let lineMatches = YodaConditionRule.regularExpression.matches(in: line.content, options: [], range: range)
+            let lineMatches = Self.regularExpression.matches(in: line.content, options: [], range: range)
             matches.append(contentsOf: lineMatches)
         }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -45,12 +45,12 @@ public struct ExplicitTypeInterfaceConfiguration: RuleConfiguration, Equatable {
 
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
 
-    private(set) var allowedKinds = ExplicitTypeInterfaceConfiguration.variableKinds
+    private(set) var allowedKinds = Self.variableKinds
 
     private(set) var allowRedundancy = false
 
     public var consoleDescription: String {
-        let excludedKinds = ExplicitTypeInterfaceConfiguration.variableKinds.subtracting(allowedKinds)
+        let excludedKinds = Self.variableKinds.subtracting(allowedKinds)
         let simplifiedExcludedKinds = excludedKinds.compactMap { $0.variableKind?.rawValue }.sorted()
         return severityConfiguration.consoleDescription +
             ", excluded: \(simplifiedExcludedKinds)" +

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -43,26 +43,26 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
         // the regex will be recompiled for each validated file.
         if let requiredString = configuration["required_string"] {
             self.requiredString = requiredString
-            if !requiredString.contains(FileHeaderConfiguration.fileNamePlaceholder) {
+            if !requiredString.contains(Self.fileNamePlaceholder) {
                 _requiredRegex = try NSRegularExpression(pattern: requiredString,
-                                                         options: FileHeaderConfiguration.stringRegexOptions)
+                                                         options: Self.stringRegexOptions)
             }
         } else if let requiredPattern = configuration["required_pattern"] {
             self.requiredPattern = requiredPattern
-            if !requiredPattern.contains(FileHeaderConfiguration.fileNamePlaceholder) {
+            if !requiredPattern.contains(Self.fileNamePlaceholder) {
                 _requiredRegex = try .cached(pattern: requiredPattern)
             }
         }
 
         if let forbiddenString = configuration["forbidden_string"] {
             self.forbiddenString = forbiddenString
-            if !forbiddenString.contains(FileHeaderConfiguration.fileNamePlaceholder) {
+            if !forbiddenString.contains(Self.fileNamePlaceholder) {
                 _forbiddenRegex = try NSRegularExpression(pattern: forbiddenString,
-                                                          options: FileHeaderConfiguration.stringRegexOptions)
+                                                          options: Self.stringRegexOptions)
             }
         } else if let forbiddenPattern = configuration["forbidden_pattern"] {
             self.forbiddenPattern = forbiddenPattern
-            if !forbiddenPattern.contains(FileHeaderConfiguration.fileNamePlaceholder) {
+            if !forbiddenPattern.contains(Self.fileNamePlaceholder) {
                 _forbiddenRegex = try .cached(pattern: forbiddenPattern)
             }
         }
@@ -80,7 +80,7 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
 
             // Replace SWIFTLINT_CURRENT_FILENAME with the filename.
             let escapedName = escapeFileName ? NSRegularExpression.escapedPattern(for: fileName) : fileName
-            return pattern.replacingOccurrences(of: FileHeaderConfiguration.fileNamePlaceholder,
+            return pattern.replacingOccurrences(of: Self.fileNamePlaceholder,
                                                 with: escapedName)
         } ?? pattern
 
@@ -92,12 +92,12 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
     }
 
     private func regexFromString(for file: SwiftLintFile, using pattern: String) -> NSRegularExpression? {
-        return makeRegex(for: file, using: pattern, options: FileHeaderConfiguration.stringRegexOptions,
+        return makeRegex(for: file, using: pattern, options: Self.stringRegexOptions,
                          escapeFileName: false)
     }
 
     private func regexFromPattern(for file: SwiftLintFile, using pattern: String) -> NSRegularExpression? {
-        return makeRegex(for: file, using: pattern, options: FileHeaderConfiguration.patternRegexOptions,
+        return makeRegex(for: file, using: pattern, options: Self.patternRegexOptions,
                          escapeFileName: true)
     }
 
@@ -115,7 +115,7 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
         }
 
         if requiredPattern == nil, requiredString == nil {
-            return FileHeaderConfiguration.defaultRegex
+            return Self.defaultRegex
         }
 
         return nil

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -9,7 +9,7 @@ public struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
 
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
 
-    private(set) var includedKinds = ImplicitReturnConfiguration.defaultIncludedKinds
+    private(set) var includedKinds = Self.defaultIncludedKinds
 
     public var consoleDescription: String {
         let includedKinds = self.includedKinds.map { $0.rawValue }
@@ -17,7 +17,7 @@ public struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
             ", included: [\(includedKinds.joined(separator: ", "))]"
     }
 
-    public init(includedKinds: Set<ReturnKind> = ImplicitReturnConfiguration.defaultIncludedKinds) {
+    public init(includedKinds: Set<ReturnKind> = Self.defaultIncludedKinds) {
         self.includedKinds = includedKinds
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -253,7 +253,7 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
         let restOfLineOffset = attributeRange.upperBound
         let restOfLineLength = line.byteRange.upperBound - restOfLineOffset
 
-        let regex = AttributesRule.regularExpression
+        let regex = Self.regularExpression
         let contents = file.stringView
 
         // check if after the token is a `(` with only spaces allowed between the token and `(`

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -81,7 +81,7 @@ extension ClosureEndIndentationRule: CorrectableRule {
             return false
         }
 
-        let regex = ClosureEndIndentationRule.notWhitespace
+        let regex = Self.notWhitespace
         if regex.firstMatch(in: contents, options: [], range: actual) != nil {
             var correction = "\n"
             correction.append(contents.substring(from: expected.location, length: expected.length))
@@ -173,7 +173,7 @@ extension ClosureEndIndentationRule {
         }
 
         let range = file.lines[startLine - 1].range
-        let regex = ClosureEndIndentationRule.notWhitespace
+        let regex = Self.notWhitespace
         let actual = endPosition - 1
         guard let match = regex.firstMatch(in: file.contents, options: [], range: range)?.range,
             case let expected = match.location - range.location,
@@ -236,7 +236,7 @@ extension ClosureEndIndentationRule {
         }
 
         let range = file.lines[startLine - 1].range
-        let regex = ClosureEndIndentationRule.notWhitespace
+        let regex = Self.notWhitespace
         let actual = endPosition - 1
         guard let match = regex.firstMatch(in: file.contents, options: [], range: range)?.range,
             case let expected = match.location - range.location,

--- a/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
@@ -123,7 +123,7 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule, 
         let parameters = dictionary.enclosedVarParameters +
             dictionary.substructure.filter { $0.declarationKind == .varLocal } // capture lists
         let rangeStart = nameOffset + nameLength
-        let regex = ClosureParameterPositionRule.openBraceRegex
+        let regex = Self.openBraceRegex
 
         // parameters from inner closures are reported on the top-level one, so we can't just
         // use the first and last parameters to check, we need to check all of them

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -76,7 +76,7 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
         let contents = file.stringView
         let range = contents.range
         let syntaxMap = file.syntaxMap
-        return CommaRule.regularExpression
+        return Self.regularExpression
             .matches(in: contents, options: [], range: range)
             .compactMap { match -> NSRange? in
                 if match.numberOfRanges != 5 { return nil } // Number of Groups in regexp
@@ -94,7 +94,7 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
 
                 // first captured range won't match kinds if it is not comment neither string
                 let firstCaptureIsCommentOrString = syntaxMap.kinds(inByteRange: matchByteFirstRange)
-                    .contains(where: CommaRule.excludingSyntaxKindsForFirstCapture.contains)
+                    .contains(where: Self.excludingSyntaxKindsForFirstCapture.contains)
                 if firstCaptureIsCommentOrString {
                     return nil
                 }
@@ -113,7 +113,7 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
 
                 // second captured range won't match kinds if it is not comment
                 let secondCaptureIsComment = syntaxMap.kinds(inByteRange: matchByteSecondRange)
-                    .contains(where: CommaRule.excludingSyntaxKindsForSecondCapture.contains)
+                    .contains(where: Self.excludingSyntaxKindsForSecondCapture.contains)
                 if secondCaptureIsComment {
                     return nil
                 }

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -87,7 +87,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
         let rangeStart = nameOffset + nameLength
         let rangeLength = (offset + length) - (nameOffset + nameLength)
         let byteRange = ByteRange(location: rangeStart, length: rangeLength)
-        let regex = EmptyParenthesesWithTrailingClosureRule.emptyParenthesesRegex
+        let regex = Self.emptyParenthesesRegex
 
         guard let range = file.stringView.byteRangeToNSRange(byteRange),
             let match = regex.firstMatch(in: file.contents, options: [], range: range)?.range,

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
@@ -112,7 +112,7 @@ internal struct FileTypesOrderRuleExamples {
     ]
 
     static let nonTriggeringExamples = [
-        Example(FileTypesOrderRuleExamples.defaultOrderParts.joined(separator: "\n\n")),
+        Example(Self.defaultOrderParts.joined(separator: "\n\n")),
         Example("""
         // Only extensions
         extension Foo {}

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -73,7 +73,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
                 // Catch mixed indentation
                 violations.append(
                     StyleViolation(
-                        ruleDescription: IndentationWidthRule.description,
+                        ruleDescription: Self.description,
                         severity: configuration.severityConfiguration.severity,
                         location: Location(file: file, characterOffset: line.range.location),
                         reason: "Code should be indented with tabs or " +
@@ -97,7 +97,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
                     // There's an indentation although this is the first line!
                     violations.append(
                         StyleViolation(
-                            ruleDescription: IndentationWidthRule.description,
+                            ruleDescription: Self.description,
                             severity: configuration.severityConfiguration.severity,
                             location: Location(file: file, characterOffset: line.range.location),
                             reason: "The first line shall not be indented."
@@ -122,7 +122,7 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
                 let indentWidth = configuration.indentationWidth
                 violations.append(
                     StyleViolation(
-                        ruleDescription: IndentationWidthRule.description,
+                        ruleDescription: Self.description,
                         severity: configuration.severityConfiguration.severity,
                         location: Location(file: file, characterOffset: line.range.location),
                         reason: isIndentation ?

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -117,7 +117,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
         let offset = content.distance(from: content.startIndex, to: startIndex)
         let location = Location(file: file, characterOffset: offset + file.lines[line].range.location)
 
-        violations.append(StyleViolation(ruleDescription: LetVarWhitespaceRule.description,
+        violations.append(StyleViolation(ruleDescription: Self.description,
                                          severity: configuration.severity,
                                          location: location))
     }

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -130,7 +130,7 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
     }
 
     private func styleViolation(for violation: Violation, in file: SwiftLintFile) -> StyleViolation {
-        let reason = "\(LiteralExpressionEndIdentationRule.description.description) " +
+        let reason = "\(Self.description.description) " +
                      "Expected \(violation.indentationRanges.expected.length), " +
                      "got \(violation.indentationRanges.actual.length)."
 
@@ -249,7 +249,7 @@ extension LiteralExpressionEndIdentationRule {
         }
 
         let range = file.lines[startLine - 1].range
-        let regex = LiteralExpressionEndIdentationRule.notWhitespace
+        let regex = Self.notWhitespace
         let actual = endPosition - 1
         guard let match = regex.firstMatch(in: file.contents, options: [], range: range)?.range,
             case let expected = match.location - range.location,

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -1,0 +1,194 @@
+import Foundation
+import SourceKittenFramework
+
+public struct PreferSelfInStaticReferencesRule: SubstitutionCorrectableASTRule, OptInRule, AutomaticTestableRule {
+    public static let description = RuleDescription(
+        identifier: "prefer_self_in_static_references",
+        name: "Prefer Self in Static References",
+        description: "Static references should be prefixed by `Self` instead of the class name.",
+        kind: .style,
+        nonTriggeringExamples: [
+            Example("""
+                class C {
+                    static let i = 0, j = C.i
+                    let h = C.i
+                }
+            """),
+            Example("""
+                class `Self` {
+                    static let i = 0
+                    func f() -> Int { Self.i }
+                }
+            """),
+            Example("""
+                class S {
+                    static func f() { Self.g(Self.f) }
+                    static func g(f: () -> Void) { f() }
+                }
+            """),
+            Example("""
+                struct T {
+                    static let i = 0
+                }
+                struct S {
+                    static let i = 0
+                }
+                extension T {
+                    static let j = S.i + Self.i
+                }
+            """),
+            Example("""
+                struct S {
+                    struct T {
+                        struct R {
+                            static let i = 3
+                        }
+                    }
+                    struct R {
+                        static let j = S.T.R.i
+                    }
+                    static let j = Self.T.R.i + Self.R.j
+                    let h = Self.T.R.i + Self.R.j
+                }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                struct C {
+                    static let i = 0
+                    static let j = ↓C.i
+                }
+            """),
+            Example("""
+                struct S {
+                    static let i = 0
+                    func f() -> Int { ↓S.i }
+                }
+            """),
+            Example("""
+                struct S {
+                    static func f() { ↓S.g(↓S.f) }
+                    static func g(f: () -> Void) { f() }
+                }
+            """),
+            Example("""
+                struct S {
+                    struct T {
+                        static let i = 3
+                    }
+                    struct R {
+                        static let j = S.T.i
+                    }
+                    static let h = ↓S.T.i + ↓S.R.j
+                }
+            """)
+        ],
+        corrections: [
+            Example("""
+                struct S {
+                    struct T {
+                        static let i = 3
+                    }
+                    static let h = ↓S.T.i
+                }
+            """): Example("""
+                struct S {
+                    struct T {
+                        static let i = 3
+                    }
+                    static let h = Self.T.i
+                }
+            """),
+            Example("""
+                struct S {
+                    static func f() { ↓S.g(↓S.f) }
+                    static func g(f: () -> Void) { f() }
+                }
+            """): Example("""
+                struct S {
+                    static func f() { Self.g(Self.f) }
+                    static func g(f: () -> Void) { f() }
+                }
+            """)
+        ]
+    )
+
+    private static let nestedKindsToIgnore: Set = [
+        SwiftDeclarationKind.class.rawValue,
+        SwiftDeclarationKind.enum.rawValue,
+        SwiftDeclarationKind.struct.rawValue
+    ]
+
+    private static let nestedKindsToIgnoreIfClass: Set = [
+        SwiftDeclarationKind.varInstance.rawValue,
+        SwiftDeclarationKind.varStatic.rawValue
+    ]
+
+    public var configuration = SeverityConfiguration(.warning)
+    public var configurationDescription = "N/A"
+
+    public init() {}
+
+    public init(configuration: Any) throws {
+        throw ConfigurationError.unknownConfiguration
+    }
+
+    public func validate(file: SwiftLintFile,
+                         kind: SwiftDeclarationKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        violationRanges(in: file, kind: kind, dictionary: dictionary)
+            .compactMap(file.stringView.NSRangeToByteRange)
+            .map { byteRange in
+                StyleViolation(
+                    ruleDescription: Self.description,
+                    severity: configuration.severity,
+                    location: Location(file: file, byteOffset: byteRange.location)
+                )
+            }
+    }
+
+    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+        (violationRange, "Self.")
+    }
+
+    public func violationRanges(in file: SwiftLintFile,
+                                kind: SwiftDeclarationKind,
+                                dictionary: SourceKittenDictionary) -> [NSRange] {
+        guard isComplexDeclaration(kind), let name = dictionary.name, let bodyRange = dictionary.bodyByteRange else {
+            return []
+        }
+
+        var rangesToIgnore = dictionary.substructure
+            .filter { shallIgnore(kind: $0.kind, in: kind) }
+            .compactMap(\.byteRange)
+            .unique
+            .sorted { $0.location < $1.location }
+        rangesToIgnore.append(ByteRange(location: bodyRange.upperBound, length: 0)) // Marks the end of the search
+
+        var location = bodyRange.location
+        return rangesToIgnore
+            .flatMap { (range: ByteRange) -> [NSRange] in
+                let searchRange = ByteRange(location: location, length: range.lowerBound - location)
+                location = range.upperBound
+                return file.match(
+                    pattern: "(?<!\\.)\\b\(name)\\.",
+                    with: [.identifier],
+                    range: file.stringView.byteRangeToNSRange(searchRange))
+            }
+    }
+
+    private func isComplexDeclaration(_ kind: SwiftDeclarationKind) -> Bool {
+        kind == .class || kind == .struct || kind == .enum || SwiftDeclarationKind.extensionKinds.contains(kind)
+    }
+
+    private func shallIgnore(kind: String?, in containingKind: SwiftDeclarationKind) -> Bool {
+        guard let kind = kind else {
+            return false
+        }
+        let shallIgnore = Self.nestedKindsToIgnore.contains(kind)
+        if containingKind == .class || containingKind == .extensionClass {
+            return shallIgnore || Self.nestedKindsToIgnoreIfClass.contains(kind)
+        }
+        return shallIgnore
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
@@ -66,7 +66,7 @@ public struct ShorthandOperatorRule: ConfigurationProviderRule, AutomaticTestabl
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let contents = file.stringView
-        let matches = ShorthandOperatorRule.violationRegex.matches(in: file)
+        let matches = Self.violationRegex.matches(in: file)
 
         return matches.compactMap { match -> StyleViolation? in
             // byteRanges will have the ranges of captured groups

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -176,7 +176,7 @@ private extension StatementPositionRule {
     func uncuddledViolationRanges(in file: SwiftLintFile) -> [NSRange] {
         let contents = file.stringView
         let syntaxMap = file.syntaxMap
-        let matches = StatementPositionRule.uncuddledRegex.matches(in: file)
+        let matches = Self.uncuddledRegex.matches(in: file)
         let validator = Self.uncuddledMatchValidator(contents: contents)
         let filterMatches = Self.uncuddledMatchFilter(contents: contents, syntaxMap: syntaxMap)
 
@@ -188,7 +188,7 @@ private extension StatementPositionRule {
     func uncuddledCorrect(file: SwiftLintFile) -> [Correction] {
         var contents = file.contents
         let syntaxMap = file.syntaxMap
-        let matches = StatementPositionRule.uncuddledRegex.matches(in: file)
+        let matches = Self.uncuddledRegex.matches(in: file)
         let validator = Self.uncuddledMatchValidator(contents: file.stringView)
         let filterRanges = Self.uncuddledMatchFilter(contents: file.stringView, syntaxMap: syntaxMap)
 

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -66,7 +66,7 @@ public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
                     their enclosing switch statement.
                     """
 
-        return StyleViolation(ruleDescription: SwitchCaseAlignmentRule.description,
+        return StyleViolation(ruleDescription: Self.description,
                               severity: configuration.severityConfiguration.severity,
                               location: location,
                               reason: reason)

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -52,8 +52,8 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
             Example("let example = [ 1,\n 2\n // 3,\n]"),
             Example("foo([1: \"\\(error)\"])\n")
         ],
-        triggeringExamples: TrailingCommaRule.triggeringExamples,
-        corrections: TrailingCommaRule.corrections
+        triggeringExamples: Self.triggeringExamples,
+        corrections: Self.corrections
     )
 
     private static let commaRegex = regex(",", options: [.ignoreMetacharacters])
@@ -142,7 +142,7 @@ public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationPr
 
     private func trailingCommaIndex(contents: String, file: SwiftLintFile, offset: ByteCount) -> ByteCount? {
         // skip commas in comments
-        return TrailingCommaRule.commaRegex
+        return Self.commaRegex
             .matches(in: contents, options: [], range: contents.fullNSRange)
             .map { $0.range }
             .last { nsRange in

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRuleExamples.swift
@@ -115,7 +115,7 @@ internal struct TypeContentsOrderRuleExamples {
     static let nonTriggeringExamples = [
         Example("""
         class TestViewController: UIViewController {
-        \(TypeContentsOrderRuleExamples.defaultOrderParts.joined(separator: "\n\n")),
+        \(Self.defaultOrderParts.joined(separator: "\n\n")),
         }
         """)
     ]

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1470,6 +1470,12 @@ extension RulesTests {
     ]
 }
 
+extension PreferSelfInStaticReferencesRuleTests {
+    static var allTests: [(String, (PreferSelfInStaticReferencesRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension SelfInPropertyInitializationRuleTests {
     static var allTests: [(String, (SelfInPropertyInitializationRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -2013,6 +2019,7 @@ XCTMain([
     testCase(RuleConfigurationTests.allTests),
     testCase(RuleTests.allTests),
     testCase(RulesTests.allTests),
+    testCase(PreferSelfInStaticReferencesRuleTests.allTests),
     testCase(SelfInPropertyInitializationRuleTests.allTests),
     testCase(ShorthandOperatorRuleTests.allTests),
     testCase(SingleTestClassRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -695,6 +695,12 @@ class ReturnArrowWhitespaceRuleTests: XCTestCase {
     }
 }
 
+class PreferSelfInStaticReferencesRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PreferSelfInStaticReferencesRule.description)
+    }
+}
+
 class SelfInPropertyInitializationRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SelfInPropertyInitializationRule.description)

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -9,7 +9,7 @@ class CollectingRuleTests: XCTestCase {
             }
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: Int]) -> [StyleViolation] {
                 XCTAssertEqual(collectedInfo[file], 42)
-                return [StyleViolation(ruleDescription: Spec.description,
+                return [StyleViolation(ruleDescription: Self.description,
                                        location: Location(file: file, byteOffset: 0))]
             }
         }
@@ -27,7 +27,7 @@ class CollectingRuleTests: XCTestCase {
                 XCTAssertTrue(values.contains("foo"))
                 XCTAssertTrue(values.contains("bar"))
                 XCTAssertTrue(values.contains("baz"))
-                return [StyleViolation(ruleDescription: Spec.description,
+                return [StyleViolation(ruleDescription: Self.description,
                                        location: Location(file: file, byteOffset: 0))]
             }
         }
@@ -44,7 +44,7 @@ class CollectingRuleTests: XCTestCase {
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: [String]], compilerArguments: [String])
                 -> [StyleViolation] {
                     XCTAssertEqual(collectedInfo[file], compilerArguments)
-                    return [StyleViolation(ruleDescription: Spec.description,
+                    return [StyleViolation(ruleDescription: Self.description,
                                            location: Location(file: file, byteOffset: 0))]
             }
         }
@@ -60,7 +60,7 @@ class CollectingRuleTests: XCTestCase {
 
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String]) -> [StyleViolation] {
                 if collectedInfo[file] == "baz" {
-                    return [StyleViolation(ruleDescription: Spec.description,
+                    return [StyleViolation(ruleDescription: Self.description,
                                            location: Location(file: file, byteOffset: 2))]
                 } else {
                     return []
@@ -69,7 +69,7 @@ class CollectingRuleTests: XCTestCase {
 
             func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String]) -> [Correction] {
                 if collectedInfo[file] == "baz" {
-                    return [Correction(ruleDescription: Spec.description,
+                    return [Correction(ruleDescription: Self.description,
                                        location: Location(file: file, byteOffset: 2))]
                 } else {
                     return []


### PR DESCRIPTION
Add optional `prefer_self_in_static_references` rule to warn if the class/struct/enum name is used to reference static variables/functions in the class/struct/enum. The advice is to use `Self` instead which is not effected by renamings.

One simple example is

    class C {
        static let i = 0
        static let j = C.i
    }

wherein `C.i` is used to reference the static `i` in this class. The rule would suggest to write `Self.i` instead.