### PR TITLE
Fix crash when parsing multi-line attributes with the `attributes` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 
 #### Bug Fixes
 
-* None.
+* Fix crash when parsing multi-line attributes with the `attributes`
+  rule.  
+  [JP Simard](https://github.com/jpsim)
+  [#3761](https://github.com/realm/SwiftLint/issues/3761)
 
 ## 0.45.1: Clothes Drying Hooks
 

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -252,6 +252,10 @@ public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
                                             line: Line, file: SwiftLintFile) -> Bool {
         let restOfLineOffset = attributeRange.upperBound
         let restOfLineLength = line.byteRange.upperBound - restOfLineOffset
+        if restOfLineLength < 0 {
+            // If attribute spans multiple lines, it must have a parameter.
+            return true
+        }
 
         let regex = Self.regularExpression
         let contents = file.stringView

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRuleExamples.swift
@@ -58,6 +58,16 @@ internal struct AttributesRuleExamples {
         func printBoolOrTrue(_ expression: @autoclosure () throws -> Bool?) rethrows {
           try print(expression() ?? true)
         }
+        """),
+        Example("""
+        import Foundation
+
+        class MyClass: NSObject {
+          @objc(
+            first:
+          )
+          static func foo(first: String) {}
+        }
         """)
     ]
 


### PR DESCRIPTION
Fixes #3761