### PR TITLE
Fix incorrect default rule documentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   [JP Simard](https://github.com/jpsim)
   [#3830](https://github.com/realm/SwiftLint/issues/3830)
 
+* Fix incorrect default rule documentations.  
+  [Hiroki Nagasawa](https://github.com/pixyzehn)
+
 ## 0.46.2: Detergent Package
 
 #### Breaking

--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -32,7 +32,7 @@ public struct RuleListDocumentation {
     // MARK: - Private
 
     private var indexContents: String {
-        let defaultRuleDocumentations = ruleDocumentations.drop { $0.isOptInRule }
+        let defaultRuleDocumentations = ruleDocumentations.filter { !$0.isOptInRule }
         let optInRuleDocumentations = ruleDocumentations.filter { $0.isOptInRule }
 
         return """


### PR DESCRIPTION
Use `filter` instead of `drop` to properly show all the default rules in [the Rule Directory](https://realm.github.io/SwiftLint/rule-directory.html).

---

Looking at the definition of [drop(while:)](https://developer.apple.com/documentation/swift/collection/2905036-drop), it mentions `Once the predicate returns false it will not be called again.`. This means that we end up showing incorrect default rules there.

For example,
- I can see all the opt-in rules in the Default Rules
- `anonymous_argument_in_multiline_closure`, `anyobject_protocol`, `array_init`, `attributes`, and `balanced_xctest_lifecycle` are skipped in the Default Rules (until it returns false at `block_based_kvo` which is the first opt-in rule on the iteration)
