### PR TITLE
Rewrite `attributes` with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   more violations:
   - `anonymous_argument_in_multiline_closure`
   - `array_init`
+  - `attributes`
   - `block_based_kvo`
   - `class_delegate_protocol`
   - `closing_brace`

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -1,5 +1,5 @@
-public struct AttributesConfiguration: RuleConfiguration, Equatable {
-    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+public struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    public var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var alwaysOnSameLine = Set<String>()
     private(set) var alwaysOnNewLine = Set<String>()
 

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -213,6 +213,14 @@ private extension AttributeListSyntax {
                 keywordLine: keywordLine,
                 shouldBeOnSameLine: false
             )
+        } else if let parent = parent.as(ExtensionDeclSyntax.self),
+                  let keywordLine = parent.extensionKeyword.startLine(locationConverter: locationConverter)
+        {
+            return RuleHelper(
+                violationPosition: parent.extensionKeyword.positionAfterSkippingLeadingTrivia,
+                keywordLine: keywordLine,
+                shouldBeOnSameLine: false
+            )
         } else if let parent = parent.as(ImportDeclSyntax.self),
                   let keywordLine = parent.importTok.startLine(locationConverter: locationConverter)
         {

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -1,335 +1,214 @@
-import Foundation
-import SourceKittenFramework
+import SwiftSyntax
 
-private enum AttributesRuleError: Error {
-    case unexpectedBlankLine
-    case moreThanOneAttributeInSameLine
-}
-
-public struct AttributesRule: ASTRule, OptInRule, ConfigurationProviderRule {
+public struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     public var configuration = AttributesConfiguration()
-
-    private static let parametersPattern = "^\\s*\\(.+\\)"
-    private static let regularExpression = regex(parametersPattern, options: [])
 
     public init() {}
 
     public static let description = RuleDescription(
         identifier: "attributes",
         name: "Attributes",
-        description: "Attributes should be on their own lines in functions and types, " +
-                     "but on the same line as variables and imports.",
+        description: """
+            Attributes should be on their own lines in functions and types, but on the same line as variables and \
+            imports.
+            """,
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,
         triggeringExamples: AttributesRuleExamples.triggeringExamples
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return validateTestableImport(file: file) +
-            validate(file: file, dictionary: file.structureDictionary)
-    }
-
-    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        let attributeShouldBeOnSameLine: Bool?
-        if SwiftDeclarationKind.variableKinds.contains(kind) {
-            attributeShouldBeOnSameLine = true
-        } else if SwiftDeclarationKind.typeKinds.contains(kind) {
-            attributeShouldBeOnSameLine = false
-        } else if SwiftDeclarationKind.functionKinds.contains(kind) {
-            attributeShouldBeOnSameLine = false
-        } else {
-            attributeShouldBeOnSameLine = nil
-        }
-
-        if let attributeShouldBeOnSameLine = attributeShouldBeOnSameLine {
-            return validateKind(file: file,
-                                attributeShouldBeOnSameLine: attributeShouldBeOnSameLine,
-                                dictionary: dictionary)
-        }
-
-        return []
-    }
-
-    private func validateTestableImport(file: SwiftLintFile) -> [StyleViolation] {
-        let pattern = "@testable[\n]+\\s*import"
-        return file.match(pattern: pattern).compactMap { range, kinds -> StyleViolation? in
-            guard kinds == [.attributeBuiltin, .keyword] else {
-                return nil
-            }
-
-            let contents = file.stringView
-            let match = contents.substring(with: range)
-            let idx = match.lastIndex(of: "import") ?? 0
-            let location = idx + range.location
-
-            return StyleViolation(ruleDescription: Self.description,
-                                  severity: configuration.severityConfiguration.severity,
-                                  location: Location(file: file, characterOffset: location))
-        }
-    }
-
-    private func validateKind(file: SwiftLintFile,
-                              attributeShouldBeOnSameLine: Bool,
-                              dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        let attributes = parseAttributes(dictionary: dictionary)
-
-        guard attributes.isNotEmpty,
-            let offset = dictionary.offset,
-            let (line, _) = file.stringView.lineAndCharacter(forByteOffset: offset) else {
-            return []
-        }
-
-        guard isViolation(lineNumber: line, file: file,
-                          attributeShouldBeOnSameLine: attributeShouldBeOnSameLine) else {
-            return []
-        }
-
-        // Violation found!
-        return violation(dictionary: dictionary, file: file)
-    }
-
-    private func isViolation(lineNumber: Int, file: SwiftLintFile,
-                             attributeShouldBeOnSameLine: Bool) -> Bool {
-        let line = file.lines[lineNumber - 1]
-
-        let tokens = file.syntaxMap.tokens(inByteRange: line.byteRange)
-        let attributesTokensWithRanges = tokens.compactMap { attributeName(token: $0, file: file) }
-
-        let attributesTokens = Set(
-            attributesTokensWithRanges.map { tokenString, _ in
-                // Some attributes are parameterized, such as `@objc(name)`, so discard anything from an opening
-                // parenthesis onward.
-                String(tokenString.prefix(while: { $0 != "(" }))
-            }
+    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
+        Visitor(
+            locationConverter: file.locationConverter,
+            configuration: configuration
         )
-
-        do {
-            let previousAttributesWithParameters = try attributesFromPreviousLines(lineNumber: lineNumber - 1,
-                                                                                   file: file)
-            let previousAttributes = Set(previousAttributesWithParameters.map { $0.0 })
-
-            if previousAttributes.isEmpty && attributesTokens.isEmpty {
-                return false
-            }
-
-            let alwaysOnSameLineAttributes = configuration.alwaysOnSameLine
-            let alwaysOnNewLineAttributes =
-                createAlwaysOnNewLineAttributes(previousAttributes: previousAttributesWithParameters,
-                                                attributesTokens: attributesTokensWithRanges,
-                                                line: line, file: file)
-
-            guard attributesTokens.isDisjoint(with: alwaysOnNewLineAttributes) &&
-                previousAttributes.isDisjoint(with: alwaysOnSameLineAttributes) else {
-                return true
-            }
-
-            // ignore attributes that are explicitly allowed
-            let attributesAfterAllowed: Set<String>
-            let newLineExceptions = previousAttributes.intersection(alwaysOnNewLineAttributes)
-            let sameLineExceptions = attributesTokens.intersection(alwaysOnSameLineAttributes)
-
-            if attributeShouldBeOnSameLine {
-                attributesAfterAllowed = attributesTokens
-                    .union(newLineExceptions)
-                    .union(sameLineExceptions)
-            } else {
-                attributesAfterAllowed = attributesTokens
-                    .subtracting(newLineExceptions)
-                    .subtracting(sameLineExceptions)
-            }
-
-            return attributesAfterAllowed.isEmpty == attributeShouldBeOnSameLine
-        } catch {
-            return true
-        }
-    }
-
-    private func createAlwaysOnNewLineAttributes(previousAttributes: [(String, Bool)],
-                                                 attributesTokens: [(String, ByteRange)],
-                                                 line: Line, file: SwiftLintFile) -> Set<String> {
-        let attributesTokensWithParameters: [(String, Bool)] = attributesTokens.map {
-            let hasParameter = attributeContainsParameter(attributeRange: $1,
-                                                          line: line, file: file)
-            return ($0, hasParameter)
-        }
-        let allAttributes = previousAttributes + attributesTokensWithParameters
-
-        return Set(allAttributes.compactMap { token, hasParameter -> String? in
-            // an attribute should be on a new line if one of these is true:
-            // 1. it's a parameterized attribute
-            //      a. the parameter is on the token (i.e. warn_unused_result)
-            //      b. the parameter was parsed in the `hasParameter` variable (most attributes)
-            // 2. it's an allowed attribute, according to the current configuration
-            let isParameterized = hasParameter || token.bridge().contains("(")
-            if isParameterized || configuration.alwaysOnNewLine.contains(token) {
-                return token
-            }
-
-            return nil
-        })
-    }
-
-    private func violation(dictionary: SourceKittenDictionary,
-                           file: SwiftLintFile) -> [StyleViolation] {
-        let location: Location
-        if let offset = dictionary.offset {
-            location = Location(file: file, byteOffset: offset)
-        } else {
-            location = Location(file: file.path)
-        }
-
-        return [
-            StyleViolation(ruleDescription: Self.description,
-                           severity: configuration.severityConfiguration.severity,
-                           location: location)
-        ]
-    }
-
-    // returns an array with the token itself (i.e. "@objc") and whether it's parameterized
-    // note: the parameter is not contained in the token
-    private func attributesFromPreviousLines(lineNumber: Int,
-                                             file: SwiftLintFile) throws -> [(String, Bool)] {
-        var currentLine = lineNumber - 1
-        var allTokens = [(String, Bool)]()
-        var foundEmptyLine = false
-
-        while currentLine >= 0 {
-            defer {
-                currentLine -= 1
-            }
-
-            let line = file.lines[currentLine]
-            let tokens = file.syntaxMap.tokens(inByteRange: line.byteRange)
-
-            if tokens.isEmpty {
-                foundEmptyLine = true
-                continue
-            }
-
-            // check if it's a line with other declaration which could have its own attributes
-            let nonAttributeTokens = tokens.filter { token in
-                guard token.kind == .keyword,
-                    let keyword = file.contents(for: token) else {
-                    return false
-                }
-
-                let keywords: Set = ["func", "var", "let", "class", "struct",
-                                     "enum", "protocol", "import"]
-                return keywords.contains(keyword)
-            }
-
-            guard nonAttributeTokens.isEmpty else {
-                break
-            }
-
-            let attributesTokens = tokens.compactMap { attributeName(token: $0, file: file) }
-            guard let firstTokenRange = attributesTokens.first?.1 else {
-                // found a line that does not contain an attribute token - we can stop looking
-                break
-            }
-
-            if attributesTokens.count > 1 {
-                // we don't allow multiple attributes in the same line if it's a previous line
-                throw AttributesRuleError.moreThanOneAttributeInSameLine
-            }
-
-            if foundEmptyLine {
-                // we don't allow attributes with empty lines between them
-                throw AttributesRuleError.unexpectedBlankLine
-            }
-
-            let hasParameter = attributeContainsParameter(attributeRange: firstTokenRange,
-                                                          line: line, file: file)
-
-            allTokens.insert(contentsOf: attributesTokens.map { ($0.0, hasParameter) }, at: 0)
-        }
-
-        return allTokens
-    }
-
-    private func attributeContainsParameter(attributeRange: ByteRange,
-                                            line: Line, file: SwiftLintFile) -> Bool {
-        let restOfLineOffset = attributeRange.upperBound
-        let restOfLineLength = line.byteRange.upperBound - restOfLineOffset
-        if restOfLineLength < 0 {
-            // If attribute spans multiple lines, it must have a parameter.
-            return true
-        }
-
-        let regex = Self.regularExpression
-        let contents = file.stringView
-
-        // check if after the token is a `(` with only spaces allowed between the token and `(`
-        let restOfLineByteRange = ByteRange(location: restOfLineOffset, length: restOfLineLength)
-        guard let restOfLine = contents.substringWithByteRange(restOfLineByteRange),
-            case let range = restOfLine.fullNSRange,
-            regex.firstMatch(in: restOfLine, options: [], range: range) != nil else {
-            return false
-        }
-
-        return true
-    }
-
-    private func attributeName(token: SwiftLintSyntaxToken, file: SwiftLintFile) -> (String, ByteRange)? {
-        guard token.kind == .attributeBuiltin else {
-            return nil
-        }
-
-        let maybeName = file.contents(for: token)
-        if let name = maybeName, isAttribute(name) {
-            return (name, token.range)
-        }
-
-        return nil
-    }
-
-    private func isAttribute(_ name: String) -> Bool {
-        if name == "@escaping" || name == "@autoclosure" {
-            return false
-        }
-
-        // all attributes *should* start with @
-        if name.hasPrefix("@") {
-            return true
-        }
-
-        // for some reason, `@` is not included if @warn_unused_result has parameters
-        if name.hasPrefix("warn_unused_result(") {
-            return true
-        }
-
-        return false
-    }
-
-    private func parseAttributes(dictionary: SourceKittenDictionary) -> [SwiftDeclarationAttributeKind] {
-        let attributes = dictionary.enclosedSwiftAttributes
-        return attributes.filter { !kIgnoredAttributes.contains($0) }
     }
 }
 
-private let kIgnoredAttributes: Set<SwiftDeclarationAttributeKind> = [
-    .dynamic,
-    .fileprivate,
-    .final,
-    .infix,
-    .internal,
-    .lazy,
-    .mutating,
-    .nonmutating,
-    .open,
-    .optional,
-    .override,
-    .postfix,
-    .prefix,
-    .private,
-    .public,
-    .required,
-    .rethrows,
-    .setterFilePrivate,
-    .setterInternal,
-    .setterOpen,
-    .setterPrivate,
-    .setterPublic,
-    .weak
-]
+private extension AttributesRule {
+    final class Visitor: SyntaxVisitor, ViolationsSyntaxVisitor {
+        private(set) var violationPositions: [AbsolutePosition] = []
+        private let locationConverter: SourceLocationConverter
+        private let configuration: AttributesConfiguration
+
+        init(locationConverter: SourceLocationConverter, configuration: AttributesConfiguration) {
+            self.locationConverter = locationConverter
+            self.configuration = configuration
+            super.init(viewMode: .sourceAccurate)
+        }
+
+        override func visitPost(_ node: ImportDeclSyntax) {
+            let importLine = node.importTok.startLine(locationConverter: locationConverter)
+            let hasViolation = node.attributes?.contains { attribute in
+                attribute.startLine(locationConverter: locationConverter) != importLine
+            } == true
+
+            if hasViolation {
+                violationPositions.append(node.importTok.positionAfterSkippingLeadingTrivia)
+            }
+        }
+
+        override func visitPost(_ node: AttributeListSyntax) {
+            guard let helper = node.makeHelper(locationConverter: locationConverter) else {
+                return
+            }
+
+            let attributesAndPlacements = node.attributesAndPlacements(
+                configuration: configuration,
+                shouldBeOnSameLine: helper.shouldBeOnSameLine
+            )
+
+            let hasViolation = helper.hasViolation(
+                locationConverter: locationConverter,
+                attributesAndPlacements: attributesAndPlacements
+            )
+
+            if hasViolation {
+                violationPositions.append(helper.violationPosition)
+                return
+            }
+
+            let linesForAttributes = attributesAndPlacements
+                .filter { $1 == .dedicatedLine }
+                .map { $0.0.endLine(locationConverter: locationConverter) }
+
+            if linesForAttributes.isEmpty {
+                return
+            } else if !linesForAttributes.contains(helper.declarationLine - 1) {
+                violationPositions.append(helper.violationPosition)
+                return
+            }
+
+            let hasMultipleNewlines = node.children(viewMode: .sourceAccurate).enumerated().contains { index, element in
+                if index > 0 && element.leadingTrivia?.hasMultipleNewlines == true {
+                    return true
+                } else {
+                    return element.trailingTrivia?.hasMultipleNewlines == true
+                }
+            }
+
+            if hasMultipleNewlines {
+                violationPositions.append(helper.violationPosition)
+                return
+            }
+        }
+    }
+}
+
+private extension SyntaxProtocol {
+    func startLine(locationConverter: SourceLocationConverter) -> Int? {
+        locationConverter.location(for: positionAfterSkippingLeadingTrivia).line
+    }
+
+    func endLine(locationConverter: SourceLocationConverter) -> Int? {
+        locationConverter.location(for: endPositionBeforeTrailingTrivia).line
+    }
+}
+
+private extension Trivia {
+    var hasMultipleNewlines: Bool {
+        reduce(0, { $0 + $1.numberOfNewlines }) > 1
+    }
+}
+
+private extension TriviaPiece {
+    var numberOfNewlines: Int {
+        if case .newlines(let numberOfNewlines) = self {
+            return numberOfNewlines
+        } else {
+            return 0
+        }
+    }
+}
+
+private enum AttributePlacement {
+    case sameLineAsDeclaration
+    case dedicatedLine
+}
+
+private struct RuleHelper {
+    let violationPosition: AbsolutePosition
+    let declarationLine: Int
+    let shouldBeOnSameLine: Bool
+
+    func hasViolation(
+        locationConverter: SourceLocationConverter,
+        attributesAndPlacements: [(AttributeSyntax, AttributePlacement)]
+    ) -> Bool {
+        var linesWithAttributes: Set<Int> = [declarationLine]
+        for (attribute, placement) in attributesAndPlacements {
+            guard let attributeStartLine = attribute.startLine(locationConverter: locationConverter) else {
+                continue
+            }
+
+            switch placement {
+            case .sameLineAsDeclaration:
+                if attributeStartLine != declarationLine {
+                    return true
+                }
+            case .dedicatedLine:
+                let hasViolation = attributeStartLine == declarationLine ||
+                    linesWithAttributes.contains(attributeStartLine)
+                linesWithAttributes.insert(attributeStartLine)
+                if hasViolation {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+
+private extension AttributeListSyntax {
+    func attributesAndPlacements(configuration: AttributesConfiguration, shouldBeOnSameLine: Bool)
+        -> [(AttributeSyntax, AttributePlacement)] {
+        self
+            .children(viewMode: .sourceAccurate)
+            .compactMap { $0.as(AttributeSyntax.self) }
+            .map { attribute in
+                let atPrefixedName = "@\(attribute.attributeName.text)"
+                if configuration.alwaysOnSameLine.contains(atPrefixedName) {
+                    return (attribute, .sameLineAsDeclaration)
+                } else if configuration.alwaysOnNewLine.contains(atPrefixedName) {
+                    return (attribute, .dedicatedLine)
+                } else if attribute.argument != nil {
+                    return (attribute, .dedicatedLine)
+                }
+
+                return shouldBeOnSameLine ? (attribute, .sameLineAsDeclaration) : (attribute, .dedicatedLine)
+            }
+    }
+
+    func makeHelper(locationConverter: SourceLocationConverter) -> RuleHelper? {
+        if
+            let parent = parent?.as(VariableDeclSyntax.self),
+            let letOrVarLine = parent.letOrVarKeyword.startLine(locationConverter: locationConverter)
+        {
+            return RuleHelper(
+                violationPosition: parent.letOrVarKeyword.positionAfterSkippingLeadingTrivia,
+                declarationLine: letOrVarLine,
+                shouldBeOnSameLine: true
+            )
+        } else if
+            let parent = parent?.as(FunctionDeclSyntax.self),
+            let funcLine = parent.funcKeyword.startLine(locationConverter: locationConverter)
+        {
+            return RuleHelper(
+                violationPosition: parent.funcKeyword.positionAfterSkippingLeadingTrivia,
+                declarationLine: funcLine,
+                shouldBeOnSameLine: false
+            )
+        } else if
+            let parent = parent?.as(ClassDeclSyntax.self),
+            let keywordLine = parent.classKeyword.startLine(locationConverter: locationConverter)
+        {
+            return RuleHelper(
+                violationPosition: parent.classKeyword.positionAfterSkippingLeadingTrivia,
+                declarationLine: keywordLine,
+                shouldBeOnSameLine: false
+            )
+        } else {
+            return nil
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -168,6 +168,8 @@ private extension AttributeListSyntax {
             }
     }
 
+    // swiftlint:disable cyclomatic_complexity function_body_length opening_brace
+
     func makeHelper(locationConverter: SourceLocationConverter) -> RuleHelper? {
         guard let parent = parent else {
             return nil

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -223,6 +223,14 @@ private extension AttributeListSyntax {
                 keywordLine: keywordLine,
                 shouldBeOnSameLine: false
             )
+        } else if let parent = parent.as(ProtocolDeclSyntax.self),
+                  let keywordLine = parent.protocolKeyword.startLine(locationConverter: locationConverter)
+        {
+            return RuleHelper(
+                violationPosition: parent.protocolKeyword.positionAfterSkippingLeadingTrivia,
+                keywordLine: keywordLine,
+                shouldBeOnSameLine: false
+            )
         } else if let parent = parent.as(ImportDeclSyntax.self),
                   let keywordLine = parent.importTok.startLine(locationConverter: locationConverter)
         {
@@ -246,7 +254,6 @@ private extension AttributeListSyntax {
         } else if parent.is(ClosureSignatureSyntax.self) {
             return nil
         } else {
-            dump(parent)
             return nil
         }
     }

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -168,93 +168,53 @@ private extension AttributeListSyntax {
             }
     }
 
-    // swiftlint:disable cyclomatic_complexity function_body_length opening_brace
-
+    // swiftlint:disable:next cyclomatic_complexity
     func makeHelper(locationConverter: SourceLocationConverter) -> RuleHelper? {
         guard let parent = parent else {
             return nil
         }
 
-        if let parent = parent.as(VariableDeclSyntax.self),
-           let keywordLine = parent.letOrVarKeyword.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.letOrVarKeyword.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: true
-            )
-        } else if let parent = parent.as(FunctionDeclSyntax.self),
-                  let keywordLine = parent.funcKeyword.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.funcKeyword.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: false
-            )
-        } else if let parent = parent.as(EnumDeclSyntax.self),
-                  let keywordLine = parent.enumKeyword.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.enumKeyword.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: false
-            )
-        } else if let parent = parent.as(StructDeclSyntax.self),
-                  let keywordLine = parent.structKeyword.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.structKeyword.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: false
-            )
-        } else if let parent = parent.as(ClassDeclSyntax.self),
-                  let keywordLine = parent.classKeyword.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.classKeyword.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: false
-            )
-        } else if let parent = parent.as(ExtensionDeclSyntax.self),
-                  let keywordLine = parent.extensionKeyword.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.extensionKeyword.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: false
-            )
-        } else if let parent = parent.as(ProtocolDeclSyntax.self),
-                  let keywordLine = parent.protocolKeyword.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.protocolKeyword.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: false
-            )
-        } else if let parent = parent.as(ImportDeclSyntax.self),
-                  let keywordLine = parent.importTok.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.importTok.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: true
-            )
-        } else if let parent = parent.as(InitializerDeclSyntax.self),
-                  let keywordLine = parent.initKeyword.startLine(locationConverter: locationConverter)
-        {
-            return RuleHelper(
-                violationPosition: parent.initKeyword.positionAfterSkippingLeadingTrivia,
-                keywordLine: keywordLine,
-                shouldBeOnSameLine: false
-            )
-        } else if parent.is(AttributedTypeSyntax.self) {
-            return nil
-        } else if parent.is(FunctionParameterSyntax.self) {
-            return nil
-        } else if parent.is(ClosureSignatureSyntax.self) {
-            return nil
+        let keyword: any SyntaxProtocol
+        let shouldBeOnSameLine: Bool
+        if let funcKeyword = parent.as(FunctionDeclSyntax.self)?.funcKeyword {
+            keyword = funcKeyword
+            shouldBeOnSameLine = false
+        } else if let initKeyword = parent.as(InitializerDeclSyntax.self)?.initKeyword {
+            keyword = initKeyword
+            shouldBeOnSameLine = false
+        } else if let enumKeyword = parent.as(EnumDeclSyntax.self)?.enumKeyword {
+            keyword = enumKeyword
+            shouldBeOnSameLine = false
+        } else if let structKeyword = parent.as(StructDeclSyntax.self)?.structKeyword {
+            keyword = structKeyword
+            shouldBeOnSameLine = false
+        } else if let classKeyword = parent.as(ClassDeclSyntax.self)?.classKeyword {
+            keyword = classKeyword
+            shouldBeOnSameLine = false
+        } else if let extensionKeyword = parent.as(ExtensionDeclSyntax.self)?.extensionKeyword {
+            keyword = extensionKeyword
+            shouldBeOnSameLine = false
+        } else if let protocolKeyword = parent.as(ProtocolDeclSyntax.self)?.protocolKeyword {
+            keyword = protocolKeyword
+            shouldBeOnSameLine = false
+        } else if let importTok = parent.as(ImportDeclSyntax.self)?.importTok {
+            keyword = importTok
+            shouldBeOnSameLine = true
+        } else if let letOrVarKeyword = parent.as(VariableDeclSyntax.self)?.letOrVarKeyword {
+            keyword = letOrVarKeyword
+            shouldBeOnSameLine = true
         } else {
             return nil
         }
+
+        guard let keywordLine = keyword.startLine(locationConverter: locationConverter) else {
+            return nil
+        }
+
+        return RuleHelper(
+            violationPosition: keyword.positionAfterSkippingLeadingTrivia,
+            keywordLine: keywordLine,
+            shouldBeOnSameLine: shouldBeOnSameLine
+        )
     }
 }


### PR DESCRIPTION
Not 100% the same as it previously was, but I think all the changes reported by OSSCheck are improvements or neutral.