### PR TITLE
Make comma_inheritance opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   values.  
   [JP Simard](https://github.com/jpsim)
 
+* Make `comma_inheritance` an opt-in rule.  
+  [Steve Madsen](https://github.com/sjmadsen)
+  [#4027](https://github.com/realm/SwiftLint/issues/4027)
+
 #### Experimental
 
 * None.
@@ -31,10 +35,6 @@
   closures inside `didSet` and other accessors.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4041](https://github.com/realm/SwiftLint/issues/4041)
-
-* Make `comma_inheritance` an opt-in rule.  
-  [Steve Madsen](https://github.com/sjmadsen)
-  [#4027](https://github.com/realm/SwiftLint/issues/4027)
 
 ## 0.48.0: Rechargeable Defuzzer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4041](https://github.com/realm/SwiftLint/issues/4041)
 
+* Make `comma_inheritance` an opt-in rule.  
+  [Steve Madsen](https://github.com/sjmadsen)
+  [#4027](https://github.com/realm/SwiftLint/issues/4027)
+
 ## 0.48.0: Rechargeable Defuzzer
 
 This is the last release to support building with Swift 5.5.x and running on

--- a/Source/SwiftLintFramework/Rules/Style/CommaInheritanceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaInheritanceRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct CommaInheritanceRule: SubstitutionCorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/CommaInheritanceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaInheritanceRule.swift
@@ -2,7 +2,8 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule,
+                                    AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}


### PR DESCRIPTION
This addresses issue #4027.

The Swift language grammar doesn't allow a comma in place of an ampersand in all cases. Specifically, if a protocol's associated type is required to conform to a composition of protocols and one of those protocols in turn requires conformance to one of the same protocols, the compiler will generate an error: "redundant conformance constraint". For example:

    protocol Transformable {
        associatedtype Unit: Equatable & CaseIterable & UnitConvertible

        ...
    }

    protocol UnitConvertible where Self: Equatable {
        ...
    }

When `&` is replaced with `,`, this produces `Redundant conformance constraint: 'Self.Unit' : 'Equatable'`.

My first thought was to disable autocorrect, but this penalizes those that want to use the rule without solving the problem for problematic code bases. It feels better to make the rule opt-in, so that developers who want to enforce the rule can still take advantage of autocorrection, while code bases where it is an issue can either leave it disabled or opt-in and selectively disable where necessary.