### PR TITLE
Speed up getting compiler invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   [PaulTaykalo](https://github.com/PaulTaykalo)
   [#issue_number](https://github.com/realm/SwiftLint/issues/3745)
 
+* Speed up analyzer rules.  
+  [PaulTaykalo](https://github.com/PaulTaykalo)
+  [#3747](https://github.com/realm/SwiftLint/issues/3747)
+
 #### Bug Fixes
 
 * Fixes a bug with the `missing_docs` rule where `excludes_inherited_types` would not be set.


### PR DESCRIPTION
When rules are searching for `compiler invocations` per path, the previous implementation will check to perform a search every time for each path in the whole list of compiler arguments

let's say we have M compiler invocations. There will be total `(M*K)/2` arguments we need to check when we're asking for compiler invocations for a specific path.
Where 'K' - are non-path arguments

So for `M` requests ( for each .swift file), we'll have about  `M*M*K/2` ~ M^2 checks. 
Let's say we have 500 files in the project, then in order to return compiler invocation per each file we would need to perform ~250K  checks

Here are some results from different project sizes:

|   | Old implementation |  this PR |
|--|--|--|
| Project 1, ~100 files | 0.42421s | 0.01347s |
| Project 2, ~1600 files | 69.90897s |  0.25364s |


## Benchmarking code
```
private var totalTime: [String: TimeInterval] = [:]
private var lock = NSLock()
func measureAndAppendToLogIfNeeded<T>(_ message: String, _ block: @autoclosure () -> T) -> T {
    let start = NSDate()
    let result = block()
    let total = NSDate().timeIntervalSince1970 - start.timeIntervalSince1970
    let totalString = String(format: "%.5f", total)
    print("\(message) - took \(totalString) seconds")
    lock.lock()
    totalTime[message, default: 0] += total
    let res = totalTime[message]!
    lock.unlock()
    print("\(message) [Total] - took \(String(format: "%.5f", res)) seconds")
    return result
}
```