### PR TITLE
Make SwiftLint available as a build tool plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@
 * Include the configured `bind_identifier` in `self_binding` violation
   messages.  
   [JP Simard](https://github.com/jpims)
+* Rewrite `large_tuple` rule using SwiftSyntax, fixing false negatives.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  
+* Add Swift Package Build Tool Plugin with support for Swift Packages 
+  and Xcode projects.
+  [Johannes Ebeling](https://github.com/technocidal) 
 
 #### Bug Fixes
 

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
     platforms: [.macOS(.v12)],
     products: [
         .executable(name: "swiftlint", targets: ["swiftlint"]),
-        .library(name: "SwiftLintFramework", targets: ["SwiftLintFramework"])
+        .library(name: "SwiftLintFramework", targets: ["SwiftLintFramework"]),
+        .plugin(name: "SwiftLintPlugin", targets: ["SwiftLintPlugin"])
     ],
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.3")),
@@ -35,6 +36,13 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit.git", from: "0.2.0")
     ] + (addCryptoSwift ? [.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.5.1"))] : []),
     targets: [
+        .plugin(
+            name: "SwiftLintPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                .target(name: "swiftlint")
+            ]
+        ),
         .executableTarget(
             name: "swiftlint",
             dependencies: [

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -1,0 +1,31 @@
+import PackagePlugin
+
+@main
+struct SwiftLintPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PackagePlugin.PluginContext, target: PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
+        [
+            .buildCommand(
+                displayName: "SwiftLint",
+                executable: try context.tool(named: "swiftlint").path,
+                arguments: []
+            ),
+        ]
+    }
+}
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension SwiftLintPlugin: XcodeBuildToolPlugin {
+
+    func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
+        [
+            .buildCommand(
+                displayName: "SwiftLint",
+                executable: try context.tool(named: "swiftlint").path,
+                arguments: []
+            )
+        ]
+    }
+}
+#endif

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -23,7 +23,9 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
             .buildCommand(
                 displayName: "SwiftLint",
                 executable: try context.tool(named: "swiftlint").path,
-                arguments: []
+                arguments: [
+                    "--cache-path", "\(context.pluginWorkDirectory)"
+                ]
             )
         ]
     }


### PR DESCRIPTION
# Motivation
SwiftLint is an important part as a build phase for many projects. Depending on where the project is being build the path where `swiftlint` is located on a machine can differ. One example is the recent Homebrew path change when Apple introduced Apple Silicon machines. Using SwiftLint as a plugin means that there is no need for an external package manager to install it, less setup during initial project setup and a more portable project overall.

# Open Questions
- Do I need to add additional parameters to the actual `swiftlint` call?