### PR TITLE
Fix broken correction for `explicit_init` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ accordingly._
 
 * Fix broken correction for `explicit_init` rule
   [KS1019](https://github.com/KS1019/)
-  [#4109](https://github.com/realm/SwiftLint/pull/4109)
+
 
 ## 0.48.0: Rechargeable Defuzzer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ accordingly._
   [KS1019](https://github.com/KS1019/)
   [#4105](https://github.com/realm/SwiftLint/pull/4105)
 
+* Fix broken correction for `explicit_init` rule
+  [KS1019](https://github.com/KS1019/)
+  [#4109](https://github.com/realm/SwiftLint/pull/4109)
+
 ## 0.48.0: Rechargeable Defuzzer
 
 This is the last release to support building with Swift 5.5.x and running on

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -44,19 +44,19 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
             Example("""
             let int = Int
             .init(1.0)
-            """),
+            """, excludeFromDocumentation: true),
             Example("""
             let int = Int
 
 
             .init(1.0)
-            """),
+            """, excludeFromDocumentation: true),
             Example("""
             let int = Int
 
 
                   .init(1.0)
-            """)
+            """, excludeFromDocumentation: true)
         ],
         corrections: [
             Example("[1].flatMap{String↓.init($0)}"): Example("[1].flatMap{String($0)}"),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -47,14 +47,14 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
             """),
             Example("""
             let int = Int
-            
-            
+
+
             .init(1.0)
             """),
             Example("""
             let int = Int
-            
-            
+
+
                   .init(1.0)
             """)
         ],
@@ -71,32 +71,32 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
                 Example("let int = Int(1.0)"),
             Example("""
             let int = Int
-            
-            
+
+
             .init(1.0)
             """):
                 Example("let int = Int(1.0)"),
             Example("""
             let int = Int
-            
-            
+
+
                   .init(1.0)
             """):
                 Example("let int = Int(1.0)"),
             Example("""
             let int = Int
-            
-            
+
+
                   .init(1.0)
-            
-            
-            
+
+
+
             """):
                 Example("""
                         let int = Int(1.0)
-                        
-                        
-                        
+
+
+
                         """)
         ]
     )

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -41,9 +41,22 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
               resultSelector: { MyType.init($0, $1) }
             ).asMaybe()
             """),
-            Example("let int = Int\n.init(1.0)"),
-            Example("let int = Int\n\n\n.init(1.0)"),
-            Example("let int = Int\n\n\n      .init(1.0)")
+            Example("""
+            let int = Int
+            .init(1.0)
+            """),
+            Example("""
+            let int = Int
+            
+            
+            .init(1.0)
+            """),
+            Example("""
+            let int = Int
+            
+            
+                  .init(1.0)
+            """)
         ],
         corrections: [
             Example("[1].flatMap{String↓.init($0)}"): Example("[1].flatMap{String($0)}"),
@@ -51,10 +64,40 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
                 Example("func foo() -> [String] {\n    return [1].flatMap { String($0) }\n}"),
             Example("class C {\n#if true\nfunc f() {\n[1].flatMap{String.init($0)}\n}\n#endif\n}"):
                 Example("class C {\n#if true\nfunc f() {\n[1].flatMap{String($0)}\n}\n#endif\n}"),
-            Example("let int = Int\n.init(1.0)"): Example("let int = Int(1.0)"),
-            Example("let int = Int\n\n\n.init(1.0)"): Example("let int = Int(1.0)"),
-            Example("let int = Int\n\n\n      .init(1.0)"): Example("let int = Int(1.0)"),
-            Example("let int = Int\n\n\n      .init(1.0)\n\n\n"): Example("let int = Int(1.0)\n\n\n")
+            Example("""
+            let int = Int
+            .init(1.0)
+            """):
+                Example("let int = Int(1.0)"),
+            Example("""
+            let int = Int
+            
+            
+            .init(1.0)
+            """):
+                Example("let int = Int(1.0)"),
+            Example("""
+            let int = Int
+            
+            
+                  .init(1.0)
+            """):
+                Example("let int = Int(1.0)"),
+            Example("""
+            let int = Int
+            
+            
+                  .init(1.0)
+            
+            
+            
+            """):
+                Example("""
+                        let int = Int(1.0)
+                        
+                        
+                        
+                        """)
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -40,14 +40,21 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
               obs2,
               resultSelector: { MyType.init($0, $1) }
             ).asMaybe()
-            """)
+            """),
+            Example("let int = Int\n.init(1.0)"),
+            Example("let int = Int\n\n\n.init(1.0)"),
+            Example("let int = Int\n\n\n      .init(1.0)")
         ],
         corrections: [
             Example("[1].flatMap{String↓.init($0)}"): Example("[1].flatMap{String($0)}"),
             Example("func foo() -> [String] {\n    return [1].flatMap { String↓.init($0) }\n}"):
                 Example("func foo() -> [String] {\n    return [1].flatMap { String($0) }\n}"),
             Example("class C {\n#if true\nfunc f() {\n[1].flatMap{String.init($0)}\n}\n#endif\n}"):
-                Example("class C {\n#if true\nfunc f() {\n[1].flatMap{String($0)}\n}\n#endif\n}")
+                Example("class C {\n#if true\nfunc f() {\n[1].flatMap{String($0)}\n}\n#endif\n}"),
+            Example("let int = Int\n.init(1.0)"): Example("let int = Int(1.0)"),
+            Example("let int = Int\n\n\n.init(1.0)"): Example("let int = Int(1.0)"),
+            Example("let int = Int\n\n\n      .init(1.0)"): Example("let int = Int(1.0)"),
+            Example("let int = Int\n\n\n      .init(1.0)\n\n\n"): Example("let int = Int(1.0)\n\n\n")
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -86,7 +86,13 @@ public struct ExplicitInitRule: SubstitutionCorrectableASTRule, ConfigurationPro
             let range = file.stringView
                 .byteRangeToNSRange(ByteRange(location: nameOffset + nameLength - length, length: length))
             else { return [] }
-        return [range]
+        var count = 0
+        while file.stringView.substring(with: NSRange(location: range.location - count - 1, length: 1))
+            .filter({ $0.isNewline || $0.isWhitespace }).count == 1 {
+            count += 1
+        }
+
+        return [NSRange(location: range.location - count, length: range.length + count)]
     }
 
     public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {


### PR DESCRIPTION
When there is space or newline between class name and .init, correcting the Swift code currently causes a compilation error. This PR adds new examples and a fix to address the issue.