### PR TITLE
Update SwiftSyntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "f7b50bc1a55abea0a03f319e17826565fa5009e4",
+          "revision": "1c4f45b54825ed5192c31d495686ac5b57efff70",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "4ad75a85f5f14caecdd6cdb41c4c9a090ce82340",
+          "revision": "f7b50bc1a55abea0a03f319e17826565fa5009e4",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.3")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("f7b50bc1a55abea0a03f319e17826565fa5009e4")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("1c4f45b54825ed5192c31d495686ac5b57efff70")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .revision("a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ private let addCryptoSwift = true
 #endif
 
 let frameworkDependencies: [Target.Dependency] = [
+    .product(name: "IDEUtils", package: "SwiftSyntax"),
     .product(name: "SourceKittenFramework", package: "SourceKitten"),
     .product(name: "SwiftSyntax", package: "SwiftSyntax"),
     .product(name: "SwiftSyntaxBuilder", package: "SwiftSyntax"),
@@ -27,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.3")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("4ad75a85f5f14caecdd6cdb41c4c9a090ce82340")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("f7b50bc1a55abea0a03f319e17826565fa5009e4")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .revision("a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -2,6 +2,7 @@
 import Darwin
 #endif
 import Foundation
+import IDEUtils
 import SourceKittenFramework
 import SwiftParser
 import SwiftParserDiagnostics
@@ -182,7 +183,7 @@ extension SwiftLintFile {
         return syntaxTokensByLines
     }
 
-    internal var syntaxKindsByLines: [[SyntaxKind]] {
+    internal var syntaxKindsByLines: [[SourceKittenFramework.SyntaxKind]] {
         guard let syntaxKindsByLines = syntaxKindsByLinesCache.get(self) else {
             if let handler = assertHandler {
                 handler()

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableConditionRule.swift
@@ -88,7 +88,7 @@ private final class UnavailableConditionRuleVisitor: ViolationsSyntaxVisitor {
         }
 
         if otherAvailabilityCheckInvolved(ifStmt: node) {
-            // If there are other conditional branches with availablilty checks it might not be possible
+            // If there are other conditional branches with availability checks it might not be possible
             // to just invert the first one.
             return
         }
@@ -101,7 +101,7 @@ private final class UnavailableConditionRuleVisitor: ViolationsSyntaxVisitor {
         )
     }
 
-    private func asAvailabilityCondition(_ condition: Syntax) -> SyntaxProtocol? {
+    private func asAvailabilityCondition(_ condition: ConditionElementSyntax.Condition) -> SyntaxProtocol? {
         condition.as(AvailabilityConditionSyntax.self) ??
             condition.as(UnavailabilityConditionSyntax.self)
     }

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -1,4 +1,5 @@
 import Foundation
+import IDEUtils
 import SourceKittenFramework
 import SwiftSyntax
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -97,7 +97,7 @@ private extension UnusedClosureParameterRule {
                         )
                     )
                 }
-                let newNode = node.withSignature(signature.withInput(Syntax(newParams)))
+                let newNode = node.withSignature(signature.withInput(.init(newParams)))
                 return super.visit(newNode)
             }
 
@@ -115,7 +115,7 @@ private extension UnusedClosureParameterRule {
                     with: param.withName(param.name.withKind(.wildcardKeyword))
                 )
             }
-            let newNode = node.withSignature(signature.withInput(Syntax(newParams)))
+            let newNode = node.withSignature(signature.withInput(.init(newParams)))
             return super.visit(newNode)
         }
     }

--- a/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
@@ -59,7 +59,9 @@ private final class YodaConditionRuleVisitor: ViolationsSyntaxVisitor {
     }
 
     private func visit(conditions: ConditionElementListSyntax) {
-        conditions.map(\.condition).compactMap(ExprSyntax.init).forEach(visit(condition:))
+        for condition in conditions.compactMap({ $0.condition.as(ExprSyntax.self) }) {
+            visit(condition: condition)
+        }
     }
 
     private func visit(condition: ExprSyntax) {

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -134,6 +134,6 @@ private final class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
         correctionPositions.append(clause.positionAfterSkippingLeadingTrivia)
 
         let paramList = ClosureParamListSyntax(items).withTrailingTrivia(.spaces(1))
-        return super.visit(node.withInput(Syntax(paramList)))
+        return super.visit(node.withInput(.init(paramList)))
     }
 }

--- a/bazel/SwiftSyntax.BUILD
+++ b/bazel/SwiftSyntax.BUILD
@@ -76,10 +76,18 @@ swift_library(
     ],
 )
 
+swift_library(
+    name = "IDEUtils",
+    srcs = glob(["Sources/IDEUtils/**/*.swift"]),
+    module_name = "IDEUtils",
+    deps = [":SwiftSyntax"],
+)
+
 opt_wrapper(
     name = "optlibs",
     visibility = ["//visibility:public"],
     deps = [
+        ":IDEUtils",
         ":SwiftOperators",
         ":SwiftParser",
         ":SwiftParserDiagnostics",

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -20,10 +20,10 @@ def swiftlint_repos():
 
     http_archive(
         name = "com_github_apple_swift_syntax",
-        sha256 = "8a695e738aff23da52dcfe8b5f8492bb1490171986c632e0b4856d54066981a9", # SwiftSyntax sha256
+        sha256 = "8c412c4230558ab03a4034a70486df98e66f5db5f04058a81ca0b141d4798d08", # SwiftSyntax sha256
         build_file = "@SwiftLint//bazel:SwiftSyntax.BUILD",
-        strip_prefix = "swift-syntax-4ad75a85f5f14caecdd6cdb41c4c9a090ce82340",
-        url = "https://github.com/apple/swift-syntax/archive/4ad75a85f5f14caecdd6cdb41c4c9a090ce82340.tar.gz",
+        strip_prefix = "swift-syntax-f7b50bc1a55abea0a03f319e17826565fa5009e4",
+        url = "https://github.com/apple/swift-syntax/archive/f7b50bc1a55abea0a03f319e17826565fa5009e4.tar.gz",
     )
 
     http_archive(

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -20,10 +20,10 @@ def swiftlint_repos():
 
     http_archive(
         name = "com_github_apple_swift_syntax",
-        sha256 = "8c412c4230558ab03a4034a70486df98e66f5db5f04058a81ca0b141d4798d08", # SwiftSyntax sha256
+        sha256 = "38be2034fb85d6e206a840cd9edecb4010aeaee757c941f614725db455983b17", # SwiftSyntax sha256
         build_file = "@SwiftLint//bazel:SwiftSyntax.BUILD",
-        strip_prefix = "swift-syntax-f7b50bc1a55abea0a03f319e17826565fa5009e4",
-        url = "https://github.com/apple/swift-syntax/archive/f7b50bc1a55abea0a03f319e17826565fa5009e4.tar.gz",
+        strip_prefix = "swift-syntax-1c4f45b54825ed5192c31d495686ac5b57efff70",
+        url = "https://github.com/apple/swift-syntax/archive/1c4f45b54825ed5192c31d495686ac5b57efff70.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Moves syntax classifications to a new IDEUtils module.

Pulls in https://github.com/apple/swift-syntax/pull/1034