### PR TITLE
Teach `--compile-commands` to parse SwiftPM yaml files

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,8 +13,10 @@ steps:
       - bundle exec danger --verbose
   - label: "Analyze"
     commands:
+      - echo "+++ Build"
+      - bazel build -c opt swiftlint
       - echo "+++ Analyze"
-      - make analyze
+      - bazel test -c opt --test_output=streamed --test_timeout=1800 --spawn_strategy=local --test_env=PROJECT_ROOT=$(bazel info workspace) analyze
   - label: "TSan"
     commands:
       - echo "+++ Test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,8 +13,10 @@ steps:
       - bundle exec danger --verbose
   - label: "Analyze"
     commands:
-      - echo "+++ Build"
+      - echo "+++ Build With Bazel"
       - bazel build -c opt swiftlint
+      - echo "+++ Build With SwiftPM"
+      - swift build
       - echo "+++ Analyze"
       - bazel test -c opt --test_output=streamed --test_timeout=1800 --spawn_strategy=local --test_env=PROJECT_ROOT=$(bazel info workspace) analyze
   - label: "TSan"

--- a/BUILD
+++ b/BUILD
@@ -122,6 +122,7 @@ genrule(
     cmd = """
 set -euo pipefail
 
+swift package clean
 swift build
 cp .build/debug.yaml $(OUTS)
     """,

--- a/BUILD
+++ b/BUILD
@@ -109,3 +109,26 @@ xcodeproj(
         "//Tests:ExtraRulesTests",
     ],
 )
+
+filegroup(
+    name = "SourceAndTestFiles",
+    srcs = glob(["Source/**", "Tests/SwiftLintFrameworkTests/**"]),
+)
+
+genrule(
+    name = "write_swiftpm_yaml",
+    srcs = [":SourceAndTestFiles", "Package.swift", "Package.resolved"],
+    outs = ["swiftpm.yaml"],
+    cmd = """
+set -euo pipefail
+
+swift build
+cp .build/debug.yaml $(OUTS)
+    """,
+)
+
+sh_test(
+    name = "analyze",
+    srcs = ["script/test-analyze.sh"],
+    data = [":swiftlint", ":LintInputs", "swiftpm.yaml"],
+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ accordingly._
   [chrisjf](https://github.com/chrisjf)
   [#4060](https://github.com/realm/SwiftLint/issues/4060)
 
+* The `--compile-commands` argument can now parse SwiftPM yaml files produced
+  when running `swift build` at `.build/{debug,release}.yaml`.  
+  [JP Simard](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Fix false positive in `self_in_property_initialization` rule when using

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -204,11 +204,16 @@ struct LintableFilesVisitor {
     }
 
     private static func loadCompileCommands(_ path: String) throws -> [File: Arguments] {
-        guard let jsonContents = FileManager.default.contents(atPath: path) else {
+        guard let fileContents = FileManager.default.contents(atPath: path) else {
             throw CompileCommandsLoadError.nonExistentFile(path)
         }
 
-        guard let object = try? JSONSerialization.jsonObject(with: jsonContents),
+        if path.hasSuffix(".yaml") || path.hasSuffix(".yml") {
+            // Assume this is a SwiftPM yaml file
+            return try SwiftPMCompilationDB.parse(yaml: fileContents)
+        }
+
+        guard let object = try? JSONSerialization.jsonObject(with: fileContents),
             let compileDB = object as? [[String: Any]] else {
             throw CompileCommandsLoadError.malformedCommands(path)
         }

--- a/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
+++ b/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
@@ -1,0 +1,75 @@
+import Foundation
+import SourceKittenFramework
+import Yams
+
+private struct SwiftPMCommand: Codable {
+    let tool: String
+    let module: String?
+    let sources: [String]?
+    let args: [String]?
+    let importPaths: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case tool
+        case module = "module-name"
+        case sources
+        case args = "other-args"
+        case importPaths = "import-paths"
+    }
+}
+
+private struct SwiftPMNode: Codable {}
+
+private struct SwiftPMNodes: Codable {
+    let nodes: [String: SwiftPMNode]
+}
+
+struct SwiftPMCompilationDB: Codable {
+    private let commands: [String: SwiftPMCommand]
+
+    static func parse(yaml: Data) throws -> [File: Arguments] {
+        let decoder = YAMLDecoder()
+        let compilationDB: SwiftPMCompilationDB
+
+        if ProcessInfo.processInfo.environment["TEST_SRCDIR"] != nil {
+            // Running tests
+            let nodes = try decoder.decode(SwiftPMNodes.self, from: yaml)
+            let suffix = "/Source/swiftlint/"
+            let pathToReplace = Array(nodes.nodes.keys.filter({ node in
+                node.hasSuffix(suffix)
+            }))[0].dropLast(suffix.count - 1)
+            let stringFileContents = String(data: yaml, encoding: .utf8)!
+                .replacingOccurrences(of: pathToReplace, with: "")
+            compilationDB = try decoder.decode(Self.self, from: stringFileContents)
+        } else {
+            compilationDB = try decoder.decode(Self.self, from: yaml)
+        }
+
+        let swiftCompilerCommands = compilationDB.commands
+            .filter { $0.value.tool == "swift-compiler" }
+        let allSwiftSources = swiftCompilerCommands
+            .flatMap { $0.value.sources ?? [] }
+            .filter { $0.hasSuffix(".swift") }
+        return Dictionary(uniqueKeysWithValues: allSwiftSources.map { swiftSource in
+            let command = swiftCompilerCommands
+                .values
+                .first { $0.sources?.contains(swiftSource) == true }
+
+            guard let command = command,
+                  let module = command.module,
+                  let sources = command.sources,
+                  let arguments = command.args,
+                  let importPaths = command.importPaths
+            else {
+                return (swiftSource, [])
+            }
+
+            let args = ["-module-name", module] +
+                sources +
+                arguments.filteringCompilerArguments +
+                ["-I"] + importPaths
+
+            return (swiftSource, args)
+        })
+    }
+}

--- a/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
+++ b/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SourceKittenFramework
 import Yams
 
 private struct SwiftPMCommand: Codable {

--- a/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
+++ b/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SourceKittenFramework
 import Yams
 
 private struct SwiftPMCommand: Codable {

--- a/script/test-analyze.sh
+++ b/script/test-analyze.sh
@@ -6,4 +6,3 @@ readonly swiftlint="$RUNFILES_DIR/SwiftLint/swiftlint"
 readonly swiftpm_yaml="$RUNFILES_DIR/SwiftLint/swiftpm.yaml"
 cd "$PROJECT_ROOT"
 "$swiftlint" analyze --strict --compile-commands "$swiftpm_yaml"
-exit 1

--- a/script/test-analyze.sh
+++ b/script/test-analyze.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly swiftlint="$RUNFILES_DIR/SwiftLint/swiftlint"
+readonly swiftpm_yaml="$RUNFILES_DIR/SwiftLint/swiftpm.yaml"
+cd "$PROJECT_ROOT"
+"$swiftlint" analyze --strict --compile-commands "$swiftpm_yaml"
+exit 1


### PR DESCRIPTION
And move analyze CI job to Bazel

Which will benefit from caching previous results, so if we make a PR that doesn't impact the analysis results (i.e. changelog or docs) we might be able to skip running this at all.