### PR TITLE
Update rules_xcodeproj to 0.12.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,8 +45,8 @@ swiftlint_deps()
 
 http_archive(
     name = "com_github_buildbuddy_io_rules_xcodeproj",
-    sha256 = "598449ff3a08972227363a55d22b54707468ecf4370ff56662f9d6026f72c7a7",
-    url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.10.1/release.tar.gz",
+    sha256 = "630e3434b49e80783430ef470c0e9a7f1c8b4e648f789b9fe324fcd37ade8a19",
+    url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.12.0/release.tar.gz",
 )
 
 load("@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl", "xcodeproj_rules_dependencies")


### PR DESCRIPTION
This is the first release to fix running unit tests since 0.10.1.

It should include some performance improvements and bug fixes that will benefit us.

https://github.com/buildbuddy-io/rules_xcodeproj/releases/tag/0.12.0