### PR TITLE
[Colon Rule] Fix case when comment is used in function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,11 @@
 
 * Speed up Computed Accessors Order rule.
   [PaulTaykalo](https://github.com/PaulTaykalo)
-  [#3727](https://github.com/realm/SwiftLint/issues/3727)  
+  [#3727](https://github.com/realm/SwiftLint/issues/3727)
+
+* [Colon Rule] Fix case when comment is used in function call.
+  [PaulTaykalo](https://github.com/PaulTaykalo)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/3740)
 
 ## 0.44.0: Travel Size Lint Roller
 

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule+FunctionCall.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule+FunctionCall.swift
@@ -12,6 +12,8 @@ extension ColonRule {
     internal func functionCallColonViolationRanges(in file: SwiftLintFile, kind: SwiftExpressionKind,
                                                    dictionary: SourceKittenDictionary) -> [ByteRange] {
         guard kind == .argument,
+              let argumentRange = dictionary.byteRange,
+              !file.syntaxMap.tokens(inByteRange: argumentRange).kinds.contains(where: { $0.isCommentLike }),
             let ranges = functionCallColonRanges(dictionary: dictionary)
         else {
             return []

--- a/Source/SwiftLintFramework/Rules/Style/ColonRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRuleExamples.swift
@@ -26,6 +26,7 @@ internal struct ColonRuleExamples {
         Example("class Foo<T: Equatable>: Bar {}\n"),
         Example("class Foo<T, U>: Bar {}\n"),
         Example("class Foo<T: Equatable> {}\n"),
+        Example("object.method(x: /* comment */ 5)\n"),
         Example("""
         switch foo {
         case .bar:


### PR DESCRIPTION
This fixes #3719