### PR TITLE
Move TSan Runs CI job to Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,15 @@ steps:
     commands:
       - echo "+++ Analyze"
       - bazel test -c opt --test_output=streamed --test_timeout=1800 --spawn_strategy=local analyze
-  - label: "TSan"
+  - label: "TSan Tests"
     commands:
       - echo "+++ Test"
-      - bazel test --xcode_version_config=//bazel:xcode_config --test_output=streamed --build_tests_only --features=tsan --test_timeout=1000 //Tests/...
+      - bazel test --test_output=streamed --build_tests_only --features=tsan --test_timeout=1000 //Tests/...
+  - label: "TSan Runs"
+    commands:
+      - echo "--- Build"
+      - bazel build --config=release --features=tsan swiftlint
+      - echo "+++ Pre-cache SwiftLint Run"
+      - ./bazel-bin/swiftlint --progress --lenient
+      - echo "+++ Post-cache SwiftLint Run"
+      - ./bazel-bin/swiftlint --progress --lenient

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,19 +77,6 @@ jobs:
     - script: bundle exec pod lib lint --verbose
       displayName: pod lib lint
 
-- job: TSan
-  pool:
-    vmImage: 'macOS-12'
-  variables:
-    DEVELOPER_DIR: /Applications/Xcode_14.0.1.app
-  steps:
-    - script: swift build --configuration release --sanitize thread --product swiftlint
-      displayName: Build SwiftLint
-    - script: swift run --configuration release --sanitize thread swiftlint --lenient
-      displayName: Pre-cache SwiftLint Run
-    - script: swift run --configuration release --sanitize thread swiftlint --lenient
-      displayName: Post-cache SwiftLint Run
-
 - job: jazzy
   pool:
     vmImage: 'macOS-12'

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -3,38 +3,3 @@ filegroup(
     srcs = glob(["*"]),
     visibility = ["//visibility:public"],
 )
-
-xcode_version(
-    name = "version14_0_0_14A309",
-    aliases = [
-        "14.0.0.14A309",
-        "14A309",
-    ],
-    default_ios_sdk_version = "16.0",
-    default_macos_sdk_version = "12.3",
-    default_tvos_sdk_version = "16.0",
-    default_watchos_sdk_version = "9.0",
-    version = "14.0.0.14A309",
-)
-
-available_xcodes(
-    name = "local_xcodes",
-    default = ":version14_0_0_14A309",
-    versions = [
-        ":version14_0_0_14A309",
-    ],
-)
-
-available_xcodes(
-    name = "remote_xcodes",
-    default = ":version14_0_0_14A309",
-    versions = [
-        ":version14_0_0_14A309",
-    ],
-)
-
-xcode_config(
-    name = "xcode_config",
-    local_versions = ":local_xcodes",
-    remote_versions = ":remote_xcodes",
-)


### PR DESCRIPTION
Now that we have more Buildkite machines, these should be faster than running on Azure Pipelines.

Also remove the `//bazel:xcode_config` configurations since they should no longer be in use.