### PR TITLE
Add rule identifiers in 'Rule Directory' documentation page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 #### Enhancements
 
-* None.
+* Add rule identifiers in "Rule Directory" documentation page.  
+  [Ethan Wong](https://github.com/GetToSet)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -18,9 +18,9 @@ struct RuleDocumentation {
         return ruleType.description.name
     }
 
-    /// The web URL fragment for this documentation.
-    var urlFragment: String {
-        return "\(ruleType.description.identifier).html"
+    /// The identifier of the documented rule.
+    var ruleIdentifier: String {
+        return ruleType.description.identifier
     }
 
     /// The name of the file on disk for this rule documentation.

--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -41,13 +41,13 @@ public struct RuleListDocumentation {
             ## Default Rules
 
             \(defaultRuleDocumentations
-                .map { "* [\($0.ruleName)](\($0.urlFragment))" }
+                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
                 .joined(separator: "\n"))
 
             ## Opt-In Rules
 
             \(optInRuleDocumentations
-                .map { "* [\($0.ruleName)](\($0.urlFragment))" }
+                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
                 .joined(separator: "\n"))
 
             """


### PR DESCRIPTION
This PR adds  rule identifiers in 'Rule Directory' documentation page.

<img width="971" alt="Screenshot 2021-12-26 20 17 55" src="https://user-images.githubusercontent.com/8158163/147407775-ba5bde4b-4221-4000-80c6-62aa6aa9f857.png">

This can help users to make sense how these rules sort and quickly reference them when editing `.swiftlint.yml` files.

Since jazzy automatically creating links for identifiers wrapped in backquotes, `RuleDocumentation.ruleIdentifier` is no longer needed anymore.