### PR TITLE
Use `raw` in SwiftSyntaxBuilder string interpolation

### DIFF
--- a/Source/SwiftLintFramework/Helpers/LegacyFunctionRuleHelper.swift
+++ b/Source/SwiftLintFramework/Helpers/LegacyFunctionRuleHelper.swift
@@ -70,13 +70,13 @@ enum LegacyFunctionRuleHelper {
             case .equal:
                 expr = "\(trimmedArguments[0]) == \(trimmedArguments[1])"
             case let .property(name: propertyName):
-                expr = "\(trimmedArguments[0]).\(propertyName)"
+                expr = "\(trimmedArguments[0]).\(raw: propertyName)"
             case let .function(name: functionName, argumentLabels: argumentLabels, reversed: reversed):
                 let arguments = reversed ? trimmedArguments.reversed() : trimmedArguments
                 let params = zip(argumentLabels, arguments.dropFirst())
                     .map { $0.isEmpty ? "\($1)" : "\($0): \($1)" }
                     .joined(separator: ", ")
-                expr = "\(arguments[0]).\(functionName)(\(params))"
+                expr = "\(arguments[0]).\(raw: functionName)(\(raw: params))"
             case .none:
                 return super.visit(node)
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/LegacyConstantRule.swift
@@ -62,7 +62,7 @@ private extension LegacyConstantRule {
             }
 
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-            return ("\(correction)" as ExprSyntax)
+            return ("\(raw: correction)" as ExprSyntax)
                 .withLeadingTrivia(node.leadingTrivia ?? .zero)
                 .withTrailingTrivia(node.trailingTrivia ?? .zero)
         }
@@ -77,7 +77,7 @@ private extension LegacyConstantRule {
             }
 
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-            return ("\(calledExpression.identifier.text).pi" as ExprSyntax)
+            return ("\(raw: calledExpression.identifier.text).pi" as ExprSyntax)
                 .withLeadingTrivia(node.leadingTrivia ?? .zero)
                 .withTrailingTrivia(node.trailingTrivia ?? .zero)
         }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -76,7 +76,7 @@ private extension PreferZeroOverExplicitInitRule {
 
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
 
-            let newNode: MemberAccessExprSyntax = "\(name).zero"
+            let newNode: MemberAccessExprSyntax = "\(raw: name).zero"
             return super.visit(
                 newNode
                     .withLeadingTrivia(node.leadingTrivia ?? .zero)


### PR DESCRIPTION
Fixing build warnings to account for https://github.com/apple/swift-syntax/pull/1090.