### PR TITLE
Revert "Add Automattic/pocket-casts-ios to oss-check"

### DIFF
--- a/tools/oss-check
+++ b/tools/oss-check
@@ -295,7 +295,6 @@ end
   Repo.new('Kickstarter', 'kickstarter/ios-oss'),
   Repo.new('Moya', 'Moya/Moya'),
   Repo.new('Nimble', 'Quick/Nimble'),
-  Repo.new('Pocket Casts', 'Automattic/pocket-casts-ios'),
   Repo.new('Quick', 'Quick/Quick'),
   Repo.new('Realm', 'realm/realm-swift'),
   Repo.new('SourceKitten', 'jpsim/SourceKitten'),


### PR DESCRIPTION
Reverts realm/SwiftLint#4434

I think this broke oss-check, probably due to the whitespace