### PR TITLE
Deprecate `inert_defer` rule in favor of the Swift compiler warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   [Cyberbeni](https://github.com/Cyberbeni)
   [#4656](https://github.com/realm/SwiftLint/issues/4656)
 
+* Deprecate the `inert_defer` rule in favor of the Swift compiler warning.
+  At the same time, make it an opt-in rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4615](https://github.com/realm/SwiftLint/issues/4615)
+
 #### Experimental
 
 * None.

--- a/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/InertDeferRule.swift
@@ -1,6 +1,18 @@
 import SwiftSyntax
 
-struct InertDeferRule: ConfigurationProviderRule, SwiftSyntaxRule {
+private let warnDeprecatedOnceImpl: Void = {
+    queuedPrintError("""
+        The `\(InertDeferRule.description.identifier)` rule is now deprecated and will be completely \
+        removed in a future release due to an equivalent warning issued by the Swift compiler.
+        """
+    )
+}()
+
+private func warnDeprecatedOnce() {
+    _ = warnDeprecatedOnceImpl
+}
+
+struct InertDeferRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
     var configuration = SeverityConfiguration(.warning)
 
     init() {}
@@ -77,7 +89,8 @@ struct InertDeferRule: ConfigurationProviderRule, SwiftSyntaxRule {
     )
 
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
+        warnDeprecatedOnce()
+        return Visitor(viewMode: .sourceAccurate)
     }
 }
 


### PR DESCRIPTION
See https://github.com/realm/SwiftLint/issues/4615#issuecomment-1336348568.