### PR TITLE
[Bazel] Set up tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,6 @@
 steps:
+  - label: "Bazel Tests"
+    command: bazel test --spawn_strategy=standalone //Tests/...
   - label: "Danger"
     commands:
       - bundle install

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -1,0 +1,60 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
+
+swift_library(
+    name = "SwiftLintFrameworkTests.library",
+    testonly = True,
+    srcs = glob(
+        ["SwiftLintFrameworkTests/**/*.swift"],
+        exclude = [
+            "SwiftLintFrameworkTests/Resources/**",
+            # Bazel doesn't support paths with spaces in them
+            "SwiftLintFrameworkTests/FileNameNoSpaceRuleTests.swift",
+            # FIXME: Get these tests passing with Bazel
+            "SwiftLintFrameworkTests/ConfigurationTests+Mock.swift",
+            "SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift",
+            "SwiftLintFrameworkTests/ConfigurationTests.swift",
+            "SwiftLintFrameworkTests/IntegrationTests.swift",
+            "SwiftLintFrameworkTests/SourceKitCrashTests.swift",
+        ],
+    ),
+    module_name = "SwiftLintFrameworkTests",
+    deps = [
+        "//:SwiftLintFramework",
+    ],
+)
+
+swift_test(
+    name = "SwiftLintFrameworkTests",
+    data = glob(
+        ["SwiftLintFrameworkTests/Resources/**"],
+        # Bazel doesn't support paths with spaces in them
+        exclude = ["SwiftLintFrameworkTests/Resources/FileNameNoSpaceRuleFixtures/**"],
+    ),
+    visibility = [
+        "//Tests:__subpackages__",
+    ],
+    deps = [
+        ":SwiftLintFrameworkTests.library",
+    ],
+)
+
+swift_library(
+    name = "ExtraRulesTests.library",
+    testonly = True,
+    srcs = [
+        "SwiftLintFrameworkTests/ExtraRulesTests.swift",
+        "SwiftLintFrameworkTests/TestHelpers.swift",
+    ],
+    module_name = "ExtraRulesTests",
+    deps = [
+        "//:SwiftLintFramework",
+    ],
+)
+
+swift_test(
+    name = "ExtraRulesTests",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ExtraRulesTests.library",
+    ],
+)

--- a/Tests/SwiftLintFrameworkTests/ExtraRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtraRulesTests.swift
@@ -1,0 +1,10 @@
+@testable import SwiftLintFramework
+import XCTest
+
+final class ExtraRulesTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        for ruleType in extraRules() {
+            verifyRule(ruleType.description)
+        }
+    }
+}


### PR DESCRIPTION
Run with `bazel test --spawn_strategy=standalone //Tests/...`

Consumers who define rules via `swiftlint_extra_rules` can run tests for their custom rules too:

```
./bazelw test \
  --spawn_strategy=standalone \
  @SwiftLint//Tests:ExtraRulesTests
```