### PR TITLE
Add `universal_swiftlint` universal macOS binary

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,4 @@
+load("@build_bazel_rules_apple//apple:apple.bzl", "apple_universal_binary")
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_binary",
@@ -48,6 +49,18 @@ swift_binary(
     deps = [
         ":swiftlint.library",
     ],
+)
+
+apple_universal_binary(
+    name = "universal_swiftlint",
+    binary = ":swiftlint",
+    forced_cpus = [
+        "x86_64",
+        "arm64",
+    ],
+    minimum_os_version = "12.0",
+    platform_type = "macos",
+    visibility = ["//visibility:public"],
 )
 
 # Linting


### PR DESCRIPTION
With architectures for x86_64 and arm64 for portable distribution.

```console
$ bazel build --config release universal_swiftlint
...
Target //:universal_swiftlint up-to-date:
  bazel-out/applebin_macos-darwin_x86_64-opt-ST-91a784f2bca7/bin/universal_swiftlint
$ file bazel-out/applebin_macos-darwin_x86_64-opt-ST-91a784f2bca7/bin/universal_swiftlint
bazel-out/applebin_macos-darwin_x86_64-opt-ST-91a784f2bca7/bin/universal_swiftlint: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
bazel-out/applebin_macos-darwin_x86_64-opt-ST-91a784f2bca7/bin/universal_swiftlint (for architecture x86_64):	Mach-O 64-bit executable x86_64
bazel-out/applebin_macos-darwin_x86_64-opt-ST-91a784f2bca7/bin/universal_swiftlint (for architecture arm64):	Mach-O 64-bit executable arm64
```