### PR TITLE
enable glob for includePaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ accordingly._
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4030](https://github.com/realm/SwiftLint/issues/4030)
 
+* Enabled (recursive) globs in `included` file paths.  
+  [sarastro-nl](https://github.com/sarastro-nl)
+
 #### Bug Fixes
 
 * Fix false positive in `self_in_property_initialization` rule when using

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ accordingly._
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4030](https://github.com/realm/SwiftLint/issues/4030)
 
-* Enabled (recursive) globs in `included` file paths.  
+* Enable (recursive) globs in `included` file paths.  
   [sarastro-nl](https://github.com/sarastro-nl)
 
 #### Bug Fixes

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -37,9 +37,9 @@ extension Configuration {
         if path.isFile && !forceExclude { return [path] }
 
         let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: path, rootDirectory: nil) : []
-        let includedPaths = self.includedPaths.parallelFlatMap {
-            fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory)
-        }
+        let includedPaths = self.includedPaths
+            .flatMap(Glob.resolveGlob)
+            .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }
 
         return excludeByPrefix
             ? filterExcludedPathsByPrefix(in: pathsForPath, includedPaths)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -297,6 +297,16 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(Set(expectedFilenames), Set(filenames))
     }
 
+    func testGlobIncludePaths() {
+        FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
+        let configuration = Configuration(includedPaths: ["**/Level2"])
+        let paths = configuration.lintablePaths(inPath: Mock.Dir.level0, forceExclude: true)
+        let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
+        let expectedFilenames = ["Level2.swift", "Level3.swift"]
+
+        XCTAssertEqual(Set(expectedFilenames), Set(filenames))
+    }
+
     func testGlobExcludePaths() {
         let configuration = Configuration(
             includedPaths: [Mock.Dir.level3],


### PR DESCRIPTION
## Description

Enable dotglob path expansion for include paths.

## Motivation and Context
We are working on a repo that uses two swiftlint yml files: one for normal swift files and the other for test files because different (read: more lenient) rules apply for test files. These test files reside in 510 directories throughout the repo and on different directory levels. They all have in common that the directory name contains the string 'Test'. So in our 'normal' swiftlint.yml it is easy to exclude those directories: we add `./**/*Test*` to the `excluded` configuration section. But since `included` doesn't accept this dotglob expression we are forced to add those 510 directories to `included` in our test swiftlint.yml. This is unmaintainable for us and the list will be outdated quickly since the list of test directories is growing every day.