### PR TITLE
Fix `empty_parentheses_with_trailing_closure` with Swift 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix `empty_parentheses_with_trailing_closure` rule when using Swift 5.6.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3846](https://github.com/realm/SwiftLint/issues/3846)
 
 ## 0.46.4: Detergent Tray
 

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -80,7 +80,7 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
 
         // avoid the more expensive regex match if there's no trailing closure in the substructure
         if SwiftVersion.current >= .fourDotTwo,
-            dictionary.substructure.last?.expressionKind != .closure {
+            !dictionary.hasTrailingClosure {
             return []
         }
 
@@ -97,5 +97,19 @@ public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableAS
         }
 
         return [match]
+    }
+}
+
+private extension SourceKittenDictionary {
+    var hasTrailingClosure: Bool {
+        guard let lastStructure = substructure.last else {
+            return false
+        }
+
+        if SwiftVersion.current >= .fiveDotSix, lastStructure.expressionKind == .argument {
+            return lastStructure.substructure.last?.expressionKind == .closure
+        } else {
+            return lastStructure.expressionKind == .closure
+        }
     }
 }


### PR DESCRIPTION
Fixes #3846