### PR TITLE
Integrate with rules_xcodeproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ xcuserdata
 
 # SwiftLint
 
+SwiftLint.xcodeproj
 SwiftLint.pkg
 *.zip
 benchmark_*

--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,11 @@ load(
     "swift_binary",
     "swift_library",
 )
+load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "xcode_schemes",
+    "xcodeproj",
+)
 
 swift_library(
     name = "SwiftLintFramework",
@@ -29,8 +34,8 @@ swift_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":SwiftLintFramework",
-        "@sourcekitten_com_github_apple_swift_argument_parser//:ArgumentParser",
         "@com_github_johnsundell_collectionconcurrencykit//:CollectionConcurrencyKit",
+        "@sourcekitten_com_github_apple_swift_argument_parser//:ArgumentParser",
         "@swiftlint_com_github_scottrhoyt_swifty_text_table//:SwiftyTextTable",
     ],
 )
@@ -45,4 +50,25 @@ filegroup(
     name = "SourceFilesToLint",
     srcs = glob(["Source/**"]),
     visibility = ["//Tests:__subpackages__"],
+)
+
+xcodeproj(
+    name = "xcodeproj",
+    build_mode = "bazel",
+    project_name = "SwiftLint",
+    schemes = [
+        xcode_schemes.scheme(
+            name = "SwiftLint",
+            launch_action = xcode_schemes.launch_action("//:swiftlint"),
+            test_action = xcode_schemes.test_action([
+                "//Tests:SwiftLintFrameworkTests",
+                "//Tests:ExtraRulesTests",
+            ]),
+        ),
+    ],
+    top_level_targets = [
+        "//:swiftlint",
+        "//Tests:SwiftLintFrameworkTests",
+        "//Tests:ExtraRulesTests",
+    ],
 )

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -27,7 +27,7 @@ swift_test(
         # Bazel doesn't support paths with spaces in them
         exclude = ["SwiftLintFrameworkTests/Resources/FileNameNoSpaceRuleFixtures/**"],
     ),
-    visibility = ["//Tests:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [":SwiftLintFrameworkTests.library"],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,3 +36,15 @@ swiftlint_repos()
 load("//bazel:deps.bzl", "swiftlint_deps")
 
 swiftlint_deps()
+
+http_archive(
+    name = "com_github_buildbuddy_io_rules_xcodeproj",
+    sha256 = "1bfc8589398afc31c47c3cb402f848c89ea11f8992c3f1c8e93efafa23619a7f",
+    # https://github.com/buildbuddy-io/rules_xcodeproj/pull/900
+    strip_prefix = "rules_xcodeproj-da3c32c91653cd98d4cb0bb7ffe9ac81a6f5f800",
+    url = "https://github.com/buildbuddy-io/rules_xcodeproj/archive/da3c32c91653cd98d4cb0bb7ffe9ac81a6f5f800.tar.gz",
+)
+
+load("@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl", "xcodeproj_rules_dependencies")
+
+xcodeproj_rules_dependencies()


### PR DESCRIPTION
Which could make it easier to debug when building with Bazel.

```
bazel run :xcodeproj && xed SwiftLint.xcodeproj
```