### PR TITLE
Warn on malformed SwiftLint directives

### DIFF
--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -107,7 +107,6 @@ public struct Command: Equatable {
             return component.isNotEmpty && component != "*/"
         }
 
-        // TODO: Can we check for invalid rules here as well?
         ruleIdentifiers = Set(ruleTexts.map(RuleIdentifier.init(_:)))
         
         guard !ruleIdentifiers.isEmpty else {

--- a/Source/SwiftLintFramework/Models/Command.swift
+++ b/Source/SwiftLintFramework/Models/Command.swift
@@ -74,16 +74,16 @@ public struct Command: Equatable {
         _ = scanner.scanString("swiftlint:")
         // (enable|disable)(:previous|:this|:next)
         guard let actionAndModifierString = scanner.scanUpToString(" "), !actionAndModifierString.isEmpty else {
-            reportSwiftLintDirectiveError("found a swiftlint directive with no action", file: file, line: line, character: character)
+            warn("found a swiftlint directive with no action", file: file, line: line, character: character)
             return nil
         }
         let actionAndModifierScanner = Scanner(string: actionAndModifierString)
         guard let actionString = actionAndModifierScanner.scanUpToString(":") else {
-            reportSwiftLintDirectiveError("found a swiftlint directive with no action terminator", file: file, line: line, character: character)
+            warn("found a swiftlint directive with no action terminator", file: file, line: line, character: character)
             return nil
         }
         guard let action = Action(rawValue: actionString) else {
-            reportSwiftLintDirectiveError("found a swiftlint directive with an invalid action", file: file, line: line, character: character)
+            warn("found a swiftlint directive with an invalid action", file: file, line: line, character: character)
             return nil
         }
         self.action = action
@@ -108,14 +108,12 @@ public struct Command: Equatable {
         }
 
         ruleIdentifiers = Set(ruleTexts.map(RuleIdentifier.init(_:)))
-        
+
         guard !ruleIdentifiers.isEmpty else {
-            reportSwiftLintDirectiveError("found a swiftlint directive with no rules specified", file: file, line: line, character: character)
+            warn("found a swiftlint directive with no rules specified", file: file, line: line, character: character)
             return nil
         }
 
-        print(">>>> ruleIdenfiers = \(ruleIdentifiers)")
-        
         // Modifier
         let hasModifier = actionAndModifierScanner.scanString(":") != nil
         if hasModifier {
@@ -125,7 +123,7 @@ public struct Command: Equatable {
               )
             )
             if modifier == nil {
-                reportSwiftLintDirectiveError("found a invalid swiftlint directive modifier", file: file, line: line, character: character)
+                warn("found an invalid swiftlint directive modifier", file: file, line: line, character: character)
             }
         } else {
             modifier = nil
@@ -160,7 +158,7 @@ public struct Command: Equatable {
     }
 }
 
-fileprivate func reportSwiftLintDirectiveError(_ message: String, file: String?, line: Int, character: Int) {
+private func warn(_ message: String, file: String?, line: Int, character: Int) {
     var errorString = ""
     if let file = file {
         errorString = "\(file):\(line):\(character): "

--- a/Source/SwiftLintFramework/Visitors/CommandVisitor.swift
+++ b/Source/SwiftLintFramework/Visitors/CommandVisitor.swift
@@ -37,7 +37,7 @@ private extension Trivia {
                     case let end = locationConverter.location(for: offset + triviaOffset),
                     let line = end.line,
                     let column = end.column,
-                    let command = Command(actionString: actionString, line: line, character: column)
+                    let command = Command(actionString: actionString, file: end.file, line: line, character: column)
                 {
                     results.append(command)
                 }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -10,7 +10,7 @@ private extension Command {
         let nsString = string.bridge()
         guard nsString.length > 7 else { return nil }
         let subString = nsString.substring(with: NSRange(location: 3, length: nsString.length - 4))
-        self.init(actionString: subString, line: 1, character: nsString.length)
+        self.init(actionString: subString, file: nil, line: 1, character: nsString.length)
     }
 }
 


### PR DESCRIPTION
WIP, but comments welcome.

Detects malformed SwiftLint directives in source code. See https://github.com/realm/SwiftLint/issues/4539

For example

<img width="793" alt="Screenshot 2022-11-11 at 23 19 29" src="https://user-images.githubusercontent.com/435558/201443389-53f06400-663f-4453-8183-f96e6bfe2e93.png">

This feels like it could actually be a rule, and that would make reporting easier. At the same time, we're parsing the directives anyway, so why do another separate pass.

Error messages and reporting - these aren't really violations per se (unless this should actually be a rule). More like the `warning: Found a configuration for 'balanced_xctest_lifecycle' rule, but it is not enabled on 'opt_in_rules'.` type messages.

But these issues have locations in source files, and it's really nice to have them show up in Xcode, so I just went with the Xcode format for right now.

I'm not sure if that is the right thing to do in all cases though - of course, if this was a rule, it could just use whatever reporter the user had configured.
