### PR TITLE
Call `super.visit` in `SyntaxRewriter` overrides

### DIFF
--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -91,7 +91,7 @@ private final class ClosureSpacingRuleRewriter: SyntaxRewriter, ViolationsSyntax
         }
 
         guard !isInDisabledRegion, node.shouldCheckForClosureSpacingRule(locationConverter: locationConverter) else {
-            return ExprSyntax(node)
+            return super.visit(node)
         }
 
         let violations = node.violations
@@ -111,7 +111,7 @@ private final class ClosureSpacingRuleRewriter: SyntaxRewriter, ViolationsSyntax
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
         }
 
-        return ExprSyntax(node)
+        return super.visit(node)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
@@ -104,7 +104,7 @@ private final class SelfBindingRuleRewriter: SyntaxRewriter, ViolationsSyntaxRew
            identifierPattern.identifier.text != bindIdentifier,
            let initializerIdentifier = node.initializer.value.as(IdentifierExprSyntax.self),
            initializerIdentifier.identifier.text == "self" else {
-            return Syntax(node)
+            return super.visit(node)
         }
 
         let isInDisabledRegion = disabledRegions.contains { region in
@@ -112,12 +112,12 @@ private final class SelfBindingRuleRewriter: SyntaxRewriter, ViolationsSyntaxRew
         }
 
         guard !isInDisabledRegion else {
-            return Syntax(node)
+            return super.visit(node)
         }
 
         correctionPositions.append(identifierPattern.positionAfterSkippingLeadingTrivia)
 
-        return Syntax(
+        return super.visit(
             node.withPattern(
                 PatternSyntax(
                     identifierPattern.withIdentifier(


### PR DESCRIPTION
As discussed in https://github.com/realm/SwiftLint/pull/4159#discussion_r962841482