### PR TITLE
Fix false positive in legacy_objc_type when a non-legacy Objective-C type name begins with a legacy Objective-C type name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
   [Jesse Crocker](https://github.com/JesseCrocker)
   [Hannes Ljungberg](https://github.com/hannseman)
 
+* Fix false positive on `legacy_objc_type` rule when using
+  types with names that start with a legacy type name.  
+  [Isaac Ressler](https://github.com/iressler)
+  [#3555](https://github.com/realm/SwiftLint/issues/3555)
+
 #### Bug Fixes
 
 * Fix `unused_import` rule incorrectly considering `SwiftShims` as a

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -41,7 +41,9 @@ public struct LegacyObjcTypeRule: OptInRule, ConfigurationProviderRule, Automati
         kind: .idiomatic,
         nonTriggeringExamples: [
             Example("var array = Array<Int>()\n"),
-            Example("var calendar: Calendar? = nil")
+            Example("var calendar: Calendar? = nil"),
+            Example("var formatter: NSDataDetector"),
+            Example("var className: String = NSStringFromClass(MyClass.self)")
         ],
         triggeringExamples: [
             Example("var array = NSArray()"),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -49,7 +49,7 @@ public struct LegacyObjcTypeRule: OptInRule, ConfigurationProviderRule, Automati
         ]
     )
 
-    private let pattern = legacyObjcTypes.joined(separator: "|")
+    private let pattern = "(?:\(legacyObjcTypes.joined(separator: "|")))[^A-Za-z]"
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.match(pattern: pattern)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -49,7 +49,7 @@ public struct LegacyObjcTypeRule: OptInRule, ConfigurationProviderRule, Automati
         ]
     )
 
-    private let pattern = "(?:\(legacyObjcTypes.joined(separator: "|")))[^A-Za-z]"
+    private let pattern = "\\b(?:\(legacyObjcTypes.joined(separator: "|")))\\b"
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.match(pattern: pattern)


### PR DESCRIPTION
This change addresses #3555 where the `legacy_objc_type` rule triggers on non legacy Objective-C types because their name contains a legacy Objective-C type name.

I updated the `legacy_objc_type` regex to require a word boundary before and after the legacy type name. This allows it to still detect usage of classes like `NSData` without also detecting `NSDataDetector`.


<s>This isn't a perfect solution because it can allow some usage like `NSStringFromClass` (found in [WordPress-iOS/PageListViewController.swift](https://github.com/wordpress-mobile/WordPress-iOS/blob/7de64fb8c63eb556c5817ad4d3baf933ba1cb384/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift#L844:27)). I'm not sure how we could detect types like `NSDataDetector` without also detecting usage like `NSStringFromClass`, unless there is a hard coded list of either the disallowed methods/types (`NSStringFromClass`) or the allowed types (`NSDataDetector`), neither of which seems reasonable to create. If anyone has any better suggestions I'd love to hear them.</s>

Edit: Turns out `NSStringFromClass()` actually creates a `String` despite the legacy name, so I'm less concerned about that than I was before.