### PR TITLE
Convert `number_separator` rule to SwiftSyntax

### DIFF
--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -1,5 +1,5 @@
-public struct NumberSeparatorConfiguration: RuleConfiguration, Equatable {
-    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+public struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var minimumLength: Int
     private(set) var minimumFractionLength: Int?
     private(set) var excludeRanges: [Range<Double>]

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -112,7 +112,6 @@ private extension NumberSeparatorRule {
 
 private protocol NumberSeparatorValidator {
     var configuration: NumberSeparatorConfiguration { get }
-    func violation(token: TokenSyntax) -> (position: AbsolutePosition, correction: String)?
 }
 
 extension NumberSeparatorValidator {

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
-import SourceKittenFramework
+import SwiftSyntax
 
-public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProviderRule {
+public struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
     public var configuration = NumberSeparatorConfiguration(
         minimumLength: 0,
         minimumFractionLength: nil,
@@ -20,92 +20,144 @@ public struct NumberSeparatorRule: OptInRule, CorrectableRule, ConfigurationProv
         corrections: NumberSeparatorRuleExamples.corrections
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violatingRanges(in: file).map { range, _ in
-            return StyleViolation(ruleDescription: Self.description,
-                                  severity: configuration.severityConfiguration.severity,
-                                  location: Location(file: file, characterOffset: range.location))
+    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
+        Visitor(configuration: configuration)
+    }
+
+    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+        file.locationConverter.map { locationConverter in
+            Rewriter(
+                configuration: configuration,
+                locationConverter: locationConverter,
+                disabledRegions: disabledRegions(file: file)
+            )
+        }
+    }
+}
+
+private extension NumberSeparatorRule {
+    final class Visitor: SyntaxVisitor, ViolationsSyntaxVisitor, NumberSeparatorValidator {
+        private(set) var violationPositions: [AbsolutePosition] = []
+        let configuration: NumberSeparatorConfiguration
+
+        init(configuration: NumberSeparatorConfiguration) {
+            self.configuration = configuration
+            super.init(viewMode: .sourceAccurate)
+        }
+
+        override func visitPost(_ node: FloatLiteralExprSyntax) {
+            if let violation = violation(token: node.floatingDigits) {
+                violationPositions.append(violation.position)
+            }
+        }
+
+        override func visitPost(_ node: IntegerLiteralExprSyntax) {
+            if let violation = violation(token: node.digits) {
+                violationPositions.append(violation.position)
+            }
         }
     }
 
-    private func violatingRanges(in file: SwiftLintFile) -> [(NSRange, String)] {
-        let numberTokens = file.syntaxMap.tokens.filter { $0.kind == .number }
-        return numberTokens.compactMap { (token: SwiftLintSyntaxToken) -> (NSRange, String)? in
-            guard
-                let content = file.contents(for: token),
-                isDecimal(number: content),
-                !isInValidRanges(number: content)
-            else {
-                return nil
+    private final class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter, NumberSeparatorValidator {
+        private(set) var correctionPositions: [AbsolutePosition] = []
+        let configuration: NumberSeparatorConfiguration
+        let locationConverter: SourceLocationConverter
+        let disabledRegions: [SourceRange]
+
+        init(configuration: NumberSeparatorConfiguration,
+             locationConverter: SourceLocationConverter,
+             disabledRegions: [SourceRange]) {
+            self.configuration = configuration
+            self.locationConverter = locationConverter
+            self.disabledRegions = disabledRegions
+        }
+
+        override func visit(_ node: FloatLiteralExprSyntax) -> ExprSyntax {
+            guard let violation = violation(token: node.floatingDigits) else {
+                return super.visit(node)
             }
 
-            let signs = CharacterSet(charactersIn: "+-")
-            let exponential = CharacterSet(charactersIn: "eE")
-            guard let nonSign = content.components(separatedBy: signs).last,
-                case let exponentialComponents = nonSign.components(separatedBy: exponential),
-                let nonExponential = exponentialComponents.first else {
-                    return nil
+            let isInDisabledRegion = disabledRegions.contains { region in
+                region.contains(node.positionAfterSkippingLeadingTrivia, locationConverter: locationConverter)
             }
 
-            let components = nonExponential.components(separatedBy: ".")
-
-            var validFraction = true
-            var expectedFraction: String?
-            if components.count == 2, let fractionSubstring = components.last {
-                let result = isValid(number: fractionSubstring, isFraction: true)
-                validFraction = result.0
-                expectedFraction = result.1
+            guard !isInDisabledRegion else {
+                return super.visit(node)
             }
 
-            guard let integerSubstring = components.first,
-                case let (valid, expected) = isValid(number: integerSubstring, isFraction: false),
-                !valid || !validFraction,
-                let range = file.stringView.byteRangeToNSRange(token.range)
-            else {
-                return nil
+            let newNode = node.withFloatingDigits(node.floatingDigits.withKind(.floatingLiteral(violation.correction)))
+            correctionPositions.append(violation.position)
+            return super.visit(newNode)
+        }
+
+        override func visit(_ node: IntegerLiteralExprSyntax) -> ExprSyntax {
+            guard let violation = violation(token: node.digits) else {
+                return super.visit(node)
             }
 
-            var corrected = ""
-            let hasSign = content.countOfLeadingCharacters(in: signs) == 1
-            if hasSign {
-                corrected += String(content.prefix(1))
+            let isInDisabledRegion = disabledRegions.contains { region in
+                region.contains(node.positionAfterSkippingLeadingTrivia, locationConverter: locationConverter)
             }
 
-            corrected += expected
-            if let fraction = expectedFraction {
-                corrected += "." + fraction
+            guard !isInDisabledRegion else {
+                return super.visit(node)
             }
 
-            if exponentialComponents.count == 2, let exponential = exponentialComponents.last {
-                let exponentialSymbol = content.contains("e") ? "e" : "E"
-                corrected += exponentialSymbol + exponential
-            }
-
-            return (range, corrected)
+            let newNode = node.withDigits(node.digits.withKind(.integerLiteral(violation.correction)))
+            correctionPositions.append(violation.position)
+            return super.visit(newNode)
         }
     }
+}
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
-        let violatingRanges = self.violatingRanges(in: file).filter { range, _ in
-            return !file.ruleEnabled(violatingRanges: [range], for: self).isEmpty
+private protocol NumberSeparatorValidator {
+    var configuration: NumberSeparatorConfiguration { get }
+    func violation(token: TokenSyntax) -> (position: AbsolutePosition, correction: String)?
+}
+
+extension NumberSeparatorValidator {
+    func violation(token: TokenSyntax) -> (position: AbsolutePosition, correction: String)? {
+        let content = token.withoutTrivia().text
+        guard isDecimal(number: content),
+            !isInValidRanges(number: content)
+        else {
+            return nil
         }
 
-        var correctedContents = file.contents
-        var adjustedLocations = [Int]()
-
-        for (violatingRange, correction) in violatingRanges.reversed() {
-            if let indexRange = correctedContents.nsrangeToIndexRange(violatingRange) {
-                correctedContents = correctedContents.replacingCharacters(in: indexRange, with: correction)
-                adjustedLocations.insert(violatingRange.location, at: 0)
-            }
+        let exponential = CharacterSet(charactersIn: "eE")
+        guard case let exponentialComponents = content.components(separatedBy: exponential),
+            let nonExponential = exponentialComponents.first else {
+                return nil
         }
 
-        file.write(correctedContents)
+        let components = nonExponential.components(separatedBy: ".")
 
-        return adjustedLocations.map {
-            Correction(ruleDescription: Self.description,
-                       location: Location(file: file, characterOffset: $0))
+        var validFraction = true
+        var expectedFraction: String?
+        if components.count == 2, let fractionSubstring = components.last {
+            let result = isValid(number: fractionSubstring, isFraction: true)
+            validFraction = result.0
+            expectedFraction = result.1
         }
+
+        guard let integerSubstring = components.first,
+            case let (valid, expected) = isValid(number: integerSubstring, isFraction: false),
+            !valid || !validFraction
+        else {
+            return nil
+        }
+
+        var corrected = expected
+        if let fraction = expectedFraction {
+            corrected += "." + fraction
+        }
+
+        if exponentialComponents.count == 2, let exponential = exponentialComponents.last {
+            let exponentialSymbol = content.contains("e") ? "e" : "E"
+            corrected += exponentialSymbol + exponential
+        }
+
+        return (token.positionAfterSkippingLeadingTrivia, corrected)
     }
 
     private func isDecimal(number: String) -> Bool {

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
@@ -16,7 +16,7 @@ internal struct NumberSeparatorRuleExamples {
                 Example("let exp = \(sign)1_000_000.000_000e2"),
                 Example("let foo: Double = \(sign)(200)"),
                 Example("let foo: Double = \(sign)(200 / 447.214)"),
-                Example("let foo = \(sign)6.283_2e-6"),
+                Example("let foo = \(sign)6.283_2e-6")
             ]
         }
     }()
@@ -37,7 +37,7 @@ internal struct NumberSeparatorRuleExamples {
                 Example("let foo = \(sign)1.0001"),
                 Example("let foo = \(sign)1_000_000.000000_1"),
                 Example("let foo = \(sign)1000000.000000_1"),
-                Example("let foo = \(sign)6.2832e-6"),
+                Example("let foo = \(sign)6.2832e-6")
             ]
         }
     }

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
@@ -15,7 +15,8 @@ internal struct NumberSeparatorRuleExamples {
                 Example("let octal = \(sign)0o21_1"),
                 Example("let exp = \(sign)1_000_000.000_000e2"),
                 Example("let foo: Double = \(sign)(200)"),
-                Example("let foo: Double = \(sign)(200 / 447.214)")
+                Example("let foo: Double = \(sign)(200 / 447.214)"),
+                Example("let foo = \(sign)6.283_2e-6"),
             ]
         }
     }()
@@ -35,7 +36,8 @@ internal struct NumberSeparatorRuleExamples {
                 Example("let foo = \(sign)1__000"),
                 Example("let foo = \(sign)1.0001"),
                 Example("let foo = \(sign)1_000_000.000000_1"),
-                Example("let foo = \(sign)1000000.000000_1")
+                Example("let foo = \(sign)1000000.000000_1"),
+                Example("let foo = \(sign)6.2832e-6"),
             ]
         }
     }
@@ -64,6 +66,7 @@ internal struct NumberSeparatorRuleExamples {
             // swiftlint:disable:next line_length
             result[Example("let foo = \(violation)1_000_000.000000_1")] = Example("let foo = \(sign)1_000_000.000_000_1")
             result[Example("let foo = \(violation)1000000.000000_1")] = Example("let foo = \(sign)1_000_000.000_000_1")
+            result[Example("let foo = \(sign)6.2832e-6")] = Example("let foo = \(sign)6.283_2e-6")
         }
 
         return result

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
@@ -20,10 +20,10 @@ internal struct NumberSeparatorRuleExamples {
         }
     }()
 
-    static let triggeringExamples = makeTriggeringExamples(signs: ["↓-", "+↓", "↓"]) +
+    static let triggeringExamples = makeTriggeringExamples(signs: ["-↓", "+↓", "↓"]) +
         makeTriggeringExamplesWithParentheses()
 
-    static let corrections = makeCorrections(signs: [("↓-", "-"), ("+↓", "+"), ("↓", "")])
+    static let corrections = makeCorrections(signs: [("-↓", "-"), ("+↓", "+"), ("↓", "")])
 
     private static func makeTriggeringExamples(signs: [String]) -> [Example] {
         return signs.flatMap { (sign: String) -> [Example] in
@@ -41,7 +41,7 @@ internal struct NumberSeparatorRuleExamples {
     }
 
     private static func makeTriggeringExamplesWithParentheses() -> [Example] {
-        let signsWithParenthesisAndViolation = ["↓-(", "+(↓", "(↓"]
+        let signsWithParenthesisAndViolation = ["-(↓", "+(↓", "(↓"]
         return signsWithParenthesisAndViolation.flatMap { (sign: String) -> [Example] in
             [
                 Example("let foo: Double = \(sign)100000)"),


### PR DESCRIPTION
I expect a lot of warnings from oss-check because the violation position has changed for negative numbers