### PR TITLE
Handle `get async` and `get throws` in `implicit_getter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   [Artem Garmash](https://github.com/agarmash)
   [#3651](https://github.com/realm/SwiftLint/issues/3651)
 
+* Handle `get async` and `get throws` (introduced in Swift 5.5) in the
+  `implicit_getter` rule.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3684](https://github.com/realm/SwiftLint/issues/3684)
+
 #### Bug Fixes
 
 * Fixes a bug with the `missing_docs` rule where `excludes_inherited_types` would not be set.

--- a/Source/SwiftLintFramework/Models/SwiftVersion.swift
+++ b/Source/SwiftLintFramework/Models/SwiftVersion.swift
@@ -35,6 +35,8 @@ public extension SwiftVersion {
     static let fiveDotThree = SwiftVersion(rawValue: "5.3.0")
     /// Swift 5.4.x - https://swift.org/download/#swift-54
     static let fiveDotFour = SwiftVersion(rawValue: "5.4.0")
+    /// Swift 5.5.x - https://swift.org/download/#swift-55
+    static let fiveDotFive = SwiftVersion(rawValue: "5.5.0")
 
     /// The current detected Swift compiler version, based on the currently accessible SourceKit version.
     ///

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRuleExamples.swift
@@ -138,14 +138,7 @@ struct ImplicitGetterRuleExamples {
                     }
                 }
             }
-            """)
-        ]
-
-        guard SwiftVersion.current >= .fourDotOne else {
-            return commonExamples
-        }
-
-        return commonExamples + [
+            """),
             Example("""
             class Foo {
                 subscript(i: Int) -> Int {
@@ -169,6 +162,35 @@ struct ImplicitGetterRuleExamples {
             Example("""
             protocol Foo {
                 subscript(i: Int) -> Int { get set }
+            }
+            """)
+        ]
+
+        guard SwiftVersion.current >= .fiveDotFive else {
+            return commonExamples
+        }
+
+        return commonExamples + [
+            Example("""
+            class DatabaseEntity {
+                var isSynced: Bool {
+                    get async {
+                        await database.isEntitySynced(self)
+                    }
+                }
+            }
+            """),
+            Example("""
+            struct Test {
+                subscript(value: Int) -> Int {
+                    get throws {
+                        if value == 0 {
+                            throw NSError()
+                        } else {
+                            return value
+                        }
+                    }
+                }
             }
             """)
         ]


### PR DESCRIPTION
Fixes #3684