### PR TITLE
Verify all examples provided in rule descriptions

### DIFF
--- a/Source/SwiftLintFramework/Models/Example.swift
+++ b/Source/SwiftLintFramework/Models/Example.swift
@@ -18,6 +18,12 @@ public struct Example {
     ///
     /// - SeeAlso: addEmoji(_:)
     public private(set) var testMultiByteOffsets: Bool
+    /// Whether tests shall verify that the example wrapped in a comment doesn't trigger
+    private(set) var testWrappingInComment: Bool
+    /// Whether tests shall verify that the example wrapped into a string doesn't trigger
+    private(set) var testWrappingInString: Bool
+    /// Whether tests shall verify that the disabled rule (comment in the example) doesn't trigger
+    private(set) var testDisableCommand: Bool
     /// Whether the example should be tested on Linux
     public private(set) var testOnLinux: Bool
     /// The path to the file where the example was created
@@ -44,13 +50,19 @@ public extension Example {
     ///   - configuration:        The untyped configuration to apply to the rule, if deviating from the default
     ///                           configuration.
     ///   - testMultibyteOffsets: Whether the example should be tested by prepending multibyte grapheme clusters.
+    ///   - testWrappingInComment:Whether test shall verify that the example wrapped in a comment doesn't trigger.
+    ///   - testWrappingInString: Whether tests shall verify that the example wrapped into a string doesn't trigger.
+    ///   - testDisableCommand:   Whether tests shall verify that the disabled rule (comment in the example) doesn't
+    ///                           trigger.
     ///   - testOnLinux:          Whether the example should be tested on Linux.
     ///   - file:                 The path to the file where the example is located.
     ///                           Defaults to the file where this initializer is called.
     ///   - line:                 The line in the file where the example is located.
     ///                           Defaults to the line where this initializer is called.
-    init(_ code: String, configuration: Any? = nil, testMultiByteOffsets: Bool = true, testOnLinux: Bool = true,
-         file: StaticString = #file, line: UInt = #line, excludeFromDocumentation: Bool = false) {
+    init(_ code: String, configuration: Any? = nil, testMultiByteOffsets: Bool = true,
+         testWrappingInComment: Bool = true, testWrappingInString: Bool = true, testDisableCommand: Bool = true,
+         testOnLinux: Bool = true, file: StaticString = #file, line: UInt = #line,
+         excludeFromDocumentation: Bool = false) {
         self.code = code
         self.configuration = configuration
         self.testMultiByteOffsets = testMultiByteOffsets
@@ -58,6 +70,9 @@ public extension Example {
         self.file = file
         self.line = line
         self.excludeFromDocumentation = excludeFromDocumentation
+        self.testWrappingInComment = testWrappingInComment
+        self.testWrappingInString = testWrappingInString
+        self.testDisableCommand = testDisableCommand
         self.isFocused = false
     }
 
@@ -73,9 +88,35 @@ public extension Example {
     func removingViolationMarkers() -> Example {
         return with(code: code.replacingOccurrences(of: "↓", with: ""))
     }
+}
 
-    /// Makes the current example focused.
-    func focused() -> Example {
+extension Example {
+    func skipWrappingInCommentTest() -> Self {
+        var new = self
+        new.testWrappingInComment = false
+        return new
+    }
+
+    func skipWrappingInStringTest() -> Self {
+        var new = self
+        new.testWrappingInString = false
+        return new
+    }
+
+    func skipMultiByteOffsetTest() -> Self {
+        var new = self
+        new.testMultiByteOffsets = false
+        return new
+    }
+
+    func skipDisableCommandTest() -> Self {
+        var new = self
+        new.testDisableCommand = false
+        return new
+    }
+
+    /// Makes the current example focused. This is for debugging purposes only.
+    func focused() -> Example { // swiftlint:disable:this unused_declaration
         var new = self
         new.isFocused = true
         return new
@@ -99,5 +140,23 @@ extension Example: Hashable {
 extension Example: Comparable {
     public static func < (lhs: Example, rhs: Example) -> Bool {
         return lhs.code < rhs.code
+    }
+}
+
+extension Array where Element == Example {
+    func skipWrappingInCommentTests() -> Self {
+        map { $0.skipWrappingInCommentTest() }
+    }
+
+    func skipWrappingInStringTests() -> Self {
+        map { $0.skipWrappingInStringTest() }
+    }
+
+    func skipMultiByteOffsetTests() -> Self {
+        map { $0.skipMultiByteOffsetTest() }
+    }
+
+    func skipDisableCommandTests() -> Self {
+        map { $0.skipDisableCommandTest() }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -1,4 +1,4 @@
-public struct DiscouragedDirectInitRule: ASTRule, ConfigurationProviderRule {
+public struct DiscouragedDirectInitRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = DiscouragedDirectInitConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
+public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
     enum ExpiryViolationLevel {
         case approachingExpiry
         case expired
@@ -36,12 +36,12 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
             Example("/** TODO: */\n")
         ],
         triggeringExamples: [
-            Example("// TODO: [10/14/2019]\n"),
-            Example("// FIXME: [10/14/2019]\n"),
-            Example("// FIXME: [1/14/2019]\n"),
-            Example("// FIXME: [10/14/2019]\n"),
-            Example("// TODO: [9999/14/10]\n")
-        ]
+            Example("// TODO: [↓10/14/2019]\n"),
+            Example("// FIXME: [↓10/14/2019]\n"),
+            Example("// FIXME: [↓1/14/2019]\n"),
+            Example("// FIXME: [↓10/14/2019]\n"),
+            Example("// TODO: [↓9999/14/10]\n")
+        ].skipWrappingInCommentTests()
     )
 
     public var configuration: ExpiringTodoConfiguration = .init()

--- a/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
+public struct MarkRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct OrphanedDocCommentRule: ConfigurationProviderRule {
+public struct OrphanedDocCommentRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -67,7 +67,7 @@ import SourceKittenFramework
 ///     case accountCreated
 /// }
 /// ````
-public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
     private typealias RequiredCase = RequiredEnumCaseRuleConfiguration.RequiredCase
 
     /// Simple representation of parsed information from the SourceKitRepresentable dictionary.
@@ -117,6 +117,10 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
 
     public init() {}
 
+    private static let exampleConfiguration = [
+        "NetworkResponsable": ["success": "warning", "error": "warning", "notConnected": "warning"]
+    ]
+
     public static let description = RuleDescription(
         identifier: "required_enum_case",
         name: "Required Enum Case",
@@ -127,50 +131,50 @@ public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRul
             enum MyNetworkResponse: String, NetworkResponsable {
                 case success, error, notConnected
             }
-            """),
+            """, configuration: exampleConfiguration),
             Example("""
             enum MyNetworkResponse: String, NetworkResponsable {
                 case success, error, notConnected(error: Error)
             }
-            """),
+            """, configuration: exampleConfiguration),
             Example("""
             enum MyNetworkResponse: String, NetworkResponsable {
                 case success
                 case error
                 case notConnected
             }
-            """),
+            """, configuration: exampleConfiguration),
             Example("""
             enum MyNetworkResponse: String, NetworkResponsable {
                 case success
                 case error
                 case notConnected(error: Error)
             }
-            """)
+            """, configuration: exampleConfiguration)
         ],
         triggeringExamples: [
             Example("""
-            enum MyNetworkResponse: String, NetworkResponsable {
+            ↓enum MyNetworkResponse: String, NetworkResponsable {
                 case success, error
             }
-            """),
+            """, configuration: exampleConfiguration),
             Example("""
-            enum MyNetworkResponse: String, NetworkResponsable {
+            ↓enum MyNetworkResponse: String, NetworkResponsable {
                 case success, error
             }
-            """),
+            """, configuration: exampleConfiguration),
             Example("""
-            enum MyNetworkResponse: String, NetworkResponsable {
+            ↓enum MyNetworkResponse: String, NetworkResponsable {
                 case success
                 case error
             }
-            """),
+            """, configuration: exampleConfiguration),
             Example("""
-            enum MyNetworkResponse: String, NetworkResponsable {
+            ↓enum MyNetworkResponse: String, NetworkResponsable {
                 case success
                 case error
             }
-            """)
+            """, configuration: exampleConfiguration)
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
@@ -8,7 +8,7 @@ public extension SyntaxKind {
     }
 }
 
-public struct TodoRule: ConfigurationProviderRule {
+public struct TodoRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -31,7 +31,7 @@ public struct TodoRule: ConfigurationProviderRule {
             Example("/* ↓TODO: */\n"),
             Example("/** ↓FIXME: */\n"),
             Example("/** ↓TODO: */\n")
-        ]
+        ].skipWrappingInCommentTests()
     )
 
     private func customMessage(file: SwiftLintFile, range: NSRange) -> String {

--- a/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
+public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = CyclomaticComplexityConfiguration(warning: 10, error: 20)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FileLengthRule: ConfigurationProviderRule {
+public struct FileLengthRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = FileLengthRuleConfiguration(warning: 400, error: 1000)
 
     public init() {}
@@ -11,13 +11,13 @@ public struct FileLengthRule: ConfigurationProviderRule {
         description: "Files should not span too many lines.",
         kind: .metrics,
         nonTriggeringExamples: [
-            Example(repeatElement("print(\"swiftlint\")\n", count: 400).joined())
+            Example(repeatElement("print(\"swiftlint\")\n", count: 399).joined())
         ],
         triggeringExamples: [
             Example(repeatElement("print(\"swiftlint\")\n", count: 401).joined()),
             Example((repeatElement("print(\"swiftlint\")\n", count: 400) + ["//\n"]).joined()),
             Example(repeatElement("print(\"swiftlint\")\n\n", count: 201).joined())
-        ]
+        ].skipWrappingInCommentTests()
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LineLengthRule: ConfigurationProviderRule {
+public struct LineLengthRule: ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = LineLengthConfiguration(warning: 120, error: 200)
 
     public init() {}
@@ -24,7 +24,7 @@ public struct LineLengthRule: ConfigurationProviderRule {
             Example(String(repeating: "/", count: 121) + "\n"),
             Example(String(repeating: "#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)", count: 121) + "\n"),
             Example(String(repeating: "#imageLiteral(resourceName: \"image.jpg\")", count: 121) + "\n")
-        ]
+        ].skipWrappingInCommentTests().skipWrappingInStringTests()
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
+public struct FileHeaderRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
     public var configuration = FileHeaderConfiguration()
 
     public init() {}
@@ -30,7 +30,7 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
             //  ↓Copyright © 2016 Realm. All rights reserved.
             //
             """)
-        ]
+        ].skipWrappingInCommentTests()
     )
 
     private static let reason = "Header comments should be consistent with project patterns."

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
+public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
     // MARK: - Subtypes
     private enum Indentation: Equatable {
         case tabs(Int)
@@ -31,15 +31,15 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
             Example("firstLine\nsecondLine"),
             Example("firstLine\n    secondLine"),
             Example("firstLine\n\tsecondLine\n\t\tthirdLine\n\n\t\tfourthLine"),
-            Example("firstLine\n\tsecondLine\n\t\tthirdLine\n//test\n\t\tfourthLine"),
+            Example("firstLine\n\tsecondLine\n\t\tthirdLine\n\t//test\n\t\tfourthLine"),
             Example("firstLine\n    secondLine\n        thirdLine\nfourthLine")
         ],
         triggeringExamples: [
-            Example("    firstLine"),
+            Example("↓    firstLine", testMultiByteOffsets: false, testDisableCommand: false),
             Example("firstLine\n        secondLine"),
-            Example("firstLine\n\tsecondLine\n\n\t\t\tfourthLine"),
-            Example("firstLine\n    secondLine\n        thirdLine\n fourthLine")
-        ]
+            Example("firstLine\n\tsecondLine\n\n↓\t\t\tfourthLine"),
+            Example("firstLine\n    secondLine\n        thirdLine\n↓ fourthLine")
+        ].skipWrappingInCommentTests()
     )
 
     // MARK: - Initializers

--- a/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
+                                     SourceKitFreeRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -11,9 +12,16 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
         name: "Leading Whitespace",
         description: "Files should not contain leading whitespace.",
         kind: .style,
-        nonTriggeringExamples: [ Example("//\n") ],
-        triggeringExamples: [ Example("\n//\n"), Example(" //\n") ],
-        corrections: [Example("\n //"): Example("//")]
+        nonTriggeringExamples: [
+            Example("//\n")
+        ],
+        triggeringExamples: [
+            Example("\n//\n"),
+            Example(" //\n")
+        ].skipMultiByteOffsetTests().skipDisableCommandTests(),
+        corrections: [
+            Example("\n //", testMultiByteOffsets: false): Example("//")
+        ]
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -8,7 +8,7 @@ private enum TrailingCommaReason: String {
 
 private typealias CommaRuleViolation = (index: ByteCount, reason: TrailingCommaReason)
 
-public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule {
+public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = TrailingCommaConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingNewlineRule.swift
@@ -18,7 +18,8 @@ extension String {
     }
 }
 
-public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule,
+                                   SourceKitFreeRule, AutomaticTestableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -34,7 +35,7 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, S
         triggeringExamples: [
             Example("let a = 0"),
             Example("let a = 0\n\n")
-        ],
+        ].skipWrappingInCommentTests().skipWrappingInStringTests(),
         corrections: [
             Example("let a = 0"): Example("let a = 0\n"),
             Example("let b = 0\n\n"): Example("let b = 0\n"),

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
+public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
     public var configuration = UnusedOptionalBindingConfiguration(ignoreOptionalTry: false)
 
     public init() {}

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -239,6 +239,12 @@ class EnumCaseAssociatedValuesLengthRuleTests: XCTestCase {
     }
 }
 
+class ExpiringTodoRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(ExpiringTodoRule.description)
+    }
+}
+
 class ExplicitACLRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExplicitACLRule.description)
@@ -284,6 +290,18 @@ class FallthroughRuleTests: XCTestCase {
 class FatalErrorMessageRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FatalErrorMessageRule.description)
+    }
+}
+
+class FileHeaderRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(FileHeaderRule.description)
+    }
+}
+
+class FileLengthRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(FileLengthRule.description)
     }
 }
 
@@ -347,6 +365,12 @@ class ImplicitGetterRuleTests: XCTestCase {
     }
 }
 
+class IndentationWidthRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(IndentationWidthRule.description)
+    }
+}
+
 class InertDeferRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(InertDeferRule.description)
@@ -374,6 +398,12 @@ class LargeTupleRuleTests: XCTestCase {
 class LastWhereRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LastWhereRule.description)
+    }
+}
+
+class LeadingWhitespaceRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(LeadingWhitespaceRule.description)
     }
 }
 
@@ -428,6 +458,12 @@ class LegacyRandomRuleTests: XCTestCase {
 class LetVarWhitespaceRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LetVarWhitespaceRule.description)
+    }
+}
+
+class LineLengthRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(LineLengthRule.description)
     }
 }
 
@@ -737,6 +773,12 @@ class RequiredDeinitRuleTests: XCTestCase {
     }
 }
 
+class RequiredEnumCaseRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RequiredEnumCaseRule.description)
+    }
+}
+
 class ReturnArrowWhitespaceRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReturnArrowWhitespaceRule.description)
@@ -815,6 +857,12 @@ class TestCaseAccessibilityRuleTests: XCTestCase {
     }
 }
 
+class TodoRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(TodoRule.description)
+    }
+}
+
 class ToggleBoolRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ToggleBoolRule.description)
@@ -824,6 +872,12 @@ class ToggleBoolRuleTests: XCTestCase {
 class TrailingCommaRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TrailingCommaRule.description)
+    }
+}
+
+class TrailingNewlineRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(TrailingNewlineRule.description)
     }
 }
 
@@ -914,6 +968,12 @@ class UnusedEnumeratedRuleTests: XCTestCase {
 class UnusedImportRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedImportRule.description)
+    }
+}
+
+class UnusedOptionalBindingRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnusedOptionalBindingRule.description)
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -131,6 +131,12 @@ class ConvenienceTypeRuleTests: XCTestCase {
     }
 }
 
+class CyclomaticComplexityRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(CyclomaticComplexityRule.description)
+    }
+}
+
 class DiscardedNotificationCenterObserverRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscardedNotificationCenterObserverRule.description)
@@ -140,6 +146,12 @@ class DiscardedNotificationCenterObserverRuleTests: XCTestCase {
 class DiscouragedAssertRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedAssertRule.description)
+    }
+}
+
+class DiscouragedDirectInitRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(DiscouragedDirectInitRule.description)
     }
 }
 
@@ -431,6 +443,12 @@ class LowerACLThanParentRuleTests: XCTestCase {
     }
 }
 
+class MarkRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(MarkRule.description)
+    }
+}
+
 class ModifierOrderRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ModifierOrderRule.description)
@@ -542,6 +560,12 @@ class OperatorUsageWhitespaceRuleTests: XCTestCase {
 class OptionalEnumCaseMatchingRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OptionalEnumCaseMatchingRule.description)
+    }
+}
+
+class OrphanedDocCommentRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(OrphanedDocCommentRule.description)
     }
 }
 
@@ -794,6 +818,12 @@ class TestCaseAccessibilityRuleTests: XCTestCase {
 class ToggleBoolRuleTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ToggleBoolRule.description)
+    }
+}
+
+class TrailingCommaRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(TrailingCommaRule.description)
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleConfigurationTests.swift
@@ -1,7 +1,8 @@
 import SwiftLintFramework
 import XCTest
 
-class CyclomaticComplexityRuleTests: XCTestCase {
+// swiftlint:disable:next type_name
+class CyclomaticComplexityRuleConfigurationTests: XCTestCase {
     private lazy var complexSwitchExample: Example = {
         var example = "func switcheroo() {\n"
         example += "    switch foo {\n"

--- a/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleConfigurationTests.swift
@@ -1,12 +1,9 @@
 import SwiftLintFramework
 import XCTest
 
-class DiscouragedDirectInitRuleTests: XCTestCase {
+// swiftlint:disable:next type_name
+class DiscouragedDirectInitRuleConfigurationTests: XCTestCase {
     private let baseDescription = DiscouragedDirectInitRule.description
-
-    func testDiscouragedDirectInitWithDefaultConfiguration() {
-        verifyRule(baseDescription)
-    }
 
     func testDiscouragedDirectInitWithConfiguredSeverity() {
         verifyRule(baseDescription, ruleConfiguration: ["severity": "error"])

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintFramework
 import XCTest
 
-class ExpiringTodoRuleTests: XCTestCase {
+class ExpiringTodoRuleConfigurationTests: XCTestCase {
     private lazy var config: Configuration = makeConfiguration()
 
     override func setUp() {

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleConfigurationTests.swift
@@ -6,7 +6,7 @@ private let fixturesDirectory = #file.bridge()
     .deletingLastPathComponent.bridge()
     .appendingPathComponent("Resources/FileHeaderRuleFixtures")
 
-class FileHeaderRuleTests: XCTestCase {
+class FileHeaderRuleConfigurationTests: XCTestCase {
     private func validate(fileName: String, using configuration: Any) throws -> [StyleViolation] {
         let file = SwiftLintFile(path: fixturesDirectory.stringByAppendingPathComponent(fileName))!
         let rule = try FileHeaderRule(configuration: configuration)

--- a/Tests/SwiftLintFrameworkTests/FileLengthRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileLengthRuleConfigurationTests.swift
@@ -1,7 +1,7 @@
 import SwiftLintFramework
 import XCTest
 
-class FileLengthRuleTests: XCTestCase {
+class FileLengthRuleConfigurationTests: XCTestCase {
     func testFileLengthWithDefaultConfiguration() {
         verifyRule(FileLengthRule.description, commentDoesntViolate: false,
                    testMultiByteOffsets: false, testShebang: false)

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintFramework
 import XCTest
 
-class IndentationWidthRuleTests: XCTestCase {
+class IndentationWidthRuleConfigurationTests: XCTestCase {
     // MARK: Examples
     /// It's not okay to have the first line indented.
     func testFirstLineIndentation() {

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintFramework
 import XCTest
 
-class LineLengthRuleTests: XCTestCase {
+class LineLengthRuleConfigurationTests: XCTestCase {
     private let longFunctionDeclarations = [
         Example("public func superDuperLongFunctionDeclaration(a: String, b: String, " +
             "c: String, d: String, e: String, f: String, g: String, h: String, i: String, " +

--- a/Tests/SwiftLintFrameworkTests/TodoRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleConfigurationTests.swift
@@ -1,7 +1,7 @@
 import SwiftLintFramework
 import XCTest
 
-class TodoRuleTests: XCTestCase {
+class TodoRuleConfigurationTests: XCTestCase {
     func testTodo() {
         verifyRule(TodoRule.description, commentDoesntViolate: false)
     }

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleConfigurationTests.swift
@@ -1,7 +1,7 @@
 import SwiftLintFramework
 import XCTest
 
-class TrailingCommaRuleTests: XCTestCase {
+class TrailingCommaRuleConfigurationTests: XCTestCase {
     func testTrailingCommaRuleWithDefaultConfiguration() {
         // Verify TrailingCommaRule with test values for when mandatory_comma is false (default).
         let triggeringExamples = TrailingCommaRule.description.triggeringExamples +
@@ -55,9 +55,9 @@ class TrailingCommaRuleTests: XCTestCase {
     }()
 
     private let mandatoryCommaRuleDescription = TrailingCommaRule.description
-        .with(nonTriggeringExamples: TrailingCommaRuleTests.nonTriggeringExamples)
-        .with(triggeringExamples: TrailingCommaRuleTests.triggeringExamples)
-        .with(corrections: TrailingCommaRuleTests.corrections)
+        .with(nonTriggeringExamples: TrailingCommaRuleConfigurationTests.nonTriggeringExamples)
+        .with(triggeringExamples: TrailingCommaRuleConfigurationTests.triggeringExamples)
+        .with(corrections: TrailingCommaRuleConfigurationTests.corrections)
 
     func testTrailingCommaRuleWithMandatoryComma() {
         // Verify TrailingCommaRule with test values for when mandatory_comma is true.

--- a/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleConfigurationTests.swift
@@ -1,7 +1,8 @@
 @testable import SwiftLintFramework
 import XCTest
 
-class UnusedOptionalBindingRuleTests: XCTestCase {
+// swiftlint:disable:next type_name
+class UnusedOptionalBindingRuleConfigurationTests: XCTestCase {
     func testDefaultConfiguration() {
         let baseDescription = UnusedOptionalBindingRule.description
         let triggeringExamples = baseDescription.triggeringExamples + [


### PR DESCRIPTION
All examples that are used in the documentation should be verified.

For some of the rules, this works without further work just by conforming to the `AutomaticTestableRule` protocol. Others require some customization of test execution, e.g. rules dealing with comments still trigger when wrapped into another comment.