### PR TITLE
Revert "Clear bazel caches"

### DIFF
--- a/script/oss-check
+++ b/script/oss-check
@@ -208,7 +208,7 @@ def build(branch)
     perform("git worktree add --detach #{dir} #{target}")
   end
 
-  build_command = "cd #{dir}; bazel clean --expunge; bazel shutdown; bazel build -c opt @SwiftLint//:swiftlint"
+  build_command = "cd #{dir}; bazel build -c opt @SwiftLint//:swiftlint"
 
   perform(build_command)
   return if $?.success?


### PR DESCRIPTION
This reverts commit fe43d6ecd432b6ef19c8b40723c7d6c3aea6bb39.

This was merged to master by accident.