### PR TITLE
Remove optionality in getting syntax tree and source location converter

### DIFF
--- a/Source/SwiftLintFramework/Extensions/SyntaxVisitor+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxVisitor+SwiftLint.swift
@@ -37,9 +37,7 @@ extension SwiftLintSyntaxVisitor {
     }
 
     func walk<T>(file: SwiftLintFile, handler: (Self) -> [T]) -> [T] {
-        guard let syntaxTree = file.syntaxTree else {
-            return []
-        }
+        let syntaxTree = file.syntaxTree
 
         return walk(tree: syntaxTree, handler: handler)
     }

--- a/Source/SwiftLintFramework/Protocols/SwiftSyntaxCorrectableRule.swift
+++ b/Source/SwiftLintFramework/Protocols/SwiftSyntaxCorrectableRule.swift
@@ -13,7 +13,7 @@ public protocol SwiftSyntaxCorrectableRule: SwiftSyntaxRule, CorrectableRule {
 public extension SwiftSyntaxCorrectableRule {
     func correct(file: SwiftLintFile) -> [Correction] {
         guard let rewriter = makeRewriter(file: file),
-              let syntaxTree = file.syntaxTree,
+              case let syntaxTree = file.syntaxTree,
               case let newTree = rewriter.visit(syntaxTree),
               rewriter.correctionPositions.isNotEmpty else {
             return []

--- a/Source/SwiftLintFramework/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintFramework/Protocols/SwiftSyntaxRule.swift
@@ -36,10 +36,7 @@ public extension SwiftSyntaxRule {
     ///
     /// - returns: The source ranges in the specified file where this rule is disabled.
     func disabledRegions(file: SwiftLintFile) -> [SourceRange] {
-        guard let locationConverter = file.locationConverter else {
-            return []
-        }
-
+        let locationConverter = file.locationConverter
         return file.regions()
             .filter { $0.isRuleDisabled(self) }
             .compactMap { $0.toSourceRange(locationConverter: locationConverter) }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -34,9 +34,7 @@ public struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRul
     )
 
     public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
-        file.locationConverter.map {
-            Visitor(locationConverter: $0)
-        }
+        Visitor(locationConverter: file.locationConverter)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -176,12 +176,10 @@ public struct ExplicitInitRule: SwiftSyntaxCorrectableRule, ConfigurationProvide
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/IfLetShadowingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/IfLetShadowingRule.swift
@@ -85,12 +85,10 @@ public struct IfLetShadowingRule: OptInRule, SwiftSyntaxCorrectableRule, Configu
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -107,12 +107,10 @@ public struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule, Configu
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            LegacyFunctionRuleHelper.Rewriter(
-                legacyFunctions: Self.legacyFunctions,
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        LegacyFunctionRuleHelper.Rewriter(
+            legacyFunctions: Self.legacyFunctions,
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
@@ -21,12 +21,10 @@ public struct LegacyConstantRule: SwiftSyntaxCorrectableRule, ConfigurationProvi
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -40,7 +40,7 @@ public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, SourceKi
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree?.folded() else {
+        guard let tree = file.syntaxTree.folded() else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -107,12 +107,10 @@ public struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule, Configu
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            LegacyFunctionRuleHelper.Rewriter(
-                legacyFunctions: Self.legacyFunctions,
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        LegacyFunctionRuleHelper.Rewriter(
+            legacyFunctions: Self.legacyFunctions,
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -28,12 +28,10 @@ public struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule,
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -36,12 +36,10 @@ public struct ToggleBoolRule: SwiftSyntaxCorrectableRule, ConfigurationProviderR
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -29,12 +29,10 @@ public struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule, ConfigurationPr
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -92,12 +92,10 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, Swi
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            UntypedErrorInCatchRuleRewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        UntypedErrorInCatchRuleRewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
@@ -48,12 +48,10 @@ public struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule, Conf
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -68,7 +68,7 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, SourceKitFreeRul
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree?.folded() else {
+        guard let tree = file.syntaxTree.folded() else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
@@ -141,13 +141,11 @@ public struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule, ConfigurationProv
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                parentClassRegex: configuration.regex,
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            parentClassRegex: configuration.regex,
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
@@ -34,12 +34,10 @@ public struct StrongIBOutletRule: ConfigurationProviderRule, SwiftSyntaxCorrecta
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -24,7 +24,7 @@ public struct ContainsOverRangeNilComparisonRule: SourceKitFreeRule, OptInRule, 
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree?.folded() else {
+        guard let tree = file.syntaxTree.folded() else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
@@ -28,12 +28,10 @@ public struct ClosingBraceRule: SwiftSyntaxCorrectableRule, ConfigurationProvide
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
@@ -97,9 +97,7 @@ public struct ClosureParameterPositionRule: SwiftSyntaxRule, ConfigurationProvid
     )
 
     public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
-        file.locationConverter.map {
-            Visitor(locationConverter: $0)
-        }
+        Visitor(locationConverter: file.locationConverter)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -39,16 +39,14 @@ public struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, ConfigurationProvi
     )
 
     public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
-        file.locationConverter.map(ClosureSpacingRuleVisitor.init)
+        ClosureSpacingRuleVisitor(locationConverter: file.locationConverter)
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            ClosureSpacingRuleRewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        ClosureSpacingRuleRewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -28,10 +28,7 @@ public struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
     }
 
     public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        guard let syntaxTree = file.syntaxTree else {
-            return []
-        }
-
+        let syntaxTree = file.syntaxTree
         let visitor = ColonRuleVisitor(viewMode: .sourceAccurate)
         visitor.walk(syntaxTree)
         let positionsToSkip = visitor.positionsToSkip

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -90,9 +90,7 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFr
     }
 
     private func violationRanges(in file: SwiftLintFile) -> [(ByteRange, shouldAddSpace: Bool)] {
-        guard let syntaxTree = file.syntaxTree else {
-            return []
-        }
+        let syntaxTree = file.syntaxTree
 
         return syntaxTree
             .windowsOfThreeTokens()

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -112,12 +112,10 @@ public struct EmptyEnumArgumentsRule: SwiftSyntaxCorrectableRule, ConfigurationP
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
@@ -38,12 +38,10 @@ public struct EmptyParametersRule: SwiftSyntaxCorrectableRule, ConfigurationProv
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -51,12 +51,10 @@ public struct EmptyParenthesesWithTrailingClosureRule: SwiftSyntaxCorrectableRul
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -50,12 +50,10 @@ public struct NoSpaceInMethodCallRule: SwiftSyntaxCorrectableRule, Configuration
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -25,13 +25,11 @@ public struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule, Config
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                configuration: configuration,
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            configuration: configuration,
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -29,12 +29,10 @@ public struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, Swi
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
@@ -56,13 +56,11 @@ public struct SelfBindingRule: SwiftSyntaxCorrectableRule, ConfigurationProvider
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            SelfBindingRuleRewriter(
-                bindIdentifier: configuration.bindIdentifier,
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        SelfBindingRuleRewriter(
+            bindIdentifier: configuration.bindIdentifier,
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
@@ -43,7 +43,7 @@ public struct ShorthandOperatorRule: ConfigurationProviderRule, SourceKitFreeRul
     fileprivate static let allOperators = ["-", "/", "+", "*"]
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree?.folded() else {
+        guard let tree = file.syntaxTree.folded() else {
             return []
         }
 

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -63,9 +63,7 @@ public struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, ConfigurationProviderRul
     )
 
     public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
-        file.locationConverter.map {
-            Visitor(locationConverter: $0)
-        }
+        Visitor(locationConverter: file.locationConverter)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -80,12 +80,10 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
     }
 
     public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        file.locationConverter.map { locationConverter in
-            Rewriter(
-                locationConverter: locationConverter,
-                disabledRegions: disabledRegions(file: file)
-            )
-        }
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
     }
 }
 


### PR DESCRIPTION
Parsing does not throw errors. See https://github.com/apple/swift-syntax/pull/912.