### PR TITLE
Adds `NSError` to the list of types in `discouraged_direct_init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 #### Enhancements
 
+* Adds `NSError` to the list of types in `discouraged_direct_init`.  
+  [jszumski](https://github.com/jszumski)
+  [#4508](https://github.com/realm/SwiftLint/issues/4508)
+
 * Fix SwiftLint support on Xcode Cloud.  
   [JagCesar](https://github.com/JagCesar)
   [westerlund](https://github.com/westerlund)

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -16,19 +16,24 @@ public struct DiscouragedDirectInitRule: SwiftSyntaxRule, ConfigurationProviderR
             Example("let foo = Bundle(path: \"bar\")"),
             Example("let foo = Bundle(identifier: \"bar\")"),
             Example("let foo = Bundle.init(path: \"bar\")"),
-            Example("let foo = Bundle.init(identifier: \"bar\")")
+            Example("let foo = Bundle.init(identifier: \"bar\")"),
+            Example("let foo = NSError(domain: \"bar\", code: 0)"),
+            Example("let foo = NSError.init(domain: \"bar\", code: 0)"),
+            Example("func testNSError()")
         ],
         triggeringExamples: [
             Example("↓UIDevice()"),
             Example("↓Bundle()"),
             Example("let foo = ↓UIDevice()"),
             Example("let foo = ↓Bundle()"),
-            Example("let foo = bar(bundle: ↓Bundle(), device: ↓UIDevice())"),
+            Example("let foo = ↓NSError()"),
+            Example("let foo = bar(bundle: ↓Bundle(), device: ↓UIDevice(), error: ↓NSError())"),
             Example("↓UIDevice.init()"),
             Example("↓Bundle.init()"),
+            Example("↓NSError.init()"),
             Example("let foo = ↓UIDevice.init()"),
             Example("let foo = ↓Bundle.init()"),
-            Example("let foo = bar(bundle: ↓Bundle.init(), device: ↓UIDevice.init())")
+            Example("let foo = bar(bundle: ↓Bundle.init(), device: ↓UIDevice.init(), error: ↓NSError.init())")
         ]
     )
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -13,6 +13,7 @@ public struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration
 
     private let defaultDiscouragedInits = [
         "Bundle",
+        "NSError",
         "UIDevice"
     ]
 


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/4507.  

Using `NSError()` at runtime shows this warning and should be discouraged: 

> -[NSError init] called; this results in an invalid NSError instance. It will raise an exception in a future release. Please call errorWithDomain:code:userInfo: or initWithDomain:code:userInfo:. This message shown only once.