### PR TITLE
Add way to preprocess syntaxTree in SwiftSyntaxRule

### DIFF
--- a/Source/SwiftLintFramework/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintFramework/Protocols/SwiftSyntaxRule.swift
@@ -19,7 +19,7 @@ public protocol SwiftSyntaxRule: SourceKitFreeRule {
 
     /// Gives a chance for the rule to do some pre-processing on the syntax tree.
     /// One typical example is using `SwiftOperators` to "fold" the tree, resolving operators precedence.
-    /// By default, returns this just returns the same `syntaxTree`.
+    /// By default, it just returns the same `syntaxTree`.
     ///
     /// - parameter syntaxTree: The syntaxTree to run pre-processing on
     ///

--- a/Source/SwiftLintFramework/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintFramework/Protocols/SwiftSyntaxRule.swift
@@ -21,7 +21,7 @@ public protocol SwiftSyntaxRule: SourceKitFreeRule {
     /// One typical example is using `SwiftOperators` to "fold" the tree, resolving operators precedence.
     /// By default, it just returns the same `syntaxTree`.
     ///
-    /// - parameter syntaxTree: The syntaxTree to run pre-processing on
+    /// - parameter syntaxTree: The syntax tree to run pre-processing on
     ///
     /// - returns: The tree that will be used to check for violations. If `nil`, this rule will return no violations.
     func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax?

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, SourceKitFreeRule {
+public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -39,18 +39,12 @@ public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, SourceKi
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree.folded() else {
-            return []
-        }
+    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+        syntaxTree.folded()
+    }
 
-        return Visitor(viewMode: .sourceAccurate)
-            .walk(tree: tree, handler: \.violationPositions)
-            .map { position in
-                StyleViolation(ruleDescription: Self.description,
-                               severity: configuration.severity,
-                               location: Location(file: file, position: position))
-            }
+    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
+        Visitor(viewMode: .sourceAccurate)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-public struct IdenticalOperandsRule: ConfigurationProviderRule, SourceKitFreeRule, OptInRule {
+public struct IdenticalOperandsRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -71,18 +71,12 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, SourceKitFreeRul
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree.folded() else {
-            return []
-        }
+    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+        syntaxTree.folded()
+    }
 
-        return Visitor(viewMode: .sourceAccurate)
-            .walk(tree: tree, handler: \.violationPositions)
-            .map { position in
-                StyleViolation(ruleDescription: Self.description,
-                               severity: configuration.severity,
-                               location: Location(file: file, position: position))
-            }
+    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
+        Visitor(viewMode: .sourceAccurate)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-public struct ContainsOverRangeNilComparisonRule: SourceKitFreeRule, OptInRule, ConfigurationProviderRule {
+public struct ContainsOverRangeNilComparisonRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public init() {}
@@ -23,18 +23,12 @@ public struct ContainsOverRangeNilComparisonRule: SourceKitFreeRule, OptInRule, 
         }
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree.folded() else {
-            return []
-        }
+    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+        syntaxTree.folded()
+    }
 
-        return Visitor(viewMode: .sourceAccurate)
-            .walk(tree: tree, handler: \.violationPositions)
-            .map { position in
-                StyleViolation(ruleDescription: Self.description,
-                               severity: configuration.severity,
-                               location: Location(file: file, position: position))
-            }
+    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
+        Visitor(viewMode: .sourceAccurate)
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-public struct ShorthandOperatorRule: ConfigurationProviderRule, SourceKitFreeRule {
+public struct ShorthandOperatorRule: ConfigurationProviderRule, SwiftSyntaxRule {
     public var configuration = SeverityConfiguration(.error)
 
     public init() {}
@@ -42,18 +42,12 @@ public struct ShorthandOperatorRule: ConfigurationProviderRule, SourceKitFreeRul
 
     fileprivate static let allOperators = ["-", "/", "+", "*"]
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
-        guard let tree = file.syntaxTree.folded() else {
-            return []
-        }
+    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+        syntaxTree.folded()
+    }
 
-        return Visitor(viewMode: .sourceAccurate)
-            .walk(tree: tree, handler: \.violationPositions)
-            .map { position in
-                StyleViolation(ruleDescription: Self.description,
-                               severity: configuration.severity,
-                               location: Location(file: file, position: position))
-            }
+    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor? {
+        Visitor(viewMode: .sourceAccurate)
     }
 }
 


### PR DESCRIPTION
This is another reason why some rules can't use `SwiftSyntaxRule` directly, so adding some convenience for them to avoid duplicating the whole `walk` dance.