### PR TITLE
Add rule for single space after period on comments

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,6 +48,7 @@ opt_in_rules:
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
+  - period_spacing
   - prefer_self_type_over_type_of_self
   - private_action
   - private_outlet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3315,6 +3315,11 @@ This is the last release to support building with Swift 4.0 and Swift 4.1.
 
 #### Enhancements
 
+* Add `period_spacing` opt-in rule that checks periods are not followed
+  by 2 or more spaces in comments.
+  [Julioacarrettoni](https://github.com/Julioacarrettoni)
+  [#4624](https://github.com/realm/SwiftLint/pull/4624)  s
+
 * Add optional filename verification to the `file_header` rule.
   All occurrences in the pattern of the `SWIFTLINT_CURRENT_FILENAME`
   placeholder are replaced by the name of the validated file.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   `single_test_class` and `empty_xctest_method` rules.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4200](https://github.com/realm/SwiftLint/issues/4200)
+  
+  * Add `period_spacing` opt-in rule that checks periods are not followed
+  by 2 or more spaces in comments.  
+  [Julioacarrettoni](https://github.com/Julioacarrettoni)
+  [#4624](https://github.com/realm/SwiftLint/pull/4624)
 
 #### Bug Fixes
 
@@ -3314,11 +3319,6 @@ This is the last release to support building with Swift 4.0 and Swift 4.1.
   [#1892](https://github.com/realm/SwiftLint/issues/1892)
 
 #### Enhancements
-
-* Add `period_spacing` opt-in rule that checks periods are not followed
-  by 2 or more spaces in comments.
-  [Julioacarrettoni](https://github.com/Julioacarrettoni)
-  [#4624](https://github.com/realm/SwiftLint/pull/4624)  s
 
 * Add optional filename verification to the `file_header` rule.
   All occurrences in the pattern of the `SWIFTLINT_CURRENT_FILENAME`

--- a/Source/SwiftLintFramework/Extensions/SyntaxClassification+isComment.swift
+++ b/Source/SwiftLintFramework/Extensions/SyntaxClassification+isComment.swift
@@ -1,0 +1,15 @@
+import IDEUtils
+
+extension SyntaxClassification {
+    // True if it is any kind of comment.
+    var isComment: Bool {
+        switch self {
+        case .lineComment, .docLineComment, .blockComment, .docBlockComment:
+            return true
+        case .none, .keyword, .identifier, .typeIdentifier, .operatorIdentifier, .dollarIdentifier, .integerLiteral,
+             .floatingLiteral, .stringLiteral, .stringInterpolationAnchor, .poundDirectiveKeyword, .buildConfigId,
+             .attribute, .objectLiteral, .editorPlaceholder:
+            return false
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -137,6 +137,7 @@ public let primaryRuleList = RuleList(rules: [
     OverriddenSuperCallRule.self,
     OverrideInExtensionRule.self,
     PatternMatchingKeywordsRule.self,
+    PeriodSpacingRule.self,
     PreferNimbleRule.self,
     PreferSelfInStaticReferencesRule.self,
     PreferSelfTypeOverTypeOfSelfRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -122,6 +122,7 @@ struct CommentSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, Substit
     func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         // Find all comment tokens in the file and regex search them for violations
         file.syntaxClassifications
+            .filter(\.kind.isComment)
             .map { $0.range.toSourceKittenByteRange() }
             .compactMap { (range: ByteRange) -> [NSRange]? in
                 return file.stringView

--- a/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/CommentSpacingRule.swift
@@ -122,15 +122,8 @@ struct CommentSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, Substit
     func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         // Find all comment tokens in the file and regex search them for violations
         file.syntaxClassifications
-            .compactMap { (classifiedRange: SyntaxClassifiedRange) -> [NSRange]? in
-                switch classifiedRange.kind {
-                case .blockComment, .docBlockComment, .lineComment, .docLineComment:
-                    break
-                default:
-                    return nil
-                }
-
-                let range = classifiedRange.range.toSourceKittenByteRange()
+            .map { $0.range.toSourceKittenByteRange() }
+            .compactMap { (range: ByteRange) -> [NSRange]? in
                 return file.stringView
                     .substringWithByteRange(range)
                     .map(StringView.init)

--- a/Source/SwiftLintFramework/Rules/Lint/PeriodSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PeriodSpacingRule.swift
@@ -1,7 +1,6 @@
 import Foundation
 import IDEUtils
 import SourceKittenFramework
-import SwiftSyntax
 
 struct PeriodSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, SubstitutionCorrectableRule {
     var configuration = SeverityConfiguration(.warning)

--- a/Source/SwiftLintFramework/Rules/Lint/PeriodSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PeriodSpacingRule.swift
@@ -1,0 +1,94 @@
+import Foundation
+import IDEUtils
+import SourceKittenFramework
+import SwiftSyntax
+
+struct PeriodSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, SubstitutionCorrectableRule {
+    var configuration = SeverityConfiguration(.warning)
+
+    init() {}
+
+    static let description = RuleDescription(
+        identifier: "period_spacing",
+        name: "Period Spacing",
+        description: "Periods should not be followed by more than one space.",
+        kind: .style,
+        nonTriggeringExamples: [
+            Example("let pi = 3.2"),
+            Example("let pi = Double.pi"),
+            Example("let pi = Double. pi"),
+            Example("let pi = Double.  pi"),
+            Example("// A. Single."),
+            Example("///   - code: Identifier of the error. Integer."),
+            Example("""
+            // value: Multiline.
+            //        Comment.
+            """)
+        ],
+        triggeringExamples: [
+            Example("/* Only god knows why.  This symbol does nothing. */", testWrappingInComment: false),
+            Example("// Only god knows why.  This symbol does nothing.", testWrappingInComment: false),
+            Example("// Single. Double.  End.", testWrappingInComment: false),
+            Example("// Single. Double.  Triple.   End.", testWrappingInComment: false),
+            Example("// Triple.   Quad.    End.", testWrappingInComment: false),
+            Example("///   - code: Identifier of the error.  Integer.", testWrappingInComment: false)
+        ],
+        corrections: [
+            Example("/* Why. ↓ Symbol does nothing. */"): Example("/* Why. Symbol does nothing. */"),
+            Example("// Why. ↓ Symbol does nothing."): Example("// Why. Symbol does nothing."),
+            Example("// Single. Double. ↓ End."): Example("// Single. Double. End."),
+            Example("// Single. Double. ↓ Triple. ↓  End."): Example("// Single. Double. Triple. End."),
+            Example("// Triple. ↓  Quad. ↓   End."): Example("// Triple. Quad. End."),
+            Example("///   - code: Identifier. ↓ Integer."): Example("///   - code: Identifier. Integer.")
+        ]
+    )
+
+    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
+        // Find all comment tokens in the file and regex search them for violations
+        file.syntaxClassifications
+            .compactMap { (classifiedRange: SyntaxClassifiedRange) -> [NSRange]? in
+                switch classifiedRange.kind {
+                case .blockComment, .docBlockComment, .lineComment, .docLineComment:
+                    break
+                default:
+                    return nil
+                }
+
+                let range = classifiedRange.range.toSourceKittenByteRange()
+                return file.stringView
+                    .substringWithByteRange(range)
+                    .map(StringView.init)
+                    .map { commentBody in
+                        // Look for a dot character followed immediately by two or more whitespaces
+                        regex(#"\.\s{2,}"#)
+                            .matches(in: commentBody)
+                            .compactMap { result in
+                                // Set the location to start from the second whitespace till the last one.
+                                return file.stringView.byteRangeToNSRange(
+                                    ByteRange(
+                                        // Safe to mix NSRange offsets with byte offsets here because the
+                                        // regex can't contain multi-byte characters
+                                        location: ByteCount(range.lowerBound.value + result.range.lowerBound + 2),
+                                        length: ByteCount(result.range.length.advanced(by: -2))
+                                    )
+                                )
+                            }
+                    }
+            }
+            .flatMap { $0 }
+    }
+
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
+        return violationRanges(in: file).map { range in
+            StyleViolation(
+                ruleDescription: Self.description,
+                severity: configuration.severity,
+                location: Location(file: file, characterOffset: range.location)
+            )
+        }
+    }
+
+    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
+        return (violationRange, "")
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/PeriodSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PeriodSpacingRule.swift
@@ -23,6 +23,13 @@ struct PeriodSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, Substitu
             Example("""
             // value: Multiline.
             //        Comment.
+            """),
+            Example("""
+            /**
+            Sentence ended in period.
+
+            - Sentence 2 new line characters after.
+            **/
             """)
         ],
         triggeringExamples: [
@@ -59,8 +66,8 @@ struct PeriodSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, Substitu
                     .substringWithByteRange(range)
                     .map(StringView.init)
                     .map { commentBody in
-                        // Look for a dot character followed immediately by two or more whitespaces
-                        regex(#"\.\s{2,}"#)
+                        // Look for a period followed by two or more whitespaces but not new line or caret returns
+                        regex(#"\.[^\S\r\n]{2,}"#)
                             .matches(in: commentBody)
                             .compactMap { result in
                                 // Set the location to start from the second whitespace till the last one.

--- a/Source/SwiftLintFramework/Rules/Lint/PeriodSpacingRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PeriodSpacingRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import IDEUtils
 import SourceKittenFramework
 
-struct PeriodSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, SubstitutionCorrectableRule {
+struct PeriodSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, OptInRule, SubstitutionCorrectableRule {
     var configuration = SeverityConfiguration(.warning)
 
     init() {}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -811,6 +811,12 @@ class PatternMatchingKeywordsRuleGeneratedTests: XCTestCase {
     }
 }
 
+class PeriodSpacingRuleGeneratedTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PeriodSpacingRule.description)
+    }
+}
+
 class PreferNimbleRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferNimbleRule.description)


### PR DESCRIPTION
Because even prose needs a style guide, and according to [owl.purdue.edu](https://owl.purdue.edu/owl/subject_specific_writing/journalism_and_journalistic_writing/ap_style.html#:~:text=million%2C%206%20cents.-,Punctuation,Use%20a%20single%20space%20after%20a%20period.,-Do%20not%20use) we should be using a single space after punctuation, I'm introducing `period_spacing`.

> Punctuation
> Use a single space after a period.

The rule simply checks and removes extra spaces after the first space following a period in `.blockComment`, `.docBlockComment`, `.lineComment`, and `.docLineComment`.

Per the [contributing guidelines](https://github.com/realm/SwiftLint/blob/4adabd8e4b0506e83937a128132eec292d8cc54a/CONTRIBUTING.md#tests) :
> SwiftLint supports building via Xcode and Swift Package Manager on macOS, and with Swift Package Manager on Linux. When contributing code changes, please ensure that all three supported build methods continue to work and pass tests.

- [x] $ xcodebuild -scheme swiftlint test -destination platform=macOS,arch=arm64,id=00006001-000411983E09801E
- [x] $ swift test
- [x] $ make docker_test (passes when applying the change from https://github.com/realm/SwiftLint/pull/4625)

This rule opt-in because it triggers in a lot of the linked repositories and it fits the definition of [opt-in-rules](https://github.com/realm/SwiftLint#opt-in-rules) nevertheless the rule does not trigger in this repository right now.

> A rule that is not general consensus or is only useful in some cases (e.g. force_unwrapping)

![triggers](https://user-images.githubusercontent.com/714458/206014709-8f828d20-9d03-4b4a-8a25-5b257b2188c9.png)
