### PR TITLE
Make `DiscouragedNoneNameRule` opt-in again

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedNoneNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedNoneNameRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-public struct DiscouragedNoneNameRule: SourceKitFreeRule, ConfigurationProviderRule {
+public struct DiscouragedNoneNameRule: SourceKitFreeRule, OptInRule, ConfigurationProviderRule {
     public var configuration = SeverityConfiguration(.warning)
 
     public static var description = RuleDescription(


### PR DESCRIPTION
I mistakenly made it enable by default when rewriting it