### PR TITLE
[bazel] Enable WMO in `release` configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,4 +5,5 @@ build --macos_minimum_os=12.0 --host_macos_minimum_os=12.0
 build --disk_cache=~/.bazel_cache
 
 build:release \
-  --compilation_mode=opt
+  --compilation_mode=opt \
+  --features=swift.opt_uses_wmo

--- a/Dangerfile
+++ b/Dangerfile
@@ -16,7 +16,7 @@ has_app_changes = !modified_files.grep(/Source/).empty?
 has_test_changes = !modified_files.grep(/Tests/).empty?
 has_danger_changes = !modified_files.grep(/Dangerfile|script\/oss-check|Gemfile/).empty?
 has_package_changes = !modified_files.grep(/Package\.swift/).empty?
-has_bazel_changes = !modified_files.grep(/WORKSPACE|bazel\/|BUILD/).empty?
+has_bazel_changes = !modified_files.grep(/\.bazelrc|WORKSPACE|bazel\/|BUILD/).empty?
 
 # Add a CHANGELOG entry for app changes
 if !modified_files.include?('CHANGELOG.md') && has_app_changes

--- a/tools/oss-check
+++ b/tools/oss-check
@@ -208,7 +208,7 @@ def build(branch)
     perform("git worktree add --detach #{dir} #{target}")
   end
 
-  build_command = "cd #{dir}; bazel build -c opt @SwiftLint//:swiftlint && mv bazel-bin/swiftlint swiftlint-#{branch}"
+  build_command = "cd #{dir}; bazel build --config=release @SwiftLint//:swiftlint && mv bazel-bin/swiftlint swiftlint-#{branch}"
 
   perform(build_command)
   return if $?.success?


### PR DESCRIPTION
Enabling WMO can make SwiftLint up to 90% faster in my testing, and matches what SwiftPM does when building with `swift buid -c release`.