### PR TITLE
Fix rewrite issue with `comma` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,19 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4612](https://github.com/realm/SwiftLint/issues/4612)
 
-* Skip `defer` statements being last in an `#if` block if the `#if` statement is
-  not itself the last statement in a block.  
+* Skip `defer` statements being last in an `#if` block if the `#if`
+  statement is not itself the last statement in a block.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4615](https://github.com/realm/SwiftLint/issues/4615)
 
-* Fix false positives in `empty_enum_arguments` when the called expression
-  is an identifier or an init call.  
+* Fix false positives in `empty_enum_arguments` when the called
+  expression is an identifier or an init call.  
   [Steffen Matthischke](https://github.com/heeaad)
   [#4597](https://github.com/realm/SwiftLint/issues/4597)
+
+* Fix correction issue in `comma` when there was too much whitespace
+  following the comma.  
+  [JP Simard](https://github.com/jpsim)
 
 ## 0.50.1: Artisanal Clothes Pegs Fixup Edition
 

--- a/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/CommaRule.swift
@@ -49,7 +49,8 @@ struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule 
                       message: My.Custom.message↓ ,
                       another: parameter, doIt: true,
                       alignment: .center)
-            """)
+            """),
+            Example(#"Logger.logError("Hat is too large"↓,  info: [])"#)
         ],
         corrections: [
             Example("func abc(a: String↓,b: String) {}\n"): Example("func abc(a: String, b: String) {}\n"),
@@ -83,7 +84,9 @@ struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule 
                           message: My.Custom.message,
                           another: parameter, doIt: true,
                           alignment: .center)
-                """)
+                """),
+            Example(#"Logger.logError("Hat is too large"↓,  info: [])"#):
+                Example(#"Logger.logError("Hat is too large", info: [])"#)
         ]
     )
 
@@ -109,7 +112,9 @@ struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule 
                     let nextIsNewline = next.leadingTrivia.containsNewlines()
                     return (ByteRange(location: start, length: end - start), shouldAddSpace: !nextIsNewline)
                 } else if !current.trailingTrivia.starts(with: [.spaces(1)]), !next.leadingTrivia.containsNewlines() {
-                    return (ByteRange(location: ByteCount(current.position), length: 1), shouldAddSpace: true)
+                    let start = ByteCount(current.position)
+                    let end = ByteCount(next.positionAfterSkippingLeadingTrivia)
+                    return (ByteRange(location: start, length: end - start), shouldAddSpace: true)
                 } else {
                     return nil
                 }


### PR DESCRIPTION
Fix correction issue in `comma` when there was too much whitespace following the comma.

For a line like this with two spaces after the comma:

```swift
Logger.logError("Hat is too large",  info: [])
```

We would previously rewrite it with three spaces:

```swift
Logger.logError("Hat is too large",   info: [])
```

With this PR we correctly rewrite it with a single space:

```swift
Logger.logError("Hat is too large", info: [])
```