### PR TITLE
Check in build that Sourcery generated files are up-to-date

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,17 @@ trigger:
 - master
 
 jobs:
+- job: Sourcery
+  pool:
+    vmImage: 'macOS-12'
+  steps:
+    - script: brew install sourcery
+      displayName: Install Sourcery
+    - script: make sourcery
+      displayName: Generate sources
+    - script: "! git diff -U0 | grep '^[-+][^-+]' | grep --invert-match '// Generated using Sourcery'"
+      displayName: Check changed files ignoring Sourcery's version
+
 - job: linux
   pool:
     vmImage: 'Ubuntu 18.04'


### PR DESCRIPTION
The idea is to check in the build that files generated by Sourcery are up-to-date, so that something like #4034 cannot happen anymore.

The job verifies that the generated files do not have changes other than the header comment containing the used Sourcery version. As long as there are no other changes in the files a different version should be acceptable.