### PR TITLE
Remove references to ImplicitlyUnwrappedOptional type

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -29,14 +29,13 @@ public struct ImplicitlyUnwrappedOptionalRule: ASTRule, ConfigurationProviderRul
             Example("let int: Int! = 42"),
             Example("let int: Int! = nil"),
             Example("var int: Int! = 42"),
-            Example("let int: ImplicitlyUnwrappedOptional<Int>"),
             Example("let collection: AnyCollection<Int!>"),
             Example("func foo(int: Int!) {}")
         ]
     )
 
     private func hasImplicitlyUnwrappedOptional(_ typeName: String) -> Bool {
-        return typeName.contains("!") || typeName.contains("ImplicitlyUnwrappedOptional<")
+        return typeName.contains("!")
     }
 
     public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -50,7 +50,6 @@ public struct SyntacticSugarRule: CorrectableRule, ConfigurationProviderRule, So
 
 private enum SugaredType: String {
     case optional = "Optional"
-    case implicitlyUnwrappedOptional = "ImplicitlyUnwrappedOptional"
     case array = "Array"
     case dictionary = "Dictionary"
 
@@ -67,8 +66,6 @@ private enum SugaredType: String {
         switch self {
         case .optional:
             return "Int?"
-        case .implicitlyUnwrappedOptional:
-            return "Int!"
         case .array:
             return "[Int]"
         case .dictionary:
@@ -78,7 +75,7 @@ private enum SugaredType: String {
 
     var desugaredExample: String {
         switch self {
-        case .optional, .implicitlyUnwrappedOptional, .array:
+        case .optional, .array:
             return "\(rawValue)<Int>"
         case .dictionary:
             return "\(rawValue)<String, Int>"
@@ -105,7 +102,6 @@ private struct SyntacticSugarRuleViolation {
         case optional
         case dictionary(commaStart: AbsolutePosition, commaEnd: AbsolutePosition)
         case array
-        case implicitlyUnwrappedOptional
     }
 
     let position: AbsolutePosition
@@ -237,8 +233,6 @@ private final class SyntacticSugarRuleVisitor: SyntaxVisitor {
         switch type {
         case .optional:
             correctionType = .optional
-        case .implicitlyUnwrappedOptional:
-            correctionType = .implicitlyUnwrappedOptional
         case .array:
             correctionType = .array
         case .dictionary:
@@ -311,11 +305,6 @@ private struct CorrectingContext {
 
         case .optional:
             replaceCharacters(in: rightRange, with: "?")
-            correctViolations(violation.children)
-            replaceCharacters(in: leftRange, with: "")
-
-        case .implicitlyUnwrappedOptional:
-            replaceCharacters(in: rightRange, with: "!")
             correctViolations(violation.children)
             replaceCharacters(in: leftRange, with: "")
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRuleExamples.swift
@@ -35,7 +35,6 @@ internal enum SyntacticSugarRuleExamples {
         Example("let x: ↓Array<String>"),
         Example("let x: ↓Dictionary<Int, String>"),
         Example("let x: ↓Optional<Int>"),
-        Example("let x: ↓ImplicitlyUnwrappedOptional<Int>"),
         Example("let x: ↓Swift.Array<String>"),
 
         Example("func x(a: ↓Array<Int>, b: Int) -> [Int: Any]"),
@@ -67,8 +66,6 @@ internal enum SyntacticSugarRuleExamples {
         Example("let x: Dictionary<Int, String>"): Example("let x: [Int: String]"),
         Example("let x: Optional<Int>"): Example("let x: Int?"),
         Example("let x: Optional< Int >"): Example("let x: Int?"),
-        Example("let x: ImplicitlyUnwrappedOptional<Int>"): Example("let x: Int!"),
-        Example("let x: ImplicitlyUnwrappedOptional< Int >"): Example("let x: Int!"),
 
         Example("let x: Dictionary<Int , String>"): Example("let x: [Int: String]"),
         Example("let x: Swift.Optional<String>"): Example("let x: String?"),
@@ -77,7 +74,6 @@ internal enum SyntacticSugarRuleExamples {
         Example("let x:↓Dictionary<↓Dictionary<↓Dictionary<Int, Int>, Int>, String>"):
             Example("let x:[[[Int: Int]: Int]: String]"),
         Example("let x:↓Array<↓Dictionary<Int, Int>>"): Example("let x:[[Int: Int]]"),
-        Example("let x:↓Optional<↓Dictionary<Int, Int>>"): Example("let x:[Int: Int]?"),
-        Example("let x:↓ImplicitlyUnwrappedOptional<↓Dictionary<Int, Int>>"): Example("let x:[Int: Int]!")
+        Example("let x:↓Optional<↓Dictionary<Int, Int>>"): Example("let x:[Int: Int]?")
     ]
 }

--- a/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
@@ -107,7 +107,7 @@ private struct ExpressibleByCompiler {
     }()
 
     private static let byNilLiteral = ExpressibleByCompiler(protocolName: "ExpressibleByNilLiteral",
-                                                            types: ["ImplicitlyUnwrappedOptional", "Optional"],
+                                                            types: ["Optional"],
                                                             arguments: [["nilLiteral"]])
 
     private static let byBooleanLiteral = ExpressibleByCompiler(protocolName: "ExpressibleByBooleanLiteral",

--- a/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
@@ -93,22 +93,12 @@ public struct ValidIBInspectableRule: ASTRule, ConfigurationProviderRule {
             """),
             Example("""
             class Foo {
-              @IBInspectable private ↓var x: ImplicitlyUnwrappedOptional<Int>
-            }
-            """),
-            Example("""
-            class Foo {
               @IBInspectable private ↓var count: Optional<Int>
             }
             """),
             Example("""
             class Foo {
               @IBInspectable private ↓var x: Optional<String>
-            }
-            """),
-            Example("""
-            class Foo {
-              @IBInspectable private ↓var x: ImplicitlyUnwrappedOptional<String>
             }
             """)
         ]


### PR DESCRIPTION
Since [SE-054](https://github.com/apple/swift-evolution/blob/master/proposals/0054-abolish-iuo.md), `ImplicitlyUnwrappedOptional` doesn't exist as a type. 

This proposal was implemented in Swift 4.2 and as we've raised the minimum supported Swift to 5.0, we can remove these references for simplicity.

Let me know if you think this deserves a note in the CHANGELOG, but I don't think it does.