### PR TITLE
Depend on swift-syntax prerelease tag

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "a2d31e8880224f5a619f24bf58c122836faf99ff"
+        "revision" : "edd2d0cdb988ac45e2515e0dd0624e4a6de54a94",
+        "version" : "0.50800.0-SNAPSHOT-2022-12-20-a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.0")),
-        .package(url: "https://github.com/apple/swift-syntax.git", revision: "a2d31e8880224f5a619f24bf58c122836faf99ff"),
+        .package(url: "https://github.com/apple/swift-syntax", from: "0.50800.0-SNAPSHOT-2022-12-20-a"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.33.1")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),


### PR DESCRIPTION
Updated the SwiftLint package to depend on the [swift-syntax prerelease](https://github.com/apple/swift-syntax/releases/tag/0.50800.0-SNAPSHOT-2022-12-20-a).