### PR TITLE
Fix default rules section in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 * Fix crash in the `closure_end_indentation` rule when linting with Swift 5.6.  
   [JP Simard](https://github.com/jpsim)
   [#3830](https://github.com/realm/SwiftLint/issues/3830)
+  
+* Fix default rules section in documentation.
+  [Natan Rolnik](https://github.com/natanrolnik)
+  [#3857](https://github.com/realm/SwiftLint/pull/3857)
 
 ## 0.46.2: Detergent Package
 

--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -32,7 +32,7 @@ public struct RuleListDocumentation {
     // MARK: - Private
 
     private var indexContents: String {
-        let defaultRuleDocumentations = ruleDocumentations.drop { $0.isOptInRule }
+        let defaultRuleDocumentations = ruleDocumentations.filter { !$0.isOptInRule }
         let optInRuleDocumentations = ruleDocumentations.filter { $0.isOptInRule }
 
         return """


### PR DESCRIPTION
While browsing the rules documentation, I noticed **many** rules were both in the Default Rules and in the Opt In Rules section.

I ran the generate-docs command and found the following:

<img width="938" alt="Xcode-2022-02-15-15 35 21" src="https://user-images.githubusercontent.com/1164565/154076787-69183b7b-5cac-4e66-9415-8f0e8bff0174.png">

The numbers confirm they don't add up.

After looking into it, the docs of the `drop(while predicate: (Element) throws -> Bool` function explains why:

> A closure that takes an element of the sequence as its argument and returns true if the element should be skipped or false if it should be included. **Once the predicate returns false it will not be called again.**

This caused the `defaultRuleDocumentations` array to contain almost all `ruleDocumentation`.

This PR fixes it:

<img width="970" alt="Xcode-2022-02-15-15 33 18" src="https://user-images.githubusercontent.com/1164565/154076906-e613e737-a060-4c3c-9100-c6cdab17e927.png">