### PR TITLE
Support .focused() in keys for corrections

### DIFF
--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -547,7 +547,7 @@ private struct FocusedRuleDescription {
     init(rule: RuleDescription) {
         let nonTriggering = rule.nonTriggeringExamples.filter(\.isFocused)
         let triggering = rule.triggeringExamples.filter(\.isFocused)
-        let corrections = rule.corrections.filter { _, value in value.isFocused }
+        let corrections = rule.corrections.filter { key, value in key.isFocused || value.isFocused }
         let anyFocused = nonTriggering.isNotEmpty || triggering.isNotEmpty || corrections.isNotEmpty
 
         if anyFocused {


### PR DESCRIPTION
I never remember that using `.focused()` only works in the right side of `corrections`, so just making this a little bit more flexible