### PR TITLE
Remove 'weak_delegate' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 #### Breaking
 
-* None.
+* The 'weak_delegate' rule has been deprecated due to its high false
+  positive rate. The identifier will become invalid in a future
+  release.  
+  [JP Simard](https://github.com/jpsim)
+  [#2786](https://github.com/realm/SwiftLint/issues/2786)
 
 #### Experimental
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [
@@ -132,6 +132,7 @@ public let primaryRuleList = RuleList(rules: [
     OverrideInExtensionRule.self,
     PatternMatchingKeywordsRule.self,
     PreferNimbleRule.self,
+    PreferSelfInStaticReferencesRule.self,
     PreferSelfTypeOverTypeOfSelfRule.self,
     PreferZeroOverExplicitInitRule.self,
     PrefixedTopLevelConstantRule.self,
@@ -160,7 +161,6 @@ public let primaryRuleList = RuleList(rules: [
     RequiredDeinitRule.self,
     RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,
-    PreferSelfInStaticReferencesRule.self,
     SelfInPropertyInitializationRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -1,5 +1,3 @@
-import SourceKittenFramework
-
 private let printDeprecationWarning: Void = {
     queuedPrintError(
         "warning: \(WeakDelegateRule.description.description)"

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -1,114 +1,29 @@
-import Foundation
 import SourceKittenFramework
 
-public struct WeakDelegateRule: ASTRule, SubstitutionCorrectableASTRule, ConfigurationProviderRule,
-    AutomaticTestableRule {
+private let printDeprecationWarning: Void = {
+    queuedPrintError(
+        "warning: \(WeakDelegateRule.description.description)"
+    )
+}()
+
+public struct WeakDelegateRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
 
     public static let description = RuleDescription(
         identifier: "weak_delegate",
-        name: "Weak Delegate",
-        description: "Delegates should be weak to avoid reference cycles.",
-        kind: .lint,
-        nonTriggeringExamples: [
-            Example("class Foo {\n  weak var delegate: SomeProtocol?\n}\n"),
-            Example("class Foo {\n  weak var someDelegate: SomeDelegateProtocol?\n}\n"),
-            Example("class Foo {\n  weak var delegateScroll: ScrollDelegate?\n}\n"),
-            // We only consider properties to be a delegate if it has "delegate" in its name
-            Example("class Foo {\n  var scrollHandler: ScrollDelegate?\n}\n"),
-            // Only trigger on instance variables, not local variables
-            Example("func foo() {\n  var delegate: SomeDelegate\n}\n"),
-            // Only trigger when variable has the suffix "-delegate" to avoid false positives
-            Example("class Foo {\n  var delegateNotified: Bool?\n}\n"),
-            // There's no way to declare a property weak in a protocol
-            Example("protocol P {\n var delegate: AnyObject? { get set }\n}\n"),
-            Example("class Foo {\n protocol P {\n var delegate: AnyObject? { get set }\n}\n}\n"),
-            Example("class Foo {\n var computedDelegate: ComputedDelegate {\n return bar() \n} \n}"),
-            Example("struct Foo {\n @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate \n}")
-        ],
-        triggeringExamples: [
-            Example("class Foo {\n  ↓var delegate: SomeProtocol?\n}\n"),
-            Example("class Foo {\n  ↓var scrollDelegate: ScrollDelegate?\n}\n")
-        ],
-        corrections: [
-            Example("class Foo {\n  ↓var delegate: SomeProtocol?\n}\n"):
-                Example("class Foo {\n  weak var delegate: SomeProtocol?\n}\n"),
-            Example("class Foo {\n  ↓var scrollDelegate: ScrollDelegate?\n}\n"):
-                Example("class Foo {\n  weak var scrollDelegate: ScrollDelegate?\n}\n")
-        ]
+        name: "Weak Delegate (Deprecated)",
+        description:
+            """
+            The 'weak_delegate' rule has been deprecated due to its high false positive rate.
+            The identifier will become invalid in a future release.
+            """,
+        kind: .lint
     )
 
-    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
-            StyleViolation(ruleDescription: Self.description,
-                           severity: configuration.severity,
-                           location: Location(file: file, characterOffset: $0.location))
-        }
-    }
-
-    public func violationRanges(in file: SwiftLintFile, kind: SwiftDeclarationKind,
-                                dictionary: SourceKittenDictionary) -> [NSRange] {
-        guard kind == .varInstance else {
-            return []
-        }
-
-        // Check if name contains "delegate"
-        guard let name = dictionary.name,
-            name.lowercased().hasSuffix("delegate") else {
-                return []
-        }
-
-        // Check if non-weak
-        let isWeak = dictionary.enclosedSwiftAttributes.contains(.weak)
-        guard !isWeak else { return [] }
-
-        // if the declaration is inside a protocol
-        if let offset = dictionary.offset,
-            protocolDeclarations(forByteOffset: offset, structureDictionary: file.structureDictionary).isNotEmpty {
-            return []
-        }
-
-        // Check if non-computed
-        let isComputed = (dictionary.bodyLength ?? 0) > 0
-        guard !isComputed else { return [] }
-
-        // Check for UIApplicationDelegateAdaptor
-        for attribute in dictionary.swiftAttributes {
-            if
-                let offset = attribute.offset,
-                let length = attribute.length,
-                let value = file.stringView.substringWithByteRange(ByteRange(location: offset, length: length)),
-                value.hasPrefix("@UIApplicationDelegateAdaptor") {
-                return []
-            }
-        }
-
-        guard let offset = dictionary.offset,
-            let range = file.stringView.byteRangeToNSRange(ByteRange(location: offset, length: 3))
-        else {
-            return []
-        }
-
-        return [range]
-    }
-
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
-        return (violationRange, "weak var")
-    }
-
-    private func protocolDeclarations(forByteOffset byteOffset: ByteCount,
-                                      structureDictionary: SourceKittenDictionary) -> [SourceKittenDictionary] {
-        return structureDictionary.traverseBreadthFirst { dictionary in
-            guard dictionary.declarationKind == .protocol,
-                let byteRange = dictionary.byteRange,
-                byteRange.contains(byteOffset)
-            else {
-                return nil
-            }
-            return [dictionary]
-        }
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        _ = printDeprecationWarning
+        return []
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @testable import SwiftLintFrameworkTests
 import XCTest
@@ -235,6 +235,10 @@ extension ConfigurationTests {
         ("testExcludeByPrefixForceExcludesDirectory", testExcludeByPrefixForceExcludesDirectory),
         ("testExcludeByPrefixForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre", testExcludeByPrefixForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre),
         ("testExcludeByPrefixGlobExcludePaths", testExcludeByPrefixGlobExcludePaths),
+        ("testDictInitWithCachePath", testDictInitWithCachePath),
+        ("testDictInitWithCachePathFromCommandLine", testDictInitWithCachePathFromCommandLine),
+        ("testMainInitWithCachePath", testMainInitWithCachePath),
+        ("testMainInitWithCachePathAndCachedConfig", testMainInitWithCachePathAndCachedConfig),
         ("testMerge", testMerge),
         ("testWarningThresholdMerging", testWarningThresholdMerging),
         ("testOnlyRulesMerging", testOnlyRulesMerging),
@@ -1200,6 +1204,12 @@ extension PreferNimbleRuleTests {
     ]
 }
 
+extension PreferSelfInStaticReferencesRuleTests {
+    static var allTests: [(String, (PreferSelfInStaticReferencesRuleTests) -> () throws -> Void)] = [
+        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
+    ]
+}
+
 extension PreferSelfTypeOverTypeOfSelfRuleTests {
     static var allTests: [(String, (PreferSelfTypeOverTypeOfSelfRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1467,12 +1477,6 @@ extension RulesTests {
         ("testRequiredEnumCase", testRequiredEnumCase),
         ("testTrailingNewline", testTrailingNewline),
         ("testOrphanedDocComment", testOrphanedDocComment)
-    ]
-}
-
-extension PreferSelfInStaticReferencesRuleTests {
-    static var allTests: [(String, (PreferSelfInStaticReferencesRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
     ]
 }
 
@@ -1780,12 +1784,6 @@ extension VoidReturnRuleTests {
     ]
 }
 
-extension WeakDelegateRuleTests {
-    static var allTests: [(String, (WeakDelegateRuleTests) -> () throws -> Void)] = [
-        ("testWithDefaultConfiguration", testWithDefaultConfiguration)
-    ]
-}
-
 extension XCTFailMessageRuleTests {
     static var allTests: [(String, (XCTFailMessageRuleTests) -> () throws -> Void)] = [
         ("testWithDefaultConfiguration", testWithDefaultConfiguration)
@@ -1986,6 +1984,7 @@ XCTMain([
     testCase(ParserDiagnosticsTests.allTests),
     testCase(PatternMatchingKeywordsRuleTests.allTests),
     testCase(PreferNimbleRuleTests.allTests),
+    testCase(PreferSelfInStaticReferencesRuleTests.allTests),
     testCase(PreferSelfTypeOverTypeOfSelfRuleTests.allTests),
     testCase(PreferZeroOverExplicitInitRuleTests.allTests),
     testCase(PrefixedTopLevelConstantRuleTests.allTests),
@@ -2019,7 +2018,6 @@ XCTMain([
     testCase(RuleConfigurationTests.allTests),
     testCase(RuleTests.allTests),
     testCase(RulesTests.allTests),
-    testCase(PreferSelfInStaticReferencesRuleTests.allTests),
     testCase(SelfInPropertyInitializationRuleTests.allTests),
     testCase(ShorthandOperatorRuleTests.allTests),
     testCase(SingleTestClassRuleTests.allTests),
@@ -2067,7 +2065,6 @@ XCTMain([
     testCase(VerticalWhitespaceOpeningBracesRuleTests.allTests),
     testCase(VerticalWhitespaceRuleTests.allTests),
     testCase(VoidReturnRuleTests.allTests),
-    testCase(WeakDelegateRuleTests.allTests),
     testCase(XCTFailMessageRuleTests.allTests),
     testCase(XCTSpecificMatcherRuleTests.allTests),
     testCase(YamlParserTests.allTests),

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.5.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import SwiftLintFramework
 import XCTest
@@ -551,6 +551,12 @@ class PreferNimbleRuleTests: XCTestCase {
     }
 }
 
+class PreferSelfInStaticReferencesRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PreferSelfInStaticReferencesRule.description)
+    }
+}
+
 class PreferSelfTypeOverTypeOfSelfRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferSelfTypeOverTypeOfSelfRule.description)
@@ -692,12 +698,6 @@ class RequiredDeinitRuleTests: XCTestCase {
 class ReturnArrowWhitespaceRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReturnArrowWhitespaceRule.description)
-    }
-}
-
-class PreferSelfInStaticReferencesRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(PreferSelfInStaticReferencesRule.description)
     }
 }
 
@@ -896,12 +896,6 @@ class VerticalWhitespaceOpeningBracesRuleTests: XCTestCase {
 class VoidReturnRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VoidReturnRule.description)
-    }
-}
-
-class WeakDelegateRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(WeakDelegateRule.description)
     }
 }
 


### PR DESCRIPTION
This was very prone to false positives and not worth keeping.

The identifier will stick around for a release to ease the migration.

Closes #2786.