### PR TITLE
Verify examples in rules by default and enforce explicit exclusion

### DIFF
--- a/.sourcery/AutomaticRuleTests.stencil
+++ b/.sourcery/AutomaticRuleTests.stencil
@@ -3,7 +3,8 @@ import XCTest
 
 // swiftlint:disable file_length single_test_class type_name
 
-{% for rule in types.structs|based:"AutomaticTestableRule" %}
+{% for rule in types.structs|!based:"ManuallyTestedExamplesRule" %}
+{% if rule.name|hasSuffix:"Rule" %}
 class {{ rule.name }}Tests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule({{ rule.name }}.description)
@@ -11,4 +12,6 @@ class {{ rule.name }}Tests: XCTestCase {
 }
 {% if not forloop.last %}
 
-{% endif %}{% endfor %}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   completely removed. Use `--fix` instead.  
   [JP Simard](https://github.com/jpsim)
 
+* Verify examples in rule descriptions by default and enforce explicit exclusion.
+  In fact, the `AutomaticTestableRule` protocol has been removed. All rules not
+  conforming to the new `ManuallyTestedExamplesRule` will be tested automatically.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 #### Experimental
 
 * None.

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.7.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.8.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Models/RuleDescription.swift
+++ b/Source/SwiftLintFramework/Models/RuleDescription.swift
@@ -18,8 +18,9 @@ public struct RuleDescription: Equatable {
     /// users of various samples of code that are considered valid by this rule. Should be valid Swift syntax but is not
     /// required to compile.
     ///
-    /// These examples are also used for testing purposes if the rule conforms to `AutomaticTestableRule`. Tests will
-    /// validate that the rule does not trigger any violations for these examples.
+    /// These examples are also used for automatic testing purposes if the rule does not conform to
+    /// `ManuallyTestedExamplesRule`. Tests will validate that the rule does not trigger any violations for these
+    /// examples.
     public let nonTriggeringExamples: [Example]
 
     /// Swift source examples that do trigger one or more violations for this rule. Used for documentation purposes to
@@ -28,8 +29,9 @@ public struct RuleDescription: Equatable {
     ///
     /// Violations should occur where `↓` markers are located.
     ///
-    /// These examples are also used for testing purposes if the rule conforms to `AutomaticTestableRule`. Tests will
-    /// validate that the rule triggers violations for these examples wherever `↓` markers are located.
+    /// These examples are also used for automatic testing purposes if the rule does not conform to
+    /// `ManuallyTestedExamplesRule`. Tests will validate that the rule triggers violations for these examples
+    /// wherever `↓` markers are located.
     public let triggeringExamples: [Example]
 
     /// Pairs of Swift source examples, where keys are examples that trigger violations for this rule, and the values

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -89,8 +89,8 @@ extension Rule {
 /// A rule that is not enabled by default. Rules conforming to this need to be explicitly enabled by users.
 public protocol OptInRule: Rule {}
 
-/// A rule that has unit tests automatically generated using Sourcery.
-public protocol AutomaticTestableRule: Rule {}
+/// A rule that does not automatically generate unit tests for its examples.
+public protocol ManuallyTestedExamplesRule: Rule {}
 
 /// A rule that is user-configurable.
 public protocol ConfigurationProviderRule: Rule {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct AnonymousArgumentInMultilineClosureRule: ASTRule, OptInRule, ConfigurationProviderRule,
-                                                       AutomaticTestableRule {
+public struct AnonymousArgumentInMultilineClosureRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct BlockBasedKVORule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ConvenienceTypeRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct DiscouragedAssertRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DiscouragedAssertRule: ASTRule, OptInRule, ConfigurationProviderRule {
     // MARK: - Properties
 
     public var configuration = SeverityConfiguration(.warning)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedNoneNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedNoneNameRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct DiscouragedNoneNameRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DiscouragedNoneNameRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
     public static var description = RuleDescription(
         identifier: "discouraged_none_name",

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -1,4 +1,4 @@
-public struct DiscouragedObjectLiteralRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct DiscouragedObjectLiteralRule: ASTRule, OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = ObjectLiteralConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DuplicateImportsRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct DuplicateImportsRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     // List of all possible import kinds

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private typealias SourceKittenElement = SourceKittenDictionary
 
-public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ExplicitEnumRawValueRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, OptInRule,
-                                AutomaticTestableRule {
+public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
+public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = ExplicitTypeInterfaceConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FallthroughRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct FallthroughRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct FatalErrorMessageRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameNoSpaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameNoSpaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileNameNoSpaceRule: ConfigurationProviderRule, OptInRule {
+public struct FileNameNoSpaceRule: ConfigurationProviderRule, OptInRule, ManuallyTestedExamplesRule {
     public var configuration = FileNameNoSpaceConfiguration(
         severity: .warning,
         excluded: []

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -14,7 +14,7 @@ private extension SourceKittenDictionary {
     }
 }
 
-public struct FileNameRule: ConfigurationProviderRule, OptInRule {
+public struct FileNameRule: ConfigurationProviderRule, OptInRule, ManuallyTestedExamplesRule {
     public var configuration = FileNameConfiguration(
         severity: .warning,
         excluded: ["main.swift", "LinuxMain.swift"],

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ForWhereRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ForWhereRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceCastRule.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct ForceCastRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct ForceCastRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ForceTryRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct ForceTryRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ForceUnwrappingRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct FunctionDefaultParameterAtEndRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule {
+public struct GenericTypeNameRule: ASTRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = NameConfiguration(minLengthWarning: 1,
                                                  minLengthError: 0,
                                                  maxLengthWarning: 20,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRule, OptInRule {
+public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRule, OptInRule,
+                                               ManuallyTestedExamplesRule {
     public var configuration = ImplicitlyUnwrappedOptionalConfiguration(mode: .allExceptIBOutlets,
                                                                         severity: SeverityConfiguration(.warning))
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/IsDisjointRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/IsDisjointRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct IsDisjointRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct IsDisjointRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct JoinedDefaultParameterRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, OptInRule,
-                                          AutomaticTestableRule {
+public struct JoinedDefaultParameterRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyCGGeometryFunctionsRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyConstantRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyConstructorRule: ASTRule, CorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct LegacyHashingRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyHashingRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyNSGeometryFunctionsRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -29,7 +29,7 @@ private let legacyObjcTypes = [
     "NSUUID"
 ]
 
-public struct LegacyObjcTypeRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyObjcTypeRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
@@ -1,4 +1,4 @@
-public struct LegacyRandomRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LegacyRandomRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, CorrectableRule, AutomaticTestableRule {
+public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, CorrectableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct NoExtensionAccessModifierRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NoExtensionAccessModifierRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NoFallthroughOnlyRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule {
+public struct ObjectLiteralRule: ASTRule, ConfigurationProviderRule, OptInRule, ManuallyTestedExamplesRule {
     public var configuration = ObjectLiteralConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct PatternMatchingKeywordsRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PreferNimbleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PreferNimbleRule.swift
@@ -1,4 +1,4 @@
-public struct PreferNimbleRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct PreferNimbleRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct PreferZeroOverExplicitInitRule: OptInRule, ConfigurationProviderRule, SubstitutionCorrectableRule,
-                                              AutomaticTestableRule {
+public struct PreferZeroOverExplicitInitRule: OptInRule, ConfigurationProviderRule, SubstitutionCorrectableRule {
     public var configuration = SeverityConfiguration(.warning)
     private var pattern: String {
         let zero = "\\s*:\\s*0(\\.0*)?\\s*"

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
+public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, SubstitutionCorrectableRule,
+                                          ManuallyTestedExamplesRule {
     public var configuration = PrivateOverFilePrivateRuleConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantNilCoalescingRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule,
-                                          AutomaticTestableRule {
+public struct RedundantNilCoalescingRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -4,8 +4,7 @@ import SourceKittenFramework
 private let kindsImplyingObjc: Set<SwiftDeclarationAttributeKind> =
     [.ibaction, .iboutlet, .ibinspectable, .gkinspectable, .ibdesignable, .nsManaged]
 
-public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
-    AutomaticTestableRule {
+public struct RedundantObjcAttributeRule: SubstitutionCorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule,
-                                                   AutomaticTestableRule {
+public struct RedundantOptionalInitializationRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct RedundantSetAccessControlRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct RedundantSetAccessControlRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -10,7 +10,7 @@ private func children(of dict: SourceKittenDictionary,
     }
 }
 
-public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct RedundantStringEnumValueRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule,
-                                           ConfigurationProviderRule, AutomaticTestableRule {
+public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public static let description = RuleDescription(

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableASTRule,
-                                       AutomaticTestableRule {
+public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableASTRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct ReturnValueFromVoidFunctionRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ReturnValueFromVoidFunctionRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct StaticOperatorRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct SyntacticSugarRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct SyntacticSugarRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ToggleBoolRule: SubstitutionCorrectableRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ToggleBoolRule: SubstitutionCorrectableRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TrailingSemicolonRule: SubstitutionCorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct TrailingSemicolonRule: SubstitutionCorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TypeNameRule: ASTRule, ConfigurationProviderRule {
+public struct TypeNameRule: ASTRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = NameConfiguration(minLengthWarning: 3,
                                                  minLengthError: 0,
                                                  maxLengthWarning: 40,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableConditionRule.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct UnavailableConditionRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct UnavailableConditionRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct UnavailableFunctionRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -12,7 +12,7 @@ private func embedInSwitch(
         }
         """, file: file, line: line)
 }
-public struct UnneededBreakInSwitchRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct UnneededBreakInSwitchRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct UnusedEnumeratedRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct VoidFunctionInTernaryConditionRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct VoidFunctionInTernaryConditionRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct XCTFailMessageRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct XCTFailMessageRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct XCTSpecificMatcherRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct XCTSpecificMatcherRule: ASTRule, OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -9,7 +9,7 @@ import SourceKittenFramework
 /// Known false negatives for Images declared as instance variables and containers that provide a label but are
 /// not accessibility elements. Known false positives for Images created in a separate function from where they
 /// have accessibility properties applied.
-public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule, OptInRule {
+public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct AnyObjectProtocolRule: SubstitutionCorrectableASTRule, OptInRule,
-                                     ConfigurationProviderRule, AutomaticTestableRule {
+public struct AnyObjectProtocolRule: SubstitutionCorrectableASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ArrayInitRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct BalancedXCTestLifecycleRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct BalancedXCTestLifecycleRule: Rule, OptInRule, ConfigurationProviderRule {
     // MARK: - Properties
 
     public var configuration = SeverityConfiguration(.warning)

--- a/Source/SwiftLintFramework/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CaptureVariableRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct CaptureVariableRule: AutomaticTestableRule, ConfigurationProviderRule, AnalyzerRule, CollectingRule {
+public struct CaptureVariableRule: ConfigurationProviderRule, AnalyzerRule, CollectingRule {
     public struct Variable: Hashable {
         let usr: String
         let offset: ByteCount

--- a/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ClassDelegateProtocolRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -1,9 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct CommentSpacingRule: ConfigurationProviderRule,
-                                  SubstitutionCorrectableRule,
-                                  AutomaticTestableRule {
+public struct CommentSpacingRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule {
+public struct CompilerProtocolInitRule: ASTRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DeploymentTargetRule: ConfigurationProviderRule {
+public struct DeploymentTargetRule: ConfigurationProviderRule, ManuallyTestedExamplesRule {
     private typealias Version = DeploymentTargetConfiguration.Version
     public var configuration = DeploymentTargetConfiguration()
 

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule,
+public struct DiscardedNotificationCenterObserverRule: ASTRule, ConfigurationProviderRule,
     OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -1,4 +1,4 @@
-public struct DiscouragedDirectInitRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DiscouragedDirectInitRule: ASTRule, ConfigurationProviderRule {
     public var configuration = DiscouragedDirectInitConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct DuplicateEnumCasesRule: ConfigurationProviderRule, ASTRule, AutomaticTestableRule {
+public struct DuplicateEnumCasesRule: ConfigurationProviderRule, ASTRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct DuplicatedKeyInDictionaryLiteralRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DuplicatedKeyInDictionaryLiteralRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct DynamicInlineRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
     enum ExpiryViolationLevel {
         case approachingExpiry
         case expired

--- a/Source/SwiftLintFramework/Rules/Lint/IBInspectableInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IBInspectableInExtensionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct IBInspectableInExtensionRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct IBInspectableInExtensionRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct InertDeferRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct InertDeferRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MarkRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -33,7 +33,7 @@ private extension SwiftLintFile {
     }
 }
 
-public struct MissingDocsRule: OptInRule, ConfigurationProviderRule {
+public struct MissingDocsRule: OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public init() {
         configuration = MissingDocsRuleConfiguration()
     }

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringKeyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringKeyRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct NSLocalizedStringKeyRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NSLocalizedStringKeyRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -1,4 +1,4 @@
-public struct NSLocalizedStringRequireBundleRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NSLocalizedStringRequireBundleRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NSObjectPreferIsEqualRule: Rule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct NotificationCenterDetachmentRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct OrphanedDocCommentRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct OrphanedDocCommentRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptInRule, AutomaticTestableRule {
+public struct OverriddenSuperCallRule: ConfigurationProviderRule, ASTRule, OptInRule {
     public var configuration = OverriddenSuperCallConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct PrivateActionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct PrivateActionRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct PrivateOutletRule: ASTRule, OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = PrivateOutletRuleConfiguration(allowPrivateSet: false)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateSubjectRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateSubjectRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct PrivateSubjectRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct PrivateSubjectRule: ASTRule, OptInRule, ConfigurationProviderRule {
     // MARK: - Properties
 
     public var configuration = SeverityConfiguration(.warning)

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
@@ -19,7 +19,7 @@ private extension SourceKittenDictionary {
     }
 }
 
-public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDescriptionProvider, AutomaticTestableRule {
+public struct PrivateUnitTestRule: ASTRule, ConfigurationProviderRule, CacheDescriptionProvider {
     public var configuration: PrivateUnitTestConfiguration = {
         var configuration = PrivateUnitTestConfiguration(identifier: "private_unit_test")
         configuration.message = "Unit test marked `private` will not be run by XCTest."

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, ASTRule, OptInRule, AutomaticTestableRule {
+public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, ASTRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule, AutomaticTestableRule {
+public struct ProhibitedSuperRule: ConfigurationProviderRule, ASTRule, OptInRule {
     public var configuration = ProhibitedSuperConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -1,7 +1,6 @@
 import SourceKittenFramework
 
-public struct RawValueForCamelCasedCodableEnumRule: ASTRule, OptInRule, ConfigurationProviderRule,
-    AutomaticTestableRule {
+public struct RawValueForCamelCasedCodableEnumRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredDeinitRule.swift
@@ -6,7 +6,7 @@ import SourceKittenFramework
 /// of objects and the deinit should print a message or remove its instance from a
 /// list of allocations. Even having an empty deinit method is useful to provide
 /// a place to put a breakpoint when chasing down leaks.
-public struct RequiredDeinitRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct RequiredDeinitRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public static let description = RuleDescription(

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -67,7 +67,7 @@ import SourceKittenFramework
 ///     case accountCreated
 /// }
 /// ````
-public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct RequiredEnumCaseRule: ASTRule, OptInRule, ConfigurationProviderRule {
     private typealias RequiredCase = RequiredEnumCaseRuleConfiguration.RequiredCase
 
     /// Simple representation of parsed information from the SourceKitRepresentable dictionary.

--- a/Source/SwiftLintFramework/Rules/Lint/SelfInPropertyInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SelfInPropertyInitializationRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct SelfInPropertyInitializationRule: ConfigurationProviderRule, ASTRule, AutomaticTestableRule {
+public struct SelfInPropertyInitializationRule: ConfigurationProviderRule, ASTRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct StrongIBOutletRule: ConfigurationProviderRule, ASTRule, SubstitutionCorrectableASTRule, OptInRule,
-    AutomaticTestableRule {
+public struct StrongIBOutletRule: ConfigurationProviderRule, ASTRule, SubstitutionCorrectableASTRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
@@ -1,4 +1,4 @@
-public struct SuperfluousDisableCommandRule: ConfigurationProviderRule {
+public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TestCaseAccessibilityRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule,
+public struct TestCaseAccessibilityRule: Rule, OptInRule, ConfigurationProviderRule,
                                          SubstitutionCorrectableRule {
     public var configuration = TestCaseAccessibilityConfiguration()
 

--- a/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
@@ -8,7 +8,7 @@ public extension SyntaxKind {
     }
 }
 
-public struct TodoRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct TodoRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TypesafeArrayInitRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct UnownedVariableCaptureRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedCaptureListRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct UnusedCaptureListRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule,
-                                          AutomaticTestableRule {
+public struct UnusedClosureParameterRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule,
-                                          AutomaticTestableRule {
+public struct UnusedControlFlowLabelRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedDeclarationRule: AutomaticTestableRule, ConfigurationProviderRule, AnalyzerRule, CollectingRule {
+public struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, CollectingRule {
     public struct FileUSRs: Hashable {
         var referenced: Set<String>
         var declared: Set<DeclaredUSR>

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private let moduleToLog = ProcessInfo.processInfo.environment["SWIFTLINT_LOG_MODULE_USAGE"]
 
-public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule, AutomaticTestableRule {
+public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
     public var configuration = UnusedImportConfiguration(severity: .warning, requireExplicitImports: false,
                                                          allowedTransitiveImports: [], alwaysKeepImports: [])
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedSetterValueRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct UnusedSetterValueRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     private static let supportedTypes = Self.createSupportedTypes()

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct WeakDelegateRule: OptInRule, ASTRule, SubstitutionCorrectableASTRule, ConfigurationProviderRule,
-    AutomaticTestableRule {
+public struct WeakDelegateRule: OptInRule, ASTRule, SubstitutionCorrectableASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct YodaConditionRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ClosureBodyLengthRule: OptInRule, ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ClosureBodyLengthRule: OptInRule, ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityLevelsConfiguration(warning: 20, error: 100)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
     public var configuration = CyclomaticComplexityConfiguration(warning: 10, error: 20)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct EnumCaseAssociatedValuesLengthRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct EnumCaseAssociatedValuesLengthRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityLevelsConfiguration(warning: 5, error: 6)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FileLengthRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct FileLengthRule: ConfigurationProviderRule {
     public var configuration = FileLengthRuleConfiguration(warning: 400, error: 1000)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule {
+public struct FunctionBodyLengthRule: ASTRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = SeverityLevelsConfiguration(warning: 40, error: 100)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule {
+public struct FunctionParameterCountRule: ASTRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = FunctionParameterCountConfiguration(warning: 5, error: 8)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
@@ -10,7 +10,7 @@ private enum RangeKind {
     case generic
 }
 
-public struct LargeTupleRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LargeTupleRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityLevelsConfiguration(warning: 2, error: 3)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LineLengthRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct LineLengthRule: ConfigurationProviderRule {
     public var configuration = LineLengthConfiguration(warning: 120, error: 200)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct NestingRule: ConfigurationProviderRule {
+public struct NestingRule: ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = NestingConfiguration(typeLevelWarning: 1,
                                                     typeLevelError: nil,
                                                     functionLevelWarning: 2,

--- a/Source/SwiftLintFramework/Rules/Metrics/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/TypeBodyLengthRule.swift
@@ -12,7 +12,7 @@ private func wrapExample(
         repeatElement(template, count: count).joined() + "\(add)}\n")
 }
 
-public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct TypeBodyLengthRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityLevelsConfiguration(warning: 200, error: 350)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ContainsOverFilterCountRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ContainsOverFilterCountRule: CallPairRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ContainsOverFilterIsEmptyRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ContainsOverFilterIsEmptyRule: CallPairRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -1,6 +1,7 @@
 import SourceKittenFramework
 
-public struct ContainsOverFirstNotNilRule: CallPairRule, OptInRule, ConfigurationProviderRule {
+public struct ContainsOverFirstNotNilRule: CallPairRule, OptInRule, ConfigurationProviderRule,
+                                           ManuallyTestedExamplesRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -1,7 +1,6 @@
 import SourceKittenFramework
 
-public struct ContainsOverRangeNilComparisonRule: CallPairRule, OptInRule, ConfigurationProviderRule,
-                                                  AutomaticTestableRule {
+public struct ContainsOverRangeNilComparisonRule: CallPairRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCollectionLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCollectionLiteralRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct EmptyCollectionLiteralRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct EmptyCollectionLiteralRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct EmptyCountRule: ConfigurationProviderRule, OptInRule {
+public struct EmptyCountRule: ConfigurationProviderRule, OptInRule, ManuallyTestedExamplesRule {
     public var configuration = EmptyCountConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct EmptyStringRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct EmptyStringRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/FlatMapOverMapReduceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FlatMapOverMapReduceRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct FlatMapOverMapReduceRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct FlatMapOverMapReduceRule: CallPairRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct LastWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct LastWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct ReduceBooleanRule: Rule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ReduceBooleanRule: Rule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ReduceIntoRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ReduceIntoRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct SortedFirstLastRule: CallPairRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct SortedFirstLastRule: CallPairRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -6,7 +6,7 @@ private enum AttributesRuleError: Error {
     case moreThanOneAttributeInSameLine
 }
 
-public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = AttributesConfiguration()
 
     private static let parametersPattern = "^\\s*\\(.+\\)"

--- a/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ClosingBraceRule: SubstitutionCorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ClosingBraceRule: SubstitutionCorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ClosureParameterPositionRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -16,7 +16,7 @@ extension NSRange {
     }
 }
 
-public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule, OptInRule {
+public struct CollectionAlignmentRule: ASTRule, ConfigurationProviderRule, OptInRule, ManuallyTestedExamplesRule {
     public var configuration = CollectionAlignmentConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -2,8 +2,8 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule, AutomaticTestableRule,
-                         SourceKitFreeRule {
+public struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule, SourceKitFreeRule,
+                         ManuallyTestedExamplesRule {
     public var configuration = ColonConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/CommaInheritanceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaInheritanceRule.swift
@@ -2,8 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule,
-                                    AutomaticTestableRule {
+public struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct CommaRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule, SourceKitFreeRule {
+public struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ComputedAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ComputedAccessorsOrderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ComputedAccessorsOrderRule: ConfigurationProviderRule {
+public struct ComputedAccessorsOrderRule: ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = ComputedAccessorsOrderRuleConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, Rule, OptInRule {
+public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, OptInRule, ManuallyTestedExamplesRule {
     public var configuration = ConditionalReturnsOnNewlineConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ControlStatementRule: ConfigurationProviderRule, AutomaticTestableRule, SubstitutionCorrectableRule {
+public struct ControlStatementRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -24,7 +24,7 @@ private func wrapInFunc(_ str: String, file: StaticString = #file, line: UInt = 
     """, file: file, line: line)
 }
 
-public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct EmptyEnumArgumentsRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct EmptyParametersRule: ConfigurationProviderRule, SubstitutionCorrectableRule, AutomaticTestableRule {
+public struct EmptyParametersRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule,
-                                                       AutomaticTestableRule {
+public struct EmptyParenthesesWithTrailingClosureRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule, AutomaticTestableRule {
+public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileHeaderRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
     public var configuration = FileHeaderConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
+public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule, ManuallyTestedExamplesRule {
     private typealias FileTypeOffset = (fileType: FileType, offset: ByteCount)
 
     public var configuration = FileTypesOrderConfiguration()

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
+public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = NameConfiguration(minLengthWarning: 3,
                                                  minLengthError: 2,
                                                  maxLengthWarning: 40,

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ImplicitGetterRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct ImplicitGetterRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule, OptInRule {
+public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule, OptInRule,
+                                  ManuallyTestedExamplesRule {
     public var configuration = ImplicitReturnConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct InclusiveLanguageRule: ASTRule, ConfigurationProviderRule {
+public struct InclusiveLanguageRule: ASTRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = InclusiveLanguageConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
     // MARK: - Subtypes
     private enum Indentation: Equatable {
         case tabs(Int)

--- a/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
-                                     SourceKitFreeRule, AutomaticTestableRule {
+public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, CorrectableRule, AutomaticTestableRule {
+public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, CorrectableRule {
     public var configuration = ModifierOrderConfiguration(
         preferredModifierOrder: [
             .override,

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = MultilineArgumentsConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultilineParametersRule: ASTRule, OptInRule, ConfigurationProviderRule {
     public var configuration = MultilineParametersConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultipleClosuresWithTrailingClosureRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct MultipleClosuresWithTrailingClosureRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule,
-                                       AutomaticTestableRule {
+public struct NoSpaceInMethodCallRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProviderRule {
+public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = NumberSeparatorConfiguration(
         minimumLength: 0,
         minimumFractionLength: nil,

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -61,7 +61,7 @@ private extension SwiftLintFile {
     }
 }
 
-public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
+public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = OpeningBraceConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorFunctionWhitespaceRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -2,8 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, ConfigurationProviderRule,
-                                           AutomaticTestableRule {
+public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, ConfigurationProviderRule {
     public var configuration = OperatorUsageWhitespaceConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct OptionalEnumCaseMatchingRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule,
-                                            AutomaticTestableRule, OptInRule {
+public struct OptionalEnumCaseMatchingRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct PreferSelfInStaticReferencesRule: SubstitutionCorrectableASTRule, OptInRule, AutomaticTestableRule {
+public struct PreferSelfInStaticReferencesRule: SubstitutionCorrectableASTRule, OptInRule {
     public static let description = RuleDescription(
         identifier: "prefer_self_in_static_references",
         name: "Prefer Self in Static References",

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct PreferSelfTypeOverTypeOfSelfRule: OptInRule, ConfigurationProviderRule, SubstitutionCorrectableRule,
-                                                AutomaticTestableRule {
+public struct PreferSelfTypeOverTypeOfSelfRule: OptInRule, ConfigurationProviderRule, SubstitutionCorrectableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public static let description = RuleDescription(

--- a/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct PrefixedTopLevelConstantRule: ASTRule, OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = PrefixedConstantRuleConfiguration(onlyPrivateMembers: false)
 
     private let topLevelPrefix = "k"

--- a/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, SubstitutionCorrectableRule,
-                                                  AutomaticTestableRule {
+public struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantDiscardableLetRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
-                                           AutomaticTestableRule {
+public struct RedundantDiscardableLetRule: SubstitutionCorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct ReturnArrowWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ShorthandOperatorRule: ConfigurationProviderRule, AutomaticTestableRule {
+public struct ShorthandOperatorRule: ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public static let description = RuleDescription(

--- a/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
@@ -46,7 +46,7 @@ private extension Sequence where Element == Line {
     }
 }
 
-public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule {
+public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = StatementConfiguration(statementMode: .default,
                                                       severity: SeverityConfiguration(.warning))
 

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule {
+public struct SwitchCaseAlignmentRule: ASTRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = SwitchCaseAlignmentConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -8,7 +8,7 @@ private func wrapInSwitch(_ str: String, file: StaticString = #file, line: UInt 
     """, file: file, line: line)
 }
 
-public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptInRule, AutomaticTestableRule {
+public struct SwitchCaseOnNewlineRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
+public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = TrailingClosureConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -8,7 +8,7 @@ private enum TrailingCommaReason: String {
 
 private typealias CommaRuleViolation = (index: ByteCount, reason: TrailingCommaReason)
 
-public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct TrailingCommaRule: SubstitutionCorrectableASTRule, ConfigurationProviderRule {
     public var configuration = TrailingCommaConfiguration()
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingNewlineRule.swift
@@ -18,8 +18,7 @@ extension String {
     }
 }
 
-public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule,
-                                   SourceKitFreeRule, AutomaticTestableRule {
+public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
+public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
                                                                ignoresComments: true)
 

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
+public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule, ManuallyTestedExamplesRule {
     private typealias TypeContentOffset = (typeContent: TypeContent, offset: ByteCount)
 
     public var configuration = TypeContentsOrderConfiguration()

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, CorrectableRule, OptInRule,
-                                                        AutomaticTestableRule {
+public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, CorrectableRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct UnusedOptionalBindingRule: ASTRule, ConfigurationProviderRule {
     public var configuration = UnusedOptionalBindingConfiguration(ignoreOptionalTry: false)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -1,7 +1,6 @@
 import SourceKittenFramework
 
-public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule,
-                                                    AutomaticTestableRule {
+public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule, AutomaticTestableRule {
+public struct VerticalParameterAlignmentRule: ASTRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -137,7 +137,7 @@ public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
     }
 }
 
-extension VerticalWhitespaceBetweenCasesRule: OptInRule, AutomaticTestableRule {
+extension VerticalWhitespaceBetweenCasesRule: OptInRule {
     public static let description = RuleDescription(
         identifier: "vertical_whitespace_between_cases",
         name: "Vertical Whitespace Between Cases",

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -107,7 +107,7 @@ public struct VerticalWhitespaceClosingBracesRule: ConfigurationProviderRule {
     private let pattern = "((?:\\n[ \\t]*)+)(\\n[ \\t]*[)}\\]])"
 }
 
-extension VerticalWhitespaceClosingBracesRule: OptInRule, AutomaticTestableRule {
+extension VerticalWhitespaceClosingBracesRule: OptInRule {
     public var configurationDescription: String { return "N/A" }
 
     public init(configuration: Any) throws {}

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -142,7 +142,7 @@ public struct VerticalWhitespaceOpeningBracesRule: ConfigurationProviderRule {
     private let pattern = "([{(\\[][ \\t]*(?:[^\\n{]+ in[ \\t]*$)?)((?:\\n[ \\t]*)+)(\\n)"
 }
 
-extension VerticalWhitespaceOpeningBracesRule: OptInRule, AutomaticTestableRule {
+extension VerticalWhitespaceOpeningBracesRule: OptInRule {
     public var configurationDescription: String { return "N/A" }
 
     public init(configuration: Any) throws {}

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private let defaultDescriptionReason = "Limit vertical whitespace to a single empty line."
 
-public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
+public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule, ManuallyTestedExamplesRule {
     public var configuration = VerticalWhitespaceConfiguration(maxEmptyLines: 1)
 
     public init() {}

--- a/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule, AutomaticTestableRule {
+public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}

--- a/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
+++ b/Tests/SwiftLintFrameworkTests/AutomaticRuleTests.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.8.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import SwiftLintFramework
 import XCTest


### PR DESCRIPTION
A rule must conform to ManuallyTestedExamplesRule to skip generation of a test for its examples.

Next step would be to get rid of the ManuallyTestedExamplesRule conformances of some rules.