### PR TITLE
Rename values for "Enabled by default" property

### DIFF
--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -55,7 +55,7 @@ private func h2(_ text: String) -> String {
 private func detailsSummary(_ rule: Rule) -> String {
     return """
         * **Identifier:** \(type(of: rule).description.identifier)
-        * **Enabled by default:** \(rule is OptInRule ? "Disabled" : "Enabled")
+        * **Enabled by default:** \(rule is OptInRule ? "No" : "Yes")
         * **Supports autocorrection:** \(rule is CorrectableRule ? "Yes" : "No")
         * **Kind:** \(type(of: rule).description.kind)
         * **Analyzer rule:** \(rule is AnalyzerRule ? "Yes" : "No")


### PR DESCRIPTION
I think "Yes" or "No" fit better as answers to "Enabled by default?".