### PR TITLE
Migrate ClosureSpacingRule to SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ accordingly._
 * Make `colon` rule about 7x faster, finding some previously missed cases.  
   [JP Simard](https://github.com/jpsim)
 
+* Make `closure_spacing` rule about 9x faster, finding some previously missed
+  cases and fixing some previously wrong corrections.  
+  [JP Simard](https://github.com/jpsim)
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4090](https://github.com/realm/SwiftLint/issues/4090)
+
 * Introduce new configuration option `include_compiler_directives` (`true` by
   default) for the `indentation_width` rule that allows to ignore compiler
   directives in the indentation analysis. This is especially useful if one (or

--- a/Source/SwiftLintFramework/Extensions/SourceRange+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SourceRange+SwiftLint.swift
@@ -1,0 +1,15 @@
+import SwiftSyntax
+
+extension SourceRange {
+    /// Check if a position is contained within this range.
+    ///
+    /// - parameter position:          The position to check.
+    /// - parameter locationConverter: The location converter to use to perform the check.
+    ///
+    /// - returns: Whether the specified position is contained within this range.
+    func contains(_ position: AbsolutePosition, locationConverter: SourceLocationConverter) -> Bool {
+        let startPosition = locationConverter.position(ofLine: start.line ?? 1, column: start.column ?? 1)
+        let endPosition = locationConverter.position(ofLine: end.line ?? 1, column: end.column ?? 1)
+        return startPosition <= position && position <= endPosition
+    }
+}

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -46,13 +46,11 @@ private var syntaxTreeCache = Cache({ file -> SourceFileSyntax? in
 })
 
 private var commandsCache = Cache({ file -> [Command] in
-    guard file.contents.contains("swiftlint:"), let tree = syntaxTreeCache.get(file) else {
+    guard file.contents.contains("swiftlint:"), let locationConverter = file.locationConverter else {
         return []
     }
-    let locationConverter = SourceLocationConverter(file: file.path ?? "<nopath>", tree: tree)
-
-    let visitor = CommandVisitor(locationConverter: locationConverter)
-    return visitor.walk(tree: tree, handler: \.commands)
+    return CommandVisitor(locationConverter: locationConverter)
+        .walk(file: file, handler: \.commands)
 })
 
 private var syntaxMapCache = Cache({ file in
@@ -209,6 +207,10 @@ extension SwiftLintFile {
     }
 
     internal var syntaxTree: SourceFileSyntax? { syntaxTreeCache.get(self) }
+
+    internal var locationConverter: SourceLocationConverter? {
+        syntaxTree.map { SourceLocationConverter(file: path ?? "<nopath>", tree: $0) }
+    }
 
     internal var commands: [Command] { commandsCache.get(self) }
 

--- a/Source/SwiftLintFramework/Models/Location.swift
+++ b/Source/SwiftLintFramework/Models/Location.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SourceKittenFramework
+import SwiftSyntax
 
 /// The placement of a segment of Swift in a collection of source files.
 public struct Location: CustomStringConvertible, Comparable, Codable {
@@ -46,6 +47,22 @@ public struct Location: CustomStringConvertible, Comparable, Codable {
         if let lineAndCharacter = file.stringView.lineAndCharacter(forByteOffset: offset) {
             line = lineAndCharacter.line
             character = lineAndCharacter.character
+        } else {
+            line = nil
+            character = nil
+        }
+    }
+
+    /// Creates a `Location` based on a `SwiftLintFile` and a SwiftSyntax `AbsolutePosition` into the file.
+    /// Fails if the specified offset was not a valid location in the file.
+    ///
+    /// - parameter file:     The file for this location.
+    /// - parameter position: The absolute position returned from SwiftSyntax.
+    public init(file: SwiftLintFile, position: AbsolutePosition) {
+        self.file = file.path
+        if let sourceLocation = file.locationConverter?.location(for: position) {
+            line = sourceLocation.line
+            character = sourceLocation.column
         } else {
             line = nil
             character = nil

--- a/Source/SwiftLintFramework/Models/Region.swift
+++ b/Source/SwiftLintFramework/Models/Region.swift
@@ -1,3 +1,5 @@
+import SwiftSyntax
+
 /// A contiguous region of Swift source code.
 public struct Region: Equatable {
     /// The location describing the start of the region. All locations that are less than this value
@@ -62,5 +64,22 @@ public struct Region: Equatable {
     public func deprecatedAliasesDisabling(rule: Rule) -> Set<String> {
         let identifiers = type(of: rule).description.deprecatedAliases
         return Set(disabledRuleIdentifiers.map { $0.stringRepresentation }).intersection(identifiers)
+    }
+
+    /// Converts this `Region` to a SwiftSyntax `SourceRange`.
+    ///
+    /// - parameter locationConverter: The SwiftSyntax location converter to use.
+    ///
+    /// - returns: The `SourceRange` if one was produced.
+    func toSourceRange(locationConverter: SourceLocationConverter) -> SourceRange? {
+        guard let startLine = start.line, let endLine = end.line else {
+            return nil
+        }
+
+        let startPosition = locationConverter.position(ofLine: startLine, column: min(1000, start.character ?? 1))
+        let endPosition = locationConverter.position(ofLine: endLine, column: min(1000, end.character ?? 1))
+        let startLocation = locationConverter.location(for: startPosition)
+        let endLocation = locationConverter.location(for: endPosition)
+        return SourceRange(start: startLocation, end: endLocation)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceCastRule.swift
@@ -1,4 +1,3 @@
-import SourceKittenFramework
 import SwiftSyntax
 
 public struct ForceCastRule: ConfigurationProviderRule {
@@ -18,12 +17,13 @@ public struct ForceCastRule: ConfigurationProviderRule {
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let visitor = ForceCastRuleVisitor()
-        return visitor.walk(file: file, handler: \.positions).map { position in
-            StyleViolation(ruleDescription: Self.description,
-                           severity: configuration.severity,
-                           location: Location(file: file, byteOffset: ByteCount(position)))
-        }
+        ForceCastRuleVisitor()
+            .walk(file: file, handler: \.positions)
+            .map { position in
+                StyleViolation(ruleDescription: Self.description,
+                               severity: configuration.severity,
+                               location: Location(file: file, position: position))
+            }
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -1,4 +1,3 @@
-import SourceKittenFramework
 import SwiftSyntax
 
 public struct VoidFunctionInTernaryConditionRule: ConfigurationProviderRule {
@@ -139,7 +138,7 @@ private class VoidFunctionInTernaryConditionVisitor: SyntaxVisitor {
         return positions.map { position in
             StyleViolation(ruleDescription: type(of: rule).description,
                            severity: rule.configuration.severity,
-                           location: Location(file: file, byteOffset: ByteCount(position)))
+                           location: Location(file: file, position: position))
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -1,4 +1,3 @@
-import SourceKittenFramework
 import SwiftSyntax
 
 // MARK: - ClosureSpacingRule
@@ -49,7 +48,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
             .map { position in
                 StyleViolation(ruleDescription: Self.description,
                                severity: configuration.severity,
-                               location: Location(file: file, byteOffset: ByteCount(position)))
+                               location: Location(file: file, position: position))
             }
     }
 
@@ -72,7 +71,7 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
         return rewriter.sortedPositions.map { position in
             Correction(
                 ruleDescription: Self.description,
-                location: Location(file: file, byteOffset: ByteCount(position))
+                location: Location(file: file, position: position)
             )
         }
     }

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -262,20 +262,6 @@ private extension TokenSyntax {
     }
 }
 
-private extension Region {
-    func toSourceRange(locationConverter: SourceLocationConverter) -> SourceRange? {
-        guard let startLine = start.line, let endLine = end.line else {
-            return nil
-        }
-
-        let startPosition = locationConverter.position(ofLine: startLine, column: min(1000, start.character ?? 1))
-        let endPosition = locationConverter.position(ofLine: endLine, column: min(1000, end.character ?? 1))
-        let startLocation = locationConverter.location(for: startPosition)
-        let endLocation = locationConverter.location(for: endPosition)
-        return SourceRange(start: startLocation, end: endLocation)
-    }
-}
-
 private extension SourceRange {
     func contains(_ position: AbsolutePosition, locationConverter: SourceLocationConverter) -> Bool {
         contains(locationConverter.location(for: position))

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -135,7 +135,8 @@ private extension TokenSyntax {
             .postfixQuestionMark,
             .rightParen,
             .rightSquareBracket,
-            .stringInterpolationAnchor
+            .stringInterpolationAnchor,
+            .leftSquareBracket
         ]
         if case .newlines = trailingTrivia.first {
             return true

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -28,11 +28,10 @@ public struct ClosureSpacingRule: ConfigurationProviderRule, OptInRule, SourceKi
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree else {
+        guard let locationConverter = file.locationConverter else {
             return []
         }
 
-        let locationConverter = SourceLocationConverter(file: file.path ?? "<nopath>", tree: tree)
         return MultilineClosureRuleVisitor(locationConverter: locationConverter)
             .walk(file: file, handler: \.sortedPositions)
             .map { position in

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -269,8 +269,8 @@ private extension Region {
             return nil
         }
 
-        let startPosition = locationConverter.position(ofLine: startLine, column: min(1_000, start.character ?? 1))
-        let endPosition = locationConverter.position(ofLine: endLine, column: min(1_000, end.character ?? 1))
+        let startPosition = locationConverter.position(ofLine: startLine, column: min(1000, start.character ?? 1))
+        let endPosition = locationConverter.position(ofLine: endLine, column: min(1000, end.character ?? 1))
         let startLocation = locationConverter.location(for: startPosition)
         let endLocation = locationConverter.location(for: endPosition)
         return SourceRange(start: startLocation, end: endLocation)

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -131,12 +131,13 @@ private extension TokenSyntax {
             .comma,
             .exclamationMark,
             .leftParen,
+            .leftSquareBracket,
             .period,
             .postfixQuestionMark,
             .rightParen,
             .rightSquareBracket,
-            .stringInterpolationAnchor,
-            .leftSquareBracket
+            .semicolon,
+            .stringInterpolationAnchor
         ]
         if case .newlines = trailingTrivia.first {
             return true

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -33,8 +33,7 @@ public struct ClosureSpacingRule: ConfigurationProviderRule, OptInRule, SourceKi
         }
 
         let locationConverter = SourceLocationConverter(file: file.path ?? "<nopath>", tree: tree)
-        let visitor = MultilineClosureRuleVisitor(locationConverter: locationConverter)
-        return visitor
+        return MultilineClosureRuleVisitor(locationConverter: locationConverter)
             .walk(file: file, handler: \.sortedPositions)
             .map { position in
                 StyleViolation(ruleDescription: Self.description,
@@ -45,7 +44,7 @@ public struct ClosureSpacingRule: ConfigurationProviderRule, OptInRule, SourceKi
 }
 
 private final class MultilineClosureRuleVisitor: SyntaxVisitor {
-    var positions: [AbsolutePosition] = []
+    private var positions: [AbsolutePosition] = []
     var sortedPositions: [AbsolutePosition] { positions.sorted() }
     let locationConverter: SourceLocationConverter
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -196,8 +196,9 @@ private extension TokenSyntax {
             return true
         }
 
-        return leadingTriviaLength.utf8Length +
-            (previousToken?.trailingTriviaLength.utf8Length ?? 0) == 1
+        let combinedLeadingTriviaLength = leadingTriviaLength.utf8Length +
+            (previousToken?.trailingTriviaLength.utf8Length ?? 0)
+        return combinedLeadingTriviaLength == 1
     }
 
     var hasSingleSpaceToItsRight: Bool {
@@ -205,8 +206,9 @@ private extension TokenSyntax {
             return true
         }
 
-        return trailingTriviaLength.utf8Length +
-            (nextToken?.leadingTriviaLength.utf8Length ?? 0) == 1
+        let combinedTrailingTriviaLength = trailingTriviaLength.utf8Length +
+            (nextToken?.leadingTriviaLength.utf8Length ?? 0)
+        return combinedTrailingTriviaLength == 1
     }
 
     var hasLeadingNewline: Bool {
@@ -230,7 +232,8 @@ private extension TokenSyntax {
     }
 
     var hasAllowedNoSpaceLeftToken: Bool {
-        parent?.previousToken?.tokenKind == .leftParen || parent?.previousToken?.tokenKind == .leftSquareBracket
+        let previousTokenKind = parent?.previousToken?.tokenKind
+        return previousTokenKind == .leftParen || previousTokenKind == .leftSquareBracket
     }
 
     var hasAllowedNoSpaceRightToken: Bool {

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -1,22 +1,8 @@
 import Foundation
 import SourceKittenFramework
+import SwiftSyntax
 
-extension NSRange {
-    private func equals(_ other: NSRange) -> Bool {
-        return NSEqualRanges(self, other)
-    }
-
-    private func isStrictSubset(of other: NSRange) -> Bool {
-        if equals(other) { return false }
-        return NSUnionRange(self, other).equals(other)
-    }
-
-    fileprivate func isStrictSubset(in others: [NSRange]) -> Bool {
-        return others.contains(where: isStrictSubset)
-    }
-}
-
-public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
+public struct ClosureSpacingRule: ConfigurationProviderRule, OptInRule, SourceKitFreeRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -30,177 +16,137 @@ public struct ClosureSpacingRule: CorrectableRule, ConfigurationProviderRule, Op
             Example("[].map ({ $0.description })"),
             Example("[].filter { $0.contains(location) }"),
             Example("extension UITableViewCell: ReusableView { }"),
-            Example("extension UITableViewCell: ReusableView {}")
+            Example("extension UITableViewCell: ReusableView {}"),
+            Example(#"let r = /\{\}/"#, excludeFromDocumentation: true)
         ],
         triggeringExamples: [
+            Example("[].filter↓{ $0.contains(location) }"),
             Example("[].filter(↓{$0.contains(location)})"),
             Example("[].map(↓{$0})"),
             Example("(↓{each in return result.contains(where: ↓{e in return e}) }).count"),
             Example("filter ↓{ sorted ↓{ $0 < $1}}")
-        ],
-        corrections: [
-            Example("[].filter(↓{$0.contains(location)})"):
-                Example("[].filter({ $0.contains(location) })"),
-            Example("[].map(↓{$0})"):
-                Example("[].map({ $0 })"),
-            // Nested braces `{ {} }` do not get corrected on the first pass.
-            Example("filter ↓{sorted { $0 < $1}}"):
-                Example("filter { sorted { $0 < $1} }"),
-            // The user has to run tool again to fix remaining nested violations.
-            Example("filter { sorted ↓{ $0 < $1} }"):
-                Example("filter { sorted { $0 < $1 } }"),
-            Example("(↓{each in return result.contains(where: {e in return 0})}).count"):
-                Example("({ each in return result.contains(where: {e in return 0}) }).count"),
-            // second pass example
-            Example("({ each in return result.contains(where: ↓{e in return 0}) }).count"):
-                Example("({ each in return result.contains(where: { e in return 0 }) }).count")
         ]
     )
 
-    // this helps cut down the time to search through a file by
-    // skipping lines that do not have at least one `{` and one `}` brace
-    private func lineContainsBraces(in range: NSRange, content: NSString) -> NSRange? {
-        let start = content.range(of: "{", options: [.literal], range: range)
-        guard start.length != 0 else { return nil }
-        let end = content.range(of: "}", options: [.literal, .backwards], range: range)
-        guard end.length != 0 else { return nil }
-        guard start.location < end.location else { return nil }
-        return NSRange(location: start.location, length: end.location - start.location + 1)
-    }
-
-    // returns ranges of braces `{` or `}` in the same line
-    private func validBraces(in file: SwiftLintFile) -> [NSRange] {
-        let nsstring = file.contents.bridge()
-        let bracePattern = regex("\\{|\\}")
-        let linesTokens = file.syntaxTokensByLines
-        let kindsToExclude = SyntaxKind.commentAndStringKinds
-
-        // find all lines and occurrences of open { and closed } braces
-        var linesWithBraces = [[NSRange]]()
-        for eachLine in file.lines {
-            guard let nsrange = lineContainsBraces(in: eachLine.range, content: nsstring) else {
-                continue
-            }
-
-            let braces = bracePattern.matches(in: file.contents, options: [],
-                                              range: nsrange).map { $0.range }
-            // filter out braces in comments and strings
-            let tokens = linesTokens[eachLine.index].filter {
-                guard let tokenKind = $0.kind else { return false }
-                return kindsToExclude.contains(tokenKind)
-            }
-            let tokenRanges = tokens.compactMap {
-                file.stringView.byteRangeToNSRange($0.range)
-            }
-            linesWithBraces.append(braces.filter({ !$0.intersects(tokenRanges) }))
-        }
-        return linesWithBraces.flatMap { $0 }
-    }
-
-    // find ranges where violation exist. Returns ranges sorted by location.
-    private func findViolations(file: SwiftLintFile) -> [NSRange] {
-        // match open braces to corresponding closing braces
-        func matchBraces(validBraceLocations: [NSRange]) -> [NSRange] {
-            if validBraceLocations.isEmpty { return [] }
-            var validBraces = validBraceLocations
-            var ranges = [NSRange]()
-            var bracesAsString = validBraces.map({
-                file.contents.substring(from: $0.location, length: $0.length)
-            }).joined()
-            while let foundRange = bracesAsString.range(of: "{}") {
-                let startIndex = bracesAsString.distance(from: bracesAsString.startIndex,
-                                                         to: foundRange.lowerBound)
-                let location = validBraces[startIndex].location
-                let length = validBraces[startIndex + 1 ].location + 1 - location
-                ranges.append(NSRange(location: location, length: length))
-                bracesAsString.replaceSubrange(foundRange, with: "")
-                validBraces.removeSubrange(startIndex...startIndex + 1)
-            }
-            return ranges
-        }
-
-        // matching ranges of `{...}`
-        return matchBraces(validBraceLocations: validBraces(in: file))
-            .filter {
-                // removes enclosing brances to just content
-                let content = file.contents.substring(from: $0.location + 1, length: $0.length - 2)
-                if content.isEmpty || content == " " {
-                    // case when {} is not a closure
-                    return false
-                }
-                let cleaned = content.trimmingCharacters(in: .whitespaces)
-                return content != " " + cleaned + " "
-            }
-            .sorted {
-                $0.location < $1.location
-            }
-    }
-
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return findViolations(file: file).compactMap {
-            StyleViolation(ruleDescription: Self.description,
-                           severity: configuration.severity,
-                           location: Location(file: file, characterOffset: $0.location))
+        guard let tree = file.syntaxTree else {
+            return []
+        }
+
+        let locationConverter = SourceLocationConverter(file: file.path ?? "<nopath>", tree: tree)
+        let visitor = MultilineClosureRuleVisitor(locationConverter: locationConverter)
+        return visitor
+            .walk(file: file, handler: \.sortedPositions)
+            .map { position in
+                StyleViolation(ruleDescription: Self.description,
+                               severity: configuration.severity,
+                               location: Location(file: file, byteOffset: ByteCount(position)))
+            }
+    }
+}
+
+private final class MultilineClosureRuleVisitor: SyntaxVisitor {
+    var positions: [AbsolutePosition] = []
+    var sortedPositions: [AbsolutePosition] { positions.sorted() }
+    let locationConverter: SourceLocationConverter
+
+    init(locationConverter: SourceLocationConverter) {
+        self.locationConverter = locationConverter
+    }
+
+    override func visitPost(_ node: ClosureExprSyntax) {
+        guard node.parent?.is(PostfixUnaryExprSyntax.self) == false else {
+            // Workaround for Regex literals
+            return
+        }
+
+        guard let startLine = node.startLocation(converter: self.locationConverter).line,
+              let endLine = node.endLocation(converter: self.locationConverter).line,
+              startLine == endLine, // Only check single-line closures
+              (node.rightBrace.position.utf8Offset - node.leftBrace.position.utf8Offset) > 1 // That aren't '{}'
+        else {
+            return
+        }
+
+        let violationPosition = node.positionAfterSkippingLeadingTrivia
+        if !node.leftBrace.hasSingleSpaceToItsLeft && !node.leftBrace.previousTokenIsAllowed &&
+            !node.leftBrace.hasLeadingNewline {
+            positions.append(violationPosition)
+        } else if !node.leftBrace.hasSingleSpaceToItsRight {
+            positions.append(violationPosition)
+        } else if !node.rightBrace.hasSingleSpaceToItsLeft {
+            positions.append(violationPosition)
+        } else if !node.rightBrace.hasSingleSpaceToItsRight && !node.rightBrace.nextTokenIsRightParenOrEOF &&
+                    !node.rightBrace.hasAllowedNoSpaceToken && !node.rightBrace.hasTrailingLineComment {
+            positions.append(violationPosition)
+        }
+    }
+}
+
+private extension TokenSyntax {
+    var previousTokenIsAllowed: Bool {
+        parent?.previousToken?.tokenKind == .leftParen || parent?.previousToken?.tokenKind == .leftSquareBracket
+    }
+
+    var nextTokenIsRightParenOrEOF: Bool {
+        (parent?.nextToken?.tokenKind == .rightParen) ||
+            (parent?.nextToken?.tokenKind == .eof)
+    }
+
+    var hasSingleSpaceToItsLeft: Bool {
+        leadingTriviaLength.utf8Length +
+            (previousToken?.trailingTriviaLength.utf8Length ?? 0) == 1
+    }
+
+    var hasSingleSpaceToItsRight: Bool {
+        if case let .spaces(spaces) = trailingTrivia.first, spaces == 1 {
+            return true
+        }
+
+        return trailingTriviaLength.utf8Length +
+            (nextToken?.leadingTriviaLength.utf8Length ?? 0) == 1
+    }
+
+    var hasLeadingNewline: Bool {
+        leadingTrivia.contains { piece in
+            if case .newlines = piece {
+                return true
+            } else {
+                return false
+            }
         }
     }
 
-    // this will try to avoid nested ranges `{{}{}}` in single line
-    private func removeNested(_ ranges: [NSRange]) -> [NSRange] {
-        return ranges.filter { current in
-            return !current.isStrictSubset(in: ranges)
+    var hasTrailingLineComment: Bool {
+        trailingTrivia.contains { piece in
+            if case .lineComment = piece {
+                return true
+            } else {
+                return false
+            }
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
-        var matches = removeNested(findViolations(file: file)).filter {
-            file.ruleEnabled(violatingRanges: [$0], for: self).isNotEmpty
-        }
-        guard matches.isNotEmpty else { return [] }
-
-        // `matches` should be sorted by location from `findViolations`.
-        let start = NSRange(location: 0, length: 0)
-        let end = NSRange(location: file.contents.utf16.count, length: 0)
-        matches.insert(start, at: 0)
-        matches.append(end)
-
-        var fixedSections = [String]()
-
-        var matchIndex = 0
-        while matchIndex < matches.count - 1 {
-            defer { matchIndex += 1 }
-            // inverses the ranges to select non rule violation content
-            let current = matches[matchIndex].location + matches[matchIndex].length
-            let nextMatch = matches[matchIndex + 1]
-            let next = nextMatch.location
-            let length = next - current
-            let nonViolationContent = file.contents.substring(from: current, length: length)
-            if nonViolationContent.isNotEmpty {
-                fixedSections.append(nonViolationContent)
-            }
-            // selects violation ranges and fixes them before adding back in
-            if nextMatch.length > 1 {
-                let violation = file.contents.substring(from: nextMatch.location + 1,
-                                                        length: nextMatch.length - 2)
-                let cleaned = "{ " + violation.trimmingCharacters(in: .whitespaces) + " }"
-                fixedSections.append(cleaned)
-            }
-
-            // Catch all. Break at the end of loop.
-            if next == end.location { break }
-        }
-
-        // removes the start and end inserted above
-        if matches.count > 2 {
-            matches.remove(at: matches.count - 1)
-            matches.remove(at: 0)
-        }
-
-        // write changes to actual file
-        file.write(fixedSections.joined())
-
-        return matches.map {
-            Correction(ruleDescription: Self.description,
-                       location: Location(file: file, characterOffset: $0.location))
+    var hasAllowedNoSpaceToken: Bool {
+        let allowedKinds = [
+            TokenKind.colon,
+            .comma,
+            .exclamationMark,
+            .leftParen,
+            .period,
+            .postfixQuestionMark,
+            .rightParen,
+            .rightSquareBracket,
+            .stringInterpolationAnchor
+        ]
+        if case .newlines = trailingTrivia.first {
+            return true
+        } else if case .newlines = nextToken?.leadingTrivia.first {
+            return true
+        } else if let nextToken = nextToken, allowedKinds.contains(nextToken.tokenKind) {
+            return true
+        } else {
+            return false
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -116,11 +116,8 @@ private final class ClosureSpacingRuleRewriter: SyntaxRewriter {
         let isInDisabledRegion = disabledRegions.contains { region in
             region.contains(node.positionAfterSkippingLeadingTrivia, locationConverter: locationConverter)
         }
-        if isInDisabledRegion {
-            return ExprSyntax(node)
-        }
 
-        guard node.shouldCheckForClosureSpacingRule(locationConverter: locationConverter) else {
+        guard !isInDisabledRegion, node.shouldCheckForClosureSpacingRule(locationConverter: locationConverter) else {
             return ExprSyntax(node)
         }
 
@@ -257,41 +254,6 @@ private extension TokenSyntax {
         } else if let nextToken = nextToken, allowedKinds.contains(nextToken.tokenKind) {
             return true
         } else {
-            return false
-        }
-    }
-}
-
-private extension SourceRange {
-    func contains(_ position: AbsolutePosition, locationConverter: SourceLocationConverter) -> Bool {
-        contains(locationConverter.location(for: position))
-    }
-
-    func contains(_ location: SwiftSyntax.SourceLocation) -> Bool {
-        start < location && location < end
-    }
-}
-
-private extension SwiftSyntax.SourceLocation {
-    static func < (lhs: Self, rhs: Self) -> Bool {
-        if lhs.file != rhs.file {
-            return lhs.file < rhs.file
-        }
-        if lhs.line != rhs.line {
-            return lhs.line < rhs.line
-        }
-        return lhs.column < rhs.column
-    }
-}
-
-private extension Optional where Wrapped: Comparable {
-    static func < (lhs: Optional, rhs: Optional) -> Bool {
-        switch (lhs, rhs) {
-        case let (lhs?, rhs?):
-            return lhs < rhs
-        case (nil, _?):
-            return true
-        default:
             return false
         }
     }


### PR DESCRIPTION
Fixes #4090. Continued from #4091.

To do:

- [x] Review OSSCheck results
- [x] Benchmark (9x faster: 123.413s to 13.163s cumulative)
- [x] Implement corrections
- [x] Clean up
- [x] Changelog entry