### PR TITLE
Rewrite `trailing_semicolon` with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
   - `strong_iboutlet`
   - `switch_case_on_newline`
   - `toggle_bool`
+  - `trailing_semicolon`
   - `unneeded_break_in_switch`
   - `unneeded_parentheses_in_closure_argument`
   - `unowned_variable_capture`


### PR DESCRIPTION
I'm open to suggestions for better ways to remove nodes in a rewriter.