### PR TITLE
Skip braces in regex literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ accordingly._
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4030](https://github.com/realm/SwiftLint/issues/4030)
 
+* Skip braces in regex literals to avoid false positive in `closure_spacing` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4090](https://github.com/realm/SwiftLint/issues/4090)
+
 #### Bug Fixes
 
 * Fix false positive in `self_in_property_initialization` rule when using

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -30,7 +30,8 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
             Example("[].map ({ $0.description })"),
             Example("[].filter { $0.contains(location) }"),
             Example("extension UITableViewCell: ReusableView { }"),
-            Example("extension UITableViewCell: ReusableView {}")
+            Example("extension UITableViewCell: ReusableView {}"),
+            Example(#"let r = /\{\}/"#, excludeFromDocumentation: true)
         ],
         triggeringExamples: [
             Example("[].filter(↓{$0.contains(location)})"),
@@ -71,7 +72,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
     // returns ranges of braces `{` or `}` in the same line
     private func validBraces(in file: SwiftLintFile) -> [NSRange] {
         let nsstring = file.contents.bridge()
-        let bracePattern = regex("\\{|\\}")
+        let bracePattern = regex(#"(?<!\\)\{|(?<!\\)\}"#)
         let linesTokens = file.syntaxTokensByLines
         let kindsToExclude = SyntaxKind.commentAndStringKinds
 


### PR DESCRIPTION
This is a workaround for the false positive reported in #4090.

Regex literals will only be supported in Swift 6. For that reason, SourceKit does not yet know anything about the syntax type "Regex Literal". The correct fix would be skipping regex literals completely in the rule like it is done for strings and comments.

The lookarounds in the regex to find the braces make the rule significantly slower as we see in the report below.