### PR TITLE
Enable Bazel disk cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
 build --macos_minimum_os=12.0 --host_macos_minimum_os=12.0
+build --disk_cache=~/.bazel_cache


### PR DESCRIPTION
Set to `~/.bazel_cache`. https://bazel.build/remote/caching#disk-cache