### PR TITLE
Add accessibility_trait_for_button rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 
 * Rewrite `large_tuple` rule using SwiftSyntax, fixing false negatives.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+* Add `accessibility_trait_for_button` rule to warn if a SwiftUI
+  View has a tap gesture added to it without having the button or
+  link accessibility trait.  
+  [Ryan Cole](https://github.com/rcole34)
 
 * Add methods from SE-0348 to `UnusedDeclarationRule`.  
   [JP Simard](https://github.com/jpims)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,7 @@ macOS < 12.
 * Support `UIEdgeInsets` type in `prefer_zero_over_explicit_init` rule.  
   [KokiHirokawa](https://github.com/KokiHirokawa)
   [#3986](https://github.com/realm/SwiftLint/issues/3986)
+
 * Add `accessibility_trait_for_button` rule to warn if a SwiftUI
   View has a tap gesture added to it without having the button or
   link accessibility trait.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 * Rewrite `large_tuple` rule using SwiftSyntax, fixing false negatives.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+
 * Add `accessibility_trait_for_button` rule to warn if a SwiftUI
   View has a tap gesture added to it without having the button or
   link accessibility trait.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,11 @@ macOS < 12.
 * Support `UIEdgeInsets` type in `prefer_zero_over_explicit_init` rule.  
   [KokiHirokawa](https://github.com/KokiHirokawa)
   [#3986](https://github.com/realm/SwiftLint/issues/3986)
+* Add `accessibility_trait_for_button` rule to warn if a SwiftUI
+  View has a tap gesture added to it without having the button or
+  link accessibility trait.  
+  [Ryan Cole](https://github.com/rcole34)  
+  [#2728](https://github.com/realm/SwiftLint/issues/2728) 
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,12 +273,6 @@ macOS < 12.
   [KokiHirokawa](https://github.com/KokiHirokawa)
   [#3986](https://github.com/realm/SwiftLint/issues/3986)
 
-* Add `accessibility_trait_for_button` rule to warn if a SwiftUI
-  View has a tap gesture added to it without having the button or
-  link accessibility trait.  
-  [Ryan Cole](https://github.com/rcole34)  
-  [#2728](https://github.com/realm/SwiftLint/issues/2728) 
-
 #### Bug Fixes
 
 * Ignore array types in `syntactic_sugar` rule if their associated `Index` is

--- a/Source/SwiftLintFramework/Extensions/SourceKittenDictionary+SwiftUI.swift
+++ b/Source/SwiftLintFramework/Extensions/SourceKittenDictionary+SwiftUI.swift
@@ -1,0 +1,190 @@
+import SourceKittenFramework
+
+/// Struct to represent SwiftUI ViewModifiers for the purpose of finding modifiers in a substructure.
+struct SwiftUIModifier {
+    struct Argument {
+        enum MatchType {
+            case prefix, suffix, substring, exactMatch, none
+
+            /// Compares the parsed argument value to a target value for the given match type
+            /// and returns true is a match is found.
+            func matches(argumentValue: String, targetValue: String) -> Bool {
+                switch self {
+                case .prefix:
+                    return argumentValue.hasPrefix(targetValue)
+                case .suffix:
+                    return argumentValue.hasSuffix(targetValue)
+                case .substring:
+                    return argumentValue.contains(targetValue)
+                case .exactMatch:
+                    return argumentValue == targetValue
+                case .none:
+                    // No matching is required for this type; we only care about the presence of the argument.
+                    return true
+                }
+            }
+        }
+
+        /// Name of the argument we want to find. For single unnamed arguments, use the empty string.
+        let name: String
+
+        /// Whether or not the argument is required. If the argument is present, value checks are enforced.
+        /// Allows for better handling of modifiers with default values for certain arguments where we want
+        /// to ensure that the default value is used.
+        let required: Bool
+
+        /// List of possible values for the argument. Typically should just be a list with a single element,
+        /// but allows for the flexibility of checking for multiple possible values. To only check for the presence
+        /// of the modifier and not enforce any certain values, use the `.none` match type. All values are parsed as
+        /// Strings; for other types (boolean, numeric, optional, etc) types you can check for "true", "5", "nil", etc.
+        let values: [String]
+
+        /// Success criteria used for matching values (prefix, suffix, substring, exact match, or none).
+        let matchType: MatchType
+
+        init(name: String, required: Bool = true, values: [String], matchType: MatchType = .exactMatch) {
+            self.name = name
+            self.required = required
+            self.values = values
+            self.matchType = matchType
+        }
+    }
+
+    /// Name of the modifier.
+    let name: String
+
+    /// List of arguments to check for in the modifier.
+    let arguments: [Argument]
+}
+
+/// Extensions for recursively checking SwiftUI code for certain modifiers.
+extension SourceKittenDictionary {
+    /// Call on a SwiftUI View to recursively check the substructure for a certain modifier with certain arguments.
+    /// - Parameters:
+    ///   - modifiers: A list of `SwiftUIModifier` structs to check for in the view's substructure.
+    ///                In most cases, this can just be a single modifier, but since some modifiers have
+    ///                multiple versions, this enables checking for any modifier from the list.
+    ///   - file: The SwiftLintFile object for the current file, used to extract argument values.
+    /// - Returns: A boolean value representing whether or not the given modifier with the specified
+    ///            arguments appears in the view's substructure.
+    func hasModifier(anyOf modifiers: [SwiftUIModifier], in file: SwiftLintFile) -> Bool {
+        // SwiftUI ViewModifiers are treated as `call` expressions, and we make sure we can get the expression's name.
+        guard expressionKind == .call, let name = name else {
+            return false
+        }
+
+        // If any modifier from the list matches, return true.
+        for modifier in modifiers {
+            // Check for the given modifier name
+            guard name.hasSuffix(modifier.name) else {
+                continue
+            }
+
+            // Check arguments.
+            var matchesArgs = true
+            for argument in modifier.arguments {
+                var foundArg = false
+                var argValue: String?
+
+                // Check for single unnamed argument.
+                if argument.name == "" {
+                    foundArg = true
+                    argValue = getSingleUnnamedArgumentValue(in: file)
+                } else if let parsedArgument = enclosedArguments.first(where: { $0.name == argument.name }) {
+                    foundArg = true
+                    argValue = parsedArgument.getArgumentValue(in: file)
+                }
+
+                // If argument is not required and we didn't find it, continue.
+                if !foundArg && !argument.required {
+                    continue
+                }
+
+                // Otherwise, we must have found an argument with a non-nil value to continue.
+                guard foundArg, let argumentValue = argValue else {
+                    matchesArgs = false
+                    break
+                }
+
+                // Argument value can match any of the options given in the argument struct.
+                if argument.matchType == .none || argument.values.contains(where: {
+                    argument.matchType.matches(argumentValue: argumentValue, targetValue: $0)
+                }) {
+                    // Found a match, continue to next argument.
+                    continue
+                } else {
+                    // Did not find a match, exit loop over arguments.
+                    matchesArgs = false
+                    break
+                }
+            }
+
+            // Return true if all arguments matched
+            if matchesArgs {
+                return true
+            }
+        }
+
+        // Recursively check substructure.
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // Image("myImage").resizable().accessibility(hidden: true).frame
+        //   --> Image("myImage").resizable().accessibility
+        //     --> Image("myImage").resizable
+        //       --> Image
+        return substructure.contains(where: { $0.hasModifier(anyOf: modifiers, in: file) })
+    }
+
+    // MARK: Sample use cases of `hasModifier` that are used in multiple rules
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityHidden(true)`
+    /// or `accessibility(hidden: true)` modifier.
+    func hasAccessibilityHiddenModifier(in file: SwiftLintFile) -> Bool {
+        return hasModifier(
+            anyOf: [
+                SwiftUIModifier(
+                    name: "accessibilityHidden",
+                    arguments: [.init(name: "", values: ["true"])]
+                ),
+                SwiftUIModifier(
+                    name: "accessibility",
+                    arguments: [.init(name: "hidden", values: ["true"])]
+                )
+            ],
+            in: file
+        )
+    }
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accessibilityElement()` or
+    /// `accessibilityElement(children: .ignore)` modifier (`.ignore` is the default parameter value).
+    func hasAccessibilityElementChildrenIgnoreModifier(in file: SwiftLintFile) -> Bool {
+        return hasModifier(
+            anyOf: [
+                SwiftUIModifier(
+                    name: "accessibilityElement",
+                    arguments: [.init(name: "children", required: false, values: [".ignore"], matchType: .suffix)]
+                )
+            ],
+            in: file
+        )
+    }
+
+    // MARK: Helpers to extract argument values
+
+    /// Helper to get the value of an argument.
+    func getArgumentValue(in file: SwiftLintFile) -> String? {
+        guard expressionKind == .argument, let bodyByteRange = bodyByteRange else {
+            return nil
+        }
+
+        return file.stringView.substringWithByteRange(bodyByteRange)
+    }
+
+    /// Helper to get the value of a single unnamed argument to a function call.
+    func getSingleUnnamedArgumentValue(in file: SwiftLintFile) -> String? {
+        guard expressionKind == .call, let bodyByteRange = bodyByteRange else {
+            return nil
+        }
+
+        return file.stringView.substringWithByteRange(bodyByteRange)
+    }
+}

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -3,6 +3,7 @@
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [
     AccessibilityLabelForImageRule.self,
+    AccessibilityTraitForButtonRule.self,
     AnonymousArgumentInMultilineClosureRule.self,
     AnyObjectProtocolRule.self,
     ArrayInitRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -130,11 +130,11 @@ private extension SourceKittenDictionary {
             anyOf: [
                 SwiftUIModifier(
                     name: "accessibilityLabel",
-                    arguments: [.init(name: "", values: [], matchType: .none)]
+                    arguments: [.init(name: "", values: [])]
                 ),
                 SwiftUIModifier(
                     name: "accessibility",
-                    arguments: [.init(name: "label", values: [], matchType: .none)]
+                    arguments: [.init(name: "label", values: [])]
                 )
             ],
             in: file

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -1,0 +1,226 @@
+import SourceKittenFramework
+
+/// The accessibility button and link traits are used to tell assistive technologies that an element is tappable. When
+/// an element has one of these traits, VoiceOver will automatically read "button" or "link" after the element's label
+/// to let the user know that they can activate it. When using a UIKit `UIButton` or SwiftUI `Button` or
+/// `Link`, the button trait is added by default, but when you manually add a tap gesture recognizer to an
+/// element, you need to explicitly add the button or link trait. In most cases the button trait should be used, but for
+/// buttons that open a URL in an external browser we use the link trait instead. This rule attempts to catch uses of
+/// the SwiftUI `.onTapGesture` modifier where the `.isButton` or `.isLink` trait is not explicitly applied.
+public struct AccessibilityTraitForButtonRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    public var configuration = SeverityConfiguration(.warning)
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "accessibility_trait_for_button",
+        name: "Accessibility Trait for Button",
+        description: "All views with tap gestures added should include the .isButton " +
+                    "accessibility trait. If a tap opens an external link the .isLink " +
+                    "trait should be used instead.",
+        kind: .lint,
+        minSwiftVersion: .fiveDotOne,
+        nonTriggeringExamples: AccessibilityTraitForButtonRuleExamples.nonTriggeringExamples,
+        triggeringExamples: AccessibilityTraitForButtonRuleExamples.triggeringExamples
+    )
+
+    // MARK: AST Rule
+
+    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        // Only proceed to check View structs.
+        guard kind == .struct,
+            dictionary.inheritedTypes.contains("View"),
+            dictionary.substructure.isNotEmpty else {
+                return []
+        }
+
+        return findButtonTraitViolations(file: file, substructure: dictionary.substructure)
+    }
+
+    /// Recursively check a file for image violations, and return all such violations.
+    private func findButtonTraitViolations(
+        file: SwiftLintFile,
+        substructure: [SourceKittenDictionary]) -> [StyleViolation] {
+        var violations = [StyleViolation]()
+        for dictionary in substructure {
+            guard let offset: ByteCount = dictionary.offset else {
+                continue
+            }
+
+            // If it has a tap gesture and does not have a button or link trait, it's a violation.
+            // Also allowing ones that are hidden from accessibility, though that's not recommended.
+            if dictionary.hasOnSingleTapModifier(in: file) {
+                if dictionary.hasAccessibilityTrait(".isButton", in: file) ||
+                    dictionary.hasAccessibilityTrait(".isLink", in: file) ||
+                    dictionary.hasAccessibilityHiddenModifier(in: file) {
+                    continue
+                }
+
+                violations.append(
+                    StyleViolation(ruleDescription: Self.description,
+                                   severity: configuration.severity,
+                                   location: Location(file: file, byteOffset: offset))
+                )
+            }
+
+            // If dictionary did not represent a View with a tap gesture, recursively check substructure,
+            // unless it's a container that hides its children from accessibility.
+            else if dictionary.substructure.isNotEmpty {
+                if dictionary.hasAccessibilityHiddenModifier(in: file) ||
+                    dictionary.hasAccessibilityElementChildrenIgnoreModifier(in: file) {
+                    continue
+                }
+
+                violations.append(contentsOf:
+                    findButtonTraitViolations(file: file, substructure: dictionary.substructure)
+                )
+            }
+        }
+
+        return violations
+    }
+}
+
+// MARK: SourceKittenDictionary extensions
+
+private extension SourceKittenDictionary {
+    /// Whether or not the dictionary represents a SwiftUI View with a tap gesture
+    /// modifier where the `count` argument is 1.
+    func hasOnSingleTapModifier(in file: SwiftLintFile) -> Bool {
+        guard expressionKind == .call, let name = name else {
+            return false
+        }
+
+        // Check for onTapGesture modifier.
+        if name.hasSuffix("onTapGesture") {
+            // If there's a count argument, the value must be 1 for these purposes.
+            if let countArg = enclosedArguments.first(where: { $0.name == "count" }) {
+                if countArg.getArgumentValue(in: file) == "1" {
+                    return true
+                }
+            } else {
+                // If there is no count argument specified, the default value is 1.
+                return true
+            }
+        }
+
+        // Check for gesture, simultaneousGesture, or highPriorityGesture modifiers with TapGesture
+        if name.hasSuffix("gesture") ||
+            name.hasSuffix("simultaneousGesture") ||
+            name.hasSuffix("highPriorityGesture") {
+            // Single unnamed argument will start with the gesture literal.
+            // We only care about TapGestures that have count 1 (1 is default) if not specified).
+            if let gestureArg = getSingleUnnamedArgumentValue(in: file),
+               gestureArg.hasPrefix("TapGesture()") || gestureArg.hasPrefix("TapGesture(count: 1)") {
+                return true
+            }
+        }
+
+        // Recursively check substructure.
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // Image("myImage").onTapGesture { }.accessibilityAddTraits
+        //     '--> Image("myImage").onTapGesture
+        return substructure.contains(where: { $0.hasOnSingleTapModifier(in: file) })
+    }
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accessibilityAddTraits()` or
+    /// `accessibility(addTraits:)` modifier with the specified trait (specify trait as a String).
+    func hasAccessibilityTrait(_ trait: String, in file: SwiftLintFile) -> Bool {
+        guard expressionKind == .call, let name = name else {
+            return false
+        }
+
+        // Check for iOS 14+ version of modifier
+        if name.hasSuffix("accessibilityAddTraits") &&
+            getSingleUnnamedArgumentValue(in: file)?.contains(trait) == true {
+            return true
+        }
+
+        // Check for iOS 13 version of modifier
+        if name.hasSuffix("accessibility"),
+           let addTraitsArg = enclosedArguments.first(where: { $0.name == "addTraits" }),
+           addTraitsArg.getArgumentValue(in: file)?.contains(trait) == true {
+            return true
+        }
+
+        // Recursively check substructure.
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // Image("myImage").resizable().accessibility(addTraits: .isButton).frame
+        //     '--> Image("myImage").resizable().accessibility
+        return substructure.contains(where: { $0.hasAccessibilityTrait(trait, in: file) })
+    }
+
+    // MARK: Below four functions are also defined in AccessibilityLabelForImageRule and could be extracted
+    // to some common file for extensions to help with parsing SwiftUI AST
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityHidden(true)`
+    /// or `accessibility(hidden: true)` modifier.
+    func hasAccessibilityHiddenModifier(in file: SwiftLintFile) -> Bool {
+        guard expressionKind == .call, let name = name else {
+            return false
+        }
+
+        // Check for iOS 14+ version of modifier
+        if name.hasSuffix("accessibilityHidden") && getSingleUnnamedArgumentValue(in: file) == "true" {
+            return true
+        }
+
+        // Check for iOS 13 version of modifier
+        if name.hasSuffix("accessibility"),
+            let hiddenArg = enclosedArguments.first(where: { $0.name == "hidden" }),
+            hiddenArg.getArgumentValue(in: file) == "true" {
+            return true
+        }
+
+        // Recursively check substructure.
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // Image("myImage").resizable().accessibility(hidden: true).frame
+        //     '--> Image("myImage").resizable().accessibility
+        return substructure.contains(where: { $0.hasAccessibilityHiddenModifier(in: file) })
+    }
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accessibilityElement()` or
+    /// `accessibilityElement(children: .ignore)` modifier (`.ignore` is the default parameter value).
+    func hasAccessibilityElementChildrenIgnoreModifier(in file: SwiftLintFile) -> Bool {
+        guard expressionKind == .call, let name = name else {
+            return false
+        }
+
+        // Check for modifier.
+        if name.hasSuffix("accessibilityElement") {
+            if enclosedArguments.isEmpty {
+                return true
+            }
+
+            if let childrenArg = enclosedArguments.first(where: { $0.name == "children" }),
+                childrenArg.getArgumentValue(in: file) == ".ignore" {
+                return true
+            }
+        }
+
+        // Recursively check substructure.
+        // SwiftUI literal Views with modifiers will have a SourceKittenDictionary structure like:
+        // VStack { ... }.accessibilityElement().padding
+        //     '--> VStack { ... }.accessibilityElement
+        return substructure.contains(where: { $0.hasAccessibilityElementChildrenIgnoreModifier(in: file) })
+    }
+
+    /// Helper to get the value of an argument.
+    func getArgumentValue(in file: SwiftLintFile) -> String? {
+        guard expressionKind == .argument, let bodyByteRange = bodyByteRange else {
+            return nil
+        }
+
+        return file.stringView.substringWithByteRange(bodyByteRange)
+    }
+
+    /// Helper to get the value of a single unnamed argument to a function call.
+    func getSingleUnnamedArgumentValue(in file: SwiftLintFile) -> String? {
+        guard expressionKind == .call, let bodyByteRange = bodyByteRange else {
+            return nil
+        }
+
+        return file.stringView.substringWithByteRange(bodyByteRange)
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -41,7 +41,8 @@ public struct AccessibilityTraitForButtonRule: ASTRule, ConfigurationProviderRul
     /// Recursively check a file for image violations, and return all such violations.
     private func findButtonTraitViolations(
         file: SwiftLintFile,
-        substructure: [SourceKittenDictionary]) -> [StyleViolation] {
+        substructure: [SourceKittenDictionary]
+    ) -> [StyleViolation] {
         var violations = [StyleViolation]()
         for dictionary in substructure {
             guard let offset: ByteCount = dictionary.offset else {
@@ -72,8 +73,8 @@ public struct AccessibilityTraitForButtonRule: ASTRule, ConfigurationProviderRul
                     continue
                 }
 
-                violations.append(contentsOf:
-                    findButtonTraitViolations(file: file, substructure: dictionary.substructure)
+                violations.append(
+                    contentsOf: findButtonTraitViolations(file: file, substructure: dictionary.substructure)
                 )
             }
         }

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityTraitForButtonRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityTraitForButtonRuleExamples.swift
@@ -1,0 +1,271 @@
+// swiftlint:disable type_body_length
+internal struct AccessibilityTraitForButtonRuleExamples {
+    static let nonTriggeringExamples = [
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Button {
+                    print("tapped")
+                } label: {
+                    Text("Learn more")
+                }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Link("Open link", destination: myUrl)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .onTapGesture {
+                        print("tapped - open URL")
+                    }
+                    .accessibility(addTraits: .isLink)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .accessibilityAddTraits(.isButton)
+                    .onTapGesture {
+                        print("tapped")
+                    }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .accessibility(addTraits: [.isButton, .isHeader])
+                    .onTapGesture {
+                        print("tapped")
+                    }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .onTapGesture {
+                        print("tapped - open URL")
+                    }
+                    .accessibilityAddTraits([.isHeader, .isLink])
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .onTapGesture(count: 1) {
+                        print("tapped")
+                    }
+                    .accessibility(addTraits: .isButton)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .onTapGesture(count: 1, perform: {
+                        print("tapped")
+                    })
+                    .accessibility(addTraits: .isButton)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    // This rule does not include tap gestures with multiple taps for now.
+                    // Custom gestures like this are also not very accessible, but require
+                    // alternative ways to accomplish the same task with assistive tech.
+                    .onTapGesture(count: 2) {
+                        print("double-tapped")
+                    }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Label("Learn more", systemImage: "info.circle")
+                    .onTapGesture(count: 1) {
+                        print("tapped")
+                    }
+                    .accessibility(addTraits: .isButton)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                HStack {
+                    Image(systemName: "info.circle")
+                    Text("Learn more")
+                }
+                .onTapGesture {
+                    print("tapped")
+                }
+                // This modifier is not strictly required — each subview will inherit the button trait.
+                // That said, grouping a tappable stack into a single element is a good way to reduce
+                // the number of swipes required for a VoiceOver user to navigate the page.
+                .accessibilityElement(children: .combine)
+                .accessibility(addTraits: .isButton)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .gesture(TapGesture().onEnded {
+                        print("tapped")
+                    })
+                    .accessibilityAddTraits(.isButton)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .simultaneousGesture(TapGesture(count: 1).onEnded {
+                        print("tapped - open URL")
+                    })
+                    .accessibilityAddTraits(.isLink)
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .highPriorityGesture(TapGesture().onEnded {
+                        print("tapped")
+                    })
+                    .accessibility(addTraits: [.isButton])
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .gesture(TapGesture(count: 2).onEnded {
+                        print("tapped")
+                    })
+            }
+        }
+        """)
+    ]
+
+    static let triggeringExamples = [
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Text("Learn more")
+                    .onTapGesture {
+                        print("tapped")
+                    }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Text("Learn more")
+                    .accessibility(addTraits: .isHeader)
+                    .onTapGesture {
+                        print("tapped")
+                    }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Text("Learn more")
+                    .onTapGesture(count: 1) {
+                        print("tapped")
+                    }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Text("Learn more")
+                    .onTapGesture(count: 1, perform: {
+                        print("tapped")
+                    })
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Label("Learn more", systemImage: "info.circle")
+                    .onTapGesture(count: 1) {
+                        print("tapped")
+                    }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓HStack {
+                    Image(systemName: "info.circle")
+                    Text("Learn more")
+                }
+                .onTapGesture {
+                    print("tapped")
+                }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Text("Learn more")
+                    .gesture(TapGesture().onEnded {
+                        print("tapped")
+                    })
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Text("Learn more")
+                    .simultaneousGesture(TapGesture(count: 1).onEnded {
+                        print("tapped")
+                    })
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Text("Learn more")
+                    .highPriorityGesture(TapGesture().onEnded {
+                        print("tapped")
+                    })
+            }
+        }
+        """)
+    ]
+}

--- a/Tests/SwiftLintFrameworkTests/GeneratedTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GeneratedTests.swift
@@ -11,6 +11,12 @@ class AccessibilityLabelForImageRuleGeneratedTests: XCTestCase {
     }
 }
 
+class AccessibilityTraitForButtonRuleGeneratedTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(AccessibilityTraitForButtonRule.description)
+    }
+}
+
 class AnonymousArgumentInMultilineClosureRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(AnonymousArgumentInMultilineClosureRule.description)


### PR DESCRIPTION
Similar to the [`accessibility_label_for_image`](https://realm.github.io/SwiftLint/accessibility_label_for_image.html) rule, this rule catches another common mistake developers make in SwiftUI that makes their apps less accessible.

The accessibility button and link traits are used to tell assistive technologies that an element is tappable. When an element has one of these traits, VoiceOver will automatically read "button" or "link" after the element's label to let the user know that they can activate it. When using a UIKit `UIButton` or SwiftUI `Button` or `Link`, the button trait is added by default, but when you manually add a tap gesture recognizer to an element, you need to explicitly add the button or link trait. In most cases the button trait should be used, but for buttons that open a URL in an external browser we use the link trait instead. This rule attempts to catch uses of the SwiftUI `.onTapGesture` modifier where the `.isButton` or `.isLink` trait is not explicitly applied.

Per @rwapp, Android will automatically add the button trait when a tap gesture is applied, but until iOS catches up with that I hope for this rule to help remind more people to add the proper accessibility traits!