### PR TITLE
Make `willMove` a lifecycle method in `type_contents_order` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@
   [#3598](https://github.com/realm/SwiftLint/issues/3456)
   [#3611](https://github.com/realm/SwiftLint/issues/3611)
 
+* Fix false-positives related to the `willMove` lifecycle method in
+  `type_contents_order` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3478](https://github.com/realm/SwiftLint/issues/3478)
+
 ## 0.49.1: Buanderie Principale
 
 _Note: The default branch for the SwiftLint git repository was renamed from

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -118,7 +118,8 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
                 "viewDidLayoutSubviews(",
                 "viewDidAppear(",
                 "viewWillDisappear(",
-                "viewDidDisappear("
+                "viewDidDisappear(",
+                "willMove("
             ]
 
             if typeContentStructure.name!.starts(with: "init(") {

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRuleExamples.swift
@@ -65,6 +65,13 @@ internal struct TypeContentsOrderRuleExamples {
                 hasLayoutedView1 = true
             }
 
+            override func willMove(toParent parent: UIViewController?) {
+                super.willMove(toParent: parent)
+                if parent == nil {
+                    viewModel.willMoveToParent()
+                }
+            }
+
             override func viewDidLayoutSubviews() {
                 super.viewDidLayoutSubviews()
 


### PR DESCRIPTION
Fixes #3478.