### PR TITLE
Add `test_parent_classes` option to `single_test_class`, `balanced_xctest_lifecycle`, and `empty_xctest` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4200](https://github.com/realm/SwiftLint/issues/4200)
 
+* Add `test_parent_classes` option to `balanced_xctest_lifecycle`, `single_test_class`
+  and `empty_xctest_method` rules.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4200](https://github.com/realm/SwiftLint/issues/4200)
+
 #### Bug Fixes
 
 * Respect `validates_start_with_lowercase` option when linting function names.  

--- a/Source/SwiftLintFramework/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 public struct BalancedXCTestLifecycleRule: Rule, OptInRule, ConfigurationProviderRule {
     // MARK: - Properties
 
-    public var configuration = SeverityConfiguration(.warning)
+    public var configuration = BalancedXCTestLifecycleConfiguration()
 
     public static let description = RuleDescription(
         identifier: "balanced_xctest_lifecycle",
@@ -120,8 +120,8 @@ public struct BalancedXCTestLifecycleRule: Rule, OptInRule, ConfigurationProvide
 
     private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
         file.structureDictionary.substructure.filter { dictionary in
-            guard dictionary.declarationKind == .class else { return false }
-            return dictionary.inheritedTypes.contains("XCTestCase")
+            dictionary.declarationKind == .class &&
+            configuration.testParentClasses.intersection(dictionary.inheritedTypes).isNotEmpty
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 public struct EmptyXCTestMethodRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+    public var configuration = EmptyXCTestMethodConfiguration()
 
     public init() {}
 
@@ -15,15 +15,28 @@ public struct EmptyXCTestMethodRule: OptInRule, ConfigurationProviderRule, Swift
     )
 
     public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
-        EmptyXCTestMethodRuleVisitor()
+        EmptyXCTestMethodRuleVisitor(testParentClasses: configuration.testParentClasses)
+    }
+    
+    public func makeViolation(file: SwiftLintFile, position: AbsolutePosition) -> StyleViolation {
+        StyleViolation(
+            ruleDescription: Self.description,
+            severity: configuration.severity,
+            location: Location(file: file, position: position)
+        )
     }
 }
 
 private final class EmptyXCTestMethodRuleVisitor: SyntaxVisitor, ViolationsSyntaxVisitor {
     private(set) var violationPositions: [AbsolutePosition] = []
+    private let testParentClasses: Set<String>
 
+    init(testParentClasses: Set<String>) {
+        self.testParentClasses = testParentClasses
+    }
+    
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-        node.isXCTestCase ? .visitChildren : .skipChildren
+        isNodeATestCase(node) ? .visitChildren : .skipChildren
     }
 
     override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -43,16 +56,18 @@ private final class EmptyXCTestMethodRuleVisitor: SyntaxVisitor, ViolationsSynta
             violationPositions.append(node.funcKeyword.positionAfterSkippingLeadingTrivia)
         }
     }
+    
+    private func isNodeATestCase(_ node: ClassDeclSyntax) -> Bool {
+        testParentClasses.intersection(node.inheritedTypes).isNotEmpty
+    }
 }
 
 private extension ClassDeclSyntax {
-    var isXCTestCase: Bool {
+    var inheritedTypes: [String] {
         guard let inheritanceList = inheritanceClause?.inheritedTypeCollection else {
-            return false
+            return []
         }
-        return inheritanceList.contains { type in
-            type.typeName.as(SimpleTypeIdentifierSyntax.self)?.name.text == "XCTestCase"
-        }
+        return inheritanceList.compactMap { $0.typeName.as(SimpleTypeIdentifierSyntax.self)?.name.text }
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/BalancedXCTestLifecycleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/BalancedXCTestLifecycleConfiguration.swift
@@ -1,0 +1,27 @@
+public struct BalancedXCTestLifecycleConfiguration: RuleConfiguration, Equatable {
+    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    public private(set) var testParentClasses: Set<String> = ["XCTestCase"]
+    
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription +
+            ", test_parent_classes: [\(testParentClasses)]"
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        if let extraTestParentClasses = configuration["test_parent_classes"] as? [String] {
+            self.testParentClasses.formUnion(extraTestParentClasses)
+        }
+    }
+
+    public var severity: ViolationSeverity {
+        return severityConfiguration.severity
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyXCTestMethodConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyXCTestMethodConfiguration.swift
@@ -1,0 +1,27 @@
+public struct EmptyXCTestMethodConfiguration: RuleConfiguration, Equatable {
+    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    public private(set) var testParentClasses: Set<String> = ["XCTestCase"]
+    
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription +
+            ", test_parent_classes: [\(testParentClasses)]"
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        if let extraTestParentClasses = configuration["test_parent_classes"] as? [String] {
+            self.testParentClasses.formUnion(extraTestParentClasses)
+        }
+    }
+
+    public var severity: ViolationSeverity {
+        return severityConfiguration.severity
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SingleTestClassConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SingleTestClassConfiguration.swift
@@ -1,0 +1,27 @@
+public struct SingleTestClassConfiguration: RuleConfiguration, Equatable {
+    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    public private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
+    
+    public var consoleDescription: String {
+        return severityConfiguration.consoleDescription +
+            ", test_parent_classes: [\(testParentClasses)]"
+    }
+
+    public mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let severityString = configuration["severity"] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        if let extraTestParentClasses = configuration["test_parent_classes"] as? [String] {
+            self.testParentClasses.formUnion(extraTestParentClasses)
+        }
+    }
+
+    public var severity: ViolationSeverity {
+        return severityConfiguration.severity
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 
 public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+    public var configuration = SingleTestClassConfiguration()
 
     public static let description = RuleDescription(
         identifier: "single_test_class",
@@ -44,8 +44,6 @@ public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule {
         ]
     )
 
-    private let testClasses: Set = ["QuickSpec", "XCTestCase"]
-
     public init() {}
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
@@ -64,10 +62,9 @@ public struct SingleTestClassRule: Rule, OptInRule, ConfigurationProviderRule {
     }
 
     private func testClasses(in file: SwiftLintFile) -> [SourceKittenDictionary] {
-        let dict = file.structureDictionary
-        return dict.substructure.filter { dictionary in
-            guard dictionary.declarationKind == .class else { return false }
-            return !testClasses.isDisjoint(with: dictionary.inheritedTypes)
+        return file.structureDictionary.substructure.filter { dictionary in
+            dictionary.declarationKind == .class &&
+            configuration.testParentClasses.intersection(dictionary.inheritedTypes).isNotEmpty
         }
     }
 }


### PR DESCRIPTION
Adds a `test_parent_classes` option to the `single_test_class`, `balanced_xctest_lifecycle`, and  `empty_xctest` rules, resolving the remaining rules mentioned in https://github.com/realm/SwiftLint/issues/4200.

Very similar to #4214 but see notes below.

For example, given

```
class MyTestCase: XCTestCase { }

class SwiftLintDemoTests: XCTestCase {
    // Unbalanced
    override func setUpWithError() throws {
        XCTFail("Hello")
    }

    // Empty
    func testExample() throws {

    }
}

// Second test class
class SwiftLintDemoTests2: XCTestCase {
    func testExample() throws {
        XCTFail("Hello")
    }
}
```

The following configurations will pick up the violations:

```
opt_in_rules:
  - balanced_xctest_lifecycle
  - single_test_class
  - empty_xctest_method

balanced_xctest_lifecycle:
  test_parent_classes: ["MyTestCase"]

single_test_class:
  test_parent_classes: ["MyTestCase"]

empty_xctest_method:
  test_parent_classes: ["MyTestCase"]
```

## [Notes](#notes)

There is a lot of redundancy in the configurations. `BalancedXCTestLifecycleConfiguration.swift` and `EmptyXCTestMethodConfiguration.swift` are identical, and `SingleTestClassConfiguration.swift` differs only in including `QuickSpec` as an additional default parent class.

I didn't roll anything up as yet, but obviously it would be trivial to either have an abstract parent class, or to have two of the configurations inherit from the other one, and to take the default parent classes as a constructor argument.

Also, I had to implement `makeViolation(file: SwiftLintFile, position: AbsolutePosition) -> StyleViolation` myself in `EmptyXCTestMethodRule.swift` because my rule's configuration was no longer a SeverityConfiguration - I wonder if there some way I could have avoided having to do that.

