### PR TITLE
Fix `type_name` regression when using backticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
   [JP Simard](https://github.com/jpsim)
   [#4588](https://github.com/realm/SwiftLint/issues/4588)
 
+* Fix `type_name` regression where names with backticks would trigger
+  violations.  
+  [JP Simard](https://github.com/jpsim)
+  [#4571](https://github.com/realm/SwiftLint/issues/4571)
+
 ## 0.50.0: Artisanal Clothes Pegs
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -9,9 +9,11 @@ struct TypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
     static let description = RuleDescription(
         identifier: "type_name",
         name: "Type Name",
-        description: "Type name should only contain alphanumeric characters, start with an " +
-                     "uppercase character and span between 3 and 40 characters in length." +
-                     "Private types may start with an underscore.",
+        description: """
+            Type name should only contain alphanumeric characters, start with an uppercase character and span between \
+            3 and 40 characters in length.
+            Private types may start with an underscore.
+            """,
         kind: .idiomatic,
         nonTriggeringExamples: TypeNameRuleExamples.nonTriggeringExamples,
         triggeringExamples: TypeNameRuleExamples.triggeringExamples
@@ -91,6 +93,7 @@ private extension TypeNameRule {
             }
 
             let name = originalName
+                .strippingBackticks()
                 .strippingLeadingUnderscoreIfPrivate(modifiers: modifiers)
                 .strippingTrailingSwiftUIPreviewProvider(inheritedTypes: inheritedTypes)
             let allowedSymbols = nameConfiguration.allowedSymbols.union(.alphanumerics)
@@ -123,6 +126,10 @@ private extension TypeNameRule {
 }
 
 private extension String {
+    func strippingBackticks() -> String {
+        replacingOccurrences(of: "`", with: "")
+    }
+
     func strippingTrailingSwiftUIPreviewProvider(inheritedTypes: InheritedTypeListSyntax?) -> String {
         guard let inheritedTypes = inheritedTypes,
               hasSuffix("_Previews"),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRuleExamples.swift
@@ -18,7 +18,14 @@ internal struct TypeNameRuleExamples {
         }
         """),
         Example("enum MyType {\ncase value\n}"),
-        Example("protocol P {}", configuration: ["validate_protocols": false])
+        Example("protocol P {}", configuration: ["validate_protocols": false]),
+        Example("""
+        struct SomeStruct {
+          enum `Type` {
+            case x, y, z
+          }
+        }
+        """)
     ]
 
     static let triggeringExamples: [Example] = [


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/4571