### PR TITLE
[CI] Use Xcode 13.4.1 on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,8 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      xcode1331:
-        DEVELOPER_DIR: /Applications/Xcode_13.3.1.app
+      xcode1341:
+        DEVELOPER_DIR: /Applications/Xcode_13.4.1.app
   steps:
     - script: |
         sw_vers
@@ -48,8 +48,8 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      xcode1331:
-        DEVELOPER_DIR: /Applications/Xcode_13.3.1.app
+      xcode1341:
+        DEVELOPER_DIR: /Applications/Xcode_13.4.1.app
   steps:
     - script: |
         sw_vers
@@ -67,7 +67,7 @@ jobs:
   pool:
     vmImage: 'macOS-12'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_13.3.1.app
+    DEVELOPER_DIR: /Applications/Xcode_13.4.1.app
   steps:
     - script: bundle install --path vendor/bundle
       displayName: bundle install
@@ -99,7 +99,7 @@ jobs:
   pool:
     vmImage: 'macOS-12'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_13.3.1.app
+    DEVELOPER_DIR: /Applications/Xcode_13.4.1.app
   steps:
     - script: swift run swiftlint generate-docs
       displayName: Run swiftlint generate-docs


### PR DESCRIPTION
For all jobs other than TSan which crashes in SwiftSyntax on Xcode 13.4.