### PR TITLE
[LegacyConstantRule] Remove unused patterns

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRuleExamples.swift
@@ -48,8 +48,6 @@ internal struct LegacyConstantRuleExamples {
         "NSZeroPoint": "NSPoint.zero",
         "NSZeroRect": "NSRect.zero",
         "NSZeroSize": "NSSize.zero",
-        "CGRectNull": "CGRect.null",
-        "CGFloat\\(M_PI\\)": "CGFloat.pi",
-        "Float\\(M_PI\\)": "Float.pi"
+        "CGRectNull": "CGRect.null"
     ]
 }


### PR DESCRIPTION
We now just need these patterns for the mapping of legacy to new.