### PR TITLE
Include the configured `bind_identifier` in `self_binding` violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 * Add methods from SE-0348 to `UnusedDeclarationRule`.  
   [JP Simard](https://github.com/jpims)
 
+* Include the configured `bind_identifier` in `self_binding` violation
+  messages.  
+  [JP Simard](https://github.com/jpims)
+
 #### Bug Fixes
 
 * None.

--- a/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
@@ -46,7 +46,8 @@ public struct SelfBindingRule: SwiftSyntaxCorrectableRule, ConfigurationProvider
         StyleViolation(
             ruleDescription: Self.description,
             severity: configuration.severityConfiguration.severity,
-            location: Location(file: file, position: position)
+            location: Location(file: file, position: position),
+            reason: "`self` should always be re-bound to `\(configuration.bindIdentifier)`"
         )
     }
 


### PR DESCRIPTION
As suggested in https://github.com/realm/SwiftLint/pull/4146#issuecomment-1241793057