### PR TITLE
Asynchronously invalidate file caches

### DIFF
--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -250,7 +250,9 @@ public struct CollectedLinter {
         }
 
         // Free some memory used for this file's caches. They shouldn't be needed after this point.
-        file.invalidateCache()
+        Task {
+            file.invalidateCache()
+        }
 
         return (violations, ruleTimes)
     }


### PR DESCRIPTION
To see if this fire-and-forget style cleanup improves lint times at all.