### PR TITLE
Update documentation for multiline_arguments_brackets and multiline_literal_brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@ accordingly._
   `swiftlint` executables are identical.  
   [JP Simard](https://github.com/jpsim)
 
+* Update documentation for `multiline_arguments_brackets` and 
+  `multiline_literal_brackets` to make it immediately obvious that common 
+  examples will trigger.  
+  [chrisjf](https://github.com/chrisjf)
+  [#4060](https://github.com/realm/SwiftLint/issues/4060)
+
 #### Bug Fixes
 
 * Fix false positive in `self_in_property_initialization` rule when using

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -87,6 +87,11 @@ public struct MultilineArgumentsBracketsRule: ASTRule, OptInRule, ConfigurationP
                 param3: "Param3"↓)
             """),
             Example("""
+            foo(↓param1: "Param1",
+                param2: "Param2",
+                param3: "Param3"↓)
+            """),
+            Example("""
             foo(↓bar(
                 x: 5,
                 y: 7

--- a/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -14,7 +14,7 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
         nonTriggeringExamples: [
             Example("""
             let trio = ["harry", "ronald", "hermione"]
-            let houseCup = ["gryffinder": 460, "hufflepuff": 370, "ravenclaw": 410, "slytherin": 450]
+            let houseCup = ["gryffindor": 460, "hufflepuff": 370, "ravenclaw": 410, "slytherin": 450]
             """),
             Example("""
             let trio = [
@@ -23,7 +23,7 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
                 "hermione"
             ]
             let houseCup = [
-                "gryffinder": 460,
+                "gryffindor": 460,
                 "hufflepuff": 370,
                 "ravenclaw": 410,
                 "slytherin": 450
@@ -34,7 +34,7 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
                 "harry", "ronald", "hermione"
             ]
             let houseCup = [
-                "gryffinder": 460, "hufflepuff": 370,
+                "gryffindor": 460, "hufflepuff": 370,
                 "ravenclaw": 410, "slytherin": 450
             ]
             """),
@@ -57,9 +57,15 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
             ]
             """),
             Example("""
-            let houseCup = [↓"gryffinder": 460, "hufflepuff": 370,
+            let houseCup = [↓"gryffindor": 460, "hufflepuff": 370,
                             "ravenclaw": 410, "slytherin": 450
             ]
+            """),
+            Example("""
+            let houseCup = [↓"gryffindor": 460,
+                            "hufflepuff": 370,
+                            "ravenclaw": 410,
+                            "slytherin": 450↓]
             """),
             Example("""
             let trio = [
@@ -69,13 +75,13 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
             """),
             Example("""
             let houseCup = [
-                "gryffinder": 460, "hufflepuff": 370,
+                "gryffindor": 460, "hufflepuff": 370,
                 "ravenclaw": 410, "slytherin": 450↓]
             """),
             Example("""
             class Hogwarts {
                 let houseCup = [
-                    "gryffinder": 460, "hufflepuff": 370,
+                    "gryffindor": 460, "hufflepuff": 370,
                     "ravenclaw": 410, "slytherin": 450↓]
             }
             """),


### PR DESCRIPTION
Hello SwiftLint Devs 👋 

Here are the changes I've made to address the issue https://github.com/realm/SwiftLint/issues/4060 which include:

- added two triggering examples that are a common style, to make it immediately obvious that they trigger the rules
- also fixed a spelling mistake throughout the examples for the multiline_literal_brackets rule ("Gryffindor" is now correctly spelt)

If more information is needed, please see the description of the issue.

Thanks,
Chris