### PR TITLE
Prevent crash for private types named `_` in `type_name` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#3502](https://github.com/realm/SwiftLint/issues/3502)
 
+* Prevent crash for private types named `_` in `type_name` rules.
+  [sinoru](https://github.com/sinoru)
+  [#3971](https://github.com/realm/SwiftLint/issues/3971)
+
 ## 0.47.1: Smarter Appliance
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -48,7 +48,7 @@ public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
                                    location: Location(file: file, byteOffset: offset),
                                    reason: "Type name should only contain alphanumeric characters: '\(name)'")]
         } else if configuration.validatesStartWithLowercase &&
-            !String(name[name.startIndex]).isUppercase() {
+            name.first?.isLowercase == true {
             return [StyleViolation(ruleDescription: Self.description,
                                    severity: .error,
                                    location: Location(file: file, byteOffset: offset),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRuleExamples.swift
@@ -36,6 +36,7 @@ internal struct TypeNameRuleExamples {
                 Example("\(type) ↓myType {}"),
                 Example("\(type) ↓_MyType {}"),
                 Example("private \(type) ↓MyType_ {}"),
+                Example("private \(type) ↓`_` {}", excludeFromDocumentation: true),
                 Example("\(type) ↓My {}"),
                 Example("\(type) ↓\(repeatElement("A", count: 41).joined()) {}"),
                 Example("\(type) ↓MyView_Previews"),


### PR DESCRIPTION
Fixes #3971