### PR TITLE
Fix jazzy CodeClimateReporter capitalization

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -7,7 +7,7 @@ github_file_prefix: https://github.com/realm/SwiftLint/tree/main
 swift_build_tool: spm
 theme: fullwidth
 clean: true
-copyright: '© 2020 [JP Simard](https://jpsim.com) under MIT.'
+copyright: '© 2022 [JP Simard](https://jpsim.com) under MIT.'
 
 documentation: rule_docs/*.md
 hide_unlisted_documentation: true
@@ -22,7 +22,7 @@ custom_categories:
     children:
       - CSVReporter
       - CheckstyleReporter
-      - CodeclimateReporter
+      - CodeClimateReporter
       - EmojiReporter
       - GitHubActionsLoggingReporter
       - HTMLReporter


### PR DESCRIPTION
Fixes the following warning:

> WARNING: No documented top-level declarations match name "CodeclimateReporter" specified in categories file

And actually renders the `CodeclimateReporter` item in the navigation side bar.