### PR TITLE
Fix regression in `last_where` rule with Swift 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3845](https://github.com/realm/SwiftLint/issues/3845)
 
+* Fix regression in `last_where` rule when using Swift 5.6.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3847](https://github.com/realm/SwiftLint/issues/3847)
+
 ## 0.46.4: Detergent Tray
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
@@ -35,7 +35,19 @@ public struct LastWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule,
                         patternSyntaxKinds: [.identifier],
                         callNameSuffix: ".filter",
                         severity: configuration.severity) { dictionary in
-            if dictionary.substructure.isNotEmpty {
+            let substructure: [SourceKittenDictionary] = {
+                if SwiftVersion.current >= .fiveDotSix {
+                    return dictionary.substructure.flatMap { dict -> [SourceKittenDictionary] in
+                        if dict.expressionKind == .argument {
+                            return dict.substructure
+                        }
+                        return [dict]
+                    }
+                }
+
+                return dictionary.substructure
+            }()
+            if substructure.isNotEmpty {
                 return true // has a substructure, like a closure
             }
 


### PR DESCRIPTION
Fixes #3847