### PR TITLE
Disable `prefer_self_in_static_references` in SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,7 +46,6 @@ opt_in_rules:
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
-  - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self
   - private_action
   - private_outlet


### PR DESCRIPTION
I find this rule to not help readability for this project at least, where `Version(value: "0.50.0")` is a lot more descriptive than `Self(value: "0.50.0")`.