### PR TITLE
Run rules serially

### DIFF
--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -222,7 +222,7 @@ public struct CollectedLinter {
         let superfluousDisableCommandRule = rules.first(where: {
             $0 is SuperfluousDisableCommandRule
         }) as? SuperfluousDisableCommandRule
-        let validationResults = rules.parallelCompactMap {
+        let validationResults = rules.compactMap {
             $0.lint(file: self.file, regions: regions, benchmark: benchmark,
                     storage: storage,
                     configuration: self.configuration,


### PR DESCRIPTION
When rules were mostly SourceKit-based, linting all rules concurrently on any given file had a performance boost.

Now that most rules are SwiftSyntax-based, it's possible this is no longer helping and in fact may be increasing thread/core contention or otherwise adding overhead.

Best way to know is to measure, so I'm doing that here.