### PR TITLE
Ignore array types if their associated `Index` is accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@
 
 #### Bug Fixes
 
-* None.
+* Ignore array types in `syntactic_sugar` rule if their associated `Index` is
+  accessed.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3502](https://github.com/realm/SwiftLint/issues/3502)
 
 ## 0.47.1: Smarter Appliance
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -177,7 +177,7 @@ private final class SyntacticSugarRuleVisitor: SyntaxVisitor {
         // Skip checks for 'self' or \T Dictionary<Key, Value>.self
         if let parent = node.parent?.as(MemberAccessExprSyntax.self),
            let lastToken = Array(parent.tokens).last?.tokenKind,
-           lastToken == .selfKeyword || lastToken == .identifier("Type") || lastToken == .identifier("none") {
+           [.selfKeyword, .identifier("Type"), .identifier("none"), .identifier("Index")].contains(lastToken) {
             return
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRuleExamples.swift
@@ -27,7 +27,8 @@ internal enum SyntacticSugarRuleExamples {
         Example("let x: Foo.Optional<String>"),
 
         Example("let x = case Optional<Any>.none = obj"),
-        Example("let a = Swift.Optional<String?>.none")
+        Example("let a = Swift.Optional<String?>.none"),
+        Example("func f() -> [Array<Int>.Index] { [Array<Int>.Index]() }", excludeFromDocumentation: true)
     ]
 
     static let triggering = [


### PR DESCRIPTION
Fixes #3502.