### PR TITLE
Add `--progress` flag to lint and analyze commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ accordingly._
   [JP Simard](https://github.com/jpsim)
   [#4048](https://github.com/realm/SwiftLint/issues/4048)
 
+* Add `--progress` flag to lint and analyze commands to show a live-updating
+  progress bar instead of each file being processed.  
+  [JP Simard](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Migrate `empty_xctest_method` rule to SwiftSyntax fixing some false positives.  

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -44,6 +44,7 @@ extension SwiftLint {
                 reporter: common.reporter,
                 quiet: quiet,
                 output: common.output,
+                progress: common.progress,
                 cachePath: nil,
                 ignoreCache: true,
                 enableAllRules: false,

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -48,6 +48,7 @@ extension SwiftLint {
                 reporter: common.reporter,
                 quiet: quiet,
                 output: common.output,
+                progress: common.progress,
                 cachePath: cachePath,
                 ignoreCache: noCache,
                 enableAllRules: enableAllRules,

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -41,6 +41,8 @@ struct LintOrAnalyzeArguments: ParsableArguments {
     var inProcessSourcekit = false
     @Option(help: "The file where violations should be saved. Prints to stdout by default.")
     var output: String?
+    @Flag(help: "Show a live-updating progress bar instead of each file being processed.")
+    var progress = false
 }
 
 // MARK: - Common Argument Help

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -73,6 +73,7 @@ struct LintableFilesVisitor {
     let action: String
     let useSTDIN: Bool
     let quiet: Bool
+    let showProgressBar: Bool
     let useScriptInputFiles: Bool
     let forceExclude: Bool
     let useExcludingByPrefix: Bool
@@ -80,16 +81,17 @@ struct LintableFilesVisitor {
     let parallel: Bool
     let allowZeroLintableFiles: Bool
     let mode: LintOrAnalyzeModeWithCompilerArguments
-    let block: (CollectedLinter) -> Void
+    let block: (CollectedLinter) async -> Void
 
     init(paths: [String], action: String, useSTDIN: Bool,
-         quiet: Bool, useScriptInputFiles: Bool, forceExclude: Bool, useExcludingByPrefix: Bool,
+         quiet: Bool, showProgressBar: Bool, useScriptInputFiles: Bool, forceExclude: Bool, useExcludingByPrefix: Bool,
          cache: LinterCache?, parallel: Bool,
-         allowZeroLintableFiles: Bool, block: @escaping (CollectedLinter) -> Void) {
+         allowZeroLintableFiles: Bool, block: @escaping (CollectedLinter) async -> Void) {
         self.paths = resolveParamsFiles(args: paths)
         self.action = action
         self.useSTDIN = useSTDIN
         self.quiet = quiet
+        self.showProgressBar = showProgressBar
         self.useScriptInputFiles = useScriptInputFiles
         self.forceExclude = forceExclude
         self.useExcludingByPrefix = useExcludingByPrefix
@@ -100,14 +102,15 @@ struct LintableFilesVisitor {
         self.block = block
     }
 
-    private init(paths: [String], action: String, useSTDIN: Bool, quiet: Bool,
+    private init(paths: [String], action: String, useSTDIN: Bool, quiet: Bool, showProgressBar: Bool,
                  useScriptInputFiles: Bool, forceExclude: Bool, useExcludingByPrefix: Bool,
                  cache: LinterCache?, compilerInvocations: CompilerInvocations?,
-                 allowZeroLintableFiles: Bool, block: @escaping (CollectedLinter) -> Void) {
+                 allowZeroLintableFiles: Bool, block: @escaping (CollectedLinter) async -> Void) {
         self.paths = resolveParamsFiles(args: paths)
         self.action = action
         self.useSTDIN = useSTDIN
         self.quiet = quiet
+        self.showProgressBar = showProgressBar
         self.useScriptInputFiles = useScriptInputFiles
         self.forceExclude = forceExclude
         self.useExcludingByPrefix = useExcludingByPrefix
@@ -129,7 +132,7 @@ struct LintableFilesVisitor {
     static func create(_ options: LintOrAnalyzeOptions,
                        cache: LinterCache?,
                        allowZeroLintableFiles: Bool,
-                       block: @escaping (CollectedLinter) -> Void)
+                       block: @escaping (CollectedLinter) async -> Void)
         throws -> LintableFilesVisitor {
         try Signposts.record(name: "LintableFilesVisitor.Create") {
             let compilerInvocations: CompilerInvocations?
@@ -141,6 +144,7 @@ struct LintableFilesVisitor {
 
             return LintableFilesVisitor(paths: options.paths, action: options.verb.bridge().capitalized,
                                         useSTDIN: options.useSTDIN, quiet: options.quiet,
+                                        showProgressBar: options.progress,
                                         useScriptInputFiles: options.useScriptInputFiles,
                                         forceExclude: options.forceExclude,
                                         useExcludingByPrefix: options.useExcludingByPrefix,

--- a/Source/swiftlint/Helpers/ProgressBar.swift
+++ b/Source/swiftlint/Helpers/ProgressBar.swift
@@ -1,0 +1,63 @@
+import Dispatch
+import Foundation
+import SwiftLintFramework
+
+// Inspired by https://github.com/jkandzi/Progress.swift
+actor ProgressBar {
+    private var index = 1
+    private var lastPrintedTime: TimeInterval = 0.0
+    private let startTime = uptime()
+    private let count: Int
+
+    init(count: Int) {
+        self.count = count
+    }
+
+    func initialize() {
+        // When progress is printed, the previous line is reset, so print an empty line before anything else
+        queuedPrintError("")
+    }
+
+    func printNext() {
+        guard index <= count else { return }
+
+        let currentTime = uptime()
+        if currentTime - lastPrintedTime > 0.1 || index == count {
+            let lineReset = "\u{1B}[1A\u{1B}[K"
+            let bar = makeBar()
+            let timeEstimate = makeTimeEstimate(currentTime: currentTime)
+            let lineContents = "\(index) of \(count) \(bar) \(timeEstimate)"
+            queuedPrintError("\(lineReset)\(lineContents)")
+            lastPrintedTime = currentTime
+        }
+
+        index += 1
+    }
+
+    // MARK: - Private
+
+    private func makeBar() -> String {
+        let barLength = 30
+        let completedBarElements = Int(Double(barLength) * (Double(index) / Double(count)))
+        let barArray = Array(repeating: "=", count: completedBarElements) +
+            Array(repeating: " ", count: barLength - completedBarElements)
+        return "[\(barArray.joined())]"
+    }
+
+    private func makeTimeEstimate(currentTime: TimeInterval) -> String {
+        let totalTime = currentTime - startTime
+        let itemsPerSecond = Double(index) / totalTime
+        let estimatedTimeRemaining = Double(count - index) / itemsPerSecond
+        let estimatedTimeRemainingString = "\(Int(estimatedTimeRemaining))s"
+        return "ETA: \(estimatedTimeRemainingString) (\(Int(itemsPerSecond)) files/s)"
+    }
+}
+
+#if os(Linux)
+// swiftlint:disable:next identifier_name
+private let NSEC_PER_SEC = 1_000_000_000
+#endif
+
+private func uptime() -> TimeInterval {
+    Double(DispatchTime.now().uptimeNanoseconds) / Double(NSEC_PER_SEC)
+}


### PR DESCRIPTION
Inspired by https://github.com/jkandzi/Progress.swift

```
4948 of 29100 [=====                         ] ETA: 44s (540 files/s)
```

Demo:

[![asciicast](https://asciinema.org/a/517985.svg)](https://asciinema.org/a/517985)
