### PR TITLE
Fix building with `swift build -c release`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## Main
+
+#### Breaking
+
+* None.
+
+#### Experimental
+
+* None.
+
+#### Enhancements
+
+* None.
+
+#### Bug Fixes
+
+* Fix building with `swift build -c release`.  
+  [JP Simard](https://github.com/jpsim)
+  [#4559](https://github.com/realm/SwiftLint/issues/4559)
+  [#4560](https://github.com/realm/SwiftLint/issues/4560)
+
 ## 0.50.0: Artisanal Clothes Pegs
 
 #### Breaking

--- a/Package.swift
+++ b/Package.swift
@@ -61,12 +61,11 @@ let package = Package(
             name: "SwiftLintFramework",
             dependencies: frameworkDependencies
         ),
-        .target(
+        .testTarget(
             name: "SwiftLintTestHelpers",
             dependencies: [
                 "SwiftLintFramework"
-            ],
-            path: "Tests/SwiftLintTestHelpers"
+            ]
         ),
         .testTarget(
             name: "SwiftLintFrameworkTests",

--- a/tools/test-analyze.sh
+++ b/tools/test-analyze.sh
@@ -6,5 +6,5 @@ readonly swiftlint="$RUNFILES_DIR/SwiftLint/swiftlint"
 readonly swiftpm_yaml="$RUNFILES_DIR/SwiftLint/swiftpm.yaml"
 # Change to workspace directory
 cd "$(dirname "$(readlink Package.swift)")"
-swift build
+swift build --build-tests
 "$swiftlint" analyze --strict --compile-commands ".build/debug.yaml"


### PR DESCRIPTION
Which previously tried to build the SwiftLintTestHelpers module, which is a test-only module.

This should fix building with precommit and Mint, both of which assume you can build the CLI targets in a Swift package with the `swift build -c release` command.