### PR TITLE
Report memory usage when `--benchmark` is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,9 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4430](https://github.com/realm/SwiftLint/issues/4430)
 
+* Report how much memory was used when `--benchmark` is specified.  
+  [JP Simard](https://github.com/jpsim)
+
 #### Bug Fixes
 
 * Respect `validates_start_with_lowercase` option when linting function names.  


### PR DESCRIPTION
With the memory increase related to https://github.com/apple/swift-syntax/issues/921, I wanted a way to quickly know how much memory was being used by SwiftLint.

Here's how much memory it took to lint SwiftLint itself at various versions in the last few weeks:

* 0.49.1: 223 MB
* 0.50.0-rc.1: 356 MB
* 0.50.0-rc.2: 444 MB
* main (458916174): 464 MB

```console
$ swiftlint --progress --benchmark
Linting Swift files in current working directory
529 of 529 [==============================] ETA: 0s (121 files/s)
Done linting! Found 0 violations, 0 serious in 529 files.
Memory used: 464 MB
$ swiftlint --progress --benchmark
Linting Swift files in current working directory
529 of 529 [==============================] ETA: 0s (16220 files/s)
Done linting! Found 0 violations, 0 serious in 529 files.
Memory used: 55.8 MB
```