### PR TITLE
Don't pass `--path` to bundle install

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
   - label: "Danger"
     commands:
-      - "bundle install --path vendor/bundle"
-      - "bundle exec danger --verbose"
+      - bundle install
+      - bundle exec danger --verbose


### PR DESCRIPTION
> [DEPRECATED] The `--path` flag is deprecated because it relies on
> being remembered across bundler invocations, which bundler will no
> longer do in future versions. Instead please use
> `bundle config set path 'vendor/bundle'`, and stop using this flag