### PR TITLE
Separate analyzer rules as an independent section in the rule directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   [jimmya](https://github.com/jimmya)
   [#issue_number](https://github.com/realm/SwiftLint/issues/4609)
 
+* Separate analyzer rules as an independent section in the rule directory of the reference.  
+  [Ethan Wong](https://github.com/GetToSet)
+  [#4664](https://github.com/realm/SwiftLint/pull/4664)
+
 #### Bug Fixes
 
 * Report violations in all `<scope>_length` rules when the error threshold is

--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -34,7 +34,8 @@ public struct RuleListDocumentation {
 
     private var indexContents: String {
         let defaultRuleDocumentations = ruleDocumentations.filter { !$0.isOptInRule }
-        let optInRuleDocumentations = ruleDocumentations.filter { $0.isOptInRule }
+        let optInRuleDocumentations = ruleDocumentations.filter { $0.isOptInRule && !$0.isAnalyzerRule }
+        let analyzerRuleDocumentations = ruleDocumentations.filter { $0.isAnalyzerRule }
 
         return """
             # Rule Directory
@@ -48,6 +49,12 @@ public struct RuleListDocumentation {
             ## Opt-In Rules
 
             \(optInRuleDocumentations
+                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
+                .joined(separator: "\n"))
+
+            ## Analyzer Rules
+
+            \(analyzerRuleDocumentations
                 .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
                 .joined(separator: "\n"))
 


### PR DESCRIPTION
PR #4620 gives warnings on misplaced analyzer rules. This PR separates analyzer rules as an independent section in the rule directory so that developers may be easier to recognize those rules should be separately treated.