### PR TITLE
add rule to check for @Environment usage

### DIFF
--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [
@@ -50,6 +50,7 @@ public let primaryRuleList = RuleList(rules: [
     EmptyStringRule.self,
     EmptyXCTestMethodRule.self,
     EnumCaseAssociatedValuesLengthRule.self,
+    EnvironmentInViewOrViewModifierRule.self,
     ExpiringTodoRule.self,
     ExplicitACLRule.self,
     ExplicitEnumRawValueRule.self,
@@ -132,6 +133,7 @@ public let primaryRuleList = RuleList(rules: [
     OverrideInExtensionRule.self,
     PatternMatchingKeywordsRule.self,
     PreferNimbleRule.self,
+    PreferSelfInStaticReferencesRule.self,
     PreferSelfTypeOverTypeOfSelfRule.self,
     PreferZeroOverExplicitInitRule.self,
     PrefixedTopLevelConstantRule.self,
@@ -160,7 +162,6 @@ public let primaryRuleList = RuleList(rules: [
     RequiredDeinitRule.self,
     RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,
-    PreferSelfInStaticReferencesRule.self,
     SelfInPropertyInitializationRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/EnvironmentInViewOrViewModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EnvironmentInViewOrViewModifierRule.swift
@@ -1,0 +1,83 @@
+import Foundation
+import SourceKittenFramework
+
+public struct EnvironmentInViewOrViewModifierRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "environment_in_view_or_viewmodifier",
+        name: "Environment in View or ViewModifier",
+        description: "@Environment should only be used in structs implementing `View` or `ViewModifier`",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+            struct Good: View {
+                @Environment(\\.keyPath) var variable
+            }
+            """),
+            Example("""
+            struct Good: View {
+                @Environment(
+                    \\.aVeryLongKeyPathName
+                ) var variable
+            }
+            """),
+            Example("""
+            struct Good: ViewModifier {
+                @Environment(\\.keyPath) var variable
+            }
+            """),
+            Example("""
+            struct Good: View {
+                @CustomPropertyWrapper @Environment(\\.keyPath) var variable
+            }
+            """),
+        ],
+        triggeringExamples: [
+            Example("""
+            struct Bad: NotAView {
+                @Environment(\\.keyPath) var variable
+            }
+            """)
+        ]
+    )
+
+    private let environmentPropertyWrapper = regex("@Environment\\(.*?\\)")
+
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        let collector = NamespaceCollector(dictionary: file.structureDictionary)
+        let elements = collector.findAllElements(of: [.struct])
+
+        return elements
+            .filter {
+                return !$0.dictionary.inheritedTypes.contains(where: { $0 == "View" || $0 == "ViewModifier" })
+            }
+            .flatMap { element in
+                return element.dictionary.substructure.compactMap { subElement -> [ByteCount] in
+                    guard subElement.declarationKind == .varInstance else { return [] }
+                    return subElement.swiftAttributes.compactMap { attribute -> ByteCount? in
+                        guard
+                            let offset = attribute.value["key.offset"] as? Int64,
+                            let length = attribute.value["key.length"] as? Int64,
+                            let attributeString = file.stringView.substringWithByteRange(
+                                ByteRange(location: ByteCount(offset), length: ByteCount(length))
+                            )
+                        else { return nil }
+                        let range = NSRange(location: 0, length: attributeString.count)
+                        let matches = environmentPropertyWrapper.numberOfMatches(
+                            in: attributeString,
+                            options: [],
+                            range: range
+                        )
+                        return matches > 0 ? ByteCount(offset) : nil
+                    }
+                }
+            }
+            .flatMap { $0 }
+            .map {
+                StyleViolation(ruleDescription: Self.description, location: Location(file: file, byteOffset: $0))
+            }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @testable import SwiftLintFrameworkTests
 import XCTest
@@ -479,6 +479,12 @@ extension EmptyXCTestMethodRuleTests {
 
 extension EnumCaseAssociatedValuesLengthRuleTests {
     static var allTests: [(String, (EnumCaseAssociatedValuesLengthRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
+extension EnvironmentInViewOrViewModifierRuleTests {
+    static var allTests: [(String, (EnvironmentInViewOrViewModifierRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]
 }
@@ -1200,6 +1206,12 @@ extension PreferNimbleRuleTests {
     ]
 }
 
+extension PreferSelfInStaticReferencesRuleTests {
+    static var allTests: [(String, (PreferSelfInStaticReferencesRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension PreferSelfTypeOverTypeOfSelfRuleTests {
     static var allTests: [(String, (PreferSelfTypeOverTypeOfSelfRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1467,12 +1479,6 @@ extension RulesTests {
         ("testRequiredEnumCase", testRequiredEnumCase),
         ("testTrailingNewline", testTrailingNewline),
         ("testOrphanedDocComment", testOrphanedDocComment)
-    ]
-}
-
-extension PreferSelfInStaticReferencesRuleTests {
-    static var allTests: [(String, (PreferSelfInStaticReferencesRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]
 }
 
@@ -1894,6 +1900,7 @@ XCTMain([
     testCase(EmptyStringRuleTests.allTests),
     testCase(EmptyXCTestMethodRuleTests.allTests),
     testCase(EnumCaseAssociatedValuesLengthRuleTests.allTests),
+    testCase(EnvironmentInViewOrViewModifierRuleTests.allTests),
     testCase(ExampleTests.allTests),
     testCase(ExpiringTodoRuleTests.allTests),
     testCase(ExplicitACLRuleTests.allTests),
@@ -1986,6 +1993,7 @@ XCTMain([
     testCase(ParserDiagnosticsTests.allTests),
     testCase(PatternMatchingKeywordsRuleTests.allTests),
     testCase(PreferNimbleRuleTests.allTests),
+    testCase(PreferSelfInStaticReferencesRuleTests.allTests),
     testCase(PreferSelfTypeOverTypeOfSelfRuleTests.allTests),
     testCase(PreferZeroOverExplicitInitRuleTests.allTests),
     testCase(PrefixedTopLevelConstantRuleTests.allTests),
@@ -2019,7 +2027,6 @@ XCTMain([
     testCase(RuleConfigurationTests.allTests),
     testCase(RuleTests.allTests),
     testCase(RulesTests.allTests),
-    testCase(PreferSelfInStaticReferencesRuleTests.allTests),
     testCase(SelfInPropertyInitializationRuleTests.allTests),
     testCase(ShorthandOperatorRuleTests.allTests),
     testCase(SingleTestClassRuleTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import SwiftLintFramework
 import XCTest
@@ -212,6 +212,12 @@ class EmptyXCTestMethodRuleTests: XCTestCase {
 class EnumCaseAssociatedValuesLengthRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EnumCaseAssociatedValuesLengthRule.description)
+    }
+}
+
+class EnvironmentInViewOrViewModifierRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(EnvironmentInViewOrViewModifierRule.description)
     }
 }
 
@@ -551,6 +557,12 @@ class PreferNimbleRuleTests: XCTestCase {
     }
 }
 
+class PreferSelfInStaticReferencesRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PreferSelfInStaticReferencesRule.description)
+    }
+}
+
 class PreferSelfTypeOverTypeOfSelfRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferSelfTypeOverTypeOfSelfRule.description)
@@ -692,12 +704,6 @@ class RequiredDeinitRuleTests: XCTestCase {
 class ReturnArrowWhitespaceRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReturnArrowWhitespaceRule.description)
-    }
-}
-
-class PreferSelfInStaticReferencesRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(PreferSelfInStaticReferencesRule.description)
     }
 }
 


### PR DESCRIPTION
There is no compiler warning about `@Environment` usage in SwiftUI, though it only works as intended if used in a `View` or `ViewModifier`, other usage results in receiving the default value only.

This rule checks for usage of the `@Environment` property wrapper usage in types not conforming to `View` or `ViewModifier` to warn of improper usage.
