### PR TITLE
[CI] Disable xcodebuild tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,21 +26,22 @@ jobs:
     - script: swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
       displayName: swift test
 
-- job: Xcode
-  pool:
-    vmImage: 'macOS-12'
-  strategy:
-    maxParallel: 10
-    matrix:
-      xcode14:
-        DEVELOPER_DIR: /Applications/Xcode_14.0.1.app
-  steps:
-    - script: |
-        sw_vers
-        xcodebuild -version
-      displayName: Version Informations
-    - script: xcodebuild -scheme swiftlint test -destination "platform=macOS" OTHER_SWIFT_FLAGS="\$(inherited) -D DISABLE_FOCUSED_EXAMPLES"
-      displayName: xcodebuild test
+# TODO: Re-enable when FB11648454 is fixed
+# - job: Xcode
+#   pool:
+#     vmImage: 'macOS-12'
+#   strategy:
+#     maxParallel: 10
+#     matrix:
+#       xcode14:
+#         DEVELOPER_DIR: /Applications/Xcode_14.0.1.app
+#   steps:
+#     - script: |
+#         sw_vers
+#         xcodebuild -version
+#       displayName: Version Informations
+#     - script: xcodebuild -scheme swiftlint test -destination "platform=macOS" OTHER_SWIFT_FLAGS="\$(inherited) -D DISABLE_FOCUSED_EXAMPLES"
+#       displayName: xcodebuild test
 
 - job: SwiftPM
   pool:


### PR DESCRIPTION
This is failing very often now due to FB11648454.

Given that we run these tests on macOS via SwiftPM and Bazel as well, I'm satisfied with the amount of coverage we have on our tests without this.