### PR TITLE
Move Analyze CI job to Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,3 +3,5 @@ steps:
     commands:
       - bundle install
       - bundle exec danger --verbose
+  - label: "Analyze"
+    command: make analyze

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,15 +71,6 @@ jobs:
     - script: bundle exec pod lib lint --verbose
       displayName: pod lib lint
 
-- job: Analyze
-  pool:
-    vmImage: 'macOS-11'
-  variables:
-    DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
-  steps:
-    - script: make analyze
-      displayName: Run SwiftLint Analyze
-
 - job: TSan
   pool:
     vmImage: 'macOS-11'


### PR DESCRIPTION
We now have two Buildkite agents thanks to a newly added M1 Mac mini from MacStadium. Running the analyze job should be considerably faster than the VMs that run on Azure Pipelines, although still slower than if we were to run them with Xcode 13.2.1 because of the performance regressions described in https://github.com/realm/SwiftLint/issues/3920.