### PR TITLE
`class_delegate_protocol`: Add line break separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * Fix crash in the `closure_end_indentation` rule when linting with Swift 5.6.  
   [JP Simard](https://github.com/jpsim)
   [#3830](https://github.com/realm/SwiftLint/issues/3830)
+* `class_delegate_protocol`: Add line break separator.  
+  [Tobisaninfo](https://github.com/Tobisaninfo)  
 
 ## 0.46.2: Detergent Package
 

--- a/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -74,7 +74,7 @@ public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule, Aut
     }
 
     private func isClassProtocol(file: SwiftLintFile, range: NSRange) -> Bool {
-        let characterSet = Set(" {:&,")
+        let characterSet = Set(" {:&,\n")
         return file.stringView.substring(with: range)
             .split(whereSeparator: characterSet.contains)
             // Check if it inherits from a delegate or if its reference bound


### PR DESCRIPTION
Hi,
recently I got some linter warnings for the rule `class_delegate_protocol` on a popper protocol like this (code formatting is important):
```swift
public protocol ImagePickerDelegate: AnyObject
{
    func didSelect(image: UIImage?)
}
``` 

If the open curly bracket of the protocol section is on the same line, the rule will not report any warning.  
To fix this issue, I added the line break symbol to the list of separators to detect the inherited reference type. At the moment, the substring and split method results a symbol like `AnyObject\n`. By adding `\n`to the separator list, the symbol is detected correctly.