### PR TITLE
[Bazel] Set `swift.enable_library_evolution` for CryptoSwift

### DIFF
--- a/bazel/CryptoSwift.BUILD
+++ b/bazel/CryptoSwift.BUILD
@@ -6,6 +6,9 @@ load(
 swift_library(
     name = "CryptoSwift",
     srcs = glob(["Sources/**/*.swift"]),
+    features = [
+        "swift.enable_library_evolution",
+    ],
     module_name = "CryptoSwift",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
To avoid this compiler warning:

```
Sources/CryptoSwift/RSA/RSA+Cipher.swift:130:7: warning: default will never be executed
      @unknown default:
      ^
```