### PR TITLE
DuplicatedKeyInDictionaryLiteralRule: fix false positives scenarios.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Master
 
+#### Bug Fixes
+
+* Fix false positive in `Duplicated Key in Dictionary Literal Violation` rule when using
+  keys that are generated at runtime with the same source code.  
+  [OrEliyahu](https://github.com/OrEliyahu)
+  [#4012](https://github.com/realm/SwiftLint/issues/4012)
+
 #### Breaking
 
 * SwiftLint now requires Swift 5.6 or higher to build, and macOS 12


### PR DESCRIPTION
The current check doesn't take into consideration that keys can be
generated in runtime. For example using UUID initializer (as in the
added example) raises a false positive diagnosis. Note that the
suggested change will not raise on true scenarios which use call, such
as:
```swift
[
  generateSameKey(): "1",
  generateSameKey(): "2"
]
func generateSameKey() -> Int { return 0 }
```

However, it is better than raising false positives.

About the solution:
Apparently when dictionary is parsed all of its keys has
exactly the same kind, `source.lang.swift.structure.elem.expr`,
regardless of their content. So in order to figure out the what is the
actual key one must reparse it.