### PR TITLE
Ignore incorrect keypath parser diagnostics

### DIFF
--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -171,6 +171,10 @@ extension SwiftLintFile {
         return ParseDiagnosticsGenerator.diagnostics(for: syntaxTree)
             .filter { $0.diagMessage.severity == .error }
             .map(\.message)
+            .filter { message in
+                // Workaround for https://github.com/apple/swift-syntax/issues/888
+                return !message.starts(with: "unexpected text '.?.")
+            }
     }
 
     internal var structure: Structure {


### PR DESCRIPTION
Works around https://github.com/apple/swift-syntax/issues/888