### PR TITLE
Warn on rules listed in wrong section in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@
 * Add methods from SE-0348 to `UnusedDeclarationRule`.  
   [JP Simard](https://github.com/jpims)
 
+* Show warnings in the console for
+  * opt-in rules that are listed in the `disabled_rules` configuration section,
+  * active-by-default rules that are listed in the `opt_in_rules` configuration section and
+  * Analyzer rules that are listed in the `opt_in_rules` configuration section
+
+  as the user's intention might not be reflected correctly in the configuration.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 #### Bug Fixes
 
 * None.


### PR DESCRIPTION
Opt-in rules do not need to be disabled, while rules active by default do not need to be enabled in the `opt_in_rules` section. Analyzer rules should be listed in their own section. In addition to misspelled rule names, warn for IDs listed in the wrong category.

This validation has been suggested in [this comment](https://github.com/realm/SwiftLint/issues/4094#issuecomment-1215901036),