### PR TITLE
Fix configuration description for some vertical whitespace rules

### DIFF
--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -57,8 +57,6 @@ extension VerticalWhitespaceClosingBracesRule {
 }
 
 extension VerticalWhitespaceClosingBracesRule: OptInRule {
-    var configurationDescription: String { return "N/A" }
-
     private static let examples = VerticalWhitespaceClosingBracesRuleExamples.self
     static let description = RuleDescription(
         identifier: "vertical_whitespace_closing_braces",

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -143,8 +143,6 @@ struct VerticalWhitespaceOpeningBracesRule: ConfigurationProviderRule {
 }
 
 extension VerticalWhitespaceOpeningBracesRule: OptInRule {
-    var configurationDescription: String { return "N/A" }
-
     init(configuration: Any) throws {}
 
     static let description = RuleDescription(


### PR DESCRIPTION
Before: `N/A`
After: `warning, only_enforce_before_trivial_lines: false`