### PR TITLE
Switch to SwiftPM conditional dependencies API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "19b3c3ceed117c5cc883517c4e658548315ba70b",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "sourcekitten",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/SourceKitten.git",

--- a/Package.swift
+++ b/Package.swift
@@ -1,26 +1,6 @@
 // swift-tools-version:5.7
 import PackageDescription
 
-#if os(macOS)
-private let addCryptoSwift = false
-private let binaryPlugin = true
-#else
-private let addCryptoSwift = true
-private let binaryPlugin = false
-#endif
-
-let frameworkDependencies: [Target.Dependency] = [
-    .product(name: "IDEUtils", package: "swift-syntax"),
-    .product(name: "SourceKittenFramework", package: "SourceKitten"),
-    .product(name: "SwiftSyntax", package: "swift-syntax"),
-    .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-    .product(name: "SwiftParser", package: "swift-syntax"),
-    .product(name: "SwiftOperators", package: "swift-syntax"),
-    "SwiftyTextTable",
-    "Yams",
-]
-+ (addCryptoSwift ? ["CryptoSwift"] : [])
-
 let package = Package(
     name: "SwiftLint",
     platforms: [.macOS(.v12)],
@@ -35,14 +15,16 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.34.1")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.5"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
-        .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit.git", from: "0.2.0")
-    ] + (addCryptoSwift ? [.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.6.0"))] : []),
+        .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit.git", from: "0.2.0"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.6.0"))
+    ],
     targets: [
         .plugin(
             name: "SwiftLintPlugin",
             capability: .buildTool(),
             dependencies: [
-                .target(name: binaryPlugin ? "SwiftLintBinary" : "swiftlint")
+                .target(name: "SwiftLintBinary", condition: .when(platforms: [.macOS])),
+                .target(name: "swiftlint", condition: .when(platforms: [.linux]))
             ]
         ),
         .executableTarget(
@@ -62,7 +44,17 @@ let package = Package(
         ),
         .target(
             name: "SwiftLintFramework",
-            dependencies: frameworkDependencies
+            dependencies: [
+                .product(name: "IDEUtils", package: "swift-syntax"),
+                .product(name: "SourceKittenFramework", package: "SourceKitten"),
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "SwiftOperators", package: "swift-syntax"),
+                "SwiftyTextTable",
+                "Yams",
+                .product(name: "CryptoSwift", package: "CryptoSwift", condition: .when(platforms: [.linux]))
+            ]
         ),
         .target(
             name: "SwiftLintTestHelpers",


### PR DESCRIPTION
This API allows us to mostly remove `#if` conditionals which enables
cross compilation from macOS -> Linux. It also removes the thrashing of
Package.resolved if you compile in a docker image.