### PR TITLE
Migrate EmptyXCTestMethodRule to SwiftSyntax fixing some false-positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ accordingly._
 * Migrate `empty_xctest_method` rule to SwiftSyntax fixing some false positives.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#3647](https://github.com/realm/SwiftLint/issues/3647)
-  [#3691](https://github.com/realm/SwiftLint/issues/3691))
+  [#3691](https://github.com/realm/SwiftLint/issues/3691)
 
 ## 0.49.0: Asynchronous Defuzzer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ accordingly._
 
 #### Bug Fixes
 
-* None.
+* Migrate `empty_xctest_method` rule to SwiftSyntax fixing some false positives.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3647](https://github.com/realm/SwiftLint/issues/3647)
+  [#3691](https://github.com/realm/SwiftLint/issues/3691))
 
 ## 0.49.0: Asynchronous Defuzzer
 

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,6 +1,6 @@
-import SourceKittenFramework
+import SwiftSyntax
 
-public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule {
+public struct EmptyXCTestMethodRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -14,34 +14,52 @@ public struct EmptyXCTestMethodRule: Rule, OptInRule, ConfigurationProviderRule 
         triggeringExamples: EmptyXCTestMethodRuleExamples.triggeringExamples
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return testClasses(in: file).flatMap { violations(in: file, for: $0) }
+    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
+        EmptyXCTestMethodRuleVisitor()
+    }
+}
+
+private class EmptyXCTestMethodRuleVisitor: SyntaxVisitor, ViolationsSyntaxVisitor {
+    private(set) var violationPositions: [AbsolutePosition] = []
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let inheritanceList = node.inheritanceClause?.inheritedTypeCollection else {
+            return .skipChildren
+        }
+        let isTestClass = inheritanceList
+            .map(\.typeName)
+            .compactMap { $0.as(SimpleTypeIdentifierSyntax.self) }
+            .map(\.name)
+            .map(\.text)
+            .contains("XCTestCase")
+        return isTestClass ? .visitChildren : .skipChildren
     }
 
-    // MARK: - Private
-
-    private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
-        let dict = file.structureDictionary
-        return dict.substructure.filter { dictionary in
-            guard dictionary.declarationKind == .class else { return false }
-            return dictionary.inheritedTypes.contains("XCTestCase")
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        if node.isOverride, node.hasEmptyBody {
+            violationPositions.append(node.funcKeyword.positionAfterSkippingLeadingTrivia)
+        } else if node.isTestMethod, node.hasEmptyBody {
+            violationPositions.append(node.funcKeyword.positionAfterSkippingLeadingTrivia)
         }
     }
+}
 
-    private func violations(in file: SwiftLintFile,
-                            for dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        return dictionary.substructure.compactMap { subDictionary -> StyleViolation? in
-            guard
-                let kind = subDictionary.declarationKind,
-                let name = subDictionary.name,
-                XCTestHelpers.isXCTestMember(kind: kind, name: name, dictionary: subDictionary),
-                let offset = subDictionary.offset,
-                subDictionary.enclosedVarParameters.isEmpty,
-                subDictionary.substructure.isEmpty else { return nil }
-
-            return StyleViolation(ruleDescription: Self.description,
-                                  severity: configuration.severity,
-                                  location: Location(file: file, byteOffset: offset))
+private extension FunctionDeclSyntax {
+    var isOverride: Bool {
+        if let modifiers = modifiers {
+            return modifiers.map(\.name).map(\.text).contains("override")
         }
+        return false
+    }
+
+    var hasEmptyBody: Bool {
+        if let body = body {
+            return body.statements.isEmpty
+        }
+        return false
+    }
+
+    var isTestMethod: Bool {
+        identifier.text.hasPrefix("test") && signature.input.parameterList.isEmpty
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -35,6 +35,18 @@ private class EmptyXCTestMethodRuleVisitor: SyntaxVisitor, ViolationsSyntaxVisit
         return isTestClass ? .visitChildren : .skipChildren
     }
 
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        .skipChildren
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        .skipChildren
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        .skipChildren
+    }
+
     override func visitPost(_ node: FunctionDeclSyntax) {
         if node.isOverride, node.hasEmptyBody {
             violationPositions.append(node.funcKeyword.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRuleExamples.swift
@@ -84,7 +84,21 @@ internal struct EmptyXCTestMethodRuleExamples {
 
             func testFoo() { XCTAssert(true) }
         }
-        """)
+        """),
+
+        Example("""
+        extension C {
+            override func foo(a: Int) {}
+        }
+
+        struct S {
+            override func foo(a: Int) {}
+        }
+
+        enum E {
+            override func foo(a: Int) {}
+        }
+        """, excludeFromDocumentation: true)
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRuleExamples.swift
@@ -11,6 +11,10 @@ internal struct EmptyXCTestMethodRuleExamples {
                 foobar = Foobar()
             }
 
+            override func setUpWithError() throws {
+                foobar = nil
+            }
+
             override func tearDown() {
                 foobar = nil
                 super.tearDown()
@@ -26,6 +30,10 @@ internal struct EmptyXCTestMethodRuleExamples {
                 XCTAssertFalse(foobar?.bar)
 
                 // comment...
+            }
+
+            func testBaz() {
+                _ = 4 + 4
             }
         }
         """),
@@ -63,6 +71,18 @@ internal struct EmptyXCTestMethodRuleExamples {
             func testFoo() { XCTAssertTrue(foobar?.foo) }
 
             func testBar() { XCTAssertFalse(foobar?.bar) }
+        }
+        """),
+
+        // Class/static variables
+
+        Example("""
+        class TotoTests: XCTestCase {
+            override class var runsForEachTargetApplicationUIConfiguration: Bool { true }
+
+            static var allTests = [("testFoo", testFoo)]
+
+            func testFoo() { XCTAssert(true) }
         }
         """)
     ]


### PR DESCRIPTION
Fixes #3647.
Fixes #3691.