### PR TITLE
Update docker_test to swift 5.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ docker_image:
 	docker build --platform linux/amd64 --force-rm --tag swiftlint .
 
 docker_test:
-	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm swift:5.6-focal swift test --parallel
+	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm swift:5.7-focal swift test --parallel
 
 docker_htop:
 	docker run --platform linux/amd64 -it --rm --pid=container:swiftlint terencewestphal/htop || reset


### PR DESCRIPTION
> macOS Ventura 13.0.1 (22A400)
> swift-driver version: 1.62.15 Apple Swift version 5.7.1 (swiftlang-5.7.1.135.3 clang-1400.0.29.51)
> Docker 4.15.0 (93002)

When running `make docker_test` it fails with
>'swiftlint': error: package 'swiftlint' is using Swift tools version 5.7.0 but the installed version is 5.6.3

Updating `docker_test` to use `swift:5.7-focal` fixes this.