### PR TITLE
Automatically enforce min Swift version for all rules

### DIFF
--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -58,6 +58,10 @@ private extension Rule {
             return nil
         }
 
+        if SwiftVersion.current < Self.description.minSwiftVersion {
+            return nil
+        }
+
         let ruleID = Self.description.identifier
 
         let violations: [StyleViolation]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -11,6 +11,7 @@ public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule, AutomaticTe
         name: "Block Based KVO",
         description: "Prefer the new block based KVO API with keypaths when using Swift 3.2 or later.",
         kind: .idiomatic,
+        minSwiftVersion: .four,
         nonTriggeringExamples: [
             Example("""
             let observer = foo.observe(\\.value, options: [.new]) { (foo, change) in
@@ -38,7 +39,7 @@ public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule, AutomaticTe
 
     public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
                          dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        guard SwiftVersion.current >= .four, kind == .functionMethodInstance,
+        guard kind == .functionMethodInstance,
             dictionary.enclosedSwiftAttributes.contains(.override),
             dictionary.name == "observeValue(forKeyPath:of:change:context:)",
             hasExpectedParamTypes(types: dictionary.enclosedVarParameters.parameterTypes),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRuleExamples.swift
@@ -80,7 +80,7 @@ internal struct NoFallthroughOnlyRuleExamples {
             }
             """)
     ]
-    
+
     static let triggeringExamples = [
         Example("""
         switch myvar {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRuleExamples.swift
@@ -1,7 +1,6 @@
 internal struct NoFallthroughOnlyRuleExamples {
-    static let nonTriggeringExamples: [Example] = {
-        let commonExamples = [
-            Example("""
+    static let nonTriggeringExamples: [Example] = [
+        Example("""
             switch myvar {
             case 1:
                 var a = 1
@@ -10,7 +9,7 @@ internal struct NoFallthroughOnlyRuleExamples {
                 var a = 2
             }
             """),
-            Example("""
+        Example("""
             switch myvar {
             case "a":
                 var one = 1
@@ -20,7 +19,7 @@ internal struct NoFallthroughOnlyRuleExamples {
                 var three = 3
             }
             """),
-            Example("""
+        Example("""
             switch myvar {
             case 1:
                 let one = 1
@@ -29,7 +28,7 @@ internal struct NoFallthroughOnlyRuleExamples {
                 var two = 2
             }
             """),
-            Example("""
+        Example("""
             switch myvar {
             case MyFunc(x: [1, 2, YourFunc(a: 23)], y: 2):
                 var three = 3
@@ -38,7 +37,7 @@ internal struct NoFallthroughOnlyRuleExamples {
                 var three = 4
             }
             """),
-            Example("""
+        Example("""
             switch myvar {
             case .alpha:
                 var one = 1
@@ -49,7 +48,7 @@ internal struct NoFallthroughOnlyRuleExamples {
                 var four = 4
             }
             """),
-            Example("""
+        Example("""
             let aPoint = (1, -1)
             switch aPoint {
             case let (x, y) where x == y:
@@ -61,7 +60,7 @@ internal struct NoFallthroughOnlyRuleExamples {
                 let C = "C"
             }
             """),
-            Example("""
+        Example("""
             switch myvar {
             case MyFun(with: { $1 }):
                 let one = 1
@@ -69,15 +68,8 @@ internal struct NoFallthroughOnlyRuleExamples {
             case "abc":
                 let two = 2
             }
-            """)
-        ]
-
-        guard SwiftVersion.current >= .five else {
-            return commonExamples
-        }
-
-        return commonExamples + [
-            Example("""
+            """),
+        Example("""
             switch enumInstance {
             case .caseA:
                 print("it's a")
@@ -87,9 +79,8 @@ internal struct NoFallthroughOnlyRuleExamples {
                 print("it's not a")
             }
             """)
-        ]
-    }()
-
+    ]
+    
     static let triggeringExamples = [
         Example("""
         switch myvar {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -52,77 +52,61 @@ public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRul
         corrections: corrections
     )
 
-    private static let triggeringExamples: [Example] = {
-        let commonExamples = [
-            Example("var myVar: Int?↓ = nil\n"),
-            Example("var myVar: Optional<Int>↓ = nil\n"),
-            Example("var myVar: Int?↓=nil\n"),
-            Example("var myVar: Optional<Int>↓=nil\n)"),
-            Example("""
+    private static let triggeringExamples: [Example] = [
+        Example("var myVar: Int?↓ = nil\n"),
+        Example("var myVar: Optional<Int>↓ = nil\n"),
+        Example("var myVar: Int?↓=nil\n"),
+        Example("var myVar: Optional<Int>↓=nil\n)"),
+        Example("""
               var myVar: String?↓ = nil {
                 didSet { print("didSet") }
               }
-              """)
-        ]
-
-        guard SwiftVersion.current >= .fourDotOne else {
-            return commonExamples
-        }
-
-        return commonExamples + [
-            Example("""
+              """),
+        Example("""
             func funcName() {
                 var myVar: String?↓ = nil
             }
             """)
-        ]
-    }()
+    ]
 
-    private static let corrections: [Example: Example] = {
-        var corrections = [
-            Example("var myVar: Int?↓ = nil\n"): Example("var myVar: Int?\n"),
-            Example("var myVar: Optional<Int>↓ = nil\n"): Example("var myVar: Optional<Int>\n"),
-            Example("var myVar: Int?↓=nil\n"): Example("var myVar: Int?\n"),
-            Example("var myVar: Optional<Int>↓=nil\n"): Example("var myVar: Optional<Int>\n"),
-            Example("class C {\n#if true\nvar myVar: Int?↓ = nil\n#endif\n}"):
-                Example("class C {\n#if true\nvar myVar: Int?\n#endif\n}"),
-            Example("""
+    private static let corrections: [Example: Example] = [
+        Example("var myVar: Int?↓ = nil\n"): Example("var myVar: Int?\n"),
+        Example("var myVar: Optional<Int>↓ = nil\n"): Example("var myVar: Optional<Int>\n"),
+        Example("var myVar: Int?↓=nil\n"): Example("var myVar: Int?\n"),
+        Example("var myVar: Optional<Int>↓=nil\n"): Example("var myVar: Optional<Int>\n"),
+        Example("class C {\n#if true\nvar myVar: Int?↓ = nil\n#endif\n}"):
+            Example("class C {\n#if true\nvar myVar: Int?\n#endif\n}"),
+        Example("""
             var myVar: Int?↓ = nil {
                 didSet { }
             }
             """):
-                Example("""
+            Example("""
                 var myVar: Int? {
                     didSet { }
                 }
                 """),
-            Example("""
+        Example("""
             var myVar: Int?↓=nil{
                 didSet { }
             }
             """):
-                Example("""
+            Example("""
                 var myVar: Int?{
                     didSet { }
                 }
-                """)
-        ]
-
-        guard SwiftVersion.current >= .fourDotOne else {
-            return corrections
-        }
-
-        corrections[Example("""
+                """),
+        Example("""
         func foo() {
             var myVar: String?↓ = nil
         }
-        """)] = Example("""
-        func foo() {
-            var myVar: String?
-        }
-        """)
-        return corrections
-    }()
+        """):
+            Example("""
+            func foo() {
+                var myVar: String?
+            }
+            """)
+    ]
 
     private let pattern = "(\\s*=\\s*nil\\b)\\s*\\{?"
 

--- a/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRuleExamples.swift
@@ -1,74 +1,56 @@
 struct LargeTupleRuleExamples {
-    static var nonTriggeringExamples: [Example] {
-        let commonExamples = [
-            Example("let foo: (Int, Int)\n"),
-            Example("let foo: (start: Int, end: Int)\n"),
-            Example("let foo: (Int, (Int, String))\n"),
-            Example("func foo() -> (Int, Int)\n"),
-            Example("func foo() -> (Int, Int) {}\n"),
-            Example("func foo(bar: String) -> (Int, Int)\n"),
-            Example("func foo(bar: String) -> (Int, Int) {}\n"),
-            Example("func foo() throws -> (Int, Int)\n"),
-            Example("func foo() throws -> (Int, Int) {}\n"),
-            Example("let foo: (Int, Int, Int) -> Void\n"),
-            Example("let foo: (Int, Int, Int) throws -> Void\n"),
-            Example("func foo(bar: (Int, String, Float) -> Void)\n"),
-            Example("func foo(bar: (Int, String, Float) throws -> Void)\n"),
-            Example("var completionHandler: ((_ data: Data?, _ resp: URLResponse?, _ e: NSError?) -> Void)!\n"),
-            Example("func getDictionaryAndInt() -> (Dictionary<Int, String>, Int)?\n"),
-            Example("func getGenericTypeAndInt() -> (Type<Int, String, Float>, Int)?\n")
-        ]
+    static let nonTriggeringExamples: [Example] = [
+        Example("let foo: (Int, Int)\n"),
+        Example("let foo: (start: Int, end: Int)\n"),
+        Example("let foo: (Int, (Int, String))\n"),
+        Example("func foo() -> (Int, Int)\n"),
+        Example("func foo() -> (Int, Int) {}\n"),
+        Example("func foo(bar: String) -> (Int, Int)\n"),
+        Example("func foo(bar: String) -> (Int, Int) {}\n"),
+        Example("func foo() throws -> (Int, Int)\n"),
+        Example("func foo() throws -> (Int, Int) {}\n"),
+        Example("let foo: (Int, Int, Int) -> Void\n"),
+        Example("let foo: (Int, Int, Int) throws -> Void\n"),
+        Example("func foo(bar: (Int, String, Float) -> Void)\n"),
+        Example("func foo(bar: (Int, String, Float) throws -> Void)\n"),
+        Example("var completionHandler: ((_ data: Data?, _ resp: URLResponse?, _ e: NSError?) -> Void)!\n"),
+        Example("func getDictionaryAndInt() -> (Dictionary<Int, String>, Int)?\n"),
+        Example("func getGenericTypeAndInt() -> (Type<Int, String, Float>, Int)?\n"),
+        Example("func foo() async -> (Int, Int)\n"),
+        Example("func foo() async -> (Int, Int) {}\n"),
+        Example("func foo(bar: String) async -> (Int, Int)\n"),
+        Example("func foo(bar: String) async -> (Int, Int) {}\n"),
+        Example("func foo() async throws -> (Int, Int)\n"),
+        Example("func foo() async throws -> (Int, Int) {}\n"),
+        Example("let foo: (Int, Int, Int) async -> Void\n"),
+        Example("let foo: (Int, Int, Int) async throws -> Void\n"),
+        Example("func foo(bar: (Int, String, Float) async -> Void)\n"),
+        Example("func foo(bar: (Int, String, Float) async throws -> Void)\n"),
+        Example("func getDictionaryAndInt() async -> (Dictionary<Int, String>, Int)?\n"),
+        Example("func getGenericTypeAndInt() async -> (Type<Int, String, Float>, Int)?\n")
+    ]
 
-        guard SwiftVersion.current >= .fiveDotFive else {
-            return commonExamples
-        }
-
-        return commonExamples + [
-            Example("func foo() async -> (Int, Int)\n"),
-            Example("func foo() async -> (Int, Int) {}\n"),
-            Example("func foo(bar: String) async -> (Int, Int)\n"),
-            Example("func foo(bar: String) async -> (Int, Int) {}\n"),
-            Example("func foo() async throws -> (Int, Int)\n"),
-            Example("func foo() async throws -> (Int, Int) {}\n"),
-            Example("let foo: (Int, Int, Int) async -> Void\n"),
-            Example("let foo: (Int, Int, Int) async throws -> Void\n"),
-            Example("func foo(bar: (Int, String, Float) async -> Void)\n"),
-            Example("func foo(bar: (Int, String, Float) async throws -> Void)\n"),
-            Example("func getDictionaryAndInt() async -> (Dictionary<Int, String>, Int)?\n"),
-            Example("func getGenericTypeAndInt() async -> (Type<Int, String, Float>, Int)?\n")
-        ]
-    }
-
-    static var triggeringExamples: [Example] {
-        let commonExamples = [
-            Example("↓let foo: (Int, Int, Int)\n"),
-            Example("↓let foo: (start: Int, end: Int, value: String)\n"),
-            Example("↓let foo: (Int, (Int, Int, Int))\n"),
-            Example("func foo(↓bar: (Int, Int, Int))\n"),
-            Example("func foo() -> ↓(Int, Int, Int)\n"),
-            Example("func foo() -> ↓(Int, Int, Int) {}\n"),
-            Example("func foo(bar: String) -> ↓(Int, Int, Int)\n"),
-            Example("func foo(bar: String) -> ↓(Int, Int, Int) {}\n"),
-            Example("func foo() throws -> ↓(Int, Int, Int)\n"),
-            Example("func foo() throws -> ↓(Int, Int, Int) {}\n"),
-            Example("func foo() throws -> ↓(Int, ↓(String, String, String), Int) {}\n"),
-            Example("func getDictionaryAndInt() -> (Dictionary<Int, ↓(String, String, String)>, Int)?\n")
-        ]
-
-        guard SwiftVersion.current >= .fiveDotFive else {
-            return commonExamples
-        }
-
-        return commonExamples + [
-            Example("func foo(↓bar: (Int, Int, Int)) async\n"),
-            Example("func foo() async -> ↓(Int, Int, Int)\n"),
-            Example("func foo() async -> ↓(Int, Int, Int) {}\n"),
-            Example("func foo(bar: String) async -> ↓(Int, Int, Int)\n"),
-            Example("func foo(bar: String) async -> ↓(Int, Int, Int) {}\n"),
-            Example("func foo() async throws -> ↓(Int, Int, Int)\n"),
-            Example("func foo() async throws -> ↓(Int, Int, Int) {}\n"),
-            Example("func foo() async throws -> ↓(Int, ↓(String, String, String), Int) {}\n"),
-            Example("func getDictionaryAndInt() async -> (Dictionary<Int, ↓(String, String, String)>, Int)?\n")
-        ]
-    }
+    static let triggeringExamples: [Example] = [
+        Example("↓let foo: (Int, Int, Int)\n"),
+        Example("↓let foo: (start: Int, end: Int, value: String)\n"),
+        Example("↓let foo: (Int, (Int, Int, Int))\n"),
+        Example("func foo(↓bar: (Int, Int, Int))\n"),
+        Example("func foo() -> ↓(Int, Int, Int)\n"),
+        Example("func foo() -> ↓(Int, Int, Int) {}\n"),
+        Example("func foo(bar: String) -> ↓(Int, Int, Int)\n"),
+        Example("func foo(bar: String) -> ↓(Int, Int, Int) {}\n"),
+        Example("func foo() throws -> ↓(Int, Int, Int)\n"),
+        Example("func foo() throws -> ↓(Int, Int, Int) {}\n"),
+        Example("func foo() throws -> ↓(Int, ↓(String, String, String), Int) {}\n"),
+        Example("func getDictionaryAndInt() -> (Dictionary<Int, ↓(String, String, String)>, Int)?\n"),
+        Example("func foo(↓bar: (Int, Int, Int)) async\n"),
+        Example("func foo() async -> ↓(Int, Int, Int)\n"),
+        Example("func foo() async -> ↓(Int, Int, Int) {}\n"),
+        Example("func foo(bar: String) async -> ↓(Int, Int, Int)\n"),
+        Example("func foo(bar: String) async -> ↓(Int, Int, Int) {}\n"),
+        Example("func foo() async throws -> ↓(Int, Int, Int)\n"),
+        Example("func foo() async throws -> ↓(Int, Int, Int) {}\n"),
+        Example("func foo() async throws -> ↓(Int, ↓(String, String, String), Int) {}\n"),
+        Example("func getDictionaryAndInt() async -> (Dictionary<Int, ↓(String, String, String)>, Int)?\n")
+    ]
 }

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRuleExamples.swift
@@ -1,8 +1,7 @@
 // swiftlint:disable:next type_body_length
 struct ImplicitGetterRuleExamples {
-    static var nonTriggeringExamples: [Example] {
-        let commonExamples = [
-            Example("""
+    static let nonTriggeringExamples: [Example] = [
+        Example("""
             class Foo {
                 var foo: Int {
                     get { return 3 }
@@ -10,21 +9,21 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 var foo: Int {
                     return 20
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 static var foo: Int {
                     return 20
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 static var foo: Int {
                     get { return 3 }
@@ -32,35 +31,35 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 var foo: Int
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 var foo: Int {
                     return getValueFromDisk()
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 var foo: String {
                     return "get"
                 }
             }
             """),
-            Example("""
+        Example("""
             protocol Foo {
                 var foo: Int { get }
             """),
-            Example("""
+        Example("""
             protocol Foo {
                 var foo: Int { get set }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 var foo: Int {
                     struct Bar {
@@ -74,12 +73,12 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             var _objCTaggedPointerBits: UInt {
                 @inline(__always) get { return 0 }
             }
             """),
-            Example("""
+        Example("""
             var next: Int? {
                 mutating get {
                     defer { self.count += 1 }
@@ -87,7 +86,7 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             extension Foo {
                 var bar: Bool {
                     get { _bar }
@@ -95,7 +94,7 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             extension Foo {
                 var bar: Bool {
                     get { _bar }
@@ -103,7 +102,7 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             extension Float {
                 var clamped: Float {
                     set {
@@ -115,7 +114,7 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             extension Reactive where Base: UITapGestureRecognizer {
                 var tapped: CocoaAction<Base>? {
                     get {
@@ -127,7 +126,7 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             extension Test {
                 var foo: Bool {
                     get {
@@ -139,14 +138,14 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 subscript(i: Int) -> Int {
                     return 20
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 subscript(i: Int) -> Int {
                     get { return 3 }
@@ -154,24 +153,17 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             protocol Foo {
                 subscript(i: Int) -> Int { get }
             }
             """),
-            Example("""
+        Example("""
             protocol Foo {
                 subscript(i: Int) -> Int { get set }
             }
-            """)
-        ]
-
-        guard SwiftVersion.current >= .fiveDotFive else {
-            return commonExamples
-        }
-
-        return commonExamples + [
-            Example("""
+            """),
+        Example("""
             class DatabaseEntity {
                 var isSynced: Bool {
                     get async {
@@ -180,7 +172,7 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             struct Test {
                 subscript(value: Int) -> Int {
                     get throws {
@@ -193,12 +185,10 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """)
-        ]
-    }
+    ]
 
-    static var triggeringExamples: [Example] {
-        let commonExamples = [
-            Example("""
+    static let triggeringExamples: [Example] = [
+        Example("""
             class Foo {
                 var foo: Int {
                     ↓get {
@@ -207,14 +197,14 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 var foo: Int {
                     ↓get{ return 20 }
                 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 static var foo: Int {
                     ↓get {
@@ -223,12 +213,12 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             var foo: Int {
                 ↓get { return 20 }
             }
             """),
-            Example("""
+        Example("""
             class Foo {
                 @objc func bar() {}
                 var foo: Int {
@@ -238,21 +228,14 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """),
-            Example("""
+        Example("""
             extension Foo {
                 var bar: Bool {
                     ↓get { _bar }
                 }
             }
-            """)
-        ]
-
-        guard SwiftVersion.current >= .fourDotOne else {
-            return commonExamples
-        }
-
-        return commonExamples + [
-            Example("""
+            """),
+        Example("""
             class Foo {
                 subscript(i: Int) -> Int {
                     ↓get {
@@ -261,6 +244,5 @@ struct ImplicitGetterRuleExamples {
                 }
             }
             """)
-        ]
-    }
+    ]
 }

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -25,7 +25,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         name: "Modifier Order",
         description: "Modifier order should be consistent.",
         kind: .style,
-        minSwiftVersion: .fourDotOne ,
+        minSwiftVersion: .fourDotOne,
         nonTriggeringExamples: ModifierOrderRuleExamples.nonTriggeringExamples,
         triggeringExamples: ModifierOrderRuleExamples.triggeringExamples
     )

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -33,33 +33,22 @@ public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, Configura
         ]
     )
 
-    private static var nonTriggeringExamples: [Example] {
-        let commonExamples = [
-            Example("foo()"),
-            Example("object.foo()"),
-            Example("object.foo(1)"),
-            Example("object.foo(value: 1)"),
-            Example("object.foo { print($0 }"),
-            Example("list.sorted { $0.0 < $1.0 }.map { $0.value }"),
-            Example("self.init(rgb: (Int) (colorInt))")
-        ]
-
-        guard SwiftVersion.current >= .fiveDotThree else {
-            return commonExamples
+    private static let nonTriggeringExamples: [Example] = [
+        Example("foo()"),
+        Example("object.foo()"),
+        Example("object.foo(1)"),
+        Example("object.foo(value: 1)"),
+        Example("object.foo { print($0 }"),
+        Example("list.sorted { $0.0 < $1.0 }.map { $0.value }"),
+        Example("self.init(rgb: (Int) (colorInt))"),
+        Example("""
+        Button {
+            print("Button tapped")
+        } label: {
+            Text("Button")
         }
-
-        let swiftFiveDot3Examples = [
-            Example("""
-            Button {
-                print("Button tapped")
-            } label: {
-                Text("Button")
-            }
-            """)
-        ]
-
-        return commonExamples + swiftFiveDot3Examples
-    }
+        """)
+    ]
 
     // MARK: - ASTRule
 

--- a/Source/SwiftLintFramework/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -167,7 +167,7 @@ public struct OptionalEnumCaseMatchingRule: SubstitutionCorrectableASTRule, Conf
     public func violationRanges(in file: SwiftLintFile,
                                 kind: StatementKind,
                                 dictionary: SourceKittenDictionary) -> [NSRange] {
-        guard SwiftVersion.current >= Self.description.minSwiftVersion, kind == .case else {
+        guard kind == .case else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -118,10 +118,6 @@ public struct PreferSelfTypeOverTypeOfSelfRule: OptInRule, ConfigurationProvider
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        guard SwiftVersion.current >= Self.description.minSwiftVersion else {
-            return []
-        }
-
         let pattern = "((?:Swift\\s*\\.\\s*)?type\\(\\s*of\\:\\s*self\\s*\\))\\s*\\."
         return file.matchesAndSyntaxKinds(matching: pattern)
             .filter {

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRuleExamples.swift
@@ -1,91 +1,73 @@
 internal struct VerticalParameterAlignmentRuleExamples {
-    static let nonTriggeringExamples: [Example] = {
-        let commonExamples = [
-            Example("""
-            func validateFunction(_ file: SwiftLintFile, kind: SwiftDeclarationKind,
-                                  dictionary: SourceKittenDictionary) { }
-            """),
-            Example("""
-            func validateFunction(_ file: SwiftLintFile, kind: SwiftDeclarationKind,
-                                  dictionary: SourceKittenDictionary) -> [StyleViolation]
-            """),
-            Example("""
-            func foo(bar: Int)
-            """),
-            Example("""
-            func foo(bar: Int) -> String
-            """),
-            Example("""
-            func validateFunction(_ file: SwiftLintFile, kind: SwiftDeclarationKind,
-                                  dictionary: SourceKittenDictionary)
-                                  -> [StyleViolation]
-            """),
-            Example("""
-            func validateFunction(
-               _ file: SwiftLintFile, kind: SwiftDeclarationKind,
-               dictionary: SourceKittenDictionary) -> [StyleViolation]
-            """),
-            Example("""
-            func validateFunction(
-               _ file: SwiftLintFile, kind: SwiftDeclarationKind,
-               dictionary: SourceKittenDictionary
-            ) -> [StyleViolation]
-            """),
-            Example("""
-            func regex(_ pattern: String,
-                       options: NSRegularExpression.Options = [.anchorsMatchLines,
-                                                               .dotMatchesLineSeparators]) -> NSRegularExpression
-            """),
-            Example("""
-            func foo(a: Void,
-                     b: [String: String] =
-                     [:]) {
-            }
-            """),
-            Example("""
-            func foo(data: (size: CGSize,
-                            identifier: String)) {}
-            """)
-        ]
-
-        guard SwiftVersion.current >= .fiveDotOne else {
-            return commonExamples
+    static let nonTriggeringExamples: [Example] = [
+        Example("""
+        func validateFunction(_ file: SwiftLintFile, kind: SwiftDeclarationKind,
+                              dictionary: SourceKittenDictionary) { }
+        """),
+        Example("""
+        func validateFunction(_ file: SwiftLintFile, kind: SwiftDeclarationKind,
+                              dictionary: SourceKittenDictionary) -> [StyleViolation]
+        """),
+        Example("""
+        func foo(bar: Int)
+        """),
+        Example("""
+        func foo(bar: Int) -> String
+        """),
+        Example("""
+        func validateFunction(_ file: SwiftLintFile, kind: SwiftDeclarationKind,
+                              dictionary: SourceKittenDictionary)
+                              -> [StyleViolation]
+        """),
+        Example("""
+        func validateFunction(
+           _ file: SwiftLintFile, kind: SwiftDeclarationKind,
+           dictionary: SourceKittenDictionary) -> [StyleViolation]
+        """),
+        Example("""
+        func validateFunction(
+           _ file: SwiftLintFile, kind: SwiftDeclarationKind,
+           dictionary: SourceKittenDictionary
+        ) -> [StyleViolation]
+        """),
+        Example("""
+        func regex(_ pattern: String,
+                   options: NSRegularExpression.Options = [.anchorsMatchLines,
+                                                           .dotMatchesLineSeparators]) -> NSRegularExpression
+        """),
+        Example("""
+        func foo(a: Void,
+                 b: [String: String] =
+                 [:]) {
         }
+        """),
+        Example("""
+        func foo(data: (size: CGSize,
+                        identifier: String)) {}
+        """),
+        Example("""
+        func foo(data: Data,
+                 @ViewBuilder content: @escaping (Data.Element.IdentifiedValue) -> Content) {}
+        """)
+    ]
 
-        return commonExamples + [
-            Example("""
-            func foo(data: Data,
-                     @ViewBuilder content: @escaping (Data.Element.IdentifiedValue) -> Content) {}
-            """)
-        ]
-    }()
-
-    static let triggeringExamples: [Example] = {
-        let commonExamples = [
-            Example("""
+    static let triggeringExamples: [Example] = [
+        Example("""
             func validateFunction(_ file: SwiftLintFile, kind: SwiftDeclarationKind,
                               ↓dictionary: SourceKittenDictionary) { }
             """),
-            Example("""
+        Example("""
             func validateFunction(_ file: SwiftLintFile, kind: SwiftDeclarationKind,
                                    ↓dictionary: SourceKittenDictionary) { }
             """),
-            Example("""
+        Example("""
             func validateFunction(_ file: SwiftLintFile,
                               ↓kind: SwiftDeclarationKind,
                               ↓dictionary: SourceKittenDictionary) { }
-            """)
-        ]
-
-        guard SwiftVersion.current >= .fiveDotOne else {
-            return commonExamples
-        }
-
-        return commonExamples + [
-            Example("""
+            """),
+        Example("""
             func foo(data: Data,
                         ↓@ViewBuilder content: @escaping (Data.Element.IdentifiedValue) -> Content) {}
             """)
-        ]
-    }()
+    ]
 }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -1,7 +1,6 @@
 import SwiftLintFramework
 import XCTest
 
-// swiftlint:disable:next type_body_length
 class ExplicitTypeInterfaceRuleTests: XCTestCase {
     func testExplicitTypeInterface() {
         verifyRule(ExplicitTypeInterfaceRule.description)

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -180,10 +180,6 @@ class ExplicitTypeInterfaceRuleTests: XCTestCase {
 
     // swiftlint:disable function_body_length
     func testSwitchCaseDeclarations() {
-        guard SwiftVersion.current >= .fourDotOne else {
-            return
-        }
-
         let nonTriggeringExamples = [
             Example("""
             enum Foo {

--- a/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
@@ -391,10 +391,6 @@ class ModifierOrderTests: XCTestCase {
     }
 
     func testViolationMessage() {
-        guard SwiftVersion.current >= ModifierOrderRule.description.minSwiftVersion else {
-            return
-        }
-
         let ruleID = ModifierOrderRule.description.identifier
         guard let config = makeConfig(["preferred_modifier_order": ["acl", "final"]], ruleID) else {
             XCTFail("Failed to create configuration")

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -4,13 +4,9 @@ import XCTest
 class TrailingCommaRuleTests: XCTestCase {
     func testTrailingCommaRuleWithDefaultConfiguration() {
         // Verify TrailingCommaRule with test values for when mandatory_comma is false (default).
-        if SwiftVersion.current >= .fourDotOne {
-            let triggeringExamples = TrailingCommaRule.description.triggeringExamples +
-                [Example("class C {\n #if true\n func f() {\n let foo = [1, 2, 3↓,]\n }\n #endif\n}")]
-            verifyRule(TrailingCommaRule.description.with(triggeringExamples: triggeringExamples))
-        } else {
-            verifyRule(TrailingCommaRule.description)
-        }
+        let triggeringExamples = TrailingCommaRule.description.triggeringExamples +
+        [Example("class C {\n #if true\n func f() {\n let foo = [1, 2, 3↓,]\n }\n #endif\n}")]
+        verifyRule(TrailingCommaRule.description.with(triggeringExamples: triggeringExamples))
 
         // Ensure the rule produces the correct reason string.
         let failingCase = Example("let array = [\n\t1,\n\t2,\n]\n")


### PR DESCRIPTION
- Automatically enforce min Swift version for all rules. This is something we've talked about but for some reason never done it. This would allow us to make rules about new Swift features enabled by default
- Clean up examples now that we require Swift 5.5 to compile and run our tests

My final goal is to bump the min supported version of Swift versions in runtime to 5.0.0. This would allow us to clean up some legacy implementations and rely on newer features of SourceKit, like the presence of closures and tuples in the structure.