### PR TITLE
Rewrite `prefer_self_in_static_references` with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
   - `overridden_super_call`
   - `override_in_extension`
   - `prefer_nimble`
+  - `prefer_self_in_static_references`
   - `prefer_self_type_over_type_of_self`
   - `prefer_zero_over_explicit_init`
   - `prefixed_toplevel_constant`

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -71,6 +71,11 @@ public struct PreferSelfInStaticReferencesRule: SwiftSyntaxRule, CorrectableRule
                 }
             """, excludeFromDocumentation: true),
             Example("""
+                class Record<T> {
+                    static func get() -> Record<T> { Record<T>() }
+                }
+            """, excludeFromDocumentation: true),
+            Example("""
                 @objc class C: NSObject {
                     @objc var s = ""
                     @objc func f() { _ = #keyPath(C.s) }
@@ -256,6 +261,7 @@ private class Visitor: ViolationsSyntaxVisitor {
     override func visitPost(_ node: IdentifierExprSyntax) {
         guard let parent = node.parent,
               parent.as(FunctionCallExprSyntax.self) == nil,
+              parent.as(SpecializeExprSyntax.self) == nil,
               parent.as(DictionaryElementSyntax.self) == nil,
               parent.as(ArrayElementSyntax.self) == nil else {
             return

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -75,6 +75,14 @@ public struct PreferSelfInStaticReferencesRule: SwiftSyntaxRule, CorrectableRule
                     @objc var s = ""
                     @objc func f() { _ = #keyPath(C.s) }
                 }
+            """, excludeFromDocumentation: true),
+            Example("""
+                extension E {
+                    class C {
+                        static let i = 2
+                        var j: Int { C.i }
+                    }
+                }
             """, excludeFromDocumentation: true)
         ],
         triggeringExamples: [
@@ -86,7 +94,7 @@ public struct PreferSelfInStaticReferencesRule: SwiftSyntaxRule, CorrectableRule
                     }
                     static let i = 1
                     let h = C.i
-                    var j: Int { ↓C.i }
+                    var j: Int { C.i }
                     func f() -> Int { ↓C.i + h }
                 }
             """),
@@ -118,15 +126,7 @@ public struct PreferSelfInStaticReferencesRule: SwiftSyntaxRule, CorrectableRule
                     static func f() -> E { ↓E.A }
                     static func g() -> E { ↓E.f() }
                 }
-            """),
-            Example("""
-                extension E {
-                    class C {
-                        static let i = 2
-                        var j: Int { ↓C.i }
-                    }
-                }
-            """, excludeFromDocumentation: true)
+            """)
         ],
         corrections: [
             Example("""
@@ -313,10 +313,6 @@ private class Visitor: ViolationsSyntaxVisitor {
     }
 
     override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-        if node.bindings.count == 1, let binding = node.bindings.first, binding.accessor != nil {
-            // Computed property
-            return .visitChildren
-        }
         if case .handleReferences = variableDeclScopes.last {
             return .visitChildren
         }

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -97,7 +97,7 @@ public struct PreferSelfInStaticReferencesRule: SwiftSyntaxRule, CorrectableRule
                     static func f() -> Int { ↓S.i }
                     func g() -> Any { ↓S.self }
                     func h() -> S { S(j: 2) }
-                    func i() -> KeyPath<S, Int> { \\↓S.j }
+                    func i() -> KeyPath<S, Int> { \\S.j }
                     func j(@Wrap(-↓S.i, ↓S.i) n: Int = ↓S.i) {}
                 }
             """),
@@ -310,13 +310,6 @@ private class Visitor: ViolationsSyntaxVisitor {
 
     override func visitPost(_ node: StructDeclSyntax) {
         _ = parentDeclScopes.popLast()
-    }
-
-    override func visitPost(_ node: SimpleTypeIdentifierSyntax) {
-        guard node.parent?.as(KeyPathExprSyntax.self) != nil else {
-            return
-        }
-        addViolation(on: node)
     }
 
     override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {


### PR DESCRIPTION
Fixes #4489.

This implementation ignores quite a few type references that could easily be found by the rule. As a first step, it should behave as before (while fixing the linked bug and some more false-positives/-negatives) even if this requires more work to purposefully ignore parts. In a next step, it can be enabled for constructor calls `MyType(...)`, key paths `\MyType.myProperty`, types in general like in `func f(inst: MyType) {...}` and other constructs.