### PR TITLE
Documentation: Separate out default rules vs opt in rules in rule list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 #### Enhancements
 
-* None.
+* Update Rule list documentation to separate out default vs opt in rules
+  [Benny Wong](https://github.com/bdotdub)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 #### Enhancements
 
-* Update Rule list documentation to separate out default vs opt in rules
+* Update Rule list documentation to distinguish between opt-in and
+  on-by-default rules.  
   [Benny Wong](https://github.com/bdotdub)
 
 #### Bug Fixes

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -1,6 +1,6 @@
 /// User-facing documentation for a SwiftLint rule.
 struct RuleDocumentation {
-    private let ruleType: Rule.Type
+    public let ruleType: Rule.Type
 
     /// Creates a RuleDocumentation instance from a Rule type.
     ///

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -1,6 +1,10 @@
 /// User-facing documentation for a SwiftLint rule.
 struct RuleDocumentation {
-    public let ruleType: Rule.Type
+    private let ruleType: Rule.Type
+
+    var isOptInRule: Bool {
+        return ruleType is OptInRule.Type
+    }
 
     /// Creates a RuleDocumentation instance from a Rule type.
     ///

--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -32,12 +32,24 @@ public struct RuleListDocumentation {
     // MARK: - Private
 
     private var indexContents: String {
+        let defaultRuleDocumentations = ruleDocumentations.drop { $0.ruleType is OptInRule.Type }
+        let optInRuleDocumentations = ruleDocumentations.filter { $0.ruleType is OptInRule.Type }
+
         return """
             # Rule Directory
 
-            \(ruleDocumentations
+            ## Default Rules
+
+            \(defaultRuleDocumentations
                 .map { "* [\($0.ruleName)](\($0.urlFragment))" }
                 .joined(separator: "\n"))
+
+            ## Opt-In Rules
+
+            \(optInRuleDocumentations
+                .map { "* [\($0.ruleName)](\($0.urlFragment))" }
+                .joined(separator: "\n"))
+
             """
     }
 }

--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -32,8 +32,8 @@ public struct RuleListDocumentation {
     // MARK: - Private
 
     private var indexContents: String {
-        let defaultRuleDocumentations = ruleDocumentations.drop { $0.ruleType is OptInRule.Type }
-        let optInRuleDocumentations = ruleDocumentations.filter { $0.ruleType is OptInRule.Type }
+        let defaultRuleDocumentations = ruleDocumentations.drop { $0.isOptInRule }
+        let optInRuleDocumentations = ruleDocumentations.filter { $0.isOptInRule }
 
         return """
             # Rule Directory


### PR DESCRIPTION
I had a tough time figuring out which rules were on by default and which ones were opt in. This PR separates them out on the "Rule Directory".

Screenshots from locally generated docs:

![image](https://user-images.githubusercontent.com/5719/142468360-23b7fdd5-5eb2-4c9b-a554-98b18ed35fc8.png)
![image](https://user-images.githubusercontent.com/5719/142468385-b558a6db-3cb7-4436-ac99-e2fdc4751258.png)
