### PR TITLE
Rewrite `type_name` rule with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
   - `trailing_comma`
   - `trailing_semicolon`
   - `type_body_length`
+  - `type_name`
   - `unneeded_break_in_switch`
   - `unneeded_parentheses_in_closure_argument`
   - `unowned_variable_capture`
@@ -208,6 +209,9 @@
   `QuickSpec`.
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4420](https://github.com/realm/SwiftLint/issues/4420)
+
+* `type_name` rule now also validates protocol declarations.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,9 +210,6 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4420](https://github.com/realm/SwiftLint/issues/4420)
 
-* `type_name` rule now also validates protocol declarations.  
-  [Marcelo Fabri](https://github.com/marcelofabri)
-
 #### Bug Fixes
 
 * Respect `validates_start_with_lowercase` option when linting function names.  

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -75,13 +75,6 @@ private extension TypeNameRule {
             }
         }
 
-        override func visitPost(_ node: ProtocolDeclSyntax) {
-            if let violation = violation(identifier: node.identifier, modifiers: node.modifiers,
-                                         inheritedTypes: node.inheritanceClause?.inheritedTypeCollection) {
-                violations.append(violation)
-            }
-        }
-
         private func violation(identifier: TokenSyntax,
                                modifiers: ModifierListSyntax?,
                                inheritedTypes: InheritedTypeListSyntax?) -> ReasonedRuleViolation? {


### PR DESCRIPTION
~This also now validates protocols, which I think was just a historical oversight.~