### PR TITLE
Ignore MARK in multiline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#3804](https://github.com/realm/SwiftLint/issues/3804)
 
+* Ignore MARK in multiline comment, fixing cases that would previously crash or
+  produce invalid results when correcting.  
+  [goranche](https://github.com/goranche)
+  [#1749](https://github.com/realm/SwiftLint/issues/1749)
+  [#3841](https://github.com/realm/SwiftLint/issues/3841)
+
 ## 0.46.3: Detergent Spill
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
@@ -17,7 +17,8 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
             Example("// MARK: -\n"),
             Example("// BOOKMARK"),
             Example("//BOOKMARK"),
-            Example("// BOOKMARKS")
+            Example("// BOOKMARKS"),
+            issue1749Example
         ],
         triggeringExamples: [
             Example("↓//MARK: bad"),
@@ -64,7 +65,8 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
             Example("↓// MARKK -"): Example("// MARK: -"),
             Example("↓/// MARK:"): Example("// MARK:"),
             Example("↓/// MARK comment"): Example("// MARK: comment"),
-            issue1029Example: issue1029Correction
+            issue1029Example: issue1029Correction,
+            issue1749Example: issue1749Correction
         ]
     )
 
@@ -183,11 +185,20 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
     }
 
     private func violationRanges(in file: SwiftLintFile, matching pattern: String) -> [NSRange] {
-        return file.rangesAndTokens(matching: pattern).filter { _, syntaxTokens in
-            guard let syntaxKind = syntaxTokens.first?.kind else {
+        return file.rangesAndTokens(matching: pattern).filter { matchRange, syntaxTokens in
+            guard let syntaxToken = syntaxTokens.first, let syntaxKind = syntaxToken.kind else {
                 return false
             }
-            return syntaxTokens.isNotEmpty && SyntaxKind.commentKinds.contains(syntaxKind)
+            guard SyntaxKind.commentKinds.contains(syntaxKind) else {
+                return false
+            }
+            let tokenLocation = Location(file: file, byteOffset: ByteCount(syntaxToken.offset.value))
+            let matchLocation = Location(file: file, characterOffset: matchRange.location)
+            // Skip those MARKs that are part of a multiline comment
+            guard let tokenLine = tokenLocation.line, let matchLine = matchLocation.line, matchLine == tokenLine else {
+                return false
+            }
+            return true
         }.compactMap { range, syntaxTokens in
             let byteRange = ByteRange(location: syntaxTokens[0].offset, length: 0)
             let identifierRange = file.stringView.byteRangeToNSRange(byteRange)
@@ -211,6 +222,21 @@ private let issue1029Correction = Example("""
     // MARK: - Bad mark
     extension MarkTest {}
     """)
+
+// https://github.com/realm/SwiftLint/issues/1749
+// https://github.com/realm/SwiftLint/issues/3841
+private let issue1749Example = Example("""
+    /*
+    func test1() {
+    }
+    //MARK: mark
+    func test2() {
+    }
+    */
+    """)
+
+// This example should not trigger changes
+private let issue1749Correction = issue1749Example
 
 // These need to be at the bottom of the file to work around https://bugs.swift.org/browse/SR-10486
 

--- a/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
@@ -186,16 +186,15 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
 
     private func violationRanges(in file: SwiftLintFile, matching pattern: String) -> [NSRange] {
         return file.rangesAndTokens(matching: pattern).filter { matchRange, syntaxTokens in
-            guard let syntaxToken = syntaxTokens.first, let syntaxKind = syntaxToken.kind else {
-                return false
-            }
-            guard SyntaxKind.commentKinds.contains(syntaxKind) else {
-                return false
-            }
-            let tokenLocation = Location(file: file, byteOffset: ByteCount(syntaxToken.offset.value))
-            let matchLocation = Location(file: file, characterOffset: matchRange.location)
-            // Skip those MARKs that are part of a multiline comment
-            guard let tokenLine = tokenLocation.line, let matchLine = matchLocation.line, matchLine == tokenLine else {
+            guard
+                let syntaxToken = syntaxTokens.first,
+                let syntaxKind = syntaxToken.kind,
+                SyntaxKind.commentKinds.contains(syntaxKind),
+                case let tokenLocation = Location(file: file, byteOffset: syntaxToken.offset),
+                case let matchLocation = Location(file: file, characterOffset: matchRange.location),
+                // Skip MARKs that are part of a multiline comment
+                tokenLocation.line == matchLocation.line
+            else {
                 return false
             }
             return true
@@ -225,7 +224,8 @@ private let issue1029Correction = Example("""
 
 // https://github.com/realm/SwiftLint/issues/1749
 // https://github.com/realm/SwiftLint/issues/3841
-private let issue1749Example = Example("""
+private let issue1749Example = Example(
+    """
     /*
     func test1() {
     }
@@ -233,7 +233,8 @@ private let issue1749Example = Example("""
     func test2() {
     }
     */
-    """)
+    """
+)
 
 // This example should not trigger changes
 private let issue1749Correction = issue1749Example


### PR DESCRIPTION
Adds a check to MarkRule to skip MARKs that are part of a multiline comment.
This prevents `swiftlint` from "eating up comments" and in some cases crashing on MARK cases.

fixes #1749
fixes #3841
