### PR TITLE
Add new `self_binding` opt-in rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ accordingly._
 
 #### Enhancements
 
-* None.
+* Add new `self_binding` opt-in rule to enforce that `self` identifiers are
+  consistently re-bound to a common identifier name. Configure `bind_identifier`
+  to the name you want to use. Defaults to `self`.  
+  [JP Simard](https://github.com/jpsim)
+  [#2495](https://github.com/realm/SwiftLint/issues/2495)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -164,6 +164,7 @@ public let primaryRuleList = RuleList(rules: [
     RequiredEnumCaseRule.self,
     ReturnArrowWhitespaceRule.self,
     ReturnValueFromVoidFunctionRule.self,
+    SelfBindingRule.self,
     SelfInPropertyInitializationRule.self,
     ShorthandOperatorRule.self,
     SingleTestClassRule.self,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -1,0 +1,26 @@
+private enum ConfigurationKey: String {
+    case severity = "severity"
+    case bindIdentifier = "bind_identifier"
+}
+
+public struct SelfBindingConfiguration: RuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var bindIdentifier = "self"
+
+    public var consoleDescription: String {
+        return [severityConfiguration.consoleDescription,
+                "\(ConfigurationKey.bindIdentifier): \(bindIdentifier)"].joined(separator: ", ")
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let severityString = configuration[ConfigurationKey.severity.rawValue] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        bindIdentifier = configuration[ConfigurationKey.bindIdentifier.rawValue] as? String ?? "self"
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
@@ -1,0 +1,130 @@
+import SwiftSyntax
+
+// MARK: - SelfBindingRule
+
+public struct SelfBindingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+    public var configuration = SelfBindingConfiguration()
+
+    public init() {}
+
+    public static let description = RuleDescription(
+        identifier: "self_binding",
+        name: "Self Binding",
+        description: "Re-bind `self` to a consistent identifier name.",
+        kind: .style,
+        nonTriggeringExamples: [
+            Example("if let self = self { return }"),
+            Example("guard let self = self else else { return }"),
+            Example("if let this = this { return }"),
+            Example("guard let this = this else else { return }"),
+            Example("if let this = self { return }", configuration: ["bind_identifier": "this"]),
+            Example("guard let this = self else else { return }", configuration: ["bind_identifier": "this"])
+        ],
+        triggeringExamples: [
+            Example("if let ↓`self` = self { return }"),
+            Example("guard let ↓`self` = self else else { return }"),
+            Example("if let ↓this = self { return }"),
+            Example("guard let ↓this = self else else { return }"),
+            Example("if let ↓self = self { return }", configuration: ["bind_identifier": "this"]),
+            Example("guard let ↓self = self else else { return }", configuration: ["bind_identifier": "this"])
+        ],
+        corrections: [
+            Example("if let ↓`self` = self { return }"):
+                Example("if let self = self { return }"),
+            Example("guard let ↓`self` = self else else { return }"):
+                Example("guard let self = self else else { return }"),
+            Example("if let ↓this = self { return }"):
+                Example("if let self = self { return }"),
+            Example("guard let ↓this = self else else { return }"):
+                Example("guard let self = self else else { return }"),
+            Example("if let ↓self = self { return }", configuration: ["bind_identifier": "this"]):
+                Example("if let this = self { return }", configuration: ["bind_identifier": "this"])
+        ]
+    )
+
+    public func makeViolation(file: SwiftLintFile, position: AbsolutePosition) -> StyleViolation {
+        StyleViolation(
+            ruleDescription: Self.description,
+            severity: configuration.severityConfiguration.severity,
+            location: Location(file: file, position: position)
+        )
+    }
+
+    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
+        SelfBindingRuleVisitor(bindIdentifier: configuration.bindIdentifier)
+    }
+
+    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+        file.locationConverter.map { locationConverter in
+            SelfBindingRuleRewriter(
+                bindIdentifier: configuration.bindIdentifier,
+                locationConverter: locationConverter,
+                disabledRegions: disabledRegions(file: file)
+            )
+        }
+    }
+}
+
+// MARK: - SelfBindingRuleVisitor
+
+private final class SelfBindingRuleVisitor: SyntaxVisitor, ViolationsSyntaxVisitor {
+    private(set) var violationPositions: [AbsolutePosition] = []
+    private let bindIdentifier: String
+
+    init(bindIdentifier: String) {
+        self.bindIdentifier = bindIdentifier
+    }
+
+    override func visitPost(_ node: OptionalBindingConditionSyntax) {
+        if let identifierPattern = node.pattern.as(IdentifierPatternSyntax.self),
+           identifierPattern.identifier.text != bindIdentifier,
+           let initializerIdentifier = node.initializer.value.as(IdentifierExprSyntax.self),
+           initializerIdentifier.identifier.text == "self" {
+            violationPositions.append(identifierPattern.positionAfterSkippingLeadingTrivia)
+        }
+    }
+}
+
+// MARK: - SelfBindingRuleRewriter
+
+private final class SelfBindingRuleRewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
+    private(set) var correctionPositions: [AbsolutePosition] = []
+    private let bindIdentifier: String
+    let locationConverter: SourceLocationConverter
+    let disabledRegions: [SourceRange]
+
+    init(bindIdentifier: String, locationConverter: SourceLocationConverter, disabledRegions: [SourceRange]) {
+        self.bindIdentifier = bindIdentifier
+        self.locationConverter = locationConverter
+        self.disabledRegions = disabledRegions
+    }
+
+    override func visit(_ node: OptionalBindingConditionSyntax) -> Syntax {
+        guard let identifierPattern = node.pattern.as(IdentifierPatternSyntax.self),
+           identifierPattern.identifier.text != bindIdentifier,
+           let initializerIdentifier = node.initializer.value.as(IdentifierExprSyntax.self),
+           initializerIdentifier.identifier.text == "self" else {
+            return Syntax(node)
+        }
+
+        let isInDisabledRegion = disabledRegions.contains { region in
+            region.contains(node.positionAfterSkippingLeadingTrivia, locationConverter: locationConverter)
+        }
+
+        guard !isInDisabledRegion else {
+            return Syntax(node)
+        }
+
+        correctionPositions.append(identifierPattern.positionAfterSkippingLeadingTrivia)
+
+        return Syntax(
+            node.withPattern(
+                PatternSyntax(
+                    identifierPattern.withIdentifier(
+                        identifierPattern.identifier.withKind(.identifier(bindIdentifier))
+                    )
+                )
+            )
+        )
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/GeneratedTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GeneratedTests.swift
@@ -971,6 +971,12 @@ class ReturnValueFromVoidFunctionRuleGeneratedTests: XCTestCase {
     }
 }
 
+class SelfBindingRuleGeneratedTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(SelfBindingRule.description)
+    }
+}
+
 class SelfInPropertyInitializationRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SelfInPropertyInitializationRule.description)


### PR DESCRIPTION
To enforce that `self` identifiers are consistently re-bound to a common identifier name.

Configure `bind_identifier` to the name you want to use.

Defaults to `self`.

Addresses https://github.com/realm/SwiftLint/issues/2495