### PR TITLE
Fix `closure_parameter_position` rule with Swift 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3846](https://github.com/realm/SwiftLint/issues/3846)
 
+* Fix false negatives in `closure_parameter_position` rule with Swift 5.6.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3845](https://github.com/realm/SwiftLint/issues/3845)
+
 ## 0.46.4: Detergent Tray
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
@@ -112,16 +112,23 @@ public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule, 
             return []
         }
 
-        guard let nameOffset = dictionary.nameOffset,
-            let nameLength = dictionary.nameLength,
-            let bodyLength = dictionary.bodyLength,
+        guard let bodyLength = dictionary.bodyLength,
             bodyLength > 0
         else {
             return []
         }
 
-        let parameters = dictionary.enclosedVarParameters +
-            dictionary.substructure.filter { $0.declarationKind == .varLocal } // capture lists
+        let nameOffset = dictionary.nameOffset ?? 0
+        let nameLength = dictionary.nameLength ?? 0
+
+        let captureLists = dictionary.substructure.flatMap { dict -> [SourceKittenDictionary] in
+            if SwiftVersion.current >= .fiveDotSix, dict.expressionKind == .argument {
+                return dict.substructure.filter { $0.declarationKind == .varLocal }
+            }
+
+            return dict.declarationKind == .varLocal ? [dict] : []
+        }
+        let parameters = dictionary.enclosedVarParameters + captureLists
         let rangeStart = nameOffset + nameLength
         let regex = Self.openBraceRegex
 


### PR DESCRIPTION
Fixes #3845