### PR TITLE
Recompute the absolute path supplied on the command line as relative,…

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -36,7 +36,14 @@ extension Configuration {
         // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
         if path.isFile && !forceExclude { return [path] }
 
-        let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: path, rootDirectory: nil) : []
+        let relativePath: String
+        if path.bridge().isAbsolutePath {
+            relativePath = path.bridge().path(relativeTo: rootDirectory)
+        } else {
+            relativePath = path
+        }
+
+        let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: relativePath, rootDirectory: nil) : []
         let includedPaths = self.includedPaths
             .flatMap(Glob.resolveGlob)
             .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -43,7 +43,10 @@ extension Configuration {
             relativePath = path
         }
 
-        let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: relativePath, rootDirectory: nil) : []
+        let pathsForPath = includedPaths.isEmpty
+            ? fileManager.filesToLint(inPath: relativePath, rootDirectory: nil)
+            : []
+
         let includedPaths = self.includedPaths
             .flatMap(Glob.resolveGlob)
             .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }


### PR DESCRIPTION
… so that it correctly resolves path case consistent with the exclude and include values.

To address this issue: https://github.com/realm/SwiftLint/issues/4415 - where a trivial use of excludes can fail if the (root) path supplied to lint is not case-identical to the path on the filesystem.

# Detailed Issue

In detail: currently the included and excluded paths are always computed as relative paths, like so:

```
        includedPaths = includedPaths.map {
            $0.bridge().absolutePathRepresentation(rootDirectory: previousBasePath).path(relativeTo: newBasePath)
        }

        excludedPaths = excludedPaths.map {
            $0.bridge().absolutePathRepresentation(rootDirectory: previousBasePath).path(relativeTo: newBasePath)
        }
    }
```

The includedPaths, excludedPaths and the rootPath (aka `path`) are searched to find all lintable files

```
    let pathsForPath = includedPaths.isEmpty
            ? fileManager.filesToLint(inPath: path, rootDirectory: nil)
            : []

       let includedPaths = self.includedPaths
            .flatMap(Glob.resolveGlob)
            .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }

        return excludeByPrefix
            ? filterExcludedPathsByPrefix(in: pathsForPath, includedPaths)
            : filterExcludedPaths(fileManager: fileManager, in: pathsForPath, includedPaths)
```

In filterExcludedPathsByPrefix the set of lintable files reachable from the excludedPaths is subtracted from the set reachable from includedPaths plus rootPath.

```
let excludedPaths = self.excludedPaths(fileManager: fileManager)
result.minusSet(Set(excludedPaths))
```

This subtraction can fail if rootPath case does not exactly match the actual case of files on disk, leading to excluded paths being unexpectedly linted.  

This is because rootPath is the only absolute path, and case errors in its path are not corrected.

However, the Include and Exclude paths are computed as paths relative to the CWD, and when they are converted back to absolute paths, any case errors are corrected.

Resolution
###

Compute the path as a path relative to CWD, and then turn it back to absolute.  

Now the exact same processing that happens to the include/exclude paths is also applied to the rootPath, which means it has the same case.

Alternatives considered:
###

This change could also be applied to sourceKitten's `absolutePathRepresentation(rootDirectory: String = FileManager.default.currentDirectoryPath)` to make its response to the different values more consistent.