### PR TITLE
[ Test Code ] fix Swift5.6.1 version

### DIFF
--- a/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
@@ -3,7 +3,9 @@ import XCTest
 
 final class SwiftVersionTests: XCTestCase {
     func testDetectSwiftVersion() {
-#if compiler(>=5.6.0)
+#if compiler(>=5.6.1)
+        let version = "5.6.1"
+#elseif compiler(>=5.6.0)
         let version = "5.6.0"
 #elseif compiler(>=5.5.3)
         let version = "5.5.3"


### PR DESCRIPTION
Hello, I'm @coffmark. Thanks for taking a look at this PR.

### motivation
Now [Swift 5.6.1](https://github.com/apple/swift/releases/tag/swift-5.6.1-RELEASE) is released, but test code is not ready for it!

### solution
- add swift 5.6.1 version in test code !
<img width="1366" alt="Screenshot 2022-04-12 9 03 03" src="https://user-images.githubusercontent.com/52638834/162852416-d584d050-5f52-4c5f-a08f-f1d048b077fc.png">

Looking forward to hearing back from you!