### PR TITLE
Severity based rule configuration

### DIFF
--- a/Source/SwiftLintFramework/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Protocols/RuleConfiguration.swift
@@ -18,6 +18,19 @@ public protocol RuleConfiguration {
     func isEqualTo(_ ruleConfiguration: RuleConfiguration) -> Bool
 }
 
+/// A configuration for a rule that allows to configure at least the severity.
+public protocol SeverityBasedRuleConfiguration: RuleConfiguration {
+    /// The configuration of a rule's severity.
+    var severityConfiguration: SeverityConfiguration { get }
+}
+
+public extension SeverityBasedRuleConfiguration {
+    /// The severity of a rule.
+    var severity: ViolationSeverity {
+        severityConfiguration.severity
+    }
+}
+
 public extension RuleConfiguration where Self: Equatable {
     func isEqualTo(_ ruleConfiguration: RuleConfiguration) -> Bool {
         return self == ruleConfiguration as? Self

--- a/Source/SwiftLintFramework/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintFramework/Protocols/SwiftSyntaxRule.swift
@@ -18,7 +18,8 @@ public protocol SwiftSyntaxRule: SourceKitFreeRule {
     func makeViolation(file: SwiftLintFile, position: AbsolutePosition) -> StyleViolation
 }
 
-public extension SwiftSyntaxRule where Self: ConfigurationProviderRule, ConfigurationType == SeverityConfiguration {
+public extension SwiftSyntaxRule where Self: ConfigurationProviderRule,
+                                       ConfigurationType: SeverityBasedRuleConfiguration {
     func makeViolation(file: SwiftLintFile, position: AbsolutePosition) -> StyleViolation {
         StyleViolation(
             ruleDescription: Self.description,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -27,14 +27,6 @@ public struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule, Configur
     public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
         Visitor(configuration: configuration)
     }
-
-    public func makeViolation(file: SwiftLintFile, position: AbsolutePosition) -> StyleViolation {
-        StyleViolation(
-            ruleDescription: Self.description,
-            severity: configuration.severityConfiguration.severity,
-            location: Location(file: file, position: position)
-        )
-    }
 }
 
 private extension DiscouragedObjectLiteralRule {

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -76,7 +76,7 @@ public struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, Co
                                 allReferencedUSRs: allReferencedUSRs)
             .map {
                 StyleViolation(ruleDescription: Self.description,
-                               severity: configuration.severity,
+                               severity: configuration.severityConfiguration.severity,
                                location: Location(file: file, byteOffset: $0))
             }
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -2,15 +2,11 @@ private func toExplicitInitMethod(typeName: String) -> String {
     return "\(typeName).init"
 }
 
-public struct DiscouragedDirectInitConfiguration: RuleConfiguration, Equatable {
+public struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
     public var severityConfiguration = SeverityConfiguration(.warning)
 
     public var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", types: \(discouragedInits.sorted(by: <))"
-    }
-
-    public var severity: ViolationSeverity {
-        return severityConfiguration.severity
     }
 
     public private(set) var discouragedInits: Set<String>

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -5,7 +5,7 @@ private enum ConfigurationKey: String {
     case overrideAllowedTerms = "override_allowed_terms"
 }
 
-public struct InclusiveLanguageConfiguration: RuleConfiguration, Equatable {
+public struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable {
     public var severityConfiguration = SeverityConfiguration(.warning)
     public var additionalTerms: Set<String>?
     public var overrideTerms: Set<String>?
@@ -18,10 +18,6 @@ public struct InclusiveLanguageConfiguration: RuleConfiguration, Equatable {
             + ", additional_terms: \(additionalTerms?.sorted() ?? [])"
             + ", override_terms: \(overrideTerms?.sorted() ?? [])"
             + ", override_allowed_terms: \(overrideAllowedTerms?.sorted() ?? [])"
-    }
-
-    public var severity: ViolationSeverity {
-        severityConfiguration.severity
     }
 
     private let defaultTerms: Set<String> = [

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -1,5 +1,5 @@
-public struct ObjectLiteralConfiguration: RuleConfiguration, Equatable {
-    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+public struct ObjectLiteralConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var imageLiteral = true
     private(set) var colorLiteral = true
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -1,4 +1,4 @@
-public struct OverriddenSuperCallConfiguration: RuleConfiguration, Equatable {
+public struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private let defaultIncluded = [
         // NSObject
         "awakeFromNib()",
@@ -34,7 +34,7 @@ public struct OverriddenSuperCallConfiguration: RuleConfiguration, Equatable {
         "tearDownWithError()"
     ]
 
-    var severityConfiguration = SeverityConfiguration(.warning)
+    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
     var excluded: [String] = []
     var included: [String] = ["*"]
 
@@ -68,10 +68,6 @@ public struct OverriddenSuperCallConfiguration: RuleConfiguration, Equatable {
         }
 
         resolvedMethodNames = calculateResolvedMethodNames()
-    }
-
-    public var severity: ViolationSeverity {
-        return severityConfiguration.severity
     }
 
     private func calculateResolvedMethodNames() -> [String] {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -1,16 +1,12 @@
 import Foundation
 
-public struct PrivateUnitTestConfiguration: RuleConfiguration, Equatable, CacheDescriptionProvider {
+public struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, CacheDescriptionProvider {
     public let identifier: String
     public var name: String?
     public var message = "Regex matched."
     public var regex: NSRegularExpression!
     public var included: NSRegularExpression?
     public var severityConfiguration = SeverityConfiguration(.warning)
-
-    public var severity: ViolationSeverity {
-        return severityConfiguration.severity
-    }
 
     public var consoleDescription: String {
         return "\(severity.rawValue): \(regex.pattern)"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -1,5 +1,5 @@
-public struct ProhibitedSuperConfiguration: RuleConfiguration, Equatable {
-    var severityConfiguration = SeverityConfiguration(.warning)
+public struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
     var excluded = [String]()
     var included = ["*"]
 
@@ -40,10 +40,6 @@ public struct ProhibitedSuperConfiguration: RuleConfiguration, Equatable {
         }
 
         resolvedMethodNames = calculateResolvedMethodNames()
-    }
-
-    public var severity: ViolationSeverity {
-        return severityConfiguration.severity
     }
 
     private func calculateResolvedMethodNames() -> [String] {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RegexConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionProvider {
+public struct RegexConfiguration: SeverityBasedRuleConfiguration, Hashable, CacheDescriptionProvider {
     public let identifier: String
     public var name: String?
     public var message = "Regex matched."
@@ -11,10 +11,6 @@ public struct RegexConfiguration: RuleConfiguration, Hashable, CacheDescriptionP
     public var excludedMatchKinds = Set<SyntaxKind>()
     public var severityConfiguration = SeverityConfiguration(.warning)
     public var captureGroup: Int = 0
-
-    public var severity: ViolationSeverity {
-        return severityConfiguration.severity
-    }
 
     public var consoleDescription: String {
         return "\(severity.rawValue): \(regex.pattern)"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SeverityConfiguration.swift
@@ -1,9 +1,13 @@
-public struct SeverityConfiguration: RuleConfiguration, Equatable {
+public struct SeverityConfiguration: SeverityBasedRuleConfiguration, Equatable {
     public var consoleDescription: String {
         return severity.rawValue
     }
 
     var severity: ViolationSeverity
+
+    public var severityConfiguration: SeverityConfiguration {
+        self
+    }
 
     public init(_ severity: ViolationSeverity) {
         self.severity = severity

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -1,4 +1,4 @@
-public struct TestCaseAccessibilityConfiguration: RuleConfiguration, Equatable {
+public struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equatable {
     public private(set) var severityConfiguration = SeverityConfiguration(.warning)
     public private(set) var allowedPrefixes: Set<String> = []
     public private(set) var testParentClasses: Set<String> = ["XCTestCase"]
@@ -25,9 +25,5 @@ public struct TestCaseAccessibilityConfiguration: RuleConfiguration, Equatable {
         if let extraTestParentClasses = configuration["test_parent_classes"] as? [String] {
             self.testParentClasses.formUnion(extraTestParentClasses)
         }
-    }
-
-    public var severity: ViolationSeverity {
-        return severityConfiguration.severity
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -6,18 +6,18 @@ private enum ConfigurationKey: String {
 
 public struct UnusedDeclarationConfiguration: RuleConfiguration, Equatable {
     private(set) var includePublicAndOpen: Bool
-    private(set) var severity: ViolationSeverity
+    private(set) var severityConfiguration: SeverityConfiguration
     private(set) var relatedUSRsToSkip: Set<String>
 
     public var consoleDescription: String {
-        return "\(ConfigurationKey.severity.rawValue): \(severity.rawValue), " +
+        return "\(ConfigurationKey.severity.rawValue): \(severityConfiguration.severity.rawValue), " +
             "\(ConfigurationKey.includePublicAndOpen.rawValue): \(includePublicAndOpen), " +
             "\(ConfigurationKey.relatedUSRsToSkip.rawValue): \(relatedUSRsToSkip.sorted())"
     }
 
     public init(severity: ViolationSeverity, includePublicAndOpen: Bool, relatedUSRsToSkip: Set<String>) {
         self.includePublicAndOpen = includePublicAndOpen
-        self.severity = severity
+        self.severityConfiguration = SeverityConfiguration(severity)
         self.relatedUSRsToSkip = relatedUSRsToSkip
     }
 
@@ -32,11 +32,7 @@ public struct UnusedDeclarationConfiguration: RuleConfiguration, Equatable {
             }
             switch (key, value) {
             case (.severity, let stringValue as String):
-                if let severityValue = ViolationSeverity(rawValue: stringValue) {
-                    severity = severityValue
-                } else {
-                    throw ConfigurationError.unknownConfiguration
-                }
+                try severityConfiguration.apply(configuration: [key: stringValue])
             case (.includePublicAndOpen, let boolValue as Bool):
                 includePublicAndOpen = boolValue
             case (.relatedUSRsToSkip, let value):


### PR DESCRIPTION
Avoids implementations of `var severity: ViolationSeverity` and custom `makeViolation` methods as long as a rule configuration is a `SeverityBasedRuleConfiguration`.