### PR TITLE
Fix violation message in untyped_error_in_catch rule

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -106,8 +106,7 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, Aut
         return violationRanges(in: file).map {
             return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
-                                  location: Location(file: file, characterOffset: $0.location),
-                                  reason: configuration.consoleDescription)
+                                  location: Location(file: file, characterOffset: $0.location))
         }
     }
 


### PR DESCRIPTION
It was just "warning". Now it is the description of the rule (default).