### PR TITLE
Deprecate the `--path` option in favor of the positional `paths` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Breaking
 
-* None.
+* Deprecate the `--path` options for `lint`/`analyze` commands. Prefer the
+  positional paths that can be added last to both commands.  
+  [SimplyDanny](https://github.com/SimplyDanny)
 
 #### Experimental
 

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import SwiftLintFramework
 
 extension SwiftLint {
     struct Analyze: ParsableCommand {
@@ -20,6 +21,9 @@ extension SwiftLint {
         mutating func run() throws {
             let allPaths: [String]
             if let path = path {
+                queuedPrintError("""
+                    warning: The --path option is deprecated. Pass the path(s) to analyze last to the swiftlint command.
+                    """)
                 allPaths = [path] + paths
             } else if !paths.isEmpty {
                 allPaths = paths

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import SwiftLintFramework
 
 extension SwiftLint {
     struct Lint: ParsableCommand {
@@ -24,6 +25,9 @@ extension SwiftLint {
         mutating func run() throws {
             let allPaths: [String]
             if let path = path {
+                queuedPrintError("""
+                    warning: The --path option is deprecated. Pass the path(s) to lint last to the swiftlint command.
+                    """)
                 allPaths = [path] + paths
             } else if !paths.isEmpty {
                 allPaths = paths

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -47,7 +47,7 @@ struct LintOrAnalyzeArguments: ParsableArguments {
 // `LintOrAnalyzeArguments`.
 
 func pathOptionDescription(for mode: LintOrAnalyzeMode) -> ArgumentHelp {
-    "The path to the file or directory to \(mode.imperative)."
+    ArgumentHelp(shouldDisplay: false)
 }
 
 func pathsArgumentDescription(for mode: LintOrAnalyzeMode) -> ArgumentHelp {


### PR DESCRIPTION
There is no real benefit for this option. Files and folders to lint/analyze
can be passed to `swiftlint` as last arguments. There cannot be multiple
`--path` arguments. If there is more than one only the last path is considered.