### PR TITLE
Add a declarative DSL to write rules that use SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 #### Experimental
 
-* None.
+* Adds a new rule protocol `SyntaxVisitorRule`. This provides a common
+  interface for all rules that want to use SwiftSyntax to traverse the
+  AST of the source file. This includes a declarative DSL to match specific 
+  syntax nodes. As a first example, a `Class` matcher is introduced to find 
+  all class declarations and filter them by attributes.
 
 #### Enhancements
 

--- a/Source/SwiftLintFramework/Extensions/SwiftSyntax/DeclSyntaxTraits.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftSyntax/DeclSyntaxTraits.swift
@@ -1,0 +1,26 @@
+import SwiftSyntax
+
+/// Provides a common interface for StructDeclSyntax, ClassDeclSyntax, and EnumDeclSyntax
+protocol DeclSyntaxTraits {
+    var inheritanceClause: TypeInheritanceClauseSyntax? { get }
+    var modifiers: ModifierListSyntax? { get }
+    var identifier: TokenSyntax { get }
+}
+
+extension DeclSyntaxTraits {
+    /// Convenience variable to collect all inherited types from a declaration syntax node
+    var inheritance: [String] {
+        inheritanceClause?.inheritedTypeCollection.map { $0.typeName.description.trimmed } ?? []
+    }
+
+    /// Convenience variable for the declaration name
+    var name: String {
+        identifier.text.trimmed
+    }
+}
+
+extension StructDeclSyntax: DeclSyntaxTraits {}
+
+extension ClassDeclSyntax: DeclSyntaxTraits {}
+
+extension EnumDeclSyntax: DeclSyntaxTraits {}

--- a/Source/SwiftLintFramework/Extensions/SwiftSyntax/ModifierListSyntax+Extensions.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftSyntax/ModifierListSyntax+Extensions.swift
@@ -1,0 +1,8 @@
+import SwiftSyntax
+
+extension ModifierListSyntax {
+    /// Convenience variable to collect all modifiers from a declaration syntax node
+    var names: [String] {
+        map { $0.name.text.trimmed }
+    }
+}

--- a/Source/SwiftLintFramework/Extensions/SwiftSyntax/String+Extensions.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftSyntax/String+Extensions.swift
@@ -1,0 +1,6 @@
+extension String {
+    /// Trims all whitespace from a string
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Source/SwiftLintFramework/Helpers/SwiftSyntaxParsingErrors.swift
+++ b/Source/SwiftLintFramework/Helpers/SwiftSyntaxParsingErrors.swift
@@ -1,0 +1,8 @@
+/// Emits an error when a source file cannot be parsed with SwiftSyntax.
+public func warnSwiftSyntaxParserFailure(for ruleName: String, in fileName: String?) {
+    var message: String = "Rule \(ruleName) is disabled because the Swift Syntax tree could not be parsed."
+    if let fileName = fileName {
+        message += "\n SwiftSyntax could not parse file: \(fileName)"
+    }
+    queuedPrintError(message)
+}

--- a/Source/SwiftLintFramework/Models/ObjectType.swift
+++ b/Source/SwiftLintFramework/Models/ObjectType.swift
@@ -1,0 +1,6 @@
+/// ObjectTypes are types that can conform to protocols or inherit from a parent class.
+public enum ObjectType: String, CaseIterable {
+    case `class`
+    case `enum`
+    case `struct`
+}

--- a/Source/SwiftLintFramework/Models/SyntaxMatchers/Class.swift
+++ b/Source/SwiftLintFramework/Models/SyntaxMatchers/Class.swift
@@ -1,0 +1,21 @@
+/// Creates a ViolationSyntaxVisitor class that will visit all class declarations 
+/// and the position of the node from the source file if it has the charactaristics
+/// declared by attributes.
+///
+/// Filter your search by using matcher modifiers. To find all classes that
+/// inherit from UICollectionView, use:
+///
+///     Class().inheritsFrom("[UICollectionView]")
+public struct Class: InheritableSyntaxVisitorBuildable {
+    public let objectType: ObjectType = .class
+
+    public var attributes = DeclVisitor.Attributes()
+    public let childValidator: SyntaxVisitorRuleValidator
+
+    public init(
+        @SyntaxVisitorRuleValidatorBuilder
+        makeChildValidator: () -> (SyntaxVisitorRuleValidator) = { SyntaxVisitorRuleValidator(visitors: []) }
+    ) {
+        self.childValidator = makeChildValidator()
+    }
+}

--- a/Source/SwiftLintFramework/Models/SyntaxMatchers/InheritableSyntaxVisitorBuildable.swift
+++ b/Source/SwiftLintFramework/Models/SyntaxMatchers/InheritableSyntaxVisitorBuildable.swift
@@ -1,0 +1,52 @@
+/// Conform to this protocol if the syntax can inherit or adopt from a protocol i.e. Classes, Structs, Enums
+public protocol InheritableSyntaxVisitorBuildable: SyntaxVisitorBuildable {
+    /// Filters to apply when searching for inheritable syntax nodes.
+    var attributes: DeclVisitor.Attributes { get set }
+    /// The actual type to look for. Tells the visitor to skip traversing other types.
+    var objectType: ObjectType { get }
+    /// If the node violates according to the attributes and the current node has children,
+    /// visit the children node with this validator.
+    var childValidator: SyntaxVisitorRuleValidator { get }
+}
+
+public extension InheritableSyntaxVisitorBuildable {
+    func makeVisitor() -> ViolationSyntaxVisiting {
+        DeclVisitor(
+            objectType: objectType,
+            attributes: attributes,
+            childVisitors: childValidator.visitors
+        )
+    }
+}
+
+// MARK: - Lint Modifiers
+public extension InheritableSyntaxVisitorBuildable {
+    /// Filter by the access control of the type
+    func accessControl(_ accessControl: AccessControlLevel) -> Self {
+        var new = self
+        new.attributes.accessControl = accessControl
+        return new
+    }
+
+    /// Skip any nodes that inherit from the given set
+    func skipIfInheritsFrom(_ skipIfInheritsFrom: Set<String>) -> Self {
+        var new = self
+        new.attributes.skipIfInheritsFrom = skipIfInheritsFrom
+        return new
+    }
+
+    /// Filter by nodes that inherit from this set.
+    /// The list will be treated as an OR statement i.e. the node inherits from any parent from the given set.
+    func inheritsFrom(_ inheritsFrom: Set<String>) -> Self {
+        var new = self
+        new.attributes.inheritsFrom = inheritsFrom
+        return new
+    }
+
+    /// Filter by the suffix of the node's name.
+    func suffix(_ suffix: String) -> Self {
+        var new = self
+        new.attributes.suffix = suffix
+        return new
+    }
+}

--- a/Source/SwiftLintFramework/Models/SyntaxMatchers/SyntaxVisitorRuleValidatorBuilder.swift
+++ b/Source/SwiftLintFramework/Models/SyntaxMatchers/SyntaxVisitorRuleValidatorBuilder.swift
@@ -1,0 +1,26 @@
+/// This result builder enables us to write lint rules that traverse
+/// the source file's AST using SwiftSyntax with a convenient DSL.
+///
+/// The components of the DSL will be objects that conform to SyntaxVisitorBuildable.
+/// The result builder will know how to compose each individual
+/// SyntaxVisitorBuildable object into a SyntaxVisitorRuleValidating object,
+/// which is just a collection of SyntaxVisitors.
+@resultBuilder
+public struct SyntaxVisitorRuleValidatorBuilder {
+    typealias Expression = SyntaxVisitorBuildable
+    typealias Component = SyntaxVisitorRuleValidator
+
+    static func buildBlock(_ component: Component...) -> Component {
+        let visitors = component.flatMap(\.visitors)
+        return SyntaxVisitorRuleValidator(visitors: visitors)
+    }
+
+    static func buildExpression(_ expression: SyntaxVisitorBuildable) -> Component {
+        let visitor = expression.makeVisitor()
+        return SyntaxVisitorRuleValidator(visitors: [visitor])
+    }
+
+    static func buildExpression(_ expression: ViolationSyntaxVisiting) -> Component {
+        return SyntaxVisitorRuleValidator(visitors: [expression])
+    }
+}

--- a/Source/SwiftLintFramework/Protocols/SyntaxVisitorBuildable.swift
+++ b/Source/SwiftLintFramework/Protocols/SyntaxVisitorBuildable.swift
@@ -1,0 +1,8 @@
+/// Builds a ViolationSyntaxVisitor that is responsible for matching a single syntax node.
+///
+/// The syntax matchers that make up the syntax for the SyntaxVisitor DSL will conform to this protocol.
+/// These builders create a mapping to the appropriate ViolationSyntaxVisiting class.
+/// It will also handle creating the parent-child relationships of visitors.
+public protocol SyntaxVisitorBuildable {
+    func makeVisitor() -> ViolationSyntaxVisiting
+}

--- a/Source/SwiftLintFramework/Protocols/SyntaxVisitorRule.swift
+++ b/Source/SwiftLintFramework/Protocols/SyntaxVisitorRule.swift
@@ -1,0 +1,47 @@
+import SourceKittenFramework
+import SwiftSyntax
+
+// MARK: - SyntaxVisitorRule
+/// A rule that uses SwiftSyntax's SyntaxVisitor to
+/// validate the rule by traversing the AST produced by the library.
+public protocol SyntaxVisitorRule: Rule {
+    /// A collection of SyntaxVisitor classes that will traverse the AST
+    /// of a Swift souce file and collect the positions of lint violations.
+    ///
+    /// Annotate this variable with @SyntaxVisitorRuleValidatorBuilder
+    /// in order to build the validator in a declarative way.
+    /// This provides an abstraction over SyntaxVisitors and creating
+    /// them yourselves.
+    var validator: SyntaxVisitorRuleValidator { get }
+}
+
+public extension SyntaxVisitorRule {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
+        guard let tree = file.syntaxTree else {
+            warnSwiftSyntaxParserFailure(for: Self.description.identifier, in: file.path)
+            return []
+        }
+
+        let positions = validator.collectViolations(tree)
+
+        return positions.map { position in
+            StyleViolation(ruleDescription: Self.description,
+                           severity: .error,
+                           location: Location(file: file, byteOffset: ByteCount(position.utf8Offset)))
+        }
+    }
+}
+
+// MARK: - SyntaxVisitorRuleValidator
+/// A collection of SyntaxVisitors to find lint violations
+public struct SyntaxVisitorRuleValidator {
+    var visitors: [ViolationSyntaxVisiting]
+
+    public init(visitors: [ViolationSyntaxVisiting]) {
+        self.visitors = visitors
+    }
+
+    func collectViolations<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> [AbsolutePosition] {
+        visitors.flatMap { $0.findViolations(node) }
+    }
+}

--- a/Source/SwiftLintFramework/Protocols/ViolationSyntaxVisiting.swift
+++ b/Source/SwiftLintFramework/Protocols/ViolationSyntaxVisiting.swift
@@ -1,0 +1,63 @@
+import SourceKittenFramework
+import SwiftSyntax
+
+/// A type that finds and collects the positions of lint violations in a file.
+public protocol ViolationCollecting: AnyObject {
+    var positionsOfViolations: [AbsolutePosition] { get }
+    var childVisitors: [ViolationSyntaxVisiting] { get }
+    func findViolations<SyntaxType: SyntaxProtocol>(_ tree: SyntaxType) -> [AbsolutePosition]
+    func addViolations<SyntaxType: SyntaxProtocol>(_ node: SyntaxType)
+}
+
+/// Convenience typealias for conforming to both ViolationCollecting and inheriting from SwiftSyntax's SyntaxVisitor
+public typealias ViolationSyntaxVisiting = ViolationCollecting & SyntaxVisitor
+
+/// Defines the shared behavior among all visitors that look for lint violations.
+///
+/// Subclass this class if you want to create a lint rule that traverses the Swift AST using SwiftSyntax.
+/// To implement your subclass, you can override any of the visitPost(node:)
+/// functions given by the SyntaxVisitor parent class and check if the node
+/// violates the lint rule. If it does, call addViolations(node:).
+///
+/// If the object does not have any childVisitors, it adds the violations to the file.
+/// Otherwise, it creates a new instance of each child visitor
+/// and recrusively adds the violations found by the child visitors.
+///
+/// To use this class, call findViolations(node:) in order to start walking the AST
+/// starting at the given node.
+open class ViolationSyntaxVisitor: ViolationSyntaxVisiting {
+    /// A collection of ViolationSyntaxVisiting classes that will be used to visit the
+    /// children of the node IF addViolations is called on the node.
+    public var childVisitors: [ViolationSyntaxVisiting] = []
+
+    /// The AbsolutePositions of leaf nodes that called addViolations.
+    ///
+    /// Use this in your rule to create StyleViolations from these positions.
+    public var positionsOfViolations: [AbsolutePosition] = []
+
+    /// Call this function to walk through the AST starting at the given node
+    /// and return all of the lint violations found.
+    ///
+    /// Calling this function will reset positionsOfViolations to an empty array and will
+    /// restart the search for violations starting at the given node.
+    public func findViolations<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> [AbsolutePosition] {
+        positionsOfViolations = []
+        walk(node)
+        return positionsOfViolations
+    }
+
+    /// Add the node's position after any leading trivia to positionsOfViolations.
+    ///
+    /// Subclasses should call this function within visitPost(node:) after determining this node violates a lint rule.
+    public func addViolations<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+        if childVisitors.isNotEmpty {
+            childVisitors.forEach { childVistor in
+                for child in node.children {
+                    positionsOfViolations += childVistor.findViolations(child)
+                }
+            }
+        } else {
+            positionsOfViolations.append(node.positionAfterSkippingLeadingTrivia)
+        }
+    }
+}

--- a/Source/SwiftLintFramework/SyntaxVisitors/DeclVisitor.swift
+++ b/Source/SwiftLintFramework/SyntaxVisitors/DeclVisitor.swift
@@ -1,0 +1,114 @@
+import SwiftSyntax
+
+/// Visits type declaration nodes such as Enum, Class, and Struct
+/// and adds a violation based on the criteria provided by Attributes.
+public class DeclVisitor: ViolationSyntaxVisitor {
+    /// These attributes will determine whether or not a decl node is violating
+    public struct Attributes {
+        /// Nodes with the specified access control will be considered a violation.
+        public var accessControl: AccessControlLevel?
+
+        /// If this is set, nodes that inherit from this set will NOT be considered a violation.
+        /// This attribute takes precedence over other attributes.
+        public var skipIfInheritsFrom: Set<String>?
+
+        /// Nodes that inherit from this set will be considered a violation.
+        public var inheritsFrom: Set<String>?
+
+        /// Nodes with names that end with the given suffix will be considered a violation.
+        public var suffix: String?
+
+        public init(
+            accessControl: AccessControlLevel? = nil,
+            skipIfInheritsFrom: Set<String>? = nil,
+            inheritsFrom: Set<String>? = nil,
+            suffix: String? = nil
+        ) {
+            self.accessControl = accessControl
+            self.skipIfInheritsFrom = skipIfInheritsFrom
+            self.inheritsFrom = inheritsFrom
+            self.suffix = suffix
+        }
+    }
+
+    /// The type to check for. Can be enum, class, or struct.
+    let objectType: ObjectType
+
+    /// The attributes that determine whether a node is violating.
+    let attributes: Attributes
+
+    public init(
+        objectType: ObjectType,
+        attributes: Attributes = Attributes(),
+        childVisitors: [ViolationSyntaxVisiting] = []
+    ) {
+        self.objectType = objectType
+        self.attributes = attributes
+        super.init()
+        self.childVisitors = childVisitors
+    }
+
+    override public func visitPost(_ node: EnumDeclSyntax) {
+        guard objectType == .enum else {
+            return
+        }
+        process(node)
+    }
+
+    override public func visitPost(_ node: ClassDeclSyntax) {
+        guard objectType == .class else {
+            return
+        }
+        process(node)
+    }
+
+    override public func visitPost(_ node: StructDeclSyntax) {
+        guard objectType == .struct else {
+            return
+        }
+        process(node)
+    }
+}
+
+// MARK: - Private
+private extension DeclVisitor {
+    func process<SyntaxType: SyntaxProtocol & DeclSyntaxTraits>(_ node: SyntaxType) {
+        guard nodeIsViolating(node) else {
+            return
+        }
+
+        addViolations(node)
+    }
+
+    func nodeIsViolating(_ node: DeclSyntaxTraits) -> Bool {
+        if let accessControl = attributes.accessControl {
+            guard node.modifiers?.names.contains(accessControl.description) == true else {
+                return false
+            }
+        }
+
+        if let skipIfInheritsFrom = attributes.skipIfInheritsFrom {
+            guard !objectInheritsFromInheritanceTypes(node.inheritance, typesToCheck: skipIfInheritsFrom) else {
+                return false
+            }
+        }
+
+        if let inheritsFrom = attributes.inheritsFrom {
+            guard objectInheritsFromInheritanceTypes(node.inheritance, typesToCheck: inheritsFrom) else {
+                return false
+            }
+        }
+
+        if let suffix = attributes.suffix {
+            guard node.name.hasSuffix(suffix) else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    func objectInheritsFromInheritanceTypes(_ inheritance: [String], typesToCheck: Set<String>) -> Bool {
+        Set(inheritance).intersection(typesToCheck).isNotEmpty
+    }
+}

--- a/Source/SwiftLintFramework/SyntaxVisitors/DeclVisitor.swift
+++ b/Source/SwiftLintFramework/SyntaxVisitors/DeclVisitor.swift
@@ -48,25 +48,31 @@ public class DeclVisitor: ViolationSyntaxVisitor {
         self.childVisitors = childVisitors
     }
 
-    override public func visitPost(_ node: EnumDeclSyntax) {
+    override public func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
         guard objectType == .enum else {
-            return
+            return .visitChildren
         }
         process(node)
+        
+        return .visitChildren
     }
 
-    override public func visitPost(_ node: ClassDeclSyntax) {
+    override public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         guard objectType == .class else {
-            return
+            return .visitChildren
         }
         process(node)
+        
+        return .visitChildren
     }
 
-    override public func visitPost(_ node: StructDeclSyntax) {
+    override public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         guard objectType == .struct else {
-            return
+            return .visitChildren
         }
         process(node)
+        
+        return .visitChildren
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.7.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/ClassMatcherTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ClassMatcherTests.swift
@@ -1,0 +1,60 @@
+@testable import SwiftLintFramework
+import SwiftSyntax
+import SwiftSyntaxParser
+import XCTest
+
+final class ClassMatcherTests: XCTestCase {
+    func testClassFindsAll() {
+        @SyntaxVisitorRuleValidatorBuilder
+        var validator: SyntaxVisitorRuleValidator {
+            Class()
+        }
+
+        XCTAssertEqual(validator.visitors.count, 1)
+
+        guard let visitor = validator.visitors.first else {
+            XCTFail("validator does not have a visitor")
+            return
+        }
+
+        XCTAssertTrue(visitor is DeclVisitor)
+        XCTAssertNoThrow(try {
+            let source = """
+                class A {}
+                struct B {}
+                struct C {}
+            """
+            let parsed = try SyntaxParser.parse(source: source)
+            let positions = validator.collectViolations(parsed)
+            XCTAssertEqual(positions.count, 1)
+        }())
+    }
+
+    func testDuplicateLintModifiersUsesLastOne() {
+        @SyntaxVisitorRuleValidatorBuilder
+        var validator: SyntaxVisitorRuleValidator {
+            Class()
+                .inheritsFrom(["Foo"])
+                .inheritsFrom(["Bar"])
+        }
+
+        XCTAssertEqual(validator.visitors.count, 1)
+
+        guard let visitor = validator.visitors.first else {
+            XCTFail("validator does not have a visitor")
+            return
+        }
+
+        XCTAssertTrue(visitor is DeclVisitor)
+        XCTAssertNoThrow(try {
+            let source = """
+                class A: Foo {}
+                class B: Foo {}
+                class C: Bar {}
+            """
+            let parsed = try SyntaxParser.parse(source: source)
+            let positions = validator.collectViolations(parsed)
+            XCTAssertEqual(positions.count, 1)
+        }())
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/DeclVisitorTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeclVisitorTests.swift
@@ -123,7 +123,7 @@ final class DeclVisitorTests: XCTestCase {
         }
         let visitor = DeclVisitor(objectType: .struct)
         let violations = visitor.findViolations(node)
-        XCTAssertTrue(violations.count == 4)
+        XCTAssertEqual(violations.count, 4)
     }
 
     func testVisitAllPublicClassesThatInheritFromClass() {
@@ -141,7 +141,7 @@ final class DeclVisitorTests: XCTestCase {
         let attributes = DeclVisitor.Attributes(accessControl: .public, inheritsFrom: ["Parent"])
         let visitor = DeclVisitor(objectType: .class, attributes: attributes)
         let violations = visitor.findViolations(node)
-        XCTAssertTrue(violations.count == 1)
+        XCTAssertEqual(violations.count, 1)
     }
 
     func testVisitChildVisitors() {
@@ -170,7 +170,7 @@ final class DeclVisitorTests: XCTestCase {
         let attributes = DeclVisitor.Attributes(accessControl: .public, inheritsFrom: ["Parent"])
         let visitor = DeclVisitor(objectType: .class, attributes: attributes, childVisitors: [childVisitor])
         let violations = visitor.findViolations(node)
-        XCTAssertTrue(violations.count == 5)
+        XCTAssertEqual(violations.count, 5)
     }
 }
 
@@ -184,7 +184,7 @@ private extension DeclVisitorTests {
                 let node = try SyntaxParser.parse(source: source)
                 let visitor = DeclVisitor(objectType: type, attributes: attributes)
                 let violations = visitor.findViolations(node)
-                XCTAssertTrue(violations.count == expectedViolationCount)
+                XCTAssertEqual(violations.count, expectedViolationCount)
             }
         }())
     }

--- a/Tests/SwiftLintFrameworkTests/DeclVisitorTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeclVisitorTests.swift
@@ -1,0 +1,191 @@
+@testable import SwiftLintFramework
+import SwiftSyntax
+import SwiftSyntaxParser
+import XCTest
+
+final class DeclVisitorTests: XCTestCase {
+    private typealias SourceCreator = (String) -> (String)
+
+    func testVisitDefaultAttributesGetsAll() {
+        let makeSource: SourceCreator = { type in
+            """
+                \(type) A {
+                    \(type) B {
+
+                    }
+                }
+                // comments
+                private \(type) C {}
+                public \(type) D {}
+            """
+        }
+
+        testDeclVisitorOnAllTypes(with: DeclVisitor.Attributes(), makeSource: makeSource, expectedViolationCount: 4)
+    }
+
+    func testVisitInheritance() {
+        let makeSource: SourceCreator = { type in
+            """
+                \(type) A: Parent {
+            """
+        }
+
+        let attributes = DeclVisitor.Attributes(inheritsFrom: ["Parent"])
+        testDeclVisitorOnAllTypes(with: attributes, makeSource: makeSource, expectedViolationCount: 1)
+    }
+
+    func testVisitSkipInheritance() {
+        let makeSource: SourceCreator = { type in
+           """
+               \(type) A: Parent {}
+               \(type) B {}
+               \(type) C: NonParent {}
+           """
+        }
+
+        let attributes = DeclVisitor.Attributes(skipIfInheritsFrom: ["Parent"])
+        testDeclVisitorOnAllTypes(with: attributes, makeSource: makeSource, expectedViolationCount: 2)
+    }
+
+    func testVisitSkipInheritanceAndLookForInheritedType() {
+        let makeSource: SourceCreator = { type in
+            """
+                \(type) A: Foo, Parent {}
+                \(type) B: Foo {}
+            """
+        }
+
+        let attributes = DeclVisitor.Attributes(skipIfInheritsFrom: ["Parent"], inheritsFrom: ["Foo"])
+        testDeclVisitorOnAllTypes(with: attributes, makeSource: makeSource, expectedViolationCount: 1)
+    }
+
+    func testVisitPublic() {
+        let makeSource: SourceCreator = { type in
+            """
+                private \(type) A {}
+                \(type) B {}
+                private \(type) C {}
+                public \(type) D {}
+                open \(type) E {}
+            """
+        }
+
+        var attributes = DeclVisitor.Attributes(accessControl: .private)
+        testDeclVisitorOnAllTypes(with: attributes, makeSource: makeSource, expectedViolationCount: 2)
+
+        attributes = DeclVisitor.Attributes(accessControl: .public)
+        testDeclVisitorOnAllTypes(with: attributes, makeSource: makeSource, expectedViolationCount: 1)
+
+        attributes = DeclVisitor.Attributes(accessControl: .open)
+        testDeclVisitorOnAllTypes(with: attributes, makeSource: makeSource, expectedViolationCount: 1)
+    }
+
+    func testVisitAllNodesWhenAccessControlIsNotSpecified() {
+        let makeSource: SourceCreator = { type in
+            """
+                private \(type) A {}
+                \(type) B {}
+                private \(type) C {}
+                public \(type) D {}
+                open \(type) E {}
+            """
+        }
+
+        let attributes = DeclVisitor.Attributes()
+        testDeclVisitorOnAllTypes(with: attributes, makeSource: makeSource, expectedViolationCount: 5)
+    }
+
+    func testVisitAllNodesWithSuffix() {
+        let makeSource: SourceCreator = { type in
+            """
+                private \(type) ATests {}
+                \(type) BTests2 {}
+            """
+        }
+
+        let attributes = DeclVisitor.Attributes(suffix: "Tests")
+        testDeclVisitorOnAllTypes(with: attributes, makeSource: makeSource, expectedViolationCount: 1)
+    }
+
+    func testVisitAllStructsInNestedClasses() {
+        let source = """
+            class A {
+                struct B {}
+                struct A {
+                    struct C {}
+                }
+            }
+            private struct D {}
+        """
+        guard let node = try? SyntaxParser.parse(source: source) else {
+            XCTFail("unable to parse source")
+            return
+        }
+        let visitor = DeclVisitor(objectType: .struct)
+        let violations = visitor.findViolations(node)
+        XCTAssertTrue(violations.count == 4)
+    }
+
+    func testVisitAllPublicClassesThatInheritFromClass() {
+        let source = """
+            public class Child: Parent {}
+            public class Foo
+            public class Bar
+            class A {}
+        """
+
+        guard let node = try? SyntaxParser.parse(source: source) else {
+            XCTFail("unable to parse source")
+            return
+        }
+        let attributes = DeclVisitor.Attributes(accessControl: .public, inheritsFrom: ["Parent"])
+        let visitor = DeclVisitor(objectType: .class, attributes: attributes)
+        let violations = visitor.findViolations(node)
+        XCTAssertTrue(violations.count == 1)
+    }
+
+    func testVisitChildVisitors() {
+        let source = """
+            public class Child: Parent {
+                private struct A {
+                    public struct B {
+                        public struct G1 {}
+                        public struct G2 {}
+                        public struct G3 {}
+                    }
+                }
+                public struct C {}
+            }
+            public struct D {}
+            public struct E {}
+            public struct F {}
+        """
+
+        guard let node = try? SyntaxParser.parse(source: source) else {
+            XCTFail("unable to parse source")
+            return
+        }
+        let childAttributes = DeclVisitor.Attributes(accessControl: .public)
+        let childVisitor = DeclVisitor(objectType: .struct, attributes: childAttributes)
+        let attributes = DeclVisitor.Attributes(accessControl: .public, inheritsFrom: ["Parent"])
+        let visitor = DeclVisitor(objectType: .class, attributes: attributes, childVisitors: [childVisitor])
+        let violations = visitor.findViolations(node)
+        XCTAssertTrue(violations.count == 5)
+    }
+}
+
+private extension DeclVisitorTests {
+    func testDeclVisitorOnAllTypes(with attributes: DeclVisitor.Attributes,
+                                   makeSource: (String) -> String,
+                                   expectedViolationCount: Int) {
+        XCTAssertNoThrow(try {
+            for type in ObjectType.allCases {
+                let source = makeSource(type.rawValue)
+                let node = try SyntaxParser.parse(source: source)
+                let visitor = DeclVisitor(objectType: type, attributes: attributes)
+                let violations = visitor.findViolations(node)
+                XCTAssertTrue(violations.count == expectedViolationCount)
+            }
+        }())
+    }
+}


### PR DESCRIPTION
This PR proposes an abstraction over writing rules that depend on SwiftSyntax. The abstraction will be a SwiftUI-like declarative DSL to write rules that use SwiftSyntax. The DSL will be made up of various `Matchers` that will map to common Swift Syntax nodes such as Class declarations, function call expressions...etc. As a proof of concept, this PR creates a matcher for `Classes`.

### Proposal

A declarative DSL to write rules that search the AST of SwiftSyntax for certain nodes.

### Motivation

At my company, we write a lot of lint rules that depend on the AST of Swift source code i.e. prohibiting the uses of a deprecated function within classes that inherit from a specific protocol. We've built a tool that does in the past called [NEAL](https://github.com/uber/NEAL/tree/master/docs).

Adding SwiftSyntax unlocked powerful parsing and inspection of the Swift AST. Currently, rules that use SwiftSyntax have a private `SyntaxVisitor` implementation to walk through the AST starting at the root and collect the positions of lint violations. The SyntaxVisitor is a powerful API, but it has some drawbacks.

**Drawbacks of SyntaxVisitor**
1. **Readability.** It can be hard to reason about how the visitor will traverse the AST just by looking at the code itself. To implement a visitor class, you must override various `visit` functions which relate to the current node being visited. This makes debugging and refactoring difficult.
2. **Code Duplication.** Rules that depend on SwiftSyntax would be repeating a lot of code to access information about Swift syntax nodes such as identifier, modifiers since all of this logic would live in private visitors that are owned by various rules.
3. **Difficulty Creating Hierarchical Rules.** Imagine a lint rule that you only want to raise within XCTestCases. You could do that by limiting the linting to classes that inherit from XCTestCase. To do that, you'll need to create two separate visitor classes and be sure to traverse the children of the class node with another visitor. Depending on the rules' complexity, the number of nested classes could grow. Any modification would require changing a lot of relationships between the SyntaxVisitor classes. 

**Goals** 
1. **Simplicity.** We want to abstract the creation and usage of these complex visitor classes with a declarative syntax. By writing rules in a declarative way, it is easy to modify and reason about the traversal of the AST.
2. **Flexibility**. There are more complicated use cases in lint rules where we want to do more than look for a single node. Developers should be able to create rules with both the DSL matchers and their own custom SyntaxVisitor classes if they want. 

### Design

Let's see a rule written with this new DSL. Our example rule will be: "For all tests, prohibit the use of a deprecated API `deprecatedTestHelper()`"

Our rule would look something like:
```
public struct DeprecatedTestHelperRule: SyntaxVisitorRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
    public var configuration = SeverityConfiguration(.error)

    public init() {}

    public static let description = RuleDescription(
        identifier: "deprecated_test_helper",
        name: "Deprecated Test Helper",
        description: "Please do not use deprecatedTestHelper(), use testHelper() instead.",
        kind: .lint,
        nonTriggeringExamples: [Example("class Test: XCTestCase { func testA() { testHelper() }}")],
        triggeringExamples: [Example("class Test: XCTestCase { func testA() { ↓deprecatedTestHelper() }}")]
    )

    @SyntaxVisitorRuleValidatorBuilder
    public var validator: SyntaxVisitorRuleValidating {
        Class {
            CallExpression().name("deprecatedTestHelper")
        }
        .inheritsFrom(["XCTestCase"])
    }
}
```

Here, the `validator` describes how to traverse the AST of the source file and collect violations. `Class` and `CallExpression` are `matchers` that will look for the equivalent syntax nodes. The `inheritsFrom` function is a `modifier` that filters out syntax nodes. The closure expression after `Class` denotes a child visitor: after finding a Class that inherits from XCTestCase, look for all call expressions with the name deprecatedTestHelper. 

The actual lint violations will be raised by the nodes that do not have child visitors. In other words "leaf nodes" such as the CallExpression above will raise the lint violation for our rule, and its position in the Swift file will be collected by the visitor.

### Implementation

**Rules**
To create a rule that uses this abstraction, conform to `SyntaxVisitorRule`. It requires you to implement a `validator` which is a collection of syntax visitors that will be used to traverse the AST of the Swift file and collect violations. It provides default functionality for taking those violation positions and turning them into `StyleViolations`.

**Validator**
The validator is built by using a resultBuilder named `SyntaxVisitorRuleValidatorBuilder`. This resultBuilder allows us to define our rules with our custom DSL. The DSL is made up of `Matchers` and `ViolationSyntaxVisitors`. It knows how to create the parent-child relationships of visitors. It also knows how to composite matchers with bare ViolationSyntaxVisitor classes into validators, providing flexibility when the DSL matchers do not provide what we want.

**Matchers**
Used to find a single Swift Syntax node. It can be filtered by applying `Lint Modifiers` which are methods which changes the attributes to look for. Matchers are responsible for creating ViolationSyntaxVisitors and its relationships to other matchers or visitors.

**ViolationSyntaxVisitors**
Traverses the AST and collects the positions of a node if it violates according to the attributes it was passed.

### Future Considerations
In the future, I hope to add more `Matchers` for various syntax nodes. We could also consider adding more operators such as anyOf() or all() or even scoped matchers (look only at the next immediate child node) to the DSL.

### Alternatives Considered

**Define these rules in the config file**
I considered defining these rules in the .swiftlint.yml file. Doing so would allow us to create rules without creating a new release of SwiftLint for each new rule. However, the maintenance of these config files would be expensive as we continue modifying these abstractions whenever we add more functionality or conform to updates from SwiftSyntax. The biggest downside is losing the debugging and testability capabilities of writing these rules in native Swift. 