### PR TITLE
Added "all" pseudo-rule for opt in rules - enables all opt in rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   [jimmya](https://github.com/jimmya)
   [#4609](https://github.com/realm/SwiftLint/issues/4609)
   [#issue_number](https://github.com/realm/SwiftLint/issues/4609)
+
 * Adds `all` pseudo-rule for `opt_in_rules` - enables all opt in rules
   that are not listed in `disabled_rules`  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@
   `opt_in_rules` configuration section.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4612](https://github.com/realm/SwiftLint/issues/4612)
+
 * Adds `all` pseudo-rule for `opt_in_rules` - enables all opt in rules
   that are not listed in `disabled_rules`  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,24 +187,10 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4200](https://github.com/realm/SwiftLint/issues/4200)
 
-* Add `period_spacing` opt-in rule that checks periods are not followed
-  by 2 or more spaces in comments.  
-  [Julioacarrettoni](https://github.com/Julioacarrettoni)
-  [#4624](https://github.com/realm/SwiftLint/pull/4624)
-
 * Show warnings in the console for Analyzer rules that are listed in the
   `opt_in_rules` configuration section.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4612](https://github.com/realm/SwiftLint/issues/4612)
-
-* Adds `all` pseudo-rule for `opt_in_rules` - enables all opt in rules
-  that are not listed in `disabled_rules`  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4540](https://github.com/realm/SwiftLint/issues/4540)
-* Allow new Quick APIs `aroundEach` and `justBeforeEach`
-  for `quick_discouraged_call`.  
-  [David Steinacher](https://github.com/stonko1994)
-  [#4626](https://github.com/realm/SwiftLint/issues/4626)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,10 @@
   `opt_in_rules` configuration section.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4612](https://github.com/realm/SwiftLint/issues/4612)
+* Adds `all` pseudo-rule for `opt_in_rules` - enables all opt in rules
+  that are not listed in `disabled_rules`  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4540](https://github.com/realm/SwiftLint/issues/4540)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 * Make forceExclude work with directly specified files.  
   [jimmya](https://github.com/jimmya)
   [#4609](https://github.com/realm/SwiftLint/issues/4609)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/4609)
+* Adds `all` pseudo-rule for `opt_in_rules` - enables all opt in rules
+  that are not listed in `disabled_rules`  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4540](https://github.com/realm/SwiftLint/issues/4540)
 
 * Separate analyzer rules as an independent section in the rule directory of
   the reference.  
@@ -181,6 +186,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4200](https://github.com/realm/SwiftLint/issues/4200)
 
+* Add `period_spacing` opt-in rule that checks periods are not followed
+  by 2 or more spaces in comments.  
+  [Julioacarrettoni](https://github.com/Julioacarrettoni)
+  [#4624](https://github.com/realm/SwiftLint/pull/4624)
+
 * Show warnings in the console for Analyzer rules that are listed in the
   `opt_in_rules` configuration section.  
   [SimplyDanny](https://github.com/SimplyDanny)
@@ -190,6 +200,10 @@
   that are not listed in `disabled_rules`  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4540](https://github.com/realm/SwiftLint/issues/4540)
+* Allow new Quick APIs `aroundEach` and `justBeforeEach`
+  for `quick_discouraged_call`.  
+  [David Steinacher](https://github.com/stonko1994)
+  [#4626](https://github.com/realm/SwiftLint/issues/4626)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Make forceExclude work with directly specified files.  
   [jimmya](https://github.com/jimmya)
   [#4609](https://github.com/realm/SwiftLint/issues/4609)
-  [#issue_number](https://github.com/realm/SwiftLint/issues/4609)
+  [#4609](https://github.com/realm/SwiftLint/issues/4609)
 
 * Adds `all` pseudo-rule for `opt_in_rules` - enables all opt in rules
   that are not listed in `disabled_rules`  

--- a/README.md
+++ b/README.md
@@ -483,7 +483,9 @@ run SwiftLint from. The following parameters can be configured:
 Rule inclusion:
 
 * `disabled_rules`: Disable rules from the default enabled set.
-* `opt_in_rules`: Enable rules that are not part of the default set.
+* `opt_in_rules`: Enable rules that are not part of the default set. The
+   special `all` rule will enable all opt in rules, except those listed
+   in `disabled_rules`.
 * `only_rules`: Only the rules specified in this list will be enabled.
    Cannot be specified alongside `disabled_rules` or `opt_in_rules`.
 * `analyzer_rules`: This is an entirely separate list of rules that are only

--- a/README.md
+++ b/README.md
@@ -484,8 +484,9 @@ Rule inclusion:
 
 * `disabled_rules`: Disable rules from the default enabled set.
 * `opt_in_rules`: Enable rules that are not part of the default set. The
-   special `all` rule will enable all opt in rules (but not the analyzer
-   rules), except the rules listed in `disabled_rules`.
+   special `all` rule will enable all opt in rules, except the rules
+   listed in `disabled_rules`. Analyzer rules will not be enabled by
+   `all`, but can be listed explicitly.
 * `only_rules`: Only the rules specified in this list will be enabled.
    Cannot be specified alongside `disabled_rules` or `opt_in_rules`.
 * `analyzer_rules`: This is an entirely separate list of rules that are only

--- a/README.md
+++ b/README.md
@@ -484,8 +484,8 @@ Rule inclusion:
 
 * `disabled_rules`: Disable rules from the default enabled set.
 * `opt_in_rules`: Enable rules that are not part of the default set. The
-   special `all` rule will enable all opt in rules, except those listed
-   in `disabled_rules`.
+   special `all` rule will enable all opt in rules (but not the analyzer
+   rules), except the rules listed in `disabled_rules`.
 * `only_rules`: Only the rules specified in this list will be enabled.
    Cannot be specified alongside `disabled_rules` or `opt_in_rules`.
 * `analyzer_rules`: This is an entirely separate list of rules that are only

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
@@ -61,7 +61,7 @@ public extension Configuration {
                 self = .only(Set(onlyRules + analyzerRules))
             } else {
                 warnAboutDuplicates(in: disabledRules)
-                
+
                 let effectiveOptInRules: [String]
                 if optInRules.contains("all") {
                     effectiveOptInRules = primaryRuleList.list.compactMap { ruleID, ruleType in
@@ -70,7 +70,7 @@ public extension Configuration {
                 } else {
                     effectiveOptInRules = optInRules
                 }
-                                
+
                 warnAboutDuplicates(in: effectiveOptInRules + analyzerRules)
                 self = .default(disabled: Set(disabledRules), optIn: Set(effectiveOptInRules + analyzerRules))
             }

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
@@ -61,8 +61,18 @@ public extension Configuration {
                 self = .only(Set(onlyRules + analyzerRules))
             } else {
                 warnAboutDuplicates(in: disabledRules)
-                warnAboutDuplicates(in: optInRules + analyzerRules)
-                self = .default(disabled: Set(disabledRules), optIn: Set(optInRules + analyzerRules))
+                
+                let effectiveOptInRules: [String]
+                if optInRules.contains("all") {
+                    effectiveOptInRules = primaryRuleList.list.compactMap { ruleID, ruleType in
+                        ruleType is OptInRule.Type ? ruleID : nil
+                    }
+                } else {
+                    effectiveOptInRules = optInRules
+                }
+                                
+                warnAboutDuplicates(in: effectiveOptInRules + analyzerRules)
+                self = .default(disabled: Set(disabledRules), optIn: Set(effectiveOptInRules + analyzerRules))
             }
         }
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
@@ -65,7 +65,7 @@ public extension Configuration {
                 let effectiveOptInRules: [String]
                 if optInRules.contains("all") {
                     effectiveOptInRules = primaryRuleList.list.compactMap { ruleID, ruleType in
-                        ruleType is OptInRule.Type ? ruleID : nil
+                        ruleType is OptInRule.Type && !(ruleType is AnalyzerRule.Type) ? ruleID : nil
                     }
                 } else {
                     effectiveOptInRules = optInRules

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
@@ -63,7 +63,7 @@ public extension Configuration {
                 warnAboutDuplicates(in: disabledRules)
 
                 let effectiveOptInRules: [String]
-                if optInRules.contains("all") {
+                if optInRules.contains(RuleIdentifier.all.stringRepresentation) {
                     let allOptInRules = primaryRuleList.list.compactMap { ruleID, ruleType in
                         ruleType is OptInRule.Type && !(ruleType is AnalyzerRule.Type) ? ruleID : nil
                     }

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesMode.swift
@@ -64,9 +64,10 @@ public extension Configuration {
 
                 let effectiveOptInRules: [String]
                 if optInRules.contains("all") {
-                    effectiveOptInRules = primaryRuleList.list.compactMap { ruleID, ruleType in
+                    let allOptInRules = primaryRuleList.list.compactMap { ruleID, ruleType in
                         ruleType is OptInRule.Type && !(ruleType is AnalyzerRule.Type) ? ruleID : nil
                     }
+                    effectiveOptInRules = Array(Set(allOptInRules + optInRules))
                 } else {
                     effectiveOptInRules = optInRules
                 }

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesWrapper.swift
@@ -114,7 +114,7 @@ internal extension Configuration {
 
         // MARK: - Methods: Validation
         private func validate(optInRuleIds: Set<String>, valid: Set<String>) -> Set<String> {
-            validate(ruleIds: optInRuleIds, valid: valid.union(["all"]))
+            validate(ruleIds: optInRuleIds, valid: valid.union([RuleIdentifier.all.stringRepresentation]))
         }
 
         private func validate(ruleIds: Set<String>, valid: Set<String>, silent: Bool = false) -> Set<String> {

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesWrapper.swift
@@ -49,7 +49,7 @@ internal extension Configuration {
             case var .default(disabledRuleIdentifiers, optInRuleIdentifiers):
                 customRulesFilter = { !disabledRuleIdentifiers.contains($0.identifier) }
                 disabledRuleIdentifiers = validate(ruleIds: disabledRuleIdentifiers, valid: validRuleIdentifiers)
-                optInRuleIdentifiers = validate(ruleIds: optInRuleIdentifiers, valid: validRuleIdentifiers)
+                optInRuleIdentifiers = validateOptInRuleIdentifiers(ruleIds: optInRuleIdentifiers, valid: validRuleIdentifiers)
                 resultingRules = allRulesWrapped.filter { tuple in
                     let id = type(of: tuple.rule).description.identifier
                     return !disabledRuleIdentifiers.contains(id)
@@ -113,6 +113,10 @@ internal extension Configuration {
         }
 
         // MARK: - Methods: Validation
+        private func validateOptInRuleIdentifiers(ruleIds: Set<String>, valid: Set<String>, silent: Bool = false) -> Set<String> {
+            validate(ruleIds: ruleIds, valid: valid.union(["all"]), silent: silent)
+        }
+
         private func validate(ruleIds: Set<String>, valid: Set<String>, silent: Bool = false) -> Set<String> {
             // Process invalid rule identifiers
             if !silent {
@@ -220,12 +224,12 @@ internal extension Configuration {
             validRuleIdentifiers: Set<String>
         ) -> RulesMode {
             let childDisabled = child.validate(ruleIds: childDisabled, valid: validRuleIdentifiers)
-            let childOptIn = child.validate(ruleIds: childOptIn, valid: validRuleIdentifiers)
+            let childOptIn = child.validateOptInRuleIdentifiers(ruleIds: childOptIn, valid: validRuleIdentifiers)
 
             switch mode { // Switch parent's mode. Child is in default mode.
             case var .default(disabled, optIn):
                 disabled = validate(ruleIds: disabled, valid: validRuleIdentifiers)
-                optIn = child.validate(ruleIds: optIn, valid: validRuleIdentifiers)
+                optIn = child.validateOptInRuleIdentifiers(ruleIds: optIn, valid: validRuleIdentifiers)
 
                 // Only use parent disabled / optIn if child config doesn't tell the opposite
                 return .default(

--- a/Source/SwiftLintFramework/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+RulesWrapper.swift
@@ -49,7 +49,7 @@ internal extension Configuration {
             case var .default(disabledRuleIdentifiers, optInRuleIdentifiers):
                 customRulesFilter = { !disabledRuleIdentifiers.contains($0.identifier) }
                 disabledRuleIdentifiers = validate(ruleIds: disabledRuleIdentifiers, valid: validRuleIdentifiers)
-                optInRuleIdentifiers = validateOptInRuleIdentifiers(ruleIds: optInRuleIdentifiers, valid: validRuleIdentifiers)
+                optInRuleIdentifiers = validate(optInRuleIds: optInRuleIdentifiers, valid: validRuleIdentifiers)
                 resultingRules = allRulesWrapped.filter { tuple in
                     let id = type(of: tuple.rule).description.identifier
                     return !disabledRuleIdentifiers.contains(id)
@@ -113,8 +113,8 @@ internal extension Configuration {
         }
 
         // MARK: - Methods: Validation
-        private func validateOptInRuleIdentifiers(ruleIds: Set<String>, valid: Set<String>, silent: Bool = false) -> Set<String> {
-            validate(ruleIds: ruleIds, valid: valid.union(["all"]), silent: silent)
+        private func validate(optInRuleIds: Set<String>, valid: Set<String>) -> Set<String> {
+            validate(ruleIds: optInRuleIds, valid: valid.union(["all"]))
         }
 
         private func validate(ruleIds: Set<String>, valid: Set<String>, silent: Bool = false) -> Set<String> {
@@ -224,12 +224,12 @@ internal extension Configuration {
             validRuleIdentifiers: Set<String>
         ) -> RulesMode {
             let childDisabled = child.validate(ruleIds: childDisabled, valid: validRuleIdentifiers)
-            let childOptIn = child.validateOptInRuleIdentifiers(ruleIds: childOptIn, valid: validRuleIdentifiers)
+            let childOptIn = child.validate(optInRuleIds: childOptIn, valid: validRuleIdentifiers)
 
             switch mode { // Switch parent's mode. Child is in default mode.
             case var .default(disabled, optIn):
                 disabled = validate(ruleIds: disabled, valid: validRuleIdentifiers)
-                optIn = child.validateOptInRuleIdentifiers(ruleIds: optIn, valid: validRuleIdentifiers)
+                optIn = child.validate(optInRuleIds: optIn, valid: validRuleIdentifiers)
 
                 // Only use parent disabled / optIn if child config doesn't tell the opposite
                 return .default(


### PR DESCRIPTION

Adds an "all" pseudo-rule - if specified in `opt_in_rules", this will enable all opt in rules.

For example: 

```
opt_in_rules:
  - all
```

Any other entries in `opt_in_rules` will be ignored (e.g. duplicates will not be reported).

See https://github.com/realm/SwiftLint/issues/4540

