### PR TITLE
Add `xctestcase_subclasses` option to `test_case_accessibility` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@
   messages.  
   [JP Simard](https://github.com/jpims)
 
+* Add `xctestcase_subclasses` option to `test_case_accessibility` rule, which
+  allows detection in subclasses of XCTestCase (or in arbitrary classes.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4200](https://github.com/realm/SwiftLint/issues/4200)
+
 #### Bug Fixes
 
 * Respect `validates_start_with_lowercase` option when linting function names.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
   [JP Simard](https://github.com/jpims)
 
 * Add `xctestcase_subclasses` option to `test_case_accessibility` rule, which
-  allows detection in subclasses of XCTestCase (or in arbitrary classes.  
+  allows detection in subclasses of XCTestCase.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4200](https://github.com/realm/SwiftLint/issues/4200)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
   messages.  
   [JP Simard](https://github.com/jpims)
 
-* Add `xctestcase_subclasses` option to `test_case_accessibility` rule, which
+* Add `test_parent_classes` option to `test_case_accessibility` rule, which
   allows detection in subclasses of XCTestCase.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4200](https://github.com/realm/SwiftLint/issues/4200)

--- a/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -41,7 +41,9 @@ public struct TestCaseAccessibilityRule: Rule, OptInRule, ConfigurationProviderR
 
     private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
         return file.structureDictionary.substructure.filter { dictionary in
-            dictionary.declarationKind == .class && dictionary.inheritedTypes.contains("XCTestCase")
+            dictionary.declarationKind == .class &&
+                (dictionary.inheritedTypes.contains("XCTestCase") ||
+                 dictionary.inheritedTypes.contains(where: configuration.xctestcaseSubclasses.contains))
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -42,8 +42,7 @@ public struct TestCaseAccessibilityRule: Rule, OptInRule, ConfigurationProviderR
     private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
         return file.structureDictionary.substructure.filter { dictionary in
             dictionary.declarationKind == .class &&
-                (dictionary.inheritedTypes.contains("XCTestCase") ||
-                 dictionary.inheritedTypes.contains(where: configuration.xctestcaseSubclasses.contains))
+            configuration.testParentClasses.intersection(dictionary.inheritedTypes).isNotEmpty
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -1,12 +1,12 @@
 public struct TestCaseAccessibilityConfiguration: RuleConfiguration, Equatable {
     public private(set) var severityConfiguration = SeverityConfiguration(.warning)
     public private(set) var allowedPrefixes: Set<String> = []
-    public private(set) var xctestcaseSubclasses: Set<String> = []
+    public private(set) var testParentClasses: Set<String> = []
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", allowed_prefixes: [\(allowedPrefixes)]" +
-            ", xctestcase_subclasses: [\(xctestcaseSubclasses)]"
+            ", test_parent_classes: [\(testParentClasses)]"
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -22,9 +22,12 @@ public struct TestCaseAccessibilityConfiguration: RuleConfiguration, Equatable {
             self.allowedPrefixes = Set(allowedPrefixes)
         }
 
-        if let xctestcaseSubclasses = configuration["xctestcase_subclasses"] as? [String] {
-            self.xctestcaseSubclasses = Set(xctestcaseSubclasses)
+        var testParentClasses = ["XCTestCase"]
+        if let extraTestParentClasses = configuration["test_parent_classes"] as? [String] {
+            testParentClasses.append(contentsOf: extraTestParentClasses)
         }
+        self.testParentClasses = Set(testParentClasses)
+
     }
 
     public var severity: ViolationSeverity {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -1,7 +1,7 @@
 public struct TestCaseAccessibilityConfiguration: RuleConfiguration, Equatable {
     public private(set) var severityConfiguration = SeverityConfiguration(.warning)
     public private(set) var allowedPrefixes: Set<String> = []
-    public private(set) var testParentClasses: Set<String> = []
+    public private(set) var testParentClasses: Set<String> = ["XCTestCase"]
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription +
@@ -22,12 +22,9 @@ public struct TestCaseAccessibilityConfiguration: RuleConfiguration, Equatable {
             self.allowedPrefixes = Set(allowedPrefixes)
         }
 
-        var testParentClasses = ["XCTestCase"]
         if let extraTestParentClasses = configuration["test_parent_classes"] as? [String] {
-            testParentClasses.append(contentsOf: extraTestParentClasses)
+            self.testParentClasses.formUnion(extraTestParentClasses)
         }
-        self.testParentClasses = Set(testParentClasses)
-
     }
 
     public var severity: ViolationSeverity {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -1,10 +1,12 @@
 public struct TestCaseAccessibilityConfiguration: RuleConfiguration, Equatable {
     public private(set) var severityConfiguration = SeverityConfiguration(.warning)
     public private(set) var allowedPrefixes: Set<String> = []
+    public private(set) var xctestcaseSubclasses: Set<String> = []
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription +
-            ", allowed_prefixes: [\(allowedPrefixes)]"
+            ", allowed_prefixes: [\(allowedPrefixes)]" +
+            ", xctestcase_subclasses: [\(xctestcaseSubclasses)]"
     }
 
     public mutating func apply(configuration: Any) throws {
@@ -18,6 +20,10 @@ public struct TestCaseAccessibilityConfiguration: RuleConfiguration, Equatable {
 
         if let allowedPrefixes = configuration["allowed_prefixes"] as? [String] {
             self.allowedPrefixes = Set(allowedPrefixes)
+        }
+
+        if let xctestcaseSubclasses = configuration["xctestcase_subclasses"] as? [String] {
+            self.xctestcaseSubclasses = Set(xctestcaseSubclasses)
         }
     }
 


### PR DESCRIPTION

Adds an `xctestcase_subclasses` option to the `test_case_accessibility` rules, partially resolving #4200 

For example, given

```
class MyTestCase: XCTestCase { }

class BrokenSwiftLintDemoTests: MyTestCase {
    func notATest() { }
}
```

```
test_case_accessibility:
  xctestcase_subclasses: ["MyTestCase"]
```

can be used so that `test_case_accessibility` can still work.

See https://github.com/realm/SwiftLint/issues/4200
