### PR TITLE
Generate Swift Syntax Dashboard in documentation

### DIFF
--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -14,6 +14,12 @@ struct RuleDocumentation {
     /// If this rule uses SourceKit.
     var usesSourceKit: Bool { !(ruleType is SourceKitFreeRule.Type) }
 
+    /// If this rule is disabled by default.
+    var isDisabledByDefault: Bool { ruleType is OptInRule.Type }
+
+    /// If this rule is enabled by default.
+    var isEnabledByDefault: Bool { !isDisabledByDefault }
+
     /// Creates a RuleDocumentation instance from a Rule type.
     ///
     /// - parameter ruleType: A subtype of the `Rule` protocol to document.

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -2,9 +2,17 @@
 struct RuleDocumentation {
     private let ruleType: Rule.Type
 
-    var isOptInRule: Bool {
-        return ruleType is OptInRule.Type
-    }
+    /// If this rule is an opt-in rule.
+    var isOptInRule: Bool { ruleType is OptInRule.Type }
+
+    /// If this rule is an analyzer rule.
+    var isAnalyzerRule: Bool { ruleType is AnalyzerRule.Type }
+
+    /// If this rule is a linter rule.
+    var isLinterRule: Bool { !isAnalyzerRule }
+
+    /// If this rule uses SourceKit.
+    var usesSourceKit: Bool { !(ruleType is SourceKitFreeRule.Type) }
 
     /// Creates a RuleDocumentation instance from a Rule type.
     ///
@@ -14,19 +22,13 @@ struct RuleDocumentation {
     }
 
     /// The name of the documented rule.
-    var ruleName: String {
-        return ruleType.description.name
-    }
+    var ruleName: String { ruleType.description.name }
 
     /// The identifier of the documented rule.
-    var ruleIdentifier: String {
-        return ruleType.description.identifier
-    }
+    var ruleIdentifier: String { ruleType.description.identifier }
 
     /// The name of the file on disk for this rule documentation.
-    var fileName: String {
-        return "\(ruleType.description.identifier).md"
-    }
+    var fileName: String { "\(ruleType.description.identifier).md" }
 
     /// The contents of the file for this rule documentation.
     var fileContents: String {
@@ -46,13 +48,9 @@ struct RuleDocumentation {
     }
 }
 
-private func h1(_ text: String) -> String {
-    return "# \(text)"
-}
+private func h1(_ text: String) -> String { "# \(text)" }
 
-private func h2(_ text: String) -> String {
-    return "## \(text)"
-}
+private func h2(_ text: String) -> String { "## \(text)" }
 
 private func detailsSummary(_ rule: Rule) -> String {
     return """

--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -24,6 +24,7 @@ public struct RuleListDocumentation {
             try text.write(to: url.appendingPathComponent(file), atomically: false, encoding: .utf8)
         }
         try write(indexContents, toFile: "Rule Directory.md")
+        try write(swiftSyntaxDashboardContents, toFile: "Swift Syntax Dashboard.md")
         for doc in ruleDocumentations {
             try write(doc.fileContents, toFile: doc.fileName)
         }
@@ -47,6 +48,38 @@ public struct RuleListDocumentation {
             ## Opt-In Rules
 
             \(optInRuleDocumentations
+                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
+                .joined(separator: "\n"))
+
+            """
+    }
+
+    private var swiftSyntaxDashboardContents: String {
+        let linterRuleDocumentations = ruleDocumentations.filter(\.isLinterRule)
+        let rulesUsingSourceKit = linterRuleDocumentations.filter(\.usesSourceKit)
+        let rulesNotUsingSourceKit = linterRuleDocumentations.filter { !$0.usesSourceKit }
+        let percentUsingSourceKit = Int(rulesUsingSourceKit.count * 100 / linterRuleDocumentations.count)
+
+        return """
+            # Swift Syntax Dashboard
+
+            Efforts are actively under way to migrate most rules off SourceKit to use SwiftSyntax instead.
+
+            Rules written using SwiftSyntax tend to be significantly faster and have fewer false positives
+            than rules that use SourceKit to get source structure information.
+
+            \(rulesUsingSourceKit.count) out of \(linterRuleDocumentations.count) (\(percentUsingSourceKit)%)
+            of SwiftLint's linter rules use SourceKit.
+
+            ## Rules Using SourceKit
+
+            \(rulesUsingSourceKit
+                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
+                .joined(separator: "\n"))
+
+            ## Rules Not Using SourceKit
+
+            \(rulesNotUsingSourceKit
                 .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
                 .joined(separator: "\n"))
 

--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -73,13 +73,33 @@ public struct RuleListDocumentation {
 
             ## Rules Using SourceKit
 
+            ### Enabled By Default (\(rulesUsingSourceKit.filter(\.isEnabledByDefault).count))
+
             \(rulesUsingSourceKit
+                .filter(\.isEnabledByDefault)
+                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
+                .joined(separator: "\n"))
+
+            ### Opt-In (\(rulesUsingSourceKit.filter(\.isDisabledByDefault).count))
+
+            \(rulesUsingSourceKit
+                .filter(\.isDisabledByDefault)
                 .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
                 .joined(separator: "\n"))
 
             ## Rules Not Using SourceKit
 
+            ### Enabled By Default (\(rulesNotUsingSourceKit.filter(\.isEnabledByDefault).count))
+
             \(rulesNotUsingSourceKit
+                .filter(\.isEnabledByDefault)
+                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
+                .joined(separator: "\n"))
+
+            ### Opt-In (\(rulesNotUsingSourceKit.filter(\.isDisabledByDefault).count))
+
+            \(rulesNotUsingSourceKit
+                .filter(\.isDisabledByDefault)
                 .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
                 .joined(separator: "\n"))
 


### PR DESCRIPTION
This is a useful overview of where the migration effort stands and what rules can be migrated next.

<img width="1278" alt="image" src="https://user-images.githubusercontent.com/474794/193347062-9adac905-45a7-473b-88db-89b83a0328b3.png">