### PR TITLE
Prevent false triggering of `unused_closure_parameter` when using list bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   [JP Simard](https://github.com/jpsim)
   [#3761](https://github.com/realm/SwiftLint/issues/3761)
 
+* Fix false trigger from `unused_closure_parameter` when using
+  list element bindings in SwiftUI.  
+  [Paul Williamson](https://github.com/squarefrog)
+  [#3790](https://github.com/realm/SwiftLint/issues/3790)
+
 ## 0.45.1: Clothes Drying Hooks
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -60,6 +60,11 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
             List($names) { $name in
                 Text(name)
             }
+            """),
+            Example("""
+            List($names) { $name in
+                TextField($name)
+            }
             """)
         ],
         triggeringExamples: [
@@ -181,10 +186,9 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
     private func rangeAndName(parameter: SourceKittenDictionary, contents: StringView, byteRange: ByteRange,
                               file: SwiftLintFile) -> (range: NSRange, name: String)? {
         guard let paramOffset = parameter.offset,
-            let name = parameter.name?.replacingOccurrences(of: "$", with: ""),
+            let name = parameter.name?.replacingOccurrences(of: "$", with: "\\$?"),
             name != "_",
-            let regex = try? NSRegularExpression(pattern: name,
-                                                 options: [.ignoreMetacharacters]),
+            let regex = try? NSRegularExpression(pattern: name, options: []),
             let range = contents.byteRangeToNSRange(byteRange)
         else {
             return nil

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -55,6 +55,11 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
             let failure: Failure = { task, error in
                 observer.sendFailed(error, task)
             }
+            """),
+            Example("""
+            List($names) { $name in
+                Text(name)
+            }
             """)
         ],
         triggeringExamples: [
@@ -76,6 +81,11 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
             Example("""
             let failure: Failure = { ↓task, error in
                 observer.sendFailed(error)
+            }
+            """),
+            Example("""
+            List($names) { ↓$name in
+                Text("Foo")
             }
             """)
         ],
@@ -171,7 +181,7 @@ public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, Config
     private func rangeAndName(parameter: SourceKittenDictionary, contents: StringView, byteRange: ByteRange,
                               file: SwiftLintFile) -> (range: NSRange, name: String)? {
         guard let paramOffset = parameter.offset,
-            let name = parameter.name,
+            let name = parameter.name?.replacingOccurrences(of: "$", with: ""),
             name != "_",
             let regex = try? NSRegularExpression(pattern: name,
                                                  options: [.ignoreMetacharacters]),


### PR DESCRIPTION
Fixes #3790.

In Xcode 13 / iOS 15, SwiftUI now lets us create a `List` or `ForEach` directly from a binding. However, this triggers a false positive `unused_closure_parameter` when running SwiftLint. Consider the following examples:

```swift
List($users) { $user in
  Text(user.name)
}
```

```swift
List($users { $user in
  Toggle("Is favorite", isOn: $user.isFavorite)
}
```

Both are valid cases, but both are triggering warnings.

This PR marks the binding character (`$`) as optional in the paramater name regex.

### Warning
The changes involved removing the `ignoreMetacharacters` option of the capture list regex. While the tests all still pass, I'm unaware of any history why this value was previously present, so it may be worth further scrutiny.

### Resources

- https://www.hackingwithswift.com/quick-start/swiftui/how-to-create-a-list-or-a-foreach-from-a-binding
- https://www.swiftbysundell.com/articles/bindable-swiftui-list-elements/