### PR TITLE
Rewrite `redundant_objc_attribute` with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
   - `reduce_boolean`
   - `redundant_discardable_let`
   - `redundant_nil_coalescing`
+  - `redundant_objc_attribute`
   - `redundant_string_enum_value`
   - `required_deinit`
   - `self_in_property_initialization`

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -109,24 +109,18 @@ private extension Syntax {
 
 private extension AttributeListSyntax {
     var violatingObjCAttribute: AttributeSyntax? {
-        if
-            let objcAttribute = objCAttribute,
-            hasAttributeImplyingObjC,
-            parent?.is(ExtensionDeclSyntax.self) != true
-        {
+        guard let objcAttribute = objCAttribute else {
+            return nil
+        }
+
+        if hasAttributeImplyingObjC, parent?.is(ExtensionDeclSyntax.self) != true {
             return objcAttribute
-        } else if
-            let objcAttribute = objCAttribute,
-            parent?.isFunctionOrStoredProperty == true,
-            let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
-            parentClassDecl.attributes?.hasObjCMembers == true
-        {
+        } else if parent?.isFunctionOrStoredProperty == true,
+                  let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
+                  parentClassDecl.attributes?.hasObjCMembers == true {
             return objcAttribute
-        } else if
-            let objcAttribute = objCAttribute,
-            let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
-            parentExtensionDecl.attributes?.objCAttribute != nil
-        {
+        } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
+                  parentExtensionDecl.attributes?.objCAttribute != nil {
             return objcAttribute
         } else {
             return nil

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -191,8 +191,7 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objc
         extension Foo {
-            ↓@objc
-            var bar: Int {
+            ↓@objc var bar: Int {
                 return 0
             }
         }
@@ -208,8 +207,7 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objc @IBDesignable
         extension Foo {
-            ↓@objc
-            var bar: Int {
+            ↓@objc var bar: Int {
                 return 0
             }
         }
@@ -243,27 +241,7 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objc
         extension Foo {
-            ↓@objc
-            private var bar: Int {
-                return 0
-            }
-        }
-        """):
-        Example("""
-        @objc
-        extension Foo {
-            private var bar: Int {
-                return 0
-            }
-        }
-        """),
-        Example("""
-        @objc
-        extension Foo {
-            ↓@objc
-
-
-            private var bar: Int {
+            ↓@objc private var bar: Int {
                 return 0
             }
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -69,6 +69,12 @@ struct RedundantObjcAttributeRuleExamples {
         class Foo {
             @objc class Bar {}
         }
+        """),
+        Example("""
+        extension BlockEditorSettings {
+            @objc(addElementsObject:)
+            @NSManaged public func addToElements(_ value: BlockEditorSettingElement)
+        }
         """)
     ]
 
@@ -191,7 +197,8 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objc
         extension Foo {
-            ↓@objc var bar: Int {
+            ↓@objc
+            var bar: Int {
                 return 0
             }
         }
@@ -207,7 +214,8 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objc @IBDesignable
         extension Foo {
-            ↓@objc var bar: Int {
+            ↓@objc
+            var bar: Int {
                 return 0
             }
         }
@@ -241,7 +249,27 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objc
         extension Foo {
-            ↓@objc private var bar: Int {
+            ↓@objc
+            private var bar: Int {
+                return 0
+            }
+        }
+        """):
+        Example("""
+        @objc
+        extension Foo {
+            private var bar: Int {
+                return 0
+            }
+        }
+        """),
+        Example("""
+        @objc
+        extension Foo {
+            ↓@objc
+
+
+            private var bar: Int {
                 return 0
             }
         }


### PR DESCRIPTION
~This version isn't as good at cleaning up whitespace after applying corrections but hopefully we can come up with a good pattern for cleaning up whitespace with SwiftSyntax soon, for the benefit of other rules too.~