### PR TITLE
Add configuration to allow additional no space operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,9 @@ macOS < 12.
   [KokiHirokawa](https://github.com/KokiHirokawa)
   [#3986](https://github.com/realm/SwiftLint/issues/3986)
 
+* Add configuration to customise no space operators.  
+  [imben123](https://github.com/imben123)
+
 #### Bug Fixes
 
 * Ignore array types in `syntactic_sugar` rule if their associated `Index` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ accordingly._
 * The `--compile-commands` argument can now parse SwiftPM yaml files produced
   when running `swift build` at `.build/{debug,release}.yaml`.  
   [JP Simard](https://github.com/jpsim)
+* Add configuration to customise no space operators.  
+  [imben123](https://github.com/imben123)
 
 #### Bug Fixes
 
@@ -163,9 +165,6 @@ macOS < 12.
 * Support `UIEdgeInsets` type in `prefer_zero_over_explicit_init` rule.  
   [KokiHirokawa](https://github.com/KokiHirokawa)
   [#3986](https://github.com/realm/SwiftLint/issues/3986)
-
-* Add configuration to customise no space operators.  
-  [imben123](https://github.com/imben123)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,8 @@ accordingly._
 * The `--compile-commands` argument can now parse SwiftPM yaml files produced
   when running `swift build` at `.build/{debug,release}.yaml`.  
   [JP Simard](https://github.com/jpsim)
-* Add configuration to customise no space operators.  
+
+* Add new configuration option `allowed_no_space_operators` to `operator_usage_whitespace` rule. It allows to specify custom operators which shall not be considered by the rule.  
   [imben123](https://github.com/imben123)
 
 #### Bug Fixes

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -2,11 +2,13 @@ public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var linesLookAround = 2
     private(set) var skipAlignedConstants = true
+    private(set) var additionalAllowedNoSpaceOperators: [String] = []
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription
             + ", lines_look_around: \(linesLookAround)"
             + ", skip_aligned_constants: \(skipAlignedConstants)"
+            + ", additional_allowed_no_space_operators: \(additionalAllowedNoSpaceOperators)"
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -16,6 +18,8 @@ public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable
 
         linesLookAround = configuration["lines_look_around"] as? Int ?? 2
         skipAlignedConstants = configuration["skip_aligned_constants"] as? Bool ?? true
+        additionalAllowedNoSpaceOperators =
+            configuration["additional_allowed_no_space_operators"] as? [String] ?? []
 
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -2,13 +2,13 @@ public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var linesLookAround = 2
     private(set) var skipAlignedConstants = true
-    private(set) var additionalAllowedNoSpaceOperators: [String] = []
+    private(set) var allowedNoSpaceOperators: [String] = ["...", "..<"]
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription
             + ", lines_look_around: \(linesLookAround)"
             + ", skip_aligned_constants: \(skipAlignedConstants)"
-            + ", additional_allowed_no_space_operators: \(additionalAllowedNoSpaceOperators)"
+            + ", allowed_no_space_operators: \(allowedNoSpaceOperators)"
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -18,8 +18,8 @@ public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable
 
         linesLookAround = configuration["lines_look_around"] as? Int ?? 2
         skipAlignedConstants = configuration["skip_aligned_constants"] as? Bool ?? true
-        additionalAllowedNoSpaceOperators =
-            configuration["additional_allowed_no_space_operators"] as? [String] ?? []
+        allowedNoSpaceOperators =
+            configuration["allowed_no_space_operators"] as? [String] ?? ["...", "..<"]
 
         if let severityString = configuration["severity"] as? String {
             try severityConfiguration.apply(configuration: severityString)

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -27,7 +27,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
 
     private func violationRanges(file: SwiftLintFile) -> [(ByteRange, String)] {
         OperatorUsageWhitespaceVisitor(
-            additionalAllowedNoSpaceOperators: configuration.additionalAllowedNoSpaceOperators
+            allowedNoSpaceOperators: configuration.allowedNoSpaceOperators
         )
         .walk(file: file, handler: \.violationRanges)
         .filter { byteRange, _ in
@@ -121,11 +121,11 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
 }
 
 private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
-    private let additionalAllowedNoSpaceOperators: Set<String>
+    private let allowedNoSpaceOperators: Set<String>
     private(set) var violationRanges: [(ByteRange, String)] = []
 
-    init(additionalAllowedNoSpaceOperators: [String]) {
-        self.additionalAllowedNoSpaceOperators = Set(additionalAllowedNoSpaceOperators)
+    init(allowedNoSpaceOperators: [String]) {
+        self.allowedNoSpaceOperators = Set(allowedNoSpaceOperators)
     }
 
     override func visitPost(_ node: BinaryOperatorExprSyntax) {
@@ -172,10 +172,8 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
         let noSpacingAfter = operatorToken.trailingTrivia.isEmpty && nextToken.leadingTrivia.isEmpty
         let noSpacing = noSpacingBefore || noSpacingAfter
 
-        let allowedNoSpacingOperators = additionalAllowedNoSpaceOperators.union(["...", "..<"])
-
         let operatorText = operatorToken.withoutTrivia().text
-        if noSpacing && allowedNoSpacingOperators.contains(operatorText) {
+        if noSpacing && allowedNoSpaceOperators.contains(operatorText) {
             return nil
         }
 
@@ -197,7 +195,7 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
             length: endPosition - location
         )
 
-        let correction = allowedNoSpacingOperators.contains(operatorText) ? operatorText : " \(operatorText) "
+        let correction = allowedNoSpaceOperators.contains(operatorText) ? operatorText : " \(operatorText) "
         return (range, correction)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -84,9 +84,13 @@ internal enum OperatorUsageWhitespaceRuleExamples {
         """, excludeFromDocumentation: true),
         Example("""
         func getAllowedTimeRange(startTime: TimeOfDay) -> TimeOfDayRange {
-            return (startTime)<..<(startTime + 3.hours)
+            let endTime = startTime + 3.hours
+            return startTime<--<endTime
         }
-        """, configuration: ["additional_allowed_no_space_operators": ["⁝"]])
+        """,
+        configuration: ["allowed_no_space_operators": ["<--<"]],
+        excludeFromDocumentation: true
+        )
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRuleExamples.swift
@@ -81,7 +81,12 @@ internal enum OperatorUsageWhitespaceRuleExamples {
         func success(for item: Item) {
             item.successHandler??()
         }
-        """, excludeFromDocumentation: true)
+        """, excludeFromDocumentation: true),
+        Example("""
+        func getAllowedTimeRange(startTime: TimeOfDay) -> TimeOfDayRange {
+            return (startTime)<..<(startTime + 3.hours)
+        }
+        """, configuration: ["additional_allowed_no_space_operators": ["⁝"]])
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
In some projects it is possible developers may have custom operators which make sense without surrounding spaces.

Currently the rule has two operators hard-coded which are exempt from having spaces either side; `...` and `..<`. This PR allows developers to customise this behaviour by providing their own list of operators which they want excluded from this condition.

This will allow them to create their own range-style custom operators. For example, a user may include this in their `.swiftlint.yml`:
```yaml
operator_usage_whitespace:
  allowed_no_space_operators: [ "<--<", "..<", "..." ]
```

----
Another example is that in my team we use a custom "tricolon" operator as an abbreviation for creating our custom `TimeOfDay` class.
```swift
let midday: TimeOfDay = 12⁝00
```
This operator similarly doesn't make sense with spaces either side of it.