### PR TITLE
Use a binary target for the build tool plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
             name: "SwiftLintPlugin",
             capability: .buildTool(),
             dependencies: [
-                .target(name: "swiftlint")
+                .target(name: "SwiftLintBinary")
             ]
         ),
         .executableTarget(
@@ -98,5 +98,10 @@ let package = Package(
                 "SwiftLintTestHelpers"
             ]
         ),
+        .binaryTarget(
+            name: "SwiftLintBinary",
+            url: "https://github.com/realm/SwiftLint/releases/download/0.50.1/SwiftLintBinary-macos.artifactbundle.zip",
+            checksum: "487c57b5a39b80d64a20a2d052312c3f5ff1a4ea28e3cf5556e43c5b9a184c0c"
+        )
     ]
 )


### PR DESCRIPTION
This will save users of the build tool plugin from having to compile the CLI tool before running the plugin. 

I'm still having a look at how to automate the updating of the binary details in the Package description.