### PR TITLE
Move SwiftPM CI job to Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,14 @@ steps:
       - bazel build :swiftlint
       - echo "+++ Test"
       - bazel test --test_output=errors //Tests/...
+  - label: "SwiftPM"
+    commands:
+      - echo "+++ Test"
+      - swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
+  - label: "Xcode"
+    commands:
+      - echo "+++ Test"
+      - xcodebuild -scheme swiftlint test -destination "platform=macOS" OTHER_SWIFT_FLAGS="\$(inherited) -D DISABLE_FOCUSED_EXAMPLES"
   - label: "Danger"
     commands:
       - echo "--- Build Danger"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,10 +9,6 @@ steps:
     commands:
       - echo "+++ Test"
       - swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
-  - label: "Xcode"
-    commands:
-      - echo "+++ Test"
-      - xcodebuild -scheme swiftlint test -destination "platform=macOS" OTHER_SWIFT_FLAGS="\$(inherited) -D DISABLE_FOCUSED_EXAMPLES"
   - label: "Danger"
     commands:
       - echo "--- Build Danger"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,44 +26,6 @@ jobs:
     - script: swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
       displayName: swift test
 
-# TODO: Re-enable when FB11648454 is fixed
-# - job: Xcode
-#   pool:
-#     vmImage: 'macOS-12'
-#   strategy:
-#     maxParallel: 10
-#     matrix:
-#       xcode14:
-#         DEVELOPER_DIR: /Applications/Xcode_14.0.1.app
-#   steps:
-#     - script: |
-#         sw_vers
-#         xcodebuild -version
-#       displayName: Version Informations
-#     - script: xcodebuild -scheme swiftlint test -destination "platform=macOS" OTHER_SWIFT_FLAGS="\$(inherited) -D DISABLE_FOCUSED_EXAMPLES"
-#       displayName: xcodebuild test
-
-- job: SwiftPM
-  pool:
-    vmImage: 'macOS-12'
-  strategy:
-    maxParallel: 10
-    matrix:
-      xcode14:
-        DEVELOPER_DIR: /Applications/Xcode_14.0.1.app
-  steps:
-    - script: |
-        sw_vers
-        xcodebuild -version
-      displayName: Version Informations
-    - script: swift test --parallel --enable-code-coverage -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
-      displayName: swift test
-    # - script: |
-    #     xcrun llvm-cov export -format="lcov" .build/debug/SwiftLintPackageTests.xctest/Contents/MacOS/SwiftLintPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
-    #     bash <(curl -s https://codecov.io/bash)
-    #   displayName: Upload code coverage
-    #   condition: eq(variables['DEVELOPER_DIR'], '/Applications/Xcode_14.0.1.app')
-
 - job: CocoaPods
   pool:
     vmImage: 'macOS-12'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,22 @@ jobs:
     - script: swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
       displayName: swift test
 
+# TODO: Re-enable when FB11648454 is fixed
+# - job: Xcode
+#   pool:
+#     vmImage: 'macOS-12'
+#   strategy:
+#     maxParallel: 10
+#     matrix:
+#       xcode14:
+#         DEVELOPER_DIR: /Applications/Xcode_14.0.1.app
+#   steps:
+#     - script: |
+#         sw_vers
+#         xcodebuild -version
+#       displayName: Version Informations
+#     - script: xcodebuild -scheme swiftlint test -destination "platform=macOS" OTHER_SWIFT_FLAGS="\$(inherited) -D DISABLE_FOCUSED_EXAMPLES"
+#       displayName: xcodebuild test
 - job: CocoaPods
   pool:
     vmImage: 'macOS-12'


### PR DESCRIPTION
We have 6 CI machines now and these should run faster on bare metal machines with lots of stuff already cached, like starting with an existing git repo.