### PR TITLE
Fix false positives in `unused_closure_parameter` when using backticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@
   `orphaned_doc_comment` and into a new opt-in `local_doc_comment` rule.  
   [JP Simard](https://github.com/jpsim)
   [#4573](https://github.com/realm/SwiftLint/issues/4573)
-* SwiftLint's Swift Package Build Tool Plugin will now only scan files in the target being built. 
-  [Tony Arnold](https://github.com/tonyarnold) 
+
+* SwiftLint's Swift Package Build Tool Plugin will now only scan files
+  in the target being built.  
+  [Tony Arnold](https://github.com/tonyarnold)
   [#4406](https://github.com/realm/SwiftLint/pull/4406)
 
 #### Bug Fixes
@@ -41,6 +43,11 @@
 * Fix line count calculation for multiline string literals.  
   [JP Simard](https://github.com/jpsim)
   [#4585](https://github.com/realm/SwiftLint/issues/4585)
+
+* Fix false positives in `unused_closure_parameter` when using
+  identifiers with backticks.  
+  [JP Simard](https://github.com/jpsim)
+  [#4588](https://github.com/realm/SwiftLint/issues/4588)
 
 ## 0.50.0: Artisanal Clothes Pegs
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRule.swift
@@ -85,7 +85,7 @@ private extension UnusedClosureParameterRule {
 
                     if name.tokenKind == .wildcardKeyword {
                         continue
-                    } else if referencedIdentifiers.contains(name.text.removingDollarPrefix) {
+                    } else if referencedIdentifiers.contains(name.text.removingDollarsAndBackticks) {
                         continue
                     }
 
@@ -105,7 +105,7 @@ private extension UnusedClosureParameterRule {
             for (index, param) in params.enumerated() {
                 if param.name.tokenKind == .wildcardKeyword {
                     continue
-                } else if referencedIdentifiers.contains(param.name.text.removingDollarPrefix) {
+                } else if referencedIdentifiers.contains(param.name.text.removingDollarsAndBackticks) {
                     continue
                 }
 
@@ -125,13 +125,14 @@ private final class IdentifierReferenceVisitor: SyntaxVisitor {
     private(set) var identifiers: Set<String> = []
 
     override func visitPost(_ node: IdentifierExprSyntax) {
-        identifiers.insert(node.identifier.text.removingDollarPrefix)
+        identifiers.insert(node.identifier.text.removingDollarsAndBackticks)
     }
 }
 
 private extension String {
-    var removingDollarPrefix: String {
-        replacingOccurrences(of: "$", with: "")
+    var removingDollarsAndBackticks: String {
+        self.replacingOccurrences(of: "$", with: "")
+            .replacingOccurrences(of: "`", with: "")
     }
 }
 
@@ -149,7 +150,7 @@ private extension ClosureExprSyntax {
                 }
                 return ClosureParam(
                     position: param.name.positionAfterSkippingLeadingTrivia,
-                    name: param.name.text.removingDollarPrefix
+                    name: param.name.text.removingDollarsAndBackticks
                 )
             }
         } else if let params = signature?.input?.as(ParameterClauseSyntax.self)?.parameterList {
@@ -160,7 +161,7 @@ private extension ClosureExprSyntax {
                 return param.firstName.map { name in
                     ClosureParam(
                         position: name.positionAfterSkippingLeadingTrivia,
-                        name: name.text.removingDollarPrefix
+                        name: name.text.removingDollarsAndBackticks
                     )
                 }
             }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedClosureParameterRuleExamples.swift
@@ -52,7 +52,9 @@ enum UnusedClosureParameterRuleExamples {
             TextField($name)
         }
         """),
-        Example(#"_ = ["a"].filter { `class` in `class`.hasPrefix("a") }"#)
+        Example(#"_ = ["a"].filter { `class` in `class`.hasPrefix("a") }"#),
+        Example("let closure: (Int) -> Void = { `foo` in _ = foo }"),
+        Example("let closure: (Int) -> Void = { foo in _ = `foo` }")
     ]
 
     static let triggering = [


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/4588