### PR TITLE
Print a warning for Analyzer rules misplaced in the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4200](https://github.com/realm/SwiftLint/issues/4200)
 
+* Show warnings in the console for Analyzer rules that are listed in the
+  `opt_in_rules` configuration section.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4612](https://github.com/realm/SwiftLint/issues/4612)
+
 #### Bug Fixes
 
 * Fix configuration parsing error in `unused_declaration` rule.  

--- a/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+Parsing.swift
@@ -57,6 +57,7 @@ extension Configuration {
             configurationDictionary: dict, disabledRules: disabledRules,
             optInRules: optInRules, onlyRules: onlyRules, ruleList: ruleList
         )
+        Self.warnAboutMisplacedAnalyzerRules(optInRules: optInRules, ruleList: ruleList)
 
         let allRulesWrapped: [ConfigurationRuleWrapper]
         do {
@@ -201,5 +202,19 @@ extension Configuration {
                 }
             }
         }
+    }
+
+    private static func warnAboutMisplacedAnalyzerRules(optInRules: [String], ruleList: RuleList) {
+        let analyzerRules = ruleList.list
+            .filter { $0.value.self is AnalyzerRule.Type }
+            .map(\.key)
+        Set(analyzerRules).intersection(optInRules)
+            .sorted()
+            .forEach {
+                queuedPrintError("""
+                    warning: '\($0)' should be listed in the 'analyzer_rules' configuration section \
+                    for more clarity as it is only run by 'swiftlint analyze'
+                    """)
+            }
     }
 }


### PR DESCRIPTION
See https://github.com/realm/SwiftLint/issues/4612#issuecomment-1336401702.