### PR TITLE
Make let_var_whitespace recognize more @ annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fixed `let_var_whitespace` wanting blank lines between properties and their
+  property wrapper or global actor annotations.
+  [Uncommon](https://github.com/Uncommon)
 
 ## 0.47.1: Smarter Appliance
 

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -217,16 +217,17 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, Automa
     private func attributeLineNumbers(file: SwiftLintFile) -> Set<Int> {
         return Set(file.syntaxMap.tokens.compactMap({ token in
             switch token.kind {
-                case .attributeBuiltin:
-                    return file.line(byteOffset: token.offset)
-                case .typeidentifier:
-                    // Skip type identifiers marked with `@` because it could be
-                    // a global actor, property wrapper, etc.
-                    guard token.offset > 0 else { return nil }
-                    let maybeAt = file.stringView.substringWithByteRange(.init(location: token.offset-1, length: 1)) ?? ""
-                    return maybeAt == "@" ? file.line(byteOffset: token.offset) : nil
-                default:
-                    return nil
+            case .attributeBuiltin:
+                return file.line(byteOffset: token.offset)
+            case .typeidentifier:
+                // Skip type identifiers marked with `@` because it could be a
+                // global actor, property wrapper, etc.
+                guard token.offset > 0 else { return nil }
+                let atRange = ByteRange(location: token.offset - 1, length: 1)
+                let maybeAt = file.stringView.substringWithByteRange(atRange) ?? ""
+                return maybeAt == "@" ? file.line(byteOffset: token.offset) : nil
+            default:
+                return nil
             }
         }))
     }


### PR DESCRIPTION
Currently, `let_var_whitespace` flags properties that have something like `@MainActor` or a property wrapper on the previous line. This is a fix for that.

For example, the rule shouldn't expect a blank line in between these two lines:
```
@MainActor
var someProperty: Int { ··· }
```