### PR TITLE
Add opt-in rule instance_or_static_variable_xctest

### DIFF
--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -7,6 +7,7 @@ public let primaryRuleList = RuleList(rules: [
     ArrayInitRule.self,
     AttributesRule.self,
     BalancedXCTestLifecycleRule.self,
+    InstanceOrStaticVariablesInXCTestRule.self,
     BlockBasedKVORule.self,
     CaptureVariableRule.self,
     ClassDelegateProtocolRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/InstanceOrStaticVariablesInXCTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InstanceOrStaticVariablesInXCTestRule.swift
@@ -1,0 +1,88 @@
+import SourceKittenFramework
+
+public struct InstanceOrStaticVariablesInXCTestRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+    // MARK: - Properties
+
+    public var configuration = SeverityConfiguration(.warning)
+
+    public static let description = RuleDescription(
+        identifier: "instance_or_static_variable_xctest",
+        name: "Instance or Static Variables in XCTest Subclass",
+        description: "Test classes must not contain instance or static variables.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example(#"""
+            final class FooTests: XCTestCase {
+                override func setUp() {}
+                func testExample() {}
+            }
+            """#)
+        ],
+        triggeringExamples: [
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                let instanceVariable = 2
+            }
+            """#),
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                private let instanceVariable = 2
+            }
+            """#),
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                var instanceVariable = 5
+            }
+            """#),
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                static let staticVariable = 5
+            }
+            """#),
+            Example(#"""
+            final class ↓FooTests: XCTestCase {
+                static var staticVariable = 5
+            }
+            """#)
+        ]
+    )
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+    // MARK: - Public
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        testClasses(in: file).compactMap { violations(in: file, for: $0) }
+    }
+
+    // MARK: - Private
+
+    private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
+        file.structureDictionary.substructure.filter { dictionary in
+            guard dictionary.declarationKind == .class else { return false }
+            return dictionary.inheritedTypes.contains("XCTestCase")
+        }
+    }
+
+    private func violations(in file: SwiftLintFile,
+                            for dictionary: SourceKittenDictionary) -> StyleViolation? {
+        let vars = dictionary.substructure
+            .compactMap { $0.kind == "source.lang.swift.decl.var.instance" ||
+                          $0.kind == "source.lang.swift.decl.var.static"
+            }
+            .filter { $0 }
+
+        guard
+            !vars.isEmpty,
+            let offset = dictionary.nameOffset
+        else {
+            return nil
+        }
+
+        return StyleViolation(ruleDescription: Self.description,
+                              severity: configuration.severity,
+                              location: Location(file: file, byteOffset: offset))
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @testable import SwiftLintFrameworkTests
 import XCTest
@@ -822,6 +822,12 @@ extension IndentationWidthRuleTests {
 
 extension InertDeferRuleTests {
     static var allTests: [(String, (InertDeferRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
+extension InstanceOrStaticVariablesInXCTestRuleTests {
+    static var allTests: [(String, (InstanceOrStaticVariablesInXCTestRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]
 }
@@ -1929,6 +1935,7 @@ XCTMain([
     testCase(InclusiveLanguageRuleTests.allTests),
     testCase(IndentationWidthRuleTests.allTests),
     testCase(InertDeferRuleTests.allTests),
+    testCase(InstanceOrStaticVariablesInXCTestRuleTests.allTests),
     testCase(IntegrationTests.allTests),
     testCase(IsDisjointRuleTests.allTests),
     testCase(JoinedDefaultParameterRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -329,6 +329,12 @@ class InertDeferRuleTests: XCTestCase {
     }
 }
 
+class InstanceOrStaticVariablesInXCTestRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(InstanceOrStaticVariablesInXCTestRule.description)
+    }
+}
+
 class IsDisjointRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(IsDisjointRule.description)


### PR DESCRIPTION
Static or Instance Variables in Unit Tests can cause flaky tests due to the fact that things can share state. This opt in rule helps to guide people to not introduce shared state in test classes. Obviously this is not fool proof, since shared state can be live at any layer of the system, but it makes it harder.

We might consider disallowing setup and tearDown as well, since they go hand in hand with shared state, and make local reasoning harder.

Feedback welcome.