### PR TITLE
Fix building tests in Xcode

### DIFF
--- a/.sourcery/GeneratedTests.stencil
+++ b/.sourcery/GeneratedTests.stencil
@@ -1,6 +1,5 @@
-@testable
 @_spi(TestHelper)
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest
 

--- a/.sourcery/GeneratedTests.stencil
+++ b/.sourcery/GeneratedTests.stencil
@@ -1,4 +1,8 @@
+// swiftlint:disable duplicate_imports
+
 @testable import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest
 

--- a/.sourcery/GeneratedTests.stencil
+++ b/.sourcery/GeneratedTests.stencil
@@ -1,8 +1,6 @@
-// swiftlint:disable duplicate_imports
-
-@testable import SwiftLintFramework
+@testable
 @_spi(TestHelper)
-import  SwiftLintFramework
+import SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest
 

--- a/Package.swift
+++ b/Package.swift
@@ -63,11 +63,12 @@ let package = Package(
             name: "SwiftLintFramework",
             dependencies: frameworkDependencies
         ),
-        .testTarget(
+        .target(
             name: "SwiftLintTestHelpers",
             dependencies: [
                 "SwiftLintFramework"
-            ]
+            ],
+            path: "Tests/SwiftLintTestHelpers"
         ),
         .testTarget(
             name: "SwiftLintFrameworkTests",

--- a/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Array+SwiftLint.swift
@@ -67,7 +67,8 @@ extension Array {
     ///
     /// - returns: The elements failing the `belongsInSecondPartition` test, followed by the elements passing the
     ///            `belongsInSecondPartition` test.
-    func partitioned(by belongsInSecondPartition: (Element) throws -> Bool) rethrows ->
+    @_spi(TestHelper)
+    public func partitioned(by belongsInSecondPartition: (Element) throws -> Bool) rethrows ->
         (first: ArraySlice<Element>, second: ArraySlice<Element>) {
             var copy = self
             let pivot = try copy.partition(by: belongsInSecondPartition)
@@ -79,7 +80,8 @@ extension Array {
     /// - parameter transform: The transformation to apply to each element.
     ///
     /// - returns: The result of applying `transform` on every element and flattening the results.
-    func parallelFlatMap<T>(transform: (Element) -> [T]) -> [T] {
+    @_spi(TestHelper)
+    public func parallelFlatMap<T>(transform: (Element) -> [T]) -> [T] {
         return parallelMap(transform: transform).flatMap { $0 }
     }
 
@@ -110,7 +112,8 @@ extension Array {
 
 extension Collection {
     /// Whether this collection has one or more element.
-    var isNotEmpty: Bool {
+    @_spi(TestHelper)
+    public var isNotEmpty: Bool {
         return !isEmpty
     }
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+FileGraph.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+FileGraph.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-internal extension Configuration {
+@_spi(TestHelper)
+public extension Configuration {
     struct FileGraph: Hashable {
         // MARK: - Properties
         private static let defaultRemoteConfigTimeout: TimeInterval = 2

--- a/Source/SwiftLintFramework/Extensions/Configuration+IndentationStyle.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+IndentationStyle.swift
@@ -7,7 +7,8 @@ public extension Configuration {
         case spaces(count: Int)
 
         /// The default indentation style if none is explicitly provided.
-        static var `default` = spaces(count: 4)
+        @_spi(TestHelper)
+        public static var `default` = spaces(count: 4)
 
         /// Creates an indentation style based on an untyped configuration value.
         ///

--- a/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Merging.swift
@@ -6,7 +6,8 @@ import SourceKittenFramework
 
 extension Configuration {
     // MARK: - Methods: Merging
-    internal func merged(
+    @_spi(TestHelper)
+    public func merged(
         withChild childConfiguration: Configuration,
         rootDirectory: String
     ) -> Configuration {

--- a/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftLintFile+Cache.swift
@@ -46,7 +46,8 @@ private let linesWithTokensCache = Cache { $0.computeLinesWithTokens() }
 internal typealias AssertHandler = () -> Void
 // Re-enable once all parser diagnostics in tests have been addressed.
 // https://github.com/realm/SwiftLint/issues/3348
-internal var parserDiagnosticsDisabledForTests = false
+@_spi(TestHelper)
+public var parserDiagnosticsDisabledForTests = false
 
 private let assertHandlers = [FileCacheKey: AssertHandler]()
 private let assertHandlerCache = Cache { file in assertHandlers[file.cacheKey] }
@@ -196,7 +197,8 @@ extension SwiftLintFile {
         linesWithTokensCache.invalidate(self)
     }
 
-    internal static func clearCaches() {
+    @_spi(TestHelper)
+    public static func clearCaches() {
         responseCache.clear()
         assertHandlerCache.clear()
         structureDictionaryCache.clear()

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -117,7 +117,8 @@ public struct Configuration {
     /// - parameter cachePath:              The location of the persisted cache to use whith this configuration.
     /// - parameter pinnedVersion:          The SwiftLint version defined in this configuration.
     /// - parameter allowZeroLintableFiles: Allow SwiftLint to exit successfully when passed ignored or unlintable files
-    internal init(
+    @_spi(TestHelper)
+    public init(
         rulesMode: RulesMode = .default(disabled: [], optIn: []),
         allRulesWrapped: [ConfigurationRuleWrapper]? = nil,
         ruleList: RuleList = primaryRuleList,

--- a/Source/SwiftLintFramework/Models/ConfigurationRuleWrapper.swift
+++ b/Source/SwiftLintFramework/Models/ConfigurationRuleWrapper.swift
@@ -1,1 +1,2 @@
-internal typealias ConfigurationRuleWrapper = (rule: Rule, initializedWithNonEmptyConfiguration: Bool)
+@_spi(TestHelper)
+public typealias ConfigurationRuleWrapper = (rule: Rule, initializedWithNonEmptyConfiguration: Bool)

--- a/Source/SwiftLintFramework/Models/Correction.swift
+++ b/Source/SwiftLintFramework/Models/Correction.swift
@@ -1,4 +1,5 @@
 /// A value describing a SwiftLint violation that was corrected.
+@_spi(TestHelper)
 public struct Correction: Equatable {
     /// The description of the rule for which this correction was applied.
     public let ruleDescription: RuleDescription
@@ -8,5 +9,13 @@ public struct Correction: Equatable {
     /// The console-printable description for this correction.
     public var consoleDescription: String {
         return "\(location) Corrected \(ruleDescription.name)"
+    }
+
+    public init (
+        ruleDescription: RuleDescription,
+        location: Location
+    ) {
+        self.ruleDescription = ruleDescription
+        self.location = location
     }
 }

--- a/Source/SwiftLintFramework/Models/Example.swift
+++ b/Source/SwiftLintFramework/Models/Example.swift
@@ -19,11 +19,14 @@ public struct Example {
     /// - SeeAlso: addEmoji(_:)
     public private(set) var testMultiByteOffsets: Bool
     /// Whether tests shall verify that the example wrapped in a comment doesn't trigger
-    private(set) var testWrappingInComment: Bool
+    @_spi(TestHelper)
+    public private(set) var testWrappingInComment: Bool
     /// Whether tests shall verify that the example wrapped into a string doesn't trigger
-    private(set) var testWrappingInString: Bool
+    @_spi(TestHelper)
+    public private(set) var testWrappingInString: Bool
     /// Whether tests shall verify that the disabled rule (comment in the example) doesn't trigger
-    private(set) var testDisableCommand: Bool
+    @_spi(TestHelper)
+    public private(set) var testDisableCommand: Bool
     /// Whether the example should be tested on Linux
     public private(set) var testOnLinux: Bool
     /// The path to the file where the example was created
@@ -40,7 +43,8 @@ public struct Example {
     let excludeFromDocumentation: Bool
 
     /// Specifies whether the test example should be the only example run during the current test case execution.
-    var isFocused: Bool
+    @_spi(TestHelper)
+    public var isFocused: Bool
 }
 
 public extension Example {

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -281,6 +281,7 @@ public struct CollectedLinter {
     /// - parameter storage: The storage object containing all collected info.
     ///
     /// - returns: All corrections that were applied.
+    @_spi(TestHelper)
     public func correct(using storage: RuleStorage) -> [Correction] {
         if let violations = cachedStyleViolations()?.0, violations.isEmpty {
             return []

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.8.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.8.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.9.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 /// The rule list containing all available rules built into SwiftLint.
 public let primaryRuleList = RuleList(rules: [

--- a/Source/SwiftLintFramework/Models/SwiftLintFile.swift
+++ b/Source/SwiftLintFramework/Models/SwiftLintFile.swift
@@ -65,7 +65,8 @@ public final class SwiftLintFile {
     }
 
     /// Mark this file as used for testing purposes.
-    func markAsTestFile() {
+    @_spi(TestHelper)
+    public func markAsTestFile() {
         isTestFile = true
     }
 }

--- a/Source/SwiftLintFramework/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintFramework/Protocols/CollectingRule.swift
@@ -1,0 +1,178 @@
+/// Type-erased protocol used to check whether a rule is collectable.
+public protocol AnyCollectingRule: Rule { }
+
+/// A rule that requires knowledge of all other files being linted.
+public protocol CollectingRule: AnyCollectingRule {
+    /// The kind of information to collect for each file being linted for this rule.
+    associatedtype FileInfo
+
+    /// Collects information for the specified file, to be analyzed by a `CollectedLinter`.
+    ///
+    /// - parameter file:              The file for which to collect info.
+    /// - parameter compilerArguments: The compiler arguments needed to compile this file.
+    ///
+    /// - returns: The collected file information.
+    func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> FileInfo
+
+    /// Collects information for the specified file, to be analyzed by a `CollectedLinter`.
+    ///
+    /// - parameter file: The file for which to collect info.
+    ///
+    /// - returns: The collected file information.
+    func collectInfo(for file: SwiftLintFile) -> FileInfo
+
+    /// Executes the rule on a file after collecting file info for all files and returns any violations to the rule's
+    /// expectations.
+    ///
+    /// - parameter file:              The file for which to execute the rule.
+    /// - parameter collectedInfo:     All collected info for all files.
+    /// - parameter compilerArguments: The compiler arguments needed to compile this file.
+    ///
+    /// - returns: All style violations to the rule's expectations.
+    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
+                  compilerArguments: [String]) -> [StyleViolation]
+
+    /// Executes the rule on a file after collecting file info for all files and returns any violations to the rule's
+    /// expectations.
+    ///
+    /// - parameter file:          The file for which to execute the rule.
+    /// - parameter collectedInfo: All collected info for all files.
+    ///
+    /// - returns: All style violations to the rule's expectations.
+    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [StyleViolation]
+}
+
+public extension CollectingRule {
+    func collectInfo(for file: SwiftLintFile, into storage: RuleStorage, compilerArguments: [String]) {
+        storage.collect(info: collectInfo(for: file, compilerArguments: compilerArguments),
+                        for: file, in: self)
+    }
+    func validate(file: SwiftLintFile, using storage: RuleStorage, compilerArguments: [String]) -> [StyleViolation] {
+        guard let info = storage.collectedInfo(for: self) else {
+            queuedFatalError("Attempt to validate a CollectingRule before collecting info for it")
+        }
+        return validate(file: file, collectedInfo: info, compilerArguments: compilerArguments)
+    }
+    func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> FileInfo {
+        return collectInfo(for: file)
+    }
+    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
+                  compilerArguments: [String]) -> [StyleViolation] {
+        return validate(file: file, collectedInfo: collectedInfo)
+    }
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
+        queuedFatalError("Must call `validate(file:collectedInfo:)` for CollectingRule")
+    }
+    func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
+        queuedFatalError("Must call `validate(file:collectedInfo:compilerArguments:)` for CollectingRule")
+    }
+}
+
+public extension CollectingRule where Self: AnalyzerRule {
+    func collectInfo(for file: SwiftLintFile) -> FileInfo {
+        queuedFatalError(
+            "Must call `collect(infoFor:compilerArguments:)` for AnalyzerRule & CollectingRule"
+        )
+    }
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
+        queuedFatalError(
+            "Must call `validate(file:collectedInfo:compilerArguments:)` for AnalyzerRule & CollectingRule"
+        )
+    }
+    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [StyleViolation] {
+        queuedFatalError(
+            "Must call `validate(file:collectedInfo:compilerArguments:)` for AnalyzerRule & CollectingRule"
+        )
+    }
+}
+
+/// A `CollectingRule` that is also a `CorrectableRule`.
+@_spi(TestHelper)
+public protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
+    /// Attempts to correct the violations to this rule in the specified file after collecting file info for all files
+    /// and returns all corrections that were applied.
+    ///
+    /// - note: This function is called by the linter and is always implemented in extensions.
+    ///
+    /// - parameter file:              The file for which to execute the rule.
+    /// - parameter collectedInfo:     All collected info.
+    /// - parameter compilerArguments: The compiler arguments needed to compile this file.
+    ///
+    /// - returns: All corrections that were applied.
+    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
+                 compilerArguments: [String]) -> [Correction]
+
+    /// Attempts to correct the violations to this rule in the specified file after collecting file info for all files
+    /// and returns all corrections that were applied.
+    ///
+    /// - note: This function is called by the linter and is always implemented in extensions.
+    ///
+    /// - parameter file:          The file for which to execute the rule.
+    /// - parameter collectedInfo: All collected info.
+    ///
+    /// - returns: All corrections that were applied.
+    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [Correction]
+}
+
+@_spi(TestHelper)
+public extension CollectingCorrectableRule {
+    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
+                 compilerArguments: [String]) -> [Correction] {
+        return correct(file: file, collectedInfo: collectedInfo)
+    }
+
+    func correct(file: SwiftLintFile, using storage: RuleStorage, compilerArguments: [String]) -> [Correction] {
+        guard let info = storage.collectedInfo(for: self) else {
+            queuedFatalError("Attempt to correct a CollectingRule before collecting info for it")
+        }
+        return correct(file: file, collectedInfo: info, compilerArguments: compilerArguments)
+    }
+
+    func correct(file: SwiftLintFile) -> [Correction] {
+        queuedFatalError("Must call `correct(file:collectedInfo:)` for AnalyzerRule")
+    }
+
+    func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
+        queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
+    }
+}
+
+public extension CollectingCorrectableRule where Self: AnalyzerRule {
+    func correct(file: SwiftLintFile) -> [Correction] {
+        queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
+    }
+    func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
+        queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
+    }
+    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [Correction] {
+        queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
+    }
+}
+
+public extension ConfigurationProviderRule {
+    init(configuration: Any) throws {
+        self.init()
+        try self.configuration.apply(configuration: configuration)
+    }
+
+    func isEqualTo(_ rule: Rule) -> Bool {
+        if let rule = rule as? Self {
+            return configuration.isEqualTo(rule.configuration)
+        }
+        return false
+    }
+
+    var configurationDescription: String {
+        return configuration.consoleDescription
+    }
+}
+
+// MARK: - == Implementations
+
+/// :nodoc:
+public extension Array where Element == Rule {
+    static func == (lhs: Array, rhs: Array) -> Bool {
+        if lhs.count != rhs.count { return false }
+        return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
+    }
+}

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -101,6 +101,7 @@ public protocol ConfigurationProviderRule: Rule {
 }
 
 /// A rule that can correct violations.
+@_spi(TestHelper)
 public protocol CorrectableRule: Rule {
     /// Attempts to correct the violations to this rule in the specified file.
     ///
@@ -130,6 +131,7 @@ public protocol CorrectableRule: Rule {
     func correct(file: SwiftLintFile, using storage: RuleStorage, compilerArguments: [String]) -> [Correction]
 }
 
+@_spi(TestHelper)
 public extension CorrectableRule {
     func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
         return correct(file: file)
@@ -141,6 +143,7 @@ public extension CorrectableRule {
 
 /// A correctable rule that can apply its corrections by replacing the content of ranges in the offending file with
 /// updated content.
+@_spi(TestHelper)
 public protocol SubstitutionCorrectableRule: CorrectableRule {
     /// Returns the NSString-based `NSRange`s to be replaced in the specified file.
     ///
@@ -158,6 +161,7 @@ public protocol SubstitutionCorrectableRule: CorrectableRule {
     func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)?
 }
 
+@_spi(TestHelper)
 public extension SubstitutionCorrectableRule {
     func correct(file: SwiftLintFile) -> [Correction] {
         let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
@@ -181,6 +185,7 @@ public extension SubstitutionCorrectableRule {
 }
 
 /// A `SubstitutionCorrectableRule` that is also an `ASTRule`.
+@_spi(TestHelper)
 public protocol SubstitutionCorrectableASTRule: SubstitutionCorrectableRule, ASTRule {
     /// Returns the NSString-based `NSRange`s to be replaced in the specified file.
     ///
@@ -216,184 +221,9 @@ public extension AnalyzerRule {
 }
 
 /// :nodoc:
+@_spi(TestHelper)
 public extension AnalyzerRule where Self: CorrectableRule {
     func correct(file: SwiftLintFile) -> [Correction] {
         queuedFatalError("Must call `correct(file:compilerArguments:)` for AnalyzerRule")
-    }
-}
-
-// MARK: - Collecting rules
-
-/// Type-erased protocol used to check whether a rule is collectable.
-public protocol AnyCollectingRule: Rule { }
-
-/// A rule that requires knowledge of all other files being linted.
-public protocol CollectingRule: AnyCollectingRule {
-    /// The kind of information to collect for each file being linted for this rule.
-    associatedtype FileInfo
-
-    /// Collects information for the specified file, to be analyzed by a `CollectedLinter`.
-    ///
-    /// - parameter file:              The file for which to collect info.
-    /// - parameter compilerArguments: The compiler arguments needed to compile this file.
-    ///
-    /// - returns: The collected file information.
-    func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> FileInfo
-
-    /// Collects information for the specified file, to be analyzed by a `CollectedLinter`.
-    ///
-    /// - parameter file: The file for which to collect info.
-    ///
-    /// - returns: The collected file information.
-    func collectInfo(for file: SwiftLintFile) -> FileInfo
-
-    /// Executes the rule on a file after collecting file info for all files and returns any violations to the rule's
-    /// expectations.
-    ///
-    /// - parameter file:              The file for which to execute the rule.
-    /// - parameter collectedInfo:     All collected info for all files.
-    /// - parameter compilerArguments: The compiler arguments needed to compile this file.
-    ///
-    /// - returns: All style violations to the rule's expectations.
-    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
-                  compilerArguments: [String]) -> [StyleViolation]
-
-    /// Executes the rule on a file after collecting file info for all files and returns any violations to the rule's
-    /// expectations.
-    ///
-    /// - parameter file:          The file for which to execute the rule.
-    /// - parameter collectedInfo: All collected info for all files.
-    ///
-    /// - returns: All style violations to the rule's expectations.
-    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [StyleViolation]
-}
-
-public extension CollectingRule {
-    func collectInfo(for file: SwiftLintFile, into storage: RuleStorage, compilerArguments: [String]) {
-        storage.collect(info: collectInfo(for: file, compilerArguments: compilerArguments),
-                        for: file, in: self)
-    }
-    func validate(file: SwiftLintFile, using storage: RuleStorage, compilerArguments: [String]) -> [StyleViolation] {
-        guard let info = storage.collectedInfo(for: self) else {
-            queuedFatalError("Attempt to validate a CollectingRule before collecting info for it")
-        }
-        return validate(file: file, collectedInfo: info, compilerArguments: compilerArguments)
-    }
-    func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> FileInfo {
-        return collectInfo(for: file)
-    }
-    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
-                  compilerArguments: [String]) -> [StyleViolation] {
-        return validate(file: file, collectedInfo: collectedInfo)
-    }
-    func validate(file: SwiftLintFile) -> [StyleViolation] {
-        queuedFatalError("Must call `validate(file:collectedInfo:)` for CollectingRule")
-    }
-    func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
-        queuedFatalError("Must call `validate(file:collectedInfo:compilerArguments:)` for CollectingRule")
-    }
-}
-
-public extension CollectingRule where Self: AnalyzerRule {
-    func collectInfo(for file: SwiftLintFile) -> FileInfo {
-        queuedFatalError(
-            "Must call `collect(infoFor:compilerArguments:)` for AnalyzerRule & CollectingRule"
-        )
-    }
-    func validate(file: SwiftLintFile) -> [StyleViolation] {
-        queuedFatalError(
-            "Must call `validate(file:collectedInfo:compilerArguments:)` for AnalyzerRule & CollectingRule"
-        )
-    }
-    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [StyleViolation] {
-        queuedFatalError(
-            "Must call `validate(file:collectedInfo:compilerArguments:)` for AnalyzerRule & CollectingRule"
-        )
-    }
-}
-
-/// A `CollectingRule` that is also a `CorrectableRule`.
-public protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
-    /// Attempts to correct the violations to this rule in the specified file after collecting file info for all files
-    /// and returns all corrections that were applied.
-    ///
-    /// - note: This function is called by the linter and is always implemented in extensions.
-    ///
-    /// - parameter file:              The file for which to execute the rule.
-    /// - parameter collectedInfo:     All collected info.
-    /// - parameter compilerArguments: The compiler arguments needed to compile this file.
-    ///
-    /// - returns: All corrections that were applied.
-    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
-                 compilerArguments: [String]) -> [Correction]
-
-    /// Attempts to correct the violations to this rule in the specified file after collecting file info for all files
-    /// and returns all corrections that were applied.
-    ///
-    /// - note: This function is called by the linter and is always implemented in extensions.
-    ///
-    /// - parameter file:          The file for which to execute the rule.
-    /// - parameter collectedInfo: All collected info.
-    ///
-    /// - returns: All corrections that were applied.
-    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [Correction]
-}
-
-public extension CollectingCorrectableRule {
-    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
-                 compilerArguments: [String]) -> [Correction] {
-        return correct(file: file, collectedInfo: collectedInfo)
-    }
-    func correct(file: SwiftLintFile, using storage: RuleStorage, compilerArguments: [String]) -> [Correction] {
-        guard let info = storage.collectedInfo(for: self) else {
-            queuedFatalError("Attempt to correct a CollectingRule before collecting info for it")
-        }
-        return correct(file: file, collectedInfo: info, compilerArguments: compilerArguments)
-    }
-    func correct(file: SwiftLintFile) -> [Correction] {
-        queuedFatalError("Must call `correct(file:collectedInfo:)` for AnalyzerRule")
-    }
-    func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
-        queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
-    }
-}
-
-public extension CollectingCorrectableRule where Self: AnalyzerRule {
-    func correct(file: SwiftLintFile) -> [Correction] {
-        queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
-    }
-    func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
-        queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
-    }
-    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [Correction] {
-        queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
-    }
-}
-
-public extension ConfigurationProviderRule {
-    init(configuration: Any) throws {
-        self.init()
-        try self.configuration.apply(configuration: configuration)
-    }
-
-    func isEqualTo(_ rule: Rule) -> Bool {
-        if let rule = rule as? Self {
-            return configuration.isEqualTo(rule.configuration)
-        }
-        return false
-    }
-
-    var configurationDescription: String {
-        return configuration.consoleDescription
-    }
-}
-
-// MARK: - == Implementations
-
-/// :nodoc:
-public extension Array where Element == Rule {
-    static func == (lhs: Array, rhs: Array) -> Bool {
-        if lhs.count != rhs.count { return false }
-        return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }
     }
 }

--- a/Source/SwiftLintFramework/Protocols/SwiftSyntaxCorrectableRule.swift
+++ b/Source/SwiftLintFramework/Protocols/SwiftSyntaxCorrectableRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
 /// A SwiftLint CorrectableRule that performs its corrections using a SwiftSyntax `SyntaxRewriter`.
+@_spi(TestHelper)
 public protocol SwiftSyntaxCorrectableRule: SwiftSyntaxRule, CorrectableRule {
     /// Produce a `ViolationsSyntaxRewriter` for the given file.
     ///
@@ -10,6 +11,7 @@ public protocol SwiftSyntaxCorrectableRule: SwiftSyntaxRule, CorrectableRule {
     func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter?
 }
 
+@_spi(TestHelper)
 public extension SwiftSyntaxCorrectableRule {
     func correct(file: SwiftLintFile) -> [Correction] {
         guard let rewriter = makeRewriter(file: file),

--- a/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
@@ -1,9 +1,10 @@
-struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKitFreeRule {
-    var configuration = SeverityConfiguration(.warning)
+@_spi(TestHelper)
+public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKitFreeRule {
+    public var configuration = SeverityConfiguration(.warning)
 
-    init() {}
+    public init() {}
 
-    static let description = RuleDescription(
+    public static let description = RuleDescription(
         identifier: "superfluous_disable_command",
         name: "Superfluous Disable Command",
         description: """
@@ -13,7 +14,7 @@ struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKitFreeRu
         kind: .lint
     )
 
-    func validate(file: SwiftLintFile) -> [StyleViolation] {
+    public func validate(file: SwiftLintFile) -> [StyleViolation] {
         // This rule is implemented in Linter.swift
         return []
     }

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -7,7 +7,8 @@ import Glibc
 #error("Unsupported platform")
 #endif
 import Foundation
-import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintFramework
 import SwiftyTextTable
 
 extension SwiftLint {

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -8,7 +8,7 @@ import Glibc
 #endif
 import Foundation
 @_spi(TestHelper)
-import  SwiftLintFramework
+import SwiftLintFramework
 import SwiftyTextTable
 
 extension SwiftLint {

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -1,6 +1,7 @@
 import Dispatch
 import Foundation
-import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintFramework
 
 enum LintOrAnalyzeMode {
     case lint, analyze

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -1,7 +1,7 @@
 import Dispatch
 import Foundation
 @_spi(TestHelper)
-import  SwiftLintFramework
+import SwiftLintFramework
 
 enum LintOrAnalyzeMode {
     case lint, analyze

--- a/Source/swiftlint/Helpers/RulesFilter.swift
+++ b/Source/swiftlint/Helpers/RulesFilter.swift
@@ -1,5 +1,5 @@
 @_spi(TestHelper)
-import  SwiftLintFramework
+import SwiftLintFramework
 
 extension RulesFilter {
     struct ExcludingOptions: OptionSet {

--- a/Source/swiftlint/Helpers/RulesFilter.swift
+++ b/Source/swiftlint/Helpers/RulesFilter.swift
@@ -1,4 +1,5 @@
-import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintFramework
 
 extension RulesFilter {
     struct ExcludingOptions: OptionSet {

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -1,6 +1,6 @@
 @testable import swiftlint
 @_spi(TestHelper)
-import  SwiftLintFramework
+import SwiftLintFramework
 import XCTest
 
 final class RulesFilterTests: XCTestCase {

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -1,5 +1,6 @@
 @testable import swiftlint
-import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintFramework
 import XCTest
 
 final class RulesFilterTests: XCTestCase {

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,8 +1,7 @@
 // Generated using Sourcery 1.9.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-@testable
 @_spi(TestHelper)
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest
 

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,10 +1,8 @@
 // Generated using Sourcery 1.9.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-// swiftlint:disable duplicate_imports
-
-@testable import SwiftLintFramework
+@testable
 @_spi(TestHelper)
-import  SwiftLintFramework
+import SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest
 

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,6 +1,10 @@
 // Generated using Sourcery 1.9.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
+// swiftlint:disable duplicate_imports
+
 @testable import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest
 

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 @_spi(TestHelper)
-import  SwiftLintFramework
+import SwiftLintFramework
 import XCTest
 
 private let config: Configuration = {

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
-@testable import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintFramework
 import XCTest
 
 private let config: Configuration = {

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -1,9 +1,8 @@
-// swiftlint:disable duplicate_imports
-@testable import SwiftLintFramework
+@testable
 @_spi(TestHelper)
 import SwiftLintFramework
 @_spi(TestHelper)
-import  SwiftLintTestHelpers
+import SwiftLintTestHelpers
 import XCTest
 
 class CollectingRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -1,6 +1,5 @@
-@testable
 @_spi(TestHelper)
-import SwiftLintFramework
+@testable import SwiftLintFramework
 @_spi(TestHelper)
 import SwiftLintTestHelpers
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -1,4 +1,9 @@
+// swiftlint:disable duplicate_imports
 @testable import SwiftLintFramework
+@_spi(TestHelper)
+import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintTestHelpers
 import XCTest
 
 class CollectingRuleTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -1,7 +1,6 @@
-// swiftlint:disable duplicate_imports
 import Foundation
 import SourceKittenFramework
-@testable import SwiftLintFramework
+@testable
 @_spi(TestHelper)
 import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -1,6 +1,9 @@
+// swiftlint:disable duplicate_imports
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework
+@_spi(TestHelper)
+import SwiftLintFramework
 import XCTest
 
 private extension Command {

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
-@testable
 @_spi(TestHelper)
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 private extension Command {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -1,5 +1,4 @@
-// swiftlint:disable duplicate_imports
-@testable import SwiftLintFramework
+@testable
 @_spi(TestHelper)
 import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -1,6 +1,5 @@
-@testable
 @_spi(TestHelper)
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 // swiftlint:disable file_length

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -1,4 +1,7 @@
+// swiftlint:disable duplicate_imports
 @testable import SwiftLintFramework
+@_spi(TestHelper)
+import SwiftLintFramework
 import XCTest
 
 // swiftlint:disable file_length

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -1,7 +1,6 @@
-// swiftlint:disable duplicate_imports
 import Foundation
 import SourceKittenFramework
-@testable import SwiftLintFramework
+@testable
 @_spi(TestHelper)
 import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -1,8 +1,7 @@
 import Foundation
 import SourceKittenFramework
-@testable
 @_spi(TestHelper)
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 // swiftlint:disable file_length

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -1,6 +1,9 @@
+// swiftlint:disable duplicate_imports
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework
+@_spi(TestHelper)
+import SwiftLintFramework
 import XCTest
 
 // swiftlint:disable file_length

--- a/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
@@ -1,6 +1,5 @@
-@testable
 @_spi(TestHelper)
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 final class ParserDiagnosticsTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
@@ -1,4 +1,7 @@
+// swiftlint:disable duplicate_imports
 @testable import SwiftLintFramework
+@_spi(TestHelper)
+import SwiftLintFramework
 import XCTest
 
 final class ParserDiagnosticsTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
@@ -1,5 +1,4 @@
-// swiftlint:disable duplicate_imports
-@testable import SwiftLintFramework
+@testable
 @_spi(TestHelper)
 import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -1,6 +1,5 @@
-@testable
 @_spi(TestHelper)
-import SwiftLintFramework
+@testable import SwiftLintFramework
 import XCTest
 
 class SourceKitCrashTests: XCTestCase {

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -1,5 +1,4 @@
-// swiftlint:disable duplicate_imports
-@testable import SwiftLintFramework
+@testable
 @_spi(TestHelper)
 import SwiftLintFramework
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -1,4 +1,7 @@
+// swiftlint:disable duplicate_imports
 @testable import SwiftLintFramework
+@_spi(TestHelper)
+import SwiftLintFramework
 import XCTest
 
 class SourceKitCrashTests: XCTestCase {

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
-@testable import SwiftLintFramework
+@_spi(TestHelper)
+import  SwiftLintFramework
 import XCTest
 
 // swiftlint:disable file_length
@@ -86,6 +87,7 @@ public extension Collection where Element == String {
                 .violations(config: config, requiresFileOnDisk: requiresFileOnDisk)
     }
 
+    @_spi(TestHelper)
     func corrections(config: Configuration = Configuration.default, requiresFileOnDisk: Bool = false) -> [Correction] {
         return map { SwiftLintFile.testFile(withContents: $0, persistToDisk: requiresFileOnDisk) }
             .corrections(config: config, requiresFileOnDisk: requiresFileOnDisk)
@@ -107,6 +109,7 @@ public extension Collection where Element: SwiftLintFile {
             return requiresFileOnDisk ? violations.withoutFiles() : violations
     }
 
+    @_spi(TestHelper)
     func corrections(config: Configuration = Configuration.default, requiresFileOnDisk: Bool = false) -> [Correction] {
         let storage = RuleStorage()
         let corrections = map({ file in

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 @_spi(TestHelper)
-import  SwiftLintFramework
+import SwiftLintFramework
 import XCTest
 
 // swiftlint:disable file_length


### PR DESCRIPTION
Fix #4606

SwiftLintTestHelpers is a testTarget in order to use @testable imports for SwiftLintFramework, which had previously failed to compile for release when the target was declared as a regular target with the following error:
```
> swift build -c release

error: module 'SwiftLintFramework' was not compiled for testing
@testable import SwiftLintFramework
```

However, this breaks building/testing the target in Xcode with the following error:
```
Unable to resolve build file: XCBCore.BuildFile (The workspace has a reference to a missing target with GUID 'PACKAGE-TARGET:SwiftLintTestHelpers')
```

In order for SwiftLintTestHelpers to use internal symbols in SwiftLintFramework without using @testable import, we use @_spi imports instead. This fixes the issues when building on Xcode and for release.

**Test Plan**

- swift build -c release
```
Compiling plugin Generate Manual...
Compiling plugin SwiftLintPlugin...
Building for production...
[32/32] Compiling SwiftLintTestHelpers RuleDescription+Examples.swift
Build complete! (225.61s)
```
- Xcode builds successfully

**Notes**
Rule.swift needed to be broken into two files to pass the file length rule