### PR TITLE
Remove availability check

### DIFF
--- a/Source/swiftlint/Helpers/Signposts.swift
+++ b/Source/swiftlint/Helpers/Signposts.swift
@@ -11,33 +11,32 @@ struct Signposts {
 
     static func record<R>(name: StaticString, span: Span = .timeline, body: () -> R) -> R {
 #if canImport(os)
-        if #available(OSX 10.14, *) {
-            let log: OSLog
-            let description: String?
-            switch span {
-            case .timeline:
-                log = timelineLog
-                description = nil
-            case .file(let file):
-                log = fileLog
-                description = file
-            }
-            let signpostID = OSSignpostID(log: log)
-            if let description = description {
-                os_signpost(.begin, log: log, name: name, signpostID: signpostID, "%{public}s", description)
-            } else {
-                os_signpost(.begin, log: log, name: name, signpostID: signpostID)
-            }
-
-            let result = body()
-            if let description = description {
-                os_signpost(.end, log: log, name: name, signpostID: signpostID, "%{public}s", description)
-            } else {
-                os_signpost(.end, log: log, name: name, signpostID: signpostID)
-            }
-            return result
+        let log: OSLog
+        let description: String?
+        switch span {
+        case .timeline:
+            log = timelineLog
+            description = nil
+        case .file(let file):
+            log = fileLog
+            description = file
         }
+        let signpostID = OSSignpostID(log: log)
+        if let description = description {
+            os_signpost(.begin, log: log, name: name, signpostID: signpostID, "%{public}s", description)
+        } else {
+            os_signpost(.begin, log: log, name: name, signpostID: signpostID)
+        }
+
+        let result = body()
+        if let description = description {
+            os_signpost(.end, log: log, name: name, signpostID: signpostID, "%{public}s", description)
+        } else {
+            os_signpost(.end, log: log, name: name, signpostID: signpostID)
+        }
+        return result
+#else
+        return try body()
 #endif
-        return body()
     }
 }


### PR DESCRIPTION
Since SwiftLint now requires macOS 12 or higher to run.