### PR TITLE
Update CI to use Xcode 14 beta 6

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -5,31 +5,31 @@ filegroup(
 )
 
 xcode_version(
-    name = "version14_0_0_14A5294e",
+    name = "version14_0_0_14A5294g",
     aliases = [
-        "14.0.0.14A5294e",
-        "14A5294e",
+        "14.0.0.14A5294g",
+        "14A5294g",
     ],
     default_ios_sdk_version = "16.0",
     default_macos_sdk_version = "13.0",
     default_tvos_sdk_version = "16.0",
     default_watchos_sdk_version = "9.0",
-    version = "14.0.0.14A5294e",
+    version = "14.0.0.14A5294g",
 )
 
 available_xcodes(
     name = "local_xcodes",
-    default = ":version14_0_0_14A5294e",
+    default = ":version14_0_0_14A5294g",
     versions = [
-        ":version14_0_0_14A5294e",
+        ":version14_0_0_14A5294g",
     ],
 )
 
 available_xcodes(
     name = "remote_xcodes",
-    default = ":version14_0_0_14A5294e",
+    default = ":version14_0_0_14A5294g",
     versions = [
-        ":version14_0_0_14A5294e",
+        ":version14_0_0_14A5294g",
     ],
 )
 


### PR DESCRIPTION
Only used for the TSan CI job right now, which was previously using Xcode 14 beta 5.

https://twitter.com/XcodeReleases/status/1562130365191315457