### PR TITLE
Fix `minimum_fraction_length` handling in `number_separator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 * Fix false positives in `lower_acl_than_parent` when the nominal parent is an extension.  
   [Steffen Matthischke](https://github.com/heeaad)
   [#4564](https://github.com/realm/SwiftLint/issues/4564)
+* Fix `minimum_fraction_length` handling in `number_separator`.  
+  [JP Simard](https://github.com/jpsim)
+  [#4576](https://github.com/realm/SwiftLint/issues/4576)
 
 ## 0.50.0: Artisanal Clothes Pegs
 

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRule.swift
@@ -168,7 +168,7 @@ extension NumberSeparatorValidator {
 
         let minimumLength: Int
         if isFraction {
-            minimumLength = configuration.minimumFractionLength ?? configuration.minimumLength
+            minimumLength = configuration.minimumFractionLength ?? .max
         } else {
             minimumLength = configuration.minimumLength
         }

--- a/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/NumberSeparatorRuleExamples.swift
@@ -5,18 +5,24 @@ internal struct NumberSeparatorRuleExamples {
                 Example("let foo = \(sign)100"),
                 Example("let foo = \(sign)1_000"),
                 Example("let foo = \(sign)1_000_000"),
-                Example("let foo = \(sign)1.000_1"),
-                Example("let foo = \(sign)1_000_000.000_000_1"),
+                Example("let foo = \(sign)1.0001"),
+                Example("let foo = \(sign)1_000_000.0000001"),
                 Example("let binary = \(sign)0b10000"),
                 Example("let binary = \(sign)0b1000_0001"),
                 Example("let hex = \(sign)0xA"),
                 Example("let hex = \(sign)0xAA_BB"),
                 Example("let octal = \(sign)0o21"),
                 Example("let octal = \(sign)0o21_1"),
-                Example("let exp = \(sign)1_000_000.000_000e2"),
+                Example("let exp = \(sign)1_000_000.000000e2"),
                 Example("let foo: Double = \(sign)(200)"),
                 Example("let foo: Double = \(sign)(200 / 447.214)"),
-                Example("let foo = \(sign)6.283_2e-6")
+                Example("let foo = \(sign)6.2832e-6"),
+                Example("""
+                let color = #colorLiteral(red: 0.3543982506, green: 0.318749547, blue: 0.6367015243, alpha: 1)
+                """, excludeFromDocumentation: true),
+                Example("""
+                let color = #colorLiteral(red: 0.354_398_250_6, green: 0.318_749_547, blue: 0.636_701_524_3, alpha: 1)
+                """, configuration: ["minimum_fraction_length": 3], excludeFromDocumentation: true)
             ]
         }
     }()
@@ -34,10 +40,10 @@ internal struct NumberSeparatorRuleExamples {
                 Example("let foo = \(sign)1000e2"),
                 Example("let foo = \(sign)1000E2"),
                 Example("let foo = \(sign)1__000"),
-                Example("let foo = \(sign)1.0001"),
-                Example("let foo = \(sign)1_000_000.000000_1"),
+                Example("let foo = \(sign)1.0001", configuration: ["minimum_fraction_length": 3]),
+                Example("let foo = \(sign)1_000_000.000000_1", configuration: ["minimum_fraction_length": 3]),
                 Example("let foo = \(sign)1000000.000000_1"),
-                Example("let foo = \(sign)6.2832e-6")
+                Example("let foo = \(sign)6.2832e-6", configuration: ["minimum_fraction_length": 3])
             ]
         }
     }
@@ -47,8 +53,8 @@ internal struct NumberSeparatorRuleExamples {
         return signsWithParenthesisAndViolation.flatMap { (sign: String) -> [Example] in
             [
                 Example("let foo: Double = \(sign)100000)"),
-                Example("let foo: Double = \(sign)10.000000_1)"),
-                Example("let foo: Double = \(sign)123456 / ↓447.214214)")
+                Example("let foo: Double = \(sign)10.000000_1)", configuration: ["minimum_fraction_length": 3]),
+                Example("let foo: Double = \(sign)123456 / ↓447.214214)", configuration: ["minimum_fraction_length": 3])
             ]
         }
     }
@@ -62,11 +68,14 @@ internal struct NumberSeparatorRuleExamples {
             result[Example("let foo = \(violation)1000e2")] = Example("let foo = \(sign)1_000e2")
             result[Example("let foo = \(violation)1000E2")] = Example("let foo = \(sign)1_000E2")
             result[Example("let foo = \(violation)1__000")] = Example("let foo = \(sign)1_000")
-            result[Example("let foo = \(violation)1.0001")] = Example("let foo = \(sign)1.000_1")
-            // swiftlint:disable:next line_length
-            result[Example("let foo = \(violation)1_000_000.000000_1")] = Example("let foo = \(sign)1_000_000.000_000_1")
-            result[Example("let foo = \(violation)1000000.000000_1")] = Example("let foo = \(sign)1_000_000.000_000_1")
-            result[Example("let foo = \(sign)6.2832e-6")] = Example("let foo = \(sign)6.283_2e-6")
+            result[Example("let foo = \(violation)1.0001", configuration: ["minimum_fraction_length": 3])] =
+                Example("let foo = \(sign)1.000_1")
+            result[Example("let foo = \(violation)1_000_000.000000_1", configuration: ["minimum_fraction_length": 3])] =
+                Example("let foo = \(sign)1_000_000.000_000_1")
+            result[Example("let foo = \(violation)1000000.000000_1", configuration: ["minimum_fraction_length": 3])] =
+                Example("let foo = \(sign)1_000_000.000_000_1")
+            result[Example("let foo = \(sign)6.2832e-6", configuration: ["minimum_fraction_length": 3])] =
+                Example("let foo = \(sign)6.283_2e-6")
         }
 
         return result

--- a/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
@@ -8,7 +8,7 @@ class NumberSeparatorRuleTests: XCTestCase {
             Example("let foo = 1000"),
             Example("let foo = 1000.0001"),
             Example("let foo = 10_000.0001"),
-            Example("let foo = 1000.000_01")
+            Example("let foo = 1000.00001")
         ]
         let triggeringExamples = [
             Example("let foo = ↓1_000"),
@@ -92,7 +92,8 @@ class NumberSeparatorRuleTests: XCTestCase {
                 "exclude_ranges": [
                     ["min": 1900, "max": 2030],
                     ["min": 2.0, "max": 3.0]
-                ]
+                ],
+                "minimum_fraction_length": 3
             ]
         )
     }


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/4576

Before it would apply the `minimum_length` parameter to the `minimal_fractional_length` setting if the latter wasn't set.