### PR TITLE
Avoid making SourceKit requests to get parser diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,11 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4202](https://github.com/realm/SwiftLint/issues/4202)
 
+* Use SwiftSyntax instead of SourceKit to determine if a file has parser errors
+  before applying corrections. This speeds up corrections significantly when
+  none of the rules use SourceKit.  
+  [JP Simard](https://github.com/jpims)
+
 #### Bug Fixes
 
 * Respect `validates_start_with_lowercase` option when linting function names.  

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -155,20 +155,22 @@ extension SwiftLintFile {
         }
     }
 
-    internal var parserDiagnostics: [[String: SourceKitRepresentable]]? {
+    internal var parserDiagnostics: [String]? {
         if parserDiagnosticsDisabledForTests {
             return nil
         }
 
-        guard let response = responseCache.get(self) else {
+        guard let syntaxTree = syntaxTree else {
             if let handler = assertHandler {
                 handler()
                 return nil
             }
-            queuedFatalError("Never call this for file that sourcekitd fails.")
+            queuedFatalError("Could not get diagnostics for file.")
         }
 
-        return response["key.diagnostics"] as? [[String: SourceKitRepresentable]]
+        return ParseDiagnosticsGenerator.diagnostics(for: syntaxTree)
+            .filter { $0.diagMessage.severity == .error }
+            .map(\.message)
     }
 
     internal var structure: Structure {

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -283,18 +283,12 @@ public struct CollectedLinter {
             return []
         }
 
-        if let parserDiagnostics = file.parserDiagnostics {
-            let errorDiagnostics = parserDiagnostics.filter { diagnostic in
-                diagnostic["key.severity"] as? String == "source.diagnostic.severity.error"
-            }
-
-            if errorDiagnostics.isNotEmpty {
-                queuedPrintError(
-                    "Skipping correcting file because it produced Swift parser errors: \(file.path ?? "<nopath>")"
-                )
-                queuedPrintError(toJSON(["diagnostics": errorDiagnostics]))
-                return []
-            }
+        if let parserDiagnostics = file.parserDiagnostics, parserDiagnostics.isNotEmpty {
+            queuedPrintError(
+                "Skipping correcting file because it produced Swift parser errors: \(file.path ?? "<nopath>")"
+            )
+            queuedPrintError(toJSON(["diagnostics": parserDiagnostics]))
+            return []
         }
 
         var corrections = [Correction]()

--- a/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
@@ -9,10 +9,9 @@ final class ParserDiagnosticsTests: XCTestCase {
 
     func testFileWithParserErrorDiagnosticsDoesntAutocorrect() throws {
         let contents = """
-        importz Foundation
-        print(CGPointZero)
+        print(CGPointZero))
         """
-        XCTAssertNotNil(SwiftLintFile(contents: contents).parserDiagnostics)
+        XCTAssertEqual(SwiftLintFile(contents: contents).parserDiagnostics, ["extraneous \')\' at top level"])
 
         let ruleDescription = LegacyConstantRule.description
             .with(corrections: [Example(contents): Example(contents)])
@@ -33,7 +32,7 @@ final class ParserDiagnosticsTests: XCTestCase {
         func foo(bar bar: String) -> Int { 0 }
         """
 
-        XCTAssertNotNil(SwiftLintFile(contents: original).parserDiagnostics)
+        XCTAssertEqual(SwiftLintFile(contents: original).parserDiagnostics, [])
 
         let ruleDescription = ReturnArrowWhitespaceRule.description
             .with(corrections: [Example(original): Example(corrected)])
@@ -45,6 +44,6 @@ final class ParserDiagnosticsTests: XCTestCase {
 
     func testFileWithoutParserDiagnostics() {
         parserDiagnosticsDisabledForTests = false
-        XCTAssertNil(SwiftLintFile(contents: "import Foundation").parserDiagnostics)
+        XCTAssertEqual(SwiftLintFile(contents: "import Foundation").parserDiagnostics, [])
     }
 }


### PR DESCRIPTION
By using SwiftSyntax instead, we avoid the overhead of a SourceKit request, which has a significant impact if none of the rules being corrected use SourceKit.
