### PR TITLE
Update SwiftSyntax to 0.50600.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: docker
 on:
   push:
     branches:
-      - update-swiftsyntax-to-0.50600.0
+      - master
     tags:
       - '*'
 
@@ -14,6 +14,22 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Extract DOCKER_TAG using tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    
+    - name: Use default DOCKER_TAG
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+    
+    - name: Set lowercase repository name
+      run: |
+        echo "REPOSITORY_LC=${REPOSITORY,,}" >>${GITHUB_ENV}
+      env:
+        REPOSITORY: '${{ github.repository }}'
+      
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       
@@ -27,4 +43,4 @@ jobs:
     - uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ghcr.io/realm/swiftlint:preview
+        tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: docker
 on:
   push:
     branches:
-      - master
+      - update-swiftsyntax-to-0.50600.0
     tags:
       - '*'
 
@@ -14,22 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Extract DOCKER_TAG using tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-    
-    - name: Use default DOCKER_TAG
-      if: startsWith(github.ref, 'refs/tags/') != true
-      run: |
-        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
-    
-    - name: Set lowercase repository name
-      run: |
-        echo "REPOSITORY_LC=${REPOSITORY,,}" >>${GITHUB_ENV}
-      env:
-        REPOSITORY: '${{ github.repository }}'
-      
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       
@@ -43,4 +27,4 @@ jobs:
     - uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }}
+        tags: ghcr.io/realm/swiftlint:preview

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,9 +21,9 @@
       },
       {
         "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
-          "branch": null,
+          "branch": "0.50600.0",
           "revision": "0467d94e8123071e8e6c24039aadb405318f1838",
           "version": null
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,9 +21,9 @@
       },
       {
         "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
-          "branch": "0.50600.0",
+          "branch": null,
           "revision": "0467d94e8123071e8e6c24039aadb405318f1838",
           "version": null
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,10 +21,10 @@
       },
       {
         "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
-          "branch": null,
-          "revision": "cf40be70deaf4ce7d44eb1a7e14299c391e2363f",
+          "branch": "0.50600.0",
+          "revision": "0467d94e8123071e8e6c24039aadb405318f1838",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,12 @@ private let staticSwiftSyntax = false
 private let staticSwiftSyntax = false
 #endif
 
+#if os(Linux) && compiler(<5.6)
+private let swiftSyntaxFiveDotSix = false
+#else
+private let swiftSyntaxFiveDotSix = true
+#endif
+
 let package = Package(
     name: "SwiftLint",
     platforms: [.macOS(.v10_12)],
@@ -24,7 +30,8 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.3")),
-        .package(url: "https://github.com/apple/swift-syntax.git", branch: "0.50600.0"),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git",
+                 .revision(swiftSyntaxFiveDotSix ? "0467d94e8123071e8e6c24039aadb405318f1838" : "cf40be70deaf4ce7d44eb1a7e14299c391e2363f")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.32.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.2"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
@@ -42,12 +49,12 @@ let package = Package(
             name: "SwiftLintFramework",
             dependencies: [
                 .product(name: "SourceKittenFramework", package: "SourceKitten"),
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
+                .product(name: "SwiftSyntax", package: "SwiftSyntax"),
                 "Yams",
             ]
             + (addCryptoSwift ? ["CryptoSwift"] : [])
             + (staticSwiftSyntax ? ["lib_InternalSwiftSyntaxParser"] : [])
+            + (swiftSyntaxFiveDotSix ? [.product(name: "SwiftSyntaxParser", package: "SwiftSyntax")] : [])
         ),
         .testTarget(
             name: "SwiftLintFrameworkTests",

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,9 @@ private let addCryptoSwift = true
 #endif
 
 #if os(macOS)
-private let staticSwiftSyntax = true
+// TODO: Set back to true when a Swift 5.6 release of
+// StaticInternalSwiftSyntaxParser is available
+private let staticSwiftSyntax = false
 #else
 private let staticSwiftSyntax = false
 #endif
@@ -22,8 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.3")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git",
-                 .revision("cf40be70deaf4ce7d44eb1a7e14299c391e2363f")),
+        .package(url: "https://github.com/apple/swift-syntax.git", branch: "0.50600.0"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.32.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.2"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
@@ -41,7 +42,8 @@ let package = Package(
             name: "SwiftLintFramework",
             dependencies: [
                 .product(name: "SourceKittenFramework", package: "SourceKitten"),
-                "SwiftSyntax",
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
                 "Yams",
             ]
             + (addCryptoSwift ? ["CryptoSwift"] : [])

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
             // Pass `-dead_strip_dylibs` to ignore the dynamic version of `lib_InternalSwiftSyntaxParser`
             // that ships with SwiftSyntax because we want the static version from
             // `StaticInternalSwiftSyntaxParser`.
-            swiftSettings: staticSwiftSyntax ? [.unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])] : []
+            linkerSettings: staticSwiftSyntax ? [.unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])] : []
         ),
         .testTarget(
             name: "SwiftLintFrameworkTests",

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -1,7 +1,9 @@
 import Foundation
 import SourceKittenFramework
 import SwiftSyntax
+#if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
+#endif
 
 private typealias FileCacheKey = UUID
 private var responseCache = Cache({ file -> [String: SourceKitRepresentable]? in

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 import SwiftSyntax
+import SwiftSyntaxParser
 
 private typealias FileCacheKey = UUID
 private var responseCache = Cache({ file -> [String: SourceKitRepresentable]? in

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,9 +84,9 @@ jobs:
   variables:
     DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
   steps:
-    - script: swift run --sanitize=thread swiftlint lint --lenient
+    - script: swift run --configuration release --sanitize thread swiftlint lint --lenient
       displayName: Pre-cache SwiftLint Run
-    - script: swift run --sanitize=thread swiftlint lint --lenient
+    - script: swift run --configuration release --sanitize thread swiftlint lint --lenient
       displayName: Post-cache SwiftLint Run
     - script: make test_tsan
       displayName: Test With TSan

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,6 +84,8 @@ jobs:
   variables:
     DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
   steps:
+    - script: swift build --configuration release --sanitize thread
+      displayName: Build SwiftLint
     - script: swift run --configuration release --sanitize thread swiftlint lint --lenient
       displayName: Pre-cache SwiftLint Run
     - script: swift run --configuration release --sanitize thread swiftlint lint --lenient

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,8 @@ jobs:
     matrix:
       swift55:
         containerImage: swift:5.5
+      swift56:
+        containerImage: swift:5.6
   container: $[ variables['containerImage'] ]
   steps:
     - script: swift test --parallel


### PR DESCRIPTION
Uses SwiftSyntax 5.5 on Linux when building with Swift 5.5. We use the 5.6 version of SwiftSyntax when building with Swift 5.5 and 5.6 on macOS because we statically link `lib_InternalSwiftSyntaxParser` thanks to https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/tag/5.6.

This keeps SwiftLint binaries portable across machines on macOS, regardless of _where_ or even _if_ `lib_InternalSwiftSyntaxParser` is installed.