### PR TITLE
Fix regression in `trailing_closure` rule with Swift 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   [JP Simard](https://github.com/jpsim)
   [#3849](https://github.com/realm/SwiftLint/issues/3849)
 
+* Fix regression in `trailing_closure` rule when using Swift 5.6.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3848](https://github.com/realm/SwiftLint/issues/3848)
+
 ## 0.46.4: Detergent Tray
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -82,8 +82,16 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
             return shouldTrigger()
         }
 
+        let argumentsCountIsExpected: Bool = {
+            if SwiftVersion.current >= .fiveDotSix, arguments.count == 1,
+               arguments[0].expressionKind == .argument {
+                return true
+            }
+
+            return arguments.isEmpty
+        }()
         // check if there's only one unnamed parameter that is a closure
-        if arguments.isEmpty,
+        if argumentsCountIsExpected,
             let offset = dictionary.offset,
             let totalLength = dictionary.length,
             let nameOffset = dictionary.nameOffset,


### PR DESCRIPTION
Fixes #3848