### PR TITLE
Add accessibility_label_for_image rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,12 +207,6 @@
 * Change fingerprint generation in `CodeClimateReporter.swift` to use
   the relative file path to better support CI/CD on multiple machines.  
   [HA Pors](https://github.com/hpors)
-  
-* Add `accessibility_label_for_image` rule to warn if a SwiftUI
-  Image does not have an accessibility label and is not hidden from
-  accessibility. When this is the case, the image's accessibility
-  label defaults to the name of the image file.  
-  [Ryan Cole](https://github.com/rcole34)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   errors reported by the Swift parser will be skipped.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3343](https://github.com/realm/SwiftLint/issues/3343)
+  
+* Add `accessibility_label_for_image` rule to warn if a SwiftUI
+  Image does not have an accessibility label and is not hidden from
+  accessibility.  
+  [Ryan Cole](https://github.com/rcole34)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,12 @@
 * Change fingerprint generation in `CodeClimateReporter.swift` to use
   the relative file path to better support CI/CD on multiple machines.  
   [HA Pors](https://github.com/hpors)
+  
+* Add `accessibility_label_for_image` rule to warn if a SwiftUI
+  Image does not have an accessibility label and is not hidden from
+  accessibility. When this is the case, the image's accessibility
+  label defaults to the name of the image file.  
+  [Ryan Cole](https://github.com/rcole34)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -2,6 +2,7 @@
 // DO NOT EDIT
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [
+    AccessibilityLabelForImageRule.self,
     AnonymousArgumentInMultilineClosureRule.self,
     AnyObjectProtocolRule.self,
     ArrayInitRule.self,

--- a/Source/SwiftLintFramework/Protocols/ASTRule.swift
+++ b/Source/SwiftLintFramework/Protocols/ASTRule.swift
@@ -11,7 +11,7 @@ public protocol ASTRule: Rule {
     ///
     /// - parameter file:       The file for which to execute the rule.
     /// - parameter kind:       The kind of token being recursed over.
-    /// - parameter dictionary: The dicttionary for an AST subset to validate.
+    /// - parameter dictionary: The dictionary for an AST subset to validate.
     ///
     /// - returns: All style violations to the rule's expectations.
     func validate(file: SwiftLintFile, kind: KindType, dictionary: SourceKittenDictionary) -> [StyleViolation]

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -16,7 +16,7 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
     public static let description = RuleDescription(
         identifier: "accessibility_label_for_image",
         name: "Accessibility Label for Image",
-        description: "All Images should either be hidden from accessibility or provide an accessibility label.",
+        description: "All Images that provide context should have an accessibility label. Purely decorative images can be hidden from accessibility.",
         kind: .lint,
         minSwiftVersion: .fiveDotOne,
         nonTriggeringExamples: AccessibilityLabelForImageRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -6,7 +6,9 @@ import SourceKittenFramework
 /// however, an `Image` is an accessibility element by default. If the developer does not explicitly hide them from
 /// accessibility or give them an accessibility label, they will inherit the name of the image file, which often creates
 /// a poor experience when VoiceOver reads things like "close icon white".
-public struct AccessibilityLabelForImageRule: ConfigurationProviderRule, AutomaticTestableRule {
+///
+/// Known false negatives for Images declared as instance variables and containers that provide a label but are not accessibility elements.
+public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -19,85 +21,458 @@ public struct AccessibilityLabelForImageRule: ConfigurationProviderRule, Automat
         minSwiftVersion: .fiveDotOne,
         nonTriggeringExamples: [
             Example("""
-            Image(decorative: "my-image")
+            struct MyView: View {
+                var body: some View {
+                    Image(decorative: "my-image")
+                }
+            }
             """),
             Example("""
-            Image("my-image")
-                .accessibility(hidden: true)
+            struct MyView: View {
+                var body: some View {
+                    Image("my-image")
+                        .accessibility(hidden: true)
+                }
+            }
             """),
             Example("""
-            Image("my-image")
-                .accessibilityHidden(true)
+            struct MyView: View {
+                var body: some View {
+                    Image("my-image")
+                        .accessibilityHidden(true)
+                }
+            }
             """),
             Example("""
-            Image("my-image")
-                .accessibility(label: Text("Alt text for my image")
+            struct MyView: View {
+                var body: some View {
+                    Image("my-image")
+                        .accessibility(label: Text("Alt text for my image")
+                }
+            }
             """),
             Example("""
-            Image("my-image")
-                .accessibilityLabel(Text("Alt text for my image"))
+            struct MyView: View {
+                var body: some View {
+                    Image("my-image")
+                        .accessibilityLabel(Text("Alt text for my image"))
+                }
+            }
             """),
             Example("""
-            Image(uiImage: myUiImage)
-                .renderingMode(.template)
-                .foregroundColor(.blue)
-                .accessibilityHidden(true)
+            struct MyView: View {
+                var body: some View {
+                    Image(uiImage: myUiImage)
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                        .accessibilityHidden(true)
+                }
+            }
             """),
             Example("""
-            Image(uiImage: myUiImage)
-                .accessibilityLabel(Text("Alt text for my image"))
+            struct MyView: View {
+                var body: some View {
+                    Image(uiImage: myUiImage)
+                        .accessibilityLabel(Text("Alt text for my image"))
+                }
+            }
             """),
             Example("""
-            SwiftUI.Image(uiImage: "my-image").resizable().accessibilityHidden(true)
+            struct MyView: View {
+                var body: some View {
+                    SwiftUI.Image(uiImage: "my-image").resizable().accessibilityHidden(true)
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    VStack {
+                        Image(decorative: "my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        Image("my-image")
+                            .accessibility(label: Text("Alt text for my image"))
+                    }
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    VStack {
+                        Image("my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        Image("my-image")
+                            .accessibility(label: Text("Alt text for my image"))
+                    }.accessibilityElement()
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    VStack {
+                        Image("my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        Image("my-image")
+                            .accessibility(label: Text("Alt text for my image"))
+                    }.accessibilityHidden(true)
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    HStack(spacing: 8) {
+                        Image(decorative: "my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        Text("Text to accompany my image")
+                    }.accessibilityElement(children: .combine)
+                    .padding(16)
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    HStack(spacing: 8) {
+                        Image("my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        Text("Text to accompany my image")
+                    }.accessibilityElement(children: .ignore)
+                    .padding(16)
+                    .accessibilityLabel(Text("Label for my image and text"))
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    Button(action: { doAction() }) {
+                        Image("my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                    }
+                    .accessibilityLabel(Text("Label for my image"))
+                }
+            }
             """)
         ],
         triggeringExamples: [
             Example("""
-            ↓Image("my-image")
-                .resizable(true)
-                .frame(width: 48, height: 48)
+            struct MyView: View {
+                var body: some View {
+                    ↓Image("my-image")
+                        .resizable(true)
+                        .frame(width: 48, height: 48)
+                }
+            }
             """),
             Example("""
-            ↓Image(uiImage: myUiImage)
+            struct MyView: View {
+                var body: some View {
+                    ↓Image(uiImage: myUiImage)
+                }
+            }
             """),
             Example("""
-            SwiftUI.↓Image(uiImage: "my-image").resizable().accessibilityHidden(false)
+            struct MyView: View {
+                var body: some View {
+                    ↓SwiftUI.Image(uiImage: "my-image").resizable().accessibilityHidden(false)
+                }
+            }
             """),
             Example("""
-            Image(uiImage: myUiImage)
-                .resizable()
-                .frame(width: 48, height: 48)
-                .accessibilityLabel(Text("Alt text for my image"))
-            ↓Image("other image")
+            struct MyView: View {
+                var body: some View {
+                    Image(uiImage: myUiImage)
+                        .resizable()
+                        .frame(width: 48, height: 48)
+                        .accessibilityLabel(Text("Alt text for my image"))
+                    ↓Image("other image")
+                }
+            }
             """),
             Example("""
-            Image(decorative: "image1")
-            ↓Image("image2")
-            Image(uiImage: "image3")
-                .accessibility(label: Text("a pretty picture"))
+            struct MyView: View {
+                var body: some View {
+                    Image(decorative: "image1")
+                    ↓Image("image2")
+                    Image(uiImage: "image3")
+                        .accessibility(label: Text("a pretty picture"))
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    VStack {
+                        Image(decorative: "my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        ↓Image("my-image")
+                    }
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    VStack {
+                        ↓Image("my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        Image("my-image")
+                            .accessibility(label: Text("Alt text for my image"))
+                    }.accessibilityElement(children: .contain)
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    VStack {
+                        ↓Image("my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        Image("my-image")
+                            .accessibility(label: Text("Alt text for my image"))
+                    }.accessibilityHidden(false)
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    HStack(spacing: 8) {
+                        ↓Image("my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                        Text("Text to accompany my image")
+                    }.accessibilityElement(children: .combine)
+                    .padding(16)
+                }
+            }
+            """),
+            Example("""
+            struct MyView: View {
+                var body: some View {
+                    Button(action: { doAction() }) {
+                        ↓Image("my-image")
+                            .renderingMode(.template)
+                            .foregroundColor(.blue)
+                    }
+                }
+            }
             """)
         ]
     )
 
-    private var pattern: String {
-        "\\bImage\\(" +                         // SwiftUI Image literal
-        "(?!" +                                 // start negative lookahead
-        "decorative:|" +                        // decorative constructor hides from accessibility, OR
-        "[^\\n]*" +                             // any more other characters before a newline
-        "(\\s*\\.[^\\n]*)*" +                 // any number of other modifiers
-        "(" +                                   // options for modifiers to hide from accessibility or provide label
-        "accessibility\\(hidden: true\\)|" +    // iOS 13 way of hiding, OR
-        "accessibilityHidden\\(true\\)|" +      // iOS 14+ way of hiding, OR
-        "accessibility\\(label:|" +             // iOS 13 way of setting label, OR
-        "accessibilityLabel\\(" +               // iOS 14+ way of setting label
-        "))"                                    // end groups
-    }
-
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return file.match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds).map {
-            StyleViolation(ruleDescription: Self.description,
-                           severity: configuration.severity,
-                           location: Location(file: file, characterOffset: $0.location))
+    // MARK: AST Rule
+    
+    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind, dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        // only proceed to check View structs
+        guard kind == .struct,
+            dictionary.inheritedTypes.contains("View"),
+            dictionary.substructure.isNotEmpty else {
+                return []
         }
+
+        return findImageViolations(file: file, substructure: dictionary.substructure)
+    }
+    
+    /// recursively check a file for image violations, and return all such violations
+    private func findImageViolations(file: SwiftLintFile, substructure: [SourceKittenDictionary]) -> [StyleViolation] {
+        var violations: [StyleViolation] = []
+        for dictionary in substructure {
+            guard let offset: ByteCount = dictionary.offset else {
+                continue
+            }
+                        
+            // if it's image, and does not hide from accessibility or provide a label, it's a violation
+            if dictionary.isImage {
+                if !(dictionary.isDecorativeImage ||
+                  dictionary.hasAccessibilityHiddenModifier(in: file) ||
+                  dictionary.hasAccessibilityLabelModifier) {
+                    violations.append(StyleViolation(ruleDescription: Self.description, severity: configuration.severity, location: Location(file: file, byteOffset: offset)))
+                }
+            }
+            
+            // if dictionary did not represent an Image, recursively check substructure unless it's a container that hides its children from accessibility or is labeled
+            else if dictionary.substructure.isNotEmpty,
+                        !(dictionary.hasAccessibilityHiddenModifier(in: file) ||
+                          dictionary.hasAccessibilityElementChildrenIgnoreModifier(in: file) ||
+                          dictionary.hasAccessibilityLabelModifier) {
+                violations.append(contentsOf: findImageViolations(file: file, substructure: dictionary.substructure))
+            }
+        }
+        
+        return violations
+    }
+}
+
+// MARK: SourceKittenDictionary extensions
+
+private extension SourceKittenDictionary {
+    /// Whether or not the dictionary represents a SwiftUI Image.
+    /// Currently only accounts for SwiftUI image literals and not instance variables.
+    var isImage: Bool {
+        // image literals will be reported as calls to the initializer
+        guard expressionKind == .call else {
+            return false
+        }
+        
+        if name == "Image" || name == "SwiftUI.Image" {
+            return true
+        }
+        
+        // recursively check substructure
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // Image(decorative: "myImage").resizable().frame
+        //     '--> Image(decorative: "myImage").resizable
+        //         '--> Image
+        for dict in substructure {
+            if dict.isImage {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    /// Whether or not the dictionary represents a SwiftUI Image using the `Image(decorative:)` constructor
+    var isDecorativeImage: Bool {
+        guard isImage else {
+            return false
+        }
+        
+        // check for Image(decorative:) constructor
+        if expressionKind == .call && enclosedArguments.contains(where: { $0.name == "decorative" }) {
+            return true
+        }
+        
+        // recursively check substructure
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // Image(decorative: "myImage").resizable().frame
+        //     '--> Image(decorative: "myImage").resizable
+        //         '--> Image
+        for dict in substructure {
+            if dict.isDecorativeImage {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityHidden(true)` or `accessibility(hidden: true)` modifier.
+    func hasAccessibilityHiddenModifier(in file: SwiftLintFile) -> Bool {
+        guard expressionKind == .call, let name: String = name else {
+            return false
+        }
+        
+        // check for iOS 14+ version of modifier
+        if name.hasSuffix("accessibilityHidden") && getSingleUnnamedArgumentValue(in: file) == "true" {
+            return true
+        }
+        
+        // check for iOS 13 version of modifier
+        if name.hasSuffix("accessibility"), let hiddenArg: SourceKittenDictionary = enclosedArguments.first(where: { $0.name == "hidden" }), hiddenArg.getArgumentValue(in: file) == "true" {
+            return true
+        }
+        
+        // recursively check substructure
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // Image("myImage").resizable().accessibility(hidden: true).frame
+        //     '--> Image("myImage").resizable().accessibility
+        for dict in substructure {
+            if dict.hasAccessibilityHiddenModifier(in: file) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityLabel(_:)` or `accessibility(label:)` modifier.
+    var hasAccessibilityLabelModifier: Bool {
+        guard expressionKind == .call, let name: String = name else {
+            return false
+        }
+        
+        // check for iOS 14+ version of modifier
+        if name.hasSuffix("accessibilityLabel") {
+            return true
+        }
+        
+        // check for iOS 13 version of modifier
+        if name.hasSuffix("accessibility"), enclosedArguments.contains(where: { $0.name == "label" }) {
+            return true
+        }
+        
+        // recursively check substructure
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // Image("myImage").resizable().accessibilityLabel(Text("Label")).frame
+        //     '--> Image("myImage").resizable().accessibilityLabel
+        for dict in substructure {
+            if dict.hasAccessibilityLabelModifier {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    /// Whether or not the dictionary represents a SwiftUI View with an `accessibilityElement()` or `accessibilityElement(children: .ignore)` modifier (`.ignore` is the default parameter value).
+    func hasAccessibilityElementChildrenIgnoreModifier(in file: SwiftLintFile) -> Bool {
+        guard expressionKind == .call, let name: String = name else {
+            return false
+        }
+        
+        // check for modifier
+        if name.hasSuffix("accessibilityElement") {
+            if enclosedArguments.isEmpty {
+                return true
+            }
+            
+            if let childrenArg: SourceKittenDictionary = enclosedArguments.first(where: { $0.name == "children" }), childrenArg.getArgumentValue(in: file) == ".ignore" {
+                return true
+            }
+        }
+        
+        // recursively check substructure
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // VStack { ... }.accessibilityElement().padding
+        //     '--> VStack { ... }.accessibilityElement
+        for dict in substructure {
+            if dict.hasAccessibilityElementChildrenIgnoreModifier(in: file) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    /// Helper to get the value of an argument
+    func getArgumentValue(in file: SwiftLintFile) -> String? {
+        guard expressionKind == .argument, let bodyByteRange: ByteRange = bodyByteRange else {
+            return nil
+        }
+        
+        return file.stringView.substringWithByteRange(bodyByteRange)
+    }
+    
+    /// Helper to get the value of a single unnamed argument to a function call
+    func getSingleUnnamedArgumentValue(in file: SwiftLintFile) -> String? {
+        guard expressionKind == .call, let bodyByteRange: ByteRange = bodyByteRange else {
+            return nil
+        }
+        
+        return file.stringView.substringWithByteRange(bodyByteRange)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SourceKittenFramework
+
+/// In UIKit, a `UIImageView` was by default not an accessibility element, and would only be visible to VoiceOver and other assistive
+/// technologies if the developer explicitly made them an accessibility element. In SwiftUI, however, an `Image` is an accessibility
+/// element by default. If the developer does not explicitly hide them from accessibility or give them an accessibility label, they will
+/// inherit the name of the image file, which often creates a poor experience when VoiceOver reads things like "close icon white".
+public struct AccessibilityLabelForImageRule: ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "accessibility_label_for_image",
+        name: "Accessibility Label for Image",
+        description: "All Images should either be hidden from accessibility or provide an accessibility label.",
+        kind: .lint,
+        minSwiftVersion: .fiveDotOne,
+        nonTriggeringExamples: [
+            Example("""
+            Image(decorative: "my-image")
+            """),
+            Example("""
+            Image("my-image")
+                .accessibility(hidden: true)
+            """),
+            Example("""
+            Image("my-image")
+                .accessibilityHidden(true)
+            """),
+            Example("""
+            Image("my-image")
+                .accessibility(label: Text("Alt text for my image")
+            """),
+            Example("""
+            Image("my-image")
+                .accessibilityLabel(Text("Alt text for my image"))
+            """),
+            Example("""
+            Image(uiImage: myUiImage)
+                .renderingMode(.template)
+                .foregroundColor(.blue)
+                .accessibilityHidden(true)
+            """),
+            Example("""
+            Image(uiImage: myUiImage)
+                .accessibilityLabel(Text("Alt text for my image"))
+            """),
+            Example("""
+            SwiftUI.Image(uiImage: "my-image").resizable().accessibilityHidden(true)
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+            ↓Image("my-image")
+                .resizable(true)
+                .frame(width: 48, height: 48)
+            """),
+            Example("""
+            ↓Image(uiImage: myUiImage)
+            """),
+            Example("""
+            SwiftUI.↓Image(uiImage: "my-image").resizable().accessibilityHidden(false)
+            """),
+            Example("""
+            Image(uiImage: myUiImage)
+                .resizable()
+                .frame(width: 48, height: 48)
+                .accessibilityLabel(Text("Alt text for my image"))
+            ↓Image("other image")
+            """),
+            Example("""
+            Image(decorative: "image1")
+            ↓Image("image2")
+            Image(uiImage: "image3")
+                .accessibility(label: Text("a pretty picture"))
+            """)
+        ]
+    )
+    
+    private var pattern: String {
+        "\\bImage\\(" +                         // SwiftUI Image literal
+        "(?!" +                                 // start negative lookahead
+        "decorative:|" +                        // decorative constructor hides from accessibility, OR
+        "[^\\n]*" +                             // any more other characters before a newline
+        "(\\s*\\.[^\\n]*)*" +                 // any number of other modifiers
+        "(" +                                   // options for modifiers to hide from accessibility or provide label
+        "accessibility\\(hidden: true\\)|" +    // iOS 13 way of hiding, OR
+        "accessibilityHidden\\(true\\)|" +      // iOS 14+ way of hiding, OR
+        "accessibility\\(label:|" +             // iOS 13 way of setting label, OR
+        "accessibilityLabel\\(" +               // iOS 14+ way of setting label
+        "))"                                    // end groups
+    }
+    
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+        return file.match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds).map {
+            StyleViolation(ruleDescription: Self.description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: $0.location))
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 
 /// In UIKit, a `UIImageView` was by default not an accessibility element, and would only be visible to VoiceOver

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -16,7 +16,8 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
     public static let description = RuleDescription(
         identifier: "accessibility_label_for_image",
         name: "Accessibility Label for Image",
-        description: "All Images that provide context should have an accessibility label. Purely decorative images can be hidden from accessibility.",
+        description: "All Images that provide context should have an accessibility label. " +
+                    "Purely decorative images can be hidden from accessibility.",
         kind: .lint,
         minSwiftVersion: .fiveDotOne,
         nonTriggeringExamples: AccessibilityLabelForImageRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -54,7 +54,7 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
                   dictionary.hasAccessibilityLabelModifier {
                     continue
                 }
-                
+
                 violations.append(
                     StyleViolation(ruleDescription: Self.description,
                                    severity: configuration.severity,
@@ -70,7 +70,7 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
                     dictionary.hasAccessibilityLabelModifier {
                     continue
                 }
-                
+
                 violations.append(contentsOf: findImageViolations(file: file, substructure: dictionary.substructure))
             }
         }

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -93,15 +93,13 @@ private extension SourceKittenDictionary {
         // Image(decorative: "myImage").resizable().frame
         //     '--> Image(decorative: "myImage").resizable
         //         '--> Image
-        for dict in substructure {
-            if dict.isImage {
-                return true
-            }
+        if substructure.contains(where: { $0.isImage }) {
+            return true
         }
 
         return false
     }
-    
+
     /// Whether or not the dictionary represents a SwiftUI Image using the `Image(decorative:)` constructor
     var isDecorativeImage: Bool {
         guard isImage else {

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -1,10 +1,11 @@
 import Foundation
 import SourceKittenFramework
 
-/// In UIKit, a `UIImageView` was by default not an accessibility element, and would only be visible to VoiceOver and other assistive
-/// technologies if the developer explicitly made them an accessibility element. In SwiftUI, however, an `Image` is an accessibility
-/// element by default. If the developer does not explicitly hide them from accessibility or give them an accessibility label, they will
-/// inherit the name of the image file, which often creates a poor experience when VoiceOver reads things like "close icon white".
+/// In UIKit, a `UIImageView` was by default not an accessibility element, and would only be visible to VoiceOver
+/// and other assistive technologies if the developer explicitly made them an accessibility element. In SwiftUI,
+/// however, an `Image` is an accessibility element by default. If the developer does not explicitly hide them from
+/// accessibility or give them an accessibility label, they will inherit the name of the image file, which often creates
+/// a poor experience when VoiceOver reads things like "close icon white".
 public struct AccessibilityLabelForImageRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -77,7 +78,7 @@ public struct AccessibilityLabelForImageRule: ConfigurationProviderRule, Automat
             """)
         ]
     )
-    
+
     private var pattern: String {
         "\\bImage\\(" +                         // SwiftUI Image literal
         "(?!" +                                 // start negative lookahead
@@ -91,7 +92,7 @@ public struct AccessibilityLabelForImageRule: ConfigurationProviderRule, Automat
         "accessibilityLabel\\(" +               // iOS 14+ way of setting label
         "))"                                    // end groups
     }
-    
+
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds).map {
             StyleViolation(ruleDescription: Self.description,

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -7,7 +7,8 @@ import SourceKittenFramework
 /// accessibility or give them an accessibility label, they will inherit the name of the image file, which often creates
 /// a poor experience when VoiceOver reads things like "close icon white".
 ///
-/// Known false negatives for Images declared as instance variables and containers that provide a label but are not accessibility elements.
+/// Known false negatives for Images declared as instance variables and containers that provide a label but are
+/// not accessibility elements.
 public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
@@ -19,263 +20,14 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
         description: "All Images should either be hidden from accessibility or provide an accessibility label.",
         kind: .lint,
         minSwiftVersion: .fiveDotOne,
-        nonTriggeringExamples: [
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image(decorative: "my-image")
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image("my-image")
-                        .accessibility(hidden: true)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image("my-image")
-                        .accessibilityHidden(true)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image("my-image")
-                        .accessibility(label: Text("Alt text for my image")
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image("my-image")
-                        .accessibilityLabel(Text("Alt text for my image"))
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image(uiImage: myUiImage)
-                        .renderingMode(.template)
-                        .foregroundColor(.blue)
-                        .accessibilityHidden(true)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image(uiImage: myUiImage)
-                        .accessibilityLabel(Text("Alt text for my image"))
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    SwiftUI.Image(uiImage: "my-image").resizable().accessibilityHidden(true)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    VStack {
-                        Image(decorative: "my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        Image("my-image")
-                            .accessibility(label: Text("Alt text for my image"))
-                    }
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    VStack {
-                        Image("my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        Image("my-image")
-                            .accessibility(label: Text("Alt text for my image"))
-                    }.accessibilityElement()
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    VStack {
-                        Image("my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        Image("my-image")
-                            .accessibility(label: Text("Alt text for my image"))
-                    }.accessibilityHidden(true)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    HStack(spacing: 8) {
-                        Image(decorative: "my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        Text("Text to accompany my image")
-                    }.accessibilityElement(children: .combine)
-                    .padding(16)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    HStack(spacing: 8) {
-                        Image("my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        Text("Text to accompany my image")
-                    }.accessibilityElement(children: .ignore)
-                    .padding(16)
-                    .accessibilityLabel(Text("Label for my image and text"))
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Button(action: { doAction() }) {
-                        Image("my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                    }
-                    .accessibilityLabel(Text("Label for my image"))
-                }
-            }
-            """)
-        ],
-        triggeringExamples: [
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    ↓Image("my-image")
-                        .resizable(true)
-                        .frame(width: 48, height: 48)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    ↓Image(uiImage: myUiImage)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    ↓SwiftUI.Image(uiImage: "my-image").resizable().accessibilityHidden(false)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image(uiImage: myUiImage)
-                        .resizable()
-                        .frame(width: 48, height: 48)
-                        .accessibilityLabel(Text("Alt text for my image"))
-                    ↓Image("other image")
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Image(decorative: "image1")
-                    ↓Image("image2")
-                    Image(uiImage: "image3")
-                        .accessibility(label: Text("a pretty picture"))
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    VStack {
-                        Image(decorative: "my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        ↓Image("my-image")
-                    }
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    VStack {
-                        ↓Image("my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        Image("my-image")
-                            .accessibility(label: Text("Alt text for my image"))
-                    }.accessibilityElement(children: .contain)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    VStack {
-                        ↓Image("my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        Image("my-image")
-                            .accessibility(label: Text("Alt text for my image"))
-                    }.accessibilityHidden(false)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    HStack(spacing: 8) {
-                        ↓Image("my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                        Text("Text to accompany my image")
-                    }.accessibilityElement(children: .combine)
-                    .padding(16)
-                }
-            }
-            """),
-            Example("""
-            struct MyView: View {
-                var body: some View {
-                    Button(action: { doAction() }) {
-                        ↓Image("my-image")
-                            .renderingMode(.template)
-                            .foregroundColor(.blue)
-                    }
-                }
-            }
-            """)
-        ]
+        nonTriggeringExamples: AccessibilityLabelForImageRuleExamples.nonTriggeringExamples,
+        triggeringExamples: AccessibilityLabelForImageRuleExamples.triggeringExamples
     )
 
     // MARK: AST Rule
-    
-    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind, dictionary: SourceKittenDictionary) -> [StyleViolation] {
+
+    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
         // only proceed to check View structs
         guard kind == .struct,
             dictionary.inheritedTypes.contains("View"),
@@ -285,7 +37,7 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
 
         return findImageViolations(file: file, substructure: dictionary.substructure)
     }
-    
+
     /// recursively check a file for image violations, and return all such violations
     private func findImageViolations(file: SwiftLintFile, substructure: [SourceKittenDictionary]) -> [StyleViolation] {
         var violations: [StyleViolation] = []
@@ -293,17 +45,22 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
             guard let offset: ByteCount = dictionary.offset else {
                 continue
             }
-                        
+
             // if it's image, and does not hide from accessibility or provide a label, it's a violation
             if dictionary.isImage {
                 if !(dictionary.isDecorativeImage ||
                   dictionary.hasAccessibilityHiddenModifier(in: file) ||
                   dictionary.hasAccessibilityLabelModifier) {
-                    violations.append(StyleViolation(ruleDescription: Self.description, severity: configuration.severity, location: Location(file: file, byteOffset: offset)))
+                    violations.append(
+                        StyleViolation(ruleDescription: Self.description,
+                                       severity: configuration.severity,
+                                       location: Location(file: file, byteOffset: offset))
+                    )
                 }
             }
-            
-            // if dictionary did not represent an Image, recursively check substructure unless it's a container that hides its children from accessibility or is labeled
+
+            // if dictionary did not represent an Image, recursively check substructure
+            // unless it's a container that hides its children from accessibility or is labeled
             else if dictionary.substructure.isNotEmpty,
                         !(dictionary.hasAccessibilityHiddenModifier(in: file) ||
                           dictionary.hasAccessibilityElementChildrenIgnoreModifier(in: file) ||
@@ -311,7 +68,7 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
                 violations.append(contentsOf: findImageViolations(file: file, substructure: dictionary.substructure))
             }
         }
-        
+
         return violations
     }
 }
@@ -326,11 +83,11 @@ private extension SourceKittenDictionary {
         guard expressionKind == .call else {
             return false
         }
-        
+
         if name == "Image" || name == "SwiftUI.Image" {
             return true
         }
-        
+
         // recursively check substructure
         // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
         // Image(decorative: "myImage").resizable().frame
@@ -341,7 +98,7 @@ private extension SourceKittenDictionary {
                 return true
             }
         }
-        
+
         return false
     }
     
@@ -350,129 +107,127 @@ private extension SourceKittenDictionary {
         guard isImage else {
             return false
         }
-        
+
         // check for Image(decorative:) constructor
         if expressionKind == .call && enclosedArguments.contains(where: { $0.name == "decorative" }) {
             return true
         }
-        
+
         // recursively check substructure
         // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
         // Image(decorative: "myImage").resizable().frame
         //     '--> Image(decorative: "myImage").resizable
         //         '--> Image
-        for dict in substructure {
-            if dict.isDecorativeImage {
-                return true
-            }
+        if substructure.contains(where: { $0.isDecorativeImage }) {
+            return true
         }
-        
+
         return false
     }
-    
-    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityHidden(true)` or `accessibility(hidden: true)` modifier.
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityHidden(true)`
+    /// or `accessibility(hidden: true)` modifier.
     func hasAccessibilityHiddenModifier(in file: SwiftLintFile) -> Bool {
         guard expressionKind == .call, let name: String = name else {
             return false
         }
-        
+
         // check for iOS 14+ version of modifier
         if name.hasSuffix("accessibilityHidden") && getSingleUnnamedArgumentValue(in: file) == "true" {
             return true
         }
-        
+
         // check for iOS 13 version of modifier
-        if name.hasSuffix("accessibility"), let hiddenArg: SourceKittenDictionary = enclosedArguments.first(where: { $0.name == "hidden" }), hiddenArg.getArgumentValue(in: file) == "true" {
+        if name.hasSuffix("accessibility"),
+            let hiddenArg: SourceKittenDictionary = enclosedArguments.first(where: { $0.name == "hidden" }),
+            hiddenArg.getArgumentValue(in: file) == "true" {
             return true
         }
-        
+
         // recursively check substructure
         // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
         // Image("myImage").resizable().accessibility(hidden: true).frame
         //     '--> Image("myImage").resizable().accessibility
-        for dict in substructure {
-            if dict.hasAccessibilityHiddenModifier(in: file) {
-                return true
-            }
+        if substructure.contains(where: { $0.hasAccessibilityHiddenModifier(in: file) }) {
+            return true
         }
-        
+
         return false
     }
-    
-    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityLabel(_:)` or `accessibility(label:)` modifier.
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityLabel(_:)`
+    /// or `accessibility(label:)` modifier.
     var hasAccessibilityLabelModifier: Bool {
         guard expressionKind == .call, let name: String = name else {
             return false
         }
-        
+
         // check for iOS 14+ version of modifier
         if name.hasSuffix("accessibilityLabel") {
             return true
         }
-        
+
         // check for iOS 13 version of modifier
         if name.hasSuffix("accessibility"), enclosedArguments.contains(where: { $0.name == "label" }) {
             return true
         }
-        
+
         // recursively check substructure
         // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
         // Image("myImage").resizable().accessibilityLabel(Text("Label")).frame
         //     '--> Image("myImage").resizable().accessibilityLabel
-        for dict in substructure {
-            if dict.hasAccessibilityLabelModifier {
-                return true
-            }
+        if substructure.contains(where: { $0.hasAccessibilityLabelModifier }) {
+            return true
         }
-        
+
         return false
     }
-    
-    /// Whether or not the dictionary represents a SwiftUI View with an `accessibilityElement()` or `accessibilityElement(children: .ignore)` modifier (`.ignore` is the default parameter value).
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accessibilityElement()` or
+    /// `accessibilityElement(children: .ignore)` modifier (`.ignore` is the default parameter value).
     func hasAccessibilityElementChildrenIgnoreModifier(in file: SwiftLintFile) -> Bool {
         guard expressionKind == .call, let name: String = name else {
             return false
         }
-        
+
         // check for modifier
         if name.hasSuffix("accessibilityElement") {
             if enclosedArguments.isEmpty {
                 return true
             }
-            
-            if let childrenArg: SourceKittenDictionary = enclosedArguments.first(where: { $0.name == "children" }), childrenArg.getArgumentValue(in: file) == ".ignore" {
+
+            if let childrenArg: SourceKittenDictionary = enclosedArguments.first(where: { $0.name == "children" }),
+                childrenArg.getArgumentValue(in: file) == ".ignore" {
                 return true
             }
         }
-        
+
         // recursively check substructure
         // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
         // VStack { ... }.accessibilityElement().padding
         //     '--> VStack { ... }.accessibilityElement
-        for dict in substructure {
-            if dict.hasAccessibilityElementChildrenIgnoreModifier(in: file) {
-                return true
-            }
+        if substructure.contains(where: { $0.hasAccessibilityElementChildrenIgnoreModifier(in: file) }) {
+            return true
         }
-        
+
         return false
     }
-    
+
     /// Helper to get the value of an argument
     func getArgumentValue(in file: SwiftLintFile) -> String? {
         guard expressionKind == .argument, let bodyByteRange: ByteRange = bodyByteRange else {
             return nil
         }
-        
+
         return file.stringView.substringWithByteRange(bodyByteRange)
     }
-    
+
     /// Helper to get the value of a single unnamed argument to a function call
     func getSingleUnnamedArgumentValue(in file: SwiftLintFile) -> String? {
         guard expressionKind == .call, let bodyByteRange: ByteRange = bodyByteRange else {
             return nil
         }
-        
+
         return file.stringView.substringWithByteRange(bodyByteRange)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -18,6 +18,13 @@ internal struct AccessibilityLabelForImageRuleExamples {
         Example("""
         struct MyView: View {
             var body: some View {
+                Image("my-image", label: Text("Alt text for my image")
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
                 Image("my-image")
                     .accessibility(hidden: true)
             }

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -1,0 +1,257 @@
+import Foundation
+
+internal struct AccessibilityLabelForImageRuleExamples {
+    static let nonTriggeringExamples = [
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image(decorative: "my-image")
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image("my-image")
+                    .accessibility(hidden: true)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image("my-image")
+                    .accessibilityHidden(true)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image("my-image")
+                    .accessibility(label: Text("Alt text for my image")
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image("my-image")
+                    .accessibilityLabel(Text("Alt text for my image"))
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image(uiImage: myUiImage)
+                    .renderingMode(.template)
+                    .foregroundColor(.blue)
+                    .accessibilityHidden(true)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image(uiImage: myUiImage)
+                    .accessibilityLabel(Text("Alt text for my image"))
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                SwiftUI.Image(uiImage: "my-image").resizable().accessibilityHidden(true)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                VStack {
+                    Image(decorative: "my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    Image("my-image")
+                        .accessibility(label: Text("Alt text for my image"))
+                }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                VStack {
+                    Image("my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    Image("my-image")
+                        .accessibility(label: Text("Alt text for my image"))
+                }.accessibilityElement()
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                VStack {
+                    Image("my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    Image("my-image")
+                        .accessibility(label: Text("Alt text for my image"))
+                }.accessibilityHidden(true)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                HStack(spacing: 8) {
+                    Image(decorative: "my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    Text("Text to accompany my image")
+                }.accessibilityElement(children: .combine)
+                .padding(16)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                HStack(spacing: 8) {
+                    Image("my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    Text("Text to accompany my image")
+                }.accessibilityElement(children: .ignore)
+                .padding(16)
+                .accessibilityLabel(Text("Label for my image and text"))
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Button(action: { doAction() }) {
+                    Image("my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                }
+                .accessibilityLabel(Text("Label for my image"))
+            }
+        }
+        """)
+    ]
+    
+    static let triggeringExamples = [
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Image("my-image")
+                    .resizable(true)
+                    .frame(width: 48, height: 48)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Image(uiImage: myUiImage)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓SwiftUI.Image(uiImage: "my-image").resizable().accessibilityHidden(false)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image(uiImage: myUiImage)
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .accessibilityLabel(Text("Alt text for my image"))
+                ↓Image("other image")
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Image(decorative: "image1")
+                ↓Image("image2")
+                Image(uiImage: "image3")
+                    .accessibility(label: Text("a pretty picture"))
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                VStack {
+                    Image(decorative: "my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    ↓Image("my-image")
+                }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                VStack {
+                    ↓Image("my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    Image("my-image")
+                        .accessibility(label: Text("Alt text for my image"))
+                }.accessibilityElement(children: .contain)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                VStack {
+                    ↓Image("my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    Image("my-image")
+                        .accessibility(label: Text("Alt text for my image"))
+                }.accessibilityHidden(false)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                HStack(spacing: 8) {
+                    ↓Image("my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                    Text("Text to accompany my image")
+                }.accessibilityElement(children: .combine)
+                .padding(16)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Button(action: { doAction() }) {
+                    ↓Image("my-image")
+                        .renderingMode(.template)
+                        .foregroundColor(.blue)
+                }
+            }
+        }
+        """)
+    ]
+}

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -11,6 +11,13 @@ internal struct AccessibilityLabelForImageRuleExamples {
         Example("""
         struct MyView: View {
             var body: some View {
+                Image(systemName: "circle.plus")
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
                 Image("my-image")
                     .accessibility(hidden: true)
             }

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -18,7 +18,7 @@ internal struct AccessibilityLabelForImageRuleExamples {
         Example("""
         struct MyView: View {
             var body: some View {
-                Image("my-image", label: Text("Alt text for my image")
+                Image("my-image", label: Text("Alt text for my image"))
             }
         }
         """),
@@ -42,7 +42,7 @@ internal struct AccessibilityLabelForImageRuleExamples {
         struct MyView: View {
             var body: some View {
                 Image("my-image")
-                    .accessibility(label: Text("Alt text for my image")
+                    .accessibility(label: Text("Alt text for my image"))
             }
         }
         """),

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -1,5 +1,4 @@
-import Foundation
-
+// swiftlint:disable type_body_length
 internal struct AccessibilityLabelForImageRuleExamples {
     static let nonTriggeringExamples = [
         Example("""
@@ -145,7 +144,7 @@ internal struct AccessibilityLabelForImageRuleExamples {
         }
         """)
     ]
-    
+
     static let triggeringExamples = [
         Example("""
         struct MyView: View {

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -5,6 +5,12 @@ import XCTest
 
 // swiftlint:disable file_length single_test_class type_name
 
+class AccessibilityLabelForImageRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(AccessibilityLabelForImageRule.description)
+    }
+}
+
 class AnonymousArgumentInMultilineClosureRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(AnonymousArgumentInMultilineClosureRule.description)

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -136,4 +136,6 @@ class RuleTests: XCTestCase {
     func testDifferentSeverityLevelRulesNotEqual() {
         XCTAssertFalse(RuleWithLevelsMock().isEqualTo(RuleWithLevelsMock2()))
     }
+    
+    
 }

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -136,6 +136,4 @@ class RuleTests: XCTestCase {
     func testDifferentSeverityLevelRulesNotEqual() {
         XCTAssertFalse(RuleWithLevelsMock().isEqualTo(RuleWithLevelsMock2()))
     }
-    
-    
 }


### PR DESCRIPTION
Add `accessibility_label_for_image` rule to warn if a SwiftUI Image does not have an accessibility label and is not hidden from accessibility. When this is the case, the image's accessibility label defaults to the name of the image file.

First time adding a rule here — tried to follow all the guidelines but let me know if I should make any changes or need to take a slightly different approach to anything!

Opening this PR with cherry-picked changes from #3806 after messing up the rebase on the old branch.