### PR TITLE
Rewrite `redundant_type_annotation` with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
   * `nimble_operator`
   * `opening_brace`
   * `orphaned_doc_comment`
+  * `redundant_type_annotation`
   * `trailing_closure`
   * `void_return`
 
@@ -1202,7 +1203,6 @@
   - `redundant_optional_initialization`
   - `redundant_set_access_control`
   - `redundant_string_enum_value`
-  - `redundant_type_annotation`
   - `required_deinit`
   - `required_enum_case`
   - `return_arrow_whitespace`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1202,6 +1202,7 @@
   - `redundant_optional_initialization`
   - `redundant_set_access_control`
   - `redundant_string_enum_value`
+  - `redundant_type_annotation`
   - `required_deinit`
   - `required_enum_case`
   - `return_arrow_whitespace`

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -54,7 +54,8 @@ struct RedundantTypeAnnotationRule: OptInRule {
 
             var direction↓: Direction = Direction.up
             """),
-            Example("let values↓: [Int] = [Int]()")
+            Example("let values↓: [Int] = [Int]()"),
+            Example(#"static let version↓: AnnouncementStore.Attribute = AnnouncementStore.Attribute("Version")"#)
         ],
         corrections: [
             Example("var url↓: URL = URL()"): Example("var url = URL()"),
@@ -75,7 +76,9 @@ struct RedundantTypeAnnotationRule: OptInRule {
               }
             }
             """),
-            Example("let values↓: [Int] = [Int]()"): Example("let values = [Int]()")
+            Example("let values↓: [Int] = [Int]()"): Example("let values = [Int]()"),
+            Example(#"static let version↓: AnnouncementStore.Attribute = AnnouncementStore.Attribute("Version")"#):
+                Example(#"static let version = AnnouncementStore.Attribute("Version")"#)
         ]
     )
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -53,7 +53,8 @@ struct RedundantTypeAnnotationRule: OptInRule {
             }
 
             var direction↓: Direction = Direction.up
-            """)
+            """),
+            Example("let values↓: [Int] = [Int]()")
         ],
         corrections: [
             Example("var url↓: URL = URL()"): Example("var url = URL()"),
@@ -73,7 +74,8 @@ struct RedundantTypeAnnotationRule: OptInRule {
                 let myVar = Int(5)
               }
             }
-            """)
+            """),
+            Example("let values↓: [Int] = [Int]()"): Example("let values = [Int]()")
         ]
     )
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -1,7 +1,8 @@
-import Foundation
-import SourceKittenFramework
+import SwiftLintCore
+import SwiftSyntax
 
-struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule {
+@SwiftSyntaxRule(explicitRewriter: true)
+struct RedundantTypeAnnotationRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -75,95 +76,81 @@ struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule {
             """)
         ]
     )
+}
 
-    func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violationRanges(in: file).map { range in
-            StyleViolation(
-                ruleDescription: Self.description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: range.location)
-            )
+private extension RedundantTypeAnnotationRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: VariableDeclSyntax) {
+            guard !node.isIBInspectable else {
+                return
+            }
+
+            for binding in node.bindings {
+                guard let typeAnnotation = binding.typeAnnotation,
+                      binding.hasViolation else {
+                    continue
+                }
+
+                violations.append(typeAnnotation.colon.positionAfterSkippingLeadingTrivia)
+            }
         }
     }
 
-    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
-        return (violationRange, "")
-    }
-
-    private let typeAnnotationPattern: String
-    private let expressionPattern: String
-
-    init() {
-        typeAnnotationPattern =
-            ":\\s*" + // semicolon and any number of whitespaces
-            "\\w+"    // type name
-
-        expressionPattern =
-            "(var|let)" + // var or let
-            "\\s+" +      // at least single whitespace
-            "\\w+" +      // variable name
-            "\\s*" +      // possible whitespaces
-            typeAnnotationPattern +
-            "\\s*=\\s*" + // assignment operator with possible surrounding whitespaces
-            "\\w+" +      // assignee name (type or keyword)
-            "[\\(\\.]?"   // possible opening parenthesis or dot
-    }
-
-    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file
-            .match(pattern: expressionPattern)
-            .filter {
-                $0.1 == [.keyword, .identifier, .typeidentifier, .identifier] ||
-                $0.1 == [.keyword, .identifier, .typeidentifier, .keyword]
+    private final class Rewriter: ViolationsSyntaxRewriter {
+        override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
+            guard !node.isIBInspectable else {
+                return super.visit(node)
             }
-            .filter { !isFalsePositive(file: file, range: $0.0) }
-            .filter { !isIBInspectable(file: file, range: $0.0) }
-            .compactMap {
-                file.match(pattern: typeAnnotationPattern,
-                           excludingSyntaxKinds: SyntaxKind.commentAndStringKinds, range: $0.0).first
+
+            var modifiedBindings: [PatternBindingSyntax] = []
+            var hasViolation = false
+
+            for binding in node.bindings {
+                guard let typeAnnotation = binding.typeAnnotation,
+                      !typeAnnotation.isContainedIn(regions: disabledRegions, locationConverter: locationConverter),
+                      binding.hasViolation else {
+                    modifiedBindings.append(binding)
+                    continue
+                }
+
+                correctionPositions.append(typeAnnotation.colon.positionAfterSkippingLeadingTrivia)
+
+                let updatedInitializer = binding.initializer?.with(\.leadingTrivia, typeAnnotation.trailingTrivia)
+                modifiedBindings.append(
+                    binding
+                        .with(\.typeAnnotation, nil)
+                        .with(\.initializer, updatedInitializer)
+                )
+                hasViolation = true
             }
+
+            guard hasViolation else {
+                return super.visit(node)
+            }
+
+            return super.visit(node.with(\.bindings, PatternBindingListSyntax(modifiedBindings)))
+        }
     }
+}
 
-    private func isFalsePositive(file: SwiftLintFile, range: NSRange) -> Bool {
-        guard let typeNames = getPartsOfExpression(in: file, range: range) else { return false }
-
-        let lhs = typeNames.variableTypeName
-        let rhs = typeNames.assigneeName
-
-        if lhs == rhs || (lhs == "Bool" && (rhs == "true" || rhs == "false")) {
+private extension PatternBindingSyntax {
+    var hasViolation: Bool {
+        guard let typeAnnotation = typeAnnotation, let initializer = initializer?.value else {
             return false
-        } else {
-            return true
         }
-    }
-
-    private func getPartsOfExpression(
-        in file: SwiftLintFile, range: NSRange
-    ) -> (variableTypeName: String, assigneeName: String)? {
-        let substring = file.stringView.substring(with: range)
-        let components = substring.components(separatedBy: "=")
-
-        guard
-            components.count == 2,
-            let variableTypeName = components[0].components(separatedBy: ":").last?.trimmingCharacters(in: .whitespaces)
-        else {
-            return nil
+        if let function = initializer.as(FunctionCallExprSyntax.self) {
+            return typeAnnotation.type.trimmed.description == function.calledExpression.trimmed.description
+        } else if let baseExpr = initializer.as(MemberAccessExprSyntax.self)?.base {
+            return typeAnnotation.type.trimmed.description == baseExpr.trimmed.description
+        } else if typeAnnotation.type.as(IdentifierTypeSyntax.self)?.name.text == "Bool" {
+            return initializer.is(BooleanLiteralExprSyntax.self)
         }
-
-        let charactersToTrimFromRhs = CharacterSet(charactersIn: ".(").union(.whitespaces)
-        let assigneeName = components[1].trimmingCharacters(in: charactersToTrimFromRhs)
-
-        return (variableTypeName, assigneeName)
+        return false
     }
+}
 
-    private func isIBInspectable(file: SwiftLintFile, range: NSRange) -> Bool {
-        guard
-            let byteRange = file.stringView.NSRangeToByteRange(start: range.location, length: range.length),
-            let dict = file.structureDictionary.structures(forByteOffset: byteRange.location).last,
-            let kind = dict.declarationKind,
-            SwiftDeclarationKind.variableKinds.contains(kind)
-        else { return false }
-
-        return dict.enclosedSwiftAttributes.contains(.ibinspectable)
+private extension VariableDeclSyntax {
+    var isIBInspectable: Bool {
+        attributes.contains { $0.as(AttributeSyntax.self)?.attributeNameText == "IBInspectable" }
     }
 }


### PR DESCRIPTION
This is WIP, but wanted to see the oss-check results before starting the correction part

Resolves #3141.
Resolves #3146.