### PR TITLE
Introduce a model for rule configuration description

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -56,6 +56,7 @@ disabled_rules:
 
 attributes:
   always_on_line_above:
+    - "@ConfigurationElement"
     - "@OptionGroup"
     - "@RuleConfigurationDescriptionBuilder"
 identifier_name:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,6 +57,7 @@ disabled_rules:
 attributes:
   always_on_line_above:
     - "@OptionGroup"
+    - "@RuleConfigurationDescriptionBuilder"
 identifier_name:
   excluded:
     - id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5072](https://github.com/realm/SwiftLint/issues/5072)
 
+* Prettify the rule configuration presentation on the command line as well as
+  on the website.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 #### Bug Fixes
 
 * Fix false positives for the `unneeded_synthesized_initializer` rule, when

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -6,10 +6,10 @@ struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var alwaysOnSameLine = Set<String>()
     private(set) var alwaysOnNewLine = Set<String>()
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", always_on_same_line: \(alwaysOnSameLine.sorted())" +
-            ", always_on_line_above: \(alwaysOnNewLine.sorted())"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "always_on_same_line" => .list(alwaysOnSameLine.sorted().map { .string($0) })
+        "always_on_line_above" => .list(alwaysOnNewLine.sorted().map { .string($0) })
     }
 
     init(alwaysOnSameLine: [String] = ["@IBAction", "@NSManaged"],

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -4,7 +4,7 @@ struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = AttributesRule
 
     @ConfigurationElement(key: "severity")
-    var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "attributes_with_arguments_always_on_line_above")
     private(set) var attributesWithArgumentsAlwaysOnNewLine = true
     @ConfigurationElement(key: "always_on_same_line")

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = AttributesRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "attributes_with_arguments_always_on_line_above")
     private(set) var attributesWithArgumentsAlwaysOnNewLine = true

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -1,16 +1,16 @@
+import SwiftLintCore
+
 struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = AttributesRule
 
+    @ConfigurationElement("severity")
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("attributes_with_arguments_always_on_line_above")
     private(set) var attributesWithArgumentsAlwaysOnNewLine = true
+    @ConfigurationElement("always_on_same_line")
     private(set) var alwaysOnSameLine = Set<String>()
+    @ConfigurationElement("always_on_line_above")
     private(set) var alwaysOnNewLine = Set<String>()
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "always_on_same_line" => .list(alwaysOnSameLine.sorted().map { .string($0) })
-        "always_on_line_above" => .list(alwaysOnNewLine.sorted().map { .string($0) })
-    }
 
     init(alwaysOnSameLine: [String] = ["@IBAction", "@NSManaged"],
          alwaysInNewLine: [String] = []) {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -3,13 +3,13 @@ import SwiftLintCore
 struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = AttributesRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("attributes_with_arguments_always_on_line_above")
+    @ConfigurationElement(key: "attributes_with_arguments_always_on_line_above")
     private(set) var attributesWithArgumentsAlwaysOnNewLine = true
-    @ConfigurationElement("always_on_same_line")
+    @ConfigurationElement(key: "always_on_same_line")
     private(set) var alwaysOnSameLine = Set<String>()
-    @ConfigurationElement("always_on_line_above")
+    @ConfigurationElement(key: "always_on_line_above")
     private(set) var alwaysOnNewLine = Set<String>()
 
     init(alwaysOnSameLine: [String] = ["@IBAction", "@NSManaged"],

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -6,7 +6,7 @@ struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var alwaysOnSameLine = Set<String>()
     private(set) var alwaysOnNewLine = Set<String>()
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "always_on_same_line" => .list(alwaysOnSameLine.sorted().map { .string($0) })
         "always_on_line_above" => .list(alwaysOnNewLine.sorted().map { .string($0) })

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
@@ -11,10 +11,10 @@ struct BlanketDisableCommandConfiguration: SeverityBasedRuleConfiguration, Equat
     ]
     private(set) var alwaysBlanketDisableRuleIdentifiers: Set<String> = []
 
-    var consoleDescription: String {
-        "severity: \(severityConfiguration.consoleDescription)" +
-        ", allowed_rules: \(allowedRuleIdentifiers.sorted())" +
-        ", always_blanket_disable: \(alwaysBlanketDisableRuleIdentifiers.sorted())"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "allowed_rules" => .list(allowedRuleIdentifiers.sorted().map { .symbol($0) })
+        "always_blanket_disable" => .list(alwaysBlanketDisableRuleIdentifiers.sorted().map { .symbol($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct BlanketDisableCommandConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = BlanketDisableCommandRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allowed_rules")
     private(set) var allowedRuleIdentifiers: Set<String> = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
@@ -1,7 +1,11 @@
+import SwiftLintCore
+
 struct BlanketDisableCommandConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = BlanketDisableCommandRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "allowed_rules")
     private(set) var allowedRuleIdentifiers: Set<String> = [
         "file_header",
         "file_length",
@@ -9,13 +13,8 @@ struct BlanketDisableCommandConfiguration: SeverityBasedRuleConfiguration, Equat
         "file_name_no_space",
         "single_test_class"
     ]
+    @ConfigurationElement(key: "always_blanket_disable")
     private(set) var alwaysBlanketDisableRuleIdentifiers: Set<String> = []
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "allowed_rules" => .list(allowedRuleIdentifiers.sorted().map { .symbol($0) })
-        "always_blanket_disable" => .list(alwaysBlanketDisableRuleIdentifiers.sorted().map { .symbol($0) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
@@ -33,9 +32,5 @@ struct BlanketDisableCommandConfiguration: SeverityBasedRuleConfiguration, Equat
         if let alwaysBlanketDisableRuleIdentifiers = configuration["always_blanket_disable"] as? [String] {
             self.alwaysBlanketDisableRuleIdentifiers = Set(alwaysBlanketDisableRuleIdentifiers)
         }
-    }
-
-    var severity: ViolationSeverity {
-        severityConfiguration.severity
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct BlanketDisableCommandConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = BlanketDisableCommandRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allowed_rules")
     private(set) var allowedRuleIdentifiers: Set<String> = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
@@ -11,7 +11,7 @@ struct BlanketDisableCommandConfiguration: SeverityBasedRuleConfiguration, Equat
     ]
     private(set) var alwaysBlanketDisableRuleIdentifiers: Set<String> = []
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "allowed_rules" => .list(allowedRuleIdentifiers.sorted().map { .symbol($0) })
         "always_blanket_disable" => .list(alwaysBlanketDisableRuleIdentifiers.sorted().map { .symbol($0) })

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = CollectionAlignmentRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("align_colons")
+    @ConfigurationElement(key: "align_colons")
     private(set) var alignColons = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -6,8 +6,9 @@ struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatab
 
     init() {}
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", align_colons: \(alignColons)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "align_colons" => .flag(alignColons)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -1,15 +1,12 @@
+import SwiftLintCore
+
 struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = CollectionAlignmentRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("align_colons")
     private(set) var alignColons = false
-
-    init() {}
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "align_colons" => .flag(alignColons)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -6,7 +6,7 @@ struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatab
 
     init() {}
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "align_colons" => .flag(alignColons)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = CollectionAlignmentRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "align_colons")
     private(set) var alignColons = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct ColonConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ColonRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "flexible_right_spacing")
     private(set) var flexibleRightSpacing = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -5,7 +5,7 @@ struct ColonConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var flexibleRightSpacing = false
     private(set) var applyToDictionaries = true
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "flexible_right_spacing" => .flag(flexibleRightSpacing)
         "apply_to_dictionaries" => .flag(applyToDictionaries)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -1,15 +1,14 @@
+import SwiftLintCore
+
 struct ColonConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ColonRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("flexible_right_spacing")
     private(set) var flexibleRightSpacing = false
+    @ConfigurationElement("apply_to_dictionaries")
     private(set) var applyToDictionaries = true
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "flexible_right_spacing" => .flag(flexibleRightSpacing)
-        "apply_to_dictionaries" => .flag(applyToDictionaries)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -3,11 +3,11 @@ import SwiftLintCore
 struct ColonConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ColonRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("flexible_right_spacing")
+    @ConfigurationElement(key: "flexible_right_spacing")
     private(set) var flexibleRightSpacing = false
-    @ConfigurationElement("apply_to_dictionaries")
+    @ConfigurationElement(key: "apply_to_dictionaries")
     private(set) var applyToDictionaries = true
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -5,10 +5,10 @@ struct ColonConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var flexibleRightSpacing = false
     private(set) var applyToDictionaries = true
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", flexible_right_spacing: \(flexibleRightSpacing)" +
-            ", apply_to_dictionaries: \(applyToDictionaries)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "flexible_right_spacing" => .flag(flexibleRightSpacing)
+        "apply_to_dictionaries" => .flag(applyToDictionaries)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
@@ -7,9 +7,7 @@ struct ComputedAccessorsOrderConfiguration: SeverityBasedRuleConfiguration, Equa
         case getSet = "get_set"
         case setGet = "set_get"
 
-        func asOption() -> OptionType {
-            .symbol(rawValue)
-        }
+        func asOption() -> OptionType { .symbol(rawValue) }
     }
 
     @ConfigurationElement

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
@@ -12,9 +12,9 @@ struct ComputedAccessorsOrderConfiguration: SeverityBasedRuleConfiguration, Equa
         }
     }
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("order")
+    @ConfigurationElement(key: "order")
     private(set) var order = Order.getSet
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
@@ -12,7 +12,7 @@ struct ComputedAccessorsOrderConfiguration: SeverityBasedRuleConfiguration, Equa
         }
     }
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "order")
     private(set) var order = Order.getSet

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
@@ -9,9 +9,9 @@ struct ComputedAccessorsOrderConfiguration: SeverityBasedRuleConfiguration, Equa
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var order = Order.getSet
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)"
-            + ", order: \(order.rawValue)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "order" => .symbol(order.rawValue)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
@@ -1,18 +1,21 @@
+import SwiftLintCore
+
 struct ComputedAccessorsOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ComputedAccessorsOrderRule
 
-    enum Order: String {
+    enum Order: String, AcceptableByConfigurationElement {
         case getSet = "get_set"
         case setGet = "set_get"
+
+        func asOption() -> OptionType {
+            .symbol(rawValue)
+        }
     }
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("order")
     private(set) var order = Order.getSet
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "order" => .symbol(order.rawValue)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
@@ -9,7 +9,7 @@ struct ComputedAccessorsOrderConfiguration: SeverityBasedRuleConfiguration, Equa
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var order = Order.getSet
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "order" => .symbol(order.rawValue)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ConditionalReturnsOnNewlineRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "if_only")
     private(set) var ifOnly = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -1,7 +1,11 @@
+import SwiftLintCore
+
 struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ConditionalReturnsOnNewlineRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("if_only")
     private(set) var ifOnly = false
 
     var parameterDescription: RuleConfigurationDescription? {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ConditionalReturnsOnNewlineRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("if_only")
+    @ConfigurationElement(key: "if_only")
     private(set) var ifOnly = false
 
     var parameterDescription: RuleConfigurationDescription? {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -8,11 +8,6 @@ struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration,
     @ConfigurationElement(key: "if_only")
     private(set) var ifOnly = false
 
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "if_only" => .flag(ifOnly)
-    }
-
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw Issue.unknownConfiguration(ruleID: Parent.identifier)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -4,7 +4,7 @@ struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration,
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var ifOnly = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "if_only" => .flag(ifOnly)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -4,8 +4,9 @@ struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration,
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var ifOnly = false
 
-    var consoleDescription: String {
-        return ["severity: \(severityConfiguration.consoleDescription)", "if_only: \(ifOnly)"].joined(separator: ", ")
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "if_only" => .flag(ifOnly)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -24,7 +24,7 @@ struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
     private(set) var length = SeverityLevelsConfiguration<Parent>(warning: 10, error: 20)
     private(set) var complexityStatements = Self.defaultComplexityStatements
 
-    @ConfigurationElement(ConfigurationKey.ignoresCaseStatements.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.ignoresCaseStatements.rawValue)
     private(set) var ignoresCaseStatements = false {
         didSet {
             if ignoresCaseStatements {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -9,11 +9,6 @@ private enum ConfigurationKey: String {
 struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
     typealias Parent = CyclomaticComplexityRule
 
-    var consoleDescription: String {
-        return length.consoleDescription +
-            ", \(ConfigurationKey.ignoresCaseStatements.rawValue): \(ignoresCaseStatements)"
-    }
-
     private static let defaultComplexityStatements: Set<StatementKind> = [
         .forEach,
         .if,
@@ -35,6 +30,11 @@ struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
                 complexityStatements.insert(.case)
             }
         }
+    }
+
+    var parameterDescription: RuleConfigurationDescription {
+        length
+        ConfigurationKey.ignoresCaseStatements.rawValue => .flag(ignoresCaseStatements)
     }
 
     var params: [RuleParameter<Int>] {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -32,7 +32,7 @@ struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
         }
     }
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         length
         ConfigurationKey.ignoresCaseStatements.rawValue => .flag(ignoresCaseStatements)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -1,4 +1,5 @@
 import SourceKittenFramework
+import SwiftLintCore
 
 private enum ConfigurationKey: String {
     case warning = "warning"
@@ -19,9 +20,11 @@ struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
         .case
     ]
 
+    @ConfigurationElement
     private(set) var length = SeverityLevelsConfiguration<Parent>(warning: 10, error: 20)
     private(set) var complexityStatements = Self.defaultComplexityStatements
 
+    @ConfigurationElement(ConfigurationKey.ignoresCaseStatements.rawValue)
     private(set) var ignoresCaseStatements = false {
         didSet {
             if ignoresCaseStatements {
@@ -30,11 +33,6 @@ struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
                 complexityStatements.insert(.case)
             }
         }
-    }
-
-    var parameterDescription: RuleConfigurationDescription? {
-        length
-        ConfigurationKey.ignoresCaseStatements.rawValue => .flag(ignoresCaseStatements)
     }
 
     var params: [RuleParameter<Int>] {
@@ -46,7 +44,7 @@ struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
             configurationArray.isNotEmpty {
             let warning = configurationArray[0]
             let error = (configurationArray.count > 1) ? configurationArray[1] : nil
-            length = SeverityLevelsConfiguration(warning: warning, error: error)
+            length = SeverityLevelsConfiguration<Parent>(warning: warning, error: error)
         } else if let configDict = configuration as? [String: Any], configDict.isNotEmpty {
             for (string, value) in configDict {
                 guard let key = ConfigurationKey(rawValue: string) else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
@@ -109,7 +109,7 @@ struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equatable 
 
     private let targets: [String: Version]
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         for (platform, target) in targets.sorted(by: { $0.key < $1.key }) {
             platform => .symbol(target.stringValue)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
@@ -109,10 +109,11 @@ struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equatable 
 
     private let targets: [String: Version]
 
-    var consoleDescription: String {
-        "severity: \(severityConfiguration.consoleDescription)" + targets
-            .sorted { $0.key < $1.key }
-            .map { ", \($0): \($1.stringValue)" }.joined()
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        for (platform, target) in targets.sorted(by: { $0.key < $1.key }) {
+            platform => .symbol(target.stringValue)
+        }
     }
 
     init() {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -7,8 +7,9 @@ struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equat
 
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", types: \(discouragedInits.sorted(by: <))"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "types" => .list(discouragedInits.sorted(by: <).map { .symbol($0) })
     }
 
     private(set) var discouragedInits: Set<String>

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -7,7 +7,7 @@ private func toExplicitInitMethod(typeName: String) -> String {
 struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = DiscouragedDirectInitRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
     private static let defaultDiscouragedInits = [
@@ -16,7 +16,7 @@ struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equat
         "UIDevice"
     ]
 
-    @ConfigurationElement("types")
+    @ConfigurationElement(key: "types")
     private(set) var discouragedInits = Set(
         Self.defaultDiscouragedInits + Self.defaultDiscouragedInits.map(toExplicitInitMethod)
     )

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -7,7 +7,7 @@ private func toExplicitInitMethod(typeName: String) -> String {
 struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = DiscouragedDirectInitRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
     private static let defaultDiscouragedInits = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private func toExplicitInitMethod(typeName: String) -> String {
     return "\(typeName).init"
 }
@@ -5,26 +7,19 @@ private func toExplicitInitMethod(typeName: String) -> String {
 struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = DiscouragedDirectInitRule
 
+    @ConfigurationElement("severity")
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "types" => .list(discouragedInits.sorted(by: <).map { .symbol($0) })
-    }
-
-    private(set) var discouragedInits: Set<String>
-
-    private let defaultDiscouragedInits = [
+    private static let defaultDiscouragedInits = [
         "Bundle",
         "NSError",
         "UIDevice"
     ]
 
-    init() {
-        discouragedInits = Set(defaultDiscouragedInits + defaultDiscouragedInits.map(toExplicitInitMethod))
-    }
-
-    // MARK: - RuleConfiguration
+    @ConfigurationElement("types")
+    private(set) var discouragedInits = Set(
+        Self.defaultDiscouragedInits + Self.defaultDiscouragedInits.map(toExplicitInitMethod)
+    )
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -7,7 +7,7 @@ struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equat
 
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "types" => .list(discouragedInits.sorted(by: <).map { .symbol($0) })
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -9,9 +9,9 @@ struct EmptyCountConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.error)
     private(set) var onlyAfterDot = false
 
-    var consoleDescription: String {
-        return ["severity: \(severityConfiguration.consoleDescription)",
-                "\(ConfigurationKey.onlyAfterDot.rawValue): \(onlyAfterDot)"].joined(separator: ", ")
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        ConfigurationKey.onlyAfterDot.rawValue => .flag(onlyAfterDot)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -9,7 +9,7 @@ struct EmptyCountConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.error)
     private(set) var onlyAfterDot = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         ConfigurationKey.onlyAfterDot.rawValue => .flag(onlyAfterDot)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case severity = "severity"
     case onlyAfterDot = "only_after_dot"
@@ -6,13 +8,10 @@ private enum ConfigurationKey: String {
 struct EmptyCountConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = EmptyCountRule
 
+    @ConfigurationElement(ConfigurationKey.severity.rawValue)
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.error)
+    @ConfigurationElement(ConfigurationKey.onlyAfterDot.rawValue)
     private(set) var onlyAfterDot = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        ConfigurationKey.onlyAfterDot.rawValue => .flag(onlyAfterDot)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -8,9 +8,9 @@ private enum ConfigurationKey: String {
 struct EmptyCountConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = EmptyCountRule
 
-    @ConfigurationElement(ConfigurationKey.severity.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.severity.rawValue)
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.error)
-    @ConfigurationElement(ConfigurationKey.onlyAfterDot.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.onlyAfterDot.rawValue)
     private(set) var onlyAfterDot = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -8,7 +8,7 @@ private enum ConfigurationKey: String {
 struct EmptyCountConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = EmptyCountRule
 
-    @ConfigurationElement(key: ConfigurationKey.severity.rawValue)
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.error)
     @ConfigurationElement(key: ConfigurationKey.onlyAfterDot.rawValue)
     private(set) var onlyAfterDot = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -18,25 +18,25 @@ struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         }
     }
 
-    @ConfigurationElement("approaching_expiry_severity")
+    @ConfigurationElement(key: "approaching_expiry_severity")
     private(set) var approachingExpirySeverity = Severity(.warning)
-    @ConfigurationElement("expired_severity")
+    @ConfigurationElement(key: "expired_severity")
     private(set) var expiredSeverity = Severity(.error)
-    @ConfigurationElement("bad_formatting_severity")
+    @ConfigurationElement(key: "bad_formatting_severity")
     private(set) var badFormattingSeverity = Severity(.error)
 
     // swiftlint:disable:next todo
     /// The number of days prior to expiry before the TODO emits a violation
-    @ConfigurationElement("approaching_expiry_threshold")
+    @ConfigurationElement(key: "approaching_expiry_threshold")
     private(set) var approachingExpiryThreshold = 15
     /// The opening/closing characters used to surround the expiry-date string
-    @ConfigurationElement("date_delimiters")
+    @ConfigurationElement(key: "date_delimiters")
     private(set) var dateDelimiters = DelimiterConfiguration.default
     /// The format which should be used to the expiry-date string into a `Date` object
-    @ConfigurationElement("date_format")
+    @ConfigurationElement(key: "date_format")
     private(set) var dateFormat = "MM/dd/yyyy"
     /// The separator used for regex detection of the expiry-date string
-    @ConfigurationElement("date_separator")
+    @ConfigurationElement(key: "date_separator")
     private(set) var dateSeparator = "/"
 
     init(

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -9,17 +9,17 @@ struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         fileprivate(set) var closing: String
     }
 
-    var consoleDescription: String {
-        let descriptions = [
-            "approaching_expiry_severity: \(approachingExpirySeverity.consoleDescription)",
-            "expired_severity: \(expiredSeverity.consoleDescription)",
-            "bad_formatting_severity: \(badFormattingSeverity.consoleDescription)",
-            "approaching_expiry_threshold: \(approachingExpiryThreshold)",
-            "date_format: \(dateFormat)",
-            "date_delimiters: { opening: \(dateDelimiters.opening)", "closing: \(dateDelimiters.closing) }",
-            "date_separator: \(dateSeparator)"
-        ]
-        return descriptions.joined(separator: ", ")
+    var parameterDescription: RuleConfigurationDescription {
+        "approaching_expiry_severity" => .severity(approachingExpirySeverity.severity)
+        "expired_severity" => .severity(expiredSeverity.severity)
+        "bad_formatting_severity" => .severity(badFormattingSeverity.severity)
+        "approaching_expiry_threshold" => .integer(approachingExpiryThreshold)
+        "date_format" => .string(dateFormat)
+        "date_delimiters" => .nest {
+            "opening" => .string(dateDelimiters.opening)
+            "closing" => .string(dateDelimiters.closing)
+        }
+        "date_separator" => .string(dateSeparator)
     }
 
     private(set) var approachingExpirySeverity: Severity

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -9,7 +9,7 @@ struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         fileprivate(set) var closing: String
     }
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         "approaching_expiry_severity" => .severity(approachingExpirySeverity.severity)
         "expired_severity" => .severity(expiredSeverity.severity)
         "bad_formatting_severity" => .severity(badFormattingSeverity.severity)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -1,42 +1,43 @@
+import SwiftLintCore
+
 struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
     typealias Parent = ExpiringTodoRule
     typealias Severity = SeverityConfiguration<Parent>
 
-    struct DelimiterConfiguration: Equatable {
+    struct DelimiterConfiguration: Equatable, AcceptableByConfigurationElement {
         static let `default`: DelimiterConfiguration = .init(opening: "[", closing: "]")
 
         fileprivate(set) var opening: String
         fileprivate(set) var closing: String
-    }
 
-    var parameterDescription: RuleConfigurationDescription? {
-        "approaching_expiry_severity" => .severity(approachingExpirySeverity.severity)
-        "expired_severity" => .severity(expiredSeverity.severity)
-        "bad_formatting_severity" => .severity(badFormattingSeverity.severity)
-        "approaching_expiry_threshold" => .integer(approachingExpiryThreshold)
-        "date_format" => .string(dateFormat)
-        "date_delimiters" => .nest {
-            "opening" => .string(dateDelimiters.opening)
-            "closing" => .string(dateDelimiters.closing)
+        func asOption() -> OptionType {
+            .nest {
+                "opening" => .string(opening)
+                "closing" => .string(closing)
+            }
         }
-        "date_separator" => .string(dateSeparator)
     }
 
-    private(set) var approachingExpirySeverity: Severity
-
-    private(set) var expiredSeverity: Severity
-
-    private(set) var badFormattingSeverity: Severity
+    @ConfigurationElement("approaching_expiry_severity")
+    private(set) var approachingExpirySeverity = Severity(.warning)
+    @ConfigurationElement("expired_severity")
+    private(set) var expiredSeverity = Severity(.error)
+    @ConfigurationElement("bad_formatting_severity")
+    private(set) var badFormattingSeverity = Severity(.error)
 
     // swiftlint:disable:next todo
     /// The number of days prior to expiry before the TODO emits a violation
-    private(set) var approachingExpiryThreshold: Int
+    @ConfigurationElement("approaching_expiry_threshold")
+    private(set) var approachingExpiryThreshold = 15
     /// The opening/closing characters used to surround the expiry-date string
-    private(set) var dateDelimiters: DelimiterConfiguration
+    @ConfigurationElement("date_delimiters")
+    private(set) var dateDelimiters = DelimiterConfiguration.default
     /// The format which should be used to the expiry-date string into a `Date` object
-    private(set) var dateFormat: String
+    @ConfigurationElement("date_format")
+    private(set) var dateFormat = "MM/dd/yyyy"
     /// The separator used for regex detection of the expiry-date string
-    private(set) var dateSeparator: String
+    @ConfigurationElement("date_separator")
+    private(set) var dateSeparator = "/"
 
     init(
         approachingExpirySeverity: Severity = .init(.warning),

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -16,7 +16,7 @@ struct ExplicitTypeInterfaceConfiguration: SeverityBasedRuleConfiguration, Equat
 
     private(set) var allowRedundancy = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         let excludedKinds = VariableKind.all.subtracting(allowedKinds).map(\.rawValue).sorted()
         severityConfiguration
         "excluded" => .list(excludedKinds.map { .symbol($0) })

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -16,7 +16,7 @@ struct ExplicitTypeInterfaceConfiguration: SeverityBasedRuleConfiguration, Equat
         }
     }
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "excluded")
     private(set) var excluded = [VariableKind]()

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -16,7 +16,7 @@ struct ExplicitTypeInterfaceConfiguration: SeverityBasedRuleConfiguration, Equat
         }
     }
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "excluded")
     private(set) var excluded = [VariableKind]()

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -11,9 +11,7 @@ struct ExplicitTypeInterfaceConfiguration: SeverityBasedRuleConfiguration, Equat
 
         static let all = Set(allCases)
 
-        func asOption() -> SwiftLintCore.OptionType {
-            .symbol(rawValue)
-        }
+        func asOption() -> SwiftLintCore.OptionType { .symbol(rawValue) }
     }
 
     @ConfigurationElement

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -16,14 +16,12 @@ struct ExplicitTypeInterfaceConfiguration: SeverityBasedRuleConfiguration, Equat
 
     private(set) var allowRedundancy = false
 
-    var consoleDescription: String {
+    var parameterDescription: RuleConfigurationDescription {
         let excludedKinds = VariableKind.all.subtracting(allowedKinds).map(\.rawValue).sorted()
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", excluded: \(excludedKinds)" +
-            ", allow_redundancy: \(allowRedundancy)"
+        severityConfiguration
+        "excluded" => .list(excludedKinds.map { .symbol($0) })
+        "allow_redundancy" => .flag(allowRedundancy)
     }
-
-    init() {}
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SourceKittenFramework
+import SwiftLintCore
 
 struct FileHeaderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileHeaderRule
@@ -9,24 +10,21 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private static let patternRegexOptions: NSRegularExpression.Options =
         [.anchorsMatchLines, .dotMatchesLineSeparators]
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    private var requiredString: String?
-    private var requiredPattern: String?
-    private var forbiddenString: String?
-    private var forbiddenPattern: String?
+    @ConfigurationElement("required_string")
+    private var requiredString: String? = nil
+    @ConfigurationElement("required_pattern")
+    private var requiredPattern: String? = nil
+    @ConfigurationElement("forbidden_string")
+    private var forbiddenString: String? = nil
+    @ConfigurationElement("forbidden_pattern")
+    private var forbiddenPattern: String? = nil
 
     private var _forbiddenRegex: NSRegularExpression?
     private var _requiredRegex: NSRegularExpression?
 
     private static let defaultRegex = regex("\\bCopyright\\b", options: [.caseInsensitive])
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "required_string" => .string(requiredString ?? "None")
-        "required_pattern" => .string(requiredPattern ?? "None")
-        "forbidden_string" => .string(forbiddenString ?? "None")
-        "forbidden_pattern" => .string(forbiddenPattern ?? "None")
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: String] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -13,13 +13,13 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "required_string")
-    private var requiredString: String? = nil
+    private var requiredString: String?
     @ConfigurationElement(key: "required_pattern")
-    private var requiredPattern: String? = nil
+    private var requiredPattern: String?
     @ConfigurationElement(key: "forbidden_string")
-    private var forbiddenString: String? = nil
+    private var forbiddenString: String?
     @ConfigurationElement(key: "forbidden_pattern")
-    private var forbiddenPattern: String? = nil
+    private var forbiddenPattern: String?
 
     private var _forbiddenRegex: NSRegularExpression?
     private var _requiredRegex: NSRegularExpression?

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -10,15 +10,15 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private static let patternRegexOptions: NSRegularExpression.Options =
         [.anchorsMatchLines, .dotMatchesLineSeparators]
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("required_string")
+    @ConfigurationElement(key: "required_string")
     private var requiredString: String? = nil
-    @ConfigurationElement("required_pattern")
+    @ConfigurationElement(key: "required_pattern")
     private var requiredPattern: String? = nil
-    @ConfigurationElement("forbidden_string")
+    @ConfigurationElement(key: "forbidden_string")
     private var forbiddenString: String? = nil
-    @ConfigurationElement("forbidden_pattern")
+    @ConfigurationElement(key: "forbidden_pattern")
     private var forbiddenPattern: String? = nil
 
     private var _forbiddenRegex: NSRegularExpression?

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -20,7 +20,7 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration, Equatable {
 
     private static let defaultRegex = regex("\\bCopyright\\b", options: [.caseInsensitive])
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "required_string" => .string(requiredString ?? "None")
         "required_pattern" => .string(requiredPattern ?? "None")

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -20,20 +20,13 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration, Equatable {
 
     private static let defaultRegex = regex("\\bCopyright\\b", options: [.caseInsensitive])
 
-    var consoleDescription: String {
-        let requiredStringDescription = requiredString ?? "None"
-        let requiredPatternDescription = requiredPattern ?? "None"
-        let forbiddenStringDescription = forbiddenString ?? "None"
-        let forbiddenPatternDescription = forbiddenPattern ?? "None"
-
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", required_string: \(requiredStringDescription)" +
-            ", required_pattern: \(requiredPatternDescription)" +
-            ", forbidden_string: \(forbiddenStringDescription)" +
-            ", forbidden_pattern: \(forbiddenPatternDescription)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "required_string" => .string(requiredString ?? "None")
+        "required_pattern" => .string(requiredPattern ?? "None")
+        "forbidden_string" => .string(forbiddenString ?? "None")
+        "forbidden_pattern" => .string(forbiddenPattern ?? "None")
     }
-
-    init() {}
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: String] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -10,7 +10,7 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private static let patternRegexOptions: NSRegularExpression.Options =
         [.anchorsMatchLines, .dotMatchesLineSeparators]
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "required_string")
     private var requiredString: String? = nil

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
@@ -10,7 +10,7 @@ struct FileLengthConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 400, error: 1000)
     private(set) var ignoreCommentOnlyLines = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         ConfigurationKey.ignoreCommentOnlyLines.rawValue => .flag(ignoreCommentOnlyLines)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
@@ -10,9 +10,9 @@ struct FileLengthConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 400, error: 1000)
     private(set) var ignoreCommentOnlyLines = false
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", \(ConfigurationKey.ignoreCommentOnlyLines.rawValue): \(ignoreCommentOnlyLines)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        ConfigurationKey.ignoreCommentOnlyLines.rawValue => .flag(ignoreCommentOnlyLines)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case warning = "warning"
     case error = "error"
@@ -7,13 +9,10 @@ private enum ConfigurationKey: String {
 struct FileLengthConfiguration: RuleConfiguration, Equatable {
     typealias Parent = FileLengthRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 400, error: 1000)
+    @ConfigurationElement(ConfigurationKey.ignoreCommentOnlyLines.rawValue)
     private(set) var ignoreCommentOnlyLines = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        ConfigurationKey.ignoreCommentOnlyLines.rawValue => .flag(ignoreCommentOnlyLines)
-    }
 
     mutating func apply(configuration: Any) throws {
         if let configurationArray = [Int].array(of: configuration),

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
@@ -11,7 +11,7 @@ struct FileLengthConfiguration: RuleConfiguration, Equatable {
 
     @ConfigurationElement
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 400, error: 1000)
-    @ConfigurationElement(ConfigurationKey.ignoreCommentOnlyLines.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.ignoreCommentOnlyLines.rawValue)
     private(set) var ignoreCommentOnlyLines = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -1,19 +1,18 @@
+import SwiftLintCore
+
 struct FileNameConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileNameRule
 
-    private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
+    @ConfigurationElement
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "excluded")
     private(set) var excluded = Set<String>(["main.swift", "LinuxMain.swift"])
+    @ConfigurationElement(key: "prefix_pattern")
     private(set) var prefixPattern = ""
+    @ConfigurationElement(key: "suffix_pattern")
     private(set) var suffixPattern = "\\+.*"
+    @ConfigurationElement(key: "nested_type_separator")
     private(set) var nestedTypeSeparator = "."
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "excluded" => .list(excluded.sorted().map { .string($0) })
-        "prefix_pattern" => .string(prefixPattern)
-        "suffix_pattern" => .string(suffixPattern)
-        "nested_type_separator" => .string(nestedTypeSeparator)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct FileNameConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileNameRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "excluded")
     private(set) var excluded = Set<String>(["main.swift", "LinuxMain.swift"])

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct FileNameConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileNameRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "excluded")
     private(set) var excluded = Set<String>(["main.swift", "LinuxMain.swift"])

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -7,7 +7,7 @@ struct FileNameConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var suffixPattern = "\\+.*"
     private(set) var nestedTypeSeparator = "."
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "excluded" => .list(excluded.sorted().map { .string($0) })
         "prefix_pattern" => .string(prefixPattern)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -1,19 +1,19 @@
 struct FileNameConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileNameRule
 
-    var consoleDescription: String {
-        return "(severity) \(severityConfiguration.consoleDescription), " +
-            "excluded: \(excluded.sorted()), " +
-            "prefix_pattern: \(prefixPattern), " +
-            "suffix_pattern: \(suffixPattern), " +
-            "nested_type_separator: \(nestedTypeSeparator)"
-    }
-
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     private(set) var excluded = Set<String>(["main.swift", "LinuxMain.swift"])
     private(set) var prefixPattern = ""
     private(set) var suffixPattern = "\\+.*"
     private(set) var nestedTypeSeparator = "."
+
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "excluded" => .list(excluded.sorted().map { .string($0) })
+        "prefix_pattern" => .string(prefixPattern)
+        "suffix_pattern" => .string(suffixPattern)
+        "nested_type_separator" => .string(nestedTypeSeparator)
+    }
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
@@ -1,13 +1,12 @@
+import SwiftLintCore
+
 struct FileNameNoSpaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileNameNoSpaceRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
+    @ConfigurationElement(key: "excluded")
     private(set) var excluded = Set<String>()
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "excluded" => .list(excluded.sorted().map { .string($0) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct FileNameNoSpaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileNameNoSpaceRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "excluded")
     private(set) var excluded = Set<String>()

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
@@ -1,13 +1,13 @@
 struct FileNameNoSpaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileNameNoSpaceRule
 
-    var consoleDescription: String {
-        return "(severity) \(severityConfiguration.consoleDescription), " +
-            "excluded: \(excluded.sorted())"
-    }
-
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     private(set) var excluded = Set<String>()
+
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "excluded" => .list(excluded.sorted().map { .string($0) })
+    }
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct FileNameNoSpaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileNameNoSpaceRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "excluded")
     private(set) var excluded = Set<String>()

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
@@ -4,7 +4,7 @@ struct FileNameNoSpaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     private(set) var excluded = Set<String>()
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "excluded" => .list(excluded.sorted().map { .string($0) })
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -15,9 +15,9 @@ enum FileType: String, AcceptableByConfigurationElement {
 struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
     typealias Parent = FileTypesOrderRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("order")
+    @ConfigurationElement(key: "order")
     private(set) var order: [[FileType]] = [
         [.supportingType],
         [.mainType],

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -18,7 +18,7 @@ struct FileTypesOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
         [.libraryContentProvider]
     ]
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "order" => .list(order.map { .list($0.map(\.rawValue).map { .symbol($0) }) })
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -18,9 +18,9 @@ struct FileTypesOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
         [.libraryContentProvider]
     ]
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", order: \(String(describing: order))"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "order" => .list(order.map { .list($0.map(\.rawValue).map { .symbol($0) }) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -15,7 +15,7 @@ enum FileType: String, AcceptableByConfigurationElement {
 struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
     typealias Parent = FileTypesOrderRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "order")
     private(set) var order: [[FileType]] = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -1,15 +1,23 @@
-enum FileType: String {
+import SwiftLintCore
+
+enum FileType: String, AcceptableByConfigurationElement {
     case supportingType = "supporting_type"
     case mainType = "main_type"
     case `extension` = "extension"
     case previewProvider = "preview_provider"
     case libraryContentProvider = "library_content_provider"
+
+    func asOption() -> OptionType {
+        .symbol(rawValue)
+    }
 }
 
-struct FileTypesOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
+struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
     typealias Parent = FileTypesOrderRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("order")
     private(set) var order: [[FileType]] = [
         [.supportingType],
         [.mainType],
@@ -17,11 +25,6 @@ struct FileTypesOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
         [.previewProvider],
         [.libraryContentProvider]
     ]
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "order" => .list(order.map { .list($0.map(\.rawValue).map { .symbol($0) }) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -7,12 +7,10 @@ enum FileType: String, AcceptableByConfigurationElement {
     case previewProvider = "preview_provider"
     case libraryContentProvider = "library_content_provider"
 
-    func asOption() -> OptionType {
-        .symbol(rawValue)
-    }
+    func asOption() -> OptionType { .symbol(rawValue) }
 }
 
-struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
+struct FileTypesOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = FileTypesOrderRule
 
     @ConfigurationElement

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
@@ -4,7 +4,7 @@ struct ForWhereConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var allowForAsFilter = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "allow_for_as_filter" => .flag(allowForAsFilter)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
@@ -1,13 +1,12 @@
+import SwiftLintCore
+
 struct ForWhereConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ForWhereRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "allow_for_as_filter")
     private(set) var allowForAsFilter = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "allow_for_as_filter" => .flag(allowForAsFilter)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct ForWhereConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ForWhereRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allow_for_as_filter")
     private(set) var allowForAsFilter = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct ForWhereConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ForWhereRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allow_for_as_filter")
     private(set) var allowForAsFilter = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
@@ -4,8 +4,9 @@ struct ForWhereConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var allowForAsFilter = false
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", allow_for_as_filter: \(allowForAsFilter)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "allow_for_as_filter" => .flag(allowForAsFilter)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -10,7 +10,7 @@ struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable {
     private(set) var ignoresDefaultParameters = true
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 5, error: 8)
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         ConfigurationKey.ignoresDefaultParameters.rawValue => .flag(ignoresDefaultParameters)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -10,9 +10,9 @@ struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable {
     private(set) var ignoresDefaultParameters = true
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 5, error: 8)
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-        ", \(ConfigurationKey.ignoresDefaultParameters.rawValue): \(ignoresDefaultParameters)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        ConfigurationKey.ignoresDefaultParameters.rawValue => .flag(ignoresDefaultParameters)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -11,7 +11,7 @@ struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable {
 
     @ConfigurationElement
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 5, error: 8)
-    @ConfigurationElement("ignores_default_parameters")
+    @ConfigurationElement(key: "ignores_default_parameters")
     private(set) var ignoresDefaultParameters = true
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case warning = "warning"
     case error = "error"
@@ -7,13 +9,10 @@ private enum ConfigurationKey: String {
 struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable {
     typealias Parent = FunctionParameterCountRule
 
-    private(set) var ignoresDefaultParameters = true
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 5, error: 8)
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        ConfigurationKey.ignoresDefaultParameters.rawValue => .flag(ignoresDefaultParameters)
-    }
+    @ConfigurationElement("ignores_default_parameters")
+    private(set) var ignoresDefaultParameters = true
 
     mutating func apply(configuration: Any) throws {
         if let configurationArray = [Int].array(of: configuration),

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -13,10 +13,10 @@ struct ImplicitReturnConfiguration: SeverityBasedRuleConfiguration, Equatable {
 
     private(set) var includedKinds = Self.defaultIncludedKinds
 
-    var consoleDescription: String {
+    var parameterDescription: RuleConfigurationDescription {
         let includedKinds = self.includedKinds.map { $0.rawValue }
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", included: [\(includedKinds.sorted().joined(separator: ", "))]"
+        severityConfiguration
+        "included" => .list(includedKinds.sorted().map { .symbol($0) })
     }
 
     init(includedKinds: Set<ReturnKind> = Self.defaultIncludedKinds) {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -13,7 +13,7 @@ struct ImplicitReturnConfiguration: SeverityBasedRuleConfiguration, Equatable {
 
     private(set) var includedKinds = Self.defaultIncludedKinds
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         let includedKinds = self.includedKinds.map { $0.rawValue }
         severityConfiguration
         "included" => .list(includedKinds.sorted().map { .symbol($0) })

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
+struct ImplicitReturnConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ImplicitReturnRule
 
     enum ReturnKind: String, CaseIterable, AcceptableByConfigurationElement, Comparable {
@@ -8,9 +8,7 @@ struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
         case function
         case getter
 
-        func asOption() -> OptionType {
-            .symbol(rawValue)
-        }
+        func asOption() -> OptionType { .symbol(rawValue) }
 
         static func < (lhs: Self, rhs: Self) -> Bool {
             lhs.rawValue < rhs.rawValue

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -19,9 +19,9 @@ struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
 
     static let defaultIncludedKinds = Set(ReturnKind.allCases)
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("included")
+    @ConfigurationElement(key: "included")
     private(set) var includedKinds = Self.defaultIncludedKinds
 
     init(includedKinds: Set<ReturnKind> = Self.defaultIncludedKinds) {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -1,23 +1,28 @@
-struct ImplicitReturnConfiguration: SeverityBasedRuleConfiguration, Equatable {
+import SwiftLintCore
+
+struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
     typealias Parent = ImplicitReturnRule
 
-    enum ReturnKind: String, CaseIterable {
+    enum ReturnKind: String, CaseIterable, AcceptableByConfigurationElement, Comparable {
         case closure
         case function
         case getter
+
+        func asOption() -> OptionType {
+            .symbol(rawValue)
+        }
+
+        static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
     }
 
     static let defaultIncludedKinds = Set(ReturnKind.allCases)
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-
+    @ConfigurationElement("included")
     private(set) var includedKinds = Self.defaultIncludedKinds
-
-    var parameterDescription: RuleConfigurationDescription? {
-        let includedKinds = self.includedKinds.map { $0.rawValue }
-        severityConfiguration
-        "included" => .list(includedKinds.sorted().map { .symbol($0) })
-    }
 
     init(includedKinds: Set<ReturnKind> = Self.defaultIncludedKinds) {
         self.includedKinds = includedKinds

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -19,7 +19,7 @@ struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
 
     static let defaultIncludedKinds = Set(ReturnKind.allCases)
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "included")
     private(set) var includedKinds = Self.defaultIncludedKinds

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -20,7 +20,7 @@ struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration,
         func asOption() -> OptionType { .symbol(rawValue) }
     }
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "mode")
     private(set) var mode = ImplicitlyUnwrappedOptionalModeConfiguration.allExceptIBOutlets

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -19,7 +19,7 @@ struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration,
     private(set) var mode = ImplicitlyUnwrappedOptionalModeConfiguration.allExceptIBOutlets
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "mode" => .symbol(mode.rawValue)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -19,9 +19,9 @@ struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration,
     private(set) var mode = ImplicitlyUnwrappedOptionalModeConfiguration.allExceptIBOutlets
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", mode: \(mode.rawValue)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "mode" => .symbol(mode.rawValue)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -20,7 +20,7 @@ struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration,
         func asOption() -> OptionType { .symbol(rawValue) }
     }
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "mode")
     private(set) var mode = ImplicitlyUnwrappedOptionalModeConfiguration.allExceptIBOutlets

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -1,8 +1,10 @@
+import SwiftLintCore
+
 struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ImplicitlyUnwrappedOptionalRule
 
     // swiftlint:disable:next type_name
-    enum ImplicitlyUnwrappedOptionalModeConfiguration: String {
+    enum ImplicitlyUnwrappedOptionalModeConfiguration: String, AcceptableByConfigurationElement {
         case all = "all"
         case allExceptIBOutlets = "all_except_iboutlets"
 
@@ -14,15 +16,14 @@ struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration,
                 throw Issue.unknownConfiguration(ruleID: Parent.identifier)
             }
         }
+
+        func asOption() -> OptionType { .symbol(rawValue) }
     }
 
-    private(set) var mode = ImplicitlyUnwrappedOptionalModeConfiguration.allExceptIBOutlets
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "mode" => .symbol(mode.rawValue)
-    }
+    @ConfigurationElement(key: "mode")
+    private(set) var mode = ImplicitlyUnwrappedOptionalModeConfiguration.allExceptIBOutlets
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -15,11 +15,11 @@ struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable
     private(set) var allTerms: [String]
     private(set) var allAllowedTerms: Set<String>
 
-    var consoleDescription: String {
-        "severity: \(severityConfiguration.consoleDescription)"
-            + ", additional_terms: \(additionalTerms?.sorted() ?? [])"
-            + ", override_terms: \(overrideTerms?.sorted() ?? [])"
-            + ", override_allowed_terms: \(overrideAllowedTerms?.sorted() ?? [])"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "additional_terms" => .list(additionalTerms?.sorted().map { .string($0) } ?? [])
+        "override_terms" => .list(overrideTerms?.sorted().map { .string($0) } ?? [])
+        "override_allowed_terms" => .list(overrideAllowedTerms?.sorted().map { .string($0) } ?? [])
     }
 
     private let defaultTerms: Set<String> = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -13,11 +13,11 @@ struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable
     @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "additional_terms")
-    private(set) var additionalTerms: Set<String>? = nil
+    private(set) var additionalTerms: Set<String>?
     @ConfigurationElement(key: "override_terms")
-    private(set) var overrideTerms: Set<String>? = nil
+    private(set) var overrideTerms: Set<String>?
     @ConfigurationElement(key: "override_allowed_terms")
-    private(set) var overrideAllowedTerms: Set<String>? = nil
+    private(set) var overrideAllowedTerms: Set<String>?
     private(set) var allTerms: [String]
     private(set) var allAllowedTerms: Set<String>
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -15,7 +15,7 @@ struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable
     private(set) var allTerms: [String]
     private(set) var allAllowedTerms: Set<String>
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "additional_terms" => .list(additionalTerms?.sorted().map { .string($0) } ?? [])
         "override_terms" => .list(overrideTerms?.sorted().map { .string($0) } ?? [])

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -10,7 +10,7 @@ private enum ConfigurationKey: String {
 struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = InclusiveLanguageRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "additional_terms")
     private(set) var additionalTerms: Set<String>? = nil

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -10,13 +10,13 @@ private enum ConfigurationKey: String {
 struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = InclusiveLanguageRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("additional_terms")
+    @ConfigurationElement(key: "additional_terms")
     private(set) var additionalTerms: Set<String>? = nil
-    @ConfigurationElement("override_terms")
+    @ConfigurationElement(key: "override_terms")
     private(set) var overrideTerms: Set<String>? = nil
-    @ConfigurationElement("override_allowed_terms")
+    @ConfigurationElement(key: "override_allowed_terms")
     private(set) var overrideAllowedTerms: Set<String>? = nil
     private(set) var allTerms: [String]
     private(set) var allAllowedTerms: Set<String>

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case severity
     case additionalTerms = "additional_terms"
@@ -8,19 +10,16 @@ private enum ConfigurationKey: String {
 struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = InclusiveLanguageRule
 
-    var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    private var additionalTerms: Set<String>?
-    private var overrideTerms: Set<String>?
-    private var overrideAllowedTerms: Set<String>?
+    @ConfigurationElement("severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("additional_terms")
+    private(set) var additionalTerms: Set<String>? = nil
+    @ConfigurationElement("override_terms")
+    private(set) var overrideTerms: Set<String>? = nil
+    @ConfigurationElement("override_allowed_terms")
+    private(set) var overrideAllowedTerms: Set<String>? = nil
     private(set) var allTerms: [String]
     private(set) var allAllowedTerms: Set<String>
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "additional_terms" => .list(additionalTerms?.sorted().map { .string($0) } ?? [])
-        "override_terms" => .list(overrideTerms?.sorted().map { .string($0) } ?? [])
-        "override_allowed_terms" => .list(overrideAllowedTerms?.sorted().map { .string($0) } ?? [])
-    }
 
     private let defaultTerms: Set<String> = [
         "whitelist",

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -1,19 +1,19 @@
 struct IndentationWidthConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = IndentationWidthRule
 
-    var consoleDescription: String {
-        return "severity: \("severity: \(severityConfiguration.consoleDescription)"), "
-            + "indentation_width: \(indentationWidth), "
-            + "include_comments: \(includeComments), "
-            + "include_compiler_directives: \(includeCompilerDirectives)"
-            + "include_multiline_strings: \(includeMultilineStrings)"
-    }
-
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     private(set) var indentationWidth = 4
     private(set) var includeComments = true
     private(set) var includeCompilerDirectives = true
     private(set) var includeMultilineStrings = true
+
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "indentation_width" => .integer(indentationWidth)
+        "include_comments" => .flag(includeComments)
+        "include_compiler_directives" => .flag(includeCompilerDirectives)
+        "include_multiline_strings" => .flag(includeMultilineStrings)
+    }
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -1,19 +1,18 @@
+import SwiftLintCore
+
 struct IndentationWidthConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = IndentationWidthRule
 
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
+    @ConfigurationElement(key: "indentation_width")
     private(set) var indentationWidth = 4
+    @ConfigurationElement(key: "include_comments")
     private(set) var includeComments = true
+    @ConfigurationElement(key: "include_compiler_directives")
     private(set) var includeCompilerDirectives = true
+    @ConfigurationElement(key: "include_multiline_strings")
     private(set) var includeMultilineStrings = true
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "indentation_width" => .integer(indentationWidth)
-        "include_comments" => .flag(includeComments)
-        "include_compiler_directives" => .flag(includeCompilerDirectives)
-        "include_multiline_strings" => .flag(includeMultilineStrings)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct IndentationWidthConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = IndentationWidthRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "indentation_width")
     private(set) var indentationWidth = 4

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -7,7 +7,7 @@ struct IndentationWidthConfiguration: SeverityBasedRuleConfiguration, Equatable 
     private(set) var includeCompilerDirectives = true
     private(set) var includeMultilineStrings = true
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "indentation_width" => .integer(indentationWidth)
         "include_comments" => .flag(includeComments)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -20,7 +20,7 @@ struct LineLengthConfiguration: RuleConfiguration, Equatable {
         return length.params
     }
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         length
         "ignores_urls" => .flag(ignoresURLs)
         "ignores_function_declarations" => .flag(ignoresFunctionDeclarations)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -14,13 +14,13 @@ struct LineLengthConfiguration: RuleConfiguration, Equatable {
 
     @ConfigurationElement
     private(set) var length = SeverityLevelsConfiguration<Parent>(warning: 120, error: 200)
-    @ConfigurationElement(ConfigurationKey.ignoresURLs.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.ignoresURLs.rawValue)
     private(set) var ignoresURLs = false
-    @ConfigurationElement(ConfigurationKey.ignoresFunctionDeclarations.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.ignoresFunctionDeclarations.rawValue)
     private(set) var ignoresFunctionDeclarations = false
-    @ConfigurationElement(ConfigurationKey.ignoresComments.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.ignoresComments.rawValue)
     private(set) var ignoresComments = false
-    @ConfigurationElement(ConfigurationKey.ignoresInterpolatedStrings.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.ignoresInterpolatedStrings.rawValue)
     private(set) var ignoresInterpolatedStrings = false
 
     var params: [RuleParameter<Int>] {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case warning = "warning"
     case error = "error"
@@ -10,22 +12,19 @@ private enum ConfigurationKey: String {
 struct LineLengthConfiguration: RuleConfiguration, Equatable {
     typealias Parent = LineLengthRule
 
+    @ConfigurationElement
     private(set) var length = SeverityLevelsConfiguration<Parent>(warning: 120, error: 200)
+    @ConfigurationElement(ConfigurationKey.ignoresURLs.rawValue)
     private(set) var ignoresURLs = false
+    @ConfigurationElement(ConfigurationKey.ignoresFunctionDeclarations.rawValue)
     private(set) var ignoresFunctionDeclarations = false
+    @ConfigurationElement(ConfigurationKey.ignoresComments.rawValue)
     private(set) var ignoresComments = false
+    @ConfigurationElement(ConfigurationKey.ignoresInterpolatedStrings.rawValue)
     private(set) var ignoresInterpolatedStrings = false
 
     var params: [RuleParameter<Int>] {
         return length.params
-    }
-
-    var parameterDescription: RuleConfigurationDescription? {
-        length
-        "ignores_urls" => .flag(ignoresURLs)
-        "ignores_function_declarations" => .flag(ignoresFunctionDeclarations)
-        "ignores_comments" => .flag(ignoresComments)
-        "ignores_interpolated_strings" => .flag(ignoresInterpolatedStrings)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -10,14 +10,6 @@ private enum ConfigurationKey: String {
 struct LineLengthConfiguration: RuleConfiguration, Equatable {
     typealias Parent = LineLengthRule
 
-    var consoleDescription: String {
-        return length.consoleDescription +
-               ", ignores_urls: \(ignoresURLs)" +
-               ", ignores_function_declarations: \(ignoresFunctionDeclarations)" +
-               ", ignores_comments: \(ignoresComments)" +
-               ", ignores_interpolated_strings: \(ignoresInterpolatedStrings)"
-    }
-
     private(set) var length = SeverityLevelsConfiguration<Parent>(warning: 120, error: 200)
     private(set) var ignoresURLs = false
     private(set) var ignoresFunctionDeclarations = false
@@ -26,6 +18,14 @@ struct LineLengthConfiguration: RuleConfiguration, Equatable {
 
     var params: [RuleParameter<Int>] {
         return length.params
+    }
+
+    var parameterDescription: RuleConfigurationDescription {
+        length
+        "ignores_urls" => .flag(ignoresURLs)
+        "ignores_function_declarations" => .flag(ignoresFunctionDeclarations)
+        "ignores_comments" => .flag(ignoresComments)
+        "ignores_interpolated_strings" => .flag(ignoresInterpolatedStrings)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
@@ -5,9 +5,9 @@ struct MissingDocsConfiguration: RuleConfiguration, Equatable {
         RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)
     ]
-    @ConfigurationElement("excludes_extensions")
+    @ConfigurationElement(key: "excludes_extensions")
     private(set) var excludesExtensions = true
-    @ConfigurationElement("excludes_inherited_types")
+    @ConfigurationElement(key: "excludes_inherited_types")
     private(set) var excludesInheritedTypes = true
     private(set) var excludesTrivialInit = false
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
@@ -9,27 +9,17 @@ struct MissingDocsConfiguration: RuleConfiguration, Equatable {
     private(set) var excludesInheritedTypes = true
     private(set) var excludesTrivialInit = false
 
-    var consoleDescription: String {
-        let parametersDescription = parameters.group { $0.severity }.sorted { $0.key.rawValue < $1.key.rawValue }.map {
-            "\($0.rawValue): \($1.map { $0.value.description }.sorted(by: <).joined(separator: ", "))"
-        }.joined(separator: ", ")
-
-        if parametersDescription.isEmpty {
-            return [
-                "excludes_extensions: \(excludesExtensions)",
-                "excludes_inherited_types: \(excludesInheritedTypes)",
-                "excludes_trivial_init: \(excludesTrivialInit)"
-            ]
-            .joined(separator: ", ")
-        } else {
-            return [
-                parametersDescription,
-                "excludes_extensions: \(excludesExtensions)",
-                "excludes_inherited_types: \(excludesInheritedTypes)",
-                "excludes_trivial_init: \(excludesTrivialInit)"
-            ]
-            .joined(separator: ", ")
+    var parameterDescription: RuleConfigurationDescription {
+        let parametersDescription = parameters.group { $0.severity }
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+        if parametersDescription.isNotEmpty {
+            for (severity, values) in parametersDescription {
+                severity.rawValue => .list(values.map(\.value.description).sorted().map { .symbol($0) })
+            }
         }
+        "excludes_extensions" => .flag(excludesExtensions)
+        "excludes_inherited_types" => .flag(excludesInheritedTypes)
+        "excludes_trivial_init" => .flag(excludesTrivialInit)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
@@ -9,7 +9,7 @@ struct MissingDocsConfiguration: RuleConfiguration, Equatable {
     private(set) var excludesInheritedTypes = true
     private(set) var excludesTrivialInit = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         let parametersDescription = parameters.group { $0.severity }
             .sorted { $0.key.rawValue < $1.key.rawValue }
         if parametersDescription.isNotEmpty {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 struct MissingDocsConfiguration: RuleConfiguration, Equatable {
     typealias Parent = MissingDocsRule
 
@@ -5,10 +7,12 @@ struct MissingDocsConfiguration: RuleConfiguration, Equatable {
         RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)
     ]
+
     @ConfigurationElement(key: "excludes_extensions")
     private(set) var excludesExtensions = true
     @ConfigurationElement(key: "excludes_inherited_types")
     private(set) var excludesInheritedTypes = true
+    @ConfigurationElement(key: "excludes_trivial_init")
     private(set) var excludesTrivialInit = false
 
     var parameterDescription: RuleConfigurationDescription? {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
@@ -5,7 +5,9 @@ struct MissingDocsConfiguration: RuleConfiguration, Equatable {
         RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)
     ]
+    @ConfigurationElement("excludes_extensions")
     private(set) var excludesExtensions = true
+    @ConfigurationElement("excludes_inherited_types")
     private(set) var excludesInheritedTypes = true
     private(set) var excludesTrivialInit = false
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -18,9 +18,9 @@ struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
         .owned
     ]
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)"
-            + ", preferred_modifier_order: \(preferredModifierOrder)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "preferred_modifier_order" => .list(preferredModifierOrder.map { .symbol($0.rawValue) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -4,7 +4,7 @@ import SwiftLintCore
 struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ModifierOrderRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "preferred_modifier_order")
     private(set) var preferredModifierOrder: [SwiftDeclarationAttributeKind.ModifierGroup] = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -44,7 +44,5 @@ struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
 }
 
 extension SwiftDeclarationAttributeKind.ModifierGroup: AcceptableByConfigurationElement {
-    public func asOption() -> OptionType {
-        .symbol(rawValue)
-    }
+    public func asOption() -> OptionType { .symbol(rawValue) }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -18,7 +18,7 @@ struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
         .owned
     ]
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "preferred_modifier_order" => .list(preferredModifierOrder.map { .symbol($0.rawValue) })
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -4,9 +4,9 @@ import SwiftLintCore
 struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ModifierOrderRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("preferred_modifier_order")
+    @ConfigurationElement(key: "preferred_modifier_order")
     private(set) var preferredModifierOrder: [SwiftDeclarationAttributeKind.ModifierGroup] = [
         .override,
         .acl,

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -1,9 +1,12 @@
 import SourceKittenFramework
+import SwiftLintCore
 
 struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ModifierOrderRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("preferred_modifier_order")
     private(set) var preferredModifierOrder: [SwiftDeclarationAttributeKind.ModifierGroup] = [
         .override,
         .acl,
@@ -17,11 +20,6 @@ struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
         .typeMethods,
         .owned
     ]
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "preferred_modifier_order" => .list(preferredModifierOrder.map { .symbol($0.rawValue) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
@@ -42,5 +40,11 @@ struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)
         }
+    }
+}
+
+extension SwiftDeclarationAttributeKind.ModifierGroup: AcceptableByConfigurationElement {
+    public func asOption() -> OptionType {
+        .symbol(rawValue)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -29,7 +29,7 @@ struct MultilineArgumentsConfiguration: SeverityBasedRuleConfiguration, Equatabl
         }
     }
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: ConfigurationKey.firstArgumentLocation.rawValue)
     private(set) var firstArgumentLocation = FirstArgumentLocation.anyLine

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -29,11 +29,11 @@ struct MultilineArgumentsConfiguration: SeverityBasedRuleConfiguration, Equatabl
         }
     }
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(ConfigurationKey.firstArgumentLocation.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.firstArgumentLocation.rawValue)
     private(set) var firstArgumentLocation = FirstArgumentLocation.anyLine
-    @ConfigurationElement(ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue)
     private(set) var onlyEnforceAfterFirstClosureOnFirstLine = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -27,7 +27,7 @@ struct MultilineArgumentsConfiguration: SeverityBasedRuleConfiguration, Equatabl
     private(set) var firstArgumentLocation = FirstArgumentLocation.anyLine
     private(set) var onlyEnforceAfterFirstClosureOnFirstLine = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         ConfigurationKey.firstArgumentLocation.rawValue => .string(firstArgumentLocation.rawValue)
         ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue => .flag(onlyEnforceAfterFirstClosureOnFirstLine)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -24,9 +24,7 @@ struct MultilineArgumentsConfiguration: SeverityBasedRuleConfiguration, Equatabl
             self = value
         }
 
-        func asOption() -> OptionType {
-            .symbol(rawValue)
-        }
+        func asOption() -> OptionType { .symbol(rawValue) }
     }
 
     @ConfigurationElement

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case severity = "severity"
     case firstArgumentLocation = "first_argument_location"
@@ -7,7 +9,7 @@ private enum ConfigurationKey: String {
 struct MultilineArgumentsConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = MultilineArgumentsRule
 
-    enum FirstArgumentLocation: String {
+    enum FirstArgumentLocation: String, AcceptableByConfigurationElement {
         case anyLine = "any_line"
         case sameLine = "same_line"
         case nextLine = "next_line"
@@ -21,18 +23,18 @@ struct MultilineArgumentsConfiguration: SeverityBasedRuleConfiguration, Equatabl
 
             self = value
         }
+
+        func asOption() -> OptionType {
+            .symbol(rawValue)
+        }
     }
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(ConfigurationKey.firstArgumentLocation.rawValue)
     private(set) var firstArgumentLocation = FirstArgumentLocation.anyLine
+    @ConfigurationElement(ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue)
     private(set) var onlyEnforceAfterFirstClosureOnFirstLine = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        ConfigurationKey.firstArgumentLocation.rawValue => .string(firstArgumentLocation.rawValue)
-        ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue => .flag(onlyEnforceAfterFirstClosureOnFirstLine)
-        // swiftlint:disable:previous line_length
-    }
 
     mutating func apply(configuration: Any) throws {
         let error = Issue.unknownConfiguration(ruleID: Parent.identifier)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -27,11 +27,11 @@ struct MultilineArgumentsConfiguration: SeverityBasedRuleConfiguration, Equatabl
     private(set) var firstArgumentLocation = FirstArgumentLocation.anyLine
     private(set) var onlyEnforceAfterFirstClosureOnFirstLine = false
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", \(ConfigurationKey.firstArgumentLocation.rawValue): \(firstArgumentLocation.rawValue)" +
-            ", \(ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue): \(onlyEnforceAfterFirstClosureOnFirstLine)"
-            // swiftlint:disable:previous line_length
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        ConfigurationKey.firstArgumentLocation.rawValue => .string(firstArgumentLocation.rawValue)
+        ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue => .flag(onlyEnforceAfterFirstClosureOnFirstLine)
+        // swiftlint:disable:previous line_length
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -1,13 +1,12 @@
+import SwiftLintCore
+
 struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = MultilineParametersRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("allows_single_line")
     private(set) var allowsSingleLine = true
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "allowsSingleLine" => .flag(allowsSingleLine)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = MultilineParametersRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("allows_single_line")
+    @ConfigurationElement(key: "allows_single_line")
     private(set) var allowsSingleLine = true
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -4,7 +4,7 @@ struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration, Equatab
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var allowsSingleLine = true
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "allowsSingleLine" => .flag(allowsSingleLine)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -4,9 +4,9 @@ struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration, Equatab
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var allowsSingleLine = true
 
-    var consoleDescription: String {
-        "severity: \(severityConfiguration.consoleDescription)"
-            + ", allowsSingleLine: \(allowsSingleLine)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "allowsSingleLine" => .flag(allowsSingleLine)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = MultilineParametersRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allows_single_line")
     private(set) var allowsSingleLine = true

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -1,25 +1,23 @@
 import Foundation
+import SwiftLintCore
 
 struct NameConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
     typealias Severity = SeverityConfiguration<Parent>
     typealias SeverityLevels = SeverityLevelsConfiguration<Parent>
     typealias StartWithLowercaseConfiguration = ChildOptionSeverityConfiguration<Parent>
 
-    var parameterDescription: RuleConfigurationDescription? {
-        "(min_length)" => .nested(minLength.parameterDescription!)
-        "(max_length)" => .nested(maxLength.parameterDescription!)
-        "excluded" => .list(excludedRegularExpressions.map(\.pattern).sorted().map { .symbol($0) })
-        "allowed_symbols" => .list(allowedSymbols.sorted().map { .string($0) })
-        "unallowed_symbols_severity" => .severity(unallowedSymbolsSeverity.severity)
-        "validates_start_with_lowercase" => .symbol(validatesStartWithLowercase.severity?.rawValue ?? "off")
-    }
-
-    private(set) var minLength: SeverityLevels
-    private(set) var maxLength: SeverityLevels
-    private(set) var excludedRegularExpressions: Set<NSRegularExpression>
-    private(set) var allowedSymbols: Set<String>
-    private(set) var unallowedSymbolsSeverity: Severity
-    private(set) var validatesStartWithLowercase: StartWithLowercaseConfiguration
+    @ConfigurationElement("min_length")
+    private(set) var minLength = SeverityLevels(warning: 0, error: 0)
+    @ConfigurationElement("max_length")
+    private(set) var maxLength = SeverityLevels(warning: 0, error: 0)
+    @ConfigurationElement("excluded")
+    private(set) var excludedRegularExpressions = Set<NSRegularExpression>()
+    @ConfigurationElement("allowed_symbols")
+    private(set) var allowedSymbols = Set<String>()
+    @ConfigurationElement("unallowed_symbols_severity")
+    private(set) var unallowedSymbolsSeverity = Severity.error
+    @ConfigurationElement("validates_start_with_lowercase")
+    private(set) var validatesStartWithLowercase = StartWithLowercaseConfiguration.error
 
     var minLengthThreshold: Int {
         return max(minLength.warning, minLength.error ?? minLength.warning)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -5,9 +5,9 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
     typealias SeverityLevels = SeverityLevelsConfiguration<Parent>
     typealias StartWithLowercaseConfiguration = ChildOptionSeverityConfiguration<Parent>
 
-    var parameterDescription: RuleConfigurationDescription {
-        "(min_length)" => .nested(minLength.parameterDescription)
-        "(max_length)" => .nested(maxLength.parameterDescription)
+    var parameterDescription: RuleConfigurationDescription? {
+        "(min_length)" => .nested(minLength.parameterDescription!)
+        "(max_length)" => .nested(maxLength.parameterDescription!)
         "excluded" => .list(excludedRegularExpressions.map(\.pattern).sorted().map { .symbol($0) })
         "allowed_symbols" => .list(allowedSymbols.sorted().map { .string($0) })
         "unallowed_symbols_severity" => .severity(unallowedSymbolsSeverity.severity)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -5,13 +5,13 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
     typealias SeverityLevels = SeverityLevelsConfiguration<Parent>
     typealias StartWithLowercaseConfiguration = ChildOptionSeverityConfiguration<Parent>
 
-    var consoleDescription: String {
-        "(min_length) \(minLength.shortConsoleDescription), " +
-            "(max_length) \(maxLength.shortConsoleDescription), " +
-            "excluded: \(excludedRegularExpressions.map { $0.pattern }.sorted()), " +
-            "allowed_symbols: \(allowedSymbols.sorted()), " +
-            "unallowed_symbols_severity: \(unallowedSymbolsSeverity.consoleDescription), " +
-            "validates_start_with_lowercase: \(validatesStartWithLowercase.consoleDescription)"
+    var parameterDescription: RuleConfigurationDescription {
+        "(min_length)" => .nested(minLength.parameterDescription)
+        "(max_length)" => .nested(maxLength.parameterDescription)
+        "excluded" => .list(excludedRegularExpressions.map(\.pattern).sorted().map { .symbol($0) })
+        "allowed_symbols" => .list(allowedSymbols.sorted().map { .string($0) })
+        "unallowed_symbols_severity" => .severity(unallowedSymbolsSeverity.severity)
+        "validates_start_with_lowercase" => .symbol(validatesStartWithLowercase.severity?.rawValue ?? "off")
     }
 
     private(set) var minLength: SeverityLevels

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -6,17 +6,17 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
     typealias SeverityLevels = SeverityLevelsConfiguration<Parent>
     typealias StartWithLowercaseConfiguration = ChildOptionSeverityConfiguration<Parent>
 
-    @ConfigurationElement("min_length")
+    @ConfigurationElement(key: "min_length")
     private(set) var minLength = SeverityLevels(warning: 0, error: 0)
-    @ConfigurationElement("max_length")
+    @ConfigurationElement(key: "max_length")
     private(set) var maxLength = SeverityLevels(warning: 0, error: 0)
-    @ConfigurationElement("excluded")
+    @ConfigurationElement(key: "excluded")
     private(set) var excludedRegularExpressions = Set<NSRegularExpression>()
-    @ConfigurationElement("allowed_symbols")
+    @ConfigurationElement(key: "allowed_symbols")
     private(set) var allowedSymbols = Set<String>()
-    @ConfigurationElement("unallowed_symbols_severity")
+    @ConfigurationElement(key: "unallowed_symbols_severity")
     private(set) var unallowedSymbolsSeverity = Severity.error
-    @ConfigurationElement("validates_start_with_lowercase")
+    @ConfigurationElement(key: "validates_start_with_lowercase")
     private(set) var validatesStartWithLowercase = StartWithLowercaseConfiguration.error
 
     var minLengthThreshold: Int {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -2,11 +2,11 @@ struct NestingConfiguration: RuleConfiguration, Equatable {
     typealias Parent = NestingRule
     typealias Severity = SeverityLevelsConfiguration<Parent>
 
-    var consoleDescription: String {
-        return "(type_level) \(typeLevel.shortConsoleDescription)"
-            + ", (function_level) \(functionLevel.shortConsoleDescription)"
-            + ", (check_nesting_in_closures_and_statements) \(checkNestingInClosuresAndStatements)"
-            + ", (always_allow_one_type_in_functions) \(alwaysAllowOneTypeInFunctions)"
+    var parameterDescription: RuleConfigurationDescription {
+        "type_level" => .nested(typeLevel.parameterDescription)
+        "function_level" => .nested(functionLevel.parameterDescription)
+        "check_nesting_in_closures_and_statements" => .flag(checkNestingInClosuresAndStatements)
+        "always_allow_one_type_in_functions" => .flag(alwaysAllowOneTypeInFunctions)
     }
 
     private(set) var typeLevel = Severity(warning: 1)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -2,9 +2,9 @@ struct NestingConfiguration: RuleConfiguration, Equatable {
     typealias Parent = NestingRule
     typealias Severity = SeverityLevelsConfiguration<Parent>
 
-    var parameterDescription: RuleConfigurationDescription {
-        "type_level" => .nested(typeLevel.parameterDescription)
-        "function_level" => .nested(functionLevel.parameterDescription)
+    var parameterDescription: RuleConfigurationDescription? {
+        "type_level" => .nested(typeLevel.parameterDescription!)
+        "function_level" => .nested(functionLevel.parameterDescription!)
         "check_nesting_in_closures_and_statements" => .flag(checkNestingInClosuresAndStatements)
         "always_allow_one_type_in_functions" => .flag(alwaysAllowOneTypeInFunctions)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -4,13 +4,13 @@ struct NestingConfiguration: RuleConfiguration, Equatable {
     typealias Parent = NestingRule
     typealias Severity = SeverityLevelsConfiguration<Parent>
 
-    @ConfigurationElement("type_level")
+    @ConfigurationElement(key: "type_level")
     private(set) var typeLevel = Severity(warning: 1)
-    @ConfigurationElement("function_level")
+    @ConfigurationElement(key: "function_level")
     private(set) var functionLevel = Severity(warning: 2)
-    @ConfigurationElement("check_nesting_in_closures_and_statements")
+    @ConfigurationElement(key: "check_nesting_in_closures_and_statements")
     private(set) var checkNestingInClosuresAndStatements = true
-    @ConfigurationElement("always_allow_one_type_in_functions")
+    @ConfigurationElement(key: "always_allow_one_type_in_functions")
     private(set) var alwaysAllowOneTypeInFunctions = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -1,17 +1,16 @@
+import SwiftLintCore
+
 struct NestingConfiguration: RuleConfiguration, Equatable {
     typealias Parent = NestingRule
     typealias Severity = SeverityLevelsConfiguration<Parent>
 
-    var parameterDescription: RuleConfigurationDescription? {
-        "type_level" => .nested(typeLevel.parameterDescription!)
-        "function_level" => .nested(functionLevel.parameterDescription!)
-        "check_nesting_in_closures_and_statements" => .flag(checkNestingInClosuresAndStatements)
-        "always_allow_one_type_in_functions" => .flag(alwaysAllowOneTypeInFunctions)
-    }
-
+    @ConfigurationElement("type_level")
     private(set) var typeLevel = Severity(warning: 1)
+    @ConfigurationElement("function_level")
     private(set) var functionLevel = Severity(warning: 2)
+    @ConfigurationElement("check_nesting_in_closures_and_statements")
     private(set) var checkNestingInClosuresAndStatements = true
+    @ConfigurationElement("always_allow_one_type_in_functions")
     private(set) var alwaysAllowOneTypeInFunctions = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -8,7 +8,7 @@ struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
     @ConfigurationElement(key: "minimum_length")
     private(set) var minimumLength = 0
     @ConfigurationElement(key: "minimum_fraction_length")
-    private(set) var minimumFractionLength: Int? = nil
+    private(set) var minimumFractionLength: Int?
 
     private(set) var excludeRanges = [Range<Double>]()
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = NumberSeparatorRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "minimum_length")
     private(set) var minimumLength = 0

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -1,20 +1,16 @@
+import SwiftLintCore
+
 struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = NumberSeparatorRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("minimum_length")
     private(set) var minimumLength = 0
-    private(set) var minimumFractionLength: Int?
-    private(set) var excludeRanges = [Range<Double>]()
+    @ConfigurationElement("minimum_fraction_length")
+    private(set) var minimumFractionLength: Int? = nil
 
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "minimum_length" => .integer(minimumLength)
-        if let minimumFractionLength {
-            "minimum_fraction_length" => .integer(minimumFractionLength)
-        } else {
-            "minimum_fraction_length" => .string("none")
-        }
-    }
+    private(set) var excludeRanges = [Range<Double>]()
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -6,7 +6,7 @@ struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var minimumFractionLength: Int?
     private(set) var excludeRanges = [Range<Double>]()
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "minimum_length" => .integer(minimumLength)
         if let minimumFractionLength {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -6,16 +6,14 @@ struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var minimumFractionLength: Int?
     private(set) var excludeRanges = [Range<Double>]()
 
-    var consoleDescription: String {
-        let minimumFractionLengthDescription: String
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "minimum_length" => .integer(minimumLength)
         if let minimumFractionLength {
-            minimumFractionLengthDescription = ", minimum_fraction_length: \(minimumFractionLength)"
+            "minimum_fraction_length" => .integer(minimumFractionLength)
         } else {
-            minimumFractionLengthDescription = ", minimum_fraction_length: none"
+            "minimum_fraction_length" => .string("none")
         }
-        return "severity: \(severityConfiguration.consoleDescription)"
-            + ", minimum_length: \(minimumLength)"
-            + minimumFractionLengthDescription
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -3,11 +3,11 @@ import SwiftLintCore
 struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = NumberSeparatorRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("minimum_length")
+    @ConfigurationElement(key: "minimum_length")
     private(set) var minimumLength = 0
-    @ConfigurationElement("minimum_fraction_length")
+    @ConfigurationElement(key: "minimum_fraction_length")
     private(set) var minimumFractionLength: Int? = nil
 
     private(set) var excludeRanges = [Range<Double>]()

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -1,15 +1,14 @@
+import SwiftLintCore
+
 typealias DiscouragedObjectLiteralConfiguration = ObjectLiteralConfiguration<DiscouragedObjectLiteralRule>
 
 struct ObjectLiteralConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable {
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("image_literal")
     private(set) var imageLiteral = true
+    @ConfigurationElement("color_literal")
     private(set) var colorLiteral = true
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "image_literal" => .flag(imageLiteral)
-        "color_literal" => .flag(colorLiteral)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -5,7 +5,7 @@ struct ObjectLiteralConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration,
     private(set) var imageLiteral = true
     private(set) var colorLiteral = true
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "image_literal" => .flag(imageLiteral)
         "color_literal" => .flag(colorLiteral)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -5,10 +5,10 @@ struct ObjectLiteralConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration,
     private(set) var imageLiteral = true
     private(set) var colorLiteral = true
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)"
-            + ", image_literal: \(imageLiteral)"
-            + ", color_literal: \(colorLiteral)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "image_literal" => .flag(imageLiteral)
+        "color_literal" => .flag(colorLiteral)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -3,11 +3,11 @@ import SwiftLintCore
 typealias DiscouragedObjectLiteralConfiguration = ObjectLiteralConfiguration<DiscouragedObjectLiteralRule>
 
 struct ObjectLiteralConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable {
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("image_literal")
+    @ConfigurationElement(key: "image_literal")
     private(set) var imageLiteral = true
-    @ConfigurationElement("color_literal")
+    @ConfigurationElement(key: "color_literal")
     private(set) var colorLiteral = true
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 typealias DiscouragedObjectLiteralConfiguration = ObjectLiteralConfiguration<DiscouragedObjectLiteralRule>
 
 struct ObjectLiteralConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable {
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "image_literal")
     private(set) var imageLiteral = true

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -9,9 +9,9 @@ struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var allowMultilineFunc = false
 
-    var consoleDescription: String {
-        return ["severity: \(severityConfiguration.consoleDescription)",
-                "\(ConfigurationKey.allowMultilineFunc): \(allowMultilineFunc)"].joined(separator: ", ")
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        ConfigurationKey.allowMultilineFunc.rawValue => .flag(allowMultilineFunc)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case severity = "severity"
     case allowMultilineFunc = "allow_multiline_func"
@@ -6,13 +8,10 @@ private enum ConfigurationKey: String {
 struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = OpeningBraceRule
 
+    @ConfigurationElement(ConfigurationKey.severity.rawValue)
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(ConfigurationKey.allowMultilineFunc.rawValue)
     private(set) var allowMultilineFunc = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        ConfigurationKey.allowMultilineFunc.rawValue => .flag(allowMultilineFunc)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -9,7 +9,7 @@ struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var allowMultilineFunc = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         ConfigurationKey.allowMultilineFunc.rawValue => .flag(allowMultilineFunc)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -8,9 +8,9 @@ private enum ConfigurationKey: String {
 struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = OpeningBraceRule
 
-    @ConfigurationElement(ConfigurationKey.severity.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.severity.rawValue)
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(ConfigurationKey.allowMultilineFunc.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.allowMultilineFunc.rawValue)
     private(set) var allowMultilineFunc = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct OperatorUsageWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = OperatorUsageWhitespaceRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "lines_look_around")
     private(set) var linesLookAround = 2

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -6,11 +6,11 @@ struct OperatorUsageWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equ
     private(set) var skipAlignedConstants = true
     private(set) var allowedNoSpaceOperators: [String] = ["...", "..<"]
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)"
-            + ", lines_look_around: \(linesLookAround)"
-            + ", skip_aligned_constants: \(skipAlignedConstants)"
-            + ", allowed_no_space_operators: \(allowedNoSpaceOperators)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "lines_look_around" => .integer(linesLookAround)
+        "skip_aligned_constants" => .flag(skipAlignedConstants)
+        "allowed_no_space_operators" => .list(allowedNoSpaceOperators.map { .string($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -1,17 +1,16 @@
+import SwiftLintCore
+
 struct OperatorUsageWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = OperatorUsageWhitespaceRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("lines_look_around")
     private(set) var linesLookAround = 2
+    @ConfigurationElement("skip_aligned_constants")
     private(set) var skipAlignedConstants = true
-    private(set) var allowedNoSpaceOperators: [String] = ["...", "..<"]
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "lines_look_around" => .integer(linesLookAround)
-        "skip_aligned_constants" => .flag(skipAlignedConstants)
-        "allowed_no_space_operators" => .list(allowedNoSpaceOperators.map { .string($0) })
-    }
+    @ConfigurationElement("allowed_no_space_operators")
+    private(set) var allowedNoSpaceOperators = ["...", "..<"]
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -3,13 +3,13 @@ import SwiftLintCore
 struct OperatorUsageWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = OperatorUsageWhitespaceRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("lines_look_around")
+    @ConfigurationElement(key: "lines_look_around")
     private(set) var linesLookAround = 2
-    @ConfigurationElement("skip_aligned_constants")
+    @ConfigurationElement(key: "skip_aligned_constants")
     private(set) var skipAlignedConstants = true
-    @ConfigurationElement("allowed_no_space_operators")
+    @ConfigurationElement(key: "allowed_no_space_operators")
     private(set) var allowedNoSpaceOperators = ["...", "..<"]
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -6,7 +6,7 @@ struct OperatorUsageWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equ
     private(set) var skipAlignedConstants = true
     private(set) var allowedNoSpaceOperators: [String] = ["...", "..<"]
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "lines_look_around" => .integer(linesLookAround)
         "skip_aligned_constants" => .flag(skipAlignedConstants)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -41,7 +41,7 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
         resolvedMethodNames = defaultIncluded
     }
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "excluded" => .list(excluded.map { .string($0) })
         "included" => .list(included.map { .string($0) })

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -33,7 +33,7 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
         "viewWillDisappear(_:)"
     ]
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "excluded")
     private(set) var excluded = [String]()

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -33,11 +33,11 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
         "viewWillDisappear(_:)"
     ]
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("excluded")
+    @ConfigurationElement(key: "excluded")
     private(set) var excluded = [String]()
-    @ConfigurationElement("included")
+    @ConfigurationElement(key: "included")
     private(set) var included = ["*"]
 
     private(set) var resolvedMethodNames: [String]

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = OverriddenSuperCallRule
 
@@ -31,20 +33,17 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
         "viewWillDisappear(_:)"
     ]
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    var excluded: [String] = []
-    var included: [String] = ["*"]
+    @ConfigurationElement("excluded")
+    private(set) var excluded = [String]()
+    @ConfigurationElement("included")
+    private(set) var included = ["*"]
 
     private(set) var resolvedMethodNames: [String]
 
     init() {
         resolvedMethodNames = defaultIncluded
-    }
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "excluded" => .list(excluded.map { .string($0) })
-        "included" => .list(included.map { .string($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -41,10 +41,10 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
         resolvedMethodNames = defaultIncluded
     }
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", excluded: \(excluded)" +
-            ", included: \(included)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "excluded" => .list(excluded.map { .string($0) })
+        "included" => .list(included.map { .string($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
@@ -4,8 +4,9 @@ struct PrefixedTopLevelConstantConfiguration: SeverityBasedRuleConfiguration, Eq
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var onlyPrivateMembers = false
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", only_private: \(onlyPrivateMembers)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "only_private" => .flag(onlyPrivateMembers)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
@@ -1,13 +1,12 @@
+import SwiftLintCore
+
 struct PrefixedTopLevelConstantConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrefixedTopLevelConstantRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "only_private")
     private(set) var onlyPrivateMembers = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "only_private" => .flag(onlyPrivateMembers)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct PrefixedTopLevelConstantConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrefixedTopLevelConstantRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "only_private")
     private(set) var onlyPrivateMembers = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
@@ -4,7 +4,7 @@ struct PrefixedTopLevelConstantConfiguration: SeverityBasedRuleConfiguration, Eq
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var onlyPrivateMembers = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "only_private" => .flag(onlyPrivateMembers)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct PrefixedTopLevelConstantConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrefixedTopLevelConstantRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "only_private")
     private(set) var onlyPrivateMembers = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
@@ -4,7 +4,7 @@ struct PrivateOutletConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var allowPrivateSet = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "allow_private_set" => .flag(allowPrivateSet)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
@@ -4,8 +4,9 @@ struct PrivateOutletConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var allowPrivateSet = false
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", allow_private_set: \(allowPrivateSet)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "allow_private_set" => .flag(allowPrivateSet)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
@@ -1,13 +1,12 @@
+import SwiftLintCore
+
 struct PrivateOutletConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrivateOutletRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "allow_private_set")
     private(set) var allowPrivateSet = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "allow_private_set" => .flag(allowPrivateSet)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct PrivateOutletConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrivateOutletRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allow_private_set")
     private(set) var allowPrivateSet = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct PrivateOutletConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrivateOutletRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allow_private_set")
     private(set) var allowPrivateSet = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
@@ -4,8 +4,9 @@ struct PrivateOverFilePrivateConfiguration: SeverityBasedRuleConfiguration, Equa
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     var validateExtensions = false
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", validate_extensions: \(validateExtensions)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "validate_extensions" => .flag(validateExtensions)
     }
 
     // MARK: - RuleConfiguration

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct PrivateOverFilePrivateConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrivateOverFilePrivateRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("validate_extensions")
+    @ConfigurationElement(key: "validate_extensions")
     var validateExtensions = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
@@ -4,7 +4,7 @@ struct PrivateOverFilePrivateConfiguration: SeverityBasedRuleConfiguration, Equa
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     var validateExtensions = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "validate_extensions" => .flag(validateExtensions)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct PrivateOverFilePrivateConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrivateOverFilePrivateRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "validate_extensions")
     var validateExtensions = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
@@ -1,15 +1,12 @@
+import SwiftLintCore
+
 struct PrivateOverFilePrivateConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = PrivateOverFilePrivateRule
 
+    @ConfigurationElement("severity")
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("validate_extensions")
     var validateExtensions = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "validate_extensions" => .flag(validateExtensions)
-    }
-
-    // MARK: - RuleConfiguration
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -12,11 +12,6 @@ struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, 
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "regex" => .string(regex.pattern)
-    }
-
     var cacheDescription: String {
         let jsonObject: [String] = [
             "private_unit_test",

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -10,7 +10,7 @@ struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, 
     private(set) var included: NSRegularExpression?
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "regex" => .string(regex.pattern)
     }
@@ -22,7 +22,7 @@ struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, 
             message,
             regex.pattern,
             included?.pattern ?? "",
-            severityConfiguration.consoleDescription
+            severityConfiguration.severity.rawValue
         ]
         if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),
           let jsonString = String(data: jsonData, encoding: .utf8) {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -4,7 +4,7 @@ import SwiftLintCore
 struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, CacheDescriptionProvider {
     typealias Parent = PrivateUnitTestRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "regex")
     private(set) var regex = SwiftLintCore.regex("XCTestCase")

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -4,13 +4,14 @@ import SwiftLintCore
 struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, CacheDescriptionProvider {
     typealias Parent = PrivateUnitTestRule
 
-    private(set) var name: String?
-    private(set) var message = "Unit test marked `private` will not be run by XCTest."
-    @ConfigurationElement(key: "regex")
-    private(set) var regex = SwiftLintCore.regex("XCTestCase")
-    private(set) var included: NSRegularExpression?
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "regex")
+    private(set) var regex = SwiftLintCore.regex("XCTestCase")
+
+    private(set) var name: String?
+    private(set) var message = "Unit test marked `private` will not be run by XCTest."
+    private(set) var included: NSRegularExpression?
 
     var cacheDescription: String {
         let jsonObject: [String] = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -6,10 +6,10 @@ struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, 
 
     private(set) var name: String?
     private(set) var message = "Unit test marked `private` will not be run by XCTest."
-    @ConfigurationElement("regex")
+    @ConfigurationElement(key: "regex")
     private(set) var regex = SwiftLintCore.regex("XCTestCase")
     private(set) var included: NSRegularExpression?
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
     var parameterDescription: RuleConfigurationDescription? {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -6,8 +6,10 @@ struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, 
 
     private(set) var name: String?
     private(set) var message = "Unit test marked `private` will not be run by XCTest."
+    @ConfigurationElement("regex")
     private(set) var regex = SwiftLintCore.regex("XCTestCase")
     private(set) var included: NSRegularExpression?
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
     var parameterDescription: RuleConfigurationDescription? {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -10,8 +10,9 @@ struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, 
     private(set) var included: NSRegularExpression?
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
-    var consoleDescription: String {
-        return "\(severity.rawValue): \(regex.pattern)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "regex" => .string(regex.pattern)
     }
 
     var cacheDescription: String {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -1,9 +1,14 @@
+import SwiftLintCore
+
 struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ProhibitedSuperRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    var excluded = [String]()
-    var included = ["*"]
+    @ConfigurationElement("excluded")
+    private(set) var excluded = [String]()
+    @ConfigurationElement("included")
+    private(set) var included = ["*"]
 
     private(set) var resolvedMethodNames = [
         // NSFileProviderExtension
@@ -15,14 +20,6 @@ struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
         // UIViewController
         "loadView()"
     ]
-
-    init() {}
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "excluded" => .list(excluded.map { .string($0) })
-        "included" => .list(included.map { .string($0) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -18,10 +18,10 @@ struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
 
     init() {}
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", excluded: [\(excluded)]" +
-            ", included: [\(included)]"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "excluded" => .list(excluded.map { .string($0) })
+        "included" => .list(included.map { .string($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -3,11 +3,11 @@ import SwiftLintCore
 struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ProhibitedSuperRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("excluded")
+    @ConfigurationElement(key: "excluded")
     private(set) var excluded = [String]()
-    @ConfigurationElement("included")
+    @ConfigurationElement(key: "included")
     private(set) var included = ["*"]
 
     private(set) var resolvedMethodNames = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = ProhibitedSuperRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "excluded")
     private(set) var excluded = [String]()

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -18,7 +18,7 @@ struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
 
     init() {}
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "excluded" => .list(excluded.map { .string($0) })
         "included" => .list(included.map { .string($0) })

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RequiredEnumCaseConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RequiredEnumCaseConfiguration.swift
@@ -13,23 +13,21 @@ struct RequiredEnumCaseConfiguration: RuleConfiguration, Equatable {
 
     var protocols: [String: Set<RequiredCase>] = [:]
 
-    var consoleDescription: String {
-        let protocols = self.protocols.sorted(by: { $0.key < $1.key }) .compactMap { name, required in
-            let caseNames: [String] = required.sorted(by: { $0.name < $1.name }).map {
-                "[name: \"\($0.name)\", severity: \"\($0.severity.rawValue)\"]"
+    var parameterDescription: RuleConfigurationDescription {
+        if protocols.isEmpty {
+            "{Protocol Name}" => .nest {
+                "{Case Name 1}" => .symbol("{warning|error}")
+                "{Case Name 2}" => .symbol("{warning|error}")
             }
-
-            return "[protocol: \"\(name)\", cases: [\(caseNames.joined(separator: ", "))]]"
-        }.joined(separator: ", ")
-
-        let instructions = "No protocols configured.  In config add 'required_enum_case' to 'opt_in_rules' and " +
-            "config using :\n\n" +
-            "'required_enum_case:\n" +
-            "  {Protocol Name}:\n" +
-            "    {Case Name}:{warning|error}\n" +
-            "    {Case Name}:{warning|error}\n"
-
-        return protocols.isEmpty ? instructions : protocols
+        } else {
+            for (protocolName, requiredCases) in protocols.sorted(by: { $0.key < $1.key }) {
+                protocolName => .nest {
+                    for requiredCase in requiredCases.sorted(by: { $0.name < $1.name }) {
+                        requiredCase.name => .symbol(requiredCase.severity.rawValue)
+                    }
+                }
+            }
+        }
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RequiredEnumCaseConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RequiredEnumCaseConfiguration.swift
@@ -13,7 +13,7 @@ struct RequiredEnumCaseConfiguration: RuleConfiguration, Equatable {
 
     var protocols: [String: Set<RequiredCase>] = [:]
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         if protocols.isEmpty {
             "{Protocol Name}" => .nest {
                 "{Case Name 1}" => .symbol("{warning|error}")

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -8,7 +8,7 @@ private enum ConfigurationKey: String {
 struct SelfBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = SelfBindingRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: ConfigurationKey.bindIdentifier.rawValue)
     private(set) var bindIdentifier = "self"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case severity = "severity"
     case bindIdentifier = "bind_identifier"
@@ -6,13 +8,10 @@ private enum ConfigurationKey: String {
 struct SelfBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = SelfBindingRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: ConfigurationKey.bindIdentifier.rawValue)
     private(set) var bindIdentifier = "self"
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        ConfigurationKey.bindIdentifier.rawValue => .symbol(bindIdentifier)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -8,7 +8,7 @@ private enum ConfigurationKey: String {
 struct SelfBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = SelfBindingRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: ConfigurationKey.bindIdentifier.rawValue)
     private(set) var bindIdentifier = "self"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -9,9 +9,9 @@ struct SelfBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var bindIdentifier = "self"
 
-    var consoleDescription: String {
-        return ["severity: \(severityConfiguration.consoleDescription)",
-                "\(ConfigurationKey.bindIdentifier): \(bindIdentifier)"].joined(separator: ", ")
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        ConfigurationKey.bindIdentifier.rawValue => .symbol(bindIdentifier)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -9,7 +9,7 @@ struct SelfBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var bindIdentifier = "self"
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         ConfigurationKey.bindIdentifier.rawValue => .symbol(bindIdentifier)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -12,9 +12,9 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
     private(set) var severity = SeverityConfiguration<Parent>(.warning)
     private(set) var grouping = SortedImportsGroupingConfiguration.names
 
-    var consoleDescription: String {
-        return "severity: \(severity.consoleDescription)"
-            + ", grouping: \(grouping)"
+    var parameterDescription: RuleConfigurationDescription {
+        severity
+        "grouping" => .symbol(grouping.rawValue)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -13,7 +13,7 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
         func asOption() -> OptionType { .symbol(rawValue) }
     }
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severity = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "grouping")
     private(set) var grouping = SortedImportsGroupingConfiguration.names

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -12,7 +12,7 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
     private(set) var severity = SeverityConfiguration<Parent>(.warning)
     private(set) var grouping = SortedImportsGroupingConfiguration.names
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severity
         "grouping" => .symbol(grouping.rawValue)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -1,21 +1,22 @@
+import SwiftLintCore
+
 struct SortedImportsConfiguration: RuleConfiguration, Equatable {
     typealias Parent = SortedImportsRule
 
-    enum SortedImportsGroupingConfiguration: String {
+    enum SortedImportsGroupingConfiguration: String, AcceptableByConfigurationElement {
         /// Sorts import lines based on any import attributes (e.g. `@testable`, `@_exported`, etc.), followed by a case
         /// insensitive comparison of the imported module name.
         case attributes
         /// Sorts import lines based on a case insensitive comparison of the imported module name.
         case names
+
+        func asOption() -> OptionType { .symbol(rawValue) }
     }
 
+    @ConfigurationElement
     private(set) var severity = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "grouping")
     private(set) var grouping = SortedImportsGroupingConfiguration.names
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severity
-        "grouping" => .symbol(grouping.rawValue)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -13,7 +13,7 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
         func asOption() -> OptionType { .symbol(rawValue) }
     }
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severity = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "grouping")
     private(set) var grouping = SortedImportsGroupingConfiguration.names

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
@@ -15,9 +15,9 @@ struct StatementPositionConfiguration: SeverityBasedRuleConfiguration, Equatable
         }
     }
 
-    var consoleDescription: String {
-        return "(statement_mode) \(statementMode.rawValue), " +
-            "(severity) \(severityConfiguration.consoleDescription)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "statement_mode" => .symbol(statementMode.rawValue)
     }
 
     private(set) var statementMode = StatementModeConfiguration.default

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
@@ -15,7 +15,7 @@ struct StatementPositionConfiguration: SeverityBasedRuleConfiguration, Equatable
         }
     }
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "statement_mode" => .symbol(statementMode.rawValue)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
@@ -19,7 +19,7 @@ struct StatementPositionConfiguration: SeverityBasedRuleConfiguration, Equatable
         func asOption() -> OptionType { .symbol(rawValue) }
     }
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "statement_mode")
     private(set) var statementMode = StatementModeConfiguration.default

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
@@ -1,7 +1,9 @@
+import SwiftLintCore
+
 struct StatementPositionConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = StatementPositionRule
 
-    enum StatementModeConfiguration: String {
+    enum StatementModeConfiguration: String, AcceptableByConfigurationElement {
         case `default` = "default"
         case uncuddledElse = "uncuddled_else"
 
@@ -13,15 +15,14 @@ struct StatementPositionConfiguration: SeverityBasedRuleConfiguration, Equatable
                 throw Issue.unknownConfiguration(ruleID: Parent.identifier)
             }
         }
+
+        func asOption() -> OptionType { .symbol(rawValue) }
     }
 
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "statement_mode" => .symbol(statementMode.rawValue)
-    }
-
-    private(set) var statementMode = StatementModeConfiguration.default
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
+    @ConfigurationElement(key: "statement_mode")
+    private(set) var statementMode = StatementModeConfiguration.default
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
@@ -19,7 +19,7 @@ struct StatementPositionConfiguration: SeverityBasedRuleConfiguration, Equatable
         func asOption() -> OptionType { .symbol(rawValue) }
     }
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "statement_mode")
     private(set) var statementMode = StatementModeConfiguration.default

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -6,7 +6,7 @@ struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatab
 
     init() {}
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "indented_cases" => .flag(indentedCases)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -6,8 +6,9 @@ struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatab
 
     init() {}
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", indented_cases: \(indentedCases)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "indented_cases" => .flag(indentedCases)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = SwitchCaseAlignmentRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("indented_cases")
+    @ConfigurationElement(key: "indented_cases")
     private(set) var indentedCases = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = SwitchCaseAlignmentRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "indented_cases")
     private(set) var indentedCases = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -1,15 +1,12 @@
+import SwiftLintCore
+
 struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = SwitchCaseAlignmentRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("indented_cases")
     private(set) var indentedCases = false
-
-    init() {}
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "indented_cases" => .flag(indentedCases)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -5,7 +5,7 @@ struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equat
     private(set) var allowedPrefixes: Set<String> = []
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "allowed_prefixes" => .list(allowedPrefixes.sorted().map { .string($0) })
         "test_parent_classes" => .list(testParentClasses.sorted().map { .symbol($0) })

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TestCaseAccessibilityRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allowed_prefixes")
     private(set) var allowedPrefixes: Set<String> = []

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -1,15 +1,14 @@
+import SwiftLintCore
+
 struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TestCaseAccessibilityRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "allowed_prefixes")
     private(set) var allowedPrefixes: Set<String> = []
+    @ConfigurationElement(key: "test_parent_classes")
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "allowed_prefixes" => .list(allowedPrefixes.sorted().map { .string($0) })
-        "test_parent_classes" => .list(testParentClasses.sorted().map { .symbol($0) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -5,10 +5,10 @@ struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equat
     private(set) var allowedPrefixes: Set<String> = []
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", allowed_prefixes: \(allowedPrefixes.sorted())" +
-            ", test_parent_classes: \(testParentClasses.sorted())"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "allowed_prefixes" => .list(allowedPrefixes.sorted().map { .string($0) })
+        "test_parent_classes" => .list(testParentClasses.sorted().map { .symbol($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TestCaseAccessibilityRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allowed_prefixes")
     private(set) var allowedPrefixes: Set<String> = []

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct TrailingClosureConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingClosureRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "only_single_muted_parameter")
     private(set) var onlySingleMutedParameter = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
@@ -4,7 +4,7 @@ struct TrailingClosureConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var onlySingleMutedParameter: Bool
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "only_single_muted_parameter" => .flag(onlySingleMutedParameter)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct TrailingClosureConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingClosureRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("only_single_muted_parameter")
+    @ConfigurationElement(key: "only_single_muted_parameter")
     private(set) var onlySingleMutedParameter = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
@@ -4,9 +4,9 @@ struct TrailingClosureConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var onlySingleMutedParameter: Bool
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)"
-            + ", only_single_muted_parameter: \(onlySingleMutedParameter)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "only_single_muted_parameter" => .flag(onlySingleMutedParameter)
     }
 
     init(onlySingleMutedParameter: Bool = false) {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
@@ -1,17 +1,12 @@
+import SwiftLintCore
+
 struct TrailingClosureConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingClosureRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    private(set) var onlySingleMutedParameter: Bool
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "only_single_muted_parameter" => .flag(onlySingleMutedParameter)
-    }
-
-    init(onlySingleMutedParameter: Bool = false) {
-        self.onlySingleMutedParameter = onlySingleMutedParameter
-    }
+    @ConfigurationElement("only_single_muted_parameter")
+    private(set) var onlySingleMutedParameter = false
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingCommaRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("mandatory_comma")
+    @ConfigurationElement(key: "mandatory_comma")
     private(set) var mandatoryComma = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -4,7 +4,7 @@ struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var mandatoryComma: Bool
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "mandatory_comma" => .flag(mandatoryComma)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingCommaRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "mandatory_comma")
     private(set) var mandatoryComma = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -4,8 +4,9 @@ struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var mandatoryComma: Bool
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", mandatory_comma: \(mandatoryComma)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "mandatory_comma" => .flag(mandatoryComma)
     }
 
     init(mandatoryComma: Bool = false) {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -1,17 +1,12 @@
+import SwiftLintCore
+
 struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingCommaRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    private(set) var mandatoryComma: Bool
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "mandatory_comma" => .flag(mandatoryComma)
-    }
-
-    init(mandatoryComma: Bool = false) {
-        self.mandatoryComma = mandatoryComma
-    }
+    @ConfigurationElement("mandatory_comma")
+    private(set) var mandatoryComma = false
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct TrailingWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingWhitespaceRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "ignores_empty_lines")
     private(set) var ignoresEmptyLines = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -1,15 +1,14 @@
+import SwiftLintCore
+
 struct TrailingWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingWhitespaceRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "ignores_empty_lines")
     private(set) var ignoresEmptyLines = false
+    @ConfigurationElement(key: "ignores_comments")
     private(set) var ignoresComments = true
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "ignores_empty_lines" => .flag(ignoresEmptyLines)
-        "ignores_comments" => .flag(ignoresComments)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct TrailingWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TrailingWhitespaceRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "ignores_empty_lines")
     private(set) var ignoresEmptyLines = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -5,10 +5,10 @@ struct TrailingWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatabl
     private(set) var ignoresEmptyLines = false
     private(set) var ignoresComments = true
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", ignores_empty_lines: \(ignoresEmptyLines)" +
-            ", ignores_comments: \(ignoresComments)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "ignores_empty_lines" => .flag(ignoresEmptyLines)
+        "ignores_comments" => .flag(ignoresComments)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -5,7 +5,7 @@ struct TrailingWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatabl
     private(set) var ignoresEmptyLines = false
     private(set) var ignoresComments = true
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "ignores_empty_lines" => .flag(ignoresEmptyLines)
         "ignores_comments" => .flag(ignoresComments)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -25,9 +25,9 @@ enum TypeContent: String, AcceptableByConfigurationElement {
 struct TypeContentsOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TypeContentsOrderRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("order")
+    @ConfigurationElement(key: "order")
     private(set) var order: [[TypeContent]] = [
         [.case],
         [.typeAlias, .associatedType],

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -17,9 +17,7 @@ enum TypeContent: String, AcceptableByConfigurationElement {
     case `subscript` = "subscript"
     case deinitializer = "deinitializer"
 
-    func asOption() -> OptionType {
-        .symbol(rawValue)
-    }
+    func asOption() -> OptionType { .symbol(rawValue) }
 }
 
 struct TypeContentsOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -37,7 +37,7 @@ struct TypeContentsOrderConfiguration: SeverityBasedRuleConfiguration, Equatable
         [.deinitializer]
     ]
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "order" => .list(order.map { .list($0.map(\.rawValue).map { .symbol($0) }) })
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -37,9 +37,9 @@ struct TypeContentsOrderConfiguration: SeverityBasedRuleConfiguration, Equatable
         [.deinitializer]
     ]
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", order: \(String(describing: order))"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "order" => .list(order.map { .list($0.map(\.rawValue).map { .symbol($0) }) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -1,4 +1,6 @@
-enum TypeContent: String {
+import SwiftLintCore
+
+enum TypeContent: String, AcceptableByConfigurationElement {
     case `case` = "case"
     case typeAlias = "type_alias"
     case associatedType = "associated_type"
@@ -14,12 +16,18 @@ enum TypeContent: String {
     case otherMethod = "other_method"
     case `subscript` = "subscript"
     case deinitializer = "deinitializer"
+
+    func asOption() -> OptionType {
+        .symbol(rawValue)
+    }
 }
 
 struct TypeContentsOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TypeContentsOrderRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("order")
     private(set) var order: [[TypeContent]] = [
         [.case],
         [.typeAlias, .associatedType],
@@ -36,11 +44,6 @@ struct TypeContentsOrderConfiguration: SeverityBasedRuleConfiguration, Equatable
         [.subscript],
         [.deinitializer]
     ]
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "order" => .list(order.map { .list($0.map(\.rawValue).map { .symbol($0) }) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -25,7 +25,7 @@ enum TypeContent: String, AcceptableByConfigurationElement {
 struct TypeContentsOrderConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TypeContentsOrderRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "order")
     private(set) var order: [[TypeContent]] = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
@@ -1,16 +1,15 @@
+import SwiftLintCore
+
 struct TypeNameConfiguration: RuleConfiguration, Equatable {
     typealias Parent = TypeNameRule
 
+    @ConfigurationElement
     private(set) var nameConfiguration = NameConfiguration<Parent>(minLengthWarning: 3,
                                                                    minLengthError: 0,
                                                                    maxLengthWarning: 40,
                                                                    maxLengthError: 1000)
+    @ConfigurationElement(key: "validate_protocols")
     private(set) var validateProtocols = true
-
-    var parameterDescription: RuleConfigurationDescription? {
-        nameConfiguration
-        "validate_protocols" => .flag(validateProtocols)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
@@ -7,7 +7,7 @@ struct TypeNameConfiguration: RuleConfiguration, Equatable {
                                                                    maxLengthError: 1000)
     private(set) var validateProtocols = true
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         nameConfiguration
         "validate_protocols" => .flag(validateProtocols)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
@@ -7,8 +7,9 @@ struct TypeNameConfiguration: RuleConfiguration, Equatable {
                                                                    maxLengthError: 1000)
     private(set) var validateProtocols = true
 
-    var consoleDescription: String {
-        return nameConfiguration.consoleDescription + ", validate_protocols: \(validateProtocols)"
+    var parameterDescription: RuleConfigurationDescription {
+        nameConfiguration
+        "validate_protocols" => .flag(validateProtocols)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
@@ -7,7 +7,7 @@ struct UnitTestConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equa
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "test_parent_classes" => .list(testParentClasses.sorted().map { .symbol($0) })
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
@@ -6,7 +6,7 @@ typealias SingleTestClassConfiguration = UnitTestConfiguration<SingleTestClassRu
 typealias NoMagicNumbersConfiguration = UnitTestConfiguration<NoMagicNumbersRule>
 
 struct UnitTestConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable {
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "test_parent_classes")
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
@@ -7,9 +7,9 @@ struct UnitTestConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equa
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", test_parent_classes: \(testParentClasses.sorted())"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "test_parent_classes" => .list(testParentClasses.sorted().map { .symbol($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
@@ -6,7 +6,7 @@ typealias SingleTestClassConfiguration = UnitTestConfiguration<SingleTestClassRu
 typealias NoMagicNumbersConfiguration = UnitTestConfiguration<NoMagicNumbersRule>
 
 struct UnitTestConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable {
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "test_parent_classes")
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
@@ -1,16 +1,15 @@
+import SwiftLintCore
+
 typealias BalancedXCTestLifecycleConfiguration = UnitTestConfiguration<BalancedXCTestLifecycleRule>
 typealias EmptyXCTestMethodConfiguration = UnitTestConfiguration<EmptyXCTestMethodRule>
 typealias SingleTestClassConfiguration = UnitTestConfiguration<SingleTestClassRule>
 typealias NoMagicNumbersConfiguration = UnitTestConfiguration<NoMagicNumbersRule>
 
 struct UnitTestConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable {
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "test_parent_classes")
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "test_parent_classes" => .list(testParentClasses.sorted().map { .symbol($0) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
@@ -24,9 +23,5 @@ struct UnitTestConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equa
         if let extraTestParentClasses = configuration["test_parent_classes"] as? [String] {
             self.testParentClasses.formUnion(extraTestParentClasses)
         }
-    }
-
-    var severity: ViolationSeverity {
-        return severityConfiguration.severity
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -11,10 +11,10 @@ struct UnusedDeclarationConfiguration: SeverityBasedRuleConfiguration, Equatable
     private(set) var includePublicAndOpen = false
     private(set) var relatedUSRsToSkip = Set(["s:7SwiftUI15PreviewProviderP"])
 
-    var consoleDescription: String {
-        return "\(ConfigurationKey.severity.rawValue): \(severityConfiguration.severity.rawValue), " +
-            "\(ConfigurationKey.includePublicAndOpen.rawValue): \(includePublicAndOpen), " +
-            "\(ConfigurationKey.relatedUSRsToSkip.rawValue): \(relatedUSRsToSkip.sorted())"
+    var parameterDescription: RuleConfigurationDescription {
+        severity
+        ConfigurationKey.includePublicAndOpen.rawValue => .flag(includePublicAndOpen)
+        ConfigurationKey.relatedUSRsToSkip.rawValue => .list(relatedUSRsToSkip.sorted().map { .string($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -9,7 +9,7 @@ private enum ConfigurationKey: String {
 struct UnusedDeclarationConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedDeclarationRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.error
     @ConfigurationElement(key: ConfigurationKey.includePublicAndOpen.rawValue)
     private(set) var includePublicAndOpen = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -9,11 +9,11 @@ private enum ConfigurationKey: String {
 struct UnusedDeclarationConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedDeclarationRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.error
-    @ConfigurationElement(ConfigurationKey.includePublicAndOpen.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.includePublicAndOpen.rawValue)
     private(set) var includePublicAndOpen = false
-    @ConfigurationElement(ConfigurationKey.relatedUSRsToSkip.rawValue)
+    @ConfigurationElement(key: ConfigurationKey.relatedUSRsToSkip.rawValue)
     private(set) var relatedUSRsToSkip = Set(["s:7SwiftUI15PreviewProviderP"])
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -11,7 +11,7 @@ struct UnusedDeclarationConfiguration: SeverityBasedRuleConfiguration, Equatable
     private(set) var includePublicAndOpen = false
     private(set) var relatedUSRsToSkip = Set(["s:7SwiftUI15PreviewProviderP"])
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severity
         ConfigurationKey.includePublicAndOpen.rawValue => .flag(includePublicAndOpen)
         ConfigurationKey.relatedUSRsToSkip.rawValue => .list(relatedUSRsToSkip.sorted().map { .string($0) })

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 private enum ConfigurationKey: String {
     case severity = "severity"
     case includePublicAndOpen = "include_public_and_open"
@@ -7,15 +9,12 @@ private enum ConfigurationKey: String {
 struct UnusedDeclarationConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedDeclarationRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.error
+    @ConfigurationElement(ConfigurationKey.includePublicAndOpen.rawValue)
     private(set) var includePublicAndOpen = false
+    @ConfigurationElement(ConfigurationKey.relatedUSRsToSkip.rawValue)
     private(set) var relatedUSRsToSkip = Set(["s:7SwiftUI15PreviewProviderP"])
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severity
-        ConfigurationKey.includePublicAndOpen.rawValue => .flag(includePublicAndOpen)
-        ConfigurationKey.relatedUSRsToSkip.rawValue => .list(relatedUSRsToSkip.sorted().map { .string($0) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configDict = configuration as? [String: Any], configDict.isNotEmpty else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -30,7 +30,7 @@ struct TransitiveModuleConfiguration<Parent: Rule>: Equatable, AcceptableByConfi
 struct UnusedImportConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedImportRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "require_explicit_imports")
     private(set) var requireExplicitImports = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -28,7 +28,7 @@ struct UnusedImportConfiguration: SeverityBasedRuleConfiguration, Equatable {
     /// A set of modules to never remove the imports of.
     private(set) var alwaysKeepImports = [String]()
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "require_explicit_imports" => .flag(requireExplicitImports)
         "allowed_transitive_imports" => .nest {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -30,7 +30,7 @@ struct TransitiveModuleConfiguration<Parent: Rule>: Equatable, AcceptableByConfi
 struct UnusedImportConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedImportRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(key: "require_explicit_imports")
     private(set) var requireExplicitImports = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -1,6 +1,8 @@
+import SwiftLintCore
+
 /// The configuration payload mapping an imported module to a set of modules that are allowed to be
 /// transitively imported.
-struct TransitiveModuleConfiguration<Parent: Rule>: Equatable {
+struct TransitiveModuleConfiguration<Parent: Rule>: Equatable, AcceptableByConfigurationElement {
     /// The module imported in a source file.
     let importedModule: String
     /// The set of modules that can be transitively imported by `importedModule`.
@@ -17,27 +19,26 @@ struct TransitiveModuleConfiguration<Parent: Rule>: Equatable {
         self.importedModule = importedModule
         self.transitivelyImportedModules = transitivelyImportedModules
     }
+
+    func asOption() -> OptionType {
+        .nest {
+            importedModule => .list(transitivelyImportedModules.map { .string($0) })
+        }
+    }
 }
 
 struct UnusedImportConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedImportRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
+    @ConfigurationElement(key: "require_explicit_imports")
     private(set) var requireExplicitImports = false
+    @ConfigurationElement(key: "allowed_transitive_imports")
     private(set) var allowedTransitiveImports = [TransitiveModuleConfiguration<Parent>]()
     /// A set of modules to never remove the imports of.
+    @ConfigurationElement(key: "always_keep_imports")
     private(set) var alwaysKeepImports = [String]()
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "require_explicit_imports" => .flag(requireExplicitImports)
-        "allowed_transitive_imports" => .nest {
-            for module in allowedTransitiveImports {
-                module.importedModule => .list(module.transitivelyImportedModules.map { .string($0) })
-            }
-        }
-        "always_keep_imports" => .list(alwaysKeepImports.map { .string($0) })
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -4,7 +4,7 @@ struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration, Equat
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var ignoreOptionalTry = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "ignore_optional_try" => .flag(ignoreOptionalTry)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedOptionalBindingRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("ignore_optional_try")
+    @ConfigurationElement(key: "ignore_optional_try")
     private(set) var ignoreOptionalTry = false
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedOptionalBindingRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "ignore_optional_try")
     private(set) var ignoreOptionalTry = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -4,8 +4,9 @@ struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration, Equat
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var ignoreOptionalTry = false
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", ignore_optional_try: \(ignoreOptionalTry)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "ignore_optional_try" => .flag(ignoreOptionalTry)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -1,13 +1,12 @@
+import SwiftLintCore
+
 struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = UnusedOptionalBindingRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("ignore_optional_try")
     private(set) var ignoreOptionalTry = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "ignore_optional_try" => .flag(ignoreOptionalTry)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
@@ -10,9 +10,9 @@ struct VerticalWhitespaceClosingBracesConfiguration: SeverityBasedRuleConfigurat
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var onlyEnforceBeforeTrivialLines = false
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" +
-            ", \(ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue): \(onlyEnforceBeforeTrivialLines)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue => .flag(onlyEnforceBeforeTrivialLines)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
@@ -1,3 +1,5 @@
+import SwiftLintCore
+
 // swiftlint:disable:next type_name
 struct VerticalWhitespaceClosingBracesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = VerticalWhitespaceClosingBracesRule
@@ -7,13 +9,10 @@ struct VerticalWhitespaceClosingBracesConfiguration: SeverityBasedRuleConfigurat
         case onlyEnforceBeforeTrivialLines = "only_enforce_before_trivial_lines"
     }
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue)
     private(set) var onlyEnforceBeforeTrivialLines = false
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue => .flag(onlyEnforceBeforeTrivialLines)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
@@ -9,7 +9,7 @@ struct VerticalWhitespaceClosingBracesConfiguration: SeverityBasedRuleConfigurat
         case onlyEnforceBeforeTrivialLines = "only_enforce_before_trivial_lines"
     }
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue)
     private(set) var onlyEnforceBeforeTrivialLines = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
@@ -10,7 +10,7 @@ struct VerticalWhitespaceClosingBracesConfiguration: SeverityBasedRuleConfigurat
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var onlyEnforceBeforeTrivialLines = false
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue => .flag(onlyEnforceBeforeTrivialLines)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
@@ -9,7 +9,7 @@ struct VerticalWhitespaceClosingBracesConfiguration: SeverityBasedRuleConfigurat
         case onlyEnforceBeforeTrivialLines = "only_enforce_before_trivial_lines"
     }
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue)
     private(set) var onlyEnforceBeforeTrivialLines = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -3,9 +3,9 @@ import SwiftLintCore
 struct VerticalWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = VerticalWhitespaceRule
 
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement("max_empty_lines")
+    @ConfigurationElement(key: "max_empty_lines")
     private(set) var maxEmptyLines = 1
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -1,13 +1,12 @@
+import SwiftLintCore
+
 struct VerticalWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = VerticalWhitespaceRule
 
+    @ConfigurationElement("severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement("max_empty_lines")
     private(set) var maxEmptyLines = 1
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "max_empty_lines" => .integer(maxEmptyLines)
-    }
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -4,8 +4,9 @@ struct VerticalWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatabl
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var maxEmptyLines = 1
 
-    var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription)" + ", max_empty_lines: \(maxEmptyLines)"
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "max_empty_lines" => .integer(maxEmptyLines)
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct VerticalWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = VerticalWhitespaceRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "max_empty_lines")
     private(set) var maxEmptyLines = 1

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -4,7 +4,7 @@ struct VerticalWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatabl
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     private(set) var maxEmptyLines = 1
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "max_empty_lines" => .integer(maxEmptyLines)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
@@ -14,7 +14,7 @@ struct XCTSpecificMatcherConfiguration: SeverityBasedRuleConfiguration, Equatabl
         case matchers
     }
 
-    var parameterDescription: RuleConfigurationDescription {
+    var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         ConfigurationKey.matchers.rawValue => .list(matchers.map(\.rawValue).sorted().map { .symbol($0) })
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct XCTSpecificMatcherConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = XCTSpecificMatcherRule
 
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: ConfigurationKey.matchers.rawValue)
     private(set) var matchers = Matcher.allCases

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
@@ -3,7 +3,7 @@ import SwiftLintCore
 struct XCTSpecificMatcherConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = XCTSpecificMatcherRule
 
-    @ConfigurationElement
+    @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: ConfigurationKey.matchers.rawValue)
     private(set) var matchers = Matcher.allCases

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
@@ -1,22 +1,23 @@
+import SwiftLintCore
+
 struct XCTSpecificMatcherConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = XCTSpecificMatcherRule
 
+    @ConfigurationElement
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    private(set) var matchers = Set(Matcher.allCases)
+    @ConfigurationElement(key: ConfigurationKey.matchers.rawValue)
+    private(set) var matchers = Matcher.allCases
 
-    enum Matcher: String, Hashable, CaseIterable {
+    enum Matcher: String, Hashable, CaseIterable, AcceptableByConfigurationElement {
         case oneArgumentAsserts = "one-argument-asserts"
         case twoArgumentAsserts = "two-argument-asserts"
+
+        func asOption() -> OptionType { .symbol(rawValue) }
     }
 
     private enum ConfigurationKey: String {
         case severity
         case matchers
-    }
-
-    var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        ConfigurationKey.matchers.rawValue => .list(matchers.map(\.rawValue).sorted().map { .symbol($0) })
     }
 
     mutating func apply(configuration: Any) throws {
@@ -29,7 +30,7 @@ struct XCTSpecificMatcherConfiguration: SeverityBasedRuleConfiguration, Equatabl
         }
 
         if let matchers = configuration[ConfigurationKey.matchers.rawValue] as? [String] {
-            self.matchers = Set(matchers.compactMap(Matcher.init(rawValue:)))
+            self.matchers = matchers.compactMap(Matcher.init)
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
@@ -14,11 +14,9 @@ struct XCTSpecificMatcherConfiguration: SeverityBasedRuleConfiguration, Equatabl
         case matchers
     }
 
-    var consoleDescription: String {
-        return [
-            "severity: \(severityConfiguration.consoleDescription)",
-            "\(ConfigurationKey.matchers): \(matchers.map(\.rawValue).sorted().joined(separator: ", "))"
-        ].joined(separator: ", ")
+    var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        ConfigurationKey.matchers.rawValue => .list(matchers.map(\.rawValue).sorted().map { .symbol($0) })
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintCore/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintCore/Documentation/RuleDocumentation.swift
@@ -59,6 +59,9 @@ private func h1(_ text: String) -> String { "# \(text)" }
 private func h2(_ text: String) -> String { "## \(text)" }
 
 private func detailsSummary(_ rule: Rule) -> String {
+    let configurationTable = rule.configurationDescription.markdown()
+        .split(separator: "\n")
+        .joined(separator: "\n  ")
     return """
         * **Identifier:** \(type(of: rule).description.identifier)
         * **Enabled by default:** \(rule is OptInRule ? "No" : "Yes")
@@ -66,7 +69,8 @@ private func detailsSummary(_ rule: Rule) -> String {
         * **Kind:** \(type(of: rule).description.kind)
         * **Analyzer rule:** \(rule is AnalyzerRule ? "Yes" : "No")
         * **Minimum Swift compiler version:** \(type(of: rule).description.minSwiftVersion.rawValue)
-        * **Default configuration:** \(rule.configurationDescription)
+        * **Default configuration:**
+          \(configurationTable)
         """
 }
 

--- a/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
@@ -14,8 +14,8 @@ public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration,
 
     private var optionSeverity: ChildOptionSeverity
 
-    public var consoleDescription: String {
-        optionSeverity.rawValue
+    public var parameterDescription: RuleConfigurationDescription {
+        "severity" => .symbol(optionSeverity.rawValue)
     }
 
     /// The `ChildOptionSeverityConfiguration` mapped to a usually used `ViolationSeverity`. It's `nil` if the option

--- a/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
@@ -14,7 +14,7 @@ public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration,
 
     private var optionSeverity: ChildOptionSeverity
 
-    public var parameterDescription: RuleConfigurationDescription {
+    public var parameterDescription: RuleConfigurationDescription? {
         "severity" => .symbol(optionSeverity.rawValue)
     }
 

--- a/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
@@ -1,7 +1,6 @@
 /// A rule configuration that allows to disable (`off`) an option of a rule or specify its severity level in which
 /// case it's active.
-public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration, Equatable, InlinableOptionType,
-                                                              AcceptableByConfigurationElement {
+public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration, Equatable, InlinableOptionType {
     /// Configuration with a warning severity.
     public static var error: Self { Self(optionSeverity: .error) }
     /// Configuration with an error severity.

--- a/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
@@ -1,6 +1,7 @@
 /// A rule configuration that allows to disable (`off`) an option of a rule or specify its severity level in which
 /// case it's active.
-public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
+public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration, Equatable,
+                                                              AcceptableByConfigurationElement {
     /// Configuration with a warning severity.
     public static var error: Self { Self(optionSeverity: .error) }
     /// Configuration with an error severity.
@@ -31,4 +32,6 @@ public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration,
         }
         self.optionSeverity = optionSeverity
     }
+
+    public func asOption() -> OptionType { .symbol(optionSeverity.rawValue) }
 }

--- a/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
@@ -1,6 +1,6 @@
 /// A rule configuration that allows to disable (`off`) an option of a rule or specify its severity level in which
 /// case it's active.
-public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration, Equatable,
+public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration, Equatable, InlinableOptionType,
                                                               AcceptableByConfigurationElement {
     /// Configuration with a warning severity.
     public static var error: Self { Self(optionSeverity: .error) }
@@ -14,10 +14,6 @@ public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration,
     }
 
     private var optionSeverity: ChildOptionSeverity
-
-    public var parameterDescription: RuleConfigurationDescription? {
-        "severity" => .symbol(optionSeverity.rawValue)
-    }
 
     /// The `ChildOptionSeverityConfiguration` mapped to a usually used `ViolationSeverity`. It's `nil` if the option
     /// is set to `off`.

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -313,7 +313,6 @@ public protocol InlinableOptionType {}
 ///    levels: warning: 1
 ///            error: 2
 ///    ```
-/// 3. ``SeverityConfiguration`` and ``ChildOptionSeverityConfiguration`` are always inlined.
 @propertyWrapper
 public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatable>: AnyConfigurationElement,
                                                                                      Equatable {
@@ -428,5 +427,22 @@ public extension RuleConfiguration {
             return .from(configuration: self)
         }
         return RuleConfigurationDescription(options: [key => asOption()])
+    }
+}
+
+public extension SeverityConfiguration {
+    func asDescription(with key: String) -> RuleConfigurationDescription {
+        let description = RuleConfigurationDescription.from(configuration: self)
+        if key.isEmpty {
+            return description
+        }
+        guard let option = description.options.onlyElement?.value, case .symbol(_) = option else {
+            queuedFatalError(
+                """
+                Severity configurations must have exaclty one option that is a violation severity.
+                """
+            )
+        }
+        return RuleConfigurationDescription(options: [key => option])
     }
 }

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -14,28 +14,8 @@ public protocol HumanReadable {
 }
 
 /// Description of a rule configuration.
-public struct RuleConfigurationDescription: HumanReadable, Equatable {
+public struct RuleConfigurationDescription: Equatable {
     fileprivate let options: [RuleConfigurationOption]
-
-    public func oneLiner() -> String {
-        options.first == .noOptions ? "" : options.map { $0.oneLiner() }.joined(separator: "; ")
-    }
-
-    public func markdown() -> String {
-        guard options.isNotEmpty, options.first != .noOptions else {
-            return ""
-        }
-        return """
-            <table>
-            <thead>
-            <tr><th>Key</th><th>Value</th></tr>
-            </thead>
-            <tbody>
-            \(options.map { $0.markdown() }.joined(separator: "\n"))
-            </tbody>
-            </table>
-            """
-    }
 
     public static func from(configuration: any RuleConfiguration) -> Self {
         // Prefer custom descriptions.
@@ -62,27 +42,38 @@ public struct RuleConfigurationDescription: HumanReadable, Equatable {
     }
 }
 
-/// Type of an option.
-public enum OptionType: Equatable {
-    case empty
-    case flag(Bool)
-    case string(String)
-    case symbol(String)
-    case integer(Int)
-    case float(Double)
-    case severity(ViolationSeverity)
-    case list([OptionType])
-    case nested(RuleConfigurationDescription)
+extension RuleConfigurationDescription: HumanReadable {
+    public func oneLiner() -> String {
+        options.first == .noOptions ? "" : options.map { $0.oneLiner() }.joined(separator: "; ")
+    }
+
+    public func markdown() -> String {
+        guard options.isNotEmpty, options.first != .noOptions else {
+            return ""
+        }
+        return """
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            \(options.map { $0.markdown() }.joined(separator: "\n"))
+            </tbody>
+            </table>
+            """
+    }
 }
 
 /// A single option of a `RuleConfigurationDescription`.
-public struct RuleConfigurationOption: HumanReadable, Equatable {
+public struct RuleConfigurationOption: Equatable {
     /// An option serving as a marker for an empty configuration description.
     public static let noOptions = Self(key: "<nothing>", value: .empty)
 
     fileprivate let key: String
     fileprivate let value: OptionType
+}
 
+extension RuleConfigurationOption: HumanReadable {
     public func markdown() -> String {
         """
         <tr>
@@ -99,6 +90,19 @@ public struct RuleConfigurationOption: HumanReadable, Equatable {
     public func oneLiner() -> String {
         "\(key): \(value.oneLiner())"
     }
+}
+
+/// Type of an option.
+public enum OptionType: Equatable {
+    case empty
+    case flag(Bool)
+    case string(String)
+    case symbol(String)
+    case integer(Int)
+    case float(Double)
+    case severity(ViolationSeverity)
+    case list([OptionType])
+    case nested(RuleConfigurationDescription)
 }
 
 extension OptionType: HumanReadable {

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -36,7 +36,7 @@ public struct RuleConfigurationDescription: Equatable {
         }
     }
 
-    public static func from(configuration: any RuleConfiguration) -> Self {
+    static func from(configuration: any RuleConfiguration) -> Self {
         // Prefer custom descriptions.
         if let customDescription = configuration.parameterDescription {
             return customDescription
@@ -190,32 +190,40 @@ extension OptionType: Documentable {
 /// A result builder creating configuration descriptions.
 @resultBuilder
 public struct RuleConfigurationDescriptionBuilder {
+    /// :nodoc:
     public typealias Description = RuleConfigurationDescription
 
+    /// :nodoc:
     public static func buildBlock(_ components: Description...) -> Description {
         Self.buildArray(components)
     }
 
+    /// :nodoc:
     public static func buildOptional(_ component: Description?) -> Description {
         component ?? Description(options: [])
     }
 
+    /// :nodoc:
     public static func buildEither(first component: Description) -> Description {
         component
     }
 
+    /// :nodoc:
     public static func buildEither(second component: Description) -> Description {
         component
     }
 
+    /// :nodoc:
     public static func buildExpression(_ expression: RuleConfigurationOption) -> Description {
         Description(options: [expression])
     }
 
+    /// :nodoc:
     public static func buildExpression(_ expression: any RuleConfiguration) -> Description {
         Description.from(configuration: expression)
     }
 
+    /// :nodoc:
     public static func buildArray(_ components: [Description]) -> Description {
         Description(options: components.flatMap { $0.options })
     }
@@ -316,13 +324,20 @@ public protocol InlinableOptionType: AcceptableByConfigurationElement {}
 @propertyWrapper
 public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatable>: AnyConfigurationElement,
                                                                                      Equatable {
+    /// Wrapped option value.
     public var wrappedValue: T
-    let key: String
+
+    private let key: String
 
     fileprivate var description: RuleConfigurationDescription {
         wrappedValue.asDescription(with: key)
     }
 
+    /// Default constructor.
+    ///
+    /// - Parameters:
+    ///   - value: Value to be wrapped.
+    ///   - key: Name of the option.
     public init(wrappedValue value: T, key: String) {
         self.wrappedValue = value
         self.key = key
@@ -331,6 +346,8 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     /// Constructor for optional values.
     ///
     /// It allows to skip explicit initialization with `nil` of the property.
+    ///
+    /// - Parameter value: Value to be wrapped.
     public init<Wrapped>(key: String) where T == Wrapped? {
         self.init(wrappedValue: nil, key: key)
     }
@@ -339,6 +356,8 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     ///
     /// ``InlinableOptionType``s are allowed to have an empty key. The configuration will be inlined into its
     /// parent configuration in this specific case.
+    ///
+    /// - Parameter value: Value to be wrapped.
     public init(wrappedValue value: T) where T: InlinableOptionType {
         self.init(wrappedValue: value, key: "")
     }
@@ -431,6 +450,8 @@ public extension RuleConfiguration {
 }
 
 public extension SeverityConfiguration {
+    /// Severity configurations are special in that they shall not be nested when an option name is provided.
+    /// Instead, their only option value must be used together with the option name.
     func asDescription(with key: String) -> RuleConfigurationDescription {
         let description = RuleConfigurationDescription.from(configuration: self)
         if key.isEmpty {

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -156,7 +156,7 @@ public struct RuleConfigurationDescriptionBuilder {
     }
 
     public static func buildExpression(_ expression: any RuleConfiguration) -> Description {
-        expression.parameterDescription
+        expression.parameterDescription ?? Description(options: [])
     }
 
     public static func buildArray(_ components: [Description]) -> Description {

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -275,7 +275,7 @@ public extension AcceptableByConfigurationElement {
 }
 
 /// An option type that does not need a key when used in a ``ConfigurationElement``. Its value will be inlined.
-public protocol InlinableOptionType {}
+public protocol InlinableOptionType: AcceptableByConfigurationElement {}
 
 /// A single parameter of a rule configuration.
 ///
@@ -284,7 +284,7 @@ public protocol InlinableOptionType {}
 /// @ConfigurationElement(key: "name")
 /// var property = true
 /// ```
-/// If the wrapped element is itself a ``RuleConfiguration`` there are three options for its representation
+/// If the wrapped element is an ``InlinableOptionType``, there are two options for its representation
 /// in the documentation:
 ///
 /// 1. It can be inlined into the parent configuration. For that, do not provide a name as an argument. E.g.
@@ -436,7 +436,7 @@ public extension SeverityConfiguration {
         if key.isEmpty {
             return description
         }
-        guard let option = description.options.onlyElement?.value, case .symbol(_) = option else {
+        guard let option = description.options.onlyElement?.value, case .symbol = option else {
             queuedFatalError(
                 """
                 Severity configurations must have exaclty one option that is a violation severity.

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -274,6 +274,9 @@ public extension AcceptableByConfigurationElement {
     }
 }
 
+/// An option type that does not need a key when used in a ``ConfigurationElement``. Its value will be inlined.
+public protocol InlinableOptionType {}
+
 /// A single parameter of a rule configuration.
 ///
 /// Apply it to a simple (e.g. boolean) property like
@@ -335,9 +338,9 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
 
     /// Constructor for a `ConfigurationElement` without a key.
     ///
-    /// Only `RuleConfiguration`s are allowed to have an empty key. The configuration will be inlined into its
+    /// ``InlinableOptionType``s are allowed to have an empty key. The configuration will be inlined into its
     /// parent configuration in this specific case.
-    public init(wrappedValue value: T) where T: RuleConfiguration {
+    public init(wrappedValue value: T) where T: InlinableOptionType {
         self.init(wrappedValue: value, key: "")
     }
 }
@@ -412,6 +415,8 @@ extension NSRegularExpression: AcceptableByConfigurationElement, Comparable {
         lhs.pattern < rhs.pattern
     }
 }
+
+// MARK: RuleConfiguration conformances
 
 public extension RuleConfiguration {
     func asOption() -> OptionType {

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -310,7 +310,7 @@ public extension AcceptableByConfigurationElement {
 ///    levels: warning: 1
 ///            error: 2
 ///    ```
-/// 3. A ``SeverityConfiguration`` is always inlined.
+/// 3. ``SeverityConfiguration`` and ``ChildOptionSeverityConfiguration`` are always inlined.
 @propertyWrapper
 public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatable>: AnyConfigurationElement,
                                                                                      Equatable {
@@ -413,12 +413,6 @@ extension NSRegularExpression: AcceptableByConfigurationElement, Comparable {
     }
 }
 
-extension ViolationSeverity: AcceptableByConfigurationElement {
-    public func asOption() -> OptionType {
-        .symbol(rawValue)
-    }
-}
-
 public extension RuleConfiguration {
     func asOption() -> OptionType {
         .nested(.from(configuration: self))
@@ -429,11 +423,5 @@ public extension RuleConfiguration {
             return .from(configuration: self)
         }
         return RuleConfigurationDescription(options: [key => asOption()])
-    }
-}
-
-extension SeverityConfiguration: AcceptableByConfigurationElement {
-    public func asOption() -> OptionType {
-        severity.asOption()
     }
 }

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -1,0 +1,196 @@
+/// A type that can be converted into a human-readable representation.
+public protocol HumanReadable {
+    /// Convert an object to Markdown.
+    ///
+    /// - Returns: A Markdown string describing the object.
+    func markdown() -> String
+
+    /// Convert an object to a single line string.
+    ///
+    /// - Returns: A "one liner" describing the object.
+    func oneLiner() -> String
+}
+
+/// Description of a rule configuration.
+public struct RuleConfigurationDescription: HumanReadable, Equatable {
+    fileprivate let options: [RuleConfigurationOption]
+
+    public func oneLiner() -> String {
+        options.first == .noOptions ? "" : options.map { $0.oneLiner() }.joined(separator: "; ")
+    }
+
+    public func markdown() -> String {
+        guard options.isNotEmpty, options.first != .noOptions else {
+            return ""
+        }
+        return """
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            \(options.map { $0.markdown() }.joined(separator: "\n"))
+            </tbody>
+            </table>
+            """
+    }
+}
+
+/// A type that can be converted into a configuration option.
+public protocol RuleConfigurationOptionConvertible {
+    /// Convert an object to a configuration option.
+    ///
+    /// - Returns: A configuration option for the object.
+    func makeOption() -> RuleConfigurationOption
+}
+
+/// A single option of a `RuleConfigurationDescription`.
+public struct RuleConfigurationOption: RuleConfigurationOptionConvertible, HumanReadable, Equatable {
+    /// Type of an option.
+    public enum OptionType: Equatable {
+        case flag(Bool)
+        case string(String)
+        case symbol(String)
+        case integer(Int)
+        case float(Double)
+        case severity(ViolationSeverity)
+        case list([OptionType])
+        case nested(RuleConfigurationDescription)
+    }
+
+    /// An option serving as a marker for an empty configuration description.
+    public static let noOptions = Self(key: "<nothing>", value: .flag(false))
+
+    fileprivate let key: String
+    fileprivate let value: OptionType
+
+    public func makeOption() -> RuleConfigurationOption {
+        self
+    }
+
+    public func markdown() -> String {
+        """
+        <tr>
+        <td>
+        \(key)
+        </td>
+        <td>
+        \(value.markdown())
+        </td>
+        </tr>
+        """
+    }
+
+    public func oneLiner() -> String {
+        "\(key): \(value.oneLiner())"
+    }
+}
+
+extension RuleConfigurationOption.OptionType: HumanReadable {
+    public func markdown() -> String {
+        switch self {
+        case let .flag(value):
+            return String(describing: value)
+        case let .string(value):
+            return "&quot;" + value + "&quot;"
+        case let .symbol(value):
+            return value
+        case let .integer(value):
+            return String(describing: value)
+        case let .float(value):
+            return String(describing: value)
+        case let .severity(value):
+            return value.rawValue
+        case let .list(options):
+            return "[" + options.map { $0.markdown() }.joined(separator: ", ") + "]"
+        case let .nested(value):
+            return value.markdown()
+        }
+    }
+
+    public func oneLiner() -> String {
+        switch self {
+        case let .flag(value):
+            return String(describing: value)
+        case let .string(value):
+            return "\"" + value + "\""
+        case let .symbol(value):
+            return value
+        case let .integer(value):
+            return String(describing: value)
+        case let .float(value):
+            return String(describing: value)
+        case let .severity(value):
+            return value.rawValue
+        case let .list(options):
+            return "[" + options.map { $0.oneLiner() }.joined(separator: ", ") + "]"
+        case let .nested(value):
+            return value.oneLiner()
+        }
+    }
+}
+
+/// A result builder creating configuration descriptions.
+@resultBuilder
+public struct RuleConfigurationDescriptionBuilder {
+    public typealias Description = RuleConfigurationDescription
+
+    public static func buildBlock(_ components: Description...) -> Description {
+        Self.buildArray(components)
+    }
+
+    public static func buildOptional(_ component: Description?) -> Description {
+        component ?? Description(options: [])
+    }
+
+    public static func buildEither(first component: Description) -> Description {
+        component
+    }
+
+    public static func buildEither(second component: Description) -> Description {
+        component
+    }
+
+    public static func buildExpression(_ expression: RuleConfigurationOptionConvertible) -> Description {
+        Description(options: [expression.makeOption()])
+    }
+
+    public static func buildExpression(_ expression: any RuleConfiguration) -> Description {
+        expression.parameterDescription
+    }
+
+    public static func buildArray(_ components: [Description]) -> Description {
+        Description(options: components.flatMap { $0.options })
+    }
+}
+
+infix operator =>: MultiplicationPrecedence
+
+public extension RuleConfigurationOption.OptionType {
+    /// Operator enabling an easy way to create a configuration option.
+    ///
+    /// - Parameters:
+    ///   - key: Name of the option.
+    ///   - value: Value of the option.
+    ///
+    /// - Returns: A configuration option built up by the given data.
+    static func => (key: String, value: RuleConfigurationOption.OptionType) -> RuleConfigurationOption {
+        RuleConfigurationOption(key: key, value: value)
+    }
+
+    /// Create an option defined by nested configuration description.
+    ///
+    /// - Parameters:
+    ///   - description: A configuration description buildable by applying the result builder syntax.
+    ///
+    /// - Returns: A configuration option with a value being another configuration description.
+    static func nest(@RuleConfigurationDescriptionBuilder _ description: () -> RuleConfigurationDescription) -> Self {
+        .nested(description())
+    }
+}
+
+extension ViolationSeverity: RuleConfigurationOptionConvertible {
+    public func makeOption() -> RuleConfigurationOption {
+        "severity" => .symbol(rawValue)
+    }
+}

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -3,7 +3,7 @@ import Foundation
 // swiftlint:disable file_length
 
 /// A type that can be converted into a human-readable representation.
-public protocol HumanReadable {
+public protocol Documentable {
     /// Convert an object to Markdown.
     ///
     /// - Returns: A Markdown string describing the object.
@@ -44,7 +44,7 @@ public struct RuleConfigurationDescription: Equatable {
     }
 }
 
-extension RuleConfigurationDescription: HumanReadable {
+extension RuleConfigurationDescription: Documentable {
     public func oneLiner() -> String {
         options.first == .noOptions ? "" : options.map { $0.oneLiner() }.joined(separator: "; ")
     }
@@ -75,7 +75,7 @@ public struct RuleConfigurationOption: Equatable {
     fileprivate let value: OptionType
 }
 
-extension RuleConfigurationOption: HumanReadable {
+extension RuleConfigurationOption: Documentable {
     public func markdown() -> String {
         """
         <tr>
@@ -116,7 +116,7 @@ public enum OptionType: Equatable {
     case nested(RuleConfigurationDescription)
 }
 
-extension OptionType: HumanReadable {
+extension OptionType: Documentable {
     public func markdown() -> String {
         switch self {
         case .empty:

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -6,8 +6,8 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
     /// Configuration with an error severity.
     public static var warning: Self { Self(.warning) }
 
-    @ConfigurationElement
-    var severity: ViolationSeverity
+    @ConfigurationElement(key: "severity")
+    var severity = ViolationSeverity.warning
 
     public var severityConfiguration: SeverityConfiguration {
         self
@@ -29,6 +29,4 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
         }
         self.severity = severity
     }
-
-    public func asOption() -> OptionType { severity.asOption() }
 }

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -5,9 +5,9 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
     /// Configuration with an error severity.
     public static var warning: Self { Self(.warning) }
 
-    public var consoleDescription: String {
-        return severity.rawValue
-    }
+    public var parameterDescription: RuleConfigurationDescription {
+         "severity" => .symbol(severity.rawValue)
+     }
 
     var severity: ViolationSeverity
 

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -1,5 +1,6 @@
 /// A rule configuration that allows specifying the desired severity level for violations.
-public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable {
+public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable,
+                                                   AcceptableByConfigurationElement {
     /// Configuration with a warning severity.
     public static var error: Self { Self(.error) }
     /// Configuration with an error severity.
@@ -31,4 +32,6 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
         }
         self.severity = severity
     }
+
+    public func asOption() -> OptionType { severity.asOption() }
 }

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -5,7 +5,7 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
     /// Configuration with an error severity.
     public static var warning: Self { Self(.warning) }
 
-    public var parameterDescription: RuleConfigurationDescription {
+    public var parameterDescription: RuleConfigurationDescription? {
          "severity" => .symbol(severity.rawValue)
      }
 

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -1,6 +1,5 @@
 /// A rule configuration that allows specifying the desired severity level for violations.
-public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable,
-                                                   AcceptableByConfigurationElement {
+public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Equatable {
     /// Configuration with a warning severity.
     public static var error: Self { Self(.error) }
     /// Configuration with an error severity.

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -6,10 +6,7 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
     /// Configuration with an error severity.
     public static var warning: Self { Self(.warning) }
 
-    public var parameterDescription: RuleConfigurationDescription? {
-         "severity" => .symbol(severity.rawValue)
-     }
-
+    @ConfigurationElement
     var severity: ViolationSeverity
 
     public var severityConfiguration: SeverityConfiguration {

--- a/Source/SwiftLintCore/Models/ViolationSeverity.swift
+++ b/Source/SwiftLintCore/Models/ViolationSeverity.swift
@@ -1,5 +1,5 @@
 /// The magnitude of a `StyleViolation`.
-public enum ViolationSeverity: String, Comparable, Codable {
+public enum ViolationSeverity: String, Comparable, Codable, AcceptableByConfigurationElement {
     /// Non-fatal. If using SwiftLint as an Xcode build phase, Xcode will mark the build as having succeeded.
     case warning
     /// Fatal. If using SwiftLint as an Xcode build phase, Xcode will mark the build as having failed.
@@ -10,4 +10,6 @@ public enum ViolationSeverity: String, Comparable, Codable {
     public static func < (lhs: ViolationSeverity, rhs: ViolationSeverity) -> Bool {
         return lhs == .warning && rhs == .error
     }
+
+    public func asOption() -> OptionType { .symbol(rawValue) }
 }

--- a/Source/SwiftLintCore/Models/ViolationSeverity.swift
+++ b/Source/SwiftLintCore/Models/ViolationSeverity.swift
@@ -1,5 +1,5 @@
 /// The magnitude of a `StyleViolation`.
-public enum ViolationSeverity: String, Comparable, Codable, AcceptableByConfigurationElement, InlinableOptionType {
+public enum ViolationSeverity: String, Comparable, Codable, InlinableOptionType {
     /// Non-fatal. If using SwiftLint as an Xcode build phase, Xcode will mark the build as having succeeded.
     case warning
     /// Fatal. If using SwiftLint as an Xcode build phase, Xcode will mark the build as having failed.

--- a/Source/SwiftLintCore/Models/ViolationSeverity.swift
+++ b/Source/SwiftLintCore/Models/ViolationSeverity.swift
@@ -1,5 +1,5 @@
 /// The magnitude of a `StyleViolation`.
-public enum ViolationSeverity: String, Comparable, Codable, AcceptableByConfigurationElement {
+public enum ViolationSeverity: String, Comparable, Codable, AcceptableByConfigurationElement, InlinableOptionType {
     /// Non-fatal. If using SwiftLint as an Xcode build phase, Xcode will mark the build as having succeeded.
     case warning
     /// Fatal. If using SwiftLint as an Xcode build phase, Xcode will mark the build as having failed.

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -162,7 +162,7 @@ public extension ConfigurationProviderRule {
         return false
     }
 
-    var configurationDescription: RuleConfigurationDescription {
+    var configurationDescription: Documentable {
         RuleConfigurationDescription.from(configuration: configuration)
     }
 }

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -162,7 +162,9 @@ public extension ConfigurationProviderRule {
         return false
     }
 
-    var configurationDescription: RuleConfigurationDescription { configuration.parameterDescription! }
+    var configurationDescription: RuleConfigurationDescription {
+        RuleConfigurationDescription.from(configuration: configuration)
+    }
 }
 
 // MARK: - == Implementations

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -162,9 +162,7 @@ public extension ConfigurationProviderRule {
         return false
     }
 
-    var configurationDescription: String {
-        return configuration.consoleDescription
-    }
+    var configurationDescription: RuleConfigurationDescription { configuration.parameterDescription }
 }
 
 // MARK: - == Implementations

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -162,7 +162,7 @@ public extension ConfigurationProviderRule {
         return false
     }
 
-    var configurationDescription: RuleConfigurationDescription { configuration.parameterDescription }
+    var configurationDescription: RuleConfigurationDescription { configuration.parameterDescription! }
 }
 
 // MARK: - == Implementations

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -8,7 +8,7 @@ public protocol Rule {
 
     /// A description of how this rule has been configured to run. It can be built using the annotated result builder.
     @RuleConfigurationDescriptionBuilder
-    var configurationDescription: RuleConfigurationDescription { get }
+    var configurationDescription: Documentable { get }
 
     /// A default initializer for rules. All rules need to be trivially initializable.
     init()

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -6,8 +6,9 @@ public protocol Rule {
     /// A verbose description of many of this rule's properties.
     static var description: RuleDescription { get }
 
-    /// A description of how this rule has been configured to run.
-    var configurationDescription: String { get }
+    /// A description of how this rule has been configured to run. It can be built using the annotated result builder.
+    @RuleConfigurationDescriptionBuilder
+    var configurationDescription: RuleConfigurationDescription { get }
 
     /// A default initializer for rules. All rules need to be trivially initializable.
     init()
@@ -84,7 +85,7 @@ public extension Rule {
     /// The cache description which will be used to determine if a previous
     /// cached value is still valid given the new cache value.
     var cacheDescription: String {
-        return (self as? CacheDescriptionProvider)?.cacheDescription ?? configurationDescription
+        (self as? CacheDescriptionProvider)?.cacheDescription ?? configurationDescription.oneLiner()
     }
 }
 

--- a/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
@@ -1,9 +1,12 @@
 /// A configuration value for a rule to allow users to modify its behavior.
-public protocol RuleConfiguration<Parent> {
+public protocol RuleConfiguration {
     /// The type of the rule that's using this configuration.
     associatedtype Parent: Rule
 
-    /// A human-readable description for this configuration and its applied values.
+    /// A description for this configuration's parameters. It can be built using the annotated result builder.
+    @RuleConfigurationDescriptionBuilder
+    var parameterDescription: RuleConfigurationDescription { get }
+
     var consoleDescription: String { get }
 
     /// Apply an untyped configuration to the current value.
@@ -38,4 +41,8 @@ public extension RuleConfiguration where Self: Equatable {
     func isEqualTo(_ ruleConfiguration: some RuleConfiguration) -> Bool {
         return self == ruleConfiguration as? Self
     }
+}
+
+public extension RuleConfiguration {
+    var consoleDescription: String { parameterDescription.oneLiner() }
 }

--- a/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
@@ -1,5 +1,5 @@
 /// A configuration value for a rule to allow users to modify its behavior.
-public protocol RuleConfiguration: AcceptableByConfigurationElement {
+public protocol RuleConfiguration: AcceptableByConfigurationElement, InlinableOptionType {
     /// The type of the rule that's using this configuration.
     associatedtype Parent: Rule
 

--- a/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
@@ -1,5 +1,5 @@
 /// A configuration value for a rule to allow users to modify its behavior.
-public protocol RuleConfiguration: AcceptableByConfigurationElement, InlinableOptionType {
+public protocol RuleConfiguration: InlinableOptionType {
     /// The type of the rule that's using this configuration.
     associatedtype Parent: Rule
 

--- a/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
@@ -1,5 +1,5 @@
 /// A configuration value for a rule to allow users to modify its behavior.
-public protocol RuleConfiguration {
+public protocol RuleConfiguration: AcceptableByConfigurationElement {
     /// The type of the rule that's using this configuration.
     associatedtype Parent: Rule
 

--- a/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
@@ -5,7 +5,7 @@ public protocol RuleConfiguration {
 
     /// A description for this configuration's parameters. It can be built using the annotated result builder.
     @RuleConfigurationDescriptionBuilder
-    var parameterDescription: RuleConfigurationDescription { get }
+    var parameterDescription: RuleConfigurationDescription? { get }
 
     /// Apply an untyped configuration to the current value.
     ///
@@ -39,4 +39,8 @@ public extension RuleConfiguration where Self: Equatable {
     func isEqualTo(_ ruleConfiguration: some RuleConfiguration) -> Bool {
         return self == ruleConfiguration as? Self
     }
+}
+
+public extension RuleConfiguration {
+    var parameterDescription: RuleConfigurationDescription? { nil }
 }

--- a/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
@@ -7,8 +7,6 @@ public protocol RuleConfiguration {
     @RuleConfigurationDescriptionBuilder
     var parameterDescription: RuleConfigurationDescription { get }
 
-    var consoleDescription: String { get }
-
     /// Apply an untyped configuration to the current value.
     ///
     /// - parameter configuration: The untyped configuration value to apply.
@@ -41,8 +39,4 @@ public extension RuleConfiguration where Self: Equatable {
     func isEqualTo(_ ruleConfiguration: some RuleConfiguration) -> Bool {
         return self == ruleConfiguration as? Self
     }
-}
-
-public extension RuleConfiguration {
-    var consoleDescription: String { parameterDescription.oneLiner() }
 }

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -8,10 +8,10 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     /// The name for this custom rule.
     public var name: String?
     /// The message to be presented when producing violations.
-    public var message = "Regex matched."
+    public var message = "Regex matched"
     /// The regular expression to apply to trigger violations for this custom rule.
     @ConfigurationElement(key: "regex")
-    var regex: NSRegularExpression! = nil
+    var regex: NSRegularExpression!
     /// Regular expressions to include when matching the file path.
     public var included: [NSRegularExpression] = []
     /// Regular expressions to exclude when matching the file path.

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -19,7 +19,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     /// The syntax kinds to exclude from matches. If the regex matched syntax kinds from this list, it would
     /// be ignored and not count as a rule violation.
     public var excludedMatchKinds = Set<SyntaxKind>()
-    @ConfigurationElement(key: "severity")
+    @ConfigurationElement
     public var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     /// The index of the regex capture group to match.
     public var captureGroup: Int = 0

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -10,7 +10,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     /// The message to be presented when producing violations.
     public var message = "Regex matched."
     /// The regular expression to apply to trigger violations for this custom rule.
-    @ConfigurationElement("regex")
+    @ConfigurationElement(key: "regex")
     var regex: NSRegularExpression! = nil
     /// Regular expressions to include when matching the file path.
     public var included: [NSRegularExpression] = []
@@ -19,7 +19,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     /// The syntax kinds to exclude from matches. If the regex matched syntax kinds from this list, it would
     /// be ignored and not count as a rule violation.
     public var excludedMatchKinds = Set<SyntaxKind>()
-    @ConfigurationElement("severity")
+    @ConfigurationElement(key: "severity")
     public var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     /// The index of the regex capture group to match.
     public var captureGroup: Int = 0

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -22,7 +22,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     /// The index of the regex capture group to match.
     public var captureGroup: Int = 0
 
-    public var parameterDescription: RuleConfigurationDescription {
+    public var parameterDescription: RuleConfigurationDescription? {
         severityConfiguration
         "regex" => .string(regex.pattern)
     }

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -22,8 +22,9 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     /// The index of the regex capture group to match.
     public var captureGroup: Int = 0
 
-    public var consoleDescription: String {
-        return "\(severity.rawValue): \(regex.pattern)"
+    public var parameterDescription: RuleConfigurationDescription {
+        severityConfiguration
+        "regex" => .string(regex.pattern)
     }
 
     public var cacheDescription: String {
@@ -36,7 +37,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
             excluded.map(\.pattern).joined(separator: ","),
             SyntaxKind.allKinds.subtracting(excludedMatchKinds)
                 .map({ $0.rawValue }).sorted(by: <).joined(separator: ","),
-            severityConfiguration.consoleDescription
+            severity.rawValue
         ]
         if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),
           let jsonString = String(data: jsonData, encoding: .utf8) {

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -8,9 +8,10 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     /// The name for this custom rule.
     public var name: String?
     /// The message to be presented when producing violations.
-    public var message = "Regex matched"
+    public var message = "Regex matched."
     /// The regular expression to apply to trigger violations for this custom rule.
-    public var regex: NSRegularExpression!
+    @ConfigurationElement("regex")
+    var regex: NSRegularExpression! = nil
     /// Regular expressions to include when matching the file path.
     public var included: [NSRegularExpression] = []
     /// Regular expressions to exclude when matching the file path.
@@ -18,14 +19,10 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     /// The syntax kinds to exclude from matches. If the regex matched syntax kinds from this list, it would
     /// be ignored and not count as a rule violation.
     public var excludedMatchKinds = Set<SyntaxKind>()
+    @ConfigurationElement("severity")
     public var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     /// The index of the regex capture group to match.
     public var captureGroup: Int = 0
-
-    public var parameterDescription: RuleConfigurationDescription? {
-        severityConfiguration
-        "regex" => .string(regex.pattern)
-    }
 
     public var cacheDescription: String {
         let jsonObject: [String] = [

--- a/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -7,14 +7,6 @@ public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Equa
     @ConfigurationElement(key: "error")
     public var error: Int?
 
-    /// A condensed console description.
-    public var shortConsoleDescription: String {
-        if let errorValue = error {
-            return "w/e: \(warning)/\(errorValue)"
-        }
-        return "w: \(warning)"
-    }
-
     /// Create a `SeverityLevelsConfiguration` based on the sepecified `warning` and `error` thresholds.
     ///
     /// - parameter warning: The threshold for a violation to be a warning.

--- a/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -1,6 +1,6 @@
 /// A rule configuration that allows specifying thresholds for `warning` and `error` severities.
 public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
-    public var parameterDescription: RuleConfigurationDescription {
+    public var parameterDescription: RuleConfigurationDescription? {
         "warning" => .integer(warning)
         if let error {
             "error" => .integer(error)

--- a/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -1,11 +1,11 @@
 /// A rule configuration that allows specifying thresholds for `warning` and `error` severities.
 public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
     /// The threshold for a violation to be a warning.
-    @ConfigurationElement("warning")
+    @ConfigurationElement(key: "warning")
     public var warning: Int = 12
     /// The threshold for a violation to be an error.
-    @ConfigurationElement("error")
-    public var error: Int? = nil
+    @ConfigurationElement(key: "error")
+    public var error: Int?
 
     /// A condensed console description.
     public var shortConsoleDescription: String {

--- a/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -1,13 +1,10 @@
 /// A rule configuration that allows specifying thresholds for `warning` and `error` severities.
 public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
-        let errorString: String
-        if let errorValue = error {
-            errorString = ", error: \(errorValue)"
-        } else {
-            errorString = ""
+    public var parameterDescription: RuleConfigurationDescription {
+        "warning" => .integer(warning)
+        if let error {
+            "error" => .integer(error)
         }
-        return "warning: \(warning)" + errorString
     }
 
     /// A condensed console description.

--- a/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -1,11 +1,11 @@
 /// A rule configuration that allows specifying thresholds for `warning` and `error` severities.
 public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Equatable {
-    public var parameterDescription: RuleConfigurationDescription? {
-        "warning" => .integer(warning)
-        if let error {
-            "error" => .integer(error)
-        }
-    }
+    /// The threshold for a violation to be a warning.
+    @ConfigurationElement("warning")
+    public var warning: Int = 12
+    /// The threshold for a violation to be an error.
+    @ConfigurationElement("error")
+    public var error: Int? = nil
 
     /// A condensed console description.
     public var shortConsoleDescription: String {
@@ -14,11 +14,6 @@ public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Equa
         }
         return "w: \(warning)"
     }
-
-    /// The threshold for a violation to be a warning.
-    public var warning: Int
-    /// The threshold for a violation to be an error.
-    public var error: Int?
 
     /// Create a `SeverityLevelsConfiguration` based on the sepecified `warning` and `error` thresholds.
     ///

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -5,7 +5,7 @@ import Foundation
 struct CustomRulesConfiguration: RuleConfiguration, Equatable, CacheDescriptionProvider {
     typealias Parent = CustomRules
 
-    var parameterDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+    var parameterDescription: RuleConfigurationDescription? { RuleConfigurationOption.noOptions }
     var cacheDescription: String {
         customRuleConfigurations
             .sorted { $0.identifier < $1.identifier }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -5,9 +5,9 @@ import Foundation
 struct CustomRulesConfiguration: RuleConfiguration, Equatable, CacheDescriptionProvider {
     typealias Parent = CustomRules
 
-    var consoleDescription: String { return "user-defined" }
+    var parameterDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
     var cacheDescription: String {
-        return customRuleConfigurations
+        customRuleConfigurations
             .sorted { $0.identifier < $1.identifier }
             .map { $0.cacheDescription }
             .joined(separator: "\n")

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -103,7 +103,7 @@ private extension TextTable {
                 ruleType.description.kind.rawValue,
                 (rule is AnalyzerRule) ? "yes" : "no",
                 (rule is SourceKitFreeRule) ? "no" : "yes",
-                truncate((configuredRule ?? rule).configurationDescription)
+                truncate((configuredRule ?? rule).configurationDescription.oneLiner())
             ])
         }
     }

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -132,7 +132,7 @@ final class RulesFilterTests: XCTestCase {
 // MARK: - Mocks
 
 private struct RuleMock1: Rule {
-    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock1", name: "",
                                              description: "", kind: .style)
@@ -146,7 +146,7 @@ private struct RuleMock1: Rule {
 }
 
 private struct RuleMock2: Rule {
-    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock2", name: "",
                                              description: "", kind: .style)
@@ -160,7 +160,7 @@ private struct RuleMock2: Rule {
 }
 
 private struct CorrectableRuleMock: CorrectableRule {
-    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "CorrectableRuleMock", name: "",
                                              description: "", kind: .style)

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -132,7 +132,8 @@ final class RulesFilterTests: XCTestCase {
 // MARK: - Mocks
 
 private struct RuleMock1: Rule {
-    var configurationDescription: String { return "N/A" }
+    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+
     static let description = RuleDescription(identifier: "RuleMock1", name: "",
                                              description: "", kind: .style)
 
@@ -145,7 +146,8 @@ private struct RuleMock1: Rule {
 }
 
 private struct RuleMock2: Rule {
-    var configurationDescription: String { return "N/A" }
+    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+
     static let description = RuleDescription(identifier: "RuleMock2", name: "",
                                              description: "", kind: .style)
 
@@ -158,7 +160,8 @@ private struct RuleMock2: Rule {
 }
 
 private struct CorrectableRuleMock: CorrectableRule {
-    var configurationDescription: String { return "N/A" }
+    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+
     static let description = RuleDescription(identifier: "CorrectableRuleMock", name: "",
                                              description: "", kind: .style)
 

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -114,7 +114,8 @@ class CollectingRuleTests: SwiftLintTestCase {
 
 private protocol MockCollectingRule: CollectingRule {}
 extension MockCollectingRule {
-    var configurationDescription: String { return "N/A" }
+    @RuleConfigurationDescriptionBuilder
+    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
     static var description: RuleDescription {
         return RuleDescription(identifier: "test_rule", name: "", description: "", kind: .lint)
     }

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -115,7 +115,7 @@ class CollectingRuleTests: SwiftLintTestCase {
 private protocol MockCollectingRule: CollectingRule {}
 extension MockCollectingRule {
     @RuleConfigurationDescriptionBuilder
-    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
     static var description: RuleDescription {
         return RuleDescription(identifier: "test_rule", name: "", description: "", kind: .lint)
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
@@ -84,7 +84,8 @@ internal extension ConfigurationTests {
 }
 
 struct RuleMock: Rule {
-    var configurationDescription: String { return "N/A" }
+    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+
     static let description = RuleDescription(identifier: "RuleMock", name: "",
                                              description: "", kind: .style)
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
@@ -84,7 +84,7 @@ internal extension ConfigurationTests {
 }
 
 struct RuleMock: Rule {
-    var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock", name: "",
                                              description: "", kind: .style)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -399,8 +399,8 @@ extension ConfigurationTests {
         )
 
         XCTAssertEqual(
-            Set(configuration1.rulesWrapper.allRulesWrapped.map { $0.rule.configurationDescription }),
-            Set(configuration2.rulesWrapper.allRulesWrapped.map { $0.rule.configurationDescription })
+            Set(configuration1.rulesWrapper.allRulesWrapped.map { $0.rule.configurationDescription.oneLiner() }),
+            Set(configuration2.rulesWrapper.allRulesWrapped.map { $0.rule.configurationDescription.oneLiner() })
         )
 
         XCTAssertEqual(Set(configuration1.includedPaths), Set(configuration2.includedPaths))

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -43,7 +43,7 @@ class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
         var config = ExplicitTypeInterfaceConfiguration()
         try config.apply(configuration: ["excluded": ["class", "instance"]])
         XCTAssertEqual(
-            config.parameterDescription?.oneLiner(),
+            RuleConfigurationDescription.from(configuration: config).oneLiner(),
             "severity: warning; excluded: [class, instance]; allow_redundancy: false"
         )
     }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -43,7 +43,7 @@ class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
         var config = ExplicitTypeInterfaceConfiguration()
         try config.apply(configuration: ["excluded": ["class", "instance"]])
         XCTAssertEqual(
-            config.consoleDescription,
+            config.parameterDescription.oneLiner(),
             "severity: warning; excluded: [class, instance]; allow_redundancy: false"
         )
     }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -44,7 +44,7 @@ class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
         try config.apply(configuration: ["excluded": ["class", "instance"]])
         XCTAssertEqual(
             config.consoleDescription,
-            "severity: warning, excluded: [\"class\", \"instance\"], allow_redundancy: false"
+            "severity: warning; excluded: [class, instance]; allow_redundancy: false"
         )
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -43,7 +43,7 @@ class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
         var config = ExplicitTypeInterfaceConfiguration()
         try config.apply(configuration: ["excluded": ["class", "instance"]])
         XCTAssertEqual(
-            config.parameterDescription.oneLiner(),
+            config.parameterDescription?.oneLiner(),
             "severity: warning; excluded: [class, instance]; allow_redundancy: false"
         )
     }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftLintBuiltInRules
+@testable import SwiftLintCore
 import XCTest
 
 class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
@@ -5,8 +5,8 @@ import XCTest
 class ImplicitlyUnwrappedOptionalConfigurationTests: SwiftLintTestCase {
     func testImplicitlyUnwrappedOptionalConfigurationProperlyAppliesConfigurationFromDictionary() throws {
         var configuration = ImplicitlyUnwrappedOptionalConfiguration(
-            mode: .allExceptIBOutlets,
-            severityConfiguration: SeverityConfiguration(.warning)
+            severityConfiguration: SeverityConfiguration(.warning),
+            mode: .allExceptIBOutlets
         )
 
         try configuration.apply(configuration: ["mode": "all", "severity": "error"])
@@ -35,8 +35,8 @@ class ImplicitlyUnwrappedOptionalConfigurationTests: SwiftLintTestCase {
 
         for badConfig in badConfigs {
             var configuration = ImplicitlyUnwrappedOptionalConfiguration(
-                mode: .allExceptIBOutlets,
-                severityConfiguration: SeverityConfiguration(.warning)
+                severityConfiguration: SeverityConfiguration(.warning),
+                mode: .allExceptIBOutlets
             )
 
             checkError(Issue.unknownConfiguration(ruleID: ImplicitlyUnwrappedOptionalRule.description.identifier)) {

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
@@ -5,7 +5,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
     func testDescriptionEmpty() {
         let configuration = MissingDocsConfiguration()
         XCTAssertEqual(
-            configuration.consoleDescription,
+            configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: false"
         )
@@ -14,7 +14,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
     func testDescriptionExcludesFalse() {
         let configuration = MissingDocsConfiguration(excludesExtensions: false, excludesInheritedTypes: false)
         XCTAssertEqual(
-            configuration.consoleDescription,
+            configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: false; " +
             "excludes_inherited_types: false; excludes_trivial_init: false"
         )
@@ -23,7 +23,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
     func testDescriptionExcludesExtensionsFalseExcludesInheritedTypesTrue() {
         let configuration = MissingDocsConfiguration(excludesExtensions: false, excludesInheritedTypes: true)
         XCTAssertEqual(
-            configuration.consoleDescription,
+            configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: false; " +
             "excludes_inherited_types: true; excludes_trivial_init: false"
         )
@@ -32,7 +32,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
     func testDescriptionExcludesExtensionsTrueExcludesInheritedTypesFalse() {
         let configuration = MissingDocsConfiguration(excludesExtensions: true, excludesInheritedTypes: false)
         XCTAssertEqual(
-            configuration.consoleDescription,
+            configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: true; " +
             "excludes_inherited_types: false; excludes_trivial_init: false"
         )
@@ -42,7 +42,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
         let configuration = MissingDocsConfiguration(
             parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
         XCTAssertEqual(
-            configuration.consoleDescription,
+            configuration.parameterDescription?.oneLiner(),
             "error: [open]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: false"
         )
@@ -53,7 +53,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
             parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open),
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
         XCTAssertEqual(
-            configuration.consoleDescription,
+            configuration.parameterDescription?.oneLiner(),
             "error: [open]; warning: [public]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: false"
         )
@@ -64,7 +64,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
             parameters: [RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
         XCTAssertEqual(
-            configuration.consoleDescription,
+            configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: false"
         )
@@ -73,7 +73,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
     func testDescriptionExcludesTrivialInitTrue() {
         let configuration = MissingDocsConfiguration(excludesTrivialInit: true)
         XCTAssertEqual(
-            configuration.consoleDescription,
+            configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: true"
         )

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
@@ -6,8 +6,8 @@ class MissingDocsRuleTests: SwiftLintTestCase {
         let configuration = MissingDocsConfiguration()
         XCTAssertEqual(
             configuration.consoleDescription,
-            "warning: open, public, excludes_extensions: true, " +
-            "excludes_inherited_types: true, excludes_trivial_init: false"
+            "warning: [open, public]; excludes_extensions: true; " +
+            "excludes_inherited_types: true; excludes_trivial_init: false"
         )
     }
 
@@ -15,8 +15,8 @@ class MissingDocsRuleTests: SwiftLintTestCase {
         let configuration = MissingDocsConfiguration(excludesExtensions: false, excludesInheritedTypes: false)
         XCTAssertEqual(
             configuration.consoleDescription,
-            "warning: open, public, excludes_extensions: false, " +
-            "excludes_inherited_types: false, excludes_trivial_init: false"
+            "warning: [open, public]; excludes_extensions: false; " +
+            "excludes_inherited_types: false; excludes_trivial_init: false"
         )
     }
 
@@ -24,8 +24,8 @@ class MissingDocsRuleTests: SwiftLintTestCase {
         let configuration = MissingDocsConfiguration(excludesExtensions: false, excludesInheritedTypes: true)
         XCTAssertEqual(
             configuration.consoleDescription,
-            "warning: open, public, excludes_extensions: false, " +
-            "excludes_inherited_types: true, excludes_trivial_init: false"
+            "warning: [open, public]; excludes_extensions: false; " +
+            "excludes_inherited_types: true; excludes_trivial_init: false"
         )
     }
 
@@ -33,8 +33,8 @@ class MissingDocsRuleTests: SwiftLintTestCase {
         let configuration = MissingDocsConfiguration(excludesExtensions: true, excludesInheritedTypes: false)
         XCTAssertEqual(
             configuration.consoleDescription,
-            "warning: open, public, excludes_extensions: true, " +
-            "excludes_inherited_types: false, excludes_trivial_init: false"
+            "warning: [open, public]; excludes_extensions: true; " +
+            "excludes_inherited_types: false; excludes_trivial_init: false"
         )
     }
 
@@ -43,8 +43,8 @@ class MissingDocsRuleTests: SwiftLintTestCase {
             parameters: [RuleParameter<AccessControlLevel>(severity: .error, value: .open)])
         XCTAssertEqual(
             configuration.consoleDescription,
-            "error: open, excludes_extensions: true, " +
-            "excludes_inherited_types: true, excludes_trivial_init: false"
+            "error: [open]; excludes_extensions: true; " +
+            "excludes_inherited_types: true; excludes_trivial_init: false"
         )
     }
 
@@ -54,8 +54,8 @@ class MissingDocsRuleTests: SwiftLintTestCase {
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
         XCTAssertEqual(
             configuration.consoleDescription,
-            "error: open, warning: public, excludes_extensions: true, " +
-            "excludes_inherited_types: true, excludes_trivial_init: false"
+            "error: [open]; warning: [public]; excludes_extensions: true; " +
+            "excludes_inherited_types: true; excludes_trivial_init: false"
         )
     }
 
@@ -65,8 +65,8 @@ class MissingDocsRuleTests: SwiftLintTestCase {
                          RuleParameter<AccessControlLevel>(severity: .warning, value: .public)])
         XCTAssertEqual(
             configuration.consoleDescription,
-            "warning: open, public, excludes_extensions: true, " +
-            "excludes_inherited_types: true, excludes_trivial_init: false"
+            "warning: [open, public]; excludes_extensions: true; " +
+            "excludes_inherited_types: true; excludes_trivial_init: false"
         )
     }
 
@@ -74,8 +74,8 @@ class MissingDocsRuleTests: SwiftLintTestCase {
         let configuration = MissingDocsConfiguration(excludesTrivialInit: true)
         XCTAssertEqual(
             configuration.consoleDescription,
-            "warning: open, public, excludes_extensions: true, " +
-            "excludes_inherited_types: true, excludes_trivial_init: true"
+            "warning: [open, public]; excludes_extensions: true; " +
+            "excludes_inherited_types: true; excludes_trivial_init: true"
         )
     }
 

--- a/Tests/SwiftLintFrameworkTests/RequiredEnumCaseConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RequiredEnumCaseConfigurationTests.swift
@@ -38,14 +38,14 @@ class RequiredEnumCaseConfigurationTests: SwiftLintTestCase {
 
     func testConsoleDescriptionReturnsAllConfiguredProtocols() {
         let expected = "NetworkResults: error: warning; RequiredProtocol: error: warning; success: warning"
-        XCTAssertEqual(config.consoleDescription, expected)
+        XCTAssertEqual(config.parameterDescription.oneLiner(), expected)
     }
 
     func testConsoleDescriptionReturnsNoConfiguredProtocols() {
         let expected = "{Protocol Name}: {Case Name 1}: {warning|error}; {Case Name 2}: {warning|error}"
 
         config.protocols.removeAll()
-        XCTAssertEqual(config.consoleDescription, expected)
+        XCTAssertEqual(config.parameterDescription.oneLiner(), expected)
     }
 
     private func validateRulesExistForProtocol1() {

--- a/Tests/SwiftLintFrameworkTests/RequiredEnumCaseConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RequiredEnumCaseConfigurationTests.swift
@@ -37,28 +37,12 @@ class RequiredEnumCaseConfigurationTests: SwiftLintTestCase {
     }
 
     func testConsoleDescriptionReturnsAllConfiguredProtocols() {
-        let expected = "[" +
-            "protocol: \"NetworkResults\", " +
-            "cases: [" +
-                "[name: \"error\", severity: \"warning\"]" +
-            "]" +
-        "], [" +
-            "protocol: \"RequiredProtocol\", " +
-            "cases: [" +
-                "[name: \"error\", severity: \"warning\"], " +
-                "[name: \"success\", severity: \"warning\"]" +
-            "]" +
-        "]"
+        let expected = "NetworkResults: error: warning; RequiredProtocol: error: warning; success: warning"
         XCTAssertEqual(config.consoleDescription, expected)
     }
 
     func testConsoleDescriptionReturnsNoConfiguredProtocols() {
-        let expected = "No protocols configured.  In config add 'required_enum_case' to 'opt_in_rules' and " +
-            "config using :\n\n" +
-            "'required_enum_case:\n" +
-            "  {Protocol Name}:\n" +
-            "    {Case Name}:{warning|error}\n" +
-            "    {Case Name}:{warning|error}\n"
+        let expected = "{Protocol Name}: {Case Name 1}: {warning|error}; {Case Name 2}: {warning|error}"
 
         config.protocols.removeAll()
         XCTAssertEqual(config.consoleDescription, expected)

--- a/Tests/SwiftLintFrameworkTests/RequiredEnumCaseConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RequiredEnumCaseConfigurationTests.swift
@@ -38,14 +38,14 @@ class RequiredEnumCaseConfigurationTests: SwiftLintTestCase {
 
     func testConsoleDescriptionReturnsAllConfiguredProtocols() {
         let expected = "NetworkResults: error: warning; RequiredProtocol: error: warning; success: warning"
-        XCTAssertEqual(config.parameterDescription.oneLiner(), expected)
+        XCTAssertEqual(config.parameterDescription?.oneLiner(), expected)
     }
 
     func testConsoleDescriptionReturnsNoConfiguredProtocols() {
         let expected = "{Protocol Name}: {Case Name 1}: {warning|error}; {Case Name 2}: {warning|error}"
 
         config.protocols.removeAll()
-        XCTAssertEqual(config.parameterDescription.oneLiner(), expected)
+        XCTAssertEqual(config.parameterDescription?.oneLiner(), expected)
     }
 
     private func validateRulesExistForProtocol1() {

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -1,0 +1,195 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class RuleConfigurationDescriptionTests: XCTestCase {
+    func testEmptyDescription() {
+        let description = description { RuleConfigurationOption.noOptions }
+
+        XCTAssertTrue(description.oneLiner().isEmpty)
+        XCTAssertTrue(description.markdown().isEmpty)
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testBasicTypes() {
+        let description = description {
+            "flag" => .flag(true)
+            "string" => .string("value")
+            "symbol" => .symbol("value")
+            "integer" => .integer(-12)
+            "float" => .float(42.0)
+            "severity" => .severity(.error)
+            "list" => .list([.symbol("value"), .string("value"), .float(12.8)])
+        }
+
+        XCTAssertEqual(description.markdown(), """
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            flag
+            </td>
+            <td>
+            true
+            </td>
+            </tr>
+            <tr>
+            <td>
+            string
+            </td>
+            <td>
+            &quot;value&quot;
+            </td>
+            </tr>
+            <tr>
+            <td>
+            symbol
+            </td>
+            <td>
+            value
+            </td>
+            </tr>
+            <tr>
+            <td>
+            integer
+            </td>
+            <td>
+            -12
+            </td>
+            </tr>
+            <tr>
+            <td>
+            float
+            </td>
+            <td>
+            42.0
+            </td>
+            </tr>
+            <tr>
+            <td>
+            severity
+            </td>
+            <td>
+            error
+            </td>
+            </tr>
+            <tr>
+            <td>
+            list
+            </td>
+            <td>
+            [value, &quot;value&quot;, 12.8]
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            """)
+
+        XCTAssertEqual(description.oneLiner(), """
+            flag: true; string: "value"; symbol: value; integer: -12; float: 42.0; \
+            severity: error; list: [value, "value", 12.8]
+            """)
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testNestedDescription() {
+        let description = description {
+            "flag" => .flag(true)
+            "nested 1" => .nest {
+                "integer" => .integer(2)
+                "nested 2" => .nest {
+                    "float" => .float(42.1)
+                }
+                "symbol" => .symbol("value")
+            }
+            "string" => .string("value")
+        }
+
+        XCTAssertEqual(description.markdown(), """
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            flag
+            </td>
+            <td>
+            true
+            </td>
+            </tr>
+            <tr>
+            <td>
+            nested 1
+            </td>
+            <td>
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            integer
+            </td>
+            <td>
+            2
+            </td>
+            </tr>
+            <tr>
+            <td>
+            nested 2
+            </td>
+            <td>
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            float
+            </td>
+            <td>
+            42.1
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            </td>
+            </tr>
+            <tr>
+            <td>
+            symbol
+            </td>
+            <td>
+            value
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            </td>
+            </tr>
+            <tr>
+            <td>
+            string
+            </td>
+            <td>
+            &quot;value&quot;
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            """)
+
+        XCTAssertEqual(description.oneLiner(), """
+            flag: true; nested 1: integer: 2; nested 2: float: 42.1; symbol: value; string: "value"
+            """)
+    }
+
+    private func description(@RuleConfigurationDescriptionBuilder _ content: () -> RuleConfigurationDescription)
+        -> RuleConfigurationDescription { content() }
+}

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -13,6 +13,8 @@ class RuleConfigurationDescriptionTests: XCTestCase {
         var symbol = Symbol(value: "value")
         @ConfigurationElement("integer")
         var integer = 2
+        @ConfigurationElement("nil")
+        var `nil`: Int? = nil
         @ConfigurationElement("double")
         var double = 2.1
         @ConfigurationElement("severity")

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -23,8 +23,10 @@ class RuleConfigurationDescriptionTests: XCTestCase {
         var severity = ViolationSeverity.warning
         @ConfigurationElement(key: "list")
         var list: [OptionType?] = [.flag(true), .string("value")]
+        @ConfigurationElement
+        var severityConfig = SeverityConfiguration<Parent>(.error)
         @ConfigurationElement(key: "SEVERITY")
-        var renamedSeverity = SeverityConfiguration<Parent>(.warning)
+        var renamedSeverityConfig = SeverityConfiguration<Parent>(.warning)
         @ConfigurationElement
         var inlinedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 1, error: 2)
         @ConfigurationElement(key: "levels")
@@ -47,6 +49,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             double: 2.1; \
             severity: warning; \
             list: [true, "value"]; \
+            severity: error; \
             SEVERITY: warning; \
             warning: 1; \
             error: 2; \
@@ -113,6 +116,14 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             </td>
             <td>
             [true, &quot;value&quot;]
+            </td>
+            </tr>
+            <tr>
+            <td>
+            severity
+            </td>
+            <td>
+            error
             </td>
             </tr>
             <tr>

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -5,27 +5,27 @@ class RuleConfigurationDescriptionTests: XCTestCase {
     private struct TestConfiguration: RuleConfiguration {
         typealias Parent = RuleMock // swiftlint:disable:this nesting
 
-        @ConfigurationElement("flag")
+        @ConfigurationElement(key: "flag")
         var flag = true
-        @ConfigurationElement("string")
+        @ConfigurationElement(key: "string")
         var string = "value"
-        @ConfigurationElement("symbol")
+        @ConfigurationElement(key: "symbol")
         var symbol = Symbol(value: "value")
-        @ConfigurationElement("integer")
+        @ConfigurationElement(key: "integer")
         var integer = 2
-        @ConfigurationElement("nil")
-        var `nil`: Int? = nil
-        @ConfigurationElement("double")
+        @ConfigurationElement(key: "nil")
+        var `nil`: Int?
+        @ConfigurationElement(key: "double")
         var double = 2.1
-        @ConfigurationElement("severity")
+        @ConfigurationElement(key: "severity")
         var severity = ViolationSeverity.warning
-        @ConfigurationElement("list")
+        @ConfigurationElement(key: "list")
         var list: [OptionType?] = [.flag(true), .string("value")]
-        @ConfigurationElement("SEVERITY")
+        @ConfigurationElement(key: "SEVERITY")
         var renamedSeverity = SeverityConfiguration<Parent>(.warning)
         @ConfigurationElement
         var inlinedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 1, error: 2)
-        @ConfigurationElement("levels")
+        @ConfigurationElement(key: "levels")
         var nestedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 3, error: nil)
 
         mutating func apply(configuration: Any) throws {}
@@ -172,7 +172,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
                 "visible" => .flag(true)
             }
 
-            @ConfigurationElement("invisible")
+            @ConfigurationElement(key: "invisible")
             var invisible = true
 
             mutating func apply(configuration: Any) throws {}

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -1,6 +1,8 @@
 @testable import SwiftLintCore
 import XCTest
 
+// swiftlint:disable file_length
+
 class RuleConfigurationDescriptionTests: XCTestCase {
     private struct TestConfiguration: RuleConfiguration {
         typealias Parent = RuleMock // swiftlint:disable:this nesting

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -1,7 +1,204 @@
-@testable import SwiftLintFramework
+@testable import SwiftLintCore
 import XCTest
 
 class RuleConfigurationDescriptionTests: XCTestCase {
+    private struct TestConfiguration: RuleConfiguration {
+        typealias Parent = RuleMock // swiftlint:disable:this nesting
+
+        @ConfigurationElement("flag")
+        var flag = true
+        @ConfigurationElement("string")
+        var string = "value"
+        @ConfigurationElement("symbol")
+        var symbol = Symbol(value: "value")
+        @ConfigurationElement("integer")
+        var integer = 2
+        @ConfigurationElement("double")
+        var double = 2.1
+        @ConfigurationElement("severity")
+        var severity = ViolationSeverity.warning
+        @ConfigurationElement("list")
+        var list: [OptionType?] = [.flag(true), .string("value")]
+        @ConfigurationElement("SEVERITY")
+        var renamedSeverity = SeverityConfiguration<Parent>(.warning)
+        @ConfigurationElement
+        var inlinedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 1, error: 2)
+        @ConfigurationElement("levels")
+        var nestedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 3, error: nil)
+
+        mutating func apply(configuration: Any) throws {}
+
+        func isEqualTo(_ ruleConfiguration: some RuleConfiguration) -> Bool { false }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testDescriptionFromConfiguration() {
+        let description = RuleConfigurationDescription.from(configuration: TestConfiguration())
+
+        XCTAssertEqual(description.oneLiner(), """
+            flag: true; \
+            string: "value"; \
+            symbol: value; \
+            integer: 2; \
+            double: 2.1; \
+            severity: warning; \
+            list: [true, "value"]; \
+            SEVERITY: warning; \
+            warning: 1; \
+            error: 2; \
+            levels: warning: 3
+            """)
+
+        XCTAssertEqual(description.markdown(), """
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            flag
+            </td>
+            <td>
+            true
+            </td>
+            </tr>
+            <tr>
+            <td>
+            string
+            </td>
+            <td>
+            &quot;value&quot;
+            </td>
+            </tr>
+            <tr>
+            <td>
+            symbol
+            </td>
+            <td>
+            value
+            </td>
+            </tr>
+            <tr>
+            <td>
+            integer
+            </td>
+            <td>
+            2
+            </td>
+            </tr>
+            <tr>
+            <td>
+            double
+            </td>
+            <td>
+            2.1
+            </td>
+            </tr>
+            <tr>
+            <td>
+            severity
+            </td>
+            <td>
+            warning
+            </td>
+            </tr>
+            <tr>
+            <td>
+            list
+            </td>
+            <td>
+            [true, &quot;value&quot;]
+            </td>
+            </tr>
+            <tr>
+            <td>
+            SEVERITY
+            </td>
+            <td>
+            warning
+            </td>
+            </tr>
+            <tr>
+            <td>
+            warning
+            </td>
+            <td>
+            1
+            </td>
+            </tr>
+            <tr>
+            <td>
+            error
+            </td>
+            <td>
+            2
+            </td>
+            </tr>
+            <tr>
+            <td>
+            levels
+            </td>
+            <td>
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            warning
+            </td>
+            <td>
+            3
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            """)
+    }
+
+    func testPrefersParameterDescription() {
+        struct Config: RuleConfiguration {
+            typealias Parent = RuleMock // swiftlint:disable:this nesting
+
+            var parameterDescription: RuleConfigurationDescription? {
+                "visible" => .flag(true)
+            }
+
+            @ConfigurationElement("invisible")
+            var invisible = true
+
+            mutating func apply(configuration: Any) throws {}
+
+            func isEqualTo(_ ruleConfiguration: some RuleConfiguration) -> Bool { false }
+        }
+
+        let description = RuleConfigurationDescription.from(configuration: Config())
+        XCTAssertEqual(description.oneLiner(), "visible: true")
+        XCTAssertEqual(description.markdown(), """
+            <table>
+            <thead>
+            <tr><th>Key</th><th>Value</th></tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            visible
+            </td>
+            <td>
+            true
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            """)
+    }
+
     func testEmptyDescription() {
         let description = description { RuleConfigurationOption.noOptions }
 

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -325,6 +325,6 @@ class RuleConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(configuration.severityConfiguration.severity, .error)
         XCTAssertEqual(configuration.order, .setGet)
 
-        XCTAssertEqual(configuration.consoleDescription, "severity: error; order: set_get")
+        XCTAssertEqual(configuration.parameterDescription.oneLiner(), "severity: error; order: set_get")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -325,6 +325,6 @@ class RuleConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(configuration.severityConfiguration.severity, .error)
         XCTAssertEqual(configuration.order, .setGet)
 
-        XCTAssertEqual(configuration.consoleDescription, "severity: error, order: set_get")
+        XCTAssertEqual(configuration.consoleDescription, "severity: error; order: set_get")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -325,6 +325,6 @@ class RuleConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(configuration.severityConfiguration.severity, .error)
         XCTAssertEqual(configuration.order, .setGet)
 
-        XCTAssertEqual(configuration.parameterDescription.oneLiner(), "severity: error; order: set_get")
+        XCTAssertEqual(configuration.parameterDescription?.oneLiner(), "severity: error; order: set_get")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -325,6 +325,8 @@ class RuleConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(configuration.severityConfiguration.severity, .error)
         XCTAssertEqual(configuration.order, .setGet)
 
-        XCTAssertEqual(configuration.parameterDescription?.oneLiner(), "severity: error; order: set_get")
+        XCTAssertEqual(
+            RuleConfigurationDescription.from(configuration: configuration).oneLiner(),
+            "severity: error; order: set_get")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -21,7 +21,7 @@ struct RuleWithLevelsMock: ConfigurationProviderRule {
 
 class RuleTests: SwiftLintTestCase {
     fileprivate struct RuleMock1: Rule {
-        var configurationDescription: String { return "N/A" }
+        var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
         static let description = RuleDescription(identifier: "RuleMock1", name: "",
                                                  description: "", kind: .style)
 
@@ -34,7 +34,7 @@ class RuleTests: SwiftLintTestCase {
     }
 
     fileprivate struct RuleMock2: Rule {
-        var configurationDescription: String { return "N/A" }
+        var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
         static let description = RuleDescription(identifier: "RuleMock2", name: "",
                                                  description: "", kind: .style)
 

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -21,7 +21,7 @@ struct RuleWithLevelsMock: ConfigurationProviderRule {
 
 class RuleTests: SwiftLintTestCase {
     fileprivate struct RuleMock1: Rule {
-        var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+        var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
         static let description = RuleDescription(identifier: "RuleMock1", name: "",
                                                  description: "", kind: .style)
 
@@ -34,7 +34,7 @@ class RuleTests: SwiftLintTestCase {
     }
 
     fileprivate struct RuleMock2: Rule {
-        var configurationDescription: RuleConfigurationDescription { RuleConfigurationOption.noOptions }
+        var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
         static let description = RuleDescription(identifier: "RuleMock2", name: "",
                                                  description: "", kind: .style)
 


### PR DESCRIPTION
The idea is to not just build a description of a rule configuration by crafting a string representation manually but applying a defined set of elements to build a model of the description.

These elements are put together by a new result builder. The model enables a common but different formatting of the console output as well as the representation on the rule's web page. Some configurations currently look quite strange either on the website or the console, especially the more complex ones with regard to their configuration:

* [required_enum_case](https://realm.github.io/SwiftLint/required_enum_case.html)
* [type_name](https://realm.github.io/SwiftLint/type_name.html)
* [type_contents_order](https://realm.github.io/SwiftLint/type_contents_order.html)

The second one now looks like:

![Screenshot 2022-04-04 at 22 09 42](https://user-images.githubusercontent.com/16365760/161623840-d652e972-9002-4885-ae1d-3c29e10d213d.png)

Predefined types make sure that it is clear whether to put the values in quotes or brackets. Nested configurations are also considered which makes it easier to get the YAML structure right.

Even though the PR is quite huge, most of the changes deal with the conversion from the string representation to the new model syntax.

Edit: For an even easier setup of the model, simple configurations can use the `@ConfigurationElement` annotation to mark properties as relevant for documentation.