### PR TITLE
cannot lint multiple files when using --path command option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@
   [Christopher Hale](https://github.com/chrispomeroyhale)
   [#3636](https://github.com/realm/SwiftLint/pull/3626)
 
+* Lint all files listed in the command even if the `--path` option is used.  
+  [coffmark](https://github.com/coffmark)
+
 ## 0.47.0: Smart Appliance
 
 #### Breaking

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -24,7 +24,7 @@ extension SwiftLint {
         mutating func run() throws {
             let allPaths: [String]
             if let path = path {
-                allPaths = [path]
+                allPaths = [path] + paths
             } else if !paths.isEmpty {
                 allPaths = paths
             } else {


### PR DESCRIPTION
Hello, i'm @coffmark. thank you for all your maintenance & update.

### motivation
1. `swiftlint lint --fix --format --path {first-file-path} {second-file-path}` 
This command only executes {first-file-path}, i expect execute {first-file-path} and {second-file-path}

2. `swiftlint lint --fix --format {first-file-path} {second-file-path}`
This command executes {first-file-path} & {second-file-path}, this is as expected.

It only doesn't work if `--path` command option is present.

### solution
when execute `swiftlint lint --fix --format --path {first-file-path} {second-file-path}`
```swift
@Option(help: ...)
var path: String? // { is assigned to first-file-path }

@Argument(help: ...)
var paths = [String]() // { is assigned to second-file-path }
```
Now, `allpaths` only gets `path`, so `paths` are ignored.
The solution is to add `paths` and `path` to `allpaths`** 

Looking forward to hearing back from you!