### PR TITLE
Report violations in all `<scope>_length` rules when error < warning threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
 
 #### Bug Fixes
 
+* Report violations in all `<scope>_length` rules when the error threshold is
+  smaller than the warning threshold.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4645](https://github.com/realm/SwiftLint/issues/4645)
+
 * Fix false positives on `private_subject` rule when using
   subjects inside functions.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/Source/SwiftLintFramework/Visitors/BodyLengthRuleVisitor.swift
+++ b/Source/SwiftLintFramework/Visitors/BodyLengthRuleVisitor.swift
@@ -115,19 +115,19 @@ final class BodyLengthRuleVisitor: ViolationsSyntaxVisitor {
 
         let lineCount = file.bodyLineCountIgnoringCommentsAndWhitespace(leftBraceLine: leftBraceLine,
                                                                         rightBraceLine: rightBraceLine)
-        guard lineCount > configuration.warning else {
+        let severity: ViolationSeverity, upperBound: Int
+        if let error = configuration.error, lineCount > error {
+            severity = .error
+            upperBound = error
+        } else if lineCount > configuration.warning {
+            severity = .warning
+            upperBound = configuration.warning
+        } else {
             return
         }
 
-        let severity: ViolationSeverity
-        if let error = configuration.error, lineCount > error {
-            severity = .error
-        } else {
-            severity = .warning
-        }
-
         let reason = """
-            \(kind.name) body should span \(configuration.warning) lines or less excluding comments and whitespace: \
+            \(kind.name) body should span \(upperBound) lines or less excluding comments and whitespace: \
             currently spans \(lineCount) lines
             """
 

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -67,8 +67,23 @@ class FunctionBodyLengthRuleTests: XCTestCase {
             "whitespace: currently spans 51 lines")])
     }
 
-    private func violations(_ example: Example) -> [StyleViolation] {
-        let config = makeConfig(nil, FunctionBodyLengthRule.description.identifier)!
+    func testConfiguration() {
+        let function = violatingFuncWithBody(repeatElement("x = 0\n", count: 10).joined())
+
+        XCTAssertEqual(self.violations(function, configuration: ["warning": 12]).count, 0)
+        XCTAssertEqual(self.violations(function, configuration: ["warning": 12, "error": 14]).count, 0)
+        XCTAssertEqual(
+            self.violations(function, configuration: ["warning": 8]).map(\.reason),
+            ["Function body should span 8 lines or less excluding comments and whitespace: currently spans 10 lines"]
+        )
+        XCTAssertEqual(
+            self.violations(function, configuration: ["warning": 12, "error": 8]).map(\.reason),
+            ["Function body should span 8 lines or less excluding comments and whitespace: currently spans 10 lines"]
+        )
+    }
+
+    private func violations(_ example: Example, configuration: Any? = nil) -> [StyleViolation] {
+        let config = makeConfig(configuration, FunctionBodyLengthRule.description.identifier)!
         return SwiftLintFrameworkTests.violations(example, config: config)
     }
 }


### PR DESCRIPTION
Fixes #4645.