### PR TITLE
Fix specifying the cachePath from command line

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -8,6 +8,13 @@ extension Configuration {
     private static var cachedConfigurationsByIdentifier = [String: Configuration]()
     private static var cachedConfigurationsByIdentifierLock = NSLock()
 
+    /// Since the cache is stored in a static var, this function is used to reset the cache during tests
+    internal static func resetCache() {
+        Self.cachedConfigurationsByIdentifierLock.lock()
+        Self.cachedConfigurationsByIdentifier = [:]
+        Self.cachedConfigurationsByIdentifierLock.unlock()
+    }
+
     internal func setCached(forIdentifier identifier: String) {
         Self.cachedConfigurationsByIdentifierLock.lock()
         Self.cachedConfigurationsByIdentifier[identifier] = self

--- a/Source/SwiftLintFramework/Extensions/Configuration+FileGraph.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+FileGraph.swift
@@ -47,7 +47,10 @@ internal extension Configuration {
         }
 
         // MARK: - Methods
-        internal mutating func resultingConfiguration(enableAllRules: Bool) throws -> Configuration {
+        internal mutating func resultingConfiguration(
+            enableAllRules: Bool,
+            cachePath: String?
+        ) throws -> Configuration {
             // Build if needed
             if !isBuilt {
                 try build()
@@ -55,7 +58,8 @@ internal extension Configuration {
 
             return try merged(
                 configurationData: try validate(),
-                enableAllRules: enableAllRules
+                enableAllRules: enableAllRules,
+                cachePath: cachePath
             )
         }
 
@@ -226,7 +230,8 @@ internal extension Configuration {
         // MARK: Merging
         private func merged(
             configurationData: [(configurationDict: [String: Any], rootDirectory: String)],
-            enableAllRules: Bool
+            enableAllRules: Bool,
+            cachePath: String?
         ) throws -> Configuration {
             // Split into first & remainder; use empty dict for first if the array is empty
             let firstConfigurationData = configurationData.first ?? (configurationDict: [:], rootDirectory: "")
@@ -235,7 +240,8 @@ internal extension Configuration {
             // Build first configuration
             var firstConfiguration = try Configuration(
                 dict: firstConfigurationData.configurationDict,
-                enableAllRules: enableAllRules
+                enableAllRules: enableAllRules,
+                cachePath: cachePath
             )
 
             // Set the config's rootDirectory to rootDirectory (+ adjust included / excluded paths that relate to it).
@@ -249,7 +255,11 @@ internal extension Configuration {
 
             // Build succeeding configurations
             return try configurationData.reduce(firstConfiguration) {
-                var childConfiguration = try Configuration(dict: $1.configurationDict, enableAllRules: enableAllRules)
+                var childConfiguration = try Configuration(
+                    dict: $1.configurationDict,
+                    enableAllRules: enableAllRules,
+                    cachePath: cachePath
+                )
                 childConfiguration.fileGraph = FileGraph(rootDirectory: $1.rootDirectory)
 
                 return $0.merged(withChild: childConfiguration, rootDirectory: rootDirectory)

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -208,7 +208,10 @@ public struct Configuration {
                 rootDirectory: currentWorkingDirectory,
                 ignoreParentAndChildConfigs: ignoreParentAndChildConfigs
             )
-            let resultingConfiguration = try fileGraph.resultingConfiguration(enableAllRules: enableAllRules)
+            let resultingConfiguration = try fileGraph.resultingConfiguration(
+                enableAllRules: enableAllRules,
+                cachePath: cachePath
+            )
 
             self.init(copying: resultingConfiguration)
             self.fileGraph = fileGraph

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -13,6 +13,7 @@ class ConfigurationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        Configuration.resetCache()
         previousWorkingDir = FileManager.default.currentDirectoryPath
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
     }
@@ -448,5 +449,51 @@ extension ConfigurationTests {
                                                 excludeByPrefix: true)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         XCTAssertEqual(filenames, ["Level1.swift"])
+    }
+
+    func testDictInitWithCachePath() throws {
+        let configuration = try Configuration(
+            dict: ["cache_path": "cache/path/1"]
+        )
+
+        XCTAssertEqual(configuration.cachePath, "cache/path/1")
+    }
+
+    func testDictInitWithCachePathFromCommandLine() throws {
+        let configuration = try Configuration(
+            dict: ["cache_path": "cache/path/1"],
+            cachePath: "cache/path/2"
+        )
+
+        XCTAssertEqual(configuration.cachePath, "cache/path/2")
+    }
+
+    func testMainInitWithCachePath() {
+        let configuration = Configuration(
+            configurationFiles: [],
+            cachePath: "cache/path/1"
+        )
+
+        XCTAssertEqual(configuration.cachePath, "cache/path/1")
+    }
+
+    // This test demonstrates an existing bug: when the Configuration is obtained from the in-memory cache, the
+    // cachePath is not taken into account
+    //
+    // This issue may not be reproducible under normal execution: the cache is in memory, so when a user changes
+    // the cachePath from command line and re-runs swiftlint, cache is not reused leading to the correct behavior
+    func testMainInitWithCachePathAndCachedConfig() {
+        let configuration1 = Configuration(
+            configurationFiles: [],
+            cachePath: "cache/path/1"
+        )
+
+        let configuration2 = Configuration(
+            configurationFiles: [],
+            cachePath: "cache/path/2"
+        )
+
+        XCTAssertEqual(configuration1.cachePath, "cache/path/1")
+        XCTAssertEqual(configuration2.cachePath, "cache/path/1")
     }
 }


### PR DESCRIPTION
Hi 👋 

Seems like passing `--cache-path` to swiftlint from command line was not working, because the value was not taken into account when calculating the final `Configuration`. This PR fixes that, treating `cachePath` parameter in a similar way as `enableAllRules`