### PR TITLE
Ignore `prefer_self_in_static_references` rule in extensions generally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Breaking
 
-* None.
+* Ignore `prefer_self_in_static_references` rule in extensions generally.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3775](ihttps://github.com/realm/SwiftLint/issues/3775)
 
 #### Experimental
 

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -60,6 +60,15 @@ public struct PreferSelfInStaticReferencesRule: SubstitutionCorrectableASTRule, 
                         return i + Self.s
                     }
                 }
+            """),
+            Example("""
+                struct S {
+                    static let i = 1
+                    static let j = { Self.i }()
+                }
+                extension S {
+                    static let k = { S.j }()
+                }
             """)
         ],
         triggeringExamples: [
@@ -197,7 +206,7 @@ public struct PreferSelfInStaticReferencesRule: SubstitutionCorrectableASTRule, 
     }
 
     private func isComplexDeclaration(_ kind: SwiftDeclarationKind) -> Bool {
-        kind == .class || kind == .struct || kind == .enum || SwiftDeclarationKind.extensionKinds.contains(kind)
+        kind == .class || kind == .struct || kind == .enum
     }
 
     private func getSubstructuresToIgnore(in structure: SourceKittenDictionary,
@@ -208,7 +217,7 @@ public struct PreferSelfInStaticReferencesRule: SubstitutionCorrectableASTRule, 
         if Self.nestedKindsToIgnore.contains(declarationKind) {
             return [structure]
         }
-        if parentKind != .class && parentKind != .extensionClass {
+        if parentKind != .class {
             return []
         }
         var structures = structure.swiftAttributes


### PR DESCRIPTION
Fixes #3775. The issue is that SourceKitten cannot tell whether an extension extends a class, a struct or an enum. Or can it somehow? 🤔 

To make it safe, it's better to ignore the rule in extensions completely for the time being.