### PR TITLE
Revert "Run TSan job on Azure Pipelines with Bazel (#4130)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,19 +83,11 @@ jobs:
   variables:
     DEVELOPER_DIR: /Applications/Xcode_14.0.1.app
   steps:
-    - script: |
-        curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.12.2/bazelisk-darwin-amd64 -o bazelisk
-        chmod +x bazelisk
-      displayName: Install Bazel
-    - script: echo "build --remote_cache=grpc://$BAZEL_REMOTE_CREDENTIALS@swiftlint-ci.jpsim.com:9092" > ci.bazelrc
-      env:
-        BAZEL_REMOTE_CREDENTIALS: $(BAZEL_REMOTE_CREDENTIALS)
-      displayName: Set CI Bazel flags
-    - script: ./bazelisk build -c opt --features=tsan swiftlint
+    - script: swift build --configuration release --sanitize thread
       displayName: Build SwiftLint
-    - script: ./bazel-bin/swiftlint --lenient
+    - script: swift run --configuration release --sanitize thread swiftlint --lenient
       displayName: Pre-cache SwiftLint Run
-    - script: ./bazel-bin/swiftlint --lenient
+    - script: swift run --configuration release --sanitize thread swiftlint --lenient
       displayName: Post-cache SwiftLint Run
 
 - job: jazzy


### PR DESCRIPTION
This reverts commit 848ec452c34475c23d65f7279b50e0b3e40d6901.

This appears to be slower most of the time.