### PR TITLE
Fix & clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ COPY Source Source/
 COPY Tests Tests/
 COPY Package.* ./
 
-RUN ln -s /usr/lib/swift/_InternalSwiftSyntaxParser .
-
 RUN swift package update
 ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib -Xlinker -lCFURLSessionInterface -Xlinker -lCFXMLInterface -Xlinker -lcurl -Xlinker -lxml2 -Xswiftc -I. -Xlinker -fuse-ld=lld -Xlinker -L/usr/lib/swift/linux"
 RUN swift build $SWIFT_FLAGS --product swiftlint
@@ -32,9 +30,10 @@ RUN apt-get update && apt-get install -y \
 COPY --from=builder /usr/lib/libsourcekitdInProc.so /usr/lib
 COPY --from=builder /usr/lib/swift/linux/libBlocksRuntime.so /usr/lib
 COPY --from=builder /usr/lib/swift/linux/libdispatch.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/lib_InternalSwiftSyntaxParser.so /usr/lib
+COPY --from=builder /usr/lib/swift/linux/libswiftCore.so /usr/lib
 COPY --from=builder /executables/* /usr/bin
 
 RUN swiftlint version
+RUN echo "_ = 0" | swiftlint --use-stdin
 
 CMD ["swiftlint"]


### PR DESCRIPTION
We no longer need `_InternalSwiftSyntaxParser`, but we do need `libswiftCore.so`.

Fixes https://github.com/realm/SwiftLint/issues/4501

Add a more useful validation test at the end of the Dockerfile. In addition to running `swiftlint version`, also actually run the linter which will exercise the SourceKit codepaths.