### PR TITLE
Add support for native custom rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,7 +6,10 @@ load(
 
 swift_library(
     name = "SwiftLintFramework",
-    srcs = glob(["Source/SwiftLintFramework/**/*.swift"]),
+    srcs = glob(
+        ["Source/SwiftLintFramework/**/*.swift"],
+        exclude = ["Source/SwiftLintFramework/Rules/ExcludedFromBazel/ExtraRules.swift"],
+    ) + ["@swiftlint_extra_rules//:extra_rules"],
     module_name = "SwiftLintFramework",
     visibility = ["//visibility:public"],
     deps = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Support for writing custom private native rules when building with
   bazel.  
   [JP Simard](https://github.com/jpsim)
+  [Keith Smiley](https://github.com/keith)
   [#3516](https://github.com/realm/SwiftLint/issues/3516)
 
 #### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 * Support for building SwiftLint with bazel.  
   [JP Simard](https://github.com/jpsim)
 
+* Support for writing custom private native rules when building with
+  bazel.  
+  [JP Simard](https://github.com/jpsim)
+  [#3516](https://github.com/realm/SwiftLint/issues/3516)
+
 #### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift
@@ -63,9 +63,8 @@ extension Configuration {
             .map { rule in [type(of: rule).description.identifier, rule.cacheDescription] }
             .sorted { $0[0] < $1[0] }
         let jsonObject: [Any] = [rootDirectory, cacheRulesDescriptions]
-        if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),
-            let jsonString = String(data: jsonData, encoding: .utf8) {
-            return jsonString.sha256()
+        if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject) {
+            return jsonData.sha256().toHexString()
         }
         queuedFatalError("Could not serialize configuration for cache")
     }
@@ -81,7 +80,14 @@ extension Configuration {
             baseURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
 #endif
         }
-        let folder = baseURL.appendingPathComponent("SwiftLint/\(Version.current.value)")
+
+        let versionedDirectory = [
+            "SwiftLint",
+            Version.current.value,
+            ExecutableInfo.buildID
+        ].compactMap({ $0 }).joined(separator: "/")
+
+        let folder = baseURL.appendingPathComponent(versionedDirectory)
 
         do {
             try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true, attributes: nil)

--- a/Source/SwiftLintFramework/Extensions/String+sha256.swift
+++ b/Source/SwiftLintFramework/Extensions/String+sha256.swift
@@ -1,14 +1,24 @@
 #if canImport(CommonCrypto)
 import CommonCrypto
+import Foundation
+
+extension Data {
+    internal func sha256() -> Data {
+        withUnsafeBytes { bytes in
+            var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+            _ = CC_SHA256(bytes.baseAddress, CC_LONG(count), &hash)
+            return Data(hash)
+        }
+    }
+
+    internal func toHexString() -> String {
+        reduce(into: "") { $0.append(String(format: "%02x", $1)) }
+    }
+}
 
 extension String {
     internal func sha256() -> String {
-        let theData = data(using: .utf8)!
-        return theData.withUnsafeBytes { bytes in
-            var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-            _ = CC_SHA256(bytes.baseAddress, CC_LONG(theData.count), &hash)
-            return hash.reduce(into: "") { $0.append(String(format: "%02x", $1)) }
-        }
+        data(using: .utf8)!.sha256().toHexString()
     }
 }
 #endif

--- a/Source/SwiftLintFramework/Helpers/ExecutableInfo.swift
+++ b/Source/SwiftLintFramework/Helpers/ExecutableInfo.swift
@@ -1,0 +1,43 @@
+#if os(macOS)
+import Foundation
+import MachO
+
+enum ExecutableInfo {
+    static let buildID: String? = {
+        // It should be possible to read the UUID directly from the `_mh_execute_header` but that fails with
+        // Fatal error: load from misaligned raw pointer
+        //
+        //   var header = _mh_execute_header
+        //   let uuidString = withUnsafePointer(to: &header) { header in
+        //       return getUUID(pointer: header)?.uuidString
+        //   }
+
+        // This works in pure Swift but requires reading the entire executable from disk, so it's 100x slower than
+        // the Objective-C version
+        let execData = try? Data(contentsOf: URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0]))
+        return execData?.withUnsafeBytes { pointer -> String? in
+            return getUUID(pointer: pointer.baseAddress!)?.uuidString
+        }
+    }()
+
+    private static func getUUID(pointer: UnsafeRawPointer) -> UUID? {
+        var offset: UInt64 = 0
+        let header = pointer.bindMemory(to: mach_header_64.self, capacity: 1)
+        offset += UInt64(MemoryLayout<mach_header_64>.size)
+        for _ in 0..<header.pointee.ncmds {
+            let loadCommand = pointer.load(fromByteOffset: Int(offset), as: load_command.self)
+            if loadCommand.cmd == LC_UUID {
+                let uuidCommand = pointer.load(fromByteOffset: Int(offset), as: uuid_command.self)
+                return UUID(uuid: uuidCommand.uuid)
+            }
+            offset += UInt64(loadCommand.cmdsize)
+        }
+        return nil
+    }
+}
+
+#else
+enum ExecutableInfo {
+    static let buildID: String? = nil
+}
+#endif

--- a/Source/SwiftLintFramework/Helpers/ExecutableInfo.swift
+++ b/Source/SwiftLintFramework/Helpers/ExecutableInfo.swift
@@ -4,20 +4,15 @@ import MachO
 
 enum ExecutableInfo {
     static let buildID: String? = {
-        // It should be possible to read the UUID directly from the `_mh_execute_header` but that fails with
-        // Fatal error: load from misaligned raw pointer
-        //
-        //   var header = _mh_execute_header
-        //   let uuidString = withUnsafePointer(to: &header) { header in
-        //       return getUUID(pointer: header)?.uuidString
-        //   }
+        if let handle = dlopen(nil, RTLD_LAZY) {
+            defer { dlclose(handle) }
 
-        // This works in pure Swift but requires reading the entire executable from disk, so it's 100x slower than
-        // the Objective-C version
-        let execData = try? Data(contentsOf: URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0]))
-        return execData?.withUnsafeBytes { pointer -> String? in
-            return getUUID(pointer: pointer.baseAddress!)?.uuidString
+            if let ptr = dlsym(handle, MH_EXECUTE_SYM) {
+                return getUUID(pointer: ptr)?.uuidString
+            }
         }
+
+        return nil
     }()
 
     private static func getUUID(pointer: UnsafeRawPointer) -> UUID? {

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -216,4 +216,4 @@ public let primaryRuleList = RuleList(rules: [
     XCTFailMessageRule.self,
     XCTSpecificMatcherRule.self,
     YodaConditionRule.self
-])
+] + extraRules())

--- a/Source/SwiftLintFramework/Rules/ExcludedFromBazel/ExtraRules.swift
+++ b/Source/SwiftLintFramework/Rules/ExcludedFromBazel/ExtraRules.swift
@@ -1,0 +1,6 @@
+// DO NOT EDIT
+
+/// This is an extension point for custom native rules for Bazel.
+///
+/// - returns: Extra rules that are compiled with Bazel.
+func extraRules() -> [Rule.Type] { [] }

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -2,6 +2,20 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@com_github_keith_swift_syntax_bazel//:deps.bzl", "swift_syntax_deps")
 load("@com_github_jpsim_sourcekitten//bazel:repos.bzl", "sourcekitten_repos")
 
+def _default_extra_swift_sources_impl(ctx):
+    ctx.file("WORKSPACE", "")
+    ctx.file("empty.swift", "func extraRules() -> [Rule.Type] { [] }")
+    ctx.file("BUILD.bazel", """
+filegroup(
+    name = "extra_rules",
+    srcs = ["empty.swift"],
+    visibility = ["//visibility:public"],
+)""")
+
+_default_extra_swift_sources = repository_rule(
+    implementation = _default_extra_swift_sources_impl,
+)
+
 def swiftlint_deps():
     """Fetches SwiftLint dependencies"""
     if not native.existing_rule("build_bazel_rules_apple"):
@@ -9,6 +23,9 @@ def swiftlint_deps():
 
     if not native.existing_rule("build_bazel_rules_swift"):
         fail("error: this depends on rules_swift but that wasn't setup")
+
+    if not native.existing_rule("swiftlint_extra_rules"):
+        _default_extra_swift_sources(name = "swiftlint_extra_rules")
 
     swift_syntax_deps()
     sourcekitten_repos()


### PR DESCRIPTION
This change makes it possible to add native custom rules when building SwiftLint via Bazel (possible as of https://github.com/realm/SwiftLint/pull/4038).

First, add a local bazel repository where custom rules will be defined to your project's `WORKSPACE`:

```python
local_repository(
    name = "swiftlint_extra_rules",
    path = "swiftlint_extra_rules",
)
```

Then in the extra rules directory, add an empty `WORKSPACE` and a `BUILD` file with the following contents:

```python
filegroup(
    name = "extra_rules",
    srcs = glob(["*.swift"]),
    visibility = ["//visibility:public"],
)
```

To add a rule (for example, `MyPrivateRule`) add the following two files:

```swift
// ExtraRules.swift
func extraRules() -> [Rule.Type] {
    [
        MyPrivateRule.self,
    ]
}
```

```swift
// MyPrivateRule.swift
import SourceKittenFramework
import SwiftSyntax

struct MyPrivateRule: ConfigurationProviderRule {
    var configuration = SeverityConfiguration(.error)

    init() {}

    static let description = RuleDescription(
        identifier: "my_private_rule",
        name: "My Private Rule",
        description: "This is my private rule.",
        kind: .idiomatic
    )

    func validate(file: SwiftLintFile) -> [StyleViolation] {
        // Perform validation here...
    }
}
```

Then you can reference the rule in your configuration or source files as though they were built in to the official SwiftLint repo.

This means that you have access to SwiftLintFramework's internal API. We make no guarantees as to the stability of these internal APIs, although if you end up using something that gets removed please reach out and we'll make a best effort to maintain some level of support.

This PR also improves the linter cache on macOS to make it correctly invalidate previous results when custom native rules are edited. This even works when doing local development of SwiftLint, where previous it was necessary to use `--no-cache` when working on SwiftLint, now the cache should always work.