### PR TITLE
Remove uses of `Result` in CLI target

### DIFF
--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -18,7 +18,7 @@ extension SwiftLint {
         @Argument(help: pathsArgumentDescription(for: .analyze))
         var paths = [String]()
 
-        mutating func run() throws {
+        func run() throws {
             let allPaths: [String]
             if let path = path {
                 queuedPrintError("""
@@ -53,13 +53,7 @@ extension SwiftLint {
                 inProcessSourcekit: common.inProcessSourcekit
             )
 
-            let result = LintOrAnalyzeCommand.run(options)
-            switch result {
-            case .success:
-                return
-            case .failure(let error):
-                throw error
-            }
+            try LintOrAnalyzeCommand.run(options)
         }
     }
 }

--- a/Source/swiftlint/Commands/Docs.swift
+++ b/Source/swiftlint/Commands/Docs.swift
@@ -7,7 +7,7 @@ extension SwiftLint {
             abstract: "Open SwiftLint documentation website in the default web browser"
         )
 
-        mutating func run() throws {
+        func run() throws {
             open(URL(string: "https://realm.github.io/SwiftLint")!)
         }
     }

--- a/Source/swiftlint/Commands/GenerateDocs.swift
+++ b/Source/swiftlint/Commands/GenerateDocs.swift
@@ -9,7 +9,7 @@ extension SwiftLint {
         @Option(help: "The directory where the documentation should be saved")
         var path = "rule_docs"
 
-        mutating func run() throws {
+        func run() throws {
             try RuleListDocumentation(primaryRuleList)
                 .write(to: URL(fileURLWithPath: path, isDirectory: true))
         }

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -22,7 +22,7 @@ extension SwiftLint {
         @Argument(help: pathsArgumentDescription(for: .lint))
         var paths = [String]()
 
-        mutating func run() throws {
+        func run() throws {
             let allPaths: [String]
             if let path = path {
                 queuedPrintError("""
@@ -56,13 +56,7 @@ extension SwiftLint {
                 compileCommands: nil,
                 inProcessSourcekit: common.inProcessSourcekit
             )
-            let result = LintOrAnalyzeCommand.run(options)
-            switch result {
-            case .success:
-                return
-            case .failure(let error):
-                throw error
-            }
+            try LintOrAnalyzeCommand.run(options)
         }
     }
 }

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -37,7 +37,7 @@ extension SwiftLint {
         @Argument(help: "The rule identifier to display description for")
         var ruleID: String?
 
-        mutating func run() throws {
+        func run() throws {
             if let ruleID = ruleID {
                 guard let rule = primaryRuleList.list[ruleID] else {
                     throw SwiftLintError.usageError(description: "No rule with identifier: \(ruleID)")

--- a/Source/swiftlint/Commands/Version.swift
+++ b/Source/swiftlint/Commands/Version.swift
@@ -7,7 +7,7 @@ extension SwiftLint {
 
         static var value: String { SwiftLintFramework.Version.current.value }
 
-        mutating func run() throws {
+        func run() throws {
             print(Self.value)
         }
     }

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -47,7 +47,7 @@ struct LintOrAnalyzeCommand {
         let options = builder.options
         let visitorMutationQueue = DispatchQueue(label: "io.realm.swiftlint.lintVisitorMutation")
         return try builder.configuration.visitLintableFiles(options: options, cache: builder.cache,
-                                                                  storage: builder.storage) { linter in
+                                                            storage: builder.storage) { linter in
             let currentViolations: [StyleViolation]
             if options.benchmark {
                 let start = Date()

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -26,27 +26,28 @@ enum LintOrAnalyzeMode {
 }
 
 struct LintOrAnalyzeCommand {
-    static func run(_ options: LintOrAnalyzeOptions) -> Result<(), SwiftLintError> {
+    static func run(_ options: LintOrAnalyzeOptions) throws {
         if options.inProcessSourcekit {
             SourceKittenConfiguration.preferInProcessSourceKit = true
         }
-        return Signposts.record(name: "LintOrAnalyzeCommand.run") {
-            options.autocorrect ? autocorrect(options) : lintOrAnalyze(options)
+        try Signposts.record(name: "LintOrAnalyzeCommand.run") {
+            try options.autocorrect ? autocorrect(options) : lintOrAnalyze(options)
         }
     }
 
-    private static func lintOrAnalyze(_ options: LintOrAnalyzeOptions) -> Result<(), SwiftLintError> {
+    private static func lintOrAnalyze(_ options: LintOrAnalyzeOptions) throws {
         let builder = LintOrAnalyzeResultBuilder(options)
-        return collectViolations(builder: builder)
-            .flatMap { postProcessViolations(files: $0, builder: builder) }
+        let files = try collectViolations(builder: builder)
+        try Signposts.record(name: "LintOrAnalyzeCommand.PostProcessViolations") {
+            try postProcessViolations(files: files, builder: builder)
+        }
     }
 
-    private static func collectViolations(builder: LintOrAnalyzeResultBuilder)
-        -> Result<[SwiftLintFile], SwiftLintError> {
+    private static func collectViolations(builder: LintOrAnalyzeResultBuilder) throws -> [SwiftLintFile] {
         let options = builder.options
         let visitorMutationQueue = DispatchQueue(label: "io.realm.swiftlint.lintVisitorMutation")
-        return builder.configuration.visitLintableFiles(options: options, cache: builder.cache,
-                                                        storage: builder.storage) { linter in
+        return try builder.configuration.visitLintableFiles(options: options, cache: builder.cache,
+                                                                  storage: builder.storage) { linter in
             let currentViolations: [StyleViolation]
             if options.benchmark {
                 let start = Date()
@@ -70,32 +71,28 @@ struct LintOrAnalyzeCommand {
         }
     }
 
-    private static func postProcessViolations(files: [SwiftLintFile], builder: LintOrAnalyzeResultBuilder)
-        -> Result<(), SwiftLintError> {
-        return Signposts.record(name: "LintOrAnalyzeCommand.PostProcessViolations") {
-            let options = builder.options
-            let configuration = builder.configuration
-            if isWarningThresholdBroken(configuration: configuration, violations: builder.violations)
-                && !options.lenient {
-                builder.violations.append(
-                    createThresholdViolation(threshold: configuration.warningThreshold!)
-                )
-                builder.reporter.report(violations: [builder.violations.last!], realtimeCondition: true)
-            }
-            builder.reporter.report(violations: builder.violations, realtimeCondition: false)
-            let numberOfSeriousViolations = builder.violations.filter({ $0.severity == .error }).count
-            if !options.quiet {
-                printStatus(violations: builder.violations, files: files, serious: numberOfSeriousViolations,
-                            verb: options.verb)
-            }
-            if options.benchmark {
-                builder.fileBenchmark.save()
-                builder.ruleBenchmark.save()
-            }
-            try? builder.cache?.save()
-            guard numberOfSeriousViolations == 0 else { exit(2) }
-            return .success(())
+    private static func postProcessViolations(files: [SwiftLintFile], builder: LintOrAnalyzeResultBuilder) throws {
+        let options = builder.options
+        let configuration = builder.configuration
+        if isWarningThresholdBroken(configuration: configuration, violations: builder.violations)
+            && !options.lenient {
+            builder.violations.append(
+                createThresholdViolation(threshold: configuration.warningThreshold!)
+            )
+            builder.reporter.report(violations: [builder.violations.last!], realtimeCondition: true)
         }
+        builder.reporter.report(violations: builder.violations, realtimeCondition: false)
+        let numberOfSeriousViolations = builder.violations.filter({ $0.severity == .error }).count
+        if !options.quiet {
+            printStatus(violations: builder.violations, files: files, serious: numberOfSeriousViolations,
+                        verb: options.verb)
+        }
+        if options.benchmark {
+            builder.fileBenchmark.save()
+            builder.ruleBenchmark.save()
+        }
+        try builder.cache?.save()
+        guard numberOfSeriousViolations == 0 else { exit(2) }
     }
 
     private static func printStatus(violations: [StyleViolation], files: [SwiftLintFile], serious: Int, verb: String) {
@@ -157,32 +154,32 @@ struct LintOrAnalyzeCommand {
         }
     }
 
-    private static func autocorrect(_ options: LintOrAnalyzeOptions) -> Result<(), SwiftLintError> {
+    private static func autocorrect(_ options: LintOrAnalyzeOptions) throws {
         let storage = RuleStorage()
         let configuration = Configuration(options: options)
-        return configuration.visitLintableFiles(options: options, cache: nil, storage: storage) { linter in
-            if options.format {
-                switch configuration.indentation {
-                case .tabs:
-                    linter.format(useTabs: true, indentWidth: 4)
-                case .spaces(let count):
-                    linter.format(useTabs: false, indentWidth: count)
+        let files = try configuration
+            .visitLintableFiles(options: options, cache: nil, storage: storage) { linter in
+                if options.format {
+                    switch configuration.indentation {
+                    case .tabs:
+                        linter.format(useTabs: true, indentWidth: 4)
+                    case .spaces(let count):
+                        linter.format(useTabs: false, indentWidth: count)
+                    }
+                }
+
+                let corrections = linter.correct(using: storage)
+                if !corrections.isEmpty && !options.quiet {
+                    let correctionLogs = corrections.map({ $0.consoleDescription })
+                    queuedPrint(correctionLogs.joined(separator: "\n"))
                 }
             }
 
-            let corrections = linter.correct(using: storage)
-            if !corrections.isEmpty && !options.quiet {
-                let correctionLogs = corrections.map({ $0.consoleDescription })
-                queuedPrint(correctionLogs.joined(separator: "\n"))
+        if !options.quiet {
+            let pluralSuffix = { (collection: [Any]) -> String in
+                return collection.count != 1 ? "s" : ""
             }
-        }.flatMap { files in
-            if !options.quiet {
-                let pluralSuffix = { (collection: [Any]) -> String in
-                    return collection.count != 1 ? "s" : ""
-                }
-                queuedPrintError("Done inspecting \(files.count) file\(pluralSuffix(files)) for auto-correction!")
-            }
-            return .success(())
+            queuedPrintError("Done inspecting \(files.count) file\(pluralSuffix(files)) for auto-correction!")
         }
     }
 }

--- a/Source/swiftlint/Helpers/Signposts.swift
+++ b/Source/swiftlint/Helpers/Signposts.swift
@@ -9,7 +9,7 @@ struct Signposts {
         case timeline, file(String)
     }
 
-    static func record<R>(name: StaticString, span: Span = .timeline, body: () -> R) -> R {
+    static func record<R>(name: StaticString, span: Span = .timeline, body: () throws -> R) rethrows -> R {
 #if canImport(os)
         let log: OSLog
         let description: String?
@@ -28,7 +28,7 @@ struct Signposts {
             os_signpost(.begin, log: log, name: name, signpostID: signpostID)
         }
 
-        let result = body()
+        let result = try body()
         if let description = description {
             os_signpost(.end, log: log, name: name, signpostID: signpostID, "%{public}s", description)
         } else {


### PR DESCRIPTION
Which will make it easier to adopt some structured concurrency features in the future.