### PR TITLE
[CI] Test OSSCheck with Xcode 13.2

### DIFF
--- a/script/oss-check
+++ b/script/oss-check
@@ -301,8 +301,7 @@ end
   Repo.new('Realm', 'realm/realm-cocoa'),
   Repo.new('SourceKitten', 'jpsim/SourceKitten'),
   Repo.new('Sourcery', 'krzysztofzablocki/Sourcery'),
-  Repo.new('Swift', 'apple/swift'),
-  Repo.new('WordPress', 'wordpress-mobile/WordPress-iOS')
+  Repo.new('Swift', 'apple/swift')
 ]
 
 # Clean up


### PR DESCRIPTION
I just updated our MacStadium Mac Mini to Xcode 13.2 & macOS 12.1.

Confirming OSSCheck still works.