### PR TITLE
Rephrase rule description

### DIFF
--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -8,7 +8,7 @@ struct DuplicateEnumCasesRule: ConfigurationProviderRule, SwiftSyntaxRule {
     static let description = RuleDescription(
         identifier: "duplicate_enum_cases",
         name: "Duplicate Enum Cases",
-        description: "Enum can't contain multiple cases with the same name",
+        description: "Enum shouldn't contain multiple cases with the same name",
         kind: .lint,
         nonTriggeringExamples: [
             Example("""


### PR DESCRIPTION
"Can't" sounds too hard. The Swift compiler allows multiple enum cases with the same name. It's rather a recommendation.