### PR TITLE
Add `version --verbose` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ accordingly._
   `--benchmark`.  
   [JP Simard](https://github.com/jpsim)
 
+* The `version` command now has an optional `--verbose` flag that prints out the
+  full version info, notably the build ID, which can be used to determine if two
+  `swiftlint` executables are identical.  
+  [JP Simard](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Fix false positive in `self_in_property_initialization` rule when using

--- a/Source/SwiftLintFramework/Helpers/ExecutableInfo.swift
+++ b/Source/SwiftLintFramework/Helpers/ExecutableInfo.swift
@@ -2,8 +2,10 @@
 import Foundation
 import MachO
 
-enum ExecutableInfo {
-    static let buildID: String? = {
+/// Information about this executable.
+public enum ExecutableInfo {
+    /// A stable identifier for this executable. Uses the Mach-O header UUID on macOS. Nil on Linux.
+    public static let buildID: String? = {
         if let handle = dlopen(nil, RTLD_LAZY) {
             defer { dlclose(handle) }
 
@@ -32,7 +34,9 @@ enum ExecutableInfo {
 }
 
 #else
-enum ExecutableInfo {
-    static let buildID: String? = nil
+/// Information about this executable.
+public enum ExecutableInfo {
+    /// A stable identifier for this executable. Uses the Mach-O header UUID on macOS. Nil on Linux.
+    public static let buildID: String? = nil
 }
 #endif

--- a/Source/swiftlint/Commands/Version.swift
+++ b/Source/swiftlint/Commands/Version.swift
@@ -3,12 +3,20 @@ import SwiftLintFramework
 
 extension SwiftLint {
     struct Version: ParsableCommand {
+        @Flag(help: "Display full version info")
+        var verbose = false
+
         static let configuration = CommandConfiguration(abstract: "Display the current version of SwiftLint")
 
         static var value: String { SwiftLintFramework.Version.current.value }
 
         func run() throws {
-            print(Self.value)
+            if verbose, let buildID = ExecutableInfo.buildID {
+                print("Version:", Self.value)
+                print("Build ID:", buildID)
+            } else {
+                print(Self.value)
+            }
         }
     }
 }


### PR DESCRIPTION
Prints out something like this on macOS:

```
Version: 0.49.0-rc.1
Build ID: B43931F3-D096-3704-B41C-FC40673A3F96
```

This can be used to determine if two `swiftlint` executables are identical.