### PR TITLE
Prevent empty files from triggering rule violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
 
 #### Enhancements
 
-* None.
+* Empty files no longer trigger any violations.  
+  [JP Simard](https://github.com/jpsim)
+  [#3854](https://github.com/realm/SwiftLint/issues/3854)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -54,6 +54,9 @@ private extension Rule {
               configuration: Configuration,
               superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
               compilerArguments: [String]) -> LintResult? {
+        // Empty files shouldn't trigger violations
+        if file.isEmpty { return nil }
+
         if !(self is SourceKitFreeRule) && file.sourcekitdFailed {
             return nil
         }
@@ -199,6 +202,11 @@ public struct CollectedLinter {
 
     private func getStyleViolations(using storage: RuleStorage,
                                     benchmark: Bool = false) -> ([StyleViolation], [(id: String, time: Double)]) {
+        guard !file.isEmpty else {
+            // Empty files shouldn't trigger violations
+            return ([], [])
+        }
+
         if let cached = cachedStyleViolations(benchmark: benchmark) {
             return cached
         }
@@ -327,5 +335,11 @@ public struct CollectedLinter {
                 )
             }
         }
+    }
+}
+
+private extension SwiftLintFile {
+    var isEmpty: Bool {
+        contents.isEmpty || contents == "\n"
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
@@ -12,7 +12,7 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
         description: "Files should not contain leading whitespace.",
         kind: .style,
         nonTriggeringExamples: [ Example("//\n") ],
-        triggeringExamples: [ Example("\n"), Example(" //\n") ],
+        triggeringExamples: [ Example("\n//\n"), Example(" //\n") ],
         corrections: [Example("\n //"): Example("//")]
     )
 

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -14,7 +14,7 @@ class CollectingRuleTests: XCTestCase {
             }
         }
 
-        XCTAssertFalse(violations(Example(""), config: Spec.configuration!).isEmpty)
+        XCTAssertFalse(violations(Example("_ = 0"), config: Spec.configuration!).isEmpty)
     }
 
     func testCollectsAllFiles() {
@@ -49,7 +49,7 @@ class CollectingRuleTests: XCTestCase {
             }
         }
 
-        XCTAssertFalse(violations(Example(""), config: Spec.configuration!, requiresFileOnDisk: true).isEmpty)
+        XCTAssertFalse(violations(Example("_ = 0"), config: Spec.configuration!, requiresFileOnDisk: true).isEmpty)
     }
 
     func testCorrects() {


### PR DESCRIPTION
There are many valid cases to have an empty Swift source files, and these shouldn't trigger violations.

Fixes #3854