### PR TITLE
Look for call expressions which are not wrapped into an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
 * Update result builder methods in `unused_declaration` rule fixing some
   false-positives.  
   [SimplyDanny](https://github.com/SimplyDanny)
+  
+* Look for call expressions which are not wrapped into an argument when
+  checking for nested (possibly multiline) arguments fixing some
+  false-negatives in (at least) Xcode 13.2.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3975](https://github.com/realm/SwiftLint/issues/3975)
 
 ## 0.47.1: Smarter Appliance
 

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -46,6 +46,11 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
             }
             """),
             Example("""
+            views.append(ViewModel(title: "MacBook", subtitle: "M1", action: { [weak self] in
+                print("action tapped")
+            }))
+            """, excludeFromDocumentation: true),
+            Example("""
             public final class Logger {
                 public static let shared = Logger(outputs: [
                     OSLoggerOutput(),
@@ -100,7 +105,13 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
                     1, 2, 3
                 ],
                 b: "two"↓)
-            """)
+            """),
+            Example("""
+            views.append(ViewModel(
+                title: "MacBook", subtitle: "M1", action: { [weak self] in
+                print("action tapped")
+            }↓))
+            """, excludeFromDocumentation: true)
         ]
     )
 
@@ -119,7 +130,7 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
 
         let parameters = dictionary.substructure.filter {
             // Argument expression types that can contain newlines
-            [.argument, .array, .dictionary, .closure].contains($0.expressionKind)
+            [.argument, .array, .dictionary, .closure, .call].contains($0.expressionKind)
         }
         let parameterBodies = parameters.compactMap { $0.content(in: file) }
         let parametersNewlineCount = parameterBodies.map { body in


### PR DESCRIPTION
This makes the added test cases work in Xcode 13.2 where the wrapping does not happen.
The call expression is the first substructure in the dictionary, while in Xcode 13.3
it's an argument containing the call expression.

Fixes #3975.