### PR TITLE
Fix `lower_acl_than_parent` false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   [#4559](https://github.com/realm/SwiftLint/issues/4559)
   [#4560](https://github.com/realm/SwiftLint/issues/4560)
 
+* Fix false positives in `lower_acl_than_parent` when the nominal parent is an extension.  
+  [Steffen Matthischke](https://github.com/heeaad)
+  [#4564](https://github.com/realm/SwiftLint/issues/4564)
+
 ## 0.50.0: Artisanal Clothes Pegs
 
 #### Breaking


### PR DESCRIPTION
Fix false positives in `lower_acl_than_parent` when the nominal parent is an extension.

The idea is to check for the nominal parent extension when the modifiers of the nominal parent don't contain a ACL modifier.

Fixes #4564

