### PR TITLE
Let Sourcery always run independent of changed files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
   steps:
     - script: brew install sourcery
       displayName: Install Sourcery
-    - script: make sourcery
+    - script: make --always-make sourcery
       displayName: Generate sources
     - script: "! git diff -U0 | grep '^[-+][^-+]' | grep --invert-match '// Generated using Sourcery'"
       displayName: Check changed files ignoring Sourcery's version


### PR DESCRIPTION
See [this comment](https://github.com/realm/SwiftLint/pull/4065#discussion_r941715865). The missing test somehow got unnoticed. Always running Sourcery should make the check more trustworthy.