### PR TITLE
Simplify analyze bazel test

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -122,14 +122,6 @@ xcodeproj(
 
 # Analyze
 
-filegroup(
-    name = "SourceAndTestFiles",
-    srcs = glob([
-        "Source/**",
-        "Tests/SwiftLintFrameworkTests/**",
-    ]),
-)
-
 sh_test(
     name = "analyze",
     srcs = ["//tools:test-analyze.sh"],
@@ -137,7 +129,6 @@ sh_test(
         "Package.resolved",
         "Package.swift",
         ":LintInputs",
-        ":SourceAndTestFiles",
         ":swiftlint",
     ],
 )


### PR DESCRIPTION
By removing SourceAndTestFiles since those files should all be covered by LintInputs.