### PR TITLE
Analyze all files listed in the command even if the `--path` option is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@
   [Christopher Hale](https://github.com/chrispomeroyhale)
   [#3636](https://github.com/realm/SwiftLint/pull/3626)
 
-* Lint all files listed in the command even if the `--path` option is used.  
+* Lint/analyze all files listed in the command even if the `--path` option is
+  used.  
   [coffmark](https://github.com/coffmark)
 
 ## 0.47.0: Smart Appliance

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -20,7 +20,7 @@ extension SwiftLint {
         mutating func run() throws {
             let allPaths: [String]
             if let path = path {
-                allPaths = [path]
+                allPaths = [path] + paths
             } else if !paths.isEmpty {
                 allPaths = paths
             } else {


### PR DESCRIPTION
Same change like #3923 for the `analyze` command.