### PR TITLE
Fixes SwiftLint support on Xcode Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 
 #### Enhancements
 
+* Fix SwiftLint support on Xcode Cloud.  
+  [JagCesar](https://github.com/JagCesar)
+  [westerlund](https://github.com/westerlund)
+  [#4484](https://github.com/realm/SwiftLint/issues/4484)
+
 * Add `no_magic_numbers` rule to avoid "Magic Numbers".  
   [Henrik Storch](https://github.com/thisisthefoxe)
   [#4031](https://github.com/realm/SwiftLint/issues/4024)

--- a/Source/swiftlint/Extensions/ProcessInfo+XcodeCloud.swift
+++ b/Source/swiftlint/Extensions/ProcessInfo+XcodeCloud.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension ProcessInfo {
+    var isLikelyXcodeCloudEnvironment: Bool {
+        // https://developer.apple.com/documentation/xcode/environment-variable-reference
+        let requiredKeys: Set = [
+            "CI",
+            "CI_BUILD_ID",
+            "CI_BUILD_NUMBER",
+            "CI_BUNDLE_ID",
+            "CI_COMMIT",
+            "CI_DERIVED_DATA_PATH",
+            "CI_PRODUCT",
+            "CI_PRODUCT_ID",
+            "CI_PRODUCT_PLATFORM",
+            "CI_PROJECT_FILE_PATH",
+            "CI_START_CONDITION",
+            "CI_TEAM_ID",
+            "CI_WORKFLOW",
+            "CI_WORKSPACE",
+            "CI_XCODE_PROJECT",
+            "CI_XCODE_SCHEME",
+            "CI_XCODEBUILD_ACTION"
+        ]
+
+        return requiredKeys.isSubset(of: environment.keys)
+    }
+}

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -262,7 +262,11 @@ private class LintOrAnalyzeResultBuilder {
         }
         configuration = config
         reporter = reporterFrom(identifier: options.reporter ?? config.reporter)
-        cache = options.ignoreCache ? nil : LinterCache(configuration: config)
+        if options.ignoreCache || ProcessInfo.processInfo.isLikelyXcodeCloudEnvironment {
+            cache = nil
+        } else {
+            cache = LinterCache(configuration: config)
+        }
         self.options = options
 
         if let outFile = options.output {


### PR DESCRIPTION
This PR fixes so SwiftLint installed as Xcode Plugin can be used on Xcode Cloud. The problem was that Xcode Cloud doesn't have write access to the `.cachesDirectory`. We solved this by always using ` NSTemporaryDirectory()` if we're being run on a CI.

This will have the side-effect of doing the same on all CI's, but we couldn't come up with a way to distinguish Xcode Cloud from other CI's.

Solved this together with @westerlund

fixes #4484