### PR TITLE
Update build phase snippet for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ target, and go to Build Phases. Click the + and select "New Run Script Phase".
 Insert the following as the script:
 
 ```bash
+export PATH="$PATH:/opt/homebrew/bin"
+
 if which swiftlint >/dev/null; then
   swiftlint
 else


### PR DESCRIPTION
Since Homebrew installs to a path that isn't in Xcode's path by default, we need to add to the path to support the default location Homebrew installs SwiftLint on Apple Silicon.

From https://stackoverflow.com/a/66003612/118631