### PR TITLE
[bazel] For SwiftSyntax to compile with optimizations

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -21,10 +21,7 @@ swift_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_jpsim_sourcekitten//:SourceKittenFramework",
-        "@com_github_apple_swift_syntax//:SwiftSyntax",
-        "@com_github_apple_swift_syntax//:SwiftSyntaxBuilder",
-        "@com_github_apple_swift_syntax//:SwiftParser",
-        "@com_github_apple_swift_syntax//:SwiftOperators",
+        "@com_github_apple_swift_syntax//:optlibs",
         "@sourcekitten_com_github_jpsim_yams//:Yams",
     ] + select({
         "@platforms//os:linux": ["@com_github_krzyzanowskim_cryptoswift//:CryptoSwift"],
@@ -34,8 +31,8 @@ swift_library(
 
 swift_library(
     name = "swiftlint.library",
-    module_name = "swiftlint",
     srcs = glob(["Source/swiftlint/**/*.swift"]),
+    module_name = "swiftlint",
     visibility = ["//visibility:public"],
     deps = [
         ":SwiftLintFramework",

--- a/bazel/SwiftSyntax.BUILD
+++ b/bazel/SwiftSyntax.BUILD
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@//bazel:opt_wrapper.bzl", "opt_wrapper")
 
 cc_library(
     name = "_CSwiftSyntax",
@@ -13,14 +14,12 @@ swift_library(
     srcs = glob(["Sources/SwiftSyntax/**/*.swift"]),
     module_name = "SwiftSyntax",
     private_deps = ["_CSwiftSyntax"],
-    visibility = ["//visibility:public"],
 )
 
 swift_library(
     name = "SwiftBasicFormat",
     srcs = glob(["Sources/SwiftBasicFormat/**/*.swift"]),
     module_name = "SwiftBasicFormat",
-    visibility = ["//visibility:public"],
     deps = [":SwiftSyntax"],
 )
 
@@ -28,7 +27,6 @@ swift_library(
     name = "SwiftDiagnostics",
     srcs = glob(["Sources/SwiftDiagnostics/**/*.swift"]),
     module_name = "SwiftDiagnostics",
-    visibility = ["//visibility:public"],
     deps = [":SwiftSyntax"],
 )
 
@@ -36,22 +34,42 @@ swift_library(
     name = "SwiftParser",
     srcs = glob(["Sources/SwiftParser/**/*.swift"]),
     module_name = "SwiftParser",
-    visibility = ["//visibility:public"],
-    deps = [":SwiftSyntax", ":SwiftDiagnostics", ":SwiftBasicFormat"],
+    deps = [
+        ":SwiftBasicFormat",
+        ":SwiftDiagnostics",
+        ":SwiftSyntax",
+    ],
 )
 
 swift_library(
     name = "SwiftSyntaxBuilder",
     srcs = glob(["Sources/SwiftSyntaxBuilder/**/*.swift"]),
     module_name = "SwiftSyntaxBuilder",
-    visibility = ["//visibility:public"],
-    deps = [":SwiftSyntax", ":SwiftBasicFormat", ":SwiftParser"],
+    deps = [
+        ":SwiftBasicFormat",
+        ":SwiftParser",
+        ":SwiftSyntax",
+    ],
 )
 
 swift_library(
     name = "SwiftOperators",
     srcs = glob(["Sources/SwiftOperators/**/*.swift"]),
     module_name = "SwiftOperators",
+    deps = [
+        ":SwiftDiagnostics",
+        ":SwiftParser",
+        ":SwiftSyntax",
+    ],
+)
+
+opt_wrapper(
+    name = "optlibs",
     visibility = ["//visibility:public"],
-    deps = [":SwiftSyntax", ":SwiftDiagnostics", ":SwiftParser"],
+    deps = [
+        ":SwiftOperators",
+        ":SwiftParser",
+        ":SwiftSyntax",
+        ":SwiftSyntaxBuilder",
+    ],
 )

--- a/bazel/opt_wrapper.bzl
+++ b/bazel/opt_wrapper.bzl
@@ -1,0 +1,35 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_common")
+
+def _force_opt_impl(_settings, _attr):
+    return {"//command_line_option:compilation_mode": "opt"}
+
+_force_opt = transition(
+    implementation = _force_opt_impl,
+    inputs = [],
+    outputs = ["//command_line_option:compilation_mode"],
+)
+
+def _impl(ctx):
+    ccinfos = []
+    swiftinfos = []
+
+    for dep in ctx.attr.deps:
+        ccinfos.append(dep[CcInfo])
+        swiftinfos.append(dep[SwiftInfo])
+
+    return [
+        cc_common.merge_cc_infos(direct_cc_infos = ccinfos),
+        swift_common.create_swift_info(swift_infos = swiftinfos),
+    ]
+
+opt_wrapper = rule(
+    implementation = _impl,
+    attrs = {
+        "deps": attr.label_list(
+            cfg = _force_opt,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
This avoids potential stack overflows and slowness when just working on
SwiftLint itself with bazel. These compiles take a lot longer but as
long as you're not updating swift-syntax that should be a 1 time penalty
