### PR TITLE
Allow to pass a rule identifier to the `swiftlint docs` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   [Julioacarrettoni](https://github.com/Julioacarrettoni)
   [#4624](https://github.com/realm/SwiftLint/pull/4624)
 
+* Allow to pass a rule identifier to the `swiftlint docs` command to open its
+  specific documentation website, e.g. `swiftlint docs for_where`.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4707](https://github.com/realm/SwiftLint/issues/4707)
+
 * Allow new Quick APIs `aroundEach` and `justBeforeEach` for
   `quick_discouraged_call`.  
   [David Steinacher](https://github.com/stonko1994)

--- a/Source/swiftlint/Commands/Docs.swift
+++ b/Source/swiftlint/Commands/Docs.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import SwiftLintFramework
 
 extension SwiftLint {
     struct Docs: ParsableCommand {
@@ -7,8 +8,20 @@ extension SwiftLint {
             abstract: "Open SwiftLint documentation website in the default web browser"
         )
 
+        @Argument(help: "The identifier of the rule to open the documentation for")
+        var ruleID: String?
+
         func run() throws {
-            open(URL(string: "https://realm.github.io/SwiftLint")!)
+            var subPage = ""
+            if let ruleID {
+                if primaryRuleList.list[ruleID] == nil {
+                    queuedPrintError("There is no rule named '\(ruleID)'. Opening rule directory instead.")
+                    subPage = "rule-directory.html"
+                } else {
+                    subPage = ruleID + ".html"
+                }
+            }
+            open(URL(string: "https://realm.github.io/SwiftLint/\(subPage)")!)
             ExitHelper.successfullyExit()
         }
     }


### PR DESCRIPTION
See #4707.