### PR TITLE
Rewrite `operator_usage_whitespace` with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Rewrite `operator_usage_whitespace` rule using SwiftSyntax, fixing
   false positives and false negatives.  
+  Note that this rule doesn't catch violations around return arrows (`->`)
+  anymore - they are already handled by `return_arrow_whitespace`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#3668](https://github.com/realm/SwiftLint/issues/3668)
   [#2728](https://github.com/realm/SwiftLint/issues/2728)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 #### Enhancements
 
-* None.
+* Rewrite `operator_usage_whitespace` rule using SwiftSyntax, fixing
+  false positives and false negatives.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3668](https://github.com/realm/SwiftLint/issues/3668)
+  [#2728](https://github.com/realm/SwiftLint/issues/2728)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   Note that this rule doesn't catch violations around return arrows (`->`)
   anymore - they are already handled by `return_arrow_whitespace`.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  [#3965](https://github.com/realm/SwiftLint/issues/3965)
   [#3668](https://github.com/realm/SwiftLint/issues/3668)
   [#2728](https://github.com/realm/SwiftLint/issues/2728)
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+Remote.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Remote.swift
@@ -183,7 +183,7 @@ internal extension Configuration.FileGraph.FilePath {
     // MARK: Caching
     private func getCachedFilePath(urlString: String, rootDirectory: String) -> String? {
         let path = filePath(for: urlString, rootDirectory: rootDirectory)
-        return FileManager.default.fileExists(atPath: path) ? path: nil
+        return FileManager.default.fileExists(atPath: path) ? path : nil
     }
 
     private func cache(configString: String, from urlString: String, rootDirectory: String) -> String? {
@@ -209,7 +209,7 @@ internal extension Configuration.FileGraph.FilePath {
             atPath: path,
             contents: Data(configString.utf8),
             attributes: [:]
-        ) ? path: nil
+        ) ? path : nil
     }
 
     private func filePath(for urlString: String, rootDirectory: String) -> String {

--- a/Source/SwiftLintFramework/Reporters/CodeClimateReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CodeClimateReporter.swift
@@ -35,7 +35,7 @@ public struct CodeClimateReporter: Reporter {
                     "end": violation.location.line ?? NSNull() as Any
                 ]
             ],
-            "severity": violation.severity == .error ? "MAJOR": "MINOR",
+            "severity": violation.severity == .error ? "MAJOR" : "MINOR",
             "type": "issue"
         ]
     }

--- a/Source/SwiftLintFramework/Reporters/SonarQubeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/SonarQubeReporter.swift
@@ -30,7 +30,7 @@ public struct SonarQubeReporter: Reporter {
                 ]
             ],
             "type": "CODE_SMELL",
-            "severity": violation.severity == .error ? "MAJOR": "MINOR"
+            "severity": violation.severity == .error ? "MAJOR" : "MINOR"
         ]
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -16,7 +16,7 @@ public struct ContainsOverFilterCountRule: CallPairRule, OptInRule, Configuratio
                 Example("let result = myList.filter { $0 % 2 == 0 }.count \(operation) 1\n"),
                 Example("let result = myList.filter(where: { $0 % 2 == 0 }).count \(operation) 01\n")
             ]
-        } +  [
+        } + [
             Example("let result = myList.contains(where: { $0 % 2 == 0 })\n"),
             Example("let result = !myList.contains(where: { $0 % 2 == 0 })\n"),
             Example("let result = myList.contains(10)\n")

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -15,7 +15,7 @@ public struct ContainsOverFilterIsEmptyRule: CallPairRule, OptInRule, Configurat
                 Example("let result = myList.filter(where: { $0 % 2 == 0 }).count \(operation) 1\n"),
                 Example("let result = myList.filter { $0 % 2 == 0 }.count \(operation) 1\n")
             ]
-        } +  [
+        } + [
             Example("let result = myList.contains(where: { $0 % 2 == 0 })\n"),
             Example("let result = !myList.contains(where: { $0 % 2 == 0 })\n"),
             Example("let result = myList.contains(10)\n")

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -11,7 +11,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
     public static let description = RuleDescription(
         identifier: "operator_usage_whitespace",
         name: "Operator Usage Whitespace",
-        description: "Operators should be surrounded by a single whitespace " + "when they are being used.",
+        description: "Operators should be surrounded by a single whitespace when they are being used.",
         kind: .style,
         nonTriggeringExamples: OperatorUsageWhitespaceRuleExamples.nonTriggeringExamples,
         triggeringExamples: OperatorUsageWhitespaceRuleExamples.triggeringExamples,
@@ -173,8 +173,9 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
 
         let tooMuchSpacingBefore = previousToken.trailingTrivia.containsTooMuchWhitespacing
         let tooMuchSpacingAfter = operatorToken.trailingTrivia.containsTooMuchWhitespacing
-        let tooMuchSpacing = (tooMuchSpacingBefore || tooMuchSpacingAfter) &&
-                             !nextToken.leadingTrivia.containsComments
+
+        let tooMuchSpacing = (tooMuchSpacingBefore || tooMuchSpacingAfter) && !operatorToken.leadingTrivia.containsComments &&
+            !nextToken.leadingTrivia.containsComments
 
         guard noSpacing || tooMuchSpacing else {
             return nil

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -13,125 +13,9 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         name: "Operator Usage Whitespace",
         description: "Operators should be surrounded by a single whitespace " + "when they are being used.",
         kind: .style,
-        nonTriggeringExamples: [
-            Example("let foo = 1 + 2\n"),
-            Example("let foo = 1 > 2\n"),
-            Example("let foo = !false\n"),
-            Example("let foo: Int?\n"),
-            Example("let foo: Array<String>\n"),
-            Example("let model = CustomView<Container<Button>, NSAttributedString>()\n"),
-            Example("let foo: [String]\n"),
-            Example("let foo = 1 + \n  2\n"),
-            Example("let range = 1...3\n"),
-            Example("let range = 1 ... 3\n"),
-            Example("let range = 1..<3\n"),
-            Example("#if swift(>=3.0)\n    foo()\n#endif\n"),
-            Example("array.removeAtIndex(-200)\n"),
-            Example("let name = \"image-1\"\n"),
-            Example("button.setImage(#imageLiteral(resourceName: \"image-1\"), for: .normal)\n"),
-            Example("let doubleValue = -9e-11\n"),
-            Example("let foo = GenericType<(UIViewController) -> Void>()\n"),
-            Example("let foo = Foo<Bar<T>, Baz>()\n"),
-            Example("let foo = SignalProducer<Signal<Value, Error>, Error>([ self.signal, next ]).flatten(.concat)\n"),
-            Example("\"let foo =  1\""),
-            Example("""
-              enum Enum {
-              case hello   = 1
-              case hello2  = 1
-              }
-            """),
-            Example("""
-            let something = Something<GenericParameter1,
-                                      GenericParameter2>()
-            """ ),
-            Example("""
-            return path.flatMap { path in
-                return compileCommands[path] ??
-                    compileCommands[path.path(relativeTo: FileManager.default.currentDirectoryPath)]
-            }
-            """),
-            Example("""
-            internal static func == (lhs: Vertix, rhs: Vertix) -> Bool {
-                return lhs.filePath == rhs.filePath
-                    && lhs.originalRemoteString == rhs.originalRemoteString
-                    && lhs.rootDirectory == rhs.rootDirectory
-            }
-            """),
-            Example("""
-            internal static func == (lhs: Vertix, rhs: Vertix) -> Bool {
-                return lhs.filePath == rhs.filePath &&
-                    lhs.originalRemoteString == rhs.originalRemoteString &&
-                    lhs.rootDirectory == rhs.rootDirectory
-            }
-            """),
-            Example(#"""
-            private static let pattern =
-                "\\S\(mainPatternGroups)" + // Regexp will match if expression not begin with comma
-                "|" +                       // or
-                "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
-            """#),
-            Example(#"""
-            private static let pattern =
-                "\\S\(mainPatternGroups)" + // Regexp will match if expression not begin with comma
-                "|"                       + // or
-                "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
-            """#)
-        ],
-        triggeringExamples: [
-            Example("let foo = 1↓+2\n"),
-            Example("let foo = 1↓   + 2\n"),
-            Example("let foo = 1↓   +    2\n"),
-            Example("let foo = 1↓ +    2\n"),
-            Example("let foo↓=1↓+2\n"),
-            Example("let foo↓=1 + 2\n"),
-            Example("let foo↓=bar\n"),
-            Example("let range = 1↓ ..<  3\n"),
-            Example("let foo = bar↓   ?? 0\n"),
-            Example("let foo = bar↓ !=  0\n"),
-            Example("let foo = bar↓ !==  bar2\n"),
-            Example("let v8 = Int8(1)↓  << 6\n"),
-            Example("let v8 = 1↓ <<  (6)\n"),
-            Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"),
-            Example("let foo↓  = [1]\n"),
-            Example("let foo↓  = \"1\"\n"),
-            Example("let foo↓ =  \"1\"\n"),
-            Example("""
-              enum Enum {
-              case one↓  =  1
-              case two  = 1
-              }
-            """),
-            Example("""
-              enum Enum {
-              case one  = 1
-              case two↓  =  1
-              }
-            """),
-            Example("""
-              enum Enum {
-              case one↓   = 1
-              case two↓  = 1
-              }
-            """)
-        ],
-        corrections: [
-            Example("let foo = 1↓+2\n"): Example("let foo = 1 + 2\n"),
-            Example("let foo = 1↓   + 2\n"): Example("let foo = 1 + 2\n"),
-            Example("let foo = 1↓   +    2\n"): Example("let foo = 1 + 2\n"),
-            Example("let foo = 1↓ +    2\n"): Example("let foo = 1 + 2\n"),
-            Example("let foo↓=1↓+2\n"): Example("let foo = 1 + 2\n"),
-            Example("let foo↓=1 + 2\n"): Example("let foo = 1 + 2\n"),
-            Example("let foo↓=bar\n"): Example("let foo = bar\n"),
-            Example("let range = 1↓ ..<  3\n"): Example("let range = 1..<3\n"),
-            Example("let foo = bar↓   ?? 0\n"): Example("let foo = bar ?? 0\n"),
-            Example("let foo = bar↓ !=  0\n"): Example("let foo = bar != 0\n"),
-            Example("let foo = bar↓ !==  bar2\n"): Example("let foo = bar !== bar2\n"),
-            Example("let v8 = Int8(1)↓  << 6\n"): Example("let v8 = Int8(1) << 6\n"),
-            Example("let v8 = 1↓ <<  (6)\n"): Example("let v8 = 1 << (6)\n"),
-            Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"): Example("let v8 = 1 << (6)\n let foo = 1 > 2\n"),
-            Example("let foo↓  = \"1\"\n"): Example("let foo = \"1\"\n"),
-            Example("let foo↓ =  \"1\"\n"): Example("let foo = \"1\"\n")
-        ]
+        nonTriggeringExamples: OperatorUsageWhitespaceRuleExamples.nonTriggeringExamples,
+        triggeringExamples: OperatorUsageWhitespaceRuleExamples.triggeringExamples,
+        corrections: OperatorUsageWhitespaceRuleExamples.corrections
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
@@ -247,34 +131,35 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
     private(set) var violationRanges: [(ByteRange, String)] = []
 
     override func visitPost(_ node: BinaryOperatorExprSyntax) {
-        guard let previousToken = node.previousToken,
-              let nextToken = node.nextToken,
-              let violation = violation(previousToken: previousToken,
-                                        nextToken: nextToken,
-                                        operatorToken: node.operatorToken) else {
-            return
+        if let violation = violation(operatorToken: node.operatorToken) {
+            violationRanges.append(violation)
         }
-
-        violationRanges.append(violation)
     }
 
     override func visitPost(_ node: InitializerClauseSyntax) {
-        guard let previousToken = node.equal.previousToken,
-              let nextToken = node.equal.nextToken,
-              let violation = violation(previousToken: previousToken,
-                                        nextToken: nextToken,
-                                        operatorToken: node.equal) else {
-            return
+        if let violation = violation(operatorToken: node.equal) {
+            violationRanges.append(violation)
         }
-
-        violationRanges.append(violation)
     }
 
-    private func violation(
-        previousToken: TokenSyntax,
-        nextToken: TokenSyntax,
-        operatorToken: TokenSyntax
-    ) -> (ByteRange, String)? {
+    override func visitPost(_ node: TypeInitializerClauseSyntax) {
+        if let violation = violation(operatorToken: node.equal) {
+            violationRanges.append(violation)
+        }
+    }
+
+    override func visitPost(_ node: AssignmentExprSyntax) {
+        if let violation = violation(operatorToken: node.assignToken) {
+            violationRanges.append(violation)
+        }
+    }
+
+    private func violation(operatorToken: TokenSyntax) -> (ByteRange, String)? {
+        guard let previousToken = operatorToken.previousToken,
+              let nextToken = operatorToken.nextToken else {
+            return nil
+        }
+
         let noSpacingBefore = previousToken.trailingTrivia.isEmpty && operatorToken.leadingTrivia.isEmpty
         let noSpacingAfter = operatorToken.trailingTrivia.isEmpty && nextToken.leadingTrivia.isEmpty
         let noSpacing = noSpacingBefore || noSpacingAfter

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -174,7 +174,8 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
         let tooMuchSpacingBefore = previousToken.trailingTrivia.containsTooMuchWhitespacing
         let tooMuchSpacingAfter = operatorToken.trailingTrivia.containsTooMuchWhitespacing
 
-        let tooMuchSpacing = (tooMuchSpacingBefore || tooMuchSpacingAfter) && !operatorToken.leadingTrivia.containsComments &&
+        let tooMuchSpacing = (tooMuchSpacingBefore || tooMuchSpacingAfter) &&
+            !operatorToken.leadingTrivia.containsComments &&
             !nextToken.leadingTrivia.containsComments
 
         guard noSpacing || tooMuchSpacing else {

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -27,21 +27,17 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
     }
 
     private func violationRanges(file: SwiftLintFile) -> [(ByteRange, String)] {
-        guard let syntaxTree = file.syntaxTree else {
-            return []
-        }
-
         let visitor = OperatorUsageWhitespaceVisitor()
-        visitor.walk(syntaxTree)
-        return visitor.violationRanges.filter { byteRange, _ in
-            if configuration.skipAlignedConstants && isAlignedConstant(in: byteRange, file: file) {
-                return false
-            }
+        return visitor.walk(file: file, handler: \.violationRanges)
+            .filter { byteRange, _ in
+                if configuration.skipAlignedConstants && isAlignedConstant(in: byteRange, file: file) {
+                    return false
+                }
 
-            return true
-        }.sorted { lhs, rhs in
-            lhs.0.location < rhs.0.location
-        }
+                return true
+            }.sorted { lhs, rhs in
+                lhs.0.location < rhs.0.location
+            }
     }
 
     public func correct(file: SwiftLintFile) -> [Correction] {

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SourceKittenFramework
+import SwiftSyntax
 
 public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, ConfigurationProviderRule,
                                            AutomaticTestableRule {
@@ -10,8 +11,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
     public static let description = RuleDescription(
         identifier: "operator_usage_whitespace",
         name: "Operator Usage Whitespace",
-        description: "Operators should be surrounded by a single whitespace " +
-                     "when they are being used.",
+        description: "Operators should be surrounded by a single whitespace " + "when they are being used.",
         kind: .style,
         nonTriggeringExamples: [
             Example("let foo = 1 + 2\n"),
@@ -39,7 +39,43 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
               case hello   = 1
               case hello2  = 1
               }
-            """)
+            """),
+            Example("""
+            let something = Something<GenericParameter1,
+                                      GenericParameter2>()
+            """ ),
+            Example("""
+            return path.flatMap { path in
+                return compileCommands[path] ??
+                    compileCommands[path.path(relativeTo: FileManager.default.currentDirectoryPath)]
+            }
+            """),
+            Example("""
+            internal static func == (lhs: Vertix, rhs: Vertix) -> Bool {
+                return lhs.filePath == rhs.filePath
+                    && lhs.originalRemoteString == rhs.originalRemoteString
+                    && lhs.rootDirectory == rhs.rootDirectory
+            }
+            """),
+            Example("""
+            internal static func == (lhs: Vertix, rhs: Vertix) -> Bool {
+                return lhs.filePath == rhs.filePath &&
+                    lhs.originalRemoteString == rhs.originalRemoteString &&
+                    lhs.rootDirectory == rhs.rootDirectory
+            }
+            """),
+            Example(#"""
+            private static let pattern =
+                "\\S\(mainPatternGroups)" + // Regexp will match if expression not begin with comma
+                "|" +                       // or
+                "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
+            """#),
+            Example(#"""
+            private static let pattern =
+                "\\S\(mainPatternGroups)" + // Regexp will match if expression not begin with comma
+                "|"                       + // or
+                "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
+            """#)
         ],
         triggeringExamples: [
             Example("let foo = 1↓+2\n"),
@@ -51,7 +87,6 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             Example("let foo↓=bar\n"),
             Example("let range = 1↓ ..<  3\n"),
             Example("let foo = bar↓   ?? 0\n"),
-            Example("let foo = bar↓??0\n"),
             Example("let foo = bar↓ !=  0\n"),
             Example("let foo = bar↓ !==  bar2\n"),
             Example("let v8 = Int8(1)↓  << 6\n"),
@@ -89,7 +124,6 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
             Example("let foo↓=bar\n"): Example("let foo = bar\n"),
             Example("let range = 1↓ ..<  3\n"): Example("let range = 1..<3\n"),
             Example("let foo = bar↓   ?? 0\n"): Example("let foo = bar ?? 0\n"),
-            Example("let foo = bar↓??0\n"): Example("let foo = bar ?? 0\n"),
             Example("let foo = bar↓ !=  0\n"): Example("let foo = bar != 0\n"),
             Example("let foo = bar↓ !==  bar2\n"): Example("let foo = bar !== bar2\n"),
             Example("let v8 = Int8(1)↓  << 6\n"): Example("let v8 = Int8(1) << 6\n"),
@@ -104,108 +138,77 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         return violationRanges(file: file).map { range, _ in
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
-                           location: Location(file: file, characterOffset: range.location))
+                           location: Location(file: file, byteOffset: range.location))
         }
     }
 
-    private func violationRanges(file: SwiftLintFile) -> [(NSRange, String)] {
-        let rangePattern = "\\.\\.(?:\\.|<)" // ... or ..<
-        let notEqualsPattern = "\\!\\=\\=?" // != or !==
-        let coalescingPattern = "\\?{2}"
-
-        let operators = "(?:[%<>&=*+|^/~-]+|\(rangePattern)|\(coalescingPattern)|" + "\(notEqualsPattern))"
-
-        let oneSpace = "[^\\S\\r\\n]" // to allow lines ending with operators to be valid
-        let zeroSpaces = oneSpace + "{0}"
-        let manySpaces = oneSpace + "{2,}"
-        let leadingExpression = "(?:\\b|\\)|\\]|\")"
-        let trailingExpression = "(?:\\b|\\(|\\[|\")"
-
-        let spaces = [(zeroSpaces, zeroSpaces), (oneSpace, manySpaces),
-                      (manySpaces, oneSpace), (manySpaces, manySpaces)]
-        let patterns = spaces.map { first, second in
-            leadingExpression + first + operators + second + trailingExpression
-        }
-        let pattern = "(?:\(patterns.joined(separator: "|")))"
-
-        let genericPattern = "<(?:\(oneSpace)|\\S)*>" // not using dot to avoid matching new line
-        let validRangePattern = leadingExpression + zeroSpaces + rangePattern + zeroSpaces + trailingExpression
-        let excludingPattern = "(?:\(genericPattern)|\(validRangePattern))"
-
-        let excludingKinds = SyntaxKind.commentKinds.union([.objectLiteral])
-
-        return file.match(pattern: pattern, excludingSyntaxKinds: excludingKinds,
-                          excludingPattern: excludingPattern).compactMap { range in
-            // if it's only a number (i.e. -9e-11), it shouldn't trigger
-            guard kinds(in: range, file: file) != [.number] else {
-                return nil
-            }
-
-            let spacesPattern = oneSpace + "*"
-            let rangeRegex = regex(spacesPattern + rangePattern + spacesPattern)
-
-            // if it's a range operator, the correction shouldn't have spaces
-            if let matchRange = rangeRegex.firstMatch(in: file.contents, options: [], range: range)?.range {
-                let correction = operatorInRange(file: file, range: matchRange)
-                // Make sure that the match is not within the string i.e `let a = "12...123"`
-                guard kinds(in: matchRange, file: file) != [.string] else {
-                    return nil
-                }
-                return (matchRange, correction)
-            }
-
-            let operatorsRegex = regex(spacesPattern + operators + spacesPattern)
-
-            guard let matchRange = operatorsRegex.firstMatch(in: file.contents,
-                                                             options: [], range: range)?.range else {
-                return nil
-            }
-
-            // Make sure that the match is not within the string i.e `let a = "12 == 123"`
-            guard kinds(in: matchRange, file: file) != [.string] else {
-                return nil
-            }
-
-            let operatorContent = operatorInRange(file: file, range: matchRange)
-            let correction = " " + operatorContent + " "
-
-            if configuration.skipAlignedConstants && isAlignedConstant(in: matchRange, file: file) {
-                return nil
-            }
-
-            return (matchRange, correction)
-        }
-    }
-
-    private func kinds(in range: NSRange, file: SwiftLintFile) -> [SyntaxKind] {
-        let contents = file.stringView
-        guard let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length) else {
+    private func violationRanges(file: SwiftLintFile) -> [(ByteRange, String)] {
+        guard let syntaxTree = file.syntaxTree else {
             return []
         }
 
-        return file.syntaxMap.kinds(inByteRange: byteRange)
+        let visitor = OperatorUsageWhitespaceVisitor()
+        visitor.walk(syntaxTree)
+        return visitor.violationRanges.filter { byteRange, _ in
+            if configuration.skipAlignedConstants && isAlignedConstant(in: byteRange, file: file) {
+                return false
+            }
+
+            return true
+        }.sorted { lhs, rhs in
+            lhs.0.location < rhs.0.location
+        }
     }
 
-    private func operatorInRange(file: SwiftLintFile, range: NSRange) -> String {
-        return file.stringView.substring(with: range).trimmingCharacters(in: .whitespaces)
+    public func correct(file: SwiftLintFile) -> [Correction] {
+        let violatingRanges = violationRanges(file: file)
+            .compactMap { byteRange, correction -> (NSRange, String)? in
+                guard let range = file.stringView.byteRangeToNSRange(byteRange) else {
+                    return nil
+                }
+
+                return (range, correction)
+            }
+            .filter { range, _ in
+                return file.ruleEnabled(violatingRanges: [range], for: self).isNotEmpty
+            }
+
+        var correctedContents = file.contents
+        var adjustedLocations = [Int]()
+
+        for (violatingRange, correction) in violatingRanges.reversed() {
+            if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
+                correctedContents = correctedContents
+                    .replacingCharacters(in: indexRange, with: correction)
+                adjustedLocations.insert(violatingRange.location, at: 0)
+            }
+        }
+
+        file.write(correctedContents)
+
+        return adjustedLocations.map {
+            Correction(ruleDescription: Self.description,
+                       location: Location(file: file, characterOffset: $0))
+        }
     }
 
-    private func isAlignedConstant(in range: NSRange, file: SwiftLintFile) -> Bool {
-        /// Make sure we have match with assignment operator and with spaces before it
-        let matchedString = file.stringView.substring(with: range)
+    private func isAlignedConstant(in byteRange: ByteRange, file: SwiftLintFile) -> Bool {
+        // Make sure we have match with assignment operator and with spaces before it
+        guard let matchedString = file.stringView.substringWithByteRange(byteRange) else {
+            return false
+        }
         let equalityOperatorRegex = regex("\\s+=\\s")
 
-        let fullRange = NSRange(location: 0, length: range.length)
         guard let match = equalityOperatorRegex.firstMatch(
-                in: matchedString,
-                options: [],
-                range: fullRange),
-              match.range == fullRange
+            in: matchedString,
+            options: [],
+            range: matchedString.fullNSRange),
+              match.range == matchedString.fullNSRange
         else {
             return false
         }
 
-        guard let (lineNumber, _) = file.stringView.lineAndCharacter(forCharacterOffset: NSMaxRange(range)),
+        guard let (lineNumber, _) = file.stringView.lineAndCharacter(forByteOffset: byteRange.upperBound),
               case let lineIndex = lineNumber - 1, lineIndex >= 0 else {
             return false
         }
@@ -238,28 +241,92 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
 
         return false
     }
+}
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
-        let violatingRanges = violationRanges(file: file).filter { range, _ in
-            return file.ruleEnabled(violatingRanges: [range], for: self).isNotEmpty
+private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
+    private(set) var violationRanges: [(ByteRange, String)] = []
+
+    override func visitPost(_ node: BinaryOperatorExprSyntax) {
+        guard let previousToken = node.previousToken,
+              let nextToken = node.nextToken,
+              let violation = violation(previousToken: previousToken,
+                                        nextToken: nextToken,
+                                        operatorToken: node.operatorToken) else {
+            return
         }
 
-        var correctedContents = file.contents
-        var adjustedLocations = [Int]()
+        violationRanges.append(violation)
+    }
 
-        for (violatingRange, correction) in violatingRanges.reversed() {
-            if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
-                correctedContents = correctedContents
-                    .replacingCharacters(in: indexRange, with: correction)
-                adjustedLocations.insert(violatingRange.location, at: 0)
+    override func visitPost(_ node: InitializerClauseSyntax) {
+        guard let previousToken = node.equal.previousToken,
+              let nextToken = node.equal.nextToken,
+              let violation = violation(previousToken: previousToken,
+                                        nextToken: nextToken,
+                                        operatorToken: node.equal) else {
+            return
+        }
+
+        violationRanges.append(violation)
+    }
+
+    private func violation(
+        previousToken: TokenSyntax,
+        nextToken: TokenSyntax,
+        operatorToken: TokenSyntax
+    ) -> (ByteRange, String)? {
+        let noSpacingBefore = previousToken.trailingTrivia.isEmpty && operatorToken.leadingTrivia.isEmpty
+        let noSpacingAfter = operatorToken.trailingTrivia.isEmpty && nextToken.leadingTrivia.isEmpty
+        let noSpacing = noSpacingBefore || noSpacingAfter
+
+        let allowedNoSpacingOperators: Set = ["...", "..<"]
+
+        let operatorText = operatorToken.withoutTrivia().text
+        if noSpacing && allowedNoSpacingOperators.contains(operatorText) {
+            return nil
+        }
+
+        let tooMuchSpacingBefore = previousToken.trailingTrivia.containsTooMuchWhitespacing
+        let tooMuchSpacingAfter = operatorToken.trailingTrivia.containsTooMuchWhitespacing
+        let tooMuchSpacing = (tooMuchSpacingBefore || tooMuchSpacingAfter) &&
+                             !nextToken.leadingTrivia.containsComments
+
+        guard noSpacing || tooMuchSpacing else {
+            return nil
+        }
+
+        let location = ByteCount(previousToken.endPositionBeforeTrailingTrivia)
+        let endPosition = ByteCount(nextToken.positionAfterSkippingLeadingTrivia)
+        let range = ByteRange(
+            location: location,
+            length: endPosition - location
+        )
+
+        let correction = allowedNoSpacingOperators.contains(operatorText) ? operatorText : " \(operatorText) "
+        return (range, correction)
+    }
+}
+
+private extension Trivia {
+    var containsTooMuchWhitespacing: Bool {
+        return contains { element in
+            guard case let .spaces(spaces) = element, spaces > 1 else {
+                return false
             }
+
+            return true
         }
+    }
 
-        file.write(correctedContents)
-
-        return adjustedLocations.map {
-            Correction(ruleDescription: Self.description,
-                       location: Location(file: file, characterOffset: $0))
+    var containsComments: Bool {
+        return contains { element in
+            switch element {
+            case .blockComment, .docLineComment, .docBlockComment, .lineComment:
+                return true
+            case .carriageReturnLineFeeds, .carriageReturns, .formfeeds,
+                 .garbageText, .newlines, .spaces, .verticalTabs, .tabs:
+                return false
+            }
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -154,6 +154,16 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
         }
     }
 
+    override func visitPost(_ node: TernaryExprSyntax) {
+        if let violation = violation(operatorToken: node.colonMark) {
+            violationRanges.append(violation)
+        }
+
+        if let violation = violation(operatorToken: node.questionMark) {
+            violationRanges.append(violation)
+        }
+    }
+
     private func violation(operatorToken: TokenSyntax) -> (ByteRange, String)? {
         guard let previousToken = operatorToken.previousToken,
               let nextToken = operatorToken.nextToken else {

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+internal enum OperatorUsageWhitespaceRuleExamples {
+    static let nonTriggeringExamples = [
+        Example("let foo = 1 + 2\n"),
+        Example("let foo = 1 > 2\n"),
+        Example("let foo = !false\n"),
+        Example("let foo: Int?\n"),
+        Example("let foo: Array<String>\n"),
+        Example("let model = CustomView<Container<Button>, NSAttributedString>()\n"),
+        Example("let foo: [String]\n"),
+        Example("let foo = 1 + \n  2\n"),
+        Example("let range = 1...3\n"),
+        Example("let range = 1 ... 3\n"),
+        Example("let range = 1..<3\n"),
+        Example("#if swift(>=3.0)\n    foo()\n#endif\n"),
+        Example("array.removeAtIndex(-200)\n"),
+        Example("let name = \"image-1\"\n"),
+        Example("button.setImage(#imageLiteral(resourceName: \"image-1\"), for: .normal)\n"),
+        Example("let doubleValue = -9e-11\n"),
+        Example("let foo = GenericType<(UIViewController) -> Void>()\n"),
+        Example("let foo = Foo<Bar<T>, Baz>()\n"),
+        Example("let foo = SignalProducer<Signal<Value, Error>, Error>([ self.signal, next ]).flatten(.concat)\n"),
+        Example("\"let foo =  1\""),
+        Example("""
+          enum Enum {
+          case hello   = 1
+          case hello2  = 1
+          }
+        """),
+        Example("""
+        let something = Something<GenericParameter1,
+                                  GenericParameter2>()
+        """ ),
+        Example("""
+        return path.flatMap { path in
+            return compileCommands[path] ??
+                compileCommands[path.path(relativeTo: FileManager.default.currentDirectoryPath)]
+        }
+        """),
+        Example("""
+        internal static func == (lhs: Vertix, rhs: Vertix) -> Bool {
+            return lhs.filePath == rhs.filePath
+                && lhs.originalRemoteString == rhs.originalRemoteString
+                && lhs.rootDirectory == rhs.rootDirectory
+        }
+        """),
+        Example("""
+        internal static func == (lhs: Vertix, rhs: Vertix) -> Bool {
+            return lhs.filePath == rhs.filePath &&
+                lhs.originalRemoteString == rhs.originalRemoteString &&
+                lhs.rootDirectory == rhs.rootDirectory
+        }
+        """),
+        Example(#"""
+        private static let pattern =
+            "\\S\(mainPatternGroups)" + // Regexp will match if expression not begin with comma
+            "|" +                       // or
+            "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
+        """#),
+        Example(#"""
+        private static let pattern =
+            "\\S\(mainPatternGroups)" + // Regexp will match if expression not begin with comma
+            "|"                       + // or
+            "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
+        """#),
+        Example("typealias Foo = Bar"),
+        Example("""
+        protocol A {
+            associatedtype B = C
+        }
+        """),
+        Example("tabbedViewController.title = nil")
+    ]
+
+    static let triggeringExamples = [
+        Example("let foo = 1↓+2\n"),
+        Example("let foo = 1↓   + 2\n"),
+        Example("let foo = 1↓   +    2\n"),
+        Example("let foo = 1↓ +    2\n"),
+        Example("let foo↓=1↓+2\n"),
+        Example("let foo↓=1 + 2\n"),
+        Example("let foo↓=bar\n"),
+        Example("let range = 1↓ ..<  3\n"),
+        Example("let foo = bar↓   ?? 0\n"),
+        Example("let foo = bar↓ !=  0\n"),
+        Example("let foo = bar↓ !==  bar2\n"),
+        Example("let v8 = Int8(1)↓  << 6\n"),
+        Example("let v8 = 1↓ <<  (6)\n"),
+        Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"),
+        Example("let foo↓  = [1]\n"),
+        Example("let foo↓  = \"1\"\n"),
+        Example("let foo↓ =  \"1\"\n"),
+        Example("""
+          enum Enum {
+          case one↓  =  1
+          case two  = 1
+          }
+        """),
+        Example("""
+          enum Enum {
+          case one  = 1
+          case two↓  =  1
+          }
+        """),
+        Example("""
+          enum Enum {
+          case one↓   = 1
+          case two↓  = 1
+          }
+        """),
+        Example("typealias Foo↓ =  Bar"),
+        Example("""
+        protocol A {
+            associatedtype B↓  = C
+        }
+        """),
+        Example("tabbedViewController.title↓  = nil")
+    ]
+
+    static let corrections = [
+        Example("let foo = 1↓+2\n"): Example("let foo = 1 + 2\n"),
+        Example("let foo = 1↓   + 2\n"): Example("let foo = 1 + 2\n"),
+        Example("let foo = 1↓   +    2\n"): Example("let foo = 1 + 2\n"),
+        Example("let foo = 1↓ +    2\n"): Example("let foo = 1 + 2\n"),
+        Example("let foo↓=1↓+2\n"): Example("let foo = 1 + 2\n"),
+        Example("let foo↓=1 + 2\n"): Example("let foo = 1 + 2\n"),
+        Example("let foo↓=bar\n"): Example("let foo = bar\n"),
+        Example("let range = 1↓ ..<  3\n"): Example("let range = 1..<3\n"),
+        Example("let foo = bar↓   ?? 0\n"): Example("let foo = bar ?? 0\n"),
+        Example("let foo = bar↓ !=  0\n"): Example("let foo = bar != 0\n"),
+        Example("let foo = bar↓ !==  bar2\n"): Example("let foo = bar !== bar2\n"),
+        Example("let v8 = Int8(1)↓  << 6\n"): Example("let v8 = Int8(1) << 6\n"),
+        Example("let v8 = 1↓ <<  (6)\n"): Example("let v8 = 1 << (6)\n"),
+        Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"): Example("let v8 = 1 << (6)\n let foo = 1 > 2\n"),
+        Example("let foo↓  = \"1\"\n"): Example("let foo = \"1\"\n"),
+        Example("let foo↓ =  \"1\"\n"): Example("let foo = \"1\"\n")
+    ]
+}

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal enum OperatorUsageWhitespaceRuleExamples {
     static let nonTriggeringExamples = [
         Example("let foo = 1 + 2\n"),

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -126,7 +126,9 @@ internal enum OperatorUsageWhitespaceRuleExamples {
             associatedtype B↓  = C
         }
         """),
-        Example("tabbedViewController.title↓  = nil")
+        Example("tabbedViewController.title↓  = nil"),
+        Example("let foo = bar ? 0↓:1"),
+        Example("let foo = bar↓ ?   0 : 1")
     ]
 
     static let corrections = [
@@ -145,6 +147,8 @@ internal enum OperatorUsageWhitespaceRuleExamples {
         Example("let v8 = 1↓ <<  (6)\n"): Example("let v8 = 1 << (6)\n"),
         Example("let v8 = 1↓ <<  (6)\n let foo = 1 > 2\n"): Example("let v8 = 1 << (6)\n let foo = 1 > 2\n"),
         Example("let foo↓  = \"1\"\n"): Example("let foo = \"1\"\n"),
-        Example("let foo↓ =  \"1\"\n"): Example("let foo = \"1\"\n")
+        Example("let foo↓ =  \"1\"\n"): Example("let foo = \"1\"\n"),
+        Example("let foo = bar ? 0↓:1"): Example("let foo = bar ? 0 : 1"),
+        Example("let foo = bar↓ ?   0 : 1"): Example("let foo = bar ? 0 : 1")
     ]
 }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -78,7 +78,12 @@ internal enum OperatorUsageWhitespaceRuleExamples {
                >>> effect({ log.debug("Done syncing. Work was done? \(workWasDone)") })
                >>> { workWasDone ? storage.doneUpdatingMetadataAfterUpload() : succeed() }    // A closure
                >>> effect({ log.debug("Done.") })
-        """#, excludeFromDocumentation: true)
+        """#, excludeFromDocumentation: true),
+        Example("""
+        func success(for item: Item) {
+            item.successHandler??()
+        }
+        """, excludeFromDocumentation: true)
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -70,7 +70,15 @@ internal enum OperatorUsageWhitespaceRuleExamples {
             associatedtype B = C
         }
         """),
-        Example("tabbedViewController.title = nil")
+        Example("tabbedViewController.title = nil"),
+        Example(#"""
+        return deferMaybe(lastTimestamp)
+              >>== uploadDeleted
+              >>== uploadModified
+               >>> effect({ log.debug("Done syncing. Work was done? \(workWasDone)") })
+               >>> { workWasDone ? storage.doneUpdatingMetadataAfterUpload() : succeed() }    // A closure
+               >>> effect({ log.debug("Done.") })
+        """#, excludeFromDocumentation: true)
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -18,7 +18,8 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
             Example("func abc() -> (Int, Int) {}\n"),
             Example("var abc = {(param: Int) -> Void in }\n"),
             Example("func abc() ->\n    Int {}\n"),
-            Example("func abc()\n    -> Int {}\n")
+            Example("func abc()\n    -> Int {}\n"),
+            Example("typealias SuccessBlock = ((Data) -> Void)")
         ],
         triggeringExamples: [
             Example("func abc()↓->Int {}\n"),
@@ -28,7 +29,8 @@ public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderR
             Example("func abc()↓ ->Int {}\n"),
             Example("func abc()↓  ->  Int {}\n"),
             Example("var abc = {(param: Int)↓ ->Bool in }\n"),
-            Example("var abc = {(param: Int)↓->Bool in }\n")
+            Example("var abc = {(param: Int)↓->Bool in }\n"),
+            Example("typealias SuccessBlock = ((Data)↓->Void)")
         ],
         corrections: [
             Example("func abc()↓->Int {}\n"): Example("func abc() -> Int {}\n"),

--- a/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
@@ -71,66 +71,93 @@ class ModifierOrderTests: XCTestCase {
     func testAtPrefixedGroup() {
         let descriptionOverride = ModifierOrderRule.description
             .with(nonTriggeringExamples: [
-                Example("class Foo { \n"                                        +
-                "   @objc \n"                                           +
-                "   internal var bar: String {\n"                       +
-                "       return \"foo\"\n"                               +
-                "   }\n"                                                +
-                "} \n"                                                  +
-                "class Bar: Foo { \n"                                   +
-                "   @objc \n"                                           +
-                "   override internal var bar: String { \n"             +
-                "       return \"bar\"\n"                               +
-                "   }\n"                                                +
-                "}"),
-                Example("@objcMembers \n"                                       +
-                "public final class Bar {} \n"),
-                Example("class Foo { \n"                                        +
-                "   @IBOutlet internal weak var bar: UIView!\n"         +
-                "}"),
-                Example("class Foo { \n"                                        +
-                "   @IBAction internal func bar() {}\n"                 +
-                "}\n"                                                   +
-                "class Bar: Foo { \n"                                   +
-                "   @IBAction override internal func bar() {}\n"        +
-                "}"),
-                Example("public class Foo {\n"                                  +
-                "   @NSCopying public final var foo:NSString = \"s\"\n" +
-                "}"),
-                Example("public class Bar {\n"                                  +
-                "   @NSManaged public final var foo: NSString \n"       +
-                "}\n")
+                Example(#"""
+                class Foo {
+                    @objc
+                    internal var bar: String {
+                       return "foo"
+                    }
+                }
+                class Bar: Foo {
+                   @objc
+                   override internal var bar: String {
+                       return "bar"
+                   }
+                }
+                """#),
+                Example("""
+                @objcMembers
+                public final class Bar {}
+                """),
+                Example("""
+                class Foo {
+                    @IBOutlet internal weak var bar: UIView!
+                }
+                """),
+                Example("""
+                class Foo {
+                    @IBAction internal func bar() {}
+                }
+                """),
+                Example("""
+                class Bar: Foo {
+                    @IBAction override internal func bar() {}
+                }
+                """),
+                Example(#"""
+                public class Foo {
+                   @NSCopying public final var foo:NSString = "s"
+                }
+                """#),
+                Example(#"""
+                public class Foo {
+                   @NSCopying public final var foo: NSString
+                }
+                """#)
             ])
             .with(triggeringExamples: [
-                Example("class Foo { \n"                                        +
-                "   @objc \n"                                           +
-                "   internal var bar: String {\n"                       +
-                "       return \"foo\"\n"                               +
-                "   }\n"                                                +
-                "} \n"                                                  +
-                "class Bar: Foo { \n"                                   +
-                "   @objc \n"                                           +
-                "   internal override var bar: String { \n"             +
-                "       return \"bar\"\n"                               +
-                "   }\n"                                                +
-                "}"),
-                Example("@objcMembers \n"                                       +
-                "final public class Bar {} \n"),
-                Example("class Foo { \n"                                        +
-                "   @IBOutlet weak internal var bar: UIView!\n"         +
-                "}"),
-                Example("class Foo { \n"                                        +
-                "   @IBAction internal func bar() {}\n"                 +
-                "}\n"                                                   +
-                "class Bar: Foo { \n"                                   +
-                "   @IBAction internal override func bar() {}\n"        +
-                "}"),
-                Example("public class Foo {\n"                                  +
-                "   @NSCopying final public var foo:NSString = \"s\"\n" +
-                "}"),
-                Example("public class Bar {\n"                                  +
-                "   @NSManaged final public var foo: NSString \n"       +
-                "}\n")
+                Example(#"""
+                class Foo {
+                    @objc
+                    internal var bar: String {
+                       return "foo"
+                    }
+                }
+                class Bar: Foo {
+                   @objc
+                    internal override var bar: String {
+                       return "bar"
+                   }
+                }
+                """#),
+                Example("""
+                @objcMembers
+                final public class Bar {}
+                """),
+                Example("""
+                class Foo {
+                    @IBOutlet weak internal var bar: UIView!
+                }
+                """),
+                Example("""
+                class Foo {
+                    @IBAction internal func bar() {}
+                }
+
+                class Bar: Foo {
+                    @IBAction internal override func bar() {}
+                }
+                """),
+                Example(#"""
+                public class Foo {
+                    @NSCopying final public var foo:NSString = "s"
+                }
+                """#),
+                Example("""
+                public class Foo {
+                    @NSManaged final public var foo: NSString
+                }
+                """)
             ])
             .with(corrections: [:])
 


### PR DESCRIPTION
Fixes #3668, #2728 and https://github.com/realm/SwiftLint/issues/3965