### PR TITLE
Reduce visibility of rules to be `internal`

### DIFF
--- a/.sourcery/GeneratedTests.stencil
+++ b/.sourcery/GeneratedTests.stencil
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   in a future release because it is now handled by the Swift compiler.  
   [JP Simard](https://github.com/jpsim)
 
+* Built-in SwiftLint rules are no longer marked as `public` in
+  SwiftLintFramework. This only impacts the programmatic API for the
+  SwiftLintFramework module.  
+  [JP Simard](https://github.com/jpsim)
+
 #### Experimental
 
 * None.

--- a/Source/SwiftLintFramework/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "anonymous_argument_in_multiline_closure",
         name: "Anonymous Argument in Multiline Closure",
         description: "Use named arguments in multiline closures",
@@ -33,7 +33,7 @@ public struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRul
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(locationConverter: file.locationConverter)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct BlockBasedKVORule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct BlockBasedKVORule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "block_based_kvo",
         name: "Block Based KVO",
         description: "Prefer the new block based KVO API with keypaths when using Swift 3.2 or later.",
@@ -35,7 +35,7 @@ public struct BlockBasedKVORule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ConvenienceTypeRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ConvenienceTypeRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "convenience_type",
         name: "Convenience Type",
         description: "Types used for hosting only static members should be implemented as a caseless enum " +
@@ -117,7 +117,7 @@ public struct ConvenienceTypeRule: SwiftSyntaxRule, OptInRule, ConfigurationProv
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DiscouragedAssertRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct DiscouragedAssertRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     // MARK: - Properties
 
-    public var configuration = SeverityConfiguration(.warning)
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "discouraged_assert",
         name: "Discouraged Assert",
         description: "Prefer `assertionFailure()` and/or `preconditionFailure()` over `assert(false)`",
@@ -27,11 +27,11 @@ public struct DiscouragedAssertRule: SwiftSyntaxRule, OptInRule, ConfigurationPr
 
     // MARK: - Life cycle
 
-    public init() {}
+    init() {}
 
     // MARK: - Public
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedNoneNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedNoneNameRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DiscouragedNoneNameRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct DiscouragedNoneNameRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "discouraged_none_name",
         name: "Discouraged None Name",
         description: "Discourages name cases/static members `none`, which can conflict with `Optional<T>.none`.",
@@ -178,7 +178,7 @@ public struct DiscouragedNoneNameRule: SwiftSyntaxRule, OptInRule, Configuration
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = ObjectLiteralConfiguration()
+struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = ObjectLiteralConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "discouraged_object_literal",
         name: "Discouraged Object Literal",
         description: "Prefer initializers over object literals.",
@@ -24,7 +24,7 @@ public struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule, Configur
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "discouraged_optional_boolean",
         name: "Discouraged Optional Boolean",
         description: "Prefer non-optional booleans over optional booleans.",
@@ -14,7 +14,7 @@ public struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRu
         triggeringExamples: DiscouragedOptionalBooleanRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
@@ -1,11 +1,11 @@
 import SourceKittenFramework
 
-public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "discouraged_optional_collection",
         name: "Discouraged Optional Collection",
         description: "Prefer empty collection over optional collection.",
@@ -14,9 +14,9 @@ public struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, Configurati
         triggeringExamples: DiscouragedOptionalCollectionExamples.triggeringExamples
     )
 
-    public func validate(file: SwiftLintFile,
-                         kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile,
+                  kind: SwiftDeclarationKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         let offsets = variableViolations(file: file, kind: kind, dictionary: dictionary) +
             functionViolations(file: file, kind: kind, dictionary: dictionary)
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct DuplicateImportsRule: ConfigurationProviderRule, CorrectableRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct DuplicateImportsRule: ConfigurationProviderRule, CorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
 
     // List of all possible import kinds
     static let importKinds = [
@@ -11,9 +11,9 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, CorrectableRule {
         "var", "func"
     ]
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "duplicate_imports",
         name: "Duplicate Imports",
         description: "Imports should be unique.",
@@ -132,7 +132,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, CorrectableRule {
         })
     }
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return duplicateImports(file: file).map { duplicateImport in
             StyleViolation(
                 ruleDescription: Self.description,
@@ -142,7 +142,7 @@ public struct DuplicateImportsRule: ConfigurationProviderRule, CorrectableRule {
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let duplicateImports = duplicateImports(file: file).reversed().filter {
             file.ruleEnabled(violatingRange: $0.range, for: self) != nil
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitACLRule.swift
@@ -3,12 +3,12 @@ import SourceKittenFramework
 
 private typealias SourceKittenElement = SourceKittenDictionary
 
-public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ExplicitACLRule: OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "explicit_acl",
         name: "Explicit ACL",
         description: "All declarations should specify Access Control Level keywords explicitly.",
@@ -122,7 +122,7 @@ public struct ExplicitACLRule: OptInRule, ConfigurationProviderRule {
         }
     }
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let implicitAndExplicitInternalElements = internalTypeElements(in: file.structureDictionary)
 
         guard implicitAndExplicitInternalElements.isNotEmpty else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ExplicitEnumRawValueRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ExplicitEnumRawValueRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "explicit_enum_raw_value",
         name: "Explicit Enum Raw Value",
         description: "Enums should be explicitly assigned their raw values.",
@@ -79,7 +79,7 @@ public struct ExplicitEnumRawValueRule: SwiftSyntaxRule, OptInRule, Configuratio
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitInitRule.swift
@@ -1,12 +1,12 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-public struct ExplicitInitRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ExplicitInitRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "explicit_init",
         name: "Explicit Init",
         description: "Explicitly calling .init() should be avoided.",
@@ -171,11 +171,11 @@ public struct ExplicitInitRule: SwiftSyntaxCorrectableRule, ConfigurationProvide
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ExplicitTopLevelACLRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ExplicitTopLevelACLRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "explicit_top_level_acl",
         name: "Explicit Top Level ACL",
         description: "Top-level declarations should specify Access Control Level keywords explicitly.",
@@ -30,7 +30,7 @@ public struct ExplicitTopLevelACLRule: SwiftSyntaxRule, OptInRule, Configuration
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
-    public var configuration = ExplicitTypeInterfaceConfiguration()
+struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
+    var configuration = ExplicitTypeInterfaceConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "explicit_type_interface",
         name: "Explicit Type Interface",
         description: "Properties should have a type interface",
@@ -67,7 +67,7 @@ public struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule {
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let captureGroupRanges = Lazy(self.captureGroupRanges(in: file))
         return file.structureDictionary.traverseWithParentsDepthFirst { parents, subDict in
             guard let kind = subDict.declarationKind,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "extension_access_modifier",
         name: "Extension Access Modifier",
         description: "Prefer to use extension access modifiers",
@@ -92,8 +92,8 @@ public struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, O
         ]
     )
 
-    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .extension, let offset = dictionary.offset,
             dictionary.inheritedTypes.isEmpty
         else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FallthroughRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct FallthroughRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct FallthroughRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "fallthrough",
         name: "Fallthrough",
         description: "Fallthrough should be avoided.",
@@ -30,7 +30,7 @@ public struct FallthroughRule: SwiftSyntaxRule, ConfigurationProviderRule, OptIn
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct FatalErrorMessageRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct FatalErrorMessageRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "fatal_error_message",
         name: "Fatal Error Message",
         description: "A fatalError call should have a message.",
@@ -36,7 +36,7 @@ public struct FatalErrorMessageRule: SwiftSyntaxRule, ConfigurationProviderRule,
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameNoSpaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameNoSpaceRule.swift
@@ -1,22 +1,22 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileNameNoSpaceRule: ConfigurationProviderRule, OptInRule, SourceKitFreeRule {
-    public var configuration = FileNameNoSpaceConfiguration(
+struct FileNameNoSpaceRule: ConfigurationProviderRule, OptInRule, SourceKitFreeRule {
+    var configuration = FileNameNoSpaceConfiguration(
         severity: .warning,
         excluded: []
     )
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "file_name_no_space",
         name: "File Name No Space",
         description: "File name should not contain any whitespace.",
         kind: .idiomatic
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         guard let filePath = file.path,
             case let fileName = filePath.bridge().lastPathComponent,
             !configuration.excluded.contains(fileName),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FileNameRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-public struct FileNameRule: ConfigurationProviderRule, OptInRule, SourceKitFreeRule {
-    public var configuration = FileNameConfiguration(
+struct FileNameRule: ConfigurationProviderRule, OptInRule, SourceKitFreeRule {
+    var configuration = FileNameConfiguration(
         severity: .warning,
         excluded: ["main.swift", "LinuxMain.swift"],
         prefixPattern: "",
@@ -9,16 +9,16 @@ public struct FileNameRule: ConfigurationProviderRule, OptInRule, SourceKitFreeR
         nestedTypeSeparator: "."
     )
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "file_name",
         name: "File Name",
         description: "File name should match a type or extension declared in the file (if any).",
         kind: .idiomatic
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         guard let filePath = file.path,
             case let fileName = filePath.bridge().lastPathComponent,
             !configuration.excluded.contains(fileName) else {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForWhereRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ForWhereRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = ForWhereRuleConfiguration()
+struct ForWhereRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = ForWhereRuleConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "for_where",
         name: "For Where",
         description: "`where` clauses are preferred over a single `if` inside a `for`.",
@@ -118,7 +118,7 @@ public struct ForWhereRule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(allowForAsFilter: configuration.allowForAsFilter)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceCastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceCastRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ForceCastRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.error)
+struct ForceCastRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.error)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "force_cast",
         name: "Force Cast",
         description: "Force casts should be avoided.",
@@ -16,7 +16,7 @@ public struct ForceCastRule: ConfigurationProviderRule, SwiftSyntaxRule {
         triggeringExamples: [ Example("NSNumber() ↓as! Int\n") ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         ForceCastRuleVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceTryRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ForceTryRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.error)
+struct ForceTryRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.error)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "force_try",
         name: "Force Try",
         description: "Force tries should be avoided.",
@@ -26,7 +26,7 @@ public struct ForceTryRule: ConfigurationProviderRule, SwiftSyntaxRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "force_unwrapping",
         name: "Force Unwrapping",
         description: "Force unwrapping should be avoided.",
@@ -67,7 +67,7 @@ public struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule, ConfigurationProv
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         ForceUnwrappingVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct FunctionDefaultParameterAtEndRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct FunctionDefaultParameterAtEndRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "function_default_parameter_at_end",
         name: "Function Default Parameter at End",
         description: "Prefer to locate parameters with defaults toward the end of the parameter list.",
@@ -51,7 +51,7 @@ public struct FunctionDefaultParameterAtEndRule: SwiftSyntaxRule, ConfigurationP
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -1,15 +1,15 @@
 import Foundation
 import SwiftSyntax
 
-public struct GenericTypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = NameConfiguration(minLengthWarning: 1,
-                                                 minLengthError: 0,
-                                                 maxLengthWarning: 20,
-                                                 maxLengthError: 1000)
+struct GenericTypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = NameConfiguration(minLengthWarning: 1,
+                                          minLengthError: 0,
+                                          maxLengthWarning: 20,
+                                          maxLengthError: 1000)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "generic_type_name",
         name: "Generic Type Name",
         description: "Generic type name should only contain alphanumeric characters, start with an " +
@@ -50,7 +50,7 @@ public struct GenericTypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
         }
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -1,14 +1,14 @@
 import SwiftSyntax
 
-public struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = ImplicitlyUnwrappedOptionalConfiguration(
+struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = ImplicitlyUnwrappedOptionalConfiguration(
         mode: .allExceptIBOutlets,
         severityConfiguration: SeverityConfiguration(.warning)
     )
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "implicitly_unwrapped_optional",
         name: "Implicitly Unwrapped Optional",
         description: "Implicitly unwrapped optionals should be avoided when possible.",
@@ -35,7 +35,7 @@ public struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, ConfigurationPro
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(mode: configuration.mode)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/IsDisjointRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/IsDisjointRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct IsDisjointRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct IsDisjointRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "is_disjoint",
         name: "Is Disjoint",
         description: "Prefer using `Set.isDisjoint(with:)` over `Set.intersection(_:).isEmpty`.",
@@ -22,7 +22,7 @@ public struct IsDisjointRule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct JoinedDefaultParameterRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct JoinedDefaultParameterRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "joined_default_parameter",
         name: "Joined Default Parameter",
         description: "Discouraged explicit usage of the default separator.",
@@ -38,11 +38,11 @@ public struct JoinedDefaultParameterRule: SwiftSyntaxCorrectableRule, Configurat
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -1,9 +1,9 @@
-public struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "legacy_cggeometry_functions",
         name: "Legacy CGGeometry Functions",
         description: "Struct extension properties and methods are preferred over legacy functions",
@@ -102,11 +102,11 @@ public struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule, Configu
         "CGRectIntersection": .function(name: "intersect", argumentLabels: [""])
     ]
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         LegacyFunctionRuleHelper.Visitor(legacyFunctions: Self.legacyFunctions)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         LegacyFunctionRuleHelper.Rewriter(
             legacyFunctions: Self.legacyFunctions,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
@@ -1,12 +1,12 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-public struct LegacyConstantRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LegacyConstantRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "legacy_constant",
         name: "Legacy Constant",
         description: "Struct-scoped constants are preferred over legacy global constants.",
@@ -16,11 +16,11 @@ public struct LegacyConstantRule: SwiftSyntaxCorrectableRule, ConfigurationProvi
         corrections: LegacyConstantRuleExamples.corrections
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct LegacyConstructorRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LegacyConstructorRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "legacy_constructor",
         name: "Legacy Constructor",
         description: "Swift constructors are preferred over legacy convenience functions.",
@@ -124,11 +124,11 @@ public struct LegacyConstructorRule: SwiftSyntaxCorrectableRule, ConfigurationPr
                                                        "NSEdgeInsetsMake": "NSEdgeInsets",
                                                        "UIOffsetMake": "UIOffset"]
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyHashingRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct LegacyHashingRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LegacyHashingRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "legacy_hashing",
         name: "Legacy Hashing",
         description: "Prefer using the `hash(into:)` function instead of overriding `hashValue`",
@@ -75,7 +75,7 @@ public struct LegacyHashingRule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "legacy_multiple",
         name: "Legacy Multiple",
         description: "Prefer using the `isMultiple(of:)` function instead of using the remainder operator (`%`).",
@@ -39,11 +39,11 @@ public struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, SwiftSyn
         ]
     )
 
-    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+    func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
         syntaxTree.folded()
     }
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -1,9 +1,9 @@
-public struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "legacy_nsgeometry_functions",
         name: "Legacy NSGeometry Functions",
         description: "Struct extension properties and methods are preferred over legacy functions",
@@ -102,11 +102,11 @@ public struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule, Configu
         "NSPointInRect": .function(name: "contains", argumentLabels: [""], reversed: true)
     ]
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         LegacyFunctionRuleHelper.Visitor(legacyFunctions: Self.legacyFunctions)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         LegacyFunctionRuleHelper.Rewriter(
             legacyFunctions: Self.legacyFunctions,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -28,12 +28,12 @@ private let legacyObjcTypes = [
     "NSUUID"
 ]
 
-public struct LegacyObjcTypeRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LegacyObjcTypeRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "legacy_objc_type",
         name: "Legacy Objective-C Reference Type",
         description: "Prefer Swift value types to bridged Objective-C reference types",
@@ -68,7 +68,7 @@ public struct LegacyObjcTypeRule: SwiftSyntaxRule, OptInRule, ConfigurationProvi
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyRandomRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct LegacyRandomRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LegacyRandomRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "legacy_random",
         name: "Legacy Random",
         description: "Prefer using `type.random(in:)` over legacy functions.",
@@ -22,7 +22,7 @@ public struct LegacyRandomRule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, CorrectableRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, CorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "nimble_operator",
         name: "Nimble Operator",
         description: "Prefer Nimble operator overloads over free matcher functions.",
@@ -98,7 +98,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
         "beNil": (to: "==", toNot: "!=", .nullary(analogueValue: "nil"))
     ]
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let matches = violationMatchesRanges(in: file)
         return matches.map {
             StyleViolation(ruleDescription: Self.description,
@@ -144,7 +144,7 @@ public struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, Correcta
             .map { $0.0 }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let matches = violationMatchesRanges(in: file)
             .filter { file.ruleEnabled(violatingRanges: [$0], for: self).isNotEmpty }
         guard matches.isNotEmpty else { return [] }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct NoExtensionAccessModifierRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.error)
+struct NoExtensionAccessModifierRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.error)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "no_extension_access_modifier",
         name: "No Extension Access Modifier",
         description: "Prefer not to use extension access modifiers",
@@ -23,7 +23,7 @@ public struct NoExtensionAccessModifierRule: SwiftSyntaxRule, OptInRule, Configu
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct NoFallthroughOnlyRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NoFallthroughOnlyRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "no_fallthrough_only",
         name: "No Fallthrough Only",
         description: "Fallthroughs can only be used if the `case` contains at least one other statement.",
@@ -14,7 +14,7 @@ public struct NoFallthroughOnlyRule: SwiftSyntaxRule, ConfigurationProviderRule 
         triggeringExamples: NoFallthroughOnlyRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -1,11 +1,11 @@
 import SourceKittenFramework
 
-public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "no_grouping_extension",
         name: "No Grouping Extension",
         description: "Extensions shouldn't be used to group code within the same source file.",
@@ -23,7 +23,7 @@ public struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule {
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let collector = NamespaceCollector(dictionary: file.structureDictionary)
         let elements = collector.findAllElements(of: [.class, .enum, .struct, .extension])
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public init() {}
+struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    init() {}
 
-    public var configuration = SeverityConfiguration(.warning)
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "no_magic_numbers",
         name: "No Magic Numbers",
         description: "Magic numbers should be replaced by named constants.",
@@ -50,7 +50,7 @@ public struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProvi
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ObjectLiteralRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = ObjectLiteralConfiguration()
+struct ObjectLiteralRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = ObjectLiteralConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "object_literal",
         name: "Object Literal",
         description: "Prefer object literals over image and color inits.",
@@ -33,7 +33,7 @@ public struct ObjectLiteralRule: SwiftSyntaxRule, ConfigurationProviderRule, Opt
         }
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(validateImageLiteral: configuration.imageLiteral, validateColorLiteral: configuration.colorLiteral)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct PatternMatchingKeywordsRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct PatternMatchingKeywordsRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "pattern_matching_keywords",
         name: "Pattern Matching Keywords",
         description: "Combine multiple pattern matching bindings by moving keywords out of tuples.",
@@ -35,7 +35,7 @@ public struct PatternMatchingKeywordsRule: SwiftSyntaxRule, ConfigurationProvide
         ].map(wrapInSwitch)
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PreferNimbleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PreferNimbleRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct PreferNimbleRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct PreferNimbleRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "prefer_nimble",
         name: "Prefer Nimble",
         description: "Prefer Nimble matchers over XCTAssert functions.",
@@ -24,7 +24,7 @@ public struct PreferNimbleRule: SwiftSyntaxRule, OptInRule, ConfigurationProvide
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -1,9 +1,9 @@
 import SwiftSyntax
 
-public struct PreferZeroOverExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct PreferZeroOverExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "prefer_zero_over_explicit_init",
         name: "Prefer Zero Over Explicit Init",
         description: "Prefer `.zero` over explicit init with zero parameters (e.g. `CGPoint(x: 0, y: 0)`)",
@@ -34,13 +34,13 @@ public struct PreferZeroOverExplicitInitRule: SwiftSyntaxCorrectableRule, OptInR
         ]
     )
 
-    public init() {}
+    init() {}
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
-    public var configuration = PrivateOverFilePrivateRuleConfiguration()
+struct PrivateOverFilePrivateRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+    var configuration = PrivateOverFilePrivateRuleConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "private_over_fileprivate",
         name: "Private over fileprivate",
         description: "Prefer `private` over `fileprivate` declarations.",
@@ -56,11 +56,11 @@ public struct PrivateOverFilePrivateRule: ConfigurationProviderRule, SwiftSyntax
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(validateExtensions: configuration.validateExtensions)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             validateExtensions: configuration.validateExtensions,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "redundant_nil_coalescing",
         name: "Redundant Nil Coalescing",
         description: "nil coalescing operator is only evaluated if the lhs is nil" +
@@ -23,11 +23,11 @@ public struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule,
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -5,12 +5,12 @@ private let attributeNamesImplyingObjc: Set<String> = [
     "IBAction", "IBOutlet", "IBInspectable", "GKInspectable", "IBDesignable", "NSManaged"
 ]
 
-public struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "redundant_objc_attribute",
         name: "Redundant @objc Attribute",
         description: "Objective-C attribute (@objc) is redundant in declaration.",
@@ -20,7 +20,7 @@ public struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectab
         corrections: RedundantObjcAttributeRuleExamples.corrections
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         final class Visitor: ViolationsSyntaxVisitor {
             override func visitPost(_ node: AttributeListSyntax) {
                 if let objcAttribute = node.violatingObjCAttribute {
@@ -31,7 +31,7 @@ public struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectab
         return Visitor(viewMode: .sourceAccurate)
     }
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         makeVisitor(file: file)
             .walk(tree: file.syntaxTree, handler: \.violations)
             .compactMap { violation in
@@ -100,7 +100,7 @@ private extension AttributeListSyntax {
     }
 }
 
-public extension RedundantObjcAttributeRule {
+extension RedundantObjcAttributeRule {
     func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         var whitespaceAndNewlineOffset = 0
         let nsCharSet = CharacterSet.whitespacesAndNewlines.bridge()

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct RedundantOptionalInitializationRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RedundantOptionalInitializationRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "redundant_optional_initialization",
         name: "Redundant Optional Initialization",
         description: "Initializing an optional variable with nil is redundant.",
@@ -106,11 +106,11 @@ public struct RedundantOptionalInitializationRule: SwiftSyntaxCorrectableRule, C
             """)
     ]
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct RedundantSetAccessControlRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RedundantSetAccessControlRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "redundant_set_access_control",
         name: "Redundant Set Access Control Rule",
         description: "Property setter access level shouldn't be explicit if " +
@@ -60,7 +60,7 @@ public struct RedundantSetAccessControlRule: ConfigurationProviderRule, SwiftSyn
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct RedundantStringEnumValueRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RedundantStringEnumValueRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "redundant_string_enum_value",
         name: "Redundant String Enum Value",
         description: "String enum values can be omitted when they are equal to the enumcase name.",
@@ -61,7 +61,7 @@ public struct RedundantStringEnumValueRule: SwiftSyntaxRule, ConfigurationProvid
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "redundant_type_annotation",
         name: "Redundant Type Annotation",
         description: "Variables should not have redundant type annotation",
@@ -76,7 +76,7 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map { range in
             StyleViolation(
                 ruleDescription: Self.description,
@@ -86,14 +86,14 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 
     private let typeAnnotationPattern: String
     private let expressionPattern: String
 
-    public init() {
+    init() {
         typeAnnotationPattern =
             ":\\s*" + // semicolon and any number of whitespaces
             "\\w+"    // type name
@@ -109,7 +109,7 @@ public struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRul
             "[\\(\\.]?"   // possible opening parenthesis or dot
     }
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let violatingRanges = file
             .match(pattern: expressionPattern)
             .filter {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableASTRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableASTRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "redundant_void_return",
         name: "Redundant Void Return",
         description: "Returning Void in a function declaration is redundant.",
@@ -60,8 +60,8 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
     private let excludingKinds = SyntaxKind.allKinds.subtracting([.typeidentifier])
     private let functionKinds = SwiftDeclarationKind.functionKinds.subtracting([.functionSubscript])
 
-    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violationRanges(in: file, kind: kind, dictionary: dictionary).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
@@ -69,8 +69,8 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
         }
     }
 
-    public func violationRanges(in file: SwiftLintFile, kind: SwiftDeclarationKind,
-                                dictionary: SourceKittenDictionary) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile, kind: SwiftDeclarationKind,
+                         dictionary: SourceKittenDictionary) -> [NSRange] {
         guard functionKinds.contains(kind),
               containsVoidReturnTypeBasedOnTypeName(dictionary: dictionary),
             let nameOffset = dictionary.nameOffset,
@@ -90,7 +90,7 @@ public struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCo
         return [match]
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ReturnValueFromVoidFunctionRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ReturnValueFromVoidFunctionRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "return_value_from_void_function",
         name: "Return Value from Void Function",
         description: "Returning values from Void functions should be avoided.",
@@ -15,7 +15,7 @@ public struct ReturnValueFromVoidFunctionRule: ConfigurationProviderRule, OptInR
         triggeringExamples: ReturnValueFromVoidFunctionRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         ReturnValueFromVoidFunctionVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
@@ -1,9 +1,9 @@
 import SwiftSyntax
 
-public struct ShorthandOptionalBindingRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ShorthandOptionalBindingRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "shorthand_optional_binding",
         name: "Shorthand Optional Binding",
         description: "Use shorthand syntax for optional binding",
@@ -79,13 +79,13 @@ public struct ShorthandOptionalBindingRule: OptInRule, SwiftSyntaxCorrectableRul
         deprecatedAliases: ["if_let_shadowing"]
     )
 
-    public init() {}
+    init() {}
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StaticOperatorRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct StaticOperatorRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct StaticOperatorRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "static_operator",
         name: "Static Operator",
         description: "Operators should be declared as static functions, not free functions.",
@@ -78,7 +78,7 @@ public struct StaticOperatorRule: SwiftSyntaxRule, ConfigurationProviderRule, Op
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "strict_fileprivate",
         name: "Strict fileprivate",
         description: "`fileprivate` should be avoided.",
@@ -58,7 +58,7 @@ public struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, Swift
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -2,12 +2,12 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct SyntacticSugarRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct SyntacticSugarRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "syntactic_sugar",
         name: "Syntactic Sugar",
         description: "Shorthand syntactic sugar should be used, i.e. [Int] instead of Array<Int>.",
@@ -17,7 +17,7 @@ public struct SyntacticSugarRule: CorrectableRule, ConfigurationProviderRule, So
         corrections: SyntacticSugarRuleExamples.corrections
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let visitor = SyntacticSugarRuleVisitor(viewMode: .sourceAccurate)
         return visitor.walk(file: file) { visitor in
             flattenViolations(visitor.violations)
@@ -33,7 +33,7 @@ public struct SyntacticSugarRule: CorrectableRule, ConfigurationProviderRule, So
         return violations.flatMap { [$0] + flattenViolations($0.children) }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let visitor = SyntacticSugarRuleVisitor(viewMode: .sourceAccurate)
         return visitor.walk(file: file) { visitor in
             var context = CorrectingContext(rule: self, file: file, contents: file.contents)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ToggleBoolRule.swift
@@ -1,12 +1,12 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-public struct ToggleBoolRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ToggleBoolRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "toggle_bool",
         name: "Toggle Bool",
         description: "Prefer `someBool.toggle()` over `someBool = !someBool`.",
@@ -31,11 +31,11 @@ public struct ToggleBoolRule: SwiftSyntaxCorrectableRule, ConfigurationProviderR
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "trailing_semicolon",
         name: "Trailing Semicolon",
         description: "Lines should not have trailing semicolons.",
@@ -24,11 +24,11 @@ public struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule, ConfigurationPr
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SwiftSyntax
 
-public struct TypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = TypeNameRuleConfiguration()
+struct TypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = TypeNameRuleConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "type_name",
         name: "Type Name",
         description: "Type name should only contain alphanumeric characters, start with an " +
@@ -17,7 +17,7 @@ public struct TypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
         triggeringExamples: TypeNameRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableConditionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UnavailableConditionRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnavailableConditionRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unavailable_condition",
         name: "Unavailable Condition",
         description: "Use #unavailable/#available instead of #available/#unavailable with an empty body.",
@@ -71,7 +71,7 @@ public struct UnavailableConditionRule: ConfigurationProviderRule, SwiftSyntaxRu
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         UnavailableConditionRuleVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UnavailableFunctionRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnavailableFunctionRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unavailable_function",
         name: "Unavailable Function",
         description: "Unimplemented functions should be marked as unavailable.",
@@ -72,7 +72,7 @@ public struct UnavailableFunctionRule: SwiftSyntaxRule, ConfigurationProviderRul
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -12,12 +12,12 @@ private func embedInSwitch(
         """, file: file, line: line)
 }
 
-public struct UnneededBreakInSwitchRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnneededBreakInSwitchRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unneeded_break_in_switch",
         name: "Unneeded Break in Switch",
         description: "Avoid using unneeded break statements.",
@@ -50,7 +50,7 @@ public struct UnneededBreakInSwitchRule: SwiftSyntaxRule, ConfigurationProviderR
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         UnneededBreakInSwitchRuleVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "untyped_error_in_catch",
         name: "Untyped Error in Catch",
         description: "Catch statements should not declare error variables without type casting.",
@@ -87,11 +87,11 @@ public struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, Swi
             Example("do {\n    try foo() \n} ↓catch (let error) {}"): Example("do {\n    try foo() \n} catch {}")
         ])
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         UntypedErrorInCatchRuleVisitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         UntypedErrorInCatchRuleRewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UnusedEnumeratedRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnusedEnumeratedRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unused_enumerated",
         name: "Unused Enumerated",
         description: "When the index or the item is not used, `.enumerated()` can be removed.",
@@ -29,7 +29,7 @@ public struct UnusedEnumeratedRule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct VoidFunctionInTernaryConditionRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct VoidFunctionInTernaryConditionRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "void_function_in_ternary",
         name: "Void Function in Ternary",
         description: "Using ternary to call Void functions should be avoided.",
@@ -108,7 +108,7 @@ public struct VoidFunctionInTernaryConditionRule: ConfigurationProviderRule, Swi
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         VoidFunctionInTernaryConditionVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct XCTFailMessageRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct XCTFailMessageRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "xctfail_message",
         name: "XCTFail Message",
         description: "An XCTFail call should include a description of the assertion.",
@@ -36,7 +36,7 @@ public struct XCTFailMessageRule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "xct_specific_matcher",
         name: "XCTest Specific Matcher",
         description: "Prefer specific XCTest matchers over `XCTAssertEqual` and `XCTAssertNotEqual`",
@@ -14,7 +14,7 @@ public struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule, ConfigurationP
         triggeringExamples: XCTSpecificMatcherRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -9,12 +9,12 @@ import SourceKittenFramework
 /// Known false negatives for Images declared as instance variables and containers that provide a label but are
 /// not accessibility elements. Known false positives for Images created in a separate function from where they
 /// have accessibility properties applied.
-public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "accessibility_label_for_image",
         name: "Accessibility Label for Image",
         description: "All Images that provide context should have an accessibility label. " +
@@ -27,8 +27,8 @@ public struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule
 
     // MARK: AST Rule
 
-    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         // Only proceed to check View structs.
         guard kind == .struct,
             dictionary.inheritedTypes.contains("View"),

--- a/Source/SwiftLintFramework/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -7,12 +7,12 @@ import SourceKittenFramework
 /// element, you need to explicitly add the button or link trait. In most cases the button trait should be used, but for
 /// buttons that open a URL in an external browser we use the link trait instead. This rule attempts to catch uses of
 /// the SwiftUI `.onTapGesture` modifier where the `.isButton` or `.isLink` trait is not explicitly applied.
-public struct AccessibilityTraitForButtonRule: ASTRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct AccessibilityTraitForButtonRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "accessibility_trait_for_button",
         name: "Accessibility Trait for Button",
         description: "All views with tap gestures added should include the .isButton " +
@@ -26,8 +26,8 @@ public struct AccessibilityTraitForButtonRule: ASTRule, ConfigurationProviderRul
 
     // MARK: AST Rule
 
-    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         // Only proceed to check View structs.
         guard kind == .struct,
             dictionary.inheritedTypes.contains("View"),

--- a/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/AnyObjectProtocolRule.swift
@@ -11,12 +11,12 @@ private func warnDeprecatedOnce() {
     _ = warnDeprecatedOnceImpl
 }
 
-public struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "anyobject_protocol",
         name: "AnyObject Protocol",
         description: "Prefer using `AnyObject` over `class` for class-only protocols.",
@@ -42,12 +42,12 @@ public struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule, Conf
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         warnDeprecatedOnce()
         return Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ArrayInitRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ArrayInitRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ArrayInitRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "array_init",
         name: "Array Init",
         description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array.",
@@ -51,7 +51,7 @@ public struct ArrayInitRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRu
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     // MARK: - Properties
 
-    public var configuration = SeverityConfiguration(.warning)
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "balanced_xctest_lifecycle",
         name: "Balanced XCTest life-cycle",
         description: "Test classes must implement balanced setUp and tearDown methods.",
@@ -108,11 +108,11 @@ public struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule, Configura
 
     // MARK: - Life cycle
 
-    public init() {}
+    init() {}
 
     // MARK: - Public
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CaptureVariableRule.swift
@@ -1,15 +1,15 @@
 import SourceKittenFramework
 
-public struct CaptureVariableRule: ConfigurationProviderRule, AnalyzerRule, CollectingRule {
-    public struct Variable: Hashable {
+struct CaptureVariableRule: ConfigurationProviderRule, AnalyzerRule, CollectingRule {
+    struct Variable: Hashable {
         let usr: String
         let offset: ByteCount
     }
 
-    public typealias USR = String
-    public typealias FileInfo = Set<USR>
+    typealias USR = String
+    typealias FileInfo = Set<USR>
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "capture_variable",
         name: "Capture Variable",
         description: "Non-constant variables should not be listed in a closure's capture list" +
@@ -152,16 +152,16 @@ public struct CaptureVariableRule: ConfigurationProviderRule, AnalyzerRule, Coll
         requiresFileOnDisk: true
     )
 
-    public var configuration = SeverityConfiguration(.warning)
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> CaptureVariableRule.FileInfo {
+    func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> CaptureVariableRule.FileInfo {
         file.declaredVariables(compilerArguments: compilerArguments)
     }
 
-    public func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: CaptureVariableRule.FileInfo],
-                         compilerArguments: [String]) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: CaptureVariableRule.FileInfo],
+                  compilerArguments: [String]) -> [StyleViolation] {
         file.captureListVariables(compilerArguments: compilerArguments)
             .filter { capturedVariable in collectedInfo.values.contains { $0.contains(capturedVariable.usr) } }
             .map {

--- a/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ClassDelegateProtocolRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ClassDelegateProtocolRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "class_delegate_protocol",
         name: "Class Delegate Protocol",
         description: "Delegate protocols should be class-only so they can be weakly referenced.",
@@ -31,7 +31,7 @@ public struct ClassDelegateProtocolRule: SwiftSyntaxRule, ConfigurationProviderR
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -2,12 +2,12 @@ import Foundation
 import IDEUtils
 import SourceKittenFramework
 
-public struct CommentSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, SubstitutionCorrectableRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct CommentSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, SubstitutionCorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "comment_spacing",
         name: "Comment Spacing",
         description: "Prefer at least one space after slashes for comments.",
@@ -119,7 +119,7 @@ public struct CommentSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, 
         ]
     )
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         // Find all comment tokens in the file and regex search them for violations
         file.syntaxClassifications
             .compactMap { (classifiedRange: SyntaxClassifiedRange) -> [NSRange]? in
@@ -156,7 +156,7 @@ public struct CommentSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, 
             .flatMap { $0 }
     }
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map { range in
             StyleViolation(
                 ruleDescription: Self.description,
@@ -166,7 +166,7 @@ public struct CommentSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, 
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, " ")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct CompilerProtocolInitRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct CompilerProtocolInitRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "compiler_protocol_init",
         name: "Compiler Protocol Init",
         description: Self.violationReason(
@@ -30,7 +30,7 @@ public struct CompilerProtocolInitRule: SwiftSyntaxRule, ConfigurationProviderRu
                 "shouldn't be called directly."
     }
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DeploymentTargetRule.swift
@@ -1,12 +1,12 @@
 import SwiftSyntax
 
-public struct DeploymentTargetRule: ConfigurationProviderRule, SwiftSyntaxRule {
+struct DeploymentTargetRule: ConfigurationProviderRule, SwiftSyntaxRule {
     private typealias Version = DeploymentTargetConfiguration.Version
-    public var configuration = DeploymentTargetConfiguration()
+    var configuration = DeploymentTargetConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "deployment_target",
         name: "Deployment Target",
         description: "Availability checks or attributes shouldn't be using older versions " +
@@ -16,7 +16,7 @@ public struct DeploymentTargetRule: ConfigurationProviderRule, SwiftSyntaxRule {
         triggeringExamples: DeploymentTargetRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(platformToConfiguredMinVersion: platformToConfiguredMinVersion)
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DiscardedNotificationCenterObserverRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct DiscardedNotificationCenterObserverRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "discarded_notification_center_observer",
         name: "Discarded Notification Center Observer",
         description: "When registering for a notification using a block, the opaque observer that is " +
@@ -50,7 +50,7 @@ public struct DiscardedNotificationCenterObserverRule: SwiftSyntaxRule, Configur
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DiscouragedDirectInitRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = DiscouragedDirectInitConfiguration()
+struct DiscouragedDirectInitRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = DiscouragedDirectInitConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "discouraged_direct_init",
         name: "Discouraged Direct Initialization",
         description: "Discouraged direct initialization of types that can be harmful.",
@@ -37,7 +37,7 @@ public struct DiscouragedDirectInitRule: SwiftSyntaxRule, ConfigurationProviderR
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(discouragedInits: configuration.discouragedInits)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DuplicateEnumCasesRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.error)
+struct DuplicateEnumCasesRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.error)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "duplicate_enum_cases",
         name: "Duplicate Enum Cases",
         description: "Enum can't contain multiple cases with the same name.",
@@ -57,7 +57,7 @@ public struct DuplicateEnumCasesRule: ConfigurationProviderRule, SwiftSyntaxRule
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DuplicatedKeyInDictionaryLiteralRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct DuplicatedKeyInDictionaryLiteralRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "duplicated_key_in_dictionary_literal",
         name: "Duplicated Key in Dictionary Literal",
         description: "Dictionary literals with duplicated keys will crash in runtime.",
@@ -79,7 +79,7 @@ public struct DuplicatedKeyInDictionaryLiteralRule: SwiftSyntaxRule, Configurati
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DynamicInlineRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct DynamicInlineRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.error)
+struct DynamicInlineRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.error)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "dynamic_inline",
         name: "Dynamic Inline",
         description: "Avoid using 'dynamic' and '@inline(__always)' together.",
@@ -24,7 +24,7 @@ public struct DynamicInlineRule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct EmptyXCTestMethodRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct EmptyXCTestMethodRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "empty_xctest_method",
         name: "Empty XCTest Method",
         description: "Empty XCTest method should be avoided.",
@@ -14,7 +14,7 @@ public struct EmptyXCTestMethodRule: OptInRule, ConfigurationProviderRule, Swift
         triggeringExamples: EmptyXCTestMethodRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         EmptyXCTestMethodRuleVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ExpiringTodoRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
+struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
     enum ExpiryViolationLevel {
         case approachingExpiry
         case expired
@@ -19,7 +19,7 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
         }
     }
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "expiring_todo",
         name: "Expiring Todo",
         description: "TODOs and FIXMEs should be resolved prior to their expiry date.",
@@ -44,11 +44,11 @@ public struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
         ].skipWrappingInCommentTests()
     )
 
-    public var configuration: ExpiringTodoConfiguration = .init()
+    var configuration: ExpiringTodoConfiguration = .init()
 
-    public init() {}
+    init() {}
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let regex = #"""
         \b(?:TODO|FIXME)(?::|\b)(?:(?!\b(?:TODO|FIXME)(?::|\b)).)*?\#
         \\#(configuration.dateDelimiters.opening)\#

--- a/Source/SwiftLintFramework/Rules/Lint/IBInspectableInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IBInspectableInExtensionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct IBInspectableInExtensionRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct IBInspectableInExtensionRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "ibinspectable_in_extension",
         name: "IBInspectable in Extension",
         description: "Extensions shouldn't add @IBInspectable properties.",
@@ -26,7 +26,7 @@ public struct IBInspectableInExtensionRule: SwiftSyntaxRule, ConfigurationProvid
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/IdenticalOperandsRule.swift
@@ -1,13 +1,13 @@
 import SwiftSyntax
 
-public struct IdenticalOperandsRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct IdenticalOperandsRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
     private static let operators = ["==", "!=", "===", "!==", ">", ">=", "<", "<="]
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "identical_operands",
         name: "Identical Operands",
         description: "Comparing two identical operands is likely a mistake.",
@@ -72,11 +72,11 @@ public struct IdenticalOperandsRule: ConfigurationProviderRule, SwiftSyntaxRule,
         ]
     )
 
-    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+    func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
         syntaxTree.folded()
     }
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct InertDeferRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct InertDeferRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "inert_defer",
         name: "Inert Defer",
         description: "If defer is at the end of its parent scope, it will be executed right where it is anyway.",
@@ -50,7 +50,7 @@ public struct InertDeferRule: ConfigurationProviderRule, SwiftSyntaxRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "lower_acl_than_parent",
         name: "Lower ACL than parent",
         description: "Ensure declarations have a lower access control level than their enclosing parent",
@@ -56,11 +56,11 @@ public struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, Swif
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MarkRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct MarkRule: CorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "mark",
         name: "Mark",
         description: "MARK comment should be in valid format. e.g. '// MARK: ...' or '// MARK: - ...'",
@@ -102,7 +102,7 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
         ].joined(separator: "|")
     }
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file, matching: pattern).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
@@ -110,7 +110,7 @@ public struct MarkRule: CorrectableRule, ConfigurationProviderRule {
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         var result = [Correction]()
 
         result.append(contentsOf: correct(file: file,

--- a/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/MissingDocsRule.swift
@@ -43,15 +43,15 @@ private extension SwiftLintFile {
     }
 }
 
-public struct MissingDocsRule: OptInRule, ConfigurationProviderRule {
-    public init() {
+struct MissingDocsRule: OptInRule, ConfigurationProviderRule {
+    init() {
         configuration = MissingDocsRuleConfiguration()
     }
 
-    public typealias ConfigurationType = MissingDocsRuleConfiguration
-    public var configuration: MissingDocsRuleConfiguration
+    typealias ConfigurationType = MissingDocsRuleConfiguration
+    var configuration: MissingDocsRuleConfiguration
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "missing_docs",
         name: "Missing Docs",
         description: "Declarations should be documented.",
@@ -119,7 +119,7 @@ public struct MissingDocsRule: OptInRule, ConfigurationProviderRule {
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let acls = configuration.parameters.map { $0.value }
         let dict = file.structureDictionary
         return file.missingDocOffsets(

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringKeyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringKeyRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct NSLocalizedStringKeyRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NSLocalizedStringKeyRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "nslocalizedstring_key",
         name: "NSLocalizedString Key",
         description: "Static strings should be used as key/comment" +
@@ -33,7 +33,7 @@ public struct NSLocalizedStringKeyRule: SwiftSyntaxRule, OptInRule, Configuratio
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct NSLocalizedStringRequireBundleRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NSLocalizedStringRequireBundleRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "nslocalizedstring_require_bundle",
         name: "NSLocalizedString Require Bundle",
         description: "Calls to NSLocalizedString should specify the bundle which contains the strings file.",
@@ -42,7 +42,7 @@ public struct NSLocalizedStringRequireBundleRule: SwiftSyntaxRule, OptInRule, Co
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/NSNumberInitAsFunctionReferenceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSNumberInitAsFunctionReferenceRule.swift
@@ -1,12 +1,12 @@
 import SwiftSyntax
 
 // this rule exists due to a compiler bug: https://github.com/apple/swift/issues/51036
-public struct NSNumberInitAsFunctionReferenceRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NSNumberInitAsFunctionReferenceRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "ns_number_init_as_function_reference",
         name: "NSNumber Init as Function Reference",
         description: "Passing `NSNumber.init` or `NSDecimalNumber.init` as a function reference is dangerous " +
@@ -24,7 +24,7 @@ public struct NSNumberInitAsFunctionReferenceRule: SwiftSyntaxRule, Configuratio
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct NSObjectPreferIsEqualRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NSObjectPreferIsEqualRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "nsobject_prefer_isequal",
         name: "NSObject Prefer isEqual",
         description: "NSObject subclasses should implement isEqual instead of ==.",
@@ -14,7 +14,7 @@ public struct NSObjectPreferIsEqualRule: SwiftSyntaxRule, ConfigurationProviderR
         triggeringExamples: NSObjectPreferIsEqualRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/NotificationCenterDetachmentRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct NotificationCenterDetachmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NotificationCenterDetachmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "notification_center_detachment",
         name: "Notification Center Detachment",
         description: "An object should only remove itself as an observer in `deinit`.",
@@ -14,7 +14,7 @@ public struct NotificationCenterDetachmentRule: SwiftSyntaxRule, ConfigurationPr
         triggeringExamples: NotificationCenterDetachmentRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
@@ -1,12 +1,12 @@
 import IDEUtils
 import SwiftSyntax
 
-public struct OrphanedDocCommentRule: SourceKitFreeRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct OrphanedDocCommentRule: SourceKitFreeRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "orphaned_doc_comment",
         name: "Orphaned Doc Comment",
         description: "A doc comment should be attached to a declaration.",
@@ -53,7 +53,7 @@ public struct OrphanedDocCommentRule: SourceKitFreeRule, ConfigurationProviderRu
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let classifications = file.syntaxClassifications
             .filter { $0.kind != .none }
         let docstringsWithOtherComments = classifications

--- a/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverriddenSuperCallRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct OverriddenSuperCallRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
-    public var configuration = OverriddenSuperCallConfiguration()
+struct OverriddenSuperCallRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+    var configuration = OverriddenSuperCallConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "overridden_super_call",
         name: "Overridden methods call super",
         description: "Some overridden methods should always call super",
@@ -76,7 +76,7 @@ public struct OverriddenSuperCallRule: ConfigurationProviderRule, SwiftSyntaxRul
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(resolvedMethodNames: configuration.resolvedMethodNames)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OverrideInExtensionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "override_in_extension",
         name: "Override in Extension",
         description: "Extensions shouldn't override declarations.",
@@ -35,7 +35,7 @@ public struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, Swi
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         let allowedExtensions = ClassNameCollectingVisitor(viewMode: .sourceAccurate)
             .walk(tree: file.syntaxTree, handler: \.classNames)
         return Visitor(allowedExtensions: allowedExtensions)

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateActionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct PrivateActionRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct PrivateActionRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "private_action",
         name: "Private Actions",
         description: "IBActions should be private.",
@@ -33,7 +33,7 @@ public struct PrivateActionRule: SwiftSyntaxRule, OptInRule, ConfigurationProvid
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct PrivateOutletRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = PrivateOutletRuleConfiguration(allowPrivateSet: false)
+struct PrivateOutletRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = PrivateOutletRuleConfiguration(allowPrivateSet: false)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "private_outlet",
         name: "Private Outlets",
         description: "IBOutlets should be private to avoid leaking UIKit to higher layers.",
@@ -78,7 +78,7 @@ public struct PrivateOutletRule: SwiftSyntaxRule, OptInRule, ConfigurationProvid
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(allowPrivateSet: configuration.allowPrivateSet)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateSubjectRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateSubjectRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct PrivateSubjectRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct PrivateSubjectRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     // MARK: - Properties
 
-    public var configuration = SeverityConfiguration(.warning)
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "private_subject",
         name: "Private Combine Subject",
         description: "Combine Subject should be private.",
@@ -16,11 +16,11 @@ public struct PrivateSubjectRule: SwiftSyntaxRule, OptInRule, ConfigurationProvi
 
     // MARK: - Life cycle
 
-    public init() {}
+    init() {}
 
     // MARK: - Public
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateUnitTestRule.swift
@@ -1,21 +1,21 @@
 import Foundation
 import SwiftSyntax
 
-public struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, CacheDescriptionProvider {
-    public var configuration: PrivateUnitTestConfiguration = {
+struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, CacheDescriptionProvider {
+    var configuration: PrivateUnitTestConfiguration = {
         var configuration = PrivateUnitTestConfiguration(identifier: "private_unit_test")
         configuration.message = "Unit test marked `private` will not be run by XCTest."
         configuration.regex = regex("XCTestCase")
         return configuration
     }()
 
-    internal var cacheDescription: String {
+    var cacheDescription: String {
         return configuration.cacheDescription
     }
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "private_unit_test",
         name: "Private Unit Test",
         description: "Unit tests marked private are silently skipped.",
@@ -136,11 +136,11 @@ public struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule, ConfigurationProv
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(parentClassRegex: configuration.regex)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             parentClassRegex: configuration.regex,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "prohibited_interface_builder",
         name: "Prohibited Interface Builder",
         description: "Creating views using Interface Builder should be avoided.",
@@ -20,7 +20,7 @@ public struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, SwiftSy
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ProhibitedSuperRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ProhibitedSuperRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
-    public var configuration = ProhibitedSuperConfiguration()
+struct ProhibitedSuperRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+    var configuration = ProhibitedSuperConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "prohibited_super_call",
         name: "Prohibited calls to super",
         description: "Some methods should not call super",
@@ -72,7 +72,7 @@ public struct ProhibitedSuperRule: ConfigurationProviderRule, SwiftSyntaxRule, O
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(resolvedMethodNames: configuration.resolvedMethodNames)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -1,11 +1,11 @@
 import SourceKittenFramework
 
-public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "quick_discouraged_call",
         name: "Quick Discouraged Call",
         description: "Discouraged call inside 'describe' and/or 'context' block.",
@@ -14,7 +14,7 @@ public struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule {
         triggeringExamples: QuickDiscouragedCallRuleExamples.triggeringExamples
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let dict = file.structureDictionary
         let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.isNotEmpty &&

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "quick_discouraged_focused_test",
         name: "Quick Discouraged Focused Test",
         description: "Discouraged focused test. Other tests won't run while this one is focused.",
@@ -14,7 +14,7 @@ public struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderR
         triggeringExamples: QuickDiscouragedFocusedTestRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "quick_discouraged_pending_test",
         name: "Quick Discouraged Pending Test",
         description: "Discouraged pending test. This test won't run while it's marked as pending.",
@@ -14,7 +14,7 @@ public struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderR
         triggeringExamples: QuickDiscouragedPendingTestRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct RawValueForCamelCasedCodableEnumRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RawValueForCamelCasedCodableEnumRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "raw_value_for_camel_cased_codable_enum",
         name: "Raw Value For Camel Cased Codable Enum",
         description: "Camel cased cases of Codable String enums should have raw value.",
@@ -93,7 +93,7 @@ public struct RawValueForCamelCasedCodableEnumRule: SwiftSyntaxRule, OptInRule, 
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredDeinitRule.swift
@@ -6,10 +6,10 @@ import SwiftSyntax
 /// of objects and the deinit should print a message or remove its instance from a
 /// list of allocations. Even having an empty deinit method is useful to provide
 /// a place to put a breakpoint when chasing down leaks.
-public struct RequiredDeinitRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RequiredDeinitRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "required_deinit",
         name: "Required Deinit",
         description: "Classes should have an explicit deinit method.",
@@ -66,9 +66,9 @@ public struct RequiredDeinitRule: SwiftSyntaxRule, OptInRule, ConfigurationProvi
         ]
     )
 
-    public init() {}
+    init() {}
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/RequiredEnumCaseRule.swift
@@ -67,16 +67,16 @@ import SwiftSyntax
 ///     case accountCreated
 /// }
 /// ````
-public struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = RequiredEnumCaseRuleConfiguration()
+struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = RequiredEnumCaseRuleConfiguration()
 
-    public init() {}
+    init() {}
 
     private static let exampleConfiguration = [
         "NetworkResponsable": ["success": "warning", "error": "warning", "notConnected": "warning"]
     ]
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "required_enum_case",
         name: "Required Enum Case",
         description: "Enums conforming to a specified protocol must implement a specific case(s).",
@@ -133,7 +133,7 @@ public struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule, ConfigurationPro
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/SelfInPropertyInitializationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SelfInPropertyInitializationRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct SelfInPropertyInitializationRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct SelfInPropertyInitializationRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "self_in_property_initialization",
         name: "Self in Property Initialization",
         description: "`self` refers to the unapplied `NSObject.self()` method, which is likely not expected. " +
@@ -92,7 +92,7 @@ public struct SelfInPropertyInitializationRule: ConfigurationProviderRule, Swift
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/StrongIBOutletRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct StrongIBOutletRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct StrongIBOutletRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "strong_iboutlet",
         name: "Strong IBOutlet",
         description: "@IBOutlets shouldn't be declared as weak.",
@@ -29,11 +29,11 @@ public struct StrongIBOutletRule: ConfigurationProviderRule, SwiftSyntaxCorrecta
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
@@ -1,32 +1,34 @@
-public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKitFreeRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "superfluous_disable_command",
         name: "Superfluous Disable Command",
-        description: "SwiftLint 'disable' commands are superfluous when the disabled rule would not have " +
-                     "triggered a violation in the disabled region. Use \" - \" if you wish to document a command.",
+        description: """
+            SwiftLint 'disable' commands are superfluous when the disabled rule would not have triggered a violation \
+            in the disabled region. Use " - " if you wish to document a command.
+            """,
         kind: .lint
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         // This rule is implemented in Linter.swift
         return []
     }
 
-    public func reason(for rule: Rule.Type) -> String {
+    func reason(for rule: Rule.Type) -> String {
         return self.reason(for: rule.description.identifier)
     }
 
-    public func reason(for rule: String) -> String {
+    func reason(for rule: String) -> String {
         """
         SwiftLint rule '\(rule)' did not trigger a violation in the disabled region. Please remove the disable command.
         """
     }
 
-    public func reason(forNonExistentRule rule: String) -> String {
+    func reason(forNonExistentRule rule: String) -> String {
         return "'\(rule)' is not a valid SwiftLint rule. Please remove it from the disable command."
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -1,13 +1,13 @@
 import Foundation
 import SwiftSyntax
 
-public struct TestCaseAccessibilityRule: SwiftSyntaxRule, OptInRule,
+struct TestCaseAccessibilityRule: SwiftSyntaxRule, OptInRule,
                                          ConfigurationProviderRule, SubstitutionCorrectableRule {
-    public var configuration = TestCaseAccessibilityConfiguration()
+    var configuration = TestCaseAccessibilityConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "test_case_accessibility",
         name: "Test case accessibility",
         description: "Test cases should only contain private non-test members.",
@@ -17,11 +17,11 @@ public struct TestCaseAccessibilityRule: SwiftSyntaxRule, OptInRule,
         corrections: TestCaseAccessibilityRuleExamples.corrections
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(allowedPrefixes: configuration.allowedPrefixes, testParentClasses: configuration.testParentClasses)
     }
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         makeVisitor(file: file)
             .walk(tree: file.syntaxTree, handler: \.violations)
             .compactMap {
@@ -29,7 +29,7 @@ public struct TestCaseAccessibilityRule: SwiftSyntaxRule, OptInRule,
             }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         (violationRange, "private ")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TodoRule.swift
@@ -1,19 +1,19 @@
 import Foundation
 import SourceKittenFramework
 
-public extension SyntaxKind {
+extension SyntaxKind {
     /// Returns if the syntax kind is comment-like.
     var isCommentLike: Bool {
         return Self.commentKinds.contains(self)
     }
 }
 
-public struct TodoRule: ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct TodoRule: ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "todo",
         name: "Todo",
         description: "TODOs and FIXMEs should be resolved.",
@@ -71,7 +71,7 @@ public struct TodoRule: ConfigurationProviderRule {
         return reason
     }
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.match(pattern: "\\b(?:TODO|FIXME)(?::|\\b)").compactMap { range, syntaxKinds in
             if syntaxKinds.contains(where: { !$0.isCommentLike }) {
                 return nil

--- a/Source/SwiftLintFramework/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TypesafeArrayInitRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "typesafe_array_init",
         name: "Type-safe Array Init",
         description: ArrayInitRule.description.description,
@@ -58,7 +58,7 @@ public struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
             \\Q(Self) -> ((Self.Element) throws -> T) throws -> [T]\\E
             """)
 
-    public func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
         guard let filePath = file.path else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unowned_variable_capture",
         name: "Unowned Variable Capture",
         description: "Prefer capturing references as weak to avoid potential crashes.",
@@ -25,7 +25,7 @@ public struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule, Configurat
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         UnownedVariableCaptureRuleVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UnusedCaptureListRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnusedCaptureListRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "unused_capture_list",
         name: "Unused Capture List",
         description: "Unused reference in a capture list should be removed.",
@@ -120,7 +120,7 @@ public struct UnusedCaptureListRule: SwiftSyntaxRule, ConfigurationProviderRule 
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -1,12 +1,12 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-public struct UnusedClosureParameterRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnusedClosureParameterRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unused_closure_parameter",
         name: "Unused Closure Parameter",
         description: "Unused parameter in a closure should be replaced with _.",
@@ -16,11 +16,11 @@ public struct UnusedClosureParameterRule: SwiftSyntaxCorrectableRule, Configurat
         corrections: UnusedClosureParameterRuleExamples.corrections
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UnusedControlFlowLabelRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnusedControlFlowLabelRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unused_control_flow_label",
         name: "Unused Control Flow Label",
         description: "Unused control flow label should be removed.",
@@ -85,11 +85,11 @@ public struct UnusedControlFlowLabelRule: SwiftSyntaxCorrectableRule, Configurat
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, CollectingRule {
-    public struct FileUSRs: Hashable {
+struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, CollectingRule {
+    struct FileUSRs: Hashable {
         var referenced: Set<String>
         var declared: Set<DeclaredUSR>
 
@@ -14,17 +14,17 @@ public struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, Co
         let nameOffset: ByteCount
     }
 
-    public typealias FileInfo = FileUSRs
+    typealias FileInfo = FileUSRs
 
-    public var configuration = UnusedDeclarationConfiguration(
+    var configuration = UnusedDeclarationConfiguration(
         severity: .error,
         includePublicAndOpen: false,
         relatedUSRsToSkip: ["s:7SwiftUI15PreviewProviderP"]
     )
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unused_declaration",
         name: "Unused Declaration",
         description: "Declarations should be referenced at least once within all files linted.",
@@ -34,7 +34,7 @@ public struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, Co
         requiresFileOnDisk: true
     )
 
-    public func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> UnusedDeclarationRule.FileUSRs {
+    func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> UnusedDeclarationRule.FileUSRs {
         guard compilerArguments.isNotEmpty else {
             queuedPrintError("""
                 Attempted to lint file at path '\(file.path ?? "...")' with the \
@@ -69,8 +69,8 @@ public struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, Co
         )
     }
 
-    public func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: UnusedDeclarationRule.FileUSRs],
-                         compilerArguments: [String]) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: UnusedDeclarationRule.FileUSRs],
+                  compilerArguments: [String]) -> [StyleViolation] {
         let allReferencedUSRs = collectedInfo.values.reduce(into: Set()) { $0.formUnion($1.referenced) }
         return violationOffsets(declaredUSRs: collectedInfo[file]?.declared ?? [],
                                 allReferencedUSRs: allReferencedUSRs)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -3,13 +3,13 @@ import SourceKittenFramework
 
 private let moduleToLog = ProcessInfo.processInfo.environment["SWIFTLINT_LOG_MODULE_USAGE"]
 
-public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
-    public var configuration = UnusedImportConfiguration(severity: .warning, requireExplicitImports: false,
-                                                         allowedTransitiveImports: [], alwaysKeepImports: [])
+struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
+    var configuration = UnusedImportConfiguration(severity: .warning, requireExplicitImports: false,
+                                                  allowedTransitiveImports: [], alwaysKeepImports: [])
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unused_import",
         name: "Unused Import",
         description: "All imported modules should be required to make the file compile.",
@@ -20,7 +20,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
         requiresFileOnDisk: true
     )
 
-    public func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
         return importUsage(in: file, compilerArguments: compilerArguments).map { importUsage in
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity.severity,
@@ -29,7 +29,7 @@ public struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, Anal
         }
     }
 
-    public func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
+    func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
         let importUsages = importUsage(in: file, compilerArguments: compilerArguments)
         let matches = file.ruleEnabled(violatingRanges: importUsages.compactMap({ $0.violationRange }), for: self)
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedSetterValueRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UnusedSetterValueRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct UnusedSetterValueRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unused_setter_value",
         name: "Unused Setter Value",
         description: "Setter value is not used.",
@@ -129,7 +129,7 @@ public struct UnusedSetterValueRule: ConfigurationProviderRule, SwiftSyntaxRule 
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/ValidIBInspectableRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ValidIBInspectableRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ValidIBInspectableRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "valid_ibinspectable",
         name: "Valid IBInspectable",
         description: """
@@ -110,7 +110,7 @@ public struct ValidIBInspectableRule: SwiftSyntaxRule, ConfigurationProviderRule
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/WeakDelegateRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct WeakDelegateRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct WeakDelegateRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "weak_delegate",
         name: "Weak Delegate",
         description: "Delegates should be weak to avoid reference cycles.",
@@ -67,7 +67,7 @@ public struct WeakDelegateRule: OptInRule, SwiftSyntaxRule, ConfigurationProvide
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/YodaConditionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct YodaConditionRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct YodaConditionRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "yoda_condition",
         name: "Yoda condition rule",
         description: "The constant literal should be placed on the right-hand side of the comparison operator.",
@@ -36,7 +36,7 @@ public struct YodaConditionRule: OptInRule, ConfigurationProviderRule, SwiftSynt
             Example("if ↓200 <= i && i <= 299 || ↓600 <= i {}")
         ])
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         YodaConditionRuleVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -1,9 +1,9 @@
-public struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 30, error: 100)
+struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityLevelsConfiguration(warning: 30, error: 100)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "closure_body_length",
         name: "Closure Body Length",
         description: "Closure bodies should not span too many lines.",
@@ -12,7 +12,7 @@ public struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule, ConfigurationPr
         triggeringExamples: ClosureBodyLengthRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         BodyLengthRuleVisitor(kind: .closure, file: file, configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/CyclomaticComplexityRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
-    public var configuration = CyclomaticComplexityConfiguration(warning: 10, error: 20)
+struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
+    var configuration = CyclomaticComplexityConfiguration(warning: 10, error: 20)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "cyclomatic_complexity",
         name: "Cyclomatic Complexity",
         description: "Complexity of function bodies should be limited.",
@@ -72,8 +72,8 @@ public struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
         ]
     )
 
-    public func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard SwiftDeclarationKind.functionKinds.contains(kind) else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 5, error: 6)
+struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityLevelsConfiguration(warning: 5, error: 6)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "enum_case_associated_values_count",
         name: "Enum Case Associated Values Count",
         description: "Number of associated values in an enum case should be low",
@@ -38,7 +38,7 @@ public struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule, Co
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FileLengthRule.swift
@@ -1,11 +1,11 @@
 import SourceKittenFramework
 
-public struct FileLengthRule: ConfigurationProviderRule {
-    public var configuration = FileLengthRuleConfiguration(warning: 400, error: 1000)
+struct FileLengthRule: ConfigurationProviderRule {
+    var configuration = FileLengthRuleConfiguration(warning: 400, error: 1000)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "file_length",
         name: "File Length",
         description: "Files should not span too many lines.",
@@ -20,7 +20,7 @@ public struct FileLengthRule: ConfigurationProviderRule {
         ].skipWrappingInCommentTests()
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         func lineCountWithoutComments() -> Int {
             let commentKinds = SyntaxKind.commentKinds
             let lineCount = file.syntaxKindsByLines.filter { kinds in

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionBodyLengthRule.swift
@@ -1,16 +1,16 @@
-public struct FunctionBodyLengthRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 50, error: 100)
+struct FunctionBodyLengthRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityLevelsConfiguration(warning: 50, error: 100)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "function_body_length",
         name: "Function Body Length",
         description: "Functions bodies should not span too many lines.",
         kind: .metrics
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         BodyLengthRuleVisitor(kind: .function, file: file, configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/FunctionParameterCountRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct FunctionParameterCountRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = FunctionParameterCountConfiguration(warning: 5, error: 8)
+struct FunctionParameterCountRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = FunctionParameterCountConfiguration(warning: 5, error: 8)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "function_parameter_count",
         name: "Function Parameter Count",
         description: "Number of function parameters should be low.",
@@ -37,7 +37,7 @@ public struct FunctionParameterCountRule: SwiftSyntaxRule, ConfigurationProvider
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LargeTupleRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct LargeTupleRule: SourceKitFreeRule, ConfigurationProviderRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 2, error: 3)
+struct LargeTupleRule: SourceKitFreeRule, ConfigurationProviderRule {
+    var configuration = SeverityLevelsConfiguration(warning: 2, error: 3)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "large_tuple",
         name: "Large Tuple",
         description: "Tuples shouldn't have too many members. Create a custom type instead.",
@@ -14,7 +14,7 @@ public struct LargeTupleRule: SourceKitFreeRule, ConfigurationProviderRule {
         triggeringExamples: LargeTupleRuleExamples.triggeringExamples
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         LargeTupleRuleVisitor(viewMode: .sourceAccurate)
             .walk(file: file, handler: \.violationPositions)
             .sorted(by: { $0.position < $1.position })

--- a/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/LineLengthRule.swift
@@ -1,16 +1,16 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LineLengthRule: ConfigurationProviderRule {
-    public var configuration = LineLengthConfiguration(warning: 120, error: 200)
+struct LineLengthRule: ConfigurationProviderRule {
+    var configuration = LineLengthConfiguration(warning: 120, error: 200)
 
-    public init() {}
+    init() {}
 
     private let commentKinds = SyntaxKind.commentKinds
     private let nonCommentKinds = SyntaxKind.allKinds.subtracting(SyntaxKind.commentKinds)
     private let functionKinds = SwiftDeclarationKind.functionKinds
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "line_length",
         name: "Line Length",
         description: "Lines should not span too many characters.",
@@ -27,7 +27,7 @@ public struct LineLengthRule: ConfigurationProviderRule {
         ].skipWrappingInCommentTests().skipWrappingInStringTests()
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let minValue = configuration.params.map({ $0.value }).min() ?? .max
         let swiftDeclarationKindsByLine = Lazy(file.swiftDeclarationKindsByLine() ?? [])
         let syntaxKindsByLine = Lazy(file.syntaxKindsByLine() ?? [])

--- a/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/NestingRule.swift
@@ -1,14 +1,14 @@
 import SourceKittenFramework
 
-public struct NestingRule: ConfigurationProviderRule {
-    public var configuration = NestingConfiguration(typeLevelWarning: 1,
-                                                    typeLevelError: nil,
-                                                    functionLevelWarning: 2,
-                                                    functionLevelError: nil)
+struct NestingRule: ConfigurationProviderRule {
+    var configuration = NestingConfiguration(typeLevelWarning: 1,
+                                             typeLevelError: nil,
+                                             functionLevelWarning: 2,
+                                             functionLevelError: nil)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "nesting",
         name: "Nesting",
         description:
@@ -35,7 +35,7 @@ public struct NestingRule: ConfigurationProviderRule {
         }
     }
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return validate(file: file, substructure: file.structureDictionary.substructure, args: ValidationArgs())
     }
 

--- a/Source/SwiftLintFramework/Rules/Metrics/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Metrics/TypeBodyLengthRule.swift
@@ -10,12 +10,12 @@ private func wrapExample(
                    repeatElement(template, count: count).joined() + "\(add)}\n", file: file, line: line)
 }
 
-public struct TypeBodyLengthRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityLevelsConfiguration(warning: 250, error: 350)
+struct TypeBodyLengthRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityLevelsConfiguration(warning: 250, error: 350)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "type_body_length",
         name: "Type Body Length",
         description: "Type bodies should not span too many lines.",
@@ -33,7 +33,7 @@ public struct TypeBodyLengthRule: SwiftSyntaxRule, ConfigurationProviderRule {
         })
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         BodyLengthRuleVisitor(kind: .type, file: file, configuration: configuration)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ContainsOverFilterCountRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ContainsOverFilterCountRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "contains_over_filter_count",
         name: "Contains Over Filter Count",
         description: "Prefer `contains` over comparing `filter(where:).count` to 0.",
@@ -30,7 +30,7 @@ public struct ContainsOverFilterCountRule: SwiftSyntaxRule, OptInRule, Configura
         }
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ContainsOverFilterIsEmptyRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ContainsOverFilterIsEmptyRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "contains_over_filter_is_empty",
         name: "Contains Over Filter Is Empty",
         description: "Prefer `contains` over using `filter(where:).isEmpty`",
@@ -28,7 +28,7 @@ public struct ContainsOverFilterIsEmptyRule: SwiftSyntaxRule, OptInRule, Configu
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ContainsOverFirstNotNilRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ContainsOverFirstNotNilRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "contains_over_first_not_nil",
         name: "Contains over first not nil",
         description: "Prefer `contains` over `first(where:) != nil` and `firstIndex(where:) != nil`.",
@@ -30,11 +30,11 @@ public struct ContainsOverFirstNotNilRule: SwiftSyntaxRule, OptInRule, Configura
         }
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+    func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
         syntaxTree.folded()
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ContainsOverRangeNilComparisonRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ContainsOverRangeNilComparisonRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "contains_over_range_nil_comparison",
         name: "Contains over range(of:) comparison to nil",
         description: "Prefer `contains` over `range(of:) != nil` and `range(of:) == nil`.",
@@ -23,11 +23,11 @@ public struct ContainsOverRangeNilComparisonRule: SwiftSyntaxRule, OptInRule, Co
         }
     )
 
-    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+    func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
         syntaxTree.folded()
     }
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCollectionLiteralRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCollectionLiteralRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct EmptyCollectionLiteralRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct EmptyCollectionLiteralRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "empty_collection_literal",
         name: "Empty Collection Literal",
         description: "Prefer checking `isEmpty` over comparing collection to an empty array or dictionary literal.",
@@ -28,7 +28,7 @@ public struct EmptyCollectionLiteralRule: SwiftSyntaxRule, ConfigurationProvider
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyCountRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct EmptyCountRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
-    public var configuration = EmptyCountConfiguration()
+struct EmptyCountRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+    var configuration = EmptyCountConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "empty_count",
         name: "Empty Count",
         description: "Prefer checking `isEmpty` over comparing `count` to zero.",
@@ -35,11 +35,11 @@ public struct EmptyCountRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxR
         ]
     )
 
-    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+    func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
         syntaxTree.folded()
     }
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(onlyAfterDot: configuration.onlyAfterDot)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/EmptyStringRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct EmptyStringRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct EmptyStringRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "empty_string",
         name: "Empty String",
         description: "Prefer checking `isEmpty` over comparing `string` to an empty string literal.",
@@ -24,7 +24,7 @@ public struct EmptyStringRule: ConfigurationProviderRule, OptInRule, SwiftSyntax
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FirstWhereRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct FirstWhereRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct FirstWhereRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "first_where",
         name: "First Where",
         description: "Prefer using `.first(where:)` over `.filter { }.first` in collections.",
@@ -32,7 +32,7 @@ public struct FirstWhereRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderR
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/FlatMapOverMapReduceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/FlatMapOverMapReduceRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct FlatMapOverMapReduceRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct FlatMapOverMapReduceRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "flatmap_over_map_reduce",
         name: "FlatMap over map and reduce",
         description: "Prefer `flatMap` over `map` followed by `reduce([], +)`.",
@@ -19,7 +19,7 @@ public struct FlatMapOverMapReduceRule: SwiftSyntaxRule, OptInRule, Configuratio
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/LastWhereRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct LastWhereRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LastWhereRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "last_where",
         name: "Last Where",
         description: "Prefer using `.last(where:)` over `.filter { }.last` in collections.",
@@ -28,7 +28,7 @@ public struct LastWhereRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRu
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ReduceBooleanRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ReduceBooleanRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "reduce_boolean",
         name: "Reduce Boolean",
         description: "Prefer using `.allSatisfy()` or `.contains()` over `reduce(true)` or `reduce(false)`",
@@ -26,7 +26,7 @@ public struct ReduceBooleanRule: SwiftSyntaxRule, ConfigurationProviderRule {
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceIntoRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ReduceIntoRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ReduceIntoRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "reduce_into",
         name: "Reduce Into",
         description: "Prefer `reduce(into:_:)` over `reduce(_:_:)` for copy-on-write types",
@@ -108,7 +108,7 @@ public struct ReduceIntoRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInR
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/SortedFirstLastRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct SortedFirstLastRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct SortedFirstLastRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "sorted_first_last",
         name: "Min or Max over Sorted First or Last",
         description: "Prefer using `min()` or `max()` over `sorted().first` or `sorted().last`",
@@ -42,7 +42,7 @@ public struct SortedFirstLastRule: SwiftSyntaxRule, OptInRule, ConfigurationProv
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -1,21 +1,21 @@
-public struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public var severityConfiguration = SeverityConfiguration(.warning)
+struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var alwaysOnSameLine = Set<String>()
     private(set) var alwaysOnNewLine = Set<String>()
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", always_on_same_line: \(alwaysOnSameLine.sorted())" +
             ", always_on_line_above: \(alwaysOnNewLine.sorted())"
     }
 
-    public init(alwaysOnSameLine: [String] = ["@IBAction", "@NSManaged"],
-                alwaysInNewLine: [String] = []) {
+    init(alwaysOnSameLine: [String] = ["@IBAction", "@NSManaged"],
+         alwaysInNewLine: [String] = []) {
         self.alwaysOnSameLine = Set(alwaysOnSameLine)
         self.alwaysOnNewLine = Set(alwaysOnNewLine)
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -1,14 +1,14 @@
-public struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
-    public private(set) var alignColons = false
+struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var alignColons = false
 
-    public init() {}
+    init() {}
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", align_colons: \(alignColons)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -1,15 +1,15 @@
-public struct ColonConfiguration: RuleConfiguration, Equatable {
+struct ColonConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var flexibleRightSpacing = false
     private(set) var applyToDictionaries = true
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", flexible_right_spacing: \(flexibleRightSpacing)" +
             ", apply_to_dictionaries: \(applyToDictionaries)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ComputedAccessorsOrderRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ComputedAccessorsOrderRuleConfiguration.swift
@@ -1,17 +1,17 @@
-public struct ComputedAccessorsOrderRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public enum Order: String {
+struct ComputedAccessorsOrderRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    enum Order: String {
         case getSet = "get_set"
         case setGet = "set_get"
     }
 
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var order = Order.getSet
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return [severityConfiguration.consoleDescription, "order: \(order.rawValue)"].joined(separator: ", ")
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -1,12 +1,12 @@
-public struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var ifOnly = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return [severityConfiguration.consoleDescription, "if_only: \(ifOnly)"].joined(separator: ", ")
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -6,13 +6,13 @@ private enum ConfigurationKey: String {
     case ignoresCaseStatements = "ignores_case_statements"
 }
 
-public struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return length.consoleDescription +
             ", \(ConfigurationKey.ignoresCaseStatements.rawValue): \(ignoresCaseStatements)"
     }
 
-    public static let defaultComplexityStatements: Set<StatementKind> = [
+    static let defaultComplexityStatements: Set<StatementKind> = [
         .forEach,
         .if,
         .guard,
@@ -22,11 +22,11 @@ public struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
         .case
     ]
 
-    public private(set) var length: SeverityLevelsConfiguration
+    private(set) var length: SeverityLevelsConfiguration
 
-    public private(set) var complexityStatements: Set<StatementKind>
+    private(set) var complexityStatements: Set<StatementKind>
 
-    public private(set) var ignoresCaseStatements: Bool {
+    private(set) var ignoresCaseStatements: Bool {
         didSet {
             if ignoresCaseStatements {
                 complexityStatements.remove(.case)
@@ -40,13 +40,13 @@ public struct CyclomaticComplexityConfiguration: RuleConfiguration, Equatable {
         return length.params
     }
 
-    public init(warning: Int, error: Int?, ignoresCaseStatements: Bool = false) {
+    init(warning: Int, error: Int?, ignoresCaseStatements: Bool = false) {
         self.length = SeverityLevelsConfiguration(warning: warning, error: error)
         self.complexityStatements = Self.defaultComplexityStatements
         self.ignoresCaseStatements = ignoresCaseStatements
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         if let configurationArray = [Int].array(of: configuration),
             configurationArray.isNotEmpty {
             let warning = configurationArray[0]

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
@@ -1,5 +1,5 @@
-public struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public enum Platform: String {
+struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    enum Platform: String {
         case iOS
         case iOSApplicationExtension
         case macOS
@@ -25,27 +25,27 @@ public struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equ
         }
     }
 
-    public class Version: Equatable, Comparable {
-        public let platform: Platform
-        public var major: Int
-        public var minor: Int
-        public var patch: Int
+    class Version: Equatable, Comparable {
+        let platform: Platform
+        var major: Int
+        var minor: Int
+        var patch: Int
 
-        public var stringValue: String {
+        var stringValue: String {
             if patch > 0 {
                 return "\(major).\(minor).\(patch)"
             }
             return "\(major).\(minor)"
         }
 
-        public init(platform: Platform, major: Int, minor: Int = 0, patch: Int = 0) {
+        init(platform: Platform, major: Int, minor: Int = 0, patch: Int = 0) {
             self.platform = platform
             self.major = major
             self.minor = minor
             self.patch = patch
         }
 
-        public convenience init(platform: Platform, rawValue: String) throws {
+        convenience init(platform: Platform, rawValue: String) throws {
             let (major, minor, patch) = try Self.parseVersion(string: rawValue)
             self.init(platform: platform, major: major, minor: minor, patch: patch)
         }
@@ -82,11 +82,11 @@ public struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equ
             }
         }
 
-        public static func == (lhs: Version, rhs: Version) -> Bool {
+        static func == (lhs: Version, rhs: Version) -> Bool {
             lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.patch == rhs.patch
         }
 
-        public static func < (lhs: Version, rhs: Version) -> Bool {
+        static func < (lhs: Version, rhs: Version) -> Bool {
             if lhs.major != rhs.major {
                 return lhs.major < rhs.major
             }
@@ -107,17 +107,17 @@ public struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equ
     private(set) var tvOSDeploymentTarget = Version(platform: .tvOS, major: 9)
     private(set) var tvOSAppExtensionDeploymentTarget = Version(platform: .tvOSApplicationExtension, major: 9)
 
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
 
     private let targets: [String: Version]
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         severityConfiguration.consoleDescription + targets
             .sorted { $0.key < $1.key }
             .map { ", \($0): \($1.stringValue)" }.joined()
     }
 
-    public init() {
+    init() {
         self.targets = Dictionary(uniqueKeysWithValues: [
                 iOSDeploymentTarget,
                 iOSAppExtensionDeploymentTarget,
@@ -130,7 +130,7 @@ public struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equ
         ].map { ($0.platform.configurationKey, $0) })
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -2,14 +2,14 @@ private func toExplicitInitMethod(typeName: String) -> String {
     return "\(typeName).init"
 }
 
-public struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public var severityConfiguration = SeverityConfiguration(.warning)
+struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.warning)
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", types: \(discouragedInits.sorted(by: <))"
     }
 
-    public private(set) var discouragedInits: Set<String>
+    private(set) var discouragedInits: Set<String>
 
     private let defaultDiscouragedInits = [
         "Bundle",
@@ -23,7 +23,7 @@ public struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration
 
     // MARK: - RuleConfiguration
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -3,16 +3,16 @@ private enum ConfigurationKey: String {
     case onlyAfterDot = "only_after_dot"
 }
 
-public struct EmptyCountConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.error)
-    public private(set) var onlyAfterDot = false
+struct EmptyCountConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.error)
+    private(set) var onlyAfterDot = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return [severityConfiguration.consoleDescription,
                 "\(ConfigurationKey.onlyAfterDot.rawValue): \(onlyAfterDot)"].joined(separator: ", ")
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -1,17 +1,17 @@
-public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
-    public struct DelimiterConfiguration: Equatable {
-        public static let `default`: DelimiterConfiguration = .init(opening: "[", closing: "]")
+struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
+    struct DelimiterConfiguration: Equatable {
+        static let `default`: DelimiterConfiguration = .init(opening: "[", closing: "]")
 
         fileprivate(set) var opening: String
         fileprivate(set) var closing: String
 
-        public init(opening: String, closing: String) {
+        init(opening: String, closing: String) {
             self.opening = opening
             self.closing = closing
         }
     }
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         let descriptions = [
             "approaching_expiry_severity: \(approachingExpirySeverity.consoleDescription)",
             "expired_severity: \(expiredSeverity.consoleDescription)",
@@ -40,7 +40,7 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
     /// The separator used for regex detection of the expiry-date string
     private(set) var dateSeparator: String
 
-    public init(
+    init(
         approachingExpirySeverity: SeverityConfiguration = .init(.warning),
         expiredSeverity: SeverityConfiguration = .init(.error),
         badFormattingSeverity: SeverityConfiguration = .init(.error),
@@ -57,7 +57,7 @@ public struct ExpiringTodoConfiguration: RuleConfiguration, Equatable {
         self.dateSeparator = dateSeparator
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -37,7 +37,7 @@ private extension SwiftDeclarationKind {
     }
 }
 
-public struct ExplicitTypeInterfaceConfiguration: RuleConfiguration, Equatable {
+struct ExplicitTypeInterfaceConfiguration: RuleConfiguration, Equatable {
     private static let variableKinds: Set<SwiftDeclarationKind> = [.varInstance,
                                                                    .varLocal,
                                                                    .varStatic,
@@ -49,7 +49,7 @@ public struct ExplicitTypeInterfaceConfiguration: RuleConfiguration, Equatable {
 
     private(set) var allowRedundancy = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         let excludedKinds = Self.variableKinds.subtracting(allowedKinds)
         let simplifiedExcludedKinds = excludedKinds.compactMap { $0.variableKind?.rawValue }.sorted()
         return severityConfiguration.consoleDescription +
@@ -57,9 +57,9 @@ public struct ExplicitTypeInterfaceConfiguration: RuleConfiguration, Equatable {
             ", allow_redundancy: \(allowRedundancy)"
     }
 
-    public init() {}
+    init() {}
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
+struct FileHeaderConfiguration: RuleConfiguration, Equatable {
     private static let fileNamePlaceholder = "SWIFTLINT_CURRENT_FILENAME"
     private static let stringRegexOptions: NSRegularExpression.Options = [.ignoreMetacharacters]
     private static let patternRegexOptions: NSRegularExpression.Options =
@@ -18,7 +18,7 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
 
     private static let defaultRegex = regex("\\bCopyright\\b", options: [.caseInsensitive])
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         let requiredStringDescription = requiredString ?? "None"
         let requiredPatternDescription = requiredPattern ?? "None"
         let forbiddenStringDescription = forbiddenString ?? "None"
@@ -31,9 +31,9 @@ public struct FileHeaderConfiguration: RuleConfiguration, Equatable {
             ", forbidden_pattern: \(forbiddenPatternDescription)"
     }
 
-    public init() {}
+    init() {}
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: String] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
@@ -4,21 +4,21 @@ private enum ConfigurationKey: String {
     case ignoreCommentOnlyLines = "ignore_comment_only_lines"
 }
 
-public struct FileLengthRuleConfiguration: RuleConfiguration, Equatable {
+struct FileLengthRuleConfiguration: RuleConfiguration, Equatable {
     private(set) var ignoreCommentOnlyLines: Bool
     private(set) var severityConfiguration: SeverityLevelsConfiguration
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", \(ConfigurationKey.ignoreCommentOnlyLines.rawValue): \(ignoreCommentOnlyLines)"
     }
 
-    public init(warning: Int, error: Int?, ignoreCommentOnlyLines: Bool = false) {
+    init(warning: Int, error: Int?, ignoreCommentOnlyLines: Bool = false) {
         self.ignoreCommentOnlyLines = ignoreCommentOnlyLines
         self.severityConfiguration = SeverityLevelsConfiguration(warning: warning, error: error)
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         if let configurationArray = [Int].array(of: configuration),
             configurationArray.isNotEmpty {
             let warning = configurationArray[0]

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -1,5 +1,5 @@
-public struct FileNameConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct FileNameConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return "(severity) \(severity.consoleDescription), " +
             "excluded: \(excluded.sorted()), " +
             "prefix_pattern: \(prefixPattern), " +
@@ -7,14 +7,14 @@ public struct FileNameConfiguration: RuleConfiguration, Equatable {
             "nested_type_separator: \(nestedTypeSeparator)"
     }
 
-    public private(set) var severity: SeverityConfiguration
-    public private(set) var excluded: Set<String>
-    public private(set) var prefixPattern: String
-    public private(set) var suffixPattern: String
-    public private(set) var nestedTypeSeparator: String
+    private(set) var severity: SeverityConfiguration
+    private(set) var excluded: Set<String>
+    private(set) var prefixPattern: String
+    private(set) var suffixPattern: String
+    private(set) var nestedTypeSeparator: String
 
-    public init(severity: ViolationSeverity, excluded: [String] = [],
-                prefixPattern: String = "", suffixPattern: String = "\\+.*", nestedTypeSeparator: String = ".") {
+    init(severity: ViolationSeverity, excluded: [String] = [],
+         prefixPattern: String = "", suffixPattern: String = "\\+.*", nestedTypeSeparator: String = ".") {
         self.severity = SeverityConfiguration(severity)
         self.excluded = Set(excluded)
         self.prefixPattern = prefixPattern
@@ -22,7 +22,7 @@ public struct FileNameConfiguration: RuleConfiguration, Equatable {
         self.nestedTypeSeparator = nestedTypeSeparator
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
@@ -1,18 +1,18 @@
-public struct FileNameNoSpaceConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct FileNameNoSpaceConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return "(severity) \(severity.consoleDescription), " +
             "excluded: \(excluded.sorted())"
     }
 
-    public private(set) var severity: SeverityConfiguration
-    public private(set) var excluded: Set<String>
+    private(set) var severity: SeverityConfiguration
+    private(set) var excluded: Set<String>
 
-    public init(severity: ViolationSeverity, excluded: [String] = []) {
+    init(severity: ViolationSeverity, excluded: [String] = []) {
         self.severity = SeverityConfiguration(severity)
         self.excluded = Set(excluded)
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -6,7 +6,7 @@ enum FileType: String {
     case libraryContentProvider = "library_content_provider"
 }
 
-public struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
+struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var order: [[FileType]] = [
         [.supportingType],
@@ -16,12 +16,12 @@ public struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
         [.libraryContentProvider]
     ]
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", order: \(String(describing: order))"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ForWhereRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ForWhereRuleConfiguration.swift
@@ -1,12 +1,12 @@
-public struct ForWhereRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
-    public private(set) var allowForAsFilter = false
+struct ForWhereRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var allowForAsFilter = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", allow_for_as_filter: \(allowForAsFilter)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -4,21 +4,21 @@ private enum ConfigurationKey: String {
     case ignoresDefaultParameters = "ignores_default_parameters"
 }
 
-public struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable {
+struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable {
     private(set) var ignoresDefaultParameters: Bool
     private(set) var severityConfiguration: SeverityLevelsConfiguration
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
         "\(ConfigurationKey.ignoresDefaultParameters.rawValue): \(ignoresDefaultParameters)"
     }
 
-    public init(warning: Int, error: Int?, ignoresDefaultParameters: Bool = true) {
+    init(warning: Int, error: Int?, ignoresDefaultParameters: Bool = true) {
         self.ignoresDefaultParameters = ignoresDefaultParameters
         self.severityConfiguration = SeverityLevelsConfiguration(warning: warning, error: error)
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         if let configurationArray = [Int].array(of: configuration),
             configurationArray.isNotEmpty {
             let warning = configurationArray[0]

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -1,27 +1,27 @@
-public struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
-    public enum ReturnKind: String, CaseIterable {
+struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
+    enum ReturnKind: String, CaseIterable {
         case closure
         case function
         case getter
     }
 
-    public static let defaultIncludedKinds = Set(ReturnKind.allCases)
+    static let defaultIncludedKinds = Set(ReturnKind.allCases)
 
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
 
     private(set) var includedKinds = Self.defaultIncludedKinds
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         let includedKinds = self.includedKinds.map { $0.rawValue }
         return severityConfiguration.consoleDescription +
             ", included: [\(includedKinds.sorted().joined(separator: ", "))]"
     }
 
-    public init(includedKinds: Set<ReturnKind> = Self.defaultIncludedKinds) {
+    init(includedKinds: Set<ReturnKind> = Self.defaultIncludedKinds) {
         self.includedKinds = includedKinds
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }
@@ -41,7 +41,7 @@ public struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
         }
     }
 
-    public func isKindIncluded(_ kind: ReturnKind) -> Bool {
+    func isKindIncluded(_ kind: ReturnKind) -> Bool {
         return self.includedKinds.contains(kind)
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -1,5 +1,5 @@
 // swiftlint:disable:next type_name
-public enum ImplicitlyUnwrappedOptionalModeConfiguration: String {
+enum ImplicitlyUnwrappedOptionalModeConfiguration: String {
     case all = "all"
     case allExceptIBOutlets = "all_except_iboutlets"
 
@@ -13,21 +13,21 @@ public enum ImplicitlyUnwrappedOptionalModeConfiguration: String {
     }
 }
 
-public struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration: SeverityConfiguration
-    public private(set) var mode: ImplicitlyUnwrappedOptionalModeConfiguration
+struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration: SeverityConfiguration
+    private(set) var mode: ImplicitlyUnwrappedOptionalModeConfiguration
 
-    public init(mode: ImplicitlyUnwrappedOptionalModeConfiguration, severityConfiguration: SeverityConfiguration) {
+    init(mode: ImplicitlyUnwrappedOptionalModeConfiguration, severityConfiguration: SeverityConfiguration) {
         self.mode = mode
         self.severityConfiguration = severityConfiguration
     }
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", mode: \(mode)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -5,15 +5,15 @@ private enum ConfigurationKey: String {
     case overrideAllowedTerms = "override_allowed_terms"
 }
 
-public struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public var severityConfiguration = SeverityConfiguration(.warning)
+struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.warning)
     private var additionalTerms: Set<String>?
     private var overrideTerms: Set<String>?
     private var overrideAllowedTerms: Set<String>?
-    public private(set) var allTerms: [String]
-    public private(set) var allAllowedTerms: Set<String>
+    private(set) var allTerms: [String]
+    private(set) var allAllowedTerms: Set<String>
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         severityConfiguration.consoleDescription
             + ", additional_terms: \(additionalTerms?.sorted() ?? [])"
             + ", override_terms: \(overrideTerms?.sorted() ?? [])"
@@ -31,12 +31,12 @@ public struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Eq
         "mastercard"
     ]
 
-    public init() {
+    init() {
         self.allTerms = defaultTerms.sorted()
         self.allAllowedTerms = defaultAllowedTerms
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -1,16 +1,16 @@
-public struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return "severity: \(severityConfiguration.consoleDescription), "
             + "indentation_width: \(indentationWidth), "
             + "include_comments: \(includeComments)"
     }
 
-    public private(set) var severityConfiguration: SeverityConfiguration
-    public private(set) var indentationWidth: Int
-    public private(set) var includeComments: Bool
-    public private(set) var includeCompilerDirectives: Bool
+    private(set) var severityConfiguration: SeverityConfiguration
+    private(set) var indentationWidth: Int
+    private(set) var includeComments: Bool
+    private(set) var includeCompilerDirectives: Bool
 
-    public init(
+    init(
         severity: ViolationSeverity,
         indentationWidth: Int,
         includeComments: Bool,
@@ -22,7 +22,7 @@ public struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
         self.includeCompilerDirectives = includeCompilerDirectives
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -1,19 +1,19 @@
-public struct LineLengthRuleOptions: OptionSet {
-    public let rawValue: Int
+struct LineLengthRuleOptions: OptionSet {
+    let rawValue: Int
 
-    public init(rawValue: Int = 0) {
+    init(rawValue: Int = 0) {
         self.rawValue = rawValue
     }
 
-    public static let ignoreURLs = Self(rawValue: 1 << 0)
-    public static let ignoreFunctionDeclarations = Self(rawValue: 1 << 1)
-    public static let ignoreComments = Self(rawValue: 1 << 2)
-    public static let ignoreInterpolatedStrings = Self(rawValue: 1 << 3)
+    static let ignoreURLs = Self(rawValue: 1 << 0)
+    static let ignoreFunctionDeclarations = Self(rawValue: 1 << 1)
+    static let ignoreComments = Self(rawValue: 1 << 2)
+    static let ignoreInterpolatedStrings = Self(rawValue: 1 << 3)
 
-    public static let all: LineLengthRuleOptions = [.ignoreURLs,
-                                                    .ignoreFunctionDeclarations,
-                                                    .ignoreComments,
-                                                    .ignoreInterpolatedStrings]
+    static let all: LineLengthRuleOptions = [.ignoreURLs,
+                                             .ignoreFunctionDeclarations,
+                                             .ignoreComments,
+                                             .ignoreInterpolatedStrings]
 }
 
 private enum ConfigurationKey: String {
@@ -25,8 +25,8 @@ private enum ConfigurationKey: String {
     case ignoresInterpolatedStrings = "ignores_interpolated_strings"
 }
 
-public struct LineLengthConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct LineLengthConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return length.consoleDescription +
                ", ignores urls: \(ignoresURLs)" +
                ", ignores function declarations: \(ignoresFunctionDeclarations)" +
@@ -44,7 +44,7 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
         return length.params
     }
 
-    public init(warning: Int, error: Int?, options: LineLengthRuleOptions = []) {
+    init(warning: Int, error: Int?, options: LineLengthRuleOptions = []) {
         self.length = SeverityLevelsConfiguration(warning: warning, error: error)
         self.ignoresURLs = options.contains(.ignoreURLs)
         self.ignoresFunctionDeclarations = options.contains(.ignoreFunctionDeclarations)
@@ -52,7 +52,7 @@ public struct LineLengthConfiguration: RuleConfiguration, Equatable {
         self.ignoresInterpolatedStrings = options.contains(.ignoreInterpolatedStrings)
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         if applyArray(configuration: configuration) {
             return
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -9,11 +9,6 @@ struct LineLengthRuleOptions: OptionSet {
     static let ignoreFunctionDeclarations = Self(rawValue: 1 << 1)
     static let ignoreComments = Self(rawValue: 1 << 2)
     static let ignoreInterpolatedStrings = Self(rawValue: 1 << 3)
-
-    static let all: LineLengthRuleOptions = [.ignoreURLs,
-                                             .ignoreFunctionDeclarations,
-                                             .ignoreComments,
-                                             .ignoreInterpolatedStrings]
 }
 
 private enum ConfigurationKey: String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MissingDocsRuleConfiguration.swift
@@ -1,4 +1,4 @@
-public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
+struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
     private(set) var parameters = [
         RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
         RuleParameter<AccessControlLevel>(severity: .warning, value: .public)
@@ -7,7 +7,7 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
     private(set) var excludesInheritedTypes = true
     private(set) var excludesTrivialInit = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         let parametersDescription = parameters.group { $0.severity }.sorted { $0.key.rawValue < $1.key.rawValue }.map {
             "\($0.rawValue): \($1.map { $0.value.description }.sorted(by: <).joined(separator: ", "))"
         }.joined(separator: ", ")
@@ -30,7 +30,7 @@ public struct MissingDocsRuleConfiguration: RuleConfiguration, Equatable {
         }
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let dict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -1,14 +1,14 @@
 import SourceKittenFramework
 
-public struct ModifierOrderConfiguration: RuleConfiguration, Equatable {
+struct ModifierOrderConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var preferredModifierOrder = [SwiftDeclarationAttributeKind.ModifierGroup]()
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", preferred_modifier_order: \(preferredModifierOrder)"
     }
 
-    public init() {
+    init() {
         self.preferredModifierOrder = []
     }
 
@@ -16,7 +16,7 @@ public struct ModifierOrderConfiguration: RuleConfiguration, Equatable {
         self.preferredModifierOrder = preferredModifierOrder
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -4,8 +4,8 @@ private enum ConfigurationKey: String {
     case onlyEnforceAfterFirstClosureOnFirstLine = "only_enforce_after_first_closure_on_first_line"
 }
 
-public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
-    public enum FirstArgumentLocation: String {
+struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
+    enum FirstArgumentLocation: String {
         case anyLine = "any_line"
         case sameLine = "same_line"
         case nextLine = "next_line"
@@ -25,14 +25,14 @@ public struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
     private(set) var firstArgumentLocation = FirstArgumentLocation.anyLine
     private(set) var onlyEnforceAfterFirstClosureOnFirstLine = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", \(ConfigurationKey.firstArgumentLocation.rawValue): \(firstArgumentLocation.rawValue)" +
             ", \(ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue): \(onlyEnforceAfterFirstClosureOnFirstLine)"
             // swiftlint:disable:previous line_length
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         let error = ConfigurationError.unknownConfiguration
 
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -1,13 +1,13 @@
-public struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
-    public private(set) var allowsSingleLine = true
+struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var allowsSingleLine = true
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         severityConfiguration.consoleDescription
             + ", allowsSingleLine: \(allowsSingleLine)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public struct NameConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct NameConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return "(min_length) \(minLength.shortConsoleDescription), " +
             "(max_length) \(maxLength.shortConsoleDescription), " +
             "excluded: \(excluded.sorted()), " +
@@ -27,13 +27,13 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
         return CharacterSet(charactersIn: allowedSymbolsSet.joined())
     }
 
-    public init(minLengthWarning: Int,
-                minLengthError: Int,
-                maxLengthWarning: Int,
-                maxLengthError: Int,
-                excluded: [String] = [],
-                allowedSymbols: [String] = [],
-                validatesStartWithLowercase: Bool = true) {
+    init(minLengthWarning: Int,
+         minLengthError: Int,
+         maxLengthWarning: Int,
+         maxLengthError: Int,
+         excluded: [String] = [],
+         allowedSymbols: [String] = [],
+         validatesStartWithLowercase: Bool = true) {
         minLength = SeverityLevelsConfiguration(warning: minLengthWarning, error: minLengthError)
         maxLength = SeverityLevelsConfiguration(warning: maxLengthWarning, error: maxLengthError)
         self.excluded = Set(excluded)
@@ -41,7 +41,7 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
         self.validatesStartWithLowercase = validatesStartWithLowercase
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }
@@ -71,13 +71,13 @@ public struct NameConfiguration: RuleConfiguration, Equatable {
 
 // MARK: - ConfigurationProviderRule extensions
 
-public extension ConfigurationProviderRule where ConfigurationType == NameConfiguration {
+extension ConfigurationProviderRule where ConfigurationType == NameConfiguration {
     func severity(forLength length: Int) -> ViolationSeverity? {
         return configuration.severity(forLength: length)
     }
 }
 
-public extension NameConfiguration {
+extension NameConfiguration {
     func severity(forLength length: Int) -> ViolationSeverity? {
         if let minError = minLength.error, length < minError {
             return .error

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -1,5 +1,5 @@
-public struct NestingConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct NestingConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return "(type_level) \(typeLevel.shortConsoleDescription)"
             + ", (function_level) \(functionLevel.shortConsoleDescription)"
             + ", (check_nesting_in_closures_and_statements) \(checkNestingInClosuresAndStatements)"
@@ -11,19 +11,19 @@ public struct NestingConfiguration: RuleConfiguration, Equatable {
     var checkNestingInClosuresAndStatements: Bool
     var alwaysAllowOneTypeInFunctions: Bool
 
-    public init(typeLevelWarning: Int,
-                typeLevelError: Int?,
-                functionLevelWarning: Int,
-                functionLevelError: Int?,
-                checkNestingInClosuresAndStatements: Bool = true,
-                alwaysAllowOneTypeInFunctions: Bool = false) {
+    init(typeLevelWarning: Int,
+         typeLevelError: Int?,
+         functionLevelWarning: Int,
+         functionLevelError: Int?,
+         checkNestingInClosuresAndStatements: Bool = true,
+         alwaysAllowOneTypeInFunctions: Bool = false) {
         self.typeLevel = SeverityLevelsConfiguration(warning: typeLevelWarning, error: typeLevelError)
         self.functionLevel = SeverityLevelsConfiguration(warning: functionLevelWarning, error: functionLevelError)
         self.checkNestingInClosuresAndStatements = checkNestingInClosuresAndStatements
         self.alwaysAllowOneTypeInFunctions = alwaysAllowOneTypeInFunctions
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -1,10 +1,10 @@
-public struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var minimumLength: Int
     private(set) var minimumFractionLength: Int?
     private(set) var excludeRanges: [Range<Double>]
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         let minimumFractionLengthDescription: String
         if let minimumFractionLength = minimumFractionLength {
             minimumFractionLengthDescription = ", minimum_fraction_length: \(minimumFractionLength)"
@@ -16,13 +16,13 @@ public struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equa
             + minimumFractionLengthDescription
     }
 
-    public init(minimumLength: Int, minimumFractionLength: Int?, excludeRanges: [Range<Double>]) {
+    init(minimumLength: Int, minimumFractionLength: Int?, excludeRanges: [Range<Double>]) {
         self.minimumLength = minimumLength
         self.minimumFractionLength = minimumFractionLength
         self.excludeRanges = excludeRanges
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -1,15 +1,15 @@
-public struct ObjectLiteralConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+struct ObjectLiteralConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var imageLiteral = true
     private(set) var colorLiteral = true
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription
             + ", image_literal: \(imageLiteral)"
             + ", color_literal: \(colorLiteral)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -3,16 +3,16 @@ private enum ConfigurationKey: String {
     case allowMultilineFunc = "allow_multiline_func"
 }
 
-public struct OpeningBraceConfiguration: RuleConfiguration, Equatable {
+struct OpeningBraceConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var allowMultilineFunc = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return [severityConfiguration.consoleDescription,
                 "\(ConfigurationKey.allowMultilineFunc): \(allowMultilineFunc)"].joined(separator: ", ")
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -1,17 +1,17 @@
-public struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable {
+struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var linesLookAround = 2
     private(set) var skipAlignedConstants = true
     private(set) var allowedNoSpaceOperators: [String] = ["...", "..<"]
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription
             + ", lines_look_around: \(linesLookAround)"
             + ", skip_aligned_constants: \(skipAlignedConstants)"
             + ", allowed_no_space_operators: \(allowedNoSpaceOperators)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -1,4 +1,4 @@
-public struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatable {
+struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private let defaultIncluded = [
         // NSObject
         "awakeFromNib()",
@@ -34,23 +34,23 @@ public struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, 
         "tearDownWithError()"
     ]
 
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     var excluded: [String] = []
     var included: [String] = ["*"]
 
-    public private(set) var resolvedMethodNames: [String]
+    private(set) var resolvedMethodNames: [String]
 
     init() {
         resolvedMethodNames = defaultIncluded
     }
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", excluded: \(excluded)" +
             ", included: \(included)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrefixedConstantRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrefixedConstantRuleConfiguration.swift
@@ -1,16 +1,16 @@
-public struct PrefixedConstantRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public var severityConfiguration = SeverityConfiguration(.warning)
-    public var onlyPrivateMembers = false
+struct PrefixedConstantRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.warning)
+    var onlyPrivateMembers = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", only_private: \(onlyPrivateMembers)"
     }
 
-    public init(onlyPrivateMembers: Bool) {
+    init(onlyPrivateMembers: Bool) {
         self.onlyPrivateMembers = onlyPrivateMembers
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -1,16 +1,16 @@
-public struct PrivateOutletRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+struct PrivateOutletRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     var allowPrivateSet = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", allow_private_set: \(allowPrivateSet)"
     }
 
-    public init(allowPrivateSet: Bool) {
+    init(allowPrivateSet: Bool) {
         self.allowPrivateSet = allowPrivateSet
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
@@ -1,14 +1,14 @@
-public struct PrivateOverFilePrivateRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public var severityConfiguration = SeverityConfiguration(.warning)
-    public var validateExtensions = false
+struct PrivateOverFilePrivateRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    var severityConfiguration = SeverityConfiguration(.warning)
+    var validateExtensions = false
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", validate_extensions: \(validateExtensions)"
     }
 
     // MARK: - RuleConfiguration
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-public struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, CacheDescriptionProvider {
-    public let identifier: String
-    public var name: String?
-    public var message = "Regex matched."
-    public var regex: NSRegularExpression!
-    public var included: NSRegularExpression?
-    public var severityConfiguration = SeverityConfiguration(.warning)
+struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equatable, CacheDescriptionProvider {
+    let identifier: String
+    var name: String?
+    var message = "Regex matched."
+    var regex: NSRegularExpression!
+    var included: NSRegularExpression?
+    var severityConfiguration = SeverityConfiguration(.warning)
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return "\(severity.rawValue): \(regex.pattern)"
     }
 
-    internal var cacheDescription: String {
+    var cacheDescription: String {
         let jsonObject: [String] = [
             identifier,
             name ?? "",
@@ -28,11 +28,11 @@ public struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration, Equa
         queuedFatalError("Could not serialize private unit test configuration for cache")
     }
 
-    public init(identifier: String) {
+    init(identifier: String) {
         self.identifier = identifier
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -1,5 +1,5 @@
-public struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     var excluded = [String]()
     var included = ["*"]
 
@@ -16,13 +16,13 @@ public struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equa
 
     init() {}
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", excluded: [\(excluded)]" +
             ", included: [\(included)]"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/RequiredEnumCaseRuleConfiguration.swift
@@ -1,4 +1,4 @@
-public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
+struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
     struct RequiredCase: Hashable {
         var name: String
         var severity: ViolationSeverity
@@ -11,7 +11,7 @@ public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
 
     var protocols: [String: Set<RequiredCase>] = [:]
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         let protocols = self.protocols.sorted(by: { $0.key < $1.key }) .compactMap { name, required in
             let caseNames: [String] = required.sorted(by: { $0.name < $1.name }).map {
                 "[name: \"\($0.name)\", severity: \"\($0.severity.rawValue)\"]"
@@ -30,7 +30,7 @@ public struct RequiredEnumCaseRuleConfiguration: RuleConfiguration, Equatable {
         return protocols.isEmpty ? instructions : protocols
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let config = configuration as? [String: [String: String]] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -3,16 +3,16 @@ private enum ConfigurationKey: String {
     case bindIdentifier = "bind_identifier"
 }
 
-public struct SelfBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+struct SelfBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var bindIdentifier = "self"
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return [severityConfiguration.consoleDescription,
                 "\(ConfigurationKey.bindIdentifier): \(bindIdentifier)"].joined(separator: ", ")
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementModeConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/StatementModeConfiguration.swift
@@ -1,4 +1,4 @@
-public enum StatementModeConfiguration: String {
+enum StatementModeConfiguration: String {
     case `default` = "default"
     case uncuddledElse = "uncuddled_else"
 
@@ -12,8 +12,8 @@ public enum StatementModeConfiguration: String {
     }
 }
 
-public struct StatementConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct StatementConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return "(statement_mode) \(statementMode.rawValue), " +
             "(severity) \(severity.consoleDescription)"
     }
@@ -21,13 +21,7 @@ public struct StatementConfiguration: RuleConfiguration, Equatable {
     var statementMode: StatementModeConfiguration
     var severity: SeverityConfiguration
 
-    public init(statementMode: StatementModeConfiguration,
-                severity: SeverityConfiguration) {
-        self.statementMode = statementMode
-        self.severity = severity
-    }
-
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -1,14 +1,14 @@
-public struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
+struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var indentedCases = false
 
     init() {}
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", indented_cases: \(indentedCases)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -1,15 +1,15 @@
-public struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
-    public private(set) var allowedPrefixes: Set<String> = []
-    public private(set) var testParentClasses: Set<String> = ["XCTestCase"]
+struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var allowedPrefixes: Set<String> = []
+    private(set) var testParentClasses: Set<String> = ["XCTestCase"]
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", allowed_prefixes: [\(allowedPrefixes)]" +
             ", test_parent_classes: [\(testParentClasses)]"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
@@ -1,16 +1,16 @@
-public struct TrailingClosureConfiguration: RuleConfiguration, Equatable {
+struct TrailingClosureConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var onlySingleMutedParameter: Bool
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", only_single_muted_parameter: \(onlySingleMutedParameter)"
     }
 
-    public init(onlySingleMutedParameter: Bool = false) {
+    init(onlySingleMutedParameter: Bool = false) {
         self.onlySingleMutedParameter = onlySingleMutedParameter
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -1,16 +1,16 @@
-public struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
-    public private(set) var mandatoryComma: Bool
+struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var mandatoryComma: Bool
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", mandatory_comma: \(mandatoryComma)"
     }
 
-    public init(mandatoryComma: Bool = false) {
+    init(mandatoryComma: Bool = false) {
         self.mandatoryComma = mandatoryComma
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -1,20 +1,20 @@
-public struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
+struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.warning)
     var ignoresEmptyLines = false
     var ignoresComments = true
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", ignores_empty_lines: \(ignoresEmptyLines)" +
             ", ignores_comments: \(ignoresComments)"
     }
 
-    public init(ignoresEmptyLines: Bool, ignoresComments: Bool) {
+    init(ignoresEmptyLines: Bool, ignoresComments: Bool) {
         self.ignoresEmptyLines = ignoresEmptyLines
         self.ignoresComments = ignoresComments
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -16,7 +16,7 @@ enum TypeContent: String {
     case deinitializer = "deinitializer"
 }
 
-public struct TypeContentsOrderConfiguration: RuleConfiguration, Equatable {
+struct TypeContentsOrderConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var order: [[TypeContent]] = [
         [.case],
@@ -35,12 +35,12 @@ public struct TypeContentsOrderConfiguration: RuleConfiguration, Equatable {
         [.deinitializer]
     ]
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription +
             ", order: \(String(describing: order))"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeNameRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeNameRuleConfiguration.swift
@@ -1,15 +1,15 @@
-public struct TypeNameRuleConfiguration: RuleConfiguration, Equatable {
+struct TypeNameRuleConfiguration: RuleConfiguration, Equatable {
     private(set) var nameConfiguration = NameConfiguration(minLengthWarning: 3,
                                                            minLengthError: 0,
                                                            maxLengthWarning: 40,
                                                            maxLengthError: 1000)
     private(set) var validateProtocols = true
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return nameConfiguration.consoleDescription + ", validate_protocols: \(validateProtocols)"
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -4,24 +4,24 @@ private enum ConfigurationKey: String {
     case relatedUSRsToSkip = "related_usrs_to_skip"
 }
 
-public struct UnusedDeclarationConfiguration: RuleConfiguration, Equatable {
+struct UnusedDeclarationConfiguration: RuleConfiguration, Equatable {
     private(set) var includePublicAndOpen: Bool
     private(set) var severityConfiguration: SeverityConfiguration
     private(set) var relatedUSRsToSkip: Set<String>
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return "\(ConfigurationKey.severity.rawValue): \(severityConfiguration.severity.rawValue), " +
             "\(ConfigurationKey.includePublicAndOpen.rawValue): \(includePublicAndOpen), " +
             "\(ConfigurationKey.relatedUSRsToSkip.rawValue): \(relatedUSRsToSkip.sorted())"
     }
 
-    public init(severity: ViolationSeverity, includePublicAndOpen: Bool, relatedUSRsToSkip: Set<String>) {
+    init(severity: ViolationSeverity, includePublicAndOpen: Bool, relatedUSRsToSkip: Set<String>) {
         self.includePublicAndOpen = includePublicAndOpen
         self.severityConfiguration = SeverityConfiguration(severity)
         self.relatedUSRsToSkip = relatedUSRsToSkip
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configDict = configuration as? [String: Any], configDict.isNotEmpty else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -1,10 +1,10 @@
 /// The configuration payload mapping an imported module to a set of modules that are allowed to be
 /// transitively imported.
-public struct TransitiveModuleConfiguration: Equatable {
+struct TransitiveModuleConfiguration: Equatable {
     /// The module imported in a source file.
-    public let importedModule: String
+    let importedModule: String
     /// The set of modules that can be transitively imported by `importedModule`.
-    public let transitivelyImportedModules: [String]
+    let transitivelyImportedModules: [String]
 
     init(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any],
@@ -19,8 +19,8 @@ public struct TransitiveModuleConfiguration: Equatable {
     }
 }
 
-public struct UnusedImportConfiguration: RuleConfiguration, Equatable {
-    public var consoleDescription: String {
+struct UnusedImportConfiguration: RuleConfiguration, Equatable {
+    var consoleDescription: String {
         return [
             "severity: \(severity.consoleDescription)",
             "require_explicit_imports: \(requireExplicitImports)",
@@ -29,22 +29,22 @@ public struct UnusedImportConfiguration: RuleConfiguration, Equatable {
         ].joined(separator: ", ")
     }
 
-    public private(set) var severity: SeverityConfiguration
-    public private(set) var requireExplicitImports: Bool
-    public private(set) var allowedTransitiveImports: [TransitiveModuleConfiguration]
+    private(set) var severity: SeverityConfiguration
+    private(set) var requireExplicitImports: Bool
+    private(set) var allowedTransitiveImports: [TransitiveModuleConfiguration]
     /// A set of modules to never remove the imports of.
-    public private(set) var alwaysKeepImports: [String]
+    private(set) var alwaysKeepImports: [String]
 
-    public init(severity: ViolationSeverity, requireExplicitImports: Bool,
-                allowedTransitiveImports: [TransitiveModuleConfiguration],
-                alwaysKeepImports: [String]) {
+    init(severity: ViolationSeverity, requireExplicitImports: Bool,
+         allowedTransitiveImports: [TransitiveModuleConfiguration],
+         alwaysKeepImports: [String]) {
         self.severity = SeverityConfiguration(severity)
         self.requireExplicitImports = requireExplicitImports
         self.allowedTransitiveImports = allowedTransitiveImports
         self.alwaysKeepImports = alwaysKeepImports
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -1,16 +1,16 @@
-public struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
-    public private(set) var severityConfiguration = SeverityConfiguration(.warning)
-    public private(set) var ignoreOptionalTry: Bool
+struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var ignoreOptionalTry: Bool
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", ignore_optional_try: \(ignoreOptionalTry)"
     }
 
-    public init(ignoreOptionalTry: Bool) {
+    init(ignoreOptionalTry: Bool) {
         self.ignoreOptionalTry = ignoreOptionalTry
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -1,16 +1,16 @@
-public struct VerticalWhitespaceConfiguration: RuleConfiguration, Equatable {
+struct VerticalWhitespaceConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration = SeverityConfiguration(.warning)
     private(set) var maxEmptyLines: Int
 
-    public var consoleDescription: String {
+    var consoleDescription: String {
         return severityConfiguration.consoleDescription + ", max_empty_lines: \(maxEmptyLines)"
     }
 
-    public init(maxEmptyLines: Int) {
+    init(maxEmptyLines: Int) {
         self.maxEmptyLines = maxEmptyLines
     }
 
-    public mutating func apply(configuration: Any) throws {
+    mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
         }

--- a/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/AttributesRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = AttributesConfiguration()
+struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = AttributesConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "attributes",
         name: "Attributes",
         description: """
@@ -17,7 +17,7 @@ public struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderR
         triggeringExamples: AttributesRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(
             locationConverter: file.locationConverter,
             configuration: configuration

--- a/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosingBraceRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ClosingBraceRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ClosingBraceRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "closing_brace",
         name: "Closing Brace Spacing",
         description: "Closing brace with closing parenthesis should not have any whitespaces in the middle.",
@@ -23,11 +23,11 @@ public struct ClosingBraceRule: SwiftSyntaxCorrectableRule, ConfigurationProvide
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureEndIndentationRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "closure_end_indentation",
         name: "Closure End Indentation",
         description: "Closure end should have the same indentation as the line that started it.",
@@ -18,7 +18,7 @@ public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderR
 
     fileprivate static let notWhitespace = regex("[^\\s]")
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violations(in: file).map { violation in
             return styleViolation(for: violation, in: file)
         }
@@ -37,7 +37,7 @@ public struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderR
 }
 
 extension ClosureEndIndentationRule: CorrectableRule {
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let allViolations = violations(in: file).reversed().filter { violation in
             guard let nsRange = file.stringView.byteRangeToNSRange(violation.range) else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureParameterPositionRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ClosureParameterPositionRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ClosureParameterPositionRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "closure_parameter_position",
         name: "Closure Parameter Position",
         description: "Closure parameters should be on the same line as opening brace.",
@@ -96,7 +96,7 @@ public struct ClosureParameterPositionRule: SwiftSyntaxRule, ConfigurationProvid
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(locationConverter: file.locationConverter)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ClosureSpacingRule.swift
@@ -2,12 +2,12 @@ import SwiftSyntax
 
 // MARK: - ClosureSpacingRule
 
-public struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "closure_spacing",
         name: "Closure Spacing",
         description: "Closure expressions should have a single space inside each brace.",
@@ -38,11 +38,11 @@ public struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, ConfigurationProvi
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         ClosureSpacingRuleVisitor(locationConverter: file.locationConverter)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         ClosureSpacingRuleRewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CollectionAlignmentRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct CollectionAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = CollectionAlignmentConfiguration()
+struct CollectionAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = CollectionAlignmentConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "collection_alignment",
         name: "Collection Element Alignment",
         description: "All elements in a collection literal should be vertically aligned",
@@ -14,7 +14,7 @@ public struct CollectionAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRul
         triggeringExamples: Examples(alignColons: false).triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(alignColons: configuration.alignColons, locationConverter: file.locationConverter)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ColonRule.swift
@@ -2,12 +2,12 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = ColonConfiguration()
+struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+    var configuration = ColonConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "colon",
         name: "Colon Spacing",
         description: """
@@ -19,7 +19,7 @@ public struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
         corrections: ColonRuleExamples.corrections
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         violationRanges(in: file).map { range in
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
@@ -27,7 +27,7 @@ public struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
         }
     }
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let syntaxTree = file.syntaxTree
         let visitor = ColonRuleVisitor(viewMode: .sourceAccurate)
         visitor.walk(syntaxTree)
@@ -86,7 +86,7 @@ public struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule,
             }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         (violationRange, ": ")
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/CommaInheritanceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaInheritanceRule.swift
@@ -2,13 +2,13 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule,
+struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule,
                                     SourceKitFreeRule {
-    public var configuration = SeverityConfiguration(.warning)
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "comma_inheritance",
         name: "Comma Inheritance Rule",
         description: "Use commas to separate types in inheritance lists",
@@ -62,7 +62,7 @@ public struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, Conf
 
     // MARK: - Rule
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
@@ -72,11 +72,11 @@ public struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, Conf
 
     // MARK: - SubstitutionCorrectableRule
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, ", ")
     }
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let visitor = CommaInheritanceRuleVisitor(viewMode: .sourceAccurate)
         return visitor.walk(file: file) { visitor -> [ByteRange] in
             visitor.violationRanges

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -2,12 +2,12 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "comma",
         name: "Comma Spacing",
         description: "There should be no space before and one after any comma.",
@@ -87,7 +87,7 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFr
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
@@ -116,7 +116,7 @@ public struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFr
             }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let initialNSRanges = Dictionary(
             uniqueKeysWithValues: violationRanges(in: file)
                 .compactMap { byteRange, shouldAddSpace in

--- a/Source/SwiftLintFramework/Rules/Style/ComputedAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ComputedAccessorsOrderRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ComputedAccessorsOrderRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = ComputedAccessorsOrderRuleConfiguration()
+struct ComputedAccessorsOrderRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = ComputedAccessorsOrderRuleConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "computed_accessors_order",
         name: "Computed Accessors Order",
         description: "Getter and setters in computed properties and subscripts should be in a consistent order.",
@@ -14,7 +14,7 @@ public struct ComputedAccessorsOrderRule: ConfigurationProviderRule, SwiftSyntax
         triggeringExamples: ComputedAccessorsOrderRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         ComputedAccessorsOrderRuleVisitor(expectedOrder: configuration.order)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
-    public var configuration = ConditionalReturnsOnNewlineConfiguration()
+struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+    var configuration = ConditionalReturnsOnNewlineConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "conditional_returns_on_newline",
         name: "Conditional Returns on Newline",
         description: "Conditional statements should always return on the next line",
@@ -34,7 +34,7 @@ public struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, OptInR
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(
             ifOnly: configuration.ifOnly,
             locationConverter: file.locationConverter

--- a/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ControlStatementRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ControlStatementRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ControlStatementRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "control_statement",
         name: "Control Statement",
         description:
@@ -80,7 +80,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, SubstitutionCorre
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map { match -> StyleViolation in
             return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,
@@ -88,7 +88,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, SubstitutionCorre
         }
     }
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let statements = ["if", "for", "guard", "switch", "while", "catch"]
         let statementPatterns: [String] = statements.map { statement -> String in
             let isGuard = statement == "guard"
@@ -116,7 +116,7 @@ public struct ControlStatementRule: ConfigurationProviderRule, SubstitutionCorre
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         var violationString = file.stringView.substring(with: violationRange)
         if violationString.contains("(") && violationString.contains(")") {
             if let openingIndex = violationString.firstIndex(of: "(") {

--- a/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -23,12 +23,12 @@ private func wrapInFunc(_ str: String, file: StaticString = #file, line: UInt = 
     """, file: file, line: line)
 }
 
-public struct EmptyEnumArgumentsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct EmptyEnumArgumentsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "empty_enum_arguments",
         name: "Empty Enum Arguments",
         description: "Arguments can be omitted when matching enums with associated values if they are not used.",
@@ -107,11 +107,11 @@ public struct EmptyEnumArgumentsRule: SwiftSyntaxCorrectableRule, ConfigurationP
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParametersRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct EmptyParametersRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct EmptyParametersRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "empty_parameters",
         name: "Empty Parameters",
         description: "Prefer `() -> ` over `Void -> `.",
@@ -33,11 +33,11 @@ public struct EmptyParametersRule: SwiftSyntaxCorrectableRule, ConfigurationProv
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct EmptyParenthesesWithTrailingClosureRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct EmptyParenthesesWithTrailingClosureRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "empty_parentheses_with_trailing_closure",
         name: "Empty Parentheses with Trailing Closure",
         description: "When using trailing closures, empty parentheses should be avoided " +
@@ -46,11 +46,11 @@ public struct EmptyParenthesesWithTrailingClosureRule: SwiftSyntaxCorrectableRul
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "explicit_self",
         name: "Explicit Self",
         description: "Instance variables and functions should be explicitly accessed with 'self.'.",
@@ -17,7 +17,7 @@ public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, Anal
         requiresFileOnDisk: true
     )
 
-    public func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
         return violationRanges(in: file, compilerArguments: compilerArguments).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
@@ -25,7 +25,7 @@ public struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, Anal
         }
     }
 
-    public func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
+    func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
         let violations = violationRanges(in: file, compilerArguments: compilerArguments)
         let matches = file.ruleEnabled(violatingRanges: violations, for: self)
         if matches.isEmpty { return [] }

--- a/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileHeaderRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
-    public var configuration = FileHeaderConfiguration()
+struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
+    var configuration = FileHeaderConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "file_header",
         name: "File Header",
         description: "Header comments should be consistent with project patterns. " +
@@ -35,7 +35,7 @@ public struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
 
     private static let reason = "Header comments should be consistent with project patterns."
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         var firstToken: SwiftLintSyntaxToken?
         var lastToken: SwiftLintSyntaxToken?
         var firstNonCommentToken: SwiftLintSyntaxToken?

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -1,14 +1,14 @@
 import Foundation
 import SourceKittenFramework
 
-public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
+struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
     private typealias FileTypeOffset = (fileType: FileType, offset: ByteCount)
 
-    public var configuration = FileTypesOrderConfiguration()
+    var configuration = FileTypesOrderConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "file_types_order",
         name: "File Types Order",
         description: "Specifies how the types within a file should be ordered.",
@@ -18,7 +18,7 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
     )
 
     // swiftlint:disable:next function_body_length
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         guard let mainTypeSubstructure = mainTypeSubstructure(in: file),
               let mainTypeSubstuctureOffset = mainTypeSubstructure.offset else { return [] }
 

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -1,16 +1,16 @@
 import Foundation
 import SourceKittenFramework
 
-public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
-    public var configuration = NameConfiguration(minLengthWarning: 3,
-                                                 minLengthError: 2,
-                                                 maxLengthWarning: 40,
-                                                 maxLengthError: 60,
-                                                 excluded: ["id"])
+struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
+    var configuration = NameConfiguration(minLengthWarning: 3,
+                                          minLengthError: 2,
+                                          maxLengthWarning: 40,
+                                          maxLengthError: 60,
+                                          excluded: ["id"])
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "identifier_name",
         name: "Identifier Name",
         description: "Identifier names should only contain alphanumeric characters and " +
@@ -25,7 +25,7 @@ public struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
     )
 
     // swiftlint:disable:next function_body_length
-    public func validate(
+    func validate(
         file: SwiftLintFile,
         kind: SwiftDeclarationKind,
         dictionary: SourceKittenDictionary

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitGetterRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ImplicitGetterRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ImplicitGetterRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "implicit_getter",
         name: "Implicit Getter",
         description: "Computed read-only properties and subscripts should avoid using the get keyword.",
@@ -14,7 +14,7 @@ public struct ImplicitGetterRule: ConfigurationProviderRule, SwiftSyntaxRule {
         triggeringExamples: ImplicitGetterRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         ImplicitGetterRuleVisitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ImplicitReturnRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule, OptInRule {
-    public var configuration = ImplicitReturnConfiguration()
+struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule, OptInRule {
+    var configuration = ImplicitReturnConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "implicit_return",
         name: "Implicit Return",
         description: "Prefer implicit returns in closures, functions and getters.",
@@ -16,7 +16,7 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
         corrections: ImplicitReturnRuleExamples.corrections
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).compactMap {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
@@ -24,11 +24,11 @@ public struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrect
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "")
     }
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let pattern = "(?:\\bin|\\{)\\s+(return\\s+)"
         let contents = file.stringView
 

--- a/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct InclusiveLanguageRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = InclusiveLanguageConfiguration()
+struct InclusiveLanguageRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = InclusiveLanguageConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "inclusive_language",
         name: "Inclusive Language",
         description: """
@@ -17,7 +17,7 @@ public struct InclusiveLanguageRule: SwiftSyntaxRule, ConfigurationProviderRule 
         triggeringExamples: InclusiveLanguageRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(allTerms: configuration.allTerms, allAllowedTerms: configuration.allAllowedTerms)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/InclusiveLanguageRuleExamples.swift
@@ -44,7 +44,7 @@ internal struct InclusiveLanguageRuleExamples {
 
     static let nonTriggeringExamplesWithConfig: [Example] = [
         Example("""
-        public let blackList = [
+        let blackList = [
             "foo", "bar"
         ]
         """, configuration: [

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
+struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
     // MARK: - Subtypes
     private enum Indentation: Equatable {
         case tabs(Int)
@@ -16,13 +16,13 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
     }
 
     // MARK: - Properties
-    public var configuration = IndentationWidthConfiguration(
+    var configuration = IndentationWidthConfiguration(
         severity: .warning,
         indentationWidth: 4,
         includeComments: true,
         includeCompilerDirectives: true
     )
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "indentation_width",
         name: "Indentation Width",
         description: "Indent code using either one tab or the configured amount of spaces, " +
@@ -44,10 +44,10 @@ public struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
     )
 
     // MARK: - Initializers
-    public init() {}
+    init() {}
 
     // MARK: - Methods: Validation
-    public func validate(file: SwiftLintFile) -> [StyleViolation] { // swiftlint:disable:this function_body_length
+    func validate(file: SwiftLintFile) -> [StyleViolation] { // swiftlint:disable:this function_body_length
         var violations: [StyleViolation] = []
         var previousLineIndentations: [Indentation] = []
 

--- a/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LeadingWhitespaceRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "leading_whitespace",
         name: "Leading Whitespace",
         description: "Files should not contain leading whitespace.",
@@ -23,7 +23,7 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let countOfLeadingWhitespace = file.contents.countOfLeadingCharacters(in: .whitespacesAndNewlines)
         if countOfLeadingWhitespace == 0 {
             return []
@@ -38,7 +38,7 @@ public struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule,
                                reason: reason)]
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let whitespaceAndNewline = CharacterSet.whitespacesAndNewlines
         let spaceCount = file.contents.countOfLeadingCharacters(in: whitespaceAndNewline)
         guard spaceCount > 0,

--- a/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LetVarWhitespaceRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "let_var_whitespace",
         name: "Variable Declaration Whitespace",
         description: "Let and var should be separated from other statements by a blank line.",
@@ -62,7 +62,7 @@ public struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule {
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let dict = file.structureDictionary
 
         var attributeLines = attributeLineNumbers(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/LiteralExpressionEndIdentationRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "literal_expression_end_indentation",
         name: "Literal Expression End Indentation",
         description: "Array and dictionary literal end should have the same indentation as the line that started it.",
@@ -123,7 +123,7 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violations(in: file).map { violation in
             return styleViolation(for: violation, in: file)
         }
@@ -144,7 +144,7 @@ public struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRul
 }
 
 extension LiteralExpressionEndIdentationRule: CorrectableRule {
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let allViolations = violations(in: file).reversed().filter { violation in
             guard let nsRange = file.stringView.byteRangeToNSRange(violation.range) else {
                 return false

--- a/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ModifierOrderRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, CorrectableRule {
-    public var configuration = ModifierOrderConfiguration(
+struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, CorrectableRule {
+    var configuration = ModifierOrderConfiguration(
         preferredModifierOrder: [
             .override,
             .acl,
@@ -18,9 +18,9 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         ]
     )
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "modifier_order",
         name: "Modifier Order",
         description: "Modifier order should be consistent.",
@@ -29,9 +29,9 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         triggeringExamples: ModifierOrderRuleExamples.triggeringExamples
     )
 
-    public func validate(file: SwiftLintFile,
-                         kind: SwiftDeclarationKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile,
+                  kind: SwiftDeclarationKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard let offset = dictionary.offset else {
             return []
         }
@@ -55,7 +55,7 @@ public struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, 
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         return file.structureDictionary.traverseDepthFirst { subDict in
             guard let kind = subDict.declarationKind else { return nil }
             return correct(file: file, kind: kind, dictionary: subDict)

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct MultilineArgumentsBracketsRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct MultilineArgumentsBracketsRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "multiline_arguments_brackets",
         name: "Multiline Arguments Brackets",
         description: "Multiline arguments should have their surrounding brackets in a new line.",
@@ -158,7 +158,7 @@ public struct MultilineArgumentsBracketsRule: SwiftSyntaxRule, OptInRule, Config
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineArgumentsRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = MultilineArgumentsConfiguration()
+struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    var configuration = MultilineArgumentsConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "multiline_arguments",
         name: "Multiline Arguments",
         description: "Arguments should be either on the same line, or one per line.",
@@ -15,9 +15,9 @@ public struct MultilineArgumentsRule: ASTRule, OptInRule, ConfigurationProviderR
         triggeringExamples: MultilineArgumentsRuleExamples.triggeringExamples
     )
 
-    public func validate(file: SwiftLintFile,
-                         kind: SwiftExpressionKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile,
+                  kind: SwiftExpressionKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             kind == .call,
             case let arguments = dictionary.enclosedArguments,

--- a/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineFunctionChainsRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "multiline_function_chains",
         name: "Multiline Function Chains",
         description: "Chained function calls should be either on the same line, or one per line.",
@@ -94,9 +94,9 @@ public struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProv
         ]
     )
 
-    public func validate(file: SwiftLintFile,
-                         kind: SwiftExpressionKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile,
+                  kind: SwiftExpressionKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         return violatingOffsets(file: file, kind: kind, dictionary: dictionary).map { offset in
             return StyleViolation(ruleDescription: Self.description,
                                   severity: configuration.severity,

--- a/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "multiline_literal_brackets",
         name: "Multiline Literal Brackets",
         description: "Multiline literals should have their surrounding brackets in a new line.",
@@ -103,9 +103,9 @@ public struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationPro
         ]
     )
 
-    public func validate(file: SwiftLintFile,
-                         kind: SwiftExpressionKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile,
+                  kind: SwiftExpressionKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard
             [.array, .dictionary].contains(kind),
             let bodyByteRange = dictionary.bodyByteRange,

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersBracketsRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "multiline_parameters_brackets",
         name: "Multiline Parameters Brackets",
         description: "Multiline parameters should have their surrounding brackets in a new line.",
@@ -92,7 +92,7 @@ public struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderR
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violations(in: file.structureDictionary, file: file)
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultilineParametersRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct MultilineParametersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = MultilineParametersConfiguration()
+struct MultilineParametersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = MultilineParametersConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "multiline_parameters",
         name: "Multiline Parameters",
         description: "Functions and methods parameters should be either on the same line, or one per line.",
@@ -14,7 +14,7 @@ public struct MultilineParametersRule: SwiftSyntaxRule, OptInRule, Configuration
         triggeringExamples: MultilineParametersRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(allowsSingleLine: configuration.allowsSingleLine, locationConverter: file.locationConverter)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct MultipleClosuresWithTrailingClosureRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct MultipleClosuresWithTrailingClosureRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "multiple_closures_with_trailing_closure",
         name: "Multiple Closures with Trailing Closure",
         description: "Trailing closure syntax should not be used when passing more than one closure argument.",
@@ -37,7 +37,7 @@ public struct MultipleClosuresWithTrailingClosureRule: SwiftSyntaxRule, Configur
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct NoSpaceInMethodCallRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct NoSpaceInMethodCallRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "no_space_in_method_call",
         name: "No Space in Method Call",
         description: "Don't add a space between the method name and the parentheses.",
@@ -45,11 +45,11 @@ public struct NoSpaceInMethodCallRule: SwiftSyntaxCorrectableRule, Configuration
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -1,16 +1,16 @@
 import Foundation
 import SwiftSyntax
 
-public struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = NumberSeparatorConfiguration(
+struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = NumberSeparatorConfiguration(
         minimumLength: 0,
         minimumFractionLength: nil,
         excludeRanges: []
     )
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "number_separator",
         name: "Number Separator",
         description: "Underscores should be used as thousand separator in large decimal numbers.",
@@ -20,11 +20,11 @@ public struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule, Config
         corrections: NumberSeparatorRuleExamples.corrections
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(configuration: configuration)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             configuration: configuration,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -61,12 +61,12 @@ private extension SwiftLintFile {
     }
 }
 
-public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
-    public var configuration = OpeningBraceConfiguration()
+struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
+    var configuration = OpeningBraceConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "opening_brace",
         name: "Opening Brace Spacing",
         description: "Opening braces should be preceded by a single space and on the same line " +
@@ -162,7 +162,7 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return file.violatingOpeningBraceRanges(allowMultilineFunc: configuration.allowMultilineFunc).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
@@ -170,7 +170,7 @@ public struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.violatingOpeningBraceRanges(allowMultilineFunc: configuration.allowMultilineFunc)
             .filter {
                 file.ruleEnabled(violatingRanges: [$0.range], for: self).isNotEmpty

--- a/Source/SwiftLintFramework/Rules/Style/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorFunctionWhitespaceRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "operator_whitespace",
         name: "Operator Function Whitespace",
         description: "Operators should be surrounded by a single whitespace when defining them.",
@@ -25,7 +25,7 @@ public struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule, SwiftSy
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -2,12 +2,12 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = OperatorUsageWhitespaceConfiguration()
+struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+    var configuration = OperatorUsageWhitespaceConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "operator_usage_whitespace",
         name: "Operator Usage Whitespace",
         description: "Operators should be surrounded by a single whitespace when they are being used.",
@@ -17,7 +17,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         corrections: OperatorUsageWhitespaceRuleExamples.corrections
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(file: file).map { range, _ in
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
@@ -37,7 +37,7 @@ public struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, Configura
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = violationRanges(file: file)
             .compactMap { byteRange, correction -> (NSRange, String)? in
                 guard let range = file.stringView.byteRangeToNSRange(byteRange) else {

--- a/Source/SwiftLintFramework/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct OptionalEnumCaseMatchingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct OptionalEnumCaseMatchingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "optional_enum_case_matching",
         name: "Optional Enum Case Match",
         description: "Matching an enum case against an optional enum without '?' is supported on Swift 5.1 and above.",
@@ -155,11 +155,11 @@ public struct OptionalEnumCaseMatchingRule: SwiftSyntaxCorrectableRule, Configur
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct PreferSelfInStaticReferencesRule: SwiftSyntaxRule, CorrectableRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct PreferSelfInStaticReferencesRule: SwiftSyntaxRule, CorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static var description = RuleDescription(
+    static var description = RuleDescription(
         identifier: "prefer_self_in_static_references",
         name: "Prefer Self in Static References",
         description: "Use `Self` to refer to the surrounding type name.",
@@ -166,11 +166,11 @@ public struct PreferSelfInStaticReferencesRule: SwiftSyntaxRule, CorrectableRule
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let ranges = Visitor(viewMode: .sourceAccurate)
             .walk(file: file, handler: \.corrections)
             .compactMap { file.stringView.NSRange(start: $0.start, end: $0.end) }

--- a/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -1,9 +1,9 @@
 import SwiftSyntax
 
-public struct PreferSelfTypeOverTypeOfSelfRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct PreferSelfTypeOverTypeOfSelfRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "prefer_self_type_over_type_of_self",
         name: "Prefer Self Type Over Type of Self",
         description: "Prefer `Self` over `type(of: self)` when accessing properties or calling methods.",
@@ -105,13 +105,13 @@ public struct PreferSelfTypeOverTypeOfSelfRule: SwiftSyntaxCorrectableRule, OptI
         ]
     )
 
-    public init() {}
+    init() {}
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = PrefixedConstantRuleConfiguration(onlyPrivateMembers: false)
+struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration = PrefixedConstantRuleConfiguration(onlyPrivateMembers: false)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "prefixed_toplevel_constant",
         name: "Prefixed Top-Level Constant",
         description: "Top-level constants should be prefixed by `k`.",
@@ -69,7 +69,7 @@ public struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule, Configur
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(onlyPrivateMembers: configuration.onlyPrivateMembers)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "protocol_property_accessors_order",
         name: "Protocol Property Accessors Order",
         description: "When declaring properties in protocols, the order of accessors should be `get set`.",
@@ -24,11 +24,11 @@ public struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, Swi
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/RedundantDiscardableLetRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct RedundantDiscardableLetRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct RedundantDiscardableLetRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "redundant_discardable_let",
         name: "Redundant Discardable Let",
         description: "Prefer `_ = foo()` over `let _ = foo()` when discarding a result from a function.",
@@ -28,11 +28,11 @@ public struct RedundantDiscardableLetRule: SwiftSyntaxCorrectableRule, Configura
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SwiftSyntax
 
-public struct ReturnArrowWhitespaceRule: SwiftSyntaxRule, CorrectableRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct ReturnArrowWhitespaceRule: SwiftSyntaxRule, CorrectableRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "return_arrow_whitespace",
         name: "Returning Whitespace",
         description: "Return arrow and return type should be separated by a single space or on a " +
@@ -55,11 +55,11 @@ public struct ReturnArrowWhitespaceRule: SwiftSyntaxRule, CorrectableRule, Confi
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let violations = Visitor(viewMode: .sourceAccurate)
             .walk(file: file, handler: \.corrections)
             .compactMap { violation in

--- a/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SelfBindingRule.swift
@@ -2,12 +2,12 @@ import SwiftSyntax
 
 // MARK: - SelfBindingRule
 
-public struct SelfBindingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SelfBindingConfiguration()
+struct SelfBindingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SelfBindingConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "self_binding",
         name: "Self Binding",
         description: "Re-bind `self` to a consistent identifier name.",
@@ -48,11 +48,11 @@ public struct SelfBindingRule: SwiftSyntaxCorrectableRule, ConfigurationProvider
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         SelfBindingRuleVisitor(bindIdentifier: configuration.bindIdentifier)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         SelfBindingRuleRewriter(
             bindIdentifier: configuration.bindIdentifier,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ShorthandOperatorRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct ShorthandOperatorRule: ConfigurationProviderRule, SwiftSyntaxRule {
-    public var configuration = SeverityConfiguration(.error)
+struct ShorthandOperatorRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration(.error)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "shorthand_operator",
         name: "Shorthand Operator",
         description: "Prefer shorthand operators (+=, -=, *=, /=) over doing the operation and assigning.",
@@ -42,11 +42,11 @@ public struct ShorthandOperatorRule: ConfigurationProviderRule, SwiftSyntaxRule 
 
     fileprivate static let allOperators = ["-", "/", "+", "*"]
 
-    public func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
+    func preprocess(syntaxTree: SourceFileSyntax) -> SourceFileSyntax? {
         syntaxTree.folded()
     }
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SingleTestClassRule.swift
@@ -1,9 +1,9 @@
 import SwiftSyntax
 
-public struct SingleTestClassRule: SourceKitFreeRule, OptInRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct SingleTestClassRule: SourceKitFreeRule, OptInRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "single_test_class",
         name: "Single Test Class",
         description: "Test files should contain a single QuickSpec or XCTestCase class.",
@@ -49,9 +49,9 @@ public struct SingleTestClassRule: SourceKitFreeRule, OptInRule, ConfigurationPr
         ]
     )
 
-    public init() {}
+    init() {}
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let classes = TestClassVisitor(viewMode: .sourceAccurate)
             .walk(tree: file.syntaxTree, handler: \.violations)
 

--- a/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SortedImportsRule.swift
@@ -46,12 +46,12 @@ private extension Sequence where Element == Line {
     }
 }
 
-public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "sorted_imports",
         name: "Sorted Imports",
         description: "Imports should be sorted.",
@@ -133,7 +133,7 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let groups = importGroups(in: file, filterEnabled: false)
         return violatingOffsets(inGroups: groups).map { index -> StyleViolation in
             let location = Location(file: file, characterOffset: index)
@@ -175,7 +175,7 @@ public struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, Opt
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let groups = importGroups(in: file, filterEnabled: true)
 
         let corrections = violatingOffsets(inGroups: groups).map { characterOffset -> Correction in

--- a/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift
@@ -1,13 +1,13 @@
 import Foundation
 import SourceKittenFramework
 
-public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule {
-    public var configuration = StatementConfiguration(statementMode: .default,
-                                                      severity: SeverityConfiguration(.warning))
+struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule {
+    var configuration = StatementConfiguration(statementMode: .default,
+                                               severity: SeverityConfiguration(.warning))
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "statement_position",
         name: "Statement Position",
         description: "Else and catch should be on the same line, one space after the previous " +
@@ -34,7 +34,7 @@ public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule 
         ]
     )
 
-    public static let uncuddledDescription = RuleDescription(
+    static let uncuddledDescription = RuleDescription(
         identifier: "statement_position",
         name: "Statement Position",
         description: "Else and catch should be on the next line, with equal indentation to the " +
@@ -64,7 +64,7 @@ public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule 
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         switch configuration.statementMode {
         case .default:
             return defaultValidate(file: file)
@@ -73,7 +73,7 @@ public struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule 
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         switch configuration.statementMode {
         case .default:
             return defaultCorrect(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct SwitchCaseAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SwitchCaseAlignmentConfiguration()
+struct SwitchCaseAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SwitchCaseAlignmentConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "switch_case_alignment",
         name: "Switch and Case Statement Alignment",
         description: """
@@ -40,7 +40,7 @@ public struct SwitchCaseAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRul
         triggeringExamples: Examples(indentedCases: false).triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(locationConverter: file.locationConverter, indentedCases: configuration.indentedCases)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -8,12 +8,12 @@ private func wrapInSwitch(_ str: String, file: StaticString = #file, line: UInt 
     """, file: file, line: line)
 }
 
-public struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "switch_case_on_newline",
         name: "Switch Case on Newline",
         description: "Cases inside a switch should always be on a newline",
@@ -62,7 +62,7 @@ public struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, ConfigurationProviderRul
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(locationConverter: file.locationConverter)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingClosureRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
-    public var configuration = TrailingClosureConfiguration()
+struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
+    var configuration = TrailingClosureConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "trailing_closure",
         name: "Trailing Closure",
         description: "Trailing closure syntax should be used whenever possible.",
@@ -30,7 +30,7 @@ public struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let dict = file.structureDictionary
         return violationOffsets(for: dict, file: file).map {
             StyleViolation(ruleDescription: Self.description,

--- a/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingCommaRule.swift
@@ -1,9 +1,9 @@
 import SwiftSyntax
 
-public struct TrailingCommaRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
-    public var configuration = TrailingCommaConfiguration()
+struct TrailingCommaRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+    var configuration = TrailingCommaConfiguration()
 
-    public init() {}
+    init() {}
 
     private static let triggeringExamples: [Example] = [
         Example("let foo = [1, 2, 3↓,]\n"),
@@ -30,7 +30,7 @@ public struct TrailingCommaRule: SwiftSyntaxCorrectableRule, ConfigurationProvid
         return result
     }()
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "trailing_comma",
         name: "Trailing Comma",
         description: "Trailing commas in arrays and dictionaries should be avoided/enforced.",
@@ -49,14 +49,14 @@ public struct TrailingCommaRule: SwiftSyntaxCorrectableRule, ConfigurationProvid
         corrections: Self.corrections
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(
             mandatoryComma: configuration.mandatoryComma,
             locationConverter: file.locationConverter
         )
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             mandatoryComma: configuration.mandatoryComma,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintFramework/Rules/Style/TrailingNewlineRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingNewlineRule.swift
@@ -18,12 +18,12 @@ extension String {
     }
 }
 
-public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "trailing_newline",
         name: "Trailing Newline",
         description: "Files should have a single trailing newline.",
@@ -42,7 +42,7 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, S
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         if file.contents.trailingNewlineCount() == 1 {
             return []
         }
@@ -51,7 +51,7 @@ public struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, S
                                location: Location(file: file.path, line: max(file.lines.count, 1)))]
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         guard let count = file.contents.trailingNewlineCount(), count != 1 else {
             return []
         }

--- a/Source/SwiftLintFramework/Rules/Style/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TrailingWhitespaceRule.swift
@@ -1,13 +1,13 @@
 import Foundation
 import SourceKittenFramework
 
-public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
-    public var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
-                                                               ignoresComments: true)
+struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
+    var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
+                                                        ignoresComments: true)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "trailing_whitespace",
         name: "Trailing Whitespace",
         description: "Lines should not have trailing whitespace.",
@@ -25,7 +25,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let filteredLines = file.lines.filter {
             guard $0.content.hasTrailingWhitespace() else { return false }
 
@@ -48,7 +48,7 @@ public struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         }
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let whitespaceCharacterSet = CharacterSet.whitespaces
         var correctedLines = [String]()
         var corrections = [Correction]()

--- a/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeContentsOrderRule.swift
@@ -1,13 +1,13 @@
 import SourceKittenFramework
 
-public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
+struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
     private typealias TypeContentOffset = (typeContent: TypeContent, offset: ByteCount)
 
-    public var configuration = TypeContentsOrderConfiguration()
+    var configuration = TypeContentsOrderConfiguration()
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "type_contents_order",
         name: "Type Contents Order",
         description: "Specifies the order of subtypes, properties, methods & more within a type.",
@@ -16,7 +16,7 @@ public struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
         triggeringExamples: TypeContentsOrderRuleExamples.triggeringExamples
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let dict = file.structureDictionary
         let substructures = dict.substructure
         return substructures.reduce(into: [StyleViolation]()) { violations, substructure in

--- a/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -1,12 +1,12 @@
 import SwiftSyntax
 
-public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule,
+struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule,
                                                         SwiftSyntaxCorrectableRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unneeded_parentheses_in_closure_argument",
         name: "Unneeded Parentheses in Closure Argument",
         description: "Parentheses are not needed when declaring closure arguments.",
@@ -75,11 +75,11 @@ public struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRul
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
 
-    public func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/UnusedOptionalBindingRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct UnusedOptionalBindingRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = UnusedOptionalBindingConfiguration(ignoreOptionalTry: false)
+struct UnusedOptionalBindingRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = UnusedOptionalBindingConfiguration(ignoreOptionalTry: false)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "unused_optional_binding",
         name: "Unused Optional Binding",
         description: "Prefer `!= nil` over `let _ =`",
@@ -41,7 +41,7 @@ public struct UnusedOptionalBindingRule: SwiftSyntaxRule, ConfigurationProviderR
         ]
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(ignoreOptionalTry: configuration.ignoreOptionalTry)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -1,11 +1,11 @@
 import SourceKittenFramework
 
-public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "vertical_parameter_alignment_on_call",
         name: "Vertical Parameter Alignment On Call",
         description: "Function parameters should be aligned vertically if they're in multiple lines in a method call.",
@@ -102,8 +102,8 @@ public struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProvid
         ]
     )
 
-    public func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
-                         dictionary: SourceKittenDictionary) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, kind: SwiftExpressionKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
         guard kind == .call,
             case let arguments = dictionary.enclosedArguments,
             arguments.count > 1,

--- a/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -1,11 +1,11 @@
 import SwiftSyntax
 
-public struct VerticalParameterAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct VerticalParameterAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "vertical_parameter_alignment",
         name: "Vertical Parameter Alignment",
         description: "Function parameters should be aligned vertically if they're in multiple lines in a declaration.",
@@ -14,7 +14,7 @@ public struct VerticalParameterAlignmentRule: SwiftSyntaxRule, ConfigurationProv
         triggeringExamples: VerticalParameterAlignmentRuleExamples.triggeringExamples
     )
 
-    public func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(locationConverter: file.locationConverter)
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -7,10 +7,10 @@ private extension SwiftLintFile {
     }
 }
 
-public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
     private static let nonTriggeringExamples: [Example] = [
         Example("""
@@ -138,7 +138,7 @@ public struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
 }
 
 extension VerticalWhitespaceBetweenCasesRule: OptInRule {
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "vertical_whitespace_between_cases",
         name: "Vertical Whitespace Between Cases",
         description: "Include a single empty line between switch cases.",
@@ -148,7 +148,7 @@ extension VerticalWhitespaceBetweenCasesRule: OptInRule {
         corrections: violatingToValidExamples.removingViolationMarkers()
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let patternRegex = regex(pattern)
         return violationRanges(in: file).compactMap { violationRange in
             let substring = file.contents.substring(from: violationRange.location, length: violationRange.length)
@@ -170,7 +170,7 @@ extension VerticalWhitespaceBetweenCasesRule: OptInRule {
 }
 
 extension VerticalWhitespaceBetweenCasesRule: CorrectableRule {
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
         guard violatingRanges.isNotEmpty else { return [] }
 

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -7,10 +7,10 @@ private extension SwiftLintFile {
     }
 }
 
-public struct VerticalWhitespaceClosingBracesRule: ConfigurationProviderRule {
-    public var configuration = Configuration()
+struct VerticalWhitespaceClosingBracesRule: ConfigurationProviderRule {
+    var configuration = Configuration()
 
-    public init() {}
+    init() {}
 
     private let pattern = "((?:\\n[ \\t]*)+)(\\n[ \\t]*[)}\\]])"
     private let trivialLinePattern = "((?:\\n[ \\t]*)+)(\\n[ \\t)}\\]]*$)"
@@ -22,16 +22,16 @@ extension VerticalWhitespaceClosingBracesRule {
         case onlyEnforceBeforeTrivialLines = "only_enforce_before_trivial_lines"
     }
 
-    public struct Configuration: RuleConfiguration, Equatable {
+    struct Configuration: RuleConfiguration, Equatable {
         private(set) var severityConfiguration = SeverityConfiguration(.warning)
         private(set) var onlyEnforceBeforeTrivialLines = false
 
-        public var consoleDescription: String {
+        var consoleDescription: String {
             return severityConfiguration.consoleDescription +
                 ", \(ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue): \(onlyEnforceBeforeTrivialLines)"
         }
 
-        public mutating func apply(configuration: Any) throws {
+        mutating func apply(configuration: Any) throws {
             let error = ConfigurationError.unknownConfiguration
 
             guard let configuration = configuration as? [String: Any] else {
@@ -57,10 +57,10 @@ extension VerticalWhitespaceClosingBracesRule {
 }
 
 extension VerticalWhitespaceClosingBracesRule: OptInRule {
-    public var configurationDescription: String { return "N/A" }
+    var configurationDescription: String { return "N/A" }
 
     private static let examples = VerticalWhitespaceClosingBracesRuleExamples.self
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "vertical_whitespace_closing_braces",
         name: "Vertical Whitespace before Closing Braces",
         description: "Don't include vertical whitespace (empty line) before closing braces.",
@@ -71,7 +71,7 @@ extension VerticalWhitespaceClosingBracesRule: OptInRule {
         corrections: examples.violatingToValidExamples.removingViolationMarkers()
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let pattern = configuration.onlyEnforceBeforeTrivialLines ? self.trivialLinePattern : self.pattern
 
         let patternRegex: NSRegularExpression = regex(pattern)
@@ -92,7 +92,7 @@ extension VerticalWhitespaceClosingBracesRule: OptInRule {
 }
 
 extension VerticalWhitespaceClosingBracesRule: CorrectableRule {
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let pattern = configuration.onlyEnforceBeforeTrivialLines ? self.trivialLinePattern : self.pattern
 
         let violatingRanges = file.ruleEnabled(violatingRanges: file.violatingRanges(for: pattern), for: self)

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -7,10 +7,10 @@ private extension SwiftLintFile {
     }
 }
 
-public struct VerticalWhitespaceOpeningBracesRule: ConfigurationProviderRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct VerticalWhitespaceOpeningBracesRule: ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
     private static let nonTriggeringExamples = [
         Example("[1, 2].map { $0 }.foo()"),
@@ -143,11 +143,11 @@ public struct VerticalWhitespaceOpeningBracesRule: ConfigurationProviderRule {
 }
 
 extension VerticalWhitespaceOpeningBracesRule: OptInRule {
-    public var configurationDescription: String { return "N/A" }
+    var configurationDescription: String { return "N/A" }
 
-    public init(configuration: Any) throws {}
+    init(configuration: Any) throws {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "vertical_whitespace_opening_braces",
         name: "Vertical Whitespace after Opening Braces",
         description: "Don't include vertical whitespace (empty line) after opening braces.",
@@ -157,7 +157,7 @@ extension VerticalWhitespaceOpeningBracesRule: OptInRule {
         corrections: violatingToValidExamples.removingViolationMarkers()
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let patternRegex: NSRegularExpression = regex(pattern)
 
         return file.violatingRanges(for: pattern).map { violationRange in
@@ -177,7 +177,7 @@ extension VerticalWhitespaceOpeningBracesRule: OptInRule {
 }
 
 extension VerticalWhitespaceOpeningBracesRule: CorrectableRule {
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.ruleEnabled(violatingRanges: file.violatingRanges(for: pattern), for: self)
         guard violatingRanges.isNotEmpty else { return [] }
 

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceRule.swift
@@ -3,12 +3,12 @@ import SourceKittenFramework
 
 private let defaultDescriptionReason = "Limit vertical whitespace to a single empty line."
 
-public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
-    public var configuration = VerticalWhitespaceConfiguration(maxEmptyLines: 1)
+struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
+    var configuration = VerticalWhitespaceConfiguration(maxEmptyLines: 1)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "vertical_whitespace",
         name: "Vertical Whitespace",
         description: defaultDescriptionReason,
@@ -38,7 +38,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         return defaultDescriptionReason
     }
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         let linesSections = violatingLineSections(in: file)
         guard linesSections.isNotEmpty else {
             return []
@@ -108,7 +108,7 @@ public struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule
         return blankLinesSections
     }
 
-    public func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> [Correction] {
         let linesSections = violatingLineSections(in: file)
         if linesSections.isEmpty { return [] }
 

--- a/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SourceKittenFramework
 
-public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
-    public var configuration = SeverityConfiguration(.warning)
+struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
 
-    public init() {}
+    init() {}
 
-    public static let description = RuleDescription(
+    static let description = RuleDescription(
         identifier: "void_return",
         name: "Void Return",
         description: "Prefer `-> Void` over `-> ()`.",
@@ -41,7 +41,7 @@ public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectable
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
         return violationRanges(in: file).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
@@ -49,7 +49,7 @@ public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectable
         }
     }
 
-    public func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         let kinds = SyntaxKind.commentAndStringKinds
         let parensPattern = "\\(\\s*(?:Void)?\\s*\\)"
         let pattern = "->\\s*\(parensPattern)\\s*(?!->)"
@@ -62,7 +62,7 @@ public struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectable
         }
     }
 
-    public func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
         return (violationRange, "Void")
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,6 +1,6 @@
 // Generated using Sourcery 1.9.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class ColonRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/ContainsOverFirstNotNilRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ContainsOverFirstNotNilRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class ContainsOverFirstNotNilRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class CyclomaticComplexityRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/DeploymentTargetRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeploymentTargetRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class DeploymentTargetRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class DiscouragedDirectInitRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/DiscouragedObjectLiteralRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DiscouragedObjectLiteralRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class DiscouragedObjectLiteralRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class ExplicitTypeInterfaceRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -1,5 +1,5 @@
 import SourceKittenFramework
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 private let fixturesDirectory = #file.bridge()

--- a/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class FileLengthRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/FileNameNoSpaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameNoSpaceRuleTests.swift
@@ -1,5 +1,5 @@
 import SourceKittenFramework
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 private let fixturesDirectory = #file.bridge()

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -1,5 +1,5 @@
 import SourceKittenFramework
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 private let fixturesDirectory = #file.bridge()

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 private func funcWithBody(_ body: String,

--- a/Tests/SwiftLintFrameworkTests/FunctionParameterCountRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionParameterCountRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 private func funcWithParameters(_ parameters: String,

--- a/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class GenericTypeNameRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class IdentifierNameRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class MultilineArgumentsRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class NestingRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class NumberSeparatorRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class ObjectLiteralRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/PrivateOverFilePrivateRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/PrivateOverFilePrivateRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class PrivateOverFilePrivateRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class RulesTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/StatementPositionRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/StatementPositionRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class StatementPositionRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class TodoRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class TrailingCommaRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/TrailingWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingWhitespaceRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class TrailingWhitespaceRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class TypeNameRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/XCTSpecificMatcherRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/XCTSpecificMatcherRuleTests.swift
@@ -1,4 +1,4 @@
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class XCTSpecificMatcherRuleTests: XCTestCase {


### PR DESCRIPTION
There's no reason to expose these publicly and this will make it nicer to move to a new module outside of the core SwiftLint functionality.