### PR TITLE
Add `excluded_regular_expressions` option for identifier_name rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 * Separate analyzer rules as an independent section in the rule directory of the reference.  
   [Ethan Wong](https://github.com/GetToSet)
   [#4664](https://github.com/realm/SwiftLint/pull/4664)
+* Add `excluded_regular_expressions` option to `identifier_name` rule.  
+  [Moly](https://github.com/kyounh12)
+  [#4655](https://github.com/realm/SwiftLint/pull/4655)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   [#4664](https://github.com/realm/SwiftLint/pull/4664)
 * Add `excluded_regular_expressions` option to `identifier_name` rule.  
 * Interpret strings in `excluded` option of `identifier_name`, 
+
+* Interpret items in `excluded` option of `identifier_name`, 
   `type_name` and `generic_type_name` rules as regex.  
   [Moly](https://github.com/kyounh12)
   [#4655](https://github.com/realm/SwiftLint/pull/4655)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   [Ethan Wong](https://github.com/GetToSet)
   [#4664](https://github.com/realm/SwiftLint/pull/4664)
 * Add `excluded_regular_expressions` option to `identifier_name` rule.  
+* Interpret strings in `excluded` option of `identifier_name`, 
+  `type_name` and `generic_type_name` rules as regex.  
   [Moly](https://github.com/kyounh12)
   [#4655](https://github.com/realm/SwiftLint/pull/4655)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,8 @@
 * Separate analyzer rules as an independent section in the rule directory of the reference.  
   [Ethan Wong](https://github.com/GetToSet)
   [#4664](https://github.com/realm/SwiftLint/pull/4664)
-* Add `excluded_regular_expressions` option to `identifier_name` rule.  
+  
 * Interpret strings in `excluded` option of `identifier_name`, 
-
-* Interpret items in `excluded` option of `identifier_name`, 
   `type_name` and `generic_type_name` rules as regex.  
   [Moly](https://github.com/kyounh12)
   [#4655](https://github.com/realm/SwiftLint/pull/4655)

--- a/Source/SwiftLintFramework/Models/ExcludedRegexExpression.swift
+++ b/Source/SwiftLintFramework/Models/ExcludedRegexExpression.swift
@@ -1,16 +1,22 @@
 import Foundation
 
-public struct ExcludedRegexExpression: Equatable, Hashable {
+public final class ExcludedRegexExpression: NSObject {
     public let regex: NSRegularExpression
 
     init?(pattern: String) {
         guard let regex = try? NSRegularExpression(pattern: pattern)  else { return nil }
         self.regex = regex
     }
-}
 
-public extension ExcludedRegexExpression {
-    static func == (lhs: ExcludedRegexExpression, rhs: ExcludedRegexExpression) -> Bool {
-        return lhs.regex.pattern == rhs.regex.pattern
+    public override func isEqual(_ object: Any?) -> Bool {
+        if let object = object as? ExcludedRegexExpression {
+            return regex.pattern == object.regex.pattern
+        } else {
+            return false
+        }
+    }
+
+    public override var hash: Int {
+        return regex.pattern.hashValue
     }
 }

--- a/Source/SwiftLintFramework/Models/ExcludedRegexExpression.swift
+++ b/Source/SwiftLintFramework/Models/ExcludedRegexExpression.swift
@@ -8,7 +8,7 @@ public final class ExcludedRegexExpression: NSObject {
         self.regex = regex
     }
 
-    public override func isEqual(_ object: Any?) -> Bool {
+    override public func isEqual(_ object: Any?) -> Bool {
         if let object = object as? ExcludedRegexExpression {
             return regex.pattern == object.regex.pattern
         } else {
@@ -16,7 +16,7 @@ public final class ExcludedRegexExpression: NSObject {
         }
     }
 
-    public override var hash: Int {
+    override public var hash: Int {
         return regex.pattern.hashValue
     }
 }

--- a/Source/SwiftLintFramework/Models/ExcludedRegexExpression.swift
+++ b/Source/SwiftLintFramework/Models/ExcludedRegexExpression.swift
@@ -1,13 +1,23 @@
 import Foundation
 
+/// Represents regex from `exclude` option in `NameConfiguration`.
+/// Using NSRegularExpression causes failure on equality check between two `NameConfiguration`s.
+/// This class compares pattern only when checking its equality
 public final class ExcludedRegexExpression: NSObject {
+    /// NSRegularExpression built from given pattern
     public let regex: NSRegularExpression
 
+    /// Creates an `ExcludedRegexExpression` with a pattern.
+    ///
+    /// - parameter pattern:   The pattern string to build regex
     init?(pattern: String) {
         guard let regex = try? NSRegularExpression(pattern: pattern)  else { return nil }
         self.regex = regex
     }
 
+    // MARK: - Equality Check
+
+    /// Compares regex pattern to check equality
     override public func isEqual(_ object: Any?) -> Bool {
         if let object = object as? ExcludedRegexExpression {
             return regex.pattern == object.regex.pattern
@@ -16,6 +26,7 @@ public final class ExcludedRegexExpression: NSObject {
         }
     }
 
+    /// Uses regex pattern as hash
     override public var hash: Int {
         return regex.pattern.hashValue
     }

--- a/Source/SwiftLintFramework/Models/ExcludedRegexExpression.swift
+++ b/Source/SwiftLintFramework/Models/ExcludedRegexExpression.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public struct ExcludedRegexExpression: Equatable, Hashable {
+    public let regex: NSRegularExpression
+
+    init?(pattern: String) {
+        guard let regex = try? NSRegularExpression(pattern: pattern)  else { return nil }
+        self.regex = regex
+    }
+}
+
+public extension ExcludedRegexExpression {
+    static func == (lhs: ExcludedRegexExpression, rhs: ExcludedRegexExpression) -> Bool {
+        return lhs.regex.pattern == rhs.regex.pattern
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -66,11 +66,7 @@ private extension GenericTypeNameRule {
 
         override func visitPost(_ node: GenericParameterSyntax) {
             let name = node.name.text
-            guard !configuration.excludedRegularExpressions.contains(where: {
-                return !$0.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
-            }) else {
-                return
-            }
+            guard !configuration.shouldExclude(name: name) else { return }
 
             let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
             if !allowedSymbols.isSuperset(of: CharacterSet(charactersIn: name)) {

--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -66,7 +66,9 @@ private extension GenericTypeNameRule {
 
         override func visitPost(_ node: GenericParameterSyntax) {
             let name = node.name.text
-            guard !configuration.excluded.contains(name) else {
+            guard !configuration.excludedRegularExpressions.contains(where: {
+                return !$0.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
+            }) else {
                 return
             }
 

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -88,16 +88,7 @@ private extension TypeNameRule {
             let originalName = identifier.text
             let nameConfiguration = configuration.nameConfiguration
 
-            guard !nameConfiguration.excludedRegularExpressions.contains(where: {
-                let matches = $0.matches(
-                    in: originalName,
-                    options: [],
-                    range: NSRange(originalName.startIndex..., in: originalName)
-                )
-                return !matches.isEmpty
-            }) else {
-                return nil
-            }
+            guard !nameConfiguration.shouldExclude(name: originalName) else { return nil }
 
             let name = originalName
                 .strippingBackticks()

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -89,7 +89,12 @@ private extension TypeNameRule {
             let nameConfiguration = configuration.nameConfiguration
 
             guard !nameConfiguration.excludedRegularExpressions.contains(where: {
-                return !$0.matches(in: originalName, options: [], range: NSRange(originalName.startIndex..., in: originalName)).isEmpty
+                let matches = $0.matches(
+                    in: originalName,
+                    options: [],
+                    range: NSRange(originalName.startIndex..., in: originalName)
+                )
+                return !matches.isEmpty
             }) else {
                 return nil
             }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TypeNameRule.swift
@@ -88,7 +88,9 @@ private extension TypeNameRule {
             let originalName = identifier.text
             let nameConfiguration = configuration.nameConfiguration
 
-            guard !nameConfiguration.excluded.contains(originalName) else {
+            guard !nameConfiguration.excludedRegularExpressions.contains(where: {
+                return !$0.matches(in: originalName, options: [], range: NSRange(originalName.startIndex..., in: originalName)).isEmpty
+            }) else {
                 return nil
             }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -90,3 +90,13 @@ extension NameConfiguration {
         return nil
     }
 }
+
+// MARK: - `exclude` option extensions
+
+extension NameConfiguration {
+    func shouldExclude(name: String) -> Bool {
+        return excludedRegularExpressions.contains(where: {
+            return !$0.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
+        })
+    }
+}

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -4,14 +4,14 @@ struct NameConfiguration: RuleConfiguration, Equatable {
     var consoleDescription: String {
         return "(min_length) \(minLength.shortConsoleDescription), " +
             "(max_length) \(maxLength.shortConsoleDescription), " +
-            "excluded: \(excludedRegularExpressions.map { $0.pattern }.sorted()), " +
+            "excluded: \(excludedRegularExpressions.map { $0.regex.pattern }.sorted()), " +
             "allowed_symbols: \(allowedSymbolsSet.sorted()), " +
             "validates_start_with_lowercase: \(validatesStartWithLowercase)"
     }
 
     var minLength: SeverityLevelsConfiguration
     var maxLength: SeverityLevelsConfiguration
-    var excludedRegularExpressions: Set<NSRegularExpression>
+    var excludedRegularExpressions: Set<ExcludedRegexExpression>
     private var allowedSymbolsSet: Set<String>
     var validatesStartWithLowercase: Bool
 
@@ -36,7 +36,7 @@ struct NameConfiguration: RuleConfiguration, Equatable {
          validatesStartWithLowercase: Bool = true) {
         minLength = SeverityLevelsConfiguration(warning: minLengthWarning, error: minLengthError)
         maxLength = SeverityLevelsConfiguration(warning: maxLengthWarning, error: maxLengthError)
-        self.excludedRegularExpressions = Set(excluded.compactMap { try? NSRegularExpression(pattern: "^\($0)$") })
+        self.excludedRegularExpressions = Set(excluded.compactMap { ExcludedRegexExpression(pattern: "^\($0)$") })
         self.allowedSymbolsSet = Set(allowedSymbols)
         self.validatesStartWithLowercase = validatesStartWithLowercase
     }
@@ -53,7 +53,7 @@ struct NameConfiguration: RuleConfiguration, Equatable {
             try maxLength.apply(configuration: maxLengthConfiguration)
         }
         if let excluded = [String].array(of: configurationDict["excluded"]) {
-            self.excludedRegularExpressions = Set(excluded.compactMap { try? NSRegularExpression(pattern: "^\($0)$") })
+            self.excludedRegularExpressions = Set(excluded.compactMap { ExcludedRegexExpression(pattern: "^\($0)$") })
         }
         if let allowedSymbols = [String].array(of: configurationDict["allowed_symbols"]) {
             self.allowedSymbolsSet = Set(allowedSymbols)
@@ -96,7 +96,7 @@ extension NameConfiguration {
 extension NameConfiguration {
     func shouldExclude(name: String) -> Bool {
         return excludedRegularExpressions.contains(where: {
-            return !$0.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
+            return !$0.regex.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
         })
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -12,6 +12,7 @@ struct NameConfiguration: RuleConfiguration, Equatable {
     var minLength: SeverityLevelsConfiguration
     var maxLength: SeverityLevelsConfiguration
     var excluded: Set<String>
+    var excludedRegularExpressions: Set<String>
     private var allowedSymbolsSet: Set<String>
     var validatesStartWithLowercase: Bool
 
@@ -32,11 +33,13 @@ struct NameConfiguration: RuleConfiguration, Equatable {
          maxLengthWarning: Int,
          maxLengthError: Int,
          excluded: [String] = [],
+         excludedRegularExpressions: [String] = [],
          allowedSymbols: [String] = [],
          validatesStartWithLowercase: Bool = true) {
         minLength = SeverityLevelsConfiguration(warning: minLengthWarning, error: minLengthError)
         maxLength = SeverityLevelsConfiguration(warning: maxLengthWarning, error: maxLengthError)
         self.excluded = Set(excluded)
+        self.excludedRegularExpressions = Set(excludedRegularExpressions)
         self.allowedSymbolsSet = Set(allowedSymbols)
         self.validatesStartWithLowercase = validatesStartWithLowercase
     }
@@ -54,6 +57,9 @@ struct NameConfiguration: RuleConfiguration, Equatable {
         }
         if let excluded = [String].array(of: configurationDict["excluded"]) {
             self.excluded = Set(excluded)
+        }
+        if let excludedRegularExpressions = [String].array(of: configurationDict["excluded_regular_expressions"]) {
+            self.excludedRegularExpressions = Set(excludedRegularExpressions)
         }
         if let allowedSymbols = [String].array(of: configurationDict["allowed_symbols"]) {
             self.allowedSymbolsSet = Set(allowedSymbols)

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NameConfiguration.swift
@@ -4,15 +4,14 @@ struct NameConfiguration: RuleConfiguration, Equatable {
     var consoleDescription: String {
         return "(min_length) \(minLength.shortConsoleDescription), " +
             "(max_length) \(maxLength.shortConsoleDescription), " +
-            "excluded: \(excluded.sorted()), " +
+            "excluded: \(excludedRegularExpressions.map { $0.pattern }.sorted()), " +
             "allowed_symbols: \(allowedSymbolsSet.sorted()), " +
             "validates_start_with_lowercase: \(validatesStartWithLowercase)"
     }
 
     var minLength: SeverityLevelsConfiguration
     var maxLength: SeverityLevelsConfiguration
-    var excluded: Set<String>
-    var excludedRegularExpressions: Set<String>
+    var excludedRegularExpressions: Set<NSRegularExpression>
     private var allowedSymbolsSet: Set<String>
     var validatesStartWithLowercase: Bool
 
@@ -33,13 +32,11 @@ struct NameConfiguration: RuleConfiguration, Equatable {
          maxLengthWarning: Int,
          maxLengthError: Int,
          excluded: [String] = [],
-         excludedRegularExpressions: [String] = [],
          allowedSymbols: [String] = [],
          validatesStartWithLowercase: Bool = true) {
         minLength = SeverityLevelsConfiguration(warning: minLengthWarning, error: minLengthError)
         maxLength = SeverityLevelsConfiguration(warning: maxLengthWarning, error: maxLengthError)
-        self.excluded = Set(excluded)
-        self.excludedRegularExpressions = Set(excludedRegularExpressions)
+        self.excludedRegularExpressions = Set(excluded.compactMap { try? NSRegularExpression(pattern: "^\($0)$") })
         self.allowedSymbolsSet = Set(allowedSymbols)
         self.validatesStartWithLowercase = validatesStartWithLowercase
     }
@@ -56,10 +53,7 @@ struct NameConfiguration: RuleConfiguration, Equatable {
             try maxLength.apply(configuration: maxLengthConfiguration)
         }
         if let excluded = [String].array(of: configurationDict["excluded"]) {
-            self.excluded = Set(excluded)
-        }
-        if let excludedRegularExpressions = [String].array(of: configurationDict["excluded_regular_expressions"]) {
-            self.excludedRegularExpressions = Set(excludedRegularExpressions)
+            self.excludedRegularExpressions = Set(excluded.compactMap { try? NSRegularExpression(pattern: "^\($0)$") })
         }
         if let allowedSymbols = [String].array(of: configurationDict["allowed_symbols"]) {
             self.allowedSymbolsSet = Set(allowedSymbols)

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -34,13 +34,10 @@ struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         }
 
         return validateName(dictionary: dictionary, kind: kind).map { name, offset in
-            guard !configuration.excluded.contains(name), let firstCharacter = name.first else {
-                return []
-            }
+            guard let firstCharacter = name.first else { return [] }
 
             guard !configuration.excludedRegularExpressions.contains(where: {
-                guard let regex = try? NSRegularExpression(pattern: $0) else { return false }
-                return !regex.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
+                return !$0.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
             }) else {
                 return []
             }

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -37,7 +37,7 @@ struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             guard !configuration.excluded.contains(name), let firstCharacter = name.first else {
                 return []
             }
-            
+
             guard !configuration.excludedRegularExpressions.contains(where: {
                 guard let regex = try? NSRegularExpression(pattern: $0) else { return false }
                 return !regex.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -37,6 +37,13 @@ struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
             guard !configuration.excluded.contains(name), let firstCharacter = name.first else {
                 return []
             }
+            
+            guard !configuration.excludedRegularExpressions.contains(where: {
+                guard let regex = try? NSRegularExpression(pattern: $0) else { return false }
+                return !regex.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
+            }) else {
+                return []
+            }
 
             let isFunction = SwiftDeclarationKind.functionKinds.contains(kind)
             let description = Self.description

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -36,11 +36,7 @@ struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         return validateName(dictionary: dictionary, kind: kind).map { name, offset in
             guard let firstCharacter = name.first else { return [] }
 
-            guard !configuration.excludedRegularExpressions.contains(where: {
-                return !$0.matches(in: name, options: [], range: NSRange(name.startIndex..., in: name)).isEmpty
-            }) else {
-                return []
-            }
+            guard !configuration.shouldExclude(name: name) else { return [] }
 
             let isFunction = SwiftDeclarationKind.functionKinds.contains(kind)
             let description = Self.description

--- a/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
@@ -2,6 +2,22 @@
 import XCTest
 
 class GenericTypeNameRuleTests: XCTestCase {
+    func testGenericTypeNameWithExcluded() {
+        let baseDescription = GenericTypeNameRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
+            Example("func foo<apple> {}\n"),
+            Example("func foo<some_apple> {}\n"),
+            Example("func foo<test123> {}\n")
+        ]
+        let triggeringExamples = baseDescription.triggeringExamples + [
+            Example("func foo<ap_ple> {}\n"),
+            Example("func foo<appleJuice> {}\n")
+        ]
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples,
+                                               triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["excluded": ["apple", "some.*", ".*st\\d+.*"]])
+    }
+
     func testGenericTypeNameWithAllowedSymbols() {
         let baseDescription = GenericTypeNameRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -2,6 +2,21 @@
 import XCTest
 
 class IdentifierNameRuleTests: XCTestCase {
+    func testIdentifierNameWithExcludedRegularExpressions() {
+        let baseDescription = IdentifierNameRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
+            Example("let Apple = 0"),
+            Example("let Some_apple = 0"),
+            Example("let test123 = 0"),
+        ]
+        let triggeringExamples = baseDescription.triggeringExamples + [
+            Example("let ap_ple = 0")
+        ]
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples,
+                                               triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["excluded_regular_expressions": ["apple", "^Apple", "\\d+"]])
+    }
+    
     func testIdentifierNameWithAllowedSymbols() {
         let baseDescription = IdentifierNameRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -2,19 +2,20 @@
 import XCTest
 
 class IdentifierNameRuleTests: XCTestCase {
-    func testIdentifierNameWithExcludedRegularExpressions() {
+    func testIdentifierNameWithExcluded() {
         let baseDescription = IdentifierNameRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
             Example("let Apple = 0"),
-            Example("let Some_apple = 0"),
-            Example("let test123 = 0")
+            Example("let some_apple = 0"),
+            Example("let Test123 = 0")
         ]
         let triggeringExamples = baseDescription.triggeringExamples + [
-            Example("let ap_ple = 0")
+            Example("let ap_ple = 0"),
+            Example("let AppleJuice = 0")
         ]
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples,
                                                triggeringExamples: triggeringExamples)
-        verifyRule(description, ruleConfiguration: ["excluded_regular_expressions": ["apple", "^Apple", "\\d+"]])
+        verifyRule(description, ruleConfiguration: ["excluded": ["Apple", "some.*", ".*\\d+.*"]])
     }
 
     func testIdentifierNameWithAllowedSymbols() {

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -7,7 +7,7 @@ class IdentifierNameRuleTests: XCTestCase {
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
             Example("let Apple = 0"),
             Example("let Some_apple = 0"),
-            Example("let test123 = 0"),
+            Example("let test123 = 0")
         ]
         let triggeringExamples = baseDescription.triggeringExamples + [
             Example("let ap_ple = 0")
@@ -16,7 +16,7 @@ class IdentifierNameRuleTests: XCTestCase {
                                                triggeringExamples: triggeringExamples)
         verifyRule(description, ruleConfiguration: ["excluded_regular_expressions": ["apple", "^Apple", "\\d+"]])
     }
-    
+
     func testIdentifierNameWithAllowedSymbols() {
         let baseDescription = IdentifierNameRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -2,6 +2,22 @@
 import XCTest
 
 class TypeNameRuleTests: XCTestCase {
+    func testTypeNameWithExcluded() {
+        let baseDescription = TypeNameRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [
+            Example("class apple {}"),
+            Example("struct some_apple {}"),
+            Example("protocol test123 {}")
+        ]
+        let triggeringExamples = baseDescription.triggeringExamples + [
+            Example("enum ap_ple {}"),
+            Example("typealias appleJuice = Void")
+        ]
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples,
+                                               triggeringExamples: triggeringExamples)
+        verifyRule(description, ruleConfiguration: ["excluded": ["apple", "some.*", ".*st\\d+.*"]])
+    }
+
     func testTypeNameWithAllowedSymbols() {
         let baseDescription = TypeNameRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [


### PR DESCRIPTION
There already exists an option called `excluded` to prevent some unwanted checks.

However, `excluded` option has limitations when we need to exclude names with similar patterns since it requires exact match.

So we may solve this problem by adding `excluded_regular_expressions` option to `identifier_name` rule and exclude some names by regex.

This would be extremely helpful in situations like below:
* exclude identifier names with other languages. ( Xcode allows identifier names with some other languages )
* exclude identifier names having similar patterns
* ...

```
identifier_name:
  excluded_regular_expressions:
    - Apple
    - ^[가-힣_]$
```