### PR TITLE
opening_brace rule bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4643](https://github.com/realm/SwiftLint/issues/4643)
 
+* Fix for compiler directives masking subsequent `opening_brace`
+  violations.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#3712](https://github.com/realm/SwiftLint/issues/3712)
+
 ## 0.50.3: Bundle of Towels
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -104,7 +104,23 @@ struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
                     func f() -> () -> Void {
                         {}
                     }
+                    """),
+            Example("""
+                    if
+                        "test".filter({ "0123456789".contains($0) }).isEmpty
+                    {
+                       // code here
+                    }
+                    """),
+            Example("""
+                    if
+                        let a = ["A", "B"].first(where: { $0 == "A" }), // removing the parameter condition of "first" here removes the warning
+                        let b = ["B"].first
+                    { // This triggers the violation
+                        print(a)
+                    }
                     """)
+            // Example("let pattern = #/(\{(?<key>\w+)\})/#")
         ],
         triggeringExamples: [
             Example("func abc()↓{\n}"),
@@ -147,6 +163,19 @@ struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
             func run_Array_method2x(_ N: Int) {
 
             }
+            """),
+            Example("""
+               class TestFile {
+                   func problemFunction() {
+                       #if DEBUG
+                       #endif
+                   }
+
+                   func openingBraceViolation()
+                   {
+                       print("Brackets")
+                   }
+               }
             """)
         ],
         corrections: [

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -18,8 +18,8 @@ private extension SwiftLintFile {
             if isAnonymousClosure(range: $0) {
                 return nil
             }
-            let branceRange = contents.bridge().range(of: "{", options: .literal, range: $0)
-            return ($0, branceRange.location)
+            let braceRange = contents.bridge().range(of: "{", options: .literal, range: $0)
+            return ($0, braceRange.location)
         }
     }
 

--- a/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/OpeningBraceRule.swift
@@ -7,9 +7,9 @@ private extension SwiftLintFile {
     func violatingOpeningBraceRanges(allowMultilineFunc: Bool) -> [(range: NSRange, location: Int)] {
         let excludingPattern: String
         if allowMultilineFunc {
-            excludingPattern = #"(?:func[^\{\n]*\n[^\{\n]*\n[^\{]*|(?:(?:if|guard|while)\n[^\{]+?\s|\{\s*))\{"#
+            excludingPattern = #"(?:func[^\{\n]*\n[^\{\n]*\n[^\{]*|(?:\b(?:if|guard|while)\n[^\{]+?\s|\{\s*))\{"#
         } else {
-            excludingPattern = #"(?:(?:if|guard|while)\n[^\{]+?\s|\{\s*)\{"#
+            excludingPattern = #"(?:\b(?:if|guard|while)\n[^\{]+?\s|\{\s*)\{"#
         }
 
         return match(pattern: #"(?:[^( ]|[\s(][\s]+)\{"#,
@@ -104,23 +104,7 @@ struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
                     func f() -> () -> Void {
                         {}
                     }
-                    """),
-            Example("""
-                    if
-                        "test".filter({ "0123456789".contains($0) }).isEmpty
-                    {
-                       // code here
-                    }
-                    """),
-            Example("""
-                    if
-                        let a = ["A", "B"].first(where: { $0 == "A" }), // removing the parameter condition of "first" here removes the warning
-                        let b = ["B"].first
-                    { // This triggers the violation
-                        print(a)
-                    }
                     """)
-            // Example("let pattern = #/(\{(?<key>\w+)\})/#")
         ],
         triggeringExamples: [
             Example("func abc()↓{\n}"),
@@ -172,7 +156,7 @@ struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
                    }
 
                    func openingBraceViolation()
-                   {
+                  ↓{
                        print("Brackets")
                    }
                }


### PR DESCRIPTION
Fix for #3712

In the example given for the defect

```
             class TestFile {
                   func problemFunction() {
                       #if DEBUG
                       #endif
                   }
                   func openingBraceViolation()
                   {
                       print("Brackets")
                   }
               }
```

The `if` in `#endif` was being matched by the regex. I added in a word boundary (`\b`), to make sure that `if`, `guard` and `while` are only matched if they start at a word boundary


