### PR TITLE
Add new type-safe ArrayInitRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 #### Enhancements
 
-* None.
+* Add type-checked analyzer rule version of `ArrayInitRule` named
+  `TypesafeArrayInitRule` with identifier `typesafe_array_init` that
+  avoids the false positives present in the lint rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3749](https://github.com/realm/SwiftLint/issues/3749)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.6.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.7.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [
@@ -185,6 +185,7 @@ public let primaryRuleList = RuleList(rules: [
     TypeBodyLengthRule.self,
     TypeContentsOrderRule.self,
     TypeNameRule.self,
+    TypesafeArrayInitRule.self,
     UnavailableFunctionRule.self,
     UnneededBreakInSwitchRule.self,
     UnneededParenthesesInClosureArgumentRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -27,18 +27,26 @@ public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, Auto
             Example("↓foo.map({ $0 })\n"),
             Example("↓foo.map { $0 }\n"),
             Example("↓foo.map { return $0 }\n"),
-            Example("↓foo.map { elem in\n" +
-            "   elem\n" +
-            "}\n"),
-            Example("↓foo.map { elem in\n" +
-            "   return elem\n" +
-            "}\n"),
-            Example("↓foo.map { (elem: String) in\n" +
-                "   elem\n" +
-            "}\n"),
-            Example("↓foo.map { elem -> String in\n" +
-            "   elem\n" +
-            "}\n"),
+            Example("""
+                ↓foo.map { elem in
+                    elem
+                }
+            """),
+            Example("""
+                ↓foo.map { elem in
+                    return elem
+                }
+            """),
+            Example("""
+                ↓foo.map { (elem: String) in
+                    elem
+                }
+            """),
+            Example("""
+                ↓foo.map { elem -> String in
+                    elem
+                }
+            """),
             Example("↓foo.map { $0 /* a comment */ }\n"),
             Example("↓foo.map { /* a comment */ $0 }\n")
         ]

--- a/Source/SwiftLintFramework/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TypesafeArrayInitRule.swift
@@ -1,0 +1,125 @@
+import Foundation
+import SourceKittenFramework
+
+public struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule, AutomaticTestableRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "typesafe_array_init",
+        name: "Type-safe Array Init",
+        description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+                enum MyError: Error {}
+                let myResult: Result<String, MyError> = .success("")
+                let result: Result<Any, MyError> = myResult.map { $0 }
+            """),
+            Example("""
+                struct IntArray {
+                    let elements = [1, 2, 3]
+                    func map<T>(_ transformer: (Int) throws -> T) rethrows -> [T] {
+                        try elements.map(transformer)
+                    }
+                }
+                let ints = IntArray()
+                let intsCopy = ints.map { $0 }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                func f<Seq: Sequence>(s: Seq) -> [Seq.Element] {
+                    ↓s.map({ $0 })
+                }
+            """),
+            Example("""
+                func f(array: [Int]) -> [Int] {
+                    ↓array.map { $0 }
+                }
+            """),
+            Example("""
+                let myInts = ↓[1, 2, 3].map { return $0 }
+            """),
+            Example("""
+                struct Generator: Sequence, IteratorProtocol {
+                    func next() -> Int? { nil }
+                }
+                let array = ↓Generator().map { i in i }
+            """)
+        ],
+        requiresFileOnDisk: true
+    )
+
+    private static let parentRule = ArrayInitRule()
+    private static let mapTypePattern = regex("""
+            \\Q<Self, T where Self : \\E(?:Sequence|Collection)> \
+            \\Q(Self) -> ((Self.Element) throws -> T) throws -> [T]\\E
+            """)
+
+    public func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
+        guard let filePath = file.path else {
+            return []
+        }
+        guard compilerArguments.isNotEmpty else {
+            queuedPrintError("""
+                Attempted to lint file at path '\(file.path ?? "...")' with the \
+                \(Self.description.identifier) rule without any compiler arguments.
+                """)
+            return []
+        }
+        let index = buildIndex(for: filePath, using: compilerArguments)
+        return index.traverseEntitiesDepthFirst { substructure -> [StyleViolation]? in
+            guard substructure.kind == "source.lang.swift.ref.function.method.instance",
+                  let line = substructure.line, let column = substructure.column else {
+                return nil
+            }
+            let offset = file.stringView.byteOffset(forLine: Int(line), column: Int(column))
+            let cursorInfoRequest = Request.cursorInfo(file: filePath, offset: offset, arguments: compilerArguments)
+            guard let cursorInfo = try? cursorInfoRequest.sendIfNotDisabled(),
+                  let isSystem = cursorInfo["key.is_system"], isSystem.isEqualTo(true),
+                  let name = cursorInfo["key.name"], name.isEqualTo("map(_:)"),
+                  let typeName = cursorInfo["key.typename"] as? String,
+                  Self.mapTypePattern.numberOfMatches(in: typeName, range: typeName.fullNSRange) == 1,
+                  let dict = pickSubstructure(from: file.structureDictionary, at: offset) else {
+                return nil
+            }
+            return Self.parentRule.validate(file: file, kind: .call, dictionary: dict)
+        }.flatMap { $0 }
+    }
+
+    private func buildIndex(for filePath: String, using compilerArguments: [String]) -> SourceKittenDictionary {
+        do {
+            return SourceKittenDictionary(
+                try Request.index(file: filePath, arguments: compilerArguments).sendIfNotDisabled()
+            )
+        } catch {
+            queuedPrintError("""
+                Indexing of file '\(filePath)' in the context of the \(Self.description.identifier) rule failed.
+                """)
+        }
+        return SourceKittenDictionary([:])
+    }
+
+    private func pickSubstructure(from: SourceKittenDictionary, at mapOffset: ByteCount) -> SourceKittenDictionary? {
+        let substructures = from.traverseBreadthFirst { substructure -> [SourceKittenDictionary]? in
+            guard substructure.expressionKind == .call,
+                  let name = substructure.name, name.hasSuffix(".map"),
+                  let nameOffset = substructure.nameOffset,
+                  let nameLength = substructure.nameLength,
+                  mapOffset + ByteCount("map".count) == nameOffset + nameLength else {
+                return nil
+            }
+            return [substructure]
+        }
+        return substructures.count == 1 ? substructures.first : nil
+    }
+}
+
+private extension StringView {
+    func byteOffset(forLine line: Int, column: Int) -> ByteCount {
+        guard line > 0 else { return ByteCount(column - 1) }
+        return lines[line - 1].byteRange.location + ByteCount(column - 1)
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.6.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.7.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import SwiftLintFramework
 import XCTest
@@ -782,6 +782,12 @@ class TrailingSemicolonRuleTests: XCTestCase {
 class TypeBodyLengthRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TypeBodyLengthRule.description)
+    }
+}
+
+class TypesafeArrayInitRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(TypesafeArrayInitRule.description)
     }
 }
 


### PR DESCRIPTION
The idea of this new Analyzer rule is to filter the calls of `map` before they are passed on to the classic ArrayInitRule which does the detailed checking of the lambda function block. The rule makes sure that only the `map` function is considered that is defined by the `Sequence` protocol.

This new rule provides a fix for #3749.