### PR TITLE
Add new `local_doc_comment` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,6 +36,7 @@ opt_in_rules:
   - last_where
   - legacy_multiple
   - literal_expression_end_indentation
+  - local_doc_comment
   - lower_acl_than_parent
   - modifier_order
   - nimble_operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 #### Enhancements
 
-* None.
+* Moved the validation of doc comments in local scopes out of
+  `orphaned_doc_comment` and into a new opt-in `local_doc_comment` rule.  
+  [JP Simard](https://github.com/jpsim)
+  [#4573](https://github.com/realm/SwiftLint/issues/4573)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -103,6 +103,7 @@ public let primaryRuleList = RuleList(rules: [
     LetVarWhitespaceRule.self,
     LineLengthRule.self,
     LiteralExpressionEndIdentationRule.self,
+    LocalDocCommentRule.self,
     LowerACLThanParentRule.self,
     MarkRule.self,
     MissingDocsRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/LocalDocCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LocalDocCommentRule.swift
@@ -1,0 +1,72 @@
+import IDEUtils
+import SwiftSyntax
+
+struct LocalDocCommentRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
+
+    init() {}
+
+    static let description = RuleDescription(
+        identifier: "local_doc_comment",
+        name: "Local Doc Comment",
+        description: "Doc comments shouldn't be used in local scopes. Use regular comments.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+            func foo() {
+              // Local scope documentation should use normal comments.
+              print("foo")
+            }
+            """),
+            Example("""
+            /// My great property
+            var myGreatProperty: String!
+            """),
+            Example("""
+            /// Look here for more info: https://github.com.
+            var myGreatProperty: String!
+            """),
+            Example("""
+            /// Look here for more info:
+            /// https://github.com.
+            var myGreatProperty: String!
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+            func foo() {
+              ↓/// Docstring inside a function declaration
+              print("foo")
+            }
+            """)
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(classifications: file.syntaxClassifications.filter { $0.kind != .none })
+    }
+}
+
+private extension LocalDocCommentRule {
+    final class Visitor: ViolationsSyntaxVisitor {
+        private let docCommentRanges: [ByteSourceRange]
+
+        init(classifications: [SyntaxClassifiedRange]) {
+            self.docCommentRanges = classifications
+                .filter { $0.kind == .docLineComment || $0.kind == .docBlockComment }
+                .map(\.range)
+            super.init(viewMode: .sourceAccurate)
+        }
+
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            guard let body = node.body else {
+                return
+            }
+
+            let violatingRange = docCommentRanges.first { $0.intersects(body.byteRange) }
+            if let violatingRange {
+                violations.append(AbsolutePosition(utf8Offset: violatingRange.offset))
+            }
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
@@ -43,22 +43,15 @@ struct OrphanedDocCommentRule: SourceKitFreeRule, ConfigurationProviderRule {
             ↓/// Look here for more info: https://github.com.
             // Not a doc string
             var myGreatProperty: String!
-            """),
-            Example("""
-            func foo() {
-              ↓/// Docstring inside a function declaration
-              print("foo")
-            }
             """)
         ]
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let classifications = file.syntaxClassifications
+        file.syntaxClassifications
             .filter { $0.kind != .none }
-        let docstringsWithOtherComments = classifications
             .pairs()
-            .compactMap { first, second -> Location? in
+            .compactMap { first, second in
                 let firstByteRange = first.range.toSourceKittenByteRange()
                 guard
                     let second = second,
@@ -71,44 +64,10 @@ struct OrphanedDocCommentRule: SourceKitFreeRule, ConfigurationProviderRule {
                     return nil
                 }
 
-                return Location(file: file, byteOffset: firstByteRange.location)
+                return StyleViolation(ruleDescription: Self.description,
+                                      severity: configuration.severity,
+                                      location: Location(file: file, byteOffset: firstByteRange.location))
             }
-
-        let docstringsInFunctionDeclarations = Visitor(classifications: classifications)
-            .walk(tree: file.syntaxTree, handler: \.violations)
-            .map { Location(file: file, position: $0.position) }
-
-        return (docstringsWithOtherComments + docstringsInFunctionDeclarations)
-            .sorted()
-            .map { location in
-                StyleViolation(ruleDescription: Self.description,
-                               severity: configuration.severity,
-                               location: location)
-            }
-    }
-}
-
-private extension OrphanedDocCommentRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let docCommentRanges: [ByteSourceRange]
-
-        init(classifications: [SyntaxClassifiedRange]) {
-            self.docCommentRanges = classifications
-                .filter { $0.kind == .docLineComment || $0.kind == .docBlockComment }
-                .map(\.range)
-            super.init(viewMode: .sourceAccurate)
-        }
-
-        override func visitPost(_ node: FunctionDeclSyntax) {
-            guard let body = node.body else {
-                return
-            }
-
-            let violatingRange = docCommentRanges.first { $0.intersects(body.byteRange) }
-            if let violatingRange {
-                violations.append(AbsolutePosition(utf8Offset: violatingRange.offset))
-            }
-        }
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/OrphanedDocCommentRule.swift
@@ -1,5 +1,4 @@
 import IDEUtils
-import SwiftSyntax
 
 struct OrphanedDocCommentRule: SourceKitFreeRule, ConfigurationProviderRule {
     var configuration = SeverityConfiguration(.warning)

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -606,6 +606,12 @@ class LiteralExpressionEndIdentationRuleGeneratedTests: XCTestCase {
     }
 }
 
+class LocalDocCommentRuleGeneratedTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(LocalDocCommentRule.description)
+    }
+}
+
 class LowerACLThanParentRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LowerACLThanParentRule.description)


### PR DESCRIPTION
Moving the validation of doc comments in local scopes out of `orphaned_doc_comment` and into a new opt-in `local_doc_comment` rule.

Addresses https://github.com/realm/SwiftLint/issues/4573.