### PR TITLE
VerticalWhitespaceClosingBracesRule: Add specialized configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,6 +392,15 @@ macOS < 12.
 
 #### Enhancements
 
+* Add new option `only_enforce_before_trivial_lines` to
+  `vertical_whitespace_closing_braces` rule. It restricts
+  the rule to apply only before trivial lines (containing
+  only closing braces, brackets and parentheses). This
+  allows empty lines before non-trivial lines of code
+  (e.g. if-else-statements).  
+  [benjamin-kramer](https://github.com/benjamin-kramer)
+  [#3940](https://github.com/realm/SwiftLint/issues/3940)
+
 * Add type-checked analyzer rule version of `ArrayInitRule` named
   `TypesafeArrayInitRule` with identifier `typesafe_array_init` that
   avoids the false positives present in the lint rule.  

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRuleExamples.swift
@@ -1,0 +1,147 @@
+// swiftlint:disable:next type_name
+internal struct VerticalWhitespaceClosingBracesRuleExamples {
+    private static let beforeTrivialLinesConfiguration = ["only_enforce_before_trivial_lines": true]
+
+    static let nonTriggeringExamples = [
+        Example("[1, 2].map { $0 }.filter { true }"),
+        Example("[1, 2].map { $0 }.filter { num in true }"),
+        Example("""
+        /*
+            class X {
+
+                let x = 5
+
+            }
+        */
+        """),
+        Example("""
+        if bool1 {
+          // do something
+          // do something
+
+        } else if bool2 {
+          // do something
+          // do something
+          // do something
+
+        } else {
+          // do something
+          // do something
+        }
+        """, configuration: beforeTrivialLinesConfiguration)
+    ]
+
+    static let violatingToValidExamples = [
+        Example("""
+        do {
+          print("x is 5")
+        ↓
+        }
+        """):
+            Example("""
+            do {
+              print("x is 5")
+            }
+            """),
+        Example("""
+        do {
+          print("x is 5")
+        ↓
+
+        }
+        """):
+            Example("""
+            do {
+              print("x is 5")
+            }
+            """),
+        Example("""
+        do {
+          print("x is 5")
+        ↓\n  \n}
+        """):
+            Example("""
+            do {
+              print("x is 5")
+            }
+            """),
+        Example("""
+        [
+        1,
+        2,
+        3
+        ↓
+        ]
+        """):
+            Example("""
+            [
+            1,
+            2,
+            3
+            ]
+            """),
+        Example("""
+        foo(
+            x: 5,
+            y:6
+        ↓
+        )
+        """):
+            Example("""
+            foo(
+                x: 5,
+                y:6
+            )
+            """),
+        Example("""
+        func foo() {
+          run(5) { x in
+            print(x)
+          }
+        ↓
+        }
+        """): Example("""
+            func foo() {
+              run(5) { x in
+                print(x)
+              }
+            }
+            """),
+        Example("""
+        print([
+          1
+        ↓
+        ])
+        """, configuration: beforeTrivialLinesConfiguration):
+            Example("""
+                    print([
+                      1
+                    ])
+                    """, configuration: beforeTrivialLinesConfiguration),
+        Example("""
+        print([foo {
+          var sum = 0
+          for i in 1...5 { sum += i }
+          return sum
+
+        }, foo {
+          var mul = 1
+          for i in 1...5 { mul *= i }
+          return mul
+        ↓
+        }])
+        """, configuration: beforeTrivialLinesConfiguration):
+            Example("""
+            print([foo {
+              var sum = 0
+              for i in 1...5 { sum += i }
+              return sum
+
+            }, foo {
+              var mul = 1
+              for i in 1...5 { mul *= i }
+              return mul
+            }])
+            """, configuration: beforeTrivialLinesConfiguration)
+    ]
+}


### PR DESCRIPTION
This solves issue #3940 

Replace the `SeverityConfiguration` with a new `VerticalWhitespaceClosingBracesConfiguration`, which includes `severity` and `only_enforce_before_trivial_lines`.

Vertical whitespace may be important for readability when the line with the closing brace is not a trivial one.
The configuration `only_enforce_before_trivial_lines` allows not enforcing the rule in such cases.

E.g.
```
if someCondition {
  // do something
  // do something
 
} else if ... {
  // do something
  // do something
  // do something

} else {
  // do something
  // do something
}
```