### PR TITLE
Make forceExclude work with directly specified files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 
 #### Enhancements
 
-* None.
+* Make forceExclude work with directly specified files.  
+  [jimmya](https://github.com/jimmya)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/4609)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -33,8 +33,16 @@ extension Configuration {
         excludeByPrefix: Bool = false,
         fileManager: LintableFileManager = FileManager.default
     ) -> [String] {
-        // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
-        if path.isFile && !forceExclude { return [path] }
+        if path.isFile {
+            if forceExclude {
+                let filteredPaths = excludeByPrefix
+                    ? filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])
+                    : filterExcludedPaths(fileManager: fileManager, in: [path.absolutePathStandardized()])
+                return filteredPaths
+            } else { // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
+                return [path]
+            }
+        }
 
         let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: path, rootDirectory: nil) : []
         let includedPaths = self.includedPaths

--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -35,13 +35,12 @@ extension Configuration {
     ) -> [String] {
         if path.isFile {
             if forceExclude {
-                let filteredPaths = excludeByPrefix
+                return excludeByPrefix
                     ? filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])
                     : filterExcludedPaths(fileManager: fileManager, in: [path.absolutePathStandardized()])
-                return filteredPaths
-            } else { // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
-                return [path]
             }
+            // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
+            return [path]
         }
 
         let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: path, rootDirectory: nil) : []


### PR DESCRIPTION
It seemed that `--force-exclude` didn't work when providing files directly.
.swiftlint.yml:
```yaml
excluded:
  - ./**/*Test*
```

Directory contents:
```
 |-.swiftlint.yml
 |-Source
 | |-FooBar.swift
 | |-FooTest.swift
 | |-Foo.swift
```

When specifying a file that matches this excluded list:
```bash
➜ swiftlint --config .swiftlint.yml --force-exclude Source/FooTest.swift
Linting Swift files at paths Source/FooTest.swift
Linting 'Foo.swift' (1/2)
Linting 'FooBar.swift' (2/2)
```
Because it fell through the if statement it started linting all included files.

When specifying a file that doesn't match:
```bash
➜ swiftlint --config .swiftlint.yml --force-exclude Source/Foo.swift    
Linting Swift files at paths Source/Foo.swift
Linting 'Foo.swift' (1/1)
```

### Expected result:
```bash
➜ swiftlint --config .swiftlint.yml --force-exclude Source/FooTest.swift                
Linting Swift files at paths Source/FooTest.swift
Error: No lintable files found at paths: 'Source/FooTest.swift'
```

This PR makes sure that this excluded list is taken into account when specifying the `--force-exclude` flag.