### PR TITLE
Skip tests requiring runfiles support when testing with rules_xcodeproj

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -122,13 +122,18 @@ xcodeproj(
                     "--progress",
                 ],
             ),
-            test_action = xcode_schemes.test_action([
-                "//Tests:CLITests",
-                "//Tests:SwiftLintFrameworkTests",
-                "//Tests:GeneratedTests",
-                "//Tests:IntegrationTests",
-                "//Tests:ExtraRulesTests",
-            ]),
+            test_action = xcode_schemes.test_action(
+                env = {
+                    "RUNNING_RULES_XCODEPROJ_TESTS": "TRUE",
+                },
+                targets = [
+                    "//Tests:CLITests",
+                    "//Tests:ExtraRulesTests",
+                    "//Tests:GeneratedTests",
+                    "//Tests:IntegrationTests",
+                    "//Tests:SwiftLintFrameworkTests",
+                ],
+            ),
         ),
     ],
     top_level_targets = [

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import SourceKittenFramework
 @_spi(TestHelper)
 import SwiftLintFramework
+import SwiftLintTestHelpers
 import XCTest
 
 private let config: Configuration = {
@@ -14,7 +15,9 @@ private let config: Configuration = {
 }()
 
 class IntegrationTests: XCTestCase {
-    func testSwiftLintLints() {
+    func testSwiftLintLints() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         // This is as close as we're ever going to get to a self-hosting linter.
         let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false)
         XCTAssert(
@@ -33,7 +36,9 @@ class IntegrationTests: XCTestCase {
         }
     }
 
-    func testSwiftLintAutoCorrects() {
+    func testSwiftLintAutoCorrects() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false)
         let storage = RuleStorage()
         let corrections = swiftFiles.parallelFlatMap {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -12,7 +12,9 @@ private extension Configuration {
 
 extension ConfigurationTests {
     // MARK: - Rules Merging
-    func testMerge() {
+    func testMerge() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let config0Merge2 = Mock.Config._0.merged(withChild: Mock.Config._2, rootDirectory: "")
 
         XCTAssertFalse(Mock.Config._0.contains(rule: ForceCastRule.self))
@@ -72,7 +74,9 @@ extension ConfigurationTests {
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceTryRule.self))
     }
 
-    func testCustomRulesMerging() {
+    func testCustomRulesMerging() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let mergedConfiguration = Mock.Config._0CustomRules.merged(
             withChild: Mock.Config._2CustomRules,
             rootDirectory: ""
@@ -90,7 +94,9 @@ extension ConfigurationTests {
         )
     }
 
-    func testMergingAllowsDisablingParentsCustomRules() {
+    func testMergingAllowsDisablingParentsCustomRules() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let mergedConfiguration = Mock.Config._0CustomRules.merged(
             withChild: Mock.Config._2CustomRulesDisabled,
             rootDirectory: ""
@@ -108,7 +114,9 @@ extension ConfigurationTests {
         )
     }
 
-    func testCustomRulesMergingWithOnlyRulesCase1() {
+    func testCustomRulesMergingWithOnlyRulesCase1() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         // The base configuration is in only rules mode
         // The child configuration is in the default rules mode
         // => all custom rules should be considered
@@ -129,7 +137,9 @@ extension ConfigurationTests {
         )
     }
 
-    func testCustomRulesMergingWithOnlyRulesCase2() {
+    func testCustomRulesMergingWithOnlyRulesCase2() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         // The base configuration is in only rules mode
         // The child configuration is in the only rules mode
         // => only the custom rules from the child configuration should be considered
@@ -151,7 +161,9 @@ extension ConfigurationTests {
         )
     }
 
-    func testCustomRulesReconfiguration() {
+    func testCustomRulesReconfiguration() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         // Custom Rule severity gets reconfigured to "error"
         let mergedConfiguration = Mock.Config._0CustomRulesOnly.merged(
             withChild: Mock.Config._2CustomRulesReconfig,
@@ -175,17 +187,23 @@ extension ConfigurationTests {
     }
 
     // MARK: - Nested Configurations
-    func testLevel0() {
+    func testLevel0() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssertEqual(Mock.Config._0.configuration(for: SwiftLintFile(path: Mock.Swift._0)!),
                        Mock.Config._0)
     }
 
-    func testLevel1() {
+    func testLevel1() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssertEqual(Mock.Config._0.configuration(for: SwiftLintFile(path: Mock.Swift._1)!),
                        Mock.Config._0)
     }
 
-    func testLevel2() {
+    func testLevel2() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let config = Mock.Config._0.configuration(for: SwiftLintFile(path: Mock.Swift._2)!)
         var config2 = Mock.Config._2
         config2.fileGraph = Configuration.FileGraph(rootDirectory: Mock.Dir.level2)
@@ -196,7 +214,9 @@ extension ConfigurationTests {
         )
     }
 
-    func testLevel3() {
+    func testLevel3() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let config = Mock.Config._0.configuration(for: SwiftLintFile(path: Mock.Swift._3)!)
         var config3 = Mock.Config._3
         config3.fileGraph = Configuration.FileGraph(rootDirectory: Mock.Dir.level3)
@@ -207,7 +227,9 @@ extension ConfigurationTests {
         )
     }
 
-    func testNestedConfigurationForOnePathPassedIn() {
+    func testNestedConfigurationForOnePathPassedIn() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         // If a path to one or more configuration files is specified, nested configurations should be ignored
         let config = Configuration(configurationFiles: [Mock.Yml._0])
         XCTAssertEqual(
@@ -216,7 +238,9 @@ extension ConfigurationTests {
         )
     }
 
-    func testParentConfigIsIgnoredAsNestedConfiguration() {
+    func testParentConfigIsIgnoredAsNestedConfiguration() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         // If a configuration has already been used to build the main config,
         // it should not again be regarded as a nested config
         XCTAssertEqual(
@@ -241,7 +265,9 @@ extension ConfigurationTests {
         }
     }
 
-    func testValidParentConfig() {
+    func testValidParentConfig() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         for path in [Mock.Dir.parentConfigTest1, Mock.Dir.parentConfigTest2] {
             FileManager.default.changeCurrentDirectoryPath(path)
 
@@ -302,7 +328,9 @@ extension ConfigurationTests {
     }
 
     // MARK: - Remote Configs
-    func testValidRemoteChildConfig() {
+    func testValidRemoteChildConfig() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.remoteConfigChild)
 
         assertEqualExceptForFileGraph(
@@ -321,7 +349,9 @@ extension ConfigurationTests {
         )
     }
 
-    func testValidRemoteParentConfig() {
+    func testValidRemoteParentConfig() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.remoteConfigParent)
 
         assertEqualExceptForFileGraph(

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import SourceKittenFramework
 @_spi(TestHelper)
 @testable import SwiftLintFramework
+import SwiftLintTestHelpers
 import XCTest
 
 // swiftlint:disable file_length
@@ -54,7 +55,9 @@ class ConfigurationTests: XCTestCase {
         XCTAssertFalse(config.allowZeroLintableFiles)
     }
 
-    func testInitWithRelativePathAndRootPath() {
+    func testInitWithRelativePathAndRootPath() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedConfig = Mock.Config._0
 
         let config = Configuration(configurationFiles: [".swiftlint.yml"])
@@ -215,7 +218,9 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(actualExcludedPath, desiredExcludedPath)
     }
 
-    func testIncludedExcludedRelativeLocationLevel0() {
+    func testIncludedExcludedRelativeLocationLevel0() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         // Same as testIncludedPathRelatedToConfigurationFileLocationLevel1(),
         // but run from the directory the config file resides in
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
@@ -286,7 +291,9 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
     }
 
-    func testLintablePaths() {
+    func testLintablePaths() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let paths = Configuration.default.lintablePaths(inPath: Mock.Dir.level0, forceExclude: false)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         let expectedFilenames = [
@@ -298,7 +305,9 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(Set(expectedFilenames), Set(filenames))
     }
 
-    func testGlobIncludePaths() {
+    func testGlobIncludePaths() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(includedPaths: ["**/Level2"])
         let paths = configuration.lintablePaths(inPath: Mock.Dir.level0, forceExclude: true)
@@ -323,26 +332,34 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(Mock.Config._0, Mock.Config._0)
     }
 
-    func testIsNotEqualTo() {
+    func testIsNotEqualTo() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssertNotEqual(Mock.Config._0, Mock.Config._2)
     }
 
     // MARK: - Testing Custom Configuration File
 
-    func testCustomConfiguration() {
+    func testCustomConfiguration() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let file = SwiftLintFile(path: Mock.Swift._0)!
         XCTAssertNotEqual(Mock.Config._0.configuration(for: file),
                           Mock.Config._0Custom.configuration(for: file))
     }
 
-    func testConfigurationWithSwiftFileAsRoot() {
+    func testConfigurationWithSwiftFileAsRoot() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let configuration = Configuration(configurationFiles: [Mock.Yml._0])
 
         let file = SwiftLintFile(path: Mock.Swift._0)!
         XCTAssertEqual(configuration.configuration(for: file), configuration)
     }
 
-    func testConfigurationWithSwiftFileAsRootAndCustomConfiguration() {
+    func testConfigurationWithSwiftFileAsRootAndCustomConfiguration() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let configuration = Mock.Config._0Custom
 
         let file = SwiftLintFile(path: Mock.Swift._0)!
@@ -395,7 +412,9 @@ class ConfigurationTests: XCTestCase {
 
 // MARK: - ExcludeByPrefix option tests
 extension ConfigurationTests {
-    func testExcludeByPrefixExcludedPaths() {
+    func testExcludeByPrefixExcludedPaths() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(includedPaths: ["Level1"],
                                           excludedPaths: ["Level1/Level1.swift",
@@ -416,7 +435,9 @@ extension ConfigurationTests {
         XCTAssertEqual([], paths)
     }
 
-    func testExcludeByPrefixForceExcludesFileNotPresentInExcluded() {
+    func testExcludeByPrefixForceExcludesFileNotPresentInExcluded() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(includedPaths: ["Level1"],
                                           excludedPaths: ["Level1/Level1.swift"])
@@ -427,7 +448,9 @@ extension ConfigurationTests {
         XCTAssertEqual(["Level2.swift", "Level3.swift"], filenames)
     }
 
-    func testExcludeByPrefixForceExcludesDirectory() {
+    func testExcludeByPrefixForceExcludesDirectory() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(
             excludedPaths: [
@@ -441,7 +464,9 @@ extension ConfigurationTests {
         XCTAssertEqual(["Level0.swift", "Level1.swift"], filenames)
     }
 
-    func testExcludeByPrefixForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() {
+    func testExcludeByPrefixForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(
             excludedPaths: [
@@ -455,7 +480,9 @@ extension ConfigurationTests {
         XCTAssertEqual(["Level0.swift"], filenames)
     }
 
-    func testExcludeByPrefixGlobExcludePaths() {
+    func testExcludeByPrefixGlobExcludePaths() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(
             includedPaths: ["Level1"],
@@ -498,7 +525,9 @@ extension ConfigurationTests {
     //
     // This issue may not be reproducible under normal execution: the cache is in memory, so when a user changes
     // the cachePath from command line and re-runs swiftlint, cache is not reused leading to the correct behavior
-    func testMainInitWithCachePathAndCachedConfig() {
+    func testMainInitWithCachePathAndCachedConfig() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let configuration1 = Configuration(
             configurationFiles: [],
             cachePath: "cache/path/1"

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -1,5 +1,6 @@
 import SourceKittenFramework
 @testable import SwiftLintFramework
+import SwiftLintTestHelpers
 import XCTest
 
 class CustomRulesTests: XCTestCase {
@@ -126,14 +127,18 @@ class CustomRulesTests: XCTestCase {
                                        reason: configs.0.message)])
     }
 
-    func testCustomRulesIncludedDefault() {
+    func testCustomRulesIncludedDefault() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         // Violation detected when included is omitted.
         let (_, customRules) = getCustomRules()
         let violations = customRules.validate(file: getTestTextFile())
         XCTAssertEqual(violations.count, 1)
     }
 
-    func testCustomRulesIncludedExcludesFile() {
+    func testCustomRulesIncludedExcludesFile() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         var (regexConfig, customRules) = getCustomRules(["included": "\\.yml$"])
 
         var customRuleConfiguration = CustomRulesConfiguration()
@@ -144,7 +149,9 @@ class CustomRulesTests: XCTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
-    func testCustomRulesExcludedExcludesFile() {
+    func testCustomRulesExcludedExcludesFile() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         var (regexConfig, customRules) = getCustomRules(["excluded": "\\.txt$"])
 
         var customRuleConfiguration = CustomRulesConfiguration()
@@ -155,7 +162,9 @@ class CustomRulesTests: XCTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
-    func testCustomRulesExcludedArrayExcludesFile() {
+    func testCustomRulesExcludedArrayExcludesFile() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         var (regexConfig, customRules) = getCustomRules(["excluded": ["\\.pdf$", "\\.txt$"]])
 
         var customRuleConfiguration = CustomRulesConfiguration()
@@ -166,7 +175,9 @@ class CustomRulesTests: XCTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
-    func testCustomRulesCaptureGroup() {
+    func testCustomRulesCaptureGroup() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let (_, customRules) = getCustomRules(["regex": #"\ba\s+(\w+)"#,
                                                "capture_group": 1])
         let violations = customRules.validate(file: getTestTextFile())

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -1,5 +1,6 @@
 import SourceKittenFramework
 @testable import SwiftLintFramework
+import SwiftLintTestHelpers
 import XCTest
 
 private let fixturesDirectory = #file.bridge()
@@ -131,7 +132,9 @@ class FileHeaderRuleTests: XCTestCase {
                    skipCommentTests: true, testMultiByteOffsets: false)
     }
 
-    func testFileHeaderWithRequiredStringUsingFilenamePlaceholder() {
+    func testFileHeaderWithRequiredStringUsingFilenamePlaceholder() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let configuration = ["required_string": "// SWIFTLINT_CURRENT_FILENAME"]
 
         // Non triggering tests
@@ -143,7 +146,9 @@ class FileHeaderRuleTests: XCTestCase {
         XCTAssertEqual(try validate(fileName: "FileNameMissing.swift", using: configuration).count, 1)
     }
 
-    func testFileHeaderWithForbiddenStringUsingFilenamePlaceholder() {
+    func testFileHeaderWithForbiddenStringUsingFilenamePlaceholder() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let configuration = ["forbidden_string": "// SWIFTLINT_CURRENT_FILENAME"]
 
         // Non triggering tests
@@ -155,7 +160,9 @@ class FileHeaderRuleTests: XCTestCase {
         XCTAssertEqual(try validate(fileName: "FileNameMatchingSimple.swift", using: configuration).count, 1)
     }
 
-    func testFileHeaderWithRequiredPatternUsingFilenamePlaceholder() {
+    func testFileHeaderWithRequiredPatternUsingFilenamePlaceholder() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let configuration1 = ["required_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
         let configuration2 = ["required_pattern":
             "// Copyright © \\d{4}\n// File: \"SWIFTLINT_CURRENT_FILENAME\""]
@@ -170,7 +177,9 @@ class FileHeaderRuleTests: XCTestCase {
         XCTAssertEqual(try validate(fileName: "FileNameMissing.swift", using: configuration1).count, 1)
     }
 
-    func testFileHeaderWithForbiddenPatternUsingFilenamePlaceholder() {
+    func testFileHeaderWithForbiddenPatternUsingFilenamePlaceholder() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let configuration1 = ["forbidden_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
         let configuration2 = ["forbidden_pattern": "//.*(\\s|\")SWIFTLINT_CURRENT_FILENAME(\\s|\").*"]
 

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -29,64 +29,92 @@ class FileNameRuleTests: XCTestCase {
         return rule.validate(file: file)
     }
 
-    func testMainDoesntTrigger() {
+    func testMainDoesntTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "main.swift").isEmpty)
     }
 
-    func testLinuxMainDoesntTrigger() {
+    func testLinuxMainDoesntTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "LinuxMain.swift").isEmpty)
     }
 
-    func testClassNameDoesntTrigger() {
+    func testClassNameDoesntTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "MyClass.swift").isEmpty)
     }
 
-    func testStructNameDoesntTrigger() {
+    func testStructNameDoesntTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "MyStruct.swift").isEmpty)
     }
 
-    func testExtensionNameDoesntTrigger() {
+    func testExtensionNameDoesntTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "NSString+Extension.swift").isEmpty)
     }
 
-    func testNestedExtensionDoesntTrigger() {
+    func testNestedExtensionDoesntTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "Notification.Name+Extension.swift").isEmpty)
     }
 
-    func testNestedTypeSeparatorDoesntTrigger() {
+    func testNestedTypeSeparatorDoesntTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "NotificationName+Extension.swift", nestedTypeSeparator: "").isEmpty)
         XCTAssert(try validate(fileName: "Notification__Name+Extension.swift", nestedTypeSeparator: "__").isEmpty)
     }
 
-    func testWrongNestedTypeSeparatorDoesTrigger() {
+    func testWrongNestedTypeSeparatorDoesTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try !validate(fileName: "Notification__Name+Extension.swift", nestedTypeSeparator: ".").isEmpty)
         XCTAssert(try !validate(fileName: "NotificationName+Extension.swift", nestedTypeSeparator: "__").isEmpty)
     }
 
-    func testMisspelledNameDoesTrigger() {
+    func testMisspelledNameDoesTrigger() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssertEqual(try validate(fileName: "MyStructf.swift").count, 1)
     }
 
-    func testMisspelledNameDoesntTriggerWithOverride() {
+    func testMisspelledNameDoesntTriggerWithOverride() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "MyStructf.swift", excludedOverride: ["MyStructf.swift"]).isEmpty)
     }
 
-    func testMainDoesTriggerWithoutOverride() {
+    func testMainDoesTriggerWithoutOverride() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssertEqual(try validate(fileName: "main.swift", excludedOverride: []).count, 1)
     }
 
-    func testCustomSuffixPattern() {
+    func testCustomSuffixPattern() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "BoolExtension.swift", suffixPattern: "Extensions?").isEmpty)
         XCTAssert(try validate(fileName: "BoolExtensions.swift", suffixPattern: "Extensions?").isEmpty)
         XCTAssert(try validate(fileName: "BoolExtensionTests.swift", suffixPattern: "Extensions?|\\+.*").isEmpty)
     }
 
-    func testCustomPrefixPattern() {
+    func testCustomPrefixPattern() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(try validate(fileName: "ExtensionBool.swift", prefixPattern: "Extensions?").isEmpty)
         XCTAssert(try validate(fileName: "ExtensionsBool.swift", prefixPattern: "Extensions?").isEmpty)
     }
 
-    func testCustomPrefixAndSuffixPatterns() {
+    func testCustomPrefixAndSuffixPatterns() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         XCTAssert(
             try validate(
                 fileName: "SLBoolExtension.swift",

--- a/Tests/SwiftLintFrameworkTests/GlobTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GlobTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftLintFramework
+import SwiftLintTestHelpers
 import XCTest
 
 final class GlobTests: XCTestCase {
@@ -6,47 +7,65 @@ final class GlobTests: XCTestCase {
         return testResourcesPath.stringByAppendingPathComponent("ProjectMock")
     }
 
-    func testOnlyGlobForWildcard() {
+    func testOnlyGlobForWildcard() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob("foo/bar.swift")
         XCTAssertEqual(files, ["foo/bar.swift"])
     }
 
-    func testNoMatchReturnsEmpty() {
+    func testNoMatchReturnsEmpty() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("NoFile*.swift"))
         XCTAssertTrue(files.isEmpty)
     }
 
-    func testMatchesFiles() {
+    func testMatchesFiles() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level*.swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
-    func testMatchesSingleCharacter() {
+    func testMatchesSingleCharacter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level?.swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
-    func testMatchesOneCharacterInBracket() {
+    func testMatchesOneCharacterInBracket() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[01].swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
-    func testNoMatchOneCharacterInBracket() {
+    func testNoMatchOneCharacterInBracket() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[ab].swift"))
          XCTAssertTrue(files.isEmpty)
     }
 
-    func testMatchesCharacterInRange() {
+    func testMatchesCharacterInRange() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[0-9].swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
-    func testNoMatchCharactersInRange() {
+    func testNoMatchCharactersInRange() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[a-z].swift"))
         XCTAssertTrue(files.isEmpty)
     }
 
-    func testMatchesMultipleFiles() {
+    func testMatchesMultipleFiles() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedFiles: Set = [
             mockPath.stringByAppendingPathComponent("Level0.swift"),
             mockPath.stringByAppendingPathComponent("Directory.swift")
@@ -56,12 +75,16 @@ final class GlobTests: XCTestCase {
         XCTAssertEqual(files.sorted(), expectedFiles.sorted())
     }
 
-    func testMatchesNestedDirectory() {
+    func testMatchesNestedDirectory() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level1/*.swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level1/Level1.swift")])
     }
 
-    func testGlobstarSupport() {
+    func testGlobstarSupport() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedFiles = Set(
             [
                 "Directory.swift",

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework
+import SwiftLintTestHelpers
 import XCTest
 
 class ReporterTests: XCTestCase {
@@ -50,25 +51,33 @@ class ReporterTests: XCTestCase {
         ]
     }
 
-    func testXcodeReporter() {
+    func testXcodeReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedXcodeReporterOutput.txt")
         let result = XcodeReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testEmojiReporter() {
+    func testEmojiReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedEmojiReporterOutput.txt")
         let result = EmojiReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testGitHubActionsLoggingReporter() {
+    func testGitHubActionsLoggingReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedGitHubActionsLoggingReporterOutput.txt")
         let result = GitHubActionsLoggingReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testGitLabJUnitReporter() {
+    func testGitLabJUnitReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedGitLabJUnitReporterOutput.xml")
         let result = GitLabJUnitReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
@@ -86,36 +95,48 @@ class ReporterTests: XCTestCase {
     }
 
     func testJSONReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedJSONReporterOutput.json")
         let result = JSONReporter.generateReport(generateViolations())
         XCTAssertEqual(try jsonValue(result), try jsonValue(expectedOutput))
     }
 
-    func testCSVReporter() {
+    func testCSVReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedCSVReporterOutput.csv")
         let result = CSVReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testCheckstyleReporter() {
+    func testCheckstyleReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedCheckstyleReporterOutput.xml")
         let result = CheckstyleReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testCodeClimateReporter() {
+    func testCodeClimateReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedCodeClimateReporterOutput.json")
         let result = CodeClimateReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testJunitReporter() {
+    func testJunitReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedJunitReporterOutput.xml")
         let result = JUnitReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testHTMLReporter() {
+    func testHTMLReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedHTMLReporterOutput.html")
         let result = HTMLReporter.generateReport(
             generateViolations(),
@@ -125,13 +146,17 @@ class ReporterTests: XCTestCase {
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testSonarQubeReporter() {
+    func testSonarQubeReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedSonarQubeReporterOutput.json")
         let result = SonarQubeReporter.generateReport(generateViolations())
         XCTAssertEqual(try jsonValue(result), try jsonValue(expectedOutput))
     }
 
-    func testMarkdownReporter() {
+    func testMarkdownReporter() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let expectedOutput = stringFromFile("CannedMarkdownReporterOutput.md")
         let result = MarkdownReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -1,5 +1,6 @@
 @_spi(TestHelper)
 @testable import SwiftLintFramework
+import SwiftLintTestHelpers
 import XCTest
 
 class SourceKitCrashTests: XCTestCase {
@@ -47,7 +48,9 @@ class SourceKitCrashTests: XCTestCase {
                       "Expects assert handler was not called on accessing SwiftLintFile.syntaxTokensByLines")
     }
 
-    func testRulesWithFileThatCrashedSourceKitService() {
+    func testRulesWithFileThatCrashedSourceKitService() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         let file = SwiftLintFile(path: #file)!
         file.sourcekitdFailed = true
         file.assertHandler = {

--- a/Tests/SwiftLintFrameworkTests/YamlSwiftLintTests.swift
+++ b/Tests/SwiftLintFrameworkTests/YamlSwiftLintTests.swift
@@ -1,9 +1,12 @@
 import Foundation
+import SwiftLintTestHelpers
 import XCTest
 import Yams
 
 class YamlSwiftLintTests: XCTestCase {
     func testFlattenYaml() throws {
+        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
+
         do {
             guard let yamlDict = try Yams.load(yaml: try getTestYaml()) as? [String: Any] else {
                 XCTFail("Failed to load YAML from file")

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -319,6 +319,11 @@ private func addShebang(_ example: Example) -> Example {
 public extension XCTestCase {
     var isRunningWithBazel: Bool { FileManager.default.currentDirectoryPath.contains("bazel-out") }
 
+    // Enable all tests when runfiles support is added - https://github.com/buildbuddy-io/rules_xcodeproj/issues/828
+    var shouldSkipRulesXcodeprojRunFiles: Bool {
+        ProcessInfo.processInfo.environment["RUNNING_RULES_XCODEPROJ_TESTS"] != nil
+    }
+
     func verifyRule(_ ruleDescription: RuleDescription,
                     ruleConfiguration: Any? = nil,
                     commentDoesntViolate: Bool = true,


### PR DESCRIPTION
rules_xcodeproj doesn't support runfiles yet: https://github.com/buildbuddy-io/rules_xcodeproj/issues/828
