### PR TITLE
Fix the regex for expiring-todos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 #### Bug Fixes
 
+* Fix the regex for expiring-todos.  
+  [Sergei Shirokov](https://github.com/serges147)
+  [#3767](https://github.com/realm/SwiftLint/issues/3767)
+
 * Fix crash when parsing multi-line attributes with the `attributes`
   rule.  
   [JP Simard](https://github.com/jpsim)

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -45,8 +45,12 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
     public init() {}
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        // swiftlint:disable:next line_length
-        let regex = "\\b(?:TODO|FIXME)(?::|\\b)(?:.*)\\\(configuration.dateDelimiters.opening)(\\d{1,4}\\\(configuration.dateSeparator)\\d{1,2}\\\(configuration.dateSeparator)\\d{1,4})\\\(configuration.dateDelimiters.closing)"
+        let regex = #"""
+        \b(?:TODO|FIXME)(?::|\b)(?:(?!\b(?:TODO|FIXME)(?::|\b)).)*?\#
+        \\#(configuration.dateDelimiters.opening)\#
+        (\d{1,4}\\#(configuration.dateSeparator)\d{1,2}\\#(configuration.dateSeparator)\d{1,4})\#
+        \\#(configuration.dateDelimiters.closing)
+        """#
 
         return file.matchesAndSyntaxKinds(matching: regex).compactMap { checkingResult, syntaxKinds in
             guard


### PR DESCRIPTION
Fixes #3767.

- Make "middle part" `.*` not so greedy with `?`.
- Use `(?!` negative look-ahead to improve matching.
- Added corresponding unit tests.