### PR TITLE
Accommodations for SPM Plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@
   environments, such as in Swift Package Manager plugins.  
   [Juozas Valancius](https://github.com/juozasvalancius)
 
+* The above can also be achieved using `--in-process-sourcekit` command line
+  option.  
+  [Juozas Valancius](https://github.com/juozasvalancius)
+
+* Added macOS `artifactbundle` as a release asset that contains the built
+  `swiftlint` tool.  
+  [Juozas Valancius](https://github.com/juozasvalancius)
+  [#3840](https://github.com/realm/SwiftLint/issues/3840)
+
 #### Bug Fixes
 
 * Extend `class_delegate_protocol` to correctly identify cases with the protocol

--- a/Makefile
+++ b/Makefile
@@ -106,11 +106,11 @@ portable_zip: installables
 	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "swiftlint" "LICENSE") > "./portable_swiftlint.zip"
 
 spm_artifactbundle_macos: installables
-	mkdir -p "$(TEMPORARY_FOLDER)/macos.artifactbundle/swiftlint-$(VERSION_STRING)-macos/bin"
-	sed 's/__VERSION__/$(VERSION_STRING)/g' script/info-macos.json.template > "$(TEMPORARY_FOLDER)/macos.artifactbundle/info.json"
-	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/swiftlint" "$(TEMPORARY_FOLDER)/macos.artifactbundle/swiftlint-$(VERSION_STRING)-macos/bin"
-	cp -f "$(LICENSE_PATH)" "$(TEMPORARY_FOLDER)/macos.artifactbundle"
-	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "macos.artifactbundle") > "./macos.artifactbundle.zip"
+	mkdir -p "$(TEMPORARY_FOLDER)/SwiftLintBinary.artifactbundle/swiftlint-$(VERSION_STRING)-macos/bin"
+	sed 's/__VERSION__/$(VERSION_STRING)/g' script/info-macos.json.template > "$(TEMPORARY_FOLDER)/SwiftLintBinary.artifactbundle/info.json"
+	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/swiftlint" "$(TEMPORARY_FOLDER)/SwiftLintBinary.artifactbundle/swiftlint-$(VERSION_STRING)-macos/bin"
+	cp -f "$(LICENSE_PATH)" "$(TEMPORARY_FOLDER)/SwiftLintBinary.artifactbundle"
+	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "SwiftLintBinary.artifactbundle") > "./SwiftLintBinary-macos.artifactbundle.zip"
 
 zip_linux: docker_image
 	$(eval TMP_FOLDER := $(shell mktemp -d))

--- a/Releasing.md
+++ b/Releasing.md
@@ -10,13 +10,15 @@ For SwiftLint contributors, follow these steps to cut a release:
 1. Push new version: `make push_version "0.2.0: Tumble Dry"`
 1. Make sure you have the latest stable Xcode version installed and
   `xcode-select`ed.
-1. Create the pkg installer, framework zip, portable zip, and Linux zip:
+1. Create the pkg installer, framework zip, portable zip,
+   macos artifactbundle zip, and Linux zip:
    `make release`
 1. Create a GitHub release: https://github.com/realm/SwiftLint/releases/new
     * Specify the tag you just pushed from the dropdown.
     * Set the release title to the new version number & release name.
     * Add the changelog section to the release description text box.
-    * Upload the pkg installer, framework zip, portable zip, and Linux zip you just built
+    * Upload the pkg installer, framework zip, portable zip,
+      macos artifactbundle zip, and Linux zip you just built
       to the GitHub release binaries.
     * Click "Publish release".
 1. Publish to Homebrew and CocoaPods trunk: `make publish`

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -45,7 +45,8 @@ extension SwiftLint {
                 autocorrect: common.fix,
                 format: common.format,
                 compilerLogPath: compilerLogPath,
-                compileCommands: compileCommands
+                compileCommands: compileCommands,
+                inProcessSourcekit: common.inProcessSourcekit
             )
 
             let result = LintOrAnalyzeCommand.run(options)

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -49,7 +49,8 @@ extension SwiftLint {
                 autocorrect: common.fix,
                 format: common.format,
                 compilerLogPath: nil,
-                compileCommands: nil
+                compileCommands: nil,
+                inProcessSourcekit: common.inProcessSourcekit
             )
             let result = LintOrAnalyzeCommand.run(options)
             switch result {

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -37,6 +37,8 @@ struct LintOrAnalyzeArguments: ParsableArguments {
     var benchmark = false
     @Option(help: "The reporter used to log errors and warnings.")
     var reporter: String?
+    @Flag(help: "Use the in-process version of sourcekit.")
+    var inProcessSourcekit = false
 }
 
 // MARK: - Common Argument Help

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -1,6 +1,7 @@
 import Dispatch
 import Foundation
 import SwiftLintFramework
+import SourceKittenFramework
 
 enum LintOrAnalyzeMode {
     case lint, analyze
@@ -27,7 +28,10 @@ enum LintOrAnalyzeMode {
 struct LintOrAnalyzeCommand {
     static func run(_ options: LintOrAnalyzeOptions) -> Result<(), SwiftLintError> {
         return Signposts.record(name: "LintOrAnalyzeCommand.run") {
-            options.autocorrect ? autocorrect(options) : lintOrAnalyze(options)
+            if options.inProcessSourcekit {
+                SourceKittenConfiguration.preferInProcessSourceKit = true
+            }
+            return options.autocorrect ? autocorrect(options) : lintOrAnalyze(options)
         }
     }
 
@@ -203,6 +207,7 @@ struct LintOrAnalyzeOptions {
     let format: Bool
     let compilerLogPath: String?
     let compileCommands: String?
+    let inProcessSourcekit: Bool
 
     var verb: String {
         if autocorrect {

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -1,7 +1,7 @@
 import Dispatch
 import Foundation
-import SwiftLintFramework
 import SourceKittenFramework
+import SwiftLintFramework
 
 enum LintOrAnalyzeMode {
     case lint, analyze

--- a/script/info-macos.json.template
+++ b/script/info-macos.json.template
@@ -1,0 +1,15 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "swiftlint": {
+            "version": "__VERSION__",
+            "type": "executable",
+            "variants": [
+                {
+                    "path": "swiftlint-__VERSION__-macos/bin/swiftlint",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
With the release of Swift 5.6, it is now possible to use compiled build tools in Swift Package Manager.

These tools should be put in a specific structure, called artifactbundle, it is described in [SE-0305](https://github.com/apple/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md).

So this PR adds the construction of this artifactbundle, which should be uploaded as a release asset together with other `zip` and `pkg` files.

----

Additionally, this PR adds a command line parameter to use the in-process version of sourcekit (https://github.com/jpsim/SourceKitten/pull/728). This is to work around the Xcode bug, which doesn't pass the specified environment variable in a `.buildCommand` in an SPM plugin.

----

With these changes, it is then possible to use swiftlint in a Swift package, and Xcode can display the lint warnings and errors, without the need to use cocoapods, or install swiftlint globally on the system. See this example project: https://github.com/juozasvalancius/ExampleSPMProjectWithSwiftLint
