### PR TITLE
Remove anyobject_protocol from configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,7 +7,6 @@ analyzer_rules:
   - unused_declaration
   - unused_import
 opt_in_rules:
-  - anyobject_protocol
   - array_init
   - attributes
   - closure_end_indentation


### PR DESCRIPTION
It's been deprecated and the compiler catches these now.