### PR TITLE
Add key to severity configuration as a hint for the correct YAML syntax

### DIFF
--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -4,7 +4,7 @@ struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var alwaysOnNewLine = Set<String>()
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", always_on_same_line: \(alwaysOnSameLine.sorted())" +
             ", always_on_line_above: \(alwaysOnNewLine.sorted())"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -5,7 +5,7 @@ struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatab
     init() {}
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", align_colons: \(alignColons)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", align_colons: \(alignColons)"
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -4,7 +4,7 @@ struct ColonConfiguration: RuleConfiguration, Equatable {
     private(set) var applyToDictionaries = true
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", flexible_right_spacing: \(flexibleRightSpacing)" +
             ", apply_to_dictionaries: \(applyToDictionaries)"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ComputedAccessorsOrderRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ComputedAccessorsOrderRuleConfiguration.swift
@@ -8,7 +8,8 @@ struct ComputedAccessorsOrderRuleConfiguration: SeverityBasedRuleConfiguration, 
     private(set) var order = Order.getSet
 
     var consoleDescription: String {
-        return [severityConfiguration.consoleDescription, "order: \(order.rawValue)"].joined(separator: ", ")
+        return "severity: \(severityConfiguration.consoleDescription)"
+            + ", order: \(order.rawValue)"
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -3,7 +3,7 @@ struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration,
     private(set) var ifOnly = false
 
     var consoleDescription: String {
-        return [severityConfiguration.consoleDescription, "if_only: \(ifOnly)"].joined(separator: ", ")
+        return ["severity: \(severityConfiguration.consoleDescription)", "if_only: \(ifOnly)"].joined(separator: ", ")
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
@@ -112,7 +112,7 @@ struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration, Equatable 
     private let targets: [String: Version]
 
     var consoleDescription: String {
-        severityConfiguration.consoleDescription + targets
+        "severity: \(severityConfiguration.consoleDescription)" + targets
             .sorted { $0.key < $1.key }
             .map { ", \($0): \($1.stringValue)" }.joined()
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -6,7 +6,7 @@ struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration, Equat
     var severityConfiguration = SeverityConfiguration(.warning)
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", types: \(discouragedInits.sorted(by: <))"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", types: \(discouragedInits.sorted(by: <))"
     }
 
     private(set) var discouragedInits: Set<String>

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -8,7 +8,7 @@ struct EmptyCountConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var onlyAfterDot = false
 
     var consoleDescription: String {
-        return [severityConfiguration.consoleDescription,
+        return ["severity: \(severityConfiguration.consoleDescription)",
                 "\(ConfigurationKey.onlyAfterDot.rawValue): \(onlyAfterDot)"].joined(separator: ", ")
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -16,7 +16,7 @@ struct ExplicitTypeInterfaceConfiguration: SeverityBasedRuleConfiguration, Equat
 
     var consoleDescription: String {
         let excludedKinds = VariableKind.all.subtracting(allowedKinds).map(\.rawValue).sorted()
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", excluded: \(excludedKinds)" +
             ", allow_redundancy: \(allowRedundancy)"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -24,7 +24,7 @@ struct FileHeaderConfiguration: RuleConfiguration, Equatable {
         let forbiddenStringDescription = forbiddenString ?? "None"
         let forbiddenPatternDescription = forbiddenPattern ?? "None"
 
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", required_string: \(requiredStringDescription)" +
             ", required_pattern: \(requiredPatternDescription)" +
             ", forbidden_string: \(forbiddenStringDescription)" +

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileLengthRuleConfiguration.swift
@@ -9,7 +9,7 @@ struct FileLengthRuleConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration: SeverityLevelsConfiguration
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", \(ConfigurationKey.ignoreCommentOnlyLines.rawValue): \(ignoreCommentOnlyLines)"
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -17,7 +17,7 @@ struct FileTypesOrderConfiguration: RuleConfiguration, Equatable {
     ]
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", order: \(String(describing: order))"
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ForWhereRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ForWhereRuleConfiguration.swift
@@ -3,7 +3,7 @@ struct ForWhereRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var allowForAsFilter = false
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", allow_for_as_filter: \(allowForAsFilter)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", allow_for_as_filter: \(allowForAsFilter)"
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -9,8 +9,8 @@ struct FunctionParameterCountConfiguration: RuleConfiguration, Equatable {
     private(set) var severityConfiguration: SeverityLevelsConfiguration
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
-        "\(ConfigurationKey.ignoresDefaultParameters.rawValue): \(ignoresDefaultParameters)"
+        return "severity: \(severityConfiguration.consoleDescription)" +
+        ", \(ConfigurationKey.ignoresDefaultParameters.rawValue): \(ignoresDefaultParameters)"
     }
 
     init(warning: Int, error: Int?, ignoresDefaultParameters: Bool = true) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -13,7 +13,7 @@ struct ImplicitReturnConfiguration: RuleConfiguration, Equatable {
 
     var consoleDescription: String {
         let includedKinds = self.includedKinds.map { $0.rawValue }
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", included: [\(includedKinds.sorted().joined(separator: ", "))]"
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -24,7 +24,7 @@ struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration,
 
     var consoleDescription: String {
         return "severity: \(severityConfiguration.consoleDescription)" +
-            ", mode: \(mode)"
+            ", mode: \(mode.rawValue)"
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -23,7 +23,7 @@ struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration,
     }
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", mode: \(mode)"
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -14,7 +14,7 @@ struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration, Equatable
     private(set) var allAllowedTerms: Set<String>
 
     var consoleDescription: String {
-        severityConfiguration.consoleDescription
+        "severity: \(severityConfiguration.consoleDescription)"
             + ", additional_terms: \(additionalTerms?.sorted() ?? [])"
             + ", override_terms: \(overrideTerms?.sorted() ?? [])"
             + ", override_allowed_terms: \(overrideAllowedTerms?.sorted() ?? [])"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -1,6 +1,6 @@
 struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
     var consoleDescription: String {
-        return "severity: \(severityConfiguration.consoleDescription), "
+        return "severity: \("severity: \(severityConfiguration.consoleDescription)"), "
             + "indentation_width: \(indentationWidth), "
             + "include_comments: \(includeComments)"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -5,7 +5,8 @@ struct ModifierOrderConfiguration: RuleConfiguration, Equatable {
     private(set) var preferredModifierOrder = [SwiftDeclarationAttributeKind.ModifierGroup]()
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", preferred_modifier_order: \(preferredModifierOrder)"
+        return "severity: \(severityConfiguration.consoleDescription)"
+            + ", preferred_modifier_order: \(preferredModifierOrder)"
     }
 
     init() {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -26,7 +26,7 @@ struct MultilineArgumentsConfiguration: RuleConfiguration, Equatable {
     private(set) var onlyEnforceAfterFirstClosureOnFirstLine = false
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", \(ConfigurationKey.firstArgumentLocation.rawValue): \(firstArgumentLocation.rawValue)" +
             ", \(ConfigurationKey.onlyEnforceAfterFirstClosureOnFirstLine.rawValue): \(onlyEnforceAfterFirstClosureOnFirstLine)"
             // swiftlint:disable:previous line_length

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -3,7 +3,7 @@ struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration, Equatab
     private(set) var allowsSingleLine = true
 
     var consoleDescription: String {
-        severityConfiguration.consoleDescription
+        "severity: \(severityConfiguration.consoleDescription)"
             + ", allowsSingleLine: \(allowsSingleLine)"
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -11,7 +11,7 @@ struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration, Equatable {
         } else {
             minimumFractionLengthDescription = ", minimum_fraction_length: none"
         }
-        return severityConfiguration.consoleDescription
+        return "severity: \(severityConfiguration.consoleDescription)"
             + ", minimum_length: \(minimumLength)"
             + minimumFractionLengthDescription
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -4,7 +4,7 @@ struct ObjectLiteralConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var colorLiteral = true
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription
+        return "severity: \(severityConfiguration.consoleDescription)"
             + ", image_literal: \(imageLiteral)"
             + ", color_literal: \(colorLiteral)"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -8,7 +8,7 @@ struct OpeningBraceConfiguration: RuleConfiguration, Equatable {
     private(set) var allowMultilineFunc = false
 
     var consoleDescription: String {
-        return [severityConfiguration.consoleDescription,
+        return ["severity: \(severityConfiguration.consoleDescription)",
                 "\(ConfigurationKey.allowMultilineFunc): \(allowMultilineFunc)"].joined(separator: ", ")
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -5,7 +5,7 @@ struct OperatorUsageWhitespaceConfiguration: RuleConfiguration, Equatable {
     private(set) var allowedNoSpaceOperators: [String] = ["...", "..<"]
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription
+        return "severity: \(severityConfiguration.consoleDescription)"
             + ", lines_look_around: \(linesLookAround)"
             + ", skip_aligned_constants: \(skipAlignedConstants)"
             + ", allowed_no_space_operators: \(allowedNoSpaceOperators)"

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -45,7 +45,7 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
     }
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", excluded: \(excluded)" +
             ", included: \(included)"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrefixedConstantRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrefixedConstantRuleConfiguration.swift
@@ -3,7 +3,7 @@ struct PrefixedConstantRuleConfiguration: SeverityBasedRuleConfiguration, Equata
     var onlyPrivateMembers = false
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", only_private: \(onlyPrivateMembers)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", only_private: \(onlyPrivateMembers)"
     }
 
     init(onlyPrivateMembers: Bool) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOutletRuleConfiguration.swift
@@ -3,7 +3,7 @@ struct PrivateOutletRuleConfiguration: SeverityBasedRuleConfiguration, Equatable
     var allowPrivateSet = false
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", allow_private_set: \(allowPrivateSet)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", allow_private_set: \(allowPrivateSet)"
     }
 
     init(allowPrivateSet: Bool) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/PrivateOverFilePrivateRuleConfiguration.swift
@@ -3,7 +3,7 @@ struct PrivateOverFilePrivateRuleConfiguration: SeverityBasedRuleConfiguration, 
     var validateExtensions = false
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", validate_extensions: \(validateExtensions)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", validate_extensions: \(validateExtensions)"
     }
 
     // MARK: - RuleConfiguration

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -17,7 +17,7 @@ struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration, Equatable {
     init() {}
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", excluded: [\(excluded)]" +
             ", included: [\(included)]"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -8,7 +8,7 @@ struct SelfBindingConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var bindIdentifier = "self"
 
     var consoleDescription: String {
-        return [severityConfiguration.consoleDescription,
+        return ["severity: \(severityConfiguration.consoleDescription)",
                 "\(ConfigurationKey.bindIdentifier): \(bindIdentifier)"].joined(separator: ", ")
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -5,7 +5,7 @@ struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration, Equatab
     init() {}
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", indented_cases: \(indentedCases)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", indented_cases: \(indentedCases)"
     }
 
     mutating func apply(configuration: Any) throws {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -4,7 +4,7 @@ struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration, Equat
     private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", allowed_prefixes: \(allowedPrefixes.sorted())" +
             ", test_parent_classes: \(testParentClasses.sorted())"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
@@ -3,7 +3,8 @@ struct TrailingClosureConfiguration: RuleConfiguration, Equatable {
     private(set) var onlySingleMutedParameter: Bool
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", only_single_muted_parameter: \(onlySingleMutedParameter)"
+        return "severity: \(severityConfiguration.consoleDescription)"
+            + ", only_single_muted_parameter: \(onlySingleMutedParameter)"
     }
 
     init(onlySingleMutedParameter: Bool = false) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -3,7 +3,7 @@ struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration, Equatable {
     private(set) var mandatoryComma: Bool
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", mandatory_comma: \(mandatoryComma)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", mandatory_comma: \(mandatoryComma)"
     }
 
     init(mandatoryComma: Bool = false) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -4,7 +4,7 @@ struct TrailingWhitespaceConfiguration: RuleConfiguration, Equatable {
     var ignoresComments = true
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", ignores_empty_lines: \(ignoresEmptyLines)" +
             ", ignores_comments: \(ignoresComments)"
     }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -36,7 +36,7 @@ struct TypeContentsOrderConfiguration: RuleConfiguration, Equatable {
     ]
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", order: \(String(describing: order))"
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnitTestRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnitTestRuleConfiguration.swift
@@ -7,7 +7,7 @@ public struct UnitTestRuleConfiguration: SeverityBasedRuleConfiguration, Equatab
     public private(set) var testParentClasses: Set<String> = ["QuickSpec", "XCTestCase"]
 
     public var consoleDescription: String {
-        return severityConfiguration.consoleDescription +
+        return "severity: \(severityConfiguration.consoleDescription)" +
             ", test_parent_classes: \(testParentClasses.sorted())"
     }
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -3,7 +3,7 @@ struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration, Equat
     private(set) var ignoreOptionalTry: Bool
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", ignore_optional_try: \(ignoreOptionalTry)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", ignore_optional_try: \(ignoreOptionalTry)"
     }
 
     init(ignoreOptionalTry: Bool) {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -3,7 +3,7 @@ struct VerticalWhitespaceConfiguration: RuleConfiguration, Equatable {
     private(set) var maxEmptyLines: Int
 
     var consoleDescription: String {
-        return severityConfiguration.consoleDescription + ", max_empty_lines: \(maxEmptyLines)"
+        return "severity: \(severityConfiguration.consoleDescription)" + ", max_empty_lines: \(maxEmptyLines)"
     }
 
     init(maxEmptyLines: Int) {

--- a/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -27,7 +27,7 @@ extension VerticalWhitespaceClosingBracesRule {
         private(set) var onlyEnforceBeforeTrivialLines = false
 
         var consoleDescription: String {
-            return severityConfiguration.consoleDescription +
+            return "severity: \(severityConfiguration.consoleDescription)" +
                 ", \(ConfigurationKey.onlyEnforceBeforeTrivialLines.rawValue): \(onlyEnforceBeforeTrivialLines)"
         }
 

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -44,7 +44,7 @@ class ExplicitTypeInterfaceConfigurationTests: XCTestCase {
         try config.apply(configuration: ["excluded": ["class", "instance"]])
         XCTAssertEqual(
             config.consoleDescription,
-            "warning, excluded: [\"class\", \"instance\"], allow_redundancy: false"
+            "severity: warning, excluded: [\"class\", \"instance\"], allow_redundancy: false"
         )
     }
 }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -383,6 +383,6 @@ class RuleConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.severityConfiguration.severity, .error)
         XCTAssertEqual(configuration.order, .setGet)
 
-        XCTAssertEqual(configuration.consoleDescription, "error, order: set_get")
+        XCTAssertEqual(configuration.consoleDescription, "severity: error, order: set_get")
     }
 }


### PR DESCRIPTION
This might help with the confusion reported in #4661.