### PR TITLE
add LibraryContentProvider to file_types_order rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@
 * Include the configured `bind_identifier` in `self_binding` violation
   messages.  
   [JP Simard](https://github.com/jpims)
+  
+* Add `library_content_provider` file type to `file_types_order` rule 
+  to allow LibraryContentProvider to be ordered independent from `main_type`
+  [dahlborn](https://github.com/dahlborn)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
   [JP Simard](https://github.com/jpims)
   
 * Add `library_content_provider` file type to `file_types_order` rule 
-  to allow LibraryContentProvider to be ordered independent from `main_type`
+  to allow `LibraryContentProvider` to be ordered independent from `main_type`.  
   [dahlborn](https://github.com/dahlborn)
 
 #### Bug Fixes

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -3,6 +3,7 @@ enum FileType: String {
     case mainType = "main_type"
     case `extension` = "extension"
     case previewProvider = "preview_provider"
+    case libraryContentProvider = "library_content_provider"
 }
 
 public struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
@@ -11,7 +12,8 @@ public struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
         [.supportingType],
         [.mainType],
         [.extension],
-        [.previewProvider]
+        [.previewProvider],
+        [.libraryContentProvider]
     ]
 
     public var consoleDescription: String {

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -117,8 +117,8 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
             guard let declarationKind = substructure.declarationKind else { return false }
             guard !substructure.hasExcludedInheritedType else { return false }
 
-            return substructure.offset != mainTypeSubstructure.offset &&
-            supportingTypeKinds.contains(declarationKind)
+            return substructure.offset != mainTypeSubstructure.offset
+                && supportingTypeKinds.contains(declarationKind)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable:next type_body_length
 internal struct FileTypesOrderRuleExamples {
     static let defaultOrderParts = [
         """
@@ -120,14 +121,23 @@ internal struct FileTypesOrderRuleExamples {
         }
         """),
         Example("""
+        // Main Type
         struct ContentView: View {
             var body: some View {
                 Text("Hello, World!")
             }
         }
 
+        // Preview Provider
         struct ContentView_Previews: PreviewProvider {
             static var previews: some View { ContentView() }
+        }
+
+        // Library Content Provider
+        struct ContentView_LibraryContent: LibraryContentProvider {
+            var views: [LibraryItem] {
+                LibraryItem(ContentView())
+            }
         }
         """)
     ]
@@ -192,6 +202,16 @@ internal struct FileTypesOrderRuleExamples {
 
         // Main Type
         struct ContentView: View {}
+        """),
+        Example("""
+        // Library Content Provider
+        ↓struct ContentView_LibraryContent: LibraryContentProvider {}
+
+        // Main Type
+        struct ContentView: View {}
+
+        // Preview Provider
+        struct ContentView_Previews: PreviewProvider {}
         """)
     ]
 }

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
@@ -198,20 +198,31 @@ internal struct FileTypesOrderRuleExamples {
         """),
         Example("""
         // Preview Provider
-        ↓struct ContentView_Previews: PreviewProvider {}
+        ↓struct ContentView_Previews: PreviewProvider {
+            static var previews: some View { ContentView() }
+        }
 
         // Main Type
-        struct ContentView: View {}
+        struct ContentView: View {
+            var body: some View {
+                Text("Hello, World!")
+            }
+        }
         """),
         Example("""
         // Library Content Provider
-        ↓struct ContentView_LibraryContent: LibraryContentProvider {}
+        ↓struct ContentView_LibraryContent: LibraryContentProvider {
+            var views: [LibraryItem] {
+                LibraryItem(ContentView())
+            }
+        }
 
         // Main Type
-        struct ContentView: View {}
-
-        // Preview Provider
-        struct ContentView_Previews: PreviewProvider {}
+        struct ContentView: View {
+            var body: some View {
+                Text("Hello, World!")
+            }
+        }
         """)
     ]
 }

--- a/Tests/SwiftLintFrameworkTests/FileTypesOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileTypesOrderRuleTests.swift
@@ -55,6 +55,19 @@ class FileTypesOrderRuleTests: XCTestCase {
             struct ContentView_Previews: PreviewProvider {
                static var previews: some View { ContentView() }
             }
+            """),
+            Example("""
+            ↓struct ContentView: View {
+               var body: some View {
+                   Text("Hello, World!")
+               }
+            }
+
+            struct ContentView_LibraryContent: LibraryContentProvider {
+                var views: [LibraryItem] {
+                    LibraryItem(ContentView())
+                }
+            }
             """)
         ]
 
@@ -65,7 +78,7 @@ class FileTypesOrderRuleTests: XCTestCase {
         verifyRule(
             reversedOrderDescription,
             ruleConfiguration: [
-                "order": ["preview_provider", "extension", "main_type", "supporting_type"]
+                "order": ["library_content_provider", "preview_provider", "extension", "main_type", "supporting_type"]
             ]
         )
     }


### PR DESCRIPTION
Added LibraryContentProvider FileType to `file_types_order` configuration to allow it to be ordered independently from `main_type` like PreviewProvider.