### PR TITLE
Only lint Swift source files within the provided target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   `orphaned_doc_comment` and into a new opt-in `local_doc_comment` rule.  
   [JP Simard](https://github.com/jpsim)
   [#4573](https://github.com/realm/SwiftLint/issues/4573)
+* SwiftLint's Swift Package Build Tool Plugin will now only scan files in the target being built. 
+  [Tony Arnold](https://github.com/tonyarnold) 
+  [#4406](https://github.com/realm/SwiftLint/pull/4406)
 
 #### Bug Fixes
 

--- a/Plugins/SwiftLintPlugin/Path+Helpers.swift
+++ b/Plugins/SwiftLintPlugin/Path+Helpers.swift
@@ -2,7 +2,7 @@ import Foundation
 import PackagePlugin
 
 extension Path {
-    /// Scans the receiver, then all of it's parents looking for a configuration file with the name ".swiftlint.yml".
+    /// Scans the receiver, then all of its parents looking for a configuration file with the name ".swiftlint.yml".
     /// - Returns: Path to the configuration file, or nil if one cannot be found.
     func firstConfigurationFileInParentDirectories() -> Path? {
         // TODO: Consider linking to the framework to get the default configuration file name

--- a/Plugins/SwiftLintPlugin/Path+Helpers.swift
+++ b/Plugins/SwiftLintPlugin/Path+Helpers.swift
@@ -1,0 +1,18 @@
+import Foundation
+import PackagePlugin
+
+extension Path {
+    /// Scans the receiver, then all of it's parents looking for a configuration file with the name ".swiftlint.yml".
+    /// - Returns: Path to the configuration file, or nil if one cannot be found.
+    func firstConfigurationFileInParentDirectories() -> Path? {
+        // TODO: Consider linking to the framework to get the default configuration file name
+        let defaultConfigurationFileName = ".swiftlint.yml"
+        let proposedDirectory = sequence(first: self, next: { $0.removingLastComponent() })
+            .first { path in
+                let potentialConfigurationFile = path.appending(subpath: defaultConfigurationFileName)
+                return FileManager.default.isReadableFile(atPath: potentialConfigurationFile.string)
+            }
+
+        return proposedDirectory?.appending(subpath: defaultConfigurationFileName)
+    }
+}

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -32,7 +32,7 @@ struct SwiftLintPlugin: BuildToolPlugin {
                 executable: swiftlint.path,
                 arguments: arguments,
                 inputFiles: inputFilePaths,
-                outputFiles: []
+                outputFiles: [context.pluginWorkDirectory]
             )
         ]
     }
@@ -69,7 +69,7 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
                 executable: swiftlint.path,
                 arguments: arguments,
                 inputFiles: inputFilePaths,
-                outputFiles: []
+                outputFiles: [context.pluginWorkDirectory]
             )
         ]
     }

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -90,19 +90,3 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
     }
 }
 #endif
-
-private extension Path {
-    /// Scans the receiver, then all of it's parents looking for a configuration file with the name ".swiftlint.yml".
-    /// - Returns: Path to the configuration file, or nil if one cannot be found.
-    func firstConfigurationFileInParentDirectories() -> Path? {
-        // TODO: Consider linking to the framework to get the default configuration file name
-        let defaultConfigurationFileName = ".swiftlint.yml"
-        let proposedDirectory = sequence(first: self, next: { $0.removingLastComponent() })
-            .first { path in
-                let potentialConfigurationFile = path.appending(subpath: defaultConfigurationFileName)
-                return FileManager.default.isReadableFile(atPath: potentialConfigurationFile.string)
-            }
-
-        return proposedDirectory?.appending(subpath: defaultConfigurationFileName)
-    }
-}

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -46,7 +46,12 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
         context: XcodePluginContext,
         target: XcodeTarget
     ) throws -> [Command] {
-        guard let sourceTarget = target as? SourceModuleTarget else {
+        let inputFilePaths = target.inputFiles
+            .filter { $0.type == .source && $0.path.extension == "swift" }
+            .map(\.path)
+
+        guard inputFilePaths.isEmpty == false else {
+            // Don't lint anything if there are no Swift source files in this target
             return []
         }
 
@@ -55,13 +60,6 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
             "lint",
             "--cache-path", "\(context.pluginWorkDirectory)"
         ]
-
-        let inputFilePaths = sourceTarget.sourceFiles(withSuffix: "swift").map(\.path)
-
-        guard inputFilePaths.isEmpty == false else {
-            // Don't lint anything if there are no Swift source files in this target
-            return []
-        }
 
         arguments += inputFilePaths.map(\.string)
 

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -28,7 +28,7 @@ struct SwiftLintPlugin: BuildToolPlugin {
 
         return [
             .buildCommand(
-                displayName: "Linting Swift sources",
+                displayName: "SwiftLint",
                 executable: swiftlint.path,
                 arguments: arguments,
                 inputFiles: inputFilePaths,
@@ -67,7 +67,7 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
 
         return [
             .buildCommand(
-                displayName: "Linting Swift sources",
+                displayName: "SwiftLint",
                 executable: swiftlint.path,
                 arguments: arguments,
                 inputFiles: inputFilePaths,

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -100,7 +100,7 @@ private extension Path {
         let proposedDirectory = sequence(first: self, next: { $0.removingLastComponent() })
             .first { path in
                 let potentialConfigurationFile = path.appending(subpath: defaultConfigurationFileName)
-                return FileManager.default.fileExists(atPath: potentialConfigurationFile.string)
+                return FileManager.default.isReadableFile(atPath: potentialConfigurationFile.string)
             }
 
         return proposedDirectory?.appending(subpath: defaultConfigurationFileName)

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -7,14 +7,32 @@ struct SwiftLintPlugin: BuildToolPlugin {
         context: PackagePlugin.PluginContext,
         target: PackagePlugin.Target
     ) async throws -> [PackagePlugin.Command] {
-        [
+        guard let sourceTarget = target as? SourceModuleTarget else {
+            return []
+        }
+
+        let swiftlint = try context.tool(named: "swiftlint")
+        var arguments: [String] = [
+            "lint",
+            "--cache-path", "\(context.pluginWorkDirectory)"
+        ]
+
+        let inputFilePaths = sourceTarget.sourceFiles(withSuffix: "swift").map(\.path)
+
+        guard inputFilePaths.isEmpty == false else {
+            // Don't lint anything if there are no Swift source files in this target
+            return []
+        }
+
+        arguments += inputFilePaths.map(\.string)
+
+        return [
             .buildCommand(
-                displayName: "SwiftLint",
-                executable: try context.tool(named: "swiftlint").path,
-                arguments: [
-                    "lint",
-                    "--cache-path", "\(context.pluginWorkDirectory)"
-                ]
+                displayName: "Linting Swift sources",
+                executable: swiftlint.path,
+                arguments: arguments,
+                inputFiles: inputFilePaths,
+                outputFiles: []
             )
         ]
     }
@@ -28,14 +46,32 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
         context: XcodePluginContext,
         target: XcodeTarget
     ) throws -> [Command] {
-        [
+        guard let sourceTarget = target as? SourceModuleTarget else {
+            return []
+        }
+
+        let swiftlint = try context.tool(named: "swiftlint")
+        var arguments: [String] = [
+            "lint",
+            "--cache-path", "\(context.pluginWorkDirectory)"
+        ]
+
+        let inputFilePaths = sourceTarget.sourceFiles(withSuffix: "swift").map(\.path)
+
+        guard inputFilePaths.isEmpty == false else {
+            // Don't lint anything if there are no Swift source files in this target
+            return []
+        }
+
+        arguments += inputFilePaths.map(\.string)
+
+        return [
             .buildCommand(
-                displayName: "SwiftLint",
-                executable: try context.tool(named: "swiftlint").path,
-                arguments: [
-                    "lint",
-                    "--cache-path", "\(context.pluginWorkDirectory)"
-                ]
+                displayName: "Linting Swift sources",
+                executable: swiftlint.path,
+                arguments: arguments,
+                inputFiles: inputFilePaths,
+                outputFiles: []
             )
         ]
     }


### PR DESCRIPTION
When running with the SwiftPM build plugin provided in #4176, I noticed that regardless of which target was being built, the entire working directory was being linted. 

This PR proposes to only lint Swift source files within the passed target by passing them as arguments to the build plugin process. 

It also bails out early if the type of target it not suitable for linting, or there are no Swift source files to lint.