### PR TITLE
Add -I to _InternalSwiftSyntaxParser on Linux

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: docker
 on:
   push:
     branches:
-      - ks/add-i-to-_internalswiftsyntaxparser-on-linux
+      - master
     tags:
       - '*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: docker
 on:
   push:
     branches:
-      - master
+      - ks/add-i-to-_internalswiftsyntaxparser-on-linux
     tags:
       - '*'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY Package.* ./
 
 RUN ln -s /usr/lib/swift/_InternalSwiftSyntaxParser .
 
-ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib -Xlinker -lCFURLSessionInterface -Xlinker -lCFXMLInterface -Xlinker -lcurl -Xlinker -lxml2 -Xswiftc -I."
+ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib -Xlinker -lCFURLSessionInterface -Xlinker -lCFXMLInterface -Xlinker -lcurl -Xlinker -lxml2 -Xswiftc -I. -Xlinker -fuse-ld=lld -Xlinker -L/usr/lib/swift/linux"
 RUN swift build $SWIFT_FLAGS
 RUN mkdir -p /executables
 RUN for executable in $(swift package completion-tool list-executables); do \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ COPY Source Source/
 COPY Tests Tests/
 COPY Package.* ./
 
-ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib -Xlinker -lCFURLSessionInterface -Xlinker -lCFXMLInterface -Xlinker -lcurl -Xlinker -lxml2"
+RUN ln -s /usr/lib/swift/_InternalSwiftSyntaxParser .
+
+ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib -Xlinker -lCFURLSessionInterface -Xlinker -lCFXMLInterface -Xlinker -lcurl -Xlinker -lxml2 -Xswiftc -I."
 RUN swift build $SWIFT_FLAGS
 RUN mkdir -p /executables
 RUN for executable in $(swift package completion-tool list-executables); do \
@@ -30,6 +32,7 @@ RUN apt-get update && apt-get install -y \
 COPY --from=builder /usr/lib/libsourcekitdInProc.so /usr/lib
 COPY --from=builder /usr/lib/swift/linux/libBlocksRuntime.so /usr/lib
 COPY --from=builder /usr/lib/swift/linux/libdispatch.so /usr/lib
+COPY --from=builder /usr/lib/swift/linux/lib_InternalSwiftSyntaxParser.so /usr/lib
 COPY --from=builder /executables/* /usr/bin
 
 RUN swiftlint version


### PR DESCRIPTION
Since `_InternalSwiftSyntaxParser` isn't in the search paths when building with the `-static-stdlib` flag, we have to manually pass an include path so the swift compiler discovers it. Unfortunately we cannot just pass `-I/usr/lib/swift` because that results in duplicate library errors since the libraries we're linking statically also live there as shared libraries. This first symlinks the module definition to the root of the checkout and uses `.` for the `-I`. Any temporary path could be used instead.