### PR TITLE
Deprecate `unused_capture_list` rule in favor of the Swift compiler warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 #### Breaking
 
-* None.
+* Deprecate the `unused_capture_list` rule in favor of the Swift compiler
+  warning. At the same time, make it an opt-in rule.  
+  [Cyberbeni](https://github.com/Cyberbeni)
+  [#4656](https://github.com/realm/SwiftLint/issues/4656)
 
 #### Experimental
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedCaptureListRule.swift
@@ -1,6 +1,18 @@
 import SwiftSyntax
 
-struct UnusedCaptureListRule: SwiftSyntaxRule, ConfigurationProviderRule {
+private let warnDeprecatedOnceImpl: Void = {
+    queuedPrintError("""
+        The `\(UnusedCaptureListRule.description.identifier)` rule is now deprecated and will be completely \
+        removed in a future release due to an equivalent warning issued by the Swift compiler.
+        """
+    )
+}()
+
+private func warnDeprecatedOnce() {
+    _ = warnDeprecatedOnceImpl
+}
+
+struct UnusedCaptureListRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
     var configuration = SeverityConfiguration(.warning)
 
     init() {}
@@ -121,7 +133,8 @@ struct UnusedCaptureListRule: SwiftSyntaxRule, ConfigurationProviderRule {
     )
 
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
+        warnDeprecatedOnce()
+        return Visitor(viewMode: .sourceAccurate)
     }
 }
 


### PR DESCRIPTION
similarly to #4618 

Tested all the triggering examples with Xcode 14.0.1