### PR TITLE
Update SwiftSyntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "e19c5f2909127ce4537d6f8981919aba4645ce4e",
+          "revision": "28813884a1659f3cd2fa61b5b3e5d01e8c25bc34",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "fc2b5f22527f0ab4222839b0eace1e1fb17f657a",
+          "revision": "e19c5f2909127ce4537d6f8981919aba4645ce4e",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "28813884a1659f3cd2fa61b5b3e5d01e8c25bc34",
+          "revision": "e1f771ea8ad8bc172de766e0963a76aeb7b08cef",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.3")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("28813884a1659f3cd2fa61b5b3e5d01e8c25bc34")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("e1f771ea8ad8bc172de766e0963a76aeb7b08cef")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .revision("a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.3")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("fc2b5f22527f0ab4222839b0eace1e1fb17f657a")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("e19c5f2909127ce4537d6f8981919aba4645ce4e")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .revision("a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.3")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("e19c5f2909127ce4537d6f8981919aba4645ce4e")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("28813884a1659f3cd2fa61b5b3e5d01e8c25bc34")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .revision("a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -20,10 +20,10 @@ def swiftlint_repos():
 
     http_archive(
         name = "com_github_apple_swift_syntax",
-        sha256 = "22622f1e59d0a5a152752a4c948e616ef515de85140f44b2bcaf0db329760bc5", # SwiftSyntax sha256
+        sha256 = "c1447afe703924ac26a86510140a8bde9b6ce1d10594c2e07f49c52a01562476", # SwiftSyntax sha256
         build_file = "@SwiftLint//bazel:SwiftSyntax.BUILD",
-        strip_prefix = "swift-syntax-28813884a1659f3cd2fa61b5b3e5d01e8c25bc34",
-        url = "https://github.com/apple/swift-syntax/archive/28813884a1659f3cd2fa61b5b3e5d01e8c25bc34.tar.gz",
+        strip_prefix = "swift-syntax-e1f771ea8ad8bc172de766e0963a76aeb7b08cef",
+        url = "https://github.com/apple/swift-syntax/archive/e1f771ea8ad8bc172de766e0963a76aeb7b08cef.tar.gz",
     )
 
     http_archive(

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -20,10 +20,10 @@ def swiftlint_repos():
 
     http_archive(
         name = "com_github_apple_swift_syntax",
-        sha256 = "29b77ad614a31b317d39175e2ac782ace7c6dfbd6abc9d1f8c03e93d3ec40ac2", # SwiftSyntax sha256
+        sha256 = "6b10e37252398d972a99bef47b91c644c2b4337f93c246e369bc758d5b5cb76c", # SwiftSyntax sha256
         build_file = "@SwiftLint//bazel:SwiftSyntax.BUILD",
-        strip_prefix = "swift-syntax-fc2b5f22527f0ab4222839b0eace1e1fb17f657a",
-        url = "https://github.com/apple/swift-syntax/archive/fc2b5f22527f0ab4222839b0eace1e1fb17f657a.tar.gz",
+        strip_prefix = "swift-syntax-e19c5f2909127ce4537d6f8981919aba4645ce4e",
+        url = "https://github.com/apple/swift-syntax/archive/e19c5f2909127ce4537d6f8981919aba4645ce4e.tar.gz",
     )
 
     http_archive(

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -20,10 +20,10 @@ def swiftlint_repos():
 
     http_archive(
         name = "com_github_apple_swift_syntax",
-        sha256 = "6b10e37252398d972a99bef47b91c644c2b4337f93c246e369bc758d5b5cb76c", # SwiftSyntax sha256
+        sha256 = "22622f1e59d0a5a152752a4c948e616ef515de85140f44b2bcaf0db329760bc5", # SwiftSyntax sha256
         build_file = "@SwiftLint//bazel:SwiftSyntax.BUILD",
-        strip_prefix = "swift-syntax-e19c5f2909127ce4537d6f8981919aba4645ce4e",
-        url = "https://github.com/apple/swift-syntax/archive/e19c5f2909127ce4537d6f8981919aba4645ce4e.tar.gz",
+        strip_prefix = "swift-syntax-28813884a1659f3cd2fa61b5b3e5d01e8c25bc34",
+        url = "https://github.com/apple/swift-syntax/archive/28813884a1659f3cd2fa61b5b3e5d01e8c25bc34.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
This update pulls in https://github.com/apple/swift-syntax/pull/1050, which fixes a memory leak, reducing memory usage by up to 3x and improves lint times by 20%-50% in my tests.