### PR TITLE
Add new `superfluous_else` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,6 +44,7 @@ disabled_rules:
   - self_binding
   - sorted_enum_cases
   - strict_fileprivate
+  - superfluous_else
   - switch_case_on_newline
   - trailing_closure
   - type_contents_order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 #### Enhancements
 
+* Add new `superfluous_else` rule that triggers on `if`-statements when an
+  attached `else`-block can be removed, because all branches of the previous
+  `if`-block(s) would certainly exit the current scope already.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Add `sorted_enum_cases` rule which warns when enum cases are not sorted.  
   [kimdv](https://github.com/kimdv)
 

--- a/Source/SwiftLintFramework/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftSyntax+SwiftLint.swift
@@ -323,6 +323,17 @@ extension TriviaPiece {
     }
 }
 
+extension TriviaPiece {
+    var isOtherThanComment: Bool {
+        switch self {
+        case .blockComment, .lineComment, .docLineComment, .docBlockComment:
+            return false
+        default:
+            return true
+        }
+    }
+}
+
 extension IntegerLiteralExprSyntax {
     var isZero: Bool {
         guard case let .integerLiteral(number) = digits.tokenKind else {

--- a/Source/SwiftLintFramework/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftSyntax+SwiftLint.swift
@@ -323,17 +323,6 @@ extension TriviaPiece {
     }
 }
 
-extension TriviaPiece {
-    var isOtherThanComment: Bool {
-        switch self {
-        case .blockComment, .lineComment, .docLineComment, .docBlockComment:
-            return false
-        default:
-            return true
-        }
-    }
-}
-
 extension IntegerLiteralExprSyntax {
     var isZero: Bool {
         guard case let .integerLiteral(number) = digits.tokenKind else {

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -187,6 +187,7 @@ let builtInRules: [Rule.Type] = [
     StrictFilePrivateRule.self,
     StrongIBOutletRule.self,
     SuperfluousDisableCommandRule.self,
+    SuperfluousElseRule.self,
     SwitchCaseAlignmentRule.self,
     SwitchCaseOnNewlineRule.self,
     SyntacticSugarRule.self,

--- a/Source/SwiftLintFramework/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SuperfluousElseRule.swift
@@ -1,0 +1,238 @@
+import SwiftSyntax
+
+struct SuperfluousElseRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
+
+    init() {}
+
+    static var description = RuleDescription(
+        identifier: "superfluous_else",
+        name: "Superfluous Else Block",
+        description: "Else-blocks should be avoided when the previous if-blocks all left the current scope",
+        kind: .style,
+        nonTriggeringExamples: [
+            Example("""
+                if i > 0 {
+                    // comment
+                } else if i < 12 {
+                    // comment
+                } else {
+                    return 3
+                }
+            """),
+            Example("""
+                if i > 0 {
+                    let a = 1
+                    if a > 1 {
+                        // comment
+                    } else {
+                        return 1
+                    }
+                    // comment
+                } else {
+                    return 3
+                }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                ↓if i > 0 {
+                    return 1
+                    // comment
+                } else {
+                    return 2
+                }
+            """),
+            Example("""
+                ↓if i > 0 {
+                    return 1
+                } else ↓if i < 12 {
+                    return 2
+                } else if i > 18 {
+                    return 3
+                }
+            """),
+            Example("""
+                ↓if i > 0 {
+                    ↓if i < 12 {
+                        return 5
+                    } else {
+                        ↓if i > 11 {
+                            return 6
+                        } else {
+                            return 7
+                        }
+                    }
+                } else ↓if i < 12 {
+                    return 2
+                } else ↓if i < 24 {
+                    return 8
+                } else {
+                    return 3
+                }
+            """)
+        ],
+        corrections: [
+            Example("""
+                func f() -> Int {
+                    ↓if i > 0 {
+                        return 1
+                        // comment
+                    } else {
+                        return 2
+                    }
+                }
+            """): Example("""
+                func f() -> Int {
+                    if i > 0 {
+                        return 1
+                        // comment
+                    }
+                    return 2
+                }
+            """),
+            Example("""
+                func f() -> Int {
+                    ↓if i > 0 {
+                        return 1
+                        // comment
+                    } else ↓if i < 10 {
+                        return 2
+                    } else {
+                        return 3
+                    }
+                }
+            """): Example("""
+                func f() -> Int {
+                    if i > 0 {
+                        return 1
+                        // comment
+                    }
+                    if i < 10 {
+                        return 2
+                    }
+                    return 3
+                }
+            """),
+            Example("""
+                func f() -> Int {
+                    ↓if i > 0 {
+                        return 1
+                        // comment
+                    } else if i < 10 {
+                        return 2
+                    }
+                }
+            """): Example("""
+                func f() -> Int {
+                    if i > 0 {
+                        return 1
+                        // comment
+                    }
+                    if i < 10 {
+                        return 2
+                    }
+                }
+            """)
+            
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(viewMode: .sourceAccurate)
+    }
+
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
+    }
+}
+
+private class Visitor: ViolationsSyntaxVisitor {
+    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+
+    override func visitPost(_ node: IfStmtSyntax) {
+        if node.violatesRule {
+            violations.append(node.ifKeyword.positionAfterSkippingLeadingTrivia)
+        }
+    }
+}
+
+private extension IfStmtSyntax {
+    var violatesRule: Bool {
+        elseKeyword != nil && lastStatementReturns(in: body)
+    }
+
+    private func lastStatementReturns(in block: CodeBlockSyntax) -> Bool {
+        guard let lastItem = block.statements.last?.as(CodeBlockItemSyntax.self)?.item else {
+            return false
+        }
+        if lastItem.is(ReturnStmtSyntax.self) {
+            return true
+        }
+        if let last = lastItem.as(IfStmtSyntax.self) {
+            return lastStatementReturns(in: last.body)
+        }
+        return false
+    }
+}
+
+private class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
+    private(set) var correctionPositions: [AbsolutePosition] = []
+    let locationConverter: SourceLocationConverter
+    let disabledRegions: [SourceRange]
+
+    init(locationConverter: SourceLocationConverter, disabledRegions: [SourceRange]) {
+        self.locationConverter = locationConverter
+        self.disabledRegions = disabledRegions
+    }
+
+    override func visit(_ node: CodeBlockSyntax) -> CodeBlockSyntax {
+        var newStatements = [CodeBlockItemSyntax]()
+        var ifStmtSeen = false
+        for item in node.statements {
+            guard let ifStmt = item.item.as(IfStmtSyntax.self), ifStmt.violatesRule,
+                  !ifStmt.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) else {
+                newStatements.append(item)
+                continue
+            }
+            ifStmtSeen = true
+            correctionPositions.append(ifStmt.ifKeyword.positionAfterSkippingLeadingTrivia)
+            let (newIfStm, removedItems) = modify(ifStmt: ifStmt)
+            newStatements.append(CodeBlockItemSyntax(item: CodeBlockItemSyntax.Item(newIfStm)))
+            newStatements.append(contentsOf: removedItems)
+        }
+        if ifStmtSeen {
+            return visit(node.withStatements(CodeBlockItemListSyntax(newStatements)))
+        }
+        return super.visit(node.withStatements(CodeBlockItemListSyntax(newStatements)))
+    }
+
+    private func modify(ifStmt: IfStmtSyntax) -> (newIfStmt: IfStmtSyntax, removedItems: [CodeBlockItemSyntax]) {
+        let ifStmtWithoutElse = removeElse(from: ifStmt)
+        if case let .codeBlock(block) = ifStmt.elseBody {
+            return (
+                ifStmtWithoutElse,
+                block.statements.map { $0.withLeadingTrivia(ifStmt.leadingTrivia ?? .zero) }
+            )
+        }
+        if case let .ifStmt(nestedIfStmt) = ifStmt.elseBody {
+            let removedItems = [
+                CodeBlockItemSyntax(
+                    item: CodeBlockItemSyntax.Item(nestedIfStmt.withLeadingTrivia(ifStmt.leadingTrivia ?? .zero))
+                )
+            ]
+            return (ifStmtWithoutElse, removedItems)
+        }
+        return (ifStmt, [])
+    }
+
+    private func removeElse(from ifStmt: IfStmtSyntax) -> IfStmtSyntax {
+        ifStmt
+            .withBody(ifStmt.body.withRightBrace(ifStmt.body.rightBrace.withTrailingTrivia(.zero)))
+            .withElseKeyword(nil)
+            .withElseBody(nil)
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SuperfluousElseRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct SuperfluousElseRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct SuperfluousElseRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
     var configuration = SeverityConfiguration(.warning)
 
     init() {}
@@ -71,83 +71,11 @@ struct SuperfluousElseRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRul
                     return 3
                 }
             """)
-        ],
-        corrections: [
-            Example("""
-                func f() -> Int {
-                    ↓if i > 0 {
-                        return 1
-                        // comment
-                    } else {
-                        return 2
-                    }
-                }
-            """): Example("""
-                func f() -> Int {
-                    if i > 0 {
-                        return 1
-                        // comment
-                    }
-                    return 2
-                }
-            """),
-            Example("""
-                func f() -> Int {
-                    ↓if i > 0 {
-                        return 1
-                        // comment
-                    } else ↓if i < 10 {
-                        return 2
-                    } else {
-                        // comment
-                        return 3
-                    }
-                }
-            """): Example("""
-                func f() -> Int {
-                    if i > 0 {
-                        return 1
-                        // comment
-                    }
-                    if i < 10 {
-                        return 2
-                    }
-                    // comment
-                    return 3
-                }
-            """),
-            Example("""
-                func f() -> Int {
-                    ↓if i > 0 {
-                        return 1
-                        // comment
-                    } else if i < 10 {
-                        return 2
-                    }
-                }
-            """): Example("""
-                func f() -> Int {
-                    if i > 0 {
-                        return 1
-                        // comment
-                    }
-                    if i < 10 {
-                        return 2
-                    }
-                }
-            """)
         ]
     )
 
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
-    }
-
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        Rewriter(
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
     }
 }
 
@@ -177,77 +105,5 @@ private extension IfStmtSyntax {
             return lastStatementReturns(in: last.body)
         }
         return false
-    }
-}
-
-private class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
-    private(set) var correctionPositions: [AbsolutePosition] = []
-    let locationConverter: SourceLocationConverter
-    let disabledRegions: [SourceRange]
-
-    init(locationConverter: SourceLocationConverter, disabledRegions: [SourceRange]) {
-        self.locationConverter = locationConverter
-        self.disabledRegions = disabledRegions
-    }
-
-    override func visit(_ node: CodeBlockSyntax) -> CodeBlockSyntax {
-        var newStatements = [CodeBlockItemSyntax]()
-        var ifStmtSeen = false
-        for item in node.statements {
-            guard let ifStmt = item.item.as(IfStmtSyntax.self), ifStmt.violatesRule,
-                  !ifStmt.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) else {
-                newStatements.append(item)
-                continue
-            }
-            ifStmtSeen = true
-            correctionPositions.append(ifStmt.ifKeyword.positionAfterSkippingLeadingTrivia)
-            let (newIfStm, removedItems) = modify(ifStmt: ifStmt)
-            newStatements.append(CodeBlockItemSyntax(item: CodeBlockItemSyntax.Item(newIfStm)))
-            newStatements.append(contentsOf: removedItems)
-        }
-        if ifStmtSeen {
-            return visit(node.withStatements(CodeBlockItemListSyntax(newStatements)))
-        }
-        return super.visit(node.withStatements(CodeBlockItemListSyntax(newStatements)))
-    }
-
-    private func modify(ifStmt: IfStmtSyntax) -> (newIfStmt: IfStmtSyntax, removedItems: [CodeBlockItemSyntax]) {
-        if case let .codeBlock(block) = ifStmt.elseBody {
-            return (
-                removeElse(from: ifStmt, withTrailingTrivia: block.leftBrace.trailingTrivia),
-                block.statements.map { stmt in
-                    let comments = stmt.leadingTrivia.dropFirstNoneComments
-                    return stmt.withLeadingTrivia((ifStmt.leadingTrivia ?? .zero) + comments)
-                }
-            )
-        }
-        if case let .ifStmt(nestedIfStmt) = ifStmt.elseBody {
-            let removedItems = [
-                CodeBlockItemSyntax(
-                    item: CodeBlockItemSyntax.Item(nestedIfStmt.withLeadingTrivia(ifStmt.leadingTrivia ?? .zero))
-                )
-            ]
-            return (
-                removeElse(from: ifStmt, withTrailingTrivia: nestedIfStmt.body.leftBrace.trailingTrivia.dropFirstNoneComments),
-                removedItems
-            )
-        }
-        return (ifStmt, [])
-    }
-
-    private func removeElse(from ifStmt: IfStmtSyntax, withTrailingTrivia trivia: Trivia) -> IfStmtSyntax {
-        ifStmt
-            .withBody(ifStmt.body.withRightBrace(ifStmt.body.rightBrace.withTrailingTrivia(trivia)))
-            .withElseKeyword(nil)
-            .withElseBody(nil)
-    }
-}
-
-private extension Trivia? {
-    var dropFirstNoneComments: Trivia {
-        if let self {
-            return Trivia(pieces: Array(self.drop(while: \.isOtherThanComment)))
-        }
-        return .zero
     }
 }

--- a/Source/SwiftLintFramework/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SuperfluousElseRule.swift
@@ -7,8 +7,8 @@ struct SuperfluousElseRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRul
 
     static var description = RuleDescription(
         identifier: "superfluous_else",
-        name: "Superfluous Else Block",
-        description: "Else-blocks should be avoided when the previous if-blocks all left the current scope",
+        name: "Superfluous Else",
+        description: "Else branches should be avoided when the previous if-block exits the current scope",
         kind: .style,
         nonTriggeringExamples: [
             Example("""

--- a/Source/SwiftLintFramework/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/SuperfluousElseRule.swift
@@ -15,7 +15,7 @@ struct SuperfluousElseRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRul
                 if i > 0 {
                     // comment
                 } else if i < 12 {
-                    // comment
+                    return 2
                 } else {
                     return 3
                 }
@@ -91,7 +91,14 @@ private class Visitor: ViolationsSyntaxVisitor {
 
 private extension IfStmtSyntax {
     var violatesRule: Bool {
-        elseKeyword != nil && lastStatementReturns(in: body)
+        if elseKeyword == nil {
+            return false
+        }
+        let thenBodyReturns = lastStatementReturns(in: body)
+        if thenBodyReturns, let parent = parent?.as(IfStmtSyntax.self) {
+            return parent.violatesRule
+        }
+        return thenBodyReturns
     }
 
     private func lastStatementReturns(in block: CodeBlockSyntax) -> Bool {

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1106,6 +1106,12 @@ class SuperfluousDisableCommandRuleGeneratedTests: XCTestCase {
     }
 }
 
+class SuperfluousElseRuleGeneratedTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(SuperfluousElseRule.description)
+    }
+}
+
 class SwitchCaseAlignmentRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SwitchCaseAlignmentRule.description)


### PR DESCRIPTION
This PR adds a new `superfluous_else` rule that triggers on `if`-statements when an attached `else`-block can be removed, because all branches of the previous `if`-block(s) would certainly exit the current scope already.

While auto-fixes are imaginable, comments make the rewrite functionality quite difficult. Apart from comments, it’s generally not easy to decrease the indentation of a complete code block. All spaces after a newline would have to be adjusted.

Therefore, the rule comes without automatic rewrite for now. This can be added at a later point in time perhaps even as a general algorithm performing indentations on entire code blocks.