### PR TITLE
Expand README Rules url

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ continues to contribute more over time.
 You can find an updated list of rules and more information about them
 [here](https://realm.github.io/SwiftLint/rule-directory.html).
 
-You can also check [Source/SwiftLintFramework/Rules](Source/SwiftLintFramework/Rules)
+You can also check [Source/SwiftLintFramework/Rules](https://github.com/realm/SwiftLint/tree/master/Source/SwiftLintFramework/Rules)
 directory to see their implementation.
 
 ### Opt-In Rules


### PR DESCRIPTION
From https://realm.github.io/SwiftLint/index.html, this would route to `https://realm.github.io/SwiftLint/Source/SwiftLintFramework/Rules`, which does not exist. Explicitly link to GitHub.