### PR TITLE
Fix regression in `unused_import` rule when using Swift 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3847](https://github.com/realm/SwiftLint/issues/3847)
 
+* Fix regression in `unused_import` rule when using Swift 5.6.  
+  [JP Simard](https://github.com/jpsim)
+  [#3849](https://github.com/realm/SwiftLint/issues/3849)
+
 ## 0.46.4: Detergent Tray
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -105,6 +105,10 @@ private extension SwiftLintFile {
         // Always disallow 'Swift' and 'SwiftShims' because they're always available without importing.
         usrFragments.remove("Swift")
         usrFragments.remove("SwiftShims")
+        if SwiftVersion.current >= .fiveDotSix {
+            usrFragments.remove("main")
+        }
+
         var unusedImports = imports.subtracting(usrFragments).subtracting(configuration.alwaysKeepImports)
         // Certain Swift attributes requires importing Foundation.
         if unusedImports.contains("Foundation") && containsAttributesRequiringFoundation() {


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/3849