### PR TITLE
fix false positives for enums and private functions with `redundant_objc_attribute` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   [#4643](https://github.com/realm/SwiftLint/issues/4643)
 * Fix false positives for enums and private functions with
   `redundant_objc_attribute` rule.  
+* Fix false positives for enums, private functions and private stored variables
+  with `redundant_objc_attribute` rule.  
   [Cyberbeni](https://github.com/Cyberbeni)
   [#4633](https://github.com/realm/SwiftLint/issues/4633)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   subjects inside functions.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4643](https://github.com/realm/SwiftLint/issues/4643)
+* Fix false positives for enums and private functions with
+  `redundant_objc_attribute` rule.  
+  [Cyberbeni](https://github.com/Cyberbeni)
+  [#4633](https://github.com/realm/SwiftLint/issues/4633)
 
 ## 0.50.3: Bundle of Towels
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@
   subjects inside functions.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4643](https://github.com/realm/SwiftLint/issues/4643)
-* Fix false positives for enums and private functions with
-  `redundant_objc_attribute` rule.  
 * Fix false positives for enums, private functions and private stored variables
   with `redundant_objc_attribute` rule.  
   [Cyberbeni](https://github.com/Cyberbeni)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -87,6 +87,11 @@ private extension AttributeListSyntax {
 
         if hasAttributeImplyingObjC, parent?.is(ExtensionDeclSyntax.self) != true {
             return objcAttribute
+        } else if parent?.is(EnumDeclSyntax.self) == true {
+            return nil
+        } else if parent?.is(FunctionDeclSyntax.self) == true,
+                  parent?.as(FunctionDeclSyntax.self)?.modifiers?.isPrivateOrFilePrivate == true {
+            return nil
         } else if parent?.isFunctionOrStoredProperty == true,
                   let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
                   parentClassDecl.attributes?.hasObjCMembers == true {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -67,11 +67,10 @@ private extension AttributeListSyntax {
 }
 
 private extension Syntax {
-    var isFunctionOrStoredProperty: Bool {
+    var isFunctionOrProperty: Bool {
         if self.is(FunctionDeclSyntax.self) {
             return true
-        } else if let variableDecl = self.as(VariableDeclSyntax.self),
-                  variableDecl.bindings.allSatisfy({ $0.accessor == nil }) {
+        } else if self.is(VariableDeclSyntax.self) {
             return true
         } else {
             return false
@@ -99,19 +98,20 @@ private extension AttributeListSyntax {
             return objcAttribute
         } else if parent?.is(EnumDeclSyntax.self) == true {
             return nil
-        } else if parent?.isFunctionOrStoredProperty == true,
-                  parent?.modifiers?.isPrivateOrFilePrivate == true {
-            return nil
-        } else if parent?.isFunctionOrStoredProperty == true,
-                  let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
-                  parentClassDecl.attributes?.hasObjCMembers == true {
-            return objcAttribute
-        } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
-                  parentExtensionDecl.attributes?.objCAttribute != nil {
-            return objcAttribute
-        } else {
-            return nil
+        } else if parent?.isFunctionOrProperty == true {
+            if let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
+               parentClassDecl.attributes?.hasObjCMembers == true,
+               parent?.modifiers?.isPrivateOrFilePrivate != true
+            {
+                return objcAttribute
+            } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
+                      parentExtensionDecl.attributes?.objCAttribute != nil,
+                      parent?.as(FunctionDeclSyntax.self)?.modifiers?.isPrivateOrFilePrivate != true
+            {
+                return objcAttribute
+            }
         }
+        return nil
     }
 }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -77,7 +77,7 @@ private extension Syntax {
             return false
         }
     }
-    
+
     var modifiers: ModifierListSyntax? {
         if let decl = self.as(FunctionDeclSyntax.self) {
             return decl.modifiers

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -77,6 +77,16 @@ private extension Syntax {
             return false
         }
     }
+    
+    var modifiers: ModifierListSyntax? {
+        if let decl = self.as(FunctionDeclSyntax.self) {
+            return decl.modifiers
+        } else if let decl = self.as(VariableDeclSyntax.self) {
+            return decl.modifiers
+        } else {
+            return nil
+        }
+    }
 }
 
 private extension AttributeListSyntax {
@@ -89,8 +99,8 @@ private extension AttributeListSyntax {
             return objcAttribute
         } else if parent?.is(EnumDeclSyntax.self) == true {
             return nil
-        } else if parent?.is(FunctionDeclSyntax.self) == true,
-                  parent?.as(FunctionDeclSyntax.self)?.modifiers?.isPrivateOrFilePrivate == true {
+        } else if parent?.isFunctionOrStoredProperty == true,
+                  parent?.modifiers?.isPrivateOrFilePrivate == true {
             return nil
         } else if parent?.isFunctionOrStoredProperty == true,
                   let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -67,17 +67,7 @@ private extension AttributeListSyntax {
 }
 
 private extension Syntax {
-    var isFunctionOrProperty: Bool {
-        if self.is(FunctionDeclSyntax.self) {
-            return true
-        } else if self.is(VariableDeclSyntax.self) {
-            return true
-        } else {
-            return false
-        }
-    }
-
-    var modifiers: ModifierListSyntax? {
+    var functionOrVariableModifiers: ModifierListSyntax? {
         if let decl = self.as(FunctionDeclSyntax.self) {
             return decl.modifiers
         } else if let decl = self.as(VariableDeclSyntax.self) {
@@ -98,18 +88,16 @@ private extension AttributeListSyntax {
             return objcAttribute
         } else if parent?.is(EnumDeclSyntax.self) == true {
             return nil
-        } else if parent?.isFunctionOrProperty == true {
-            if let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
-               parentClassDecl.attributes?.hasObjCMembers == true,
-               parent?.modifiers?.isPrivateOrFilePrivate != true
-            {
-                return objcAttribute
-            } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
-                      parentExtensionDecl.attributes?.objCAttribute != nil,
-                      parent?.as(FunctionDeclSyntax.self)?.modifiers?.isPrivateOrFilePrivate != true
-            {
-                return objcAttribute
-            }
+        } else if let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
+                  parentClassDecl.attributes?.hasObjCMembers == true,
+                  parent?.functionOrVariableModifiers?.isPrivateOrFilePrivate != true
+        {
+            return objcAttribute
+        } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
+                  parentExtensionDecl.attributes?.objCAttribute != nil,
+                  parent?.as(FunctionDeclSyntax.self)?.modifiers?.isPrivateOrFilePrivate != true
+        {
+            return objcAttribute
         }
         return nil
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -90,13 +90,11 @@ private extension AttributeListSyntax {
             return nil
         } else if let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
                   parentClassDecl.attributes?.hasObjCMembers == true,
-                  parent?.functionOrVariableModifiers?.isPrivateOrFilePrivate != true
-        {
+                  parent?.functionOrVariableModifiers?.isPrivateOrFilePrivate != true {
             return objcAttribute
         } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
                   parentExtensionDecl.attributes?.objCAttribute != nil,
-                  parent?.as(FunctionDeclSyntax.self)?.modifiers?.isPrivateOrFilePrivate != true
-        {
+                  parent?.as(FunctionDeclSyntax.self)?.modifiers?.isPrivateOrFilePrivate != true {
             return objcAttribute
         }
         return nil

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -1,6 +1,11 @@
 struct RedundantObjcAttributeRuleExamples {
     static let nonTriggeringExamples = [
-        Example("@objc private var foo: String? {}"),
+        Example("""
+        @objcMembers
+        class Foo: NSObject {
+            @objc private var foo: String? {}
+        }
+        """),
         Example("@IBInspectable private var foo: String? {}"),
         Example("""
         @objcMembers

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -2,7 +2,12 @@ struct RedundantObjcAttributeRuleExamples {
     static let nonTriggeringExamples = [
         Example("@objc private var foo: String? {}"),
         Example("@IBInspectable private var foo: String? {}"),
-        Example("@objc private func foo(_ sender: Any) {}"),
+        Example("""
+        @objcMembers
+        class Foo: NSObject {
+            @objc private func foo(_ sender: Any) {}
+        }
+        """),
         Example("@IBAction private func foo(_ sender: Any) {}"),
         Example("@GKInspectable private var foo: String! {}"),
         Example("private @GKInspectable var foo: String! {}"),
@@ -75,6 +80,15 @@ struct RedundantObjcAttributeRuleExamples {
             @objc(addElementsObject:)
             @NSManaged public func addToElements(_ value: BlockEditorSettingElement)
         }
+        """),
+        Example("""
+        @objcMembers
+        class Foo: NSObject {
+            @objc
+            private enum Bar: Int {
+                case bar
+            }
+        }
         """)
     ]
 
@@ -140,6 +154,12 @@ struct RedundantObjcAttributeRuleExamples {
             private var bar: Int {
                 return 0
             }
+        }
+        """),
+        Example("""
+        @objcMembers
+        class Foo: NSObject {
+            ↓@objc func foo(_ sender: Any) {}
         }
         """)
     ]

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -3,7 +3,7 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objcMembers
         class Foo: NSObject {
-            @objc private var foo: String? {}
+            @objc private var foo: String?
         }
         """),
         Example("@IBInspectable private var foo: String? {}"),

--- a/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -19,17 +19,6 @@ struct RedundantObjcAttributeRuleExamples {
         Example("@NSManaged var foo: String!"),
         Example("@objc @NSCopying var foo: String!"),
         Example("""
-        @objcMembers
-        class Foo {
-            var bar: Any?
-            @objc
-            class Bar {
-                @objc
-                var foo: Any?
-            }
-        }
-        """),
-        Example("""
         @objc
         extension Foo {
             var bar: Int {
@@ -75,12 +64,6 @@ struct RedundantObjcAttributeRuleExamples {
         }
         """),
         Example("""
-        @objcMembers
-        class Foo {
-            @objc class Bar {}
-        }
-        """),
-        Example("""
         extension BlockEditorSettings {
             @objc(addElementsObject:)
             @NSManaged public func addToElements(_ value: BlockEditorSettingElement)
@@ -116,9 +99,15 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objcMembers
         class Foo {
+            ↓@objc class Bar {}
+        }
+        """),
+        Example("""
+        @objcMembers
+        class Foo {
             ↓@objc var bar: Any?
             ↓@objc var foo: Any?
-            @objc
+            ↓@objc
             class Bar {
                 @objc
                 var foo: Any?
@@ -200,7 +189,7 @@ struct RedundantObjcAttributeRuleExamples {
         class Foo {
             ↓@objc var bar: Any?
             ↓@objc var foo: Any?
-            @objc
+            ↓@objc
             class Bar {
                 @objc
                 var foo2: Any?
@@ -212,7 +201,6 @@ struct RedundantObjcAttributeRuleExamples {
         class Foo {
             var bar: Any?
             var foo: Any?
-            @objc
             class Bar {
                 @objc
                 var foo2: Any?

--- a/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/PrivateOutletRule.swift
@@ -116,7 +116,7 @@ private extension AttributeListSyntax {
     }
 }
 
-private extension ModifierListSyntax {
+extension ModifierListSyntax {
     var isPrivateOrFilePrivate: Bool {
         contains(where: \.isPrivateOrFilePrivate)
     }


### PR DESCRIPTION
fixes #4633

other examples of this rule might also need updating