### PR TITLE
Respect 'validates_start_with_lowercase'  value when linting function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@
 
 #### Bug Fixes
 
-* None.
+* Respect `validates_start_with_lowercase` value when linting function names
+  [Chris Brakebill](https://github.com/braker1nine)
+  [#2708](https://github.com/realm/SwiftLint/issues/2708)
 
 ## 0.49.1: Buanderie Principale
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 #### Bug Fixes
 
-* Respect `validates_start_with_lowercase` value when linting function names
+* Respect `validates_start_with_lowercase` option when linting function names.  
   [Chris Brakebill](https://github.com/braker1nine)
   [#2708](https://github.com/realm/SwiftLint/issues/2708)
 

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -72,7 +72,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             guard !firstCharacterIsAllowed else {
                 return []
             }
-            let requiresCaseCheck = configuration.validatesStartWithLowercase || isFunction
+            let requiresCaseCheck = configuration.validatesStartWithLowercase
             if requiresCaseCheck &&
                 kind != .varStatic && name.isViolatingCase && !name.isOperator {
                 let reason = "\(type) name should start with a lowercase character: '\(name)'"

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -30,7 +30,8 @@ class IdentifierNameRuleTests: XCTestCase {
         let baseDescription = IdentifierNameRule.description
         let triggeringExamplesToRemove = [
             Example("↓let MyLet = 0"),
-            Example("enum Foo { case ↓MyEnum }")
+            Example("enum Foo { case ↓MyEnum }"),
+            Example("↓func IsOperator(name: String) -> Bool")
         ]
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples +
             triggeringExamplesToRemove.removingViolationMarkers()


### PR DESCRIPTION
Previously functions were being treated as an exception to this rule configuration. 

Resolves #2708