### PR TITLE
Revert "Enable `typesafe_array_init` rule in repository (#3942)"

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,6 @@ included:
 excluded:
   - Tests/SwiftLintFrameworkTests/Resources
 analyzer_rules:
-  - typesafe_array_init
   - unused_declaration
   - unused_import
 opt_in_rules:


### PR DESCRIPTION
See #3942 for the reasons behind the revert.
