### PR TITLE
Add support for new Quick APIs `aroundEach` and `justBeforeEach`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4612](https://github.com/realm/SwiftLint/issues/4612)
 
+* Allow new Quick APIs `aroundEach` and `justBeforeEach`
+  for `quick_discouraged_call`.  
+  [David Steinacher](https://github.com/stonko1994)
+  [#4626](https://github.com/realm/SwiftLint/issues/4626)
+
 #### Bug Fixes
 
 * Fix configuration parsing error in `unused_declaration` rule.  

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -107,7 +107,9 @@ private enum QuickCallKind: String {
     case context
     case sharedExamples
     case itBehavesLike
+    case aroundEach
     case beforeEach
+    case justBeforeEach
     case beforeSuite
     case afterEach
     case afterSuite

--- a/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
@@ -40,6 +40,30 @@ internal struct QuickDiscouragedCallRuleExamples {
         class TotoTests: QuickSpec {
            override func spec() {
                describe("foo") {
+                   justBeforeEach {
+                       let foo = Foo()
+                       foo.toto()
+                   }
+               }
+           }
+        }
+        """),
+        Example("""
+        class TotoTests: QuickSpec {
+           override func spec() {
+               describe("foo") {
+                   aroundEach {
+                       let foo = Foo()
+                       foo.toto()
+                   }
+               }
+           }
+        }
+        """),
+        Example("""
+        class TotoTests: QuickSpec {
+           override func spec() {
+               describe("foo") {
                   itBehavesLike("bar")
                }
            }


### PR DESCRIPTION
Issue: https://github.com/realm/SwiftLint/issues/4626

### Description
Quick [5.0.0](https://github.com/Quick/Quick/releases/tag/v5.0.0) introduced `aroundEach` and Quick [6.0.0](https://github.com/Quick/Quick/releases/tag/v6.0.0) introduced `justBeforeEach`. Both are currently flagged as violations for `quick_discouraged_call`.

This PR adds support to allow this new APIs.

_As there are no existing tests for this rule, I did not add a new one to cover the two new closures._