### PR TITLE
[CI] Increase timeout for `analyze` CI job to 60 minutes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
   - label: "Analyze"
     commands:
       - echo "+++ Analyze"
-      - bazel test -c opt --test_output=streamed --test_timeout=1800 --spawn_strategy=local analyze
+      - bazel test -c opt --test_output=streamed --test_timeout=3600 --spawn_strategy=local analyze
   - label: "TSan Tests"
     commands:
       - echo "+++ Test"


### PR DESCRIPTION
I recently moved CI machines over to use Xcode 14.2 and it's possible that running SwiftLint analyzer rules now take longer.