### PR TITLE
[ClosureEndIndentationRule] Fix crash with Swift 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix crash in the `closure_end_indentation` rule when linting with Swift 5.6.  
+  [JP Simard](https://github.com/jpsim)
+  [#3830](https://github.com/realm/SwiftLint/issues/3830)
 
 ## 0.46.2: Detergent Package
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -337,6 +337,7 @@ extension ClosureEndIndentationRule {
             let firstArgumentOffset = firstArgument.offset,
             case let offset = nameOffset + nameLength,
             case let length = firstArgumentOffset - offset,
+            length > 0,
             case let byteRange = ByteRange(location: offset, length: length),
             let range = file.stringView.byteRangeToNSRange(byteRange),
             let match = regex("\\(\\s*\\n\\s*").firstMatch(in: file.contents, options: [], range: range)?.range,

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRuleExamples.swift
@@ -32,7 +32,8 @@ internal struct ClosureEndIndentationRuleExamples {
         "    },\n" +
         "    anotherClosure: { y in\n" +
         "        print(y)\n" +
-        "    })")
+        "    })"),
+        Example("(-variable).foo()")
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/3830
