### PR TITLE
Support arrays for `included` & `excluded` in custom rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   [#3668](https://github.com/realm/SwiftLint/issues/3668)
   [#2728](https://github.com/realm/SwiftLint/issues/2728)
 
+* Support arrays for the `included` and `excluded` options when defining
+  a custom rule.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+
 #### Bug Fixes
 
 * Ignore array types in `syntactic_sugar` rule if their associated `Index` is

--- a/README.md
+++ b/README.md
@@ -445,8 +445,10 @@ following syntax:
 ```yaml
 custom_rules:
   pirates_beat_ninjas: # rule identifier
-    included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    included: 
+      - ".*\\.swift" # regex that defines paths to include during linting. optional.
+    excluded: 
+      - ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Pirates Beat Ninjas" # rule name. optional.
     regex: "([nN]inja)" # matching pattern
     capture_group: 0 # number of regex capture group to highlight the rule violation at. optional.

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -95,6 +95,21 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
         hasher.combine(identifier)
     }
 
+    func shouldValidate(filePath: String) -> Bool {
+        let pathRange = filePath.fullNSRange
+        let isIncluded = included.isEmpty || included.contains { regex in
+            regex.firstMatch(in: filePath, range: pathRange) != nil
+        }
+
+        guard isIncluded else {
+            return false
+        }
+
+        return excluded.allSatisfy { regex in
+            regex.firstMatch(in: filePath, range: pathRange) == nil
+        }
+    }
+
     private func excludedMatchKinds(from configurationDict: [String: Any]) throws -> Set<SyntaxKind> {
         let matchKinds = [String].array(of: configurationDict["match_kinds"])
         let excludedMatchKinds = [String].array(of: configurationDict["excluded_match_kinds"])

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -6,8 +6,8 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
     public var name: String?
     public var message = "Regex matched."
     public var regex: NSRegularExpression!
-    public var included: NSRegularExpression?
-    public var excluded: NSRegularExpression?
+    public var included: [NSRegularExpression] = []
+    public var excluded: [NSRegularExpression] = []
     public var excludedMatchKinds = Set<SyntaxKind>()
     public var severityConfiguration = SeverityConfiguration(.warning)
     public var captureGroup: Int = 0
@@ -26,8 +26,8 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
             name ?? "",
             message,
             regex.pattern,
-            included?.pattern ?? "",
-            excluded?.pattern ?? "",
+            included.map(\.pattern).joined(separator: ","),
+            excluded.map(\.pattern).joined(separator: ","),
             SyntaxKind.allKinds.subtracting(excludedMatchKinds)
                 .map({ $0.rawValue }).sorted(by: <).joined(separator: ","),
             severityConfiguration.consoleDescription
@@ -57,11 +57,19 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
         regex = try .cached(pattern: regexString)
 
         if let includedString = configurationDict["included"] as? String {
-            included = try .cached(pattern: includedString)
+            included = [try .cached(pattern: includedString)]
+        } else if let includedArray = configurationDict["included"] as? [String] {
+            included = try includedArray.map { pattern in
+                try .cached(pattern: pattern)
+            }
         }
 
         if let excludedString = configurationDict["excluded"] as? String {
-            excluded = try .cached(pattern: excludedString)
+            excluded = [try .cached(pattern: excludedString)]
+        } else if let excludedArray = configurationDict["excluded"] as? [String] {
+            excluded = try excludedArray.map { pattern in
+                try .cached(pattern: pattern)
+            }
         }
 
         if let name = configurationDict["name"] as? String {

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -69,19 +69,16 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
         if let path = file.path {
             let pathRange = path.fullNSRange
             configurations = configurations.filter { config in
-                let included: Bool
-                if let includedRegex = config.included {
-                    included = includedRegex.matches(in: path, options: [], range: pathRange).isNotEmpty
-                } else {
-                    included = true
+                let included = config.included.isEmpty || config.included.contains { regex in
+                    regex.firstMatch(in: path, range: pathRange) != nil
                 }
                 guard included else {
                     return false
                 }
-                guard let excludedRegex = config.excluded else {
-                    return true
+
+                return config.excluded.allSatisfy { regex in
+                    regex.firstMatch(in: path, range: pathRange) == nil
                 }
-                return excludedRegex.matches(in: path, options: [], range: pathRange).isEmpty
             }
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CustomRules.swift
@@ -67,18 +67,8 @@ public struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProv
         }
 
         if let path = file.path {
-            let pathRange = path.fullNSRange
             configurations = configurations.filter { config in
-                let included = config.included.isEmpty || config.included.contains { regex in
-                    regex.firstMatch(in: path, range: pathRange) != nil
-                }
-                guard included else {
-                    return false
-                }
-
-                return config.excluded.allSatisfy { regex in
-                    regex.firstMatch(in: path, range: pathRange) == nil
-                }
+                config.shouldValidate(filePath: path)
             }
         }
 

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -155,6 +155,17 @@ class CustomRulesTests: XCTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
+    func testCustomRulesExcludedArrayExcludesFile() {
+        var (regexConfig, customRules) = getCustomRules(["excluded": ["\\.pdf$", "\\.txt$"]])
+
+        var customRuleConfiguration = CustomRulesConfiguration()
+        customRuleConfiguration.customRuleConfigurations = [regexConfig]
+        customRules.configuration = customRuleConfiguration
+
+        let violations = customRules.validate(file: getTestTextFile())
+        XCTAssertEqual(violations.count, 0)
+    }
+
     func testCustomRulesCaptureGroup() {
         let (_, customRules) = getCustomRules(["regex": #"\ba\s+(\w+)"#,
                                                "capture_group": 1])

--- a/Tests/SwiftLintFrameworkTests/RegexConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RegexConfigurationTests.swift
@@ -1,0 +1,84 @@
+@testable import SwiftLintFramework
+import XCTest
+
+class RegexConfigurationTests: XCTestCase {
+    func testShouldValidateIsTrueByDefault() {
+        let config = RegexConfiguration(identifier: "example")
+        XCTAssertTrue(config.shouldValidate(filePath: "App/file.swift"))
+    }
+
+    func testShouldValidateWithSingleExluded() throws {
+        var config = RegexConfiguration(identifier: "example")
+        try config.apply(configuration: [
+            "regex": "try!",
+            "excluded": "Tests/.*\\.swift"
+        ])
+
+        XCTAssertFalse(config.shouldValidate(filePath: "Tests/file.swift"))
+        XCTAssertTrue(config.shouldValidate(filePath: "App/file.swift"))
+    }
+
+    func testShouldValidateWithArrayExluded() throws {
+        var config = RegexConfiguration(identifier: "example")
+        try config.apply(configuration: [
+            "regex": "try!",
+            "excluded": [
+                "^Tests/.*\\.swift",
+                "^MyFramework/Tests/.*\\.swift"
+            ]
+        ])
+
+        XCTAssertFalse(config.shouldValidate(filePath: "Tests/file.swift"))
+        XCTAssertFalse(config.shouldValidate(filePath: "MyFramework/Tests/file.swift"))
+        XCTAssertTrue(config.shouldValidate(filePath: "App/file.swift"))
+    }
+
+    func testShouldValidateWithSingleIncluded() throws {
+        var config = RegexConfiguration(identifier: "example")
+        try config.apply(configuration: [
+            "regex": "try!",
+            "included": "App/.*\\.swift"
+        ])
+
+        XCTAssertFalse(config.shouldValidate(filePath: "Tests/file.swift"))
+        XCTAssertFalse(config.shouldValidate(filePath: "MyFramework/Tests/file.swift"))
+        XCTAssertTrue(config.shouldValidate(filePath: "App/file.swift"))
+    }
+
+    func testShouldValidateWithArrayIncluded() throws {
+        var config = RegexConfiguration(identifier: "example")
+        try config.apply(configuration: [
+            "regex": "try!",
+            "included": [
+                "App/.*\\.swift",
+                "MyFramework/.*\\.swift"
+            ]
+        ])
+
+        XCTAssertFalse(config.shouldValidate(filePath: "Tests/file.swift"))
+        XCTAssertTrue(config.shouldValidate(filePath: "App/file.swift"))
+        XCTAssertTrue(config.shouldValidate(filePath: "MyFramework/file.swift"))
+    }
+
+    func testShouldValidateWithIncludedAndExcluded() throws {
+        var config = RegexConfiguration(identifier: "example")
+        try config.apply(configuration: [
+            "regex": "try!",
+            "included": [
+                "App/.*\\.swift",
+                "MyFramework/.*\\.swift"
+            ],
+            "excluded": [
+                "Tests/.*\\.swift",
+                "App/Fixtures/.*\\.swift"
+            ]
+        ])
+
+        XCTAssertTrue(config.shouldValidate(filePath: "App/file.swift"))
+        XCTAssertTrue(config.shouldValidate(filePath: "MyFramework/file.swift"))
+
+        XCTAssertFalse(config.shouldValidate(filePath: "App/Fixtures/file.swift"))
+        XCTAssertFalse(config.shouldValidate(filePath: "Tests/file.swift"))
+        XCTAssertFalse(config.shouldValidate(filePath: "MyFramework/Tests/file.swift"))
+    }
+}


### PR DESCRIPTION
In certain cases, it's easier to specify multiple patterns than combining everything in one.