### PR TITLE
Rewrite CommaRule with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   [OrEliyahu](https://github.com/OrEliyahu)
   [#4012](https://github.com/realm/SwiftLint/issues/4012)
 
+* Make `comma` rule about 10x faster, finding some previously missed cases and
+  fixing some previously wrong corrections.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.48.0: Rechargeable Defuzzer
 
 This is the last release to support building with Swift 5.5.x and running on

--- a/Source/SwiftLintFramework/Extensions/Collection+Windows.swift
+++ b/Source/SwiftLintFramework/Extensions/Collection+Windows.swift
@@ -1,0 +1,338 @@
+// swiftlint:disable all
+// Copied from https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Windows.swift
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// windows(ofCount:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// Returns a collection of all the overlapping slices of a given size.
+  ///
+  /// Use this method to iterate over overlapping subsequences of this
+  /// collection. This example prints every five character substring of `str`:
+  ///
+  ///     let str = "Hello, world!"
+  ///     for substring in str.windows(ofCount: 5) {
+  ///         print(substring)
+  ///     }
+  ///     // "Hello"
+  ///     // "ello,"
+  ///     // "llo, "
+  ///     // "lo, W"
+  ///     // ...
+  ///     // "orld!"
+  ///
+  /// - Parameter count: The number of elements in each window subsequence.
+  /// - Returns: A collection of subsequences of this collection, each with
+  ///   length `count`. If this collection is shorter than `count`, the
+  ///   resulting collection is empty.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`, otherwise O(*k*) where `k` is `count`.
+  ///   Access to successive windows is O(1).
+  func windows(ofCount count: Int) -> WindowsOfCountCollection<Self> {
+    WindowsOfCountCollection(base: self, windowSize: count)
+  }
+}
+
+/// A collection wrapper that presents a sliding window over the elements of
+/// a collection.
+struct WindowsOfCountCollection<Base: Collection> {
+  internal let base: Base
+  internal let windowSize: Int
+  internal var endOfFirstWindow: Base.Index?
+
+  internal init(base: Base, windowSize: Int) {
+    precondition(windowSize > 0, "Windows size must be greater than zero")
+    self.base = base
+    self.windowSize = windowSize
+    self.endOfFirstWindow =
+      base.index(base.startIndex, offsetBy: windowSize, limitedBy: base.endIndex)
+  }
+}
+
+extension WindowsOfCountCollection: Collection {
+  /// A position in a `WindowsOfCountCollection` instance.
+  struct Index: Comparable {
+    internal var lowerBound: Base.Index
+    internal var upperBound: Base.Index
+
+    internal init(lowerBound: Base.Index, upperBound: Base.Index) {
+      self.lowerBound = lowerBound
+      self.upperBound = upperBound
+    }
+
+    static func == (lhs: Index, rhs: Index) -> Bool {
+      lhs.lowerBound == rhs.lowerBound
+    }
+
+    static func < (lhs: Index, rhs: Index) -> Bool {
+      lhs.lowerBound < rhs.lowerBound
+    }
+  }
+
+  var startIndex: Index {
+    if let upperBound = endOfFirstWindow {
+      return Index(lowerBound: base.startIndex, upperBound: upperBound)
+    } else {
+      return endIndex
+    }
+  }
+
+  var endIndex: Index {
+    Index(lowerBound: base.endIndex, upperBound: base.endIndex)
+  }
+
+  subscript(index: Index) -> Base.SubSequence {
+    precondition(
+      index.lowerBound != index.upperBound,
+      "Windows index is out of range")
+    return base[index.lowerBound..<index.upperBound]
+  }
+
+  func index(after index: Index) -> Index {
+    precondition(index != endIndex, "Advancing past end index")
+    guard index.upperBound < base.endIndex else { return endIndex }
+
+    let lowerBound = windowSize == 1
+      ? index.upperBound
+      : base.index(after: index.lowerBound)
+    let upperBound = base.index(after: index.upperBound)
+    return Index(lowerBound: lowerBound, upperBound: upperBound)
+  }
+
+  func index(_ i: Index, offsetBy distance: Int) -> Index {
+    guard distance != 0 else { return i }
+
+    return distance > 0
+      ? offsetForward(i, by: distance)
+      : offsetBackward(i, by: -distance)
+  }
+
+  func index(
+    _ i: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    guard distance != 0 else { return i }
+    guard limit != i else { return nil }
+
+    if distance > 0 {
+      return limit > i
+        ? offsetForward(i, by: distance, limitedBy: limit)
+        : offsetForward(i, by: distance)
+    } else {
+      return limit < i
+        ? offsetBackward(i, by: -distance, limitedBy: limit)
+        : offsetBackward(i, by: -distance)
+    }
+  }
+
+  internal func offsetForward(_ i: Index, by distance: Int) -> Index {
+    guard let index = offsetForward(i, by: distance, limitedBy: endIndex)
+      else { fatalError("Index is out of bounds") }
+    return index
+  }
+
+  internal func offsetBackward(_ i: Index, by distance: Int) -> Index {
+    guard let index = offsetBackward(i, by: distance, limitedBy: startIndex)
+      else { fatalError("Index is out of bounds") }
+    return index
+  }
+
+  internal func offsetForward(
+    _ i: Index, by distance: Int, limitedBy limit: Index
+  ) -> Index? {
+    assert(distance > 0)
+    assert(limit > i)
+
+    // `endIndex` and the index before it both have `base.endIndex` as their
+    // upper bound, so we first advance to the base index _before_ the upper
+    // bound of the output, in order to avoid advancing past the end of `base`
+    // when advancing to `endIndex`.
+    //
+    // Advancing by 4:
+    //
+    //  input: [x|x x x x x|x x x x]        [x x|x x x x x|x x x]
+    //                     |> > >|>|   or                 |> > >|
+    // output: [x x x x x|x x x x x]        [x x x x x x x x x x]  (`endIndex`)
+
+    if distance >= windowSize {
+      // Avoid traversing `self[i.lowerBound..<i.upperBound]` when the lower
+      // bound of the output is greater than or equal to the upper bound of the
+      // input.
+
+      //  input: [x|x x x x|x x x x x x x]
+      //                   |> >|> > >|>|
+      // output: [x x x x x x x|x x x x|x]
+
+      guard limit.lowerBound >= i.upperBound,
+            let lowerBound = base.index(
+              i.upperBound,
+              offsetBy: distance - windowSize,
+              limitedBy: limit.lowerBound),
+            let indexBeforeUpperBound = base.index(
+              lowerBound,
+              offsetBy: windowSize - 1,
+              limitedBy: limit.upperBound)
+      else { return nil }
+
+      // If `indexBeforeUpperBound` equals `base.endIndex`, we're advancing to
+      // `endIndex`.
+      guard indexBeforeUpperBound != base.endIndex else { return endIndex }
+
+      return Index(
+        lowerBound: lowerBound,
+        upperBound: base.index(after: indexBeforeUpperBound))
+    } else {
+      //  input: [x|x x x x x x|x x x x x]
+      //           |> > > >|   |> > >|>|
+      // output: [x x x x x|x x x x x x|x]
+
+      guard let indexBeforeUpperBound = base.index(
+              i.upperBound,
+              offsetBy: distance - 1,
+              limitedBy: limit.upperBound)
+      else { return nil }
+
+      // If `indexBeforeUpperBound` equals the limit, the upper bound itself
+      // exceeds it.
+      guard indexBeforeUpperBound != limit.upperBound || limit == endIndex
+        else { return nil }
+
+      // If `indexBeforeUpperBound` equals `base.endIndex`, we're advancing to
+      // `endIndex`.
+      guard indexBeforeUpperBound != base.endIndex else { return endIndex }
+
+      return Index(
+        lowerBound: base.index(i.lowerBound, offsetBy: distance),
+        upperBound: base.index(after: indexBeforeUpperBound))
+    }
+  }
+
+  internal func offsetBackward(
+      _ i: Index, by distance: Int, limitedBy limit: Index
+    ) -> Index? {
+    assert(distance > 0)
+    assert(limit < i)
+
+    if i == endIndex {
+      // Advance `base.endIndex` by `distance - 1`, because the index before
+      // `endIndex` also has `base.endIndex` as its upper bound.
+      //
+      // Advancing by 4:
+      //
+      //  input: [x x x x x x x x x x]  (`endIndex`)
+      //             |< < < < <|< < <|
+      // output: [x x|x x x x x|x x x]
+
+      guard let upperBound = base.index(
+              base.endIndex,
+              offsetBy: -(distance - 1),
+              limitedBy: limit.upperBound)
+      else { return nil }
+
+      return Index(
+        lowerBound: base.index(upperBound, offsetBy: -windowSize),
+        upperBound: upperBound)
+    } else if distance >= windowSize {
+      // Avoid traversing `self[i.lowerBound..<i.upperBound]` when the upper
+      // bound of the output is less than or equal to the lower bound of the
+      // input.
+      //
+      //  input: [x x x x x x x|x x x x|x]
+      //           |< < < <|< <|
+      // output: [x|x x x x|x x x x x x x]
+
+      guard limit.upperBound <= i.lowerBound,
+            let upperBound = base.index(
+              i.lowerBound,
+              offsetBy: -(distance - windowSize),
+              limitedBy: limit.upperBound)
+      else { return nil }
+
+      return Index(
+        lowerBound: base.index(upperBound, offsetBy: -windowSize),
+        upperBound: upperBound)
+    } else {
+      //  input: [x x x x x|x x x x x x|x]
+      //           |< < < <|   |< < < <|
+      // output: [x|x x x x x x|x x x x x]
+
+      guard let lowerBound = base.index(
+              i.lowerBound,
+              offsetBy: -distance,
+              limitedBy: limit.lowerBound)
+      else { return nil }
+
+      return Index(
+        lowerBound: lowerBound,
+        upperBound: base.index(i.lowerBound, offsetBy: -distance))
+    }
+  }
+
+  func distance(from start: Index, to end: Index) -> Int {
+    guard start <= end else { return -distance(from: end, to: start) }
+    guard start != end else { return 0 }
+    guard end != endIndex else {
+      // We add 1 here because the index before `endIndex` also has
+      // `base.endIndex` as its upper bound.
+      return base[start.upperBound...].count + 1
+    }
+
+    if start.upperBound <= end.lowerBound {
+      // The distance between `start.lowerBound` and `start.upperBound` is
+      // already known.
+      //
+      // start: [x|x x x x|x x x x x x x]
+      //          |- - - -|> >|
+      //   end: [x x x x x x x|x x x x|x]
+
+      return windowSize + base[start.upperBound..<end.lowerBound].count
+    } else {
+      // start: [x|x x x x x x|x x x x x]
+      //          |> > > >|
+      //   end: [x x x x x|x x x x x x|x]
+
+      return base[start.lowerBound..<end.lowerBound].count
+    }
+  }
+}
+
+extension WindowsOfCountCollection: BidirectionalCollection
+  where Base: BidirectionalCollection
+{
+  func index(before index: Index) -> Index {
+    precondition(index != startIndex, "Incrementing past start index")
+    if index == endIndex {
+      return Index(
+        lowerBound: base.index(index.lowerBound, offsetBy: -windowSize),
+        upperBound: index.upperBound
+      )
+    } else {
+      return Index(
+        lowerBound: base.index(before: index.lowerBound),
+        upperBound: base.index(before: index.upperBound)
+      )
+    }
+  }
+}
+
+extension WindowsOfCountCollection: RandomAccessCollection
+  where Base: RandomAccessCollection {}
+
+extension WindowsOfCountCollection: LazySequenceProtocol, LazyCollectionProtocol
+  where Base: LazySequenceProtocol {}
+
+extension WindowsOfCountCollection.Index: Hashable where Base.Index: Hashable {}

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SourceKittenFramework
+import SwiftSyntax
 
-public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct CommaRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule, SourceKitFreeRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -24,7 +25,21 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
             Example("func abc(a: String↓ ,b: String↓ ,c: String↓ ,d: String) { }"),
             Example("abc(a: \"string\"↓,b: \"string\""),
             Example("enum a { case a↓ ,b }"),
-            Example("let result = plus(\n    first: 3↓ , // #683\n    second: 4\n)\n")
+            Example("let result = plus(\n    first: 3↓ , // #683\n    second: 4\n)\n"),
+            Example("""
+            Foo(
+              parameter: a.b.c,
+              tag: a.d,
+              value: a.identifier.flatMap { Int64($0) }↓ ,
+              reason: Self.abcd()
+            )
+            """),
+            Example("""
+            return Foo(bar: .baz, title: fuzz,
+                      message: My.Custom.message↓ ,
+                      another: parameter, doIt: true,
+                      alignment: .center)
+            """)
         ],
         corrections: [
             Example("func abc(a: String↓,b: String) {}\n"): Example("func abc(a: String, b: String) {}\n"),
@@ -32,7 +47,33 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
             Example("abc(a: \"string\"↓  ,  b: \"string\"\n"): Example("abc(a: \"string\", b: \"string\"\n"),
             Example("enum a { case a↓  ,b }\n"): Example("enum a { case a, b }\n"),
             Example("let a = [1↓,1]\nlet b = 1\nf(1, b)\n"): Example("let a = [1, 1]\nlet b = 1\nf(1, b)\n"),
-            Example("let a = [1↓,1↓,1↓,1]\n"): Example("let a = [1, 1, 1, 1]\n")
+            Example("let a = [1↓,1↓,1↓,1]\n"): Example("let a = [1, 1, 1, 1]\n"),
+            Example("""
+            Foo(
+              parameter: a.b.c,
+              tag: a.d,
+              value: a.identifier.flatMap { Int64($0) }↓ ,
+              reason: Self.abcd()
+            )
+            """): Example("""
+                Foo(
+                  parameter: a.b.c,
+                  tag: a.d,
+                  value: a.identifier.flatMap { Int64($0) },
+                  reason: Self.abcd()
+                )
+                """),
+            Example("""
+            return Foo(bar: .baz, title: fuzz,
+                      message: My.Custom.message↓ ,
+                      another: parameter, doIt: true,
+                      alignment: .center)
+            """): Example("""
+                return Foo(bar: .baz, title: fuzz,
+                          message: My.Custom.message,
+                          another: parameter, doIt: true,
+                          alignment: .center)
+                """)
         ]
     )
 
@@ -40,86 +81,75 @@ public struct CommaRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
         return violationRanges(in: file).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
-                           location: Location(file: file, characterOffset: $0.location))
+                           location: Location(file: file, byteOffset: $0.0.location))
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
-        return (violationRange, ", ")
+    private func violationRanges(in file: SwiftLintFile) -> [(ByteRange, shouldAddSpace: Bool)] {
+        guard let syntaxTree = file.syntaxTree else {
+            return []
+        }
+
+        return Array(syntaxTree.tokens)
+            .windows(ofCount: 3)
+            .compactMap { subsequence -> (ByteRange, shouldAddSpace: Bool)? in
+                let previous = subsequence[subsequence.startIndex]
+                let current = subsequence[subsequence.startIndex + 1]
+                let next = subsequence[subsequence.startIndex + 2]
+
+                if current.tokenKind != .comma {
+                    return nil
+                } else if !previous.trailingTrivia.isEmpty {
+                    let start = ByteCount(previous.endPositionBeforeTrailingTrivia)
+                    let end = ByteCount(current.endPosition)
+                    let nextIsNewline = next.leadingTrivia.containsNewlines()
+                    return (ByteRange(location: start, length: end - start), shouldAddSpace: !nextIsNewline)
+                } else if current.trailingTrivia != [.spaces(1)] && !next.leadingTrivia.containsNewlines() {
+                    return (ByteRange(location: ByteCount(current.position), length: 1), shouldAddSpace: true)
+                } else {
+                    return nil
+                }
+            }
     }
 
-    // captures spaces and comma only
-    // http://userguide.icu-project.org/strings/regexp
-
-    private static let mainPatternGroups =
-        "(" +                  // start first capure
-        "\\s+" +               // followed by whitespace
-        "," +                  // to the left of a comma
-        "[\\t\\p{Z}]*" +       // followed by any amount of tab or space.
-        "|" +                  // or
-        "," +                  // immediately followed by a comma
-        "(?:[\\t\\p{Z}]{0}|" + // followed by 0
-        "[\\t\\p{Z}]{2,})" +   // or 2+ tab or space characters.
-        ")" +                  // end capture
-        "(\\S)"                // second capture is not whitespace.
-
-    private static let pattern =
-        "\\S\(mainPatternGroups)" + // Regexp will match if expression not begin with comma
-        "|" +                       // or
-        "\(mainPatternGroups)"      // Regexp will match if expression begins with comma
-
-    private static let regularExpression = regex(pattern, options: [])
-    private static let excludingSyntaxKindsForFirstCapture = SyntaxKind.commentAndStringKinds.union([.objectLiteral])
-    private static let excludingSyntaxKindsForSecondCapture = SyntaxKind.commentKinds.union([.objectLiteral])
-
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        let contents = file.stringView
-        let range = contents.range
-        let syntaxMap = file.syntaxMap
-        return Self.regularExpression
-            .matches(in: contents, options: [], range: range)
-            .compactMap { match -> NSRange? in
-                if match.numberOfRanges != 5 { return nil } // Number of Groups in regexp
-
-                var indexStartRange = 1
-                if match.range(at: indexStartRange).location == NSNotFound {
-                    indexStartRange += 2
+    public func correct(file: SwiftLintFile) -> [Correction] {
+        let initialNSRanges = Dictionary(
+            uniqueKeysWithValues: violationRanges(in: file)
+                .compactMap { byteRange, shouldAddSpace in
+                    file.stringView
+                        .byteRangeToNSRange(byteRange)
+                        .flatMap { ($0, shouldAddSpace) }
                 }
+        )
 
-                // check first captured range
-                let firstRange = match.range(at: indexStartRange)
-                guard let matchByteFirstRange = contents
-                    .NSRangeToByteRange(start: firstRange.location, length: firstRange.length)
-                    else { return nil }
+        let violatingRanges = file.ruleEnabled(violatingRanges: Array(initialNSRanges.keys), for: self)
+        guard violatingRanges.isNotEmpty else { return [] }
 
-                // first captured range won't match kinds if it is not comment neither string
-                let firstCaptureIsCommentOrString = syntaxMap.kinds(inByteRange: matchByteFirstRange)
-                    .contains(where: Self.excludingSyntaxKindsForFirstCapture.contains)
-                if firstCaptureIsCommentOrString {
-                    return nil
-                }
+        let description = Self.description
+        var corrections = [Correction]()
+        var contents = file.contents
+        for range in violatingRanges.sorted(by: { $0.location > $1.location }) {
+            let contentsNSString = contents.bridge()
+            let shouldAddSpace = initialNSRanges[range] ?? true
+            contents = contentsNSString.replacingCharacters(in: range, with: ",\(shouldAddSpace ? " " : "")")
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: description, location: location))
+        }
 
-                // If the first range does not start with comma, it already violates this rule
-                // no matter what is contained in the second range.
-                if !contents.substring(with: firstRange).hasPrefix(", ") {
-                    return firstRange
-                }
+        file.write(contents)
+        return corrections
+    }
+}
 
-                // check second captured range
-                let secondRange = match.range(at: indexStartRange + 1)
-                guard let matchByteSecondRange = contents
-                    .NSRangeToByteRange(start: secondRange.location, length: secondRange.length)
-                    else { return nil }
-
-                // second captured range won't match kinds if it is not comment
-                let secondCaptureIsComment = syntaxMap.kinds(inByteRange: matchByteSecondRange)
-                    .contains(where: Self.excludingSyntaxKindsForSecondCapture.contains)
-                if secondCaptureIsComment {
-                    return nil
-                }
-
-                // return first captured range
-                return firstRange
+private extension Trivia {
+    func containsNewlines() -> Bool {
+        contains { piece in
+            switch piece {
+            case .newlines:
+                return true
+            default:
+                return false
             }
+        }
     }
 }

--- a/script/oss-check
+++ b/script/oss-check
@@ -272,7 +272,7 @@ def set_globals
     end
   end.compact.sort
   # True iff the only Swift files that were changed are SwiftLint rules, and that number is one or greater
-  @only_rules_changed = !@rules_changed.empty? && @changed_swift_files.count == @rules_changed.count
+  @only_rules_changed = true
 end
 
 def print_rules_changed

--- a/script/oss-check
+++ b/script/oss-check
@@ -272,7 +272,7 @@ def set_globals
     end
   end.compact.sort
   # True iff the only Swift files that were changed are SwiftLint rules, and that number is one or greater
-  @only_rules_changed = true
+  @only_rules_changed = !@rules_changed.empty? && @changed_swift_files.count == @rules_changed.count
 end
 
 def print_rules_changed


### PR DESCRIPTION
Making it about 10x faster, finding some previously missed cases and fixing some previously wrong corrections.

This pulls in the `Collection.windows(ofCount:)` function from Swift Algorithms.