### PR TITLE
Make `duplicate_imports` rule correctable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * None.
 
 #### Enhancements
+  
+* Make `duplicate_imports` rule correctable. Fix `duplicate_imports` rule 
+  reporting redundant violations when more than one duplicate is present.  
+  [Timofey Solonin](https://github.com/abdulowork)
 
 * Support for building SwiftLint with bazel.  
   [JP Simard](https://github.com/jpsim)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -205,7 +205,7 @@ private extension Line {
                 subpath: importedSubpathParts[0..<importedSubpathParts.count],
                 type: .complete
             )
-        ] + stride(from: 1, to: importedSubpathParts.count, by: 1).map {
+        ] + (1..<importedSubpathParts.count).map {
             ImportSlice(
                 subpath: importedSubpathParts[0..<importedSubpathParts.count - $0],
                 type: .parent

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
@@ -39,7 +39,7 @@ internal struct DuplicateImportsRuleExamples {
     static let triggeringExamples: [Example] = Array(corrections.keys)
 
     static let corrections: [Example: Example] = {
-        var corrections: [Example: Example] = [
+        var corrections = [
             Example("""
             import Foundation
             import Dispatch
@@ -50,8 +50,7 @@ internal struct DuplicateImportsRuleExamples {
                 import Foundation
                 import Dispatch
 
-                """
-                ),
+                """),
             Example("""
             import Foundation
             ↓import Foundation.NSString
@@ -193,7 +192,7 @@ internal struct DuplicateImportsRuleExamples {
                 import A
                 ↓import \(importKind) A.B.Foo
 
-                """)
+                """, excludeFromDocumentation: true)
         }.forEach {
             corrections[$0] = Example(
                 """
@@ -207,7 +206,7 @@ internal struct DuplicateImportsRuleExamples {
                 import A.B
                 ↓import \(importKind) A.B.Foo
 
-                """)
+                """, excludeFromDocumentation: true)
         }.forEach {
             corrections[$0] = Example(
                 """

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
@@ -1,6 +1,6 @@
 // swiftlint:disable type_body_length
 internal struct DuplicateImportsRuleExamples {
-    static let nonTriggeringExamples: [Example] = [
+    static let nonTriggeringExamples = [
         Example("""
         import A
         import B
@@ -36,7 +36,7 @@ internal struct DuplicateImportsRuleExamples {
         """)
     ]
 
-    static let triggeringExamples: [Example] = Array(corrections.keys)
+    static let triggeringExamples = Array(corrections.keys)
 
     static let corrections: [Example: Example] = {
         var corrections = [

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
@@ -1,9 +1,23 @@
+// swiftlint:disable type_body_length
 internal struct DuplicateImportsRuleExamples {
     static let nonTriggeringExamples: [Example] = [
-        Example("import A\nimport B\nimport C"),
-        Example("import A.B\nimport A.C"),
-        Example("@_implementationOnly import A\n@_implementationOnly import B"),
-        Example("@testable import A\n@testable import B"),
+        Example("""
+        import A
+        import B
+        import C
+        """),
+        Example("""
+        import A.B
+        import A.C
+        """),
+        Example("""
+        @_implementationOnly import A
+        @_implementationOnly import B
+        """),
+        Example("""
+        @testable import A
+        @testable import B
+        """),
         Example("""
         #if DEBUG
             @testable import KsApi
@@ -11,7 +25,10 @@ internal struct DuplicateImportsRuleExamples {
             import KsApi
         #endif
         """),
-        Example("import A // module\nimport B // module"),
+        Example("""
+        import A // module
+        import B // module
+        """),
         Example("""
         #if TEST
         func test() {
@@ -19,15 +36,70 @@ internal struct DuplicateImportsRuleExamples {
         """)
     ]
 
-    static let triggeringExamples: [Example] = {
-        var list: [Example] = [
-            Example("import Foundation\nimport Dispatch\n↓import Foundation"),
-            Example("import Foundation\n↓import Foundation.NSString"),
-            Example("@_implementationOnly import A\n@_implementationOnly import A"),
-            Example("@testable import A\n@testable import A"),
-            Example("↓import Foundation.NSString\nimport Foundation"),
-            Example("↓import A.B.C\nimport A.B"),
-            Example("import A.B\n↓import A.B.C"),
+    static let triggeringExamples: [Example] = Array(corrections.keys)
+
+    static let corrections: [Example: Example] = {
+        var corrections: [Example: Example] = [
+            Example("""
+            import Foundation
+            import Dispatch
+            ↓import Foundation
+
+            """): Example(
+                """
+                import Foundation
+                import Dispatch
+
+                """
+                ),
+            Example("""
+            import Foundation
+            ↓import Foundation.NSString
+
+            """): Example("""
+                import Foundation
+
+                """),
+            Example("""
+            ↓import Foundation.NSString
+            import Foundation
+
+            """): Example("""
+                import Foundation
+
+                """),
+            Example("""
+            @_implementationOnly import A
+            ↓@_implementationOnly import A
+
+            """): Example("""
+                @_implementationOnly import A
+
+                """),
+            Example("""
+            @testable import A
+            ↓@testable import A
+
+            """): Example("""
+                @testable import A
+
+                """),
+            Example("""
+            ↓import A.B.C
+            import A.B
+
+            """): Example("""
+                import A.B
+
+                """),
+            Example("""
+            import A.B
+            ↓import A.B.C
+
+            """): Example("""
+                import A.B
+
+                """),
             Example("""
             import A
             #if DEBUG
@@ -36,30 +108,114 @@ internal struct DuplicateImportsRuleExamples {
                 import KsApi
             #endif
             ↓import A
-            """)
+
+            """): Example("""
+                import A
+                #if DEBUG
+                    @testable import KsApi
+                #else
+                    import KsApi
+                #endif
+
+                """),
+            Example("""
+            import Foundation
+            ↓import Foundation
+            ↓import Foundation
+
+            """): Example("""
+                import Foundation
+
+                """),
+            Example("""
+            ↓import A.B.C
+            ↓import A.B
+            import A
+
+            """, excludeFromDocumentation: true): Example("""
+                import A
+
+                """),
+            Example("""
+            import A.B.C
+            ↓import A.B.C.D
+            ↓import A.B.C.E
+
+            """, excludeFromDocumentation: true): Example("""
+                import A.B.C
+
+                """),
+            Example("""
+            ↓import A.B.C
+            import A
+            ↓import A.B
+
+            """, excludeFromDocumentation: true): Example("""
+                import A
+
+                """),
+            Example("""
+            ↓import A.B
+            import A
+            ↓import A.B.C
+
+            """, excludeFromDocumentation: true): Example("""
+                import A
+
+                """),
+            Example("""
+            import A
+            ↓import A.B.C
+            ↓import A.B
+
+            """, excludeFromDocumentation: true): Example("""
+                import A
+
+                """)
         ]
 
-        list += DuplicateImportsRule.importKinds.map { importKind in
+        DuplicateImportsRule.importKinds.map { importKind in
             Example("""
                 import A
                 ↓import \(importKind) A.Foo
+
+                """)
+        }.forEach {
+            corrections[$0] = Example(
+                """
+                import A
+
                 """)
         }
 
-        list += DuplicateImportsRule.importKinds.map { importKind in
+        DuplicateImportsRule.importKinds.map { importKind in
             Example("""
                 import A
                 ↓import \(importKind) A.B.Foo
+
+                """)
+        }.forEach {
+            corrections[$0] = Example(
+                """
+                import A
+
                 """)
         }
 
-        list += DuplicateImportsRule.importKinds.map { importKind in
+        DuplicateImportsRule.importKinds.map { importKind in
             Example("""
                 import A.B
                 ↓import \(importKind) A.B.Foo
+
+                """)
+        }.forEach {
+            corrections[$0] = Example(
+                """
+                import A.B
+
                 """)
         }
 
-        return list
+        return corrections
     }()
 }


### PR DESCRIPTION
This PR:

* Makes `duplicate_imports` rule correctable.
* Fixes an issue where more than one duplicate resulted in redundant violations being reported. For example in this file: 
```swift
import Foundation
import Foundation
import Foundation
```
3 violations were reported with a redundant one in the end:
```
file.swift:2:1: warning: Duplicate Imports Violation: Imports should be unique. (duplicate_imports)
file.swift:3:1: warning: Duplicate Imports Violation: Imports should be unique. (duplicate_imports)
file.swift:3:1: warning: Duplicate Imports Violation: Imports should be unique. (duplicate_imports)
```

* Makes the rule faster for large number of imports. I benchmarked it on a file with 1000 `import Foundation` and it now completes in 160 ms. compared to 9 s. prior to the change.