### PR TITLE
Revert rules_xcodeproj to 0.10.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,8 +39,8 @@ swiftlint_deps()
 
 http_archive(
     name = "com_github_buildbuddy_io_rules_xcodeproj",
-    sha256 = "2533b977ac8540a30323fde7fdb6ca49219edd21d3753b69d43f39c576b11a88",
-    url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.11.0/release.tar.gz",
+    sha256 = "598449ff3a08972227363a55d22b54707468ecf4370ff56662f9d6026f72c7a7",
+    url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.10.1/release.tar.gz",
 )
 
 load("@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl", "xcodeproj_rules_dependencies")


### PR DESCRIPTION
It looks like later versions can't run tests because of https://github.com/buildbuddy-io/rules_xcodeproj/issues/1586.
