### PR TITLE
Reduce memory usage

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "b5f9bb749057dd396e93f97956bef64672bc2a04",
-          "version": "0.33.0"
+          "revision": "a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.3")),
         .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("26bf2172cc5b7d54f28b10d18e8b5de351b5c4a3")),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.33.0"),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", .revision("a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit.git", from: "0.2.0")

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -249,6 +249,9 @@ public struct CollectedLinter {
                 "completely removed in a future release.")
         }
 
+        // Free some memory used for this file's caches. They shouldn't be needed after this point.
+        file.invalidateCache()
+
         return (violations, ruleTimes)
     }
 

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -2,11 +2,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def swiftlint_repos():
     """Fetches SwiftLint repositories"""
+    # https://github.com/jpsim/SourceKitten/pull/749
     http_archive(
         name = "com_github_jpsim_sourcekitten",
-        sha256 = "beeddf444ff079dc2248c5b9b0df3e6ee9d886b03a68c4e372e955e5e76c16b9",
-        strip_prefix = "SourceKitten-0.33.0",
-        url = "https://github.com/jpsim/SourceKitten/archive/refs/tags/0.33.0.tar.gz",
+        sha256 = "ebce266e1f30d7a96593e7bb884ea702f546ad07d51535c7a1ec91fcd5d2db02",
+        strip_prefix = "SourceKitten-a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871",
+        url = "https://github.com/jpsim/SourceKitten/archive/a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
When linting SwiftLint, this brings memory usage down by around 20%, going from 372MB to 297MB.

This is achieved by removing the unused `RebuildQueue` and by clearing cached data associated with files after processing them.

Depends on https://github.com/jpsim/SourceKitten/pull/749.