### PR TITLE
Make `Quick*` rules more permissive

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -17,7 +17,7 @@ public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule {
     public func validate(file: SwiftLintFile) -> [StyleViolation] {
         let dict = file.structureDictionary
         let testClasses = dict.substructure.filter {
-            return $0.inheritedTypes.contains("QuickSpec") &&
+            return $0.inheritedTypes.isNotEmpty &&
                 $0.declarationKind == .class
         }
 

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
@@ -276,6 +276,18 @@ internal struct QuickDiscouragedCallRuleExamples {
                }
            }
         }
+        """),
+        Example("""
+        class TotoTests: QuickSpecSubclass {
+           override func spec() {
+               xcontext("foo") {
+                   let foo = ↓Foo()
+               }
+               fcontext("foo") {
+                   let foo = ↓Foo()
+               }
+           }
+        }
         """)
     ]
 }

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -32,7 +32,7 @@ private extension QuickDiscouragedFocusedTestRule {
         }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-            node.isQuickSpec ? .visitChildren : .skipChildren
+            node.containsInheritance ? .visitChildren : .skipChildren
         }
 
         override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -42,14 +42,12 @@ private extension QuickDiscouragedFocusedTestRule {
 }
 
 private extension ClassDeclSyntax {
-    var isQuickSpec: Bool {
+    var containsInheritance: Bool {
         guard let inheritanceList = inheritanceClause?.inheritedTypeCollection else {
             return false
         }
 
-        return inheritanceList.contains { type in
-            type.typeName.as(SimpleTypeIdentifierSyntax.self)?.name.text == "QuickSpec"
-        }
+        return inheritanceList.isNotEmpty
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRuleExamples.swift
@@ -73,6 +73,13 @@ internal struct QuickDiscouragedFocusedTestRuleExamples {
                ↓fitBehavesLike("foo")
            }
         }
+        """),
+        Example("""
+        class TotoTests: QuickSpecSubclass {
+           override func spec() {
+               ↓fitBehavesLike("foo")
+           }
+        }
         """)
     ]
 }

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -32,7 +32,7 @@ private extension QuickDiscouragedPendingTestRule {
         }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-            node.isQuickSpec ? .visitChildren : .skipChildren
+            node.containsInheritance ? .visitChildren : .skipChildren
         }
 
         override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -42,14 +42,12 @@ private extension QuickDiscouragedPendingTestRule {
 }
 
 private extension ClassDeclSyntax {
-    var isQuickSpec: Bool {
+    var containsInheritance: Bool {
         guard let inheritanceList = inheritanceClause?.inheritedTypeCollection else {
             return false
         }
 
-        return inheritanceList.contains { type in
-            type.typeName.as(SimpleTypeIdentifierSyntax.self)?.name.text == "QuickSpec"
-        }
+        return inheritanceList.isNotEmpty
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRuleExamples.swift
@@ -80,6 +80,13 @@ internal struct QuickDiscouragedPendingTestRuleExamples {
                ↓xitBehavesLike("foo")
            }
         }
+        """),
+        Example("""
+        class TotoTests: QuickSpecSubclass {
+           override func spec() {
+               ↓xitBehavesLike("foo")
+           }
+        }
         """)
     ]
 }


### PR DESCRIPTION
Fixes #4420

Given the other constraints (i.e. requiring an `override func spec()` method) and that these rules are opt-in, I think this is a good tradeoff, supporting `QuickSpec` subclasses even if in theory this could lead to false positives.