### PR TITLE
Fix first_where false negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ accordingly._
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4081](https://github.com/realm/SwiftLint/issues/4081)
 
+* Fix false negatives in `first_where` rule when filtering array of dictionaries with String keys
+  [KS1019](https://github.com/KS1019/)
+  [#4105](https://github.com/realm/SwiftLint/pull/4105)
+
 ## 0.48.0: Rechargeable Defuzzer
 
 This is the last release to support building with Swift 5.5.x and running on

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -53,7 +53,7 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
             }
 
             let syntaxKinds = file.syntaxMap.kinds(inByteRange: bodyRange)
-            return syntaxKinds == [.identifier, .string] || !syntaxKinds.contains(.string)
+            return syntaxKinds == [.identifier, .keyword, .identifier, .string] || syntaxKinds == [.identifier, .string] || !syntaxKinds.contains(.string)
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -27,6 +27,7 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
             Example("↓myList.filter(someFunction).first\n"),
             Example("↓myList.filter({ $0 % 2 == 0 })\n.first\n"),
             Example("(↓myList.filter { $0 == 1 }).first\n"),
+            Example("↓myListOfDict.filter { dict in dict[\"1\"] }.first"),
             Example("↓myListOfDict.filter { $0[\"someString\"] }.first")
         ]
     )

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -53,7 +53,9 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
             }
 
             let syntaxKinds = file.syntaxMap.kinds(inByteRange: bodyRange)
-            return syntaxKinds == [.identifier, .keyword, .identifier, .string] || syntaxKinds == [.identifier, .string] || !syntaxKinds.contains(.string)
+            let isStringKeyDict = syntaxKinds == [.identifier, .keyword, .identifier, .string]
+            let isStringKeyShortenedDict = syntaxKinds == [.identifier, .string]
+            return  isStringKeyDict || isStringKeyShortenedDict || !syntaxKinds.contains(.string)
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -52,7 +52,7 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
             }
 
             let syntaxKinds = file.syntaxMap.kinds(inByteRange: bodyRange)
-            return !syntaxKinds.contains(.string)
+            return syntaxKinds == [.identifier, .string] || !syntaxKinds.contains(.string)
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -26,7 +26,8 @@ public struct FirstWhereRule: CallPairRule, OptInRule, ConfigurationProviderRule
             Example("↓myList.map { $0 + 1 }.filter({ $0 % 2 == 0 }).first?.something()\n"),
             Example("↓myList.filter(someFunction).first\n"),
             Example("↓myList.filter({ $0 % 2 == 0 })\n.first\n"),
-            Example("(↓myList.filter { $0 == 1 }).first\n")
+            Example("(↓myList.filter { $0 == 1 }).first\n"),
+            Example("↓myListOfDict.filter { $0[\"someString\"] }.first")
         ]
     )
 


### PR DESCRIPTION
When filtering against an array of dictionaries with String keys, SwiftLint does not trigger a violation. This PR adds a new triggering example and a fix to address the issue.