### PR TITLE
Rewrite `multiline_arguments_brackets` with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,11 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4234](https://github.com/realm/SwiftLint/issues/4234)
 
+* Fix false-positives from `multiline_arguments_brackets` when a function call has a
+  single line trailing closure.  
+  [CraigSiemens](https://github.com/CraigSiemens)
+  [#4510](https://github.com/realm/SwiftLint/issues/4510)
+
 ## 0.49.1: Buanderie Principale
 
 _Note: The default branch for the SwiftLint git repository was renamed from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
   - `legacy_objc_type`
   - `legacy_random`
   - `lower_acl_than_parent`
+  - `multiline_arguments_brackets`
   - `multiline_parameters`
   - `multiple_closures_with_trailing_closure`
   - `no_extension_access_modifier`

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftSyntax
 
 public struct MultilineArgumentsBracketsRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {


### PR DESCRIPTION
While I was making #4511 I decided to try rewriting it using `SwiftSyntax` since the repo is moving all the rules that way anyway.

---

Between this PR and #4511, only one would need to be accepted. Both resolve #4510 which was my original goal.

This PR builds also contains the commit from the other one to get the added examples and changelog update.