### PR TITLE
Enable all tests when using rules_xcodeproj

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -122,18 +122,13 @@ xcodeproj(
                     "--progress",
                 ],
             ),
-            test_action = xcode_schemes.test_action(
-                env = {
-                    "RUNNING_RULES_XCODEPROJ_TESTS": "TRUE",
-                },
-                targets = [
-                    "//Tests:CLITests",
-                    "//Tests:ExtraRulesTests",
-                    "//Tests:GeneratedTests",
-                    "//Tests:IntegrationTests",
-                    "//Tests:SwiftLintFrameworkTests",
-                ],
-            ),
+            test_action = xcode_schemes.test_action([
+                "//Tests:CLITests",
+                "//Tests:SwiftLintFrameworkTests",
+                "//Tests:GeneratedTests",
+                "//Tests:IntegrationTests",
+                "//Tests:ExtraRulesTests",
+            ]),
         ),
     ],
     top_level_targets = [

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import SourceKittenFramework
 @_spi(TestHelper)
 import SwiftLintFramework
-import SwiftLintTestHelpers
 import XCTest
 
 private let config: Configuration = {
@@ -15,9 +14,7 @@ private let config: Configuration = {
 }()
 
 class IntegrationTests: XCTestCase {
-    func testSwiftLintLints() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testSwiftLintLints() {
         // This is as close as we're ever going to get to a self-hosting linter.
         let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false)
         XCTAssert(
@@ -36,9 +33,7 @@ class IntegrationTests: XCTestCase {
         }
     }
 
-    func testSwiftLintAutoCorrects() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testSwiftLintAutoCorrects() {
         let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false)
         let storage = RuleStorage()
         let corrections = swiftFiles.parallelFlatMap {

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -5,11 +5,12 @@ import SwiftLintFramework
 import XCTest
 
 private let config: Configuration = {
-    let directory = #file.bridge()
+    let bazelWorkspaceDirectory = ProcessInfo.processInfo.environment["BUILD_WORKSPACE_DIRECTORY"]
+    let rootProjectDirectory = bazelWorkspaceDirectory ?? #file.bridge()
         .deletingLastPathComponent.bridge()
         .deletingLastPathComponent.bridge()
         .deletingLastPathComponent
-    _ = FileManager.default.changeCurrentDirectoryPath(directory)
+    _ = FileManager.default.changeCurrentDirectoryPath(rootProjectDirectory)
     return Configuration(configurationFiles: [Configuration.defaultFileName])
 }()
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -12,9 +12,7 @@ private extension Configuration {
 
 extension ConfigurationTests {
     // MARK: - Rules Merging
-    func testMerge() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMerge() {
         let config0Merge2 = Mock.Config._0.merged(withChild: Mock.Config._2, rootDirectory: "")
 
         XCTAssertFalse(Mock.Config._0.contains(rule: ForceCastRule.self))
@@ -74,9 +72,7 @@ extension ConfigurationTests {
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceTryRule.self))
     }
 
-    func testCustomRulesMerging() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesMerging() {
         let mergedConfiguration = Mock.Config._0CustomRules.merged(
             withChild: Mock.Config._2CustomRules,
             rootDirectory: ""
@@ -94,9 +90,7 @@ extension ConfigurationTests {
         )
     }
 
-    func testMergingAllowsDisablingParentsCustomRules() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMergingAllowsDisablingParentsCustomRules() {
         let mergedConfiguration = Mock.Config._0CustomRules.merged(
             withChild: Mock.Config._2CustomRulesDisabled,
             rootDirectory: ""
@@ -114,9 +108,7 @@ extension ConfigurationTests {
         )
     }
 
-    func testCustomRulesMergingWithOnlyRulesCase1() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesMergingWithOnlyRulesCase1() {
         // The base configuration is in only rules mode
         // The child configuration is in the default rules mode
         // => all custom rules should be considered
@@ -137,9 +129,7 @@ extension ConfigurationTests {
         )
     }
 
-    func testCustomRulesMergingWithOnlyRulesCase2() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesMergingWithOnlyRulesCase2() {
         // The base configuration is in only rules mode
         // The child configuration is in the only rules mode
         // => only the custom rules from the child configuration should be considered
@@ -161,9 +151,7 @@ extension ConfigurationTests {
         )
     }
 
-    func testCustomRulesReconfiguration() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesReconfiguration() {
         // Custom Rule severity gets reconfigured to "error"
         let mergedConfiguration = Mock.Config._0CustomRulesOnly.merged(
             withChild: Mock.Config._2CustomRulesReconfig,
@@ -187,23 +175,17 @@ extension ConfigurationTests {
     }
 
     // MARK: - Nested Configurations
-    func testLevel0() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testLevel0() {
         XCTAssertEqual(Mock.Config._0.configuration(for: SwiftLintFile(path: Mock.Swift._0)!),
                        Mock.Config._0)
     }
 
-    func testLevel1() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testLevel1() {
         XCTAssertEqual(Mock.Config._0.configuration(for: SwiftLintFile(path: Mock.Swift._1)!),
                        Mock.Config._0)
     }
 
-    func testLevel2() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testLevel2() {
         let config = Mock.Config._0.configuration(for: SwiftLintFile(path: Mock.Swift._2)!)
         var config2 = Mock.Config._2
         config2.fileGraph = Configuration.FileGraph(rootDirectory: Mock.Dir.level2)
@@ -214,9 +196,7 @@ extension ConfigurationTests {
         )
     }
 
-    func testLevel3() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testLevel3() {
         let config = Mock.Config._0.configuration(for: SwiftLintFile(path: Mock.Swift._3)!)
         var config3 = Mock.Config._3
         config3.fileGraph = Configuration.FileGraph(rootDirectory: Mock.Dir.level3)
@@ -227,9 +207,7 @@ extension ConfigurationTests {
         )
     }
 
-    func testNestedConfigurationForOnePathPassedIn() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testNestedConfigurationForOnePathPassedIn() {
         // If a path to one or more configuration files is specified, nested configurations should be ignored
         let config = Configuration(configurationFiles: [Mock.Yml._0])
         XCTAssertEqual(
@@ -238,9 +216,7 @@ extension ConfigurationTests {
         )
     }
 
-    func testParentConfigIsIgnoredAsNestedConfiguration() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testParentConfigIsIgnoredAsNestedConfiguration() {
         // If a configuration has already been used to build the main config,
         // it should not again be regarded as a nested config
         XCTAssertEqual(
@@ -265,9 +241,7 @@ extension ConfigurationTests {
         }
     }
 
-    func testValidParentConfig() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testValidParentConfig() {
         for path in [Mock.Dir.parentConfigTest1, Mock.Dir.parentConfigTest2] {
             FileManager.default.changeCurrentDirectoryPath(path)
 
@@ -328,9 +302,7 @@ extension ConfigurationTests {
     }
 
     // MARK: - Remote Configs
-    func testValidRemoteChildConfig() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testValidRemoteChildConfig() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.remoteConfigChild)
 
         assertEqualExceptForFileGraph(
@@ -349,9 +321,7 @@ extension ConfigurationTests {
         )
     }
 
-    func testValidRemoteParentConfig() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testValidRemoteParentConfig() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.remoteConfigParent)
 
         assertEqualExceptForFileGraph(

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import SourceKittenFramework
 @_spi(TestHelper)
 @testable import SwiftLintFramework
-import SwiftLintTestHelpers
 import XCTest
 
 // swiftlint:disable file_length
@@ -55,9 +54,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertFalse(config.allowZeroLintableFiles)
     }
 
-    func testInitWithRelativePathAndRootPath() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testInitWithRelativePathAndRootPath() {
         let expectedConfig = Mock.Config._0
 
         let config = Configuration(configurationFiles: [".swiftlint.yml"])
@@ -218,9 +215,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(actualExcludedPath, desiredExcludedPath)
     }
 
-    func testIncludedExcludedRelativeLocationLevel0() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testIncludedExcludedRelativeLocationLevel0() {
         // Same as testIncludedPathRelatedToConfigurationFileLocationLevel1(),
         // but run from the directory the config file resides in
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
@@ -291,9 +286,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
     }
 
-    func testLintablePaths() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testLintablePaths() {
         let paths = Configuration.default.lintablePaths(inPath: Mock.Dir.level0, forceExclude: false)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         let expectedFilenames = [
@@ -305,9 +298,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(Set(expectedFilenames), Set(filenames))
     }
 
-    func testGlobIncludePaths() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testGlobIncludePaths() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(includedPaths: ["**/Level2"])
         let paths = configuration.lintablePaths(inPath: Mock.Dir.level0, forceExclude: true)
@@ -332,34 +323,26 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(Mock.Config._0, Mock.Config._0)
     }
 
-    func testIsNotEqualTo() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testIsNotEqualTo() {
         XCTAssertNotEqual(Mock.Config._0, Mock.Config._2)
     }
 
     // MARK: - Testing Custom Configuration File
 
-    func testCustomConfiguration() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomConfiguration() {
         let file = SwiftLintFile(path: Mock.Swift._0)!
         XCTAssertNotEqual(Mock.Config._0.configuration(for: file),
                           Mock.Config._0Custom.configuration(for: file))
     }
 
-    func testConfigurationWithSwiftFileAsRoot() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testConfigurationWithSwiftFileAsRoot() {
         let configuration = Configuration(configurationFiles: [Mock.Yml._0])
 
         let file = SwiftLintFile(path: Mock.Swift._0)!
         XCTAssertEqual(configuration.configuration(for: file), configuration)
     }
 
-    func testConfigurationWithSwiftFileAsRootAndCustomConfiguration() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testConfigurationWithSwiftFileAsRootAndCustomConfiguration() {
         let configuration = Mock.Config._0Custom
 
         let file = SwiftLintFile(path: Mock.Swift._0)!
@@ -412,9 +395,7 @@ class ConfigurationTests: XCTestCase {
 
 // MARK: - ExcludeByPrefix option tests
 extension ConfigurationTests {
-    func testExcludeByPrefixExcludedPaths() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testExcludeByPrefixExcludedPaths() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(includedPaths: ["Level1"],
                                           excludedPaths: ["Level1/Level1.swift",
@@ -435,9 +416,7 @@ extension ConfigurationTests {
         XCTAssertEqual([], paths)
     }
 
-    func testExcludeByPrefixForceExcludesFileNotPresentInExcluded() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testExcludeByPrefixForceExcludesFileNotPresentInExcluded() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(includedPaths: ["Level1"],
                                           excludedPaths: ["Level1/Level1.swift"])
@@ -448,9 +427,7 @@ extension ConfigurationTests {
         XCTAssertEqual(["Level2.swift", "Level3.swift"], filenames)
     }
 
-    func testExcludeByPrefixForceExcludesDirectory() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testExcludeByPrefixForceExcludesDirectory() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(
             excludedPaths: [
@@ -464,9 +441,7 @@ extension ConfigurationTests {
         XCTAssertEqual(["Level0.swift", "Level1.swift"], filenames)
     }
 
-    func testExcludeByPrefixForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testExcludeByPrefixForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(
             excludedPaths: [
@@ -480,9 +455,7 @@ extension ConfigurationTests {
         XCTAssertEqual(["Level0.swift"], filenames)
     }
 
-    func testExcludeByPrefixGlobExcludePaths() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testExcludeByPrefixGlobExcludePaths() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(
             includedPaths: ["Level1"],
@@ -525,9 +498,7 @@ extension ConfigurationTests {
     //
     // This issue may not be reproducible under normal execution: the cache is in memory, so when a user changes
     // the cachePath from command line and re-runs swiftlint, cache is not reused leading to the correct behavior
-    func testMainInitWithCachePathAndCachedConfig() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMainInitWithCachePathAndCachedConfig() {
         let configuration1 = Configuration(
             configurationFiles: [],
             cachePath: "cache/path/1"

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -1,6 +1,5 @@
 import SourceKittenFramework
 @testable import SwiftLintFramework
-import SwiftLintTestHelpers
 import XCTest
 
 class CustomRulesTests: XCTestCase {
@@ -127,18 +126,14 @@ class CustomRulesTests: XCTestCase {
                                        reason: configs.0.message)])
     }
 
-    func testCustomRulesIncludedDefault() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesIncludedDefault() {
         // Violation detected when included is omitted.
         let (_, customRules) = getCustomRules()
         let violations = customRules.validate(file: getTestTextFile())
         XCTAssertEqual(violations.count, 1)
     }
 
-    func testCustomRulesIncludedExcludesFile() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesIncludedExcludesFile() {
         var (regexConfig, customRules) = getCustomRules(["included": "\\.yml$"])
 
         var customRuleConfiguration = CustomRulesConfiguration()
@@ -149,9 +144,7 @@ class CustomRulesTests: XCTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
-    func testCustomRulesExcludedExcludesFile() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesExcludedExcludesFile() {
         var (regexConfig, customRules) = getCustomRules(["excluded": "\\.txt$"])
 
         var customRuleConfiguration = CustomRulesConfiguration()
@@ -162,9 +155,7 @@ class CustomRulesTests: XCTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
-    func testCustomRulesExcludedArrayExcludesFile() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesExcludedArrayExcludesFile() {
         var (regexConfig, customRules) = getCustomRules(["excluded": ["\\.pdf$", "\\.txt$"]])
 
         var customRuleConfiguration = CustomRulesConfiguration()
@@ -175,9 +166,7 @@ class CustomRulesTests: XCTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
-    func testCustomRulesCaptureGroup() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomRulesCaptureGroup() {
         let (_, customRules) = getCustomRules(["regex": #"\ba\s+(\w+)"#,
                                                "capture_group": 1])
         let violations = customRules.validate(file: getTestTextFile())

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -1,4 +1,3 @@
-import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -2,9 +2,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-private let fixturesDirectory = #file.bridge()
-    .deletingLastPathComponent.bridge()
-    .appendingPathComponent("Resources/FileHeaderRuleFixtures")
+private let fixturesDirectory = "\(TestResources.path)/FileHeaderRuleFixtures"
 
 class FileHeaderRuleTests: XCTestCase {
     private func validate(fileName: String, using configuration: Any) throws -> [StyleViolation] {

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -1,6 +1,5 @@
 import SourceKittenFramework
 @testable import SwiftLintFramework
-import SwiftLintTestHelpers
 import XCTest
 
 private let fixturesDirectory = #file.bridge()
@@ -132,9 +131,7 @@ class FileHeaderRuleTests: XCTestCase {
                    skipCommentTests: true, testMultiByteOffsets: false)
     }
 
-    func testFileHeaderWithRequiredStringUsingFilenamePlaceholder() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testFileHeaderWithRequiredStringUsingFilenamePlaceholder() {
         let configuration = ["required_string": "// SWIFTLINT_CURRENT_FILENAME"]
 
         // Non triggering tests
@@ -146,9 +143,7 @@ class FileHeaderRuleTests: XCTestCase {
         XCTAssertEqual(try validate(fileName: "FileNameMissing.swift", using: configuration).count, 1)
     }
 
-    func testFileHeaderWithForbiddenStringUsingFilenamePlaceholder() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testFileHeaderWithForbiddenStringUsingFilenamePlaceholder() {
         let configuration = ["forbidden_string": "// SWIFTLINT_CURRENT_FILENAME"]
 
         // Non triggering tests
@@ -160,9 +155,7 @@ class FileHeaderRuleTests: XCTestCase {
         XCTAssertEqual(try validate(fileName: "FileNameMatchingSimple.swift", using: configuration).count, 1)
     }
 
-    func testFileHeaderWithRequiredPatternUsingFilenamePlaceholder() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testFileHeaderWithRequiredPatternUsingFilenamePlaceholder() {
         let configuration1 = ["required_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
         let configuration2 = ["required_pattern":
             "// Copyright © \\d{4}\n// File: \"SWIFTLINT_CURRENT_FILENAME\""]
@@ -177,9 +170,7 @@ class FileHeaderRuleTests: XCTestCase {
         XCTAssertEqual(try validate(fileName: "FileNameMissing.swift", using: configuration1).count, 1)
     }
 
-    func testFileHeaderWithForbiddenPatternUsingFilenamePlaceholder() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testFileHeaderWithForbiddenPatternUsingFilenamePlaceholder() {
         let configuration1 = ["forbidden_pattern": "// SWIFTLINT_CURRENT_FILENAME\n.*\\d{4}"]
         let configuration2 = ["forbidden_pattern": "//.*(\\s|\")SWIFTLINT_CURRENT_FILENAME(\\s|\").*"]
 

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -1,4 +1,3 @@
-import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -2,9 +2,7 @@ import SourceKittenFramework
 @testable import SwiftLintFramework
 import XCTest
 
-private let fixturesDirectory = #file.bridge()
-    .deletingLastPathComponent.bridge()
-    .appendingPathComponent("Resources/FileNameRuleFixtures")
+private let fixturesDirectory = "\(TestResources.path)/FileNameRuleFixtures"
 
 class FileNameRuleTests: XCTestCase {
     private func validate(fileName: String, excludedOverride: [String]? = nil,

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -29,92 +29,64 @@ class FileNameRuleTests: XCTestCase {
         return rule.validate(file: file)
     }
 
-    func testMainDoesntTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMainDoesntTrigger() {
         XCTAssert(try validate(fileName: "main.swift").isEmpty)
     }
 
-    func testLinuxMainDoesntTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testLinuxMainDoesntTrigger() {
         XCTAssert(try validate(fileName: "LinuxMain.swift").isEmpty)
     }
 
-    func testClassNameDoesntTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testClassNameDoesntTrigger() {
         XCTAssert(try validate(fileName: "MyClass.swift").isEmpty)
     }
 
-    func testStructNameDoesntTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testStructNameDoesntTrigger() {
         XCTAssert(try validate(fileName: "MyStruct.swift").isEmpty)
     }
 
-    func testExtensionNameDoesntTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testExtensionNameDoesntTrigger() {
         XCTAssert(try validate(fileName: "NSString+Extension.swift").isEmpty)
     }
 
-    func testNestedExtensionDoesntTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testNestedExtensionDoesntTrigger() {
         XCTAssert(try validate(fileName: "Notification.Name+Extension.swift").isEmpty)
     }
 
-    func testNestedTypeSeparatorDoesntTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testNestedTypeSeparatorDoesntTrigger() {
         XCTAssert(try validate(fileName: "NotificationName+Extension.swift", nestedTypeSeparator: "").isEmpty)
         XCTAssert(try validate(fileName: "Notification__Name+Extension.swift", nestedTypeSeparator: "__").isEmpty)
     }
 
-    func testWrongNestedTypeSeparatorDoesTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testWrongNestedTypeSeparatorDoesTrigger() {
         XCTAssert(try !validate(fileName: "Notification__Name+Extension.swift", nestedTypeSeparator: ".").isEmpty)
         XCTAssert(try !validate(fileName: "NotificationName+Extension.swift", nestedTypeSeparator: "__").isEmpty)
     }
 
-    func testMisspelledNameDoesTrigger() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMisspelledNameDoesTrigger() {
         XCTAssertEqual(try validate(fileName: "MyStructf.swift").count, 1)
     }
 
-    func testMisspelledNameDoesntTriggerWithOverride() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMisspelledNameDoesntTriggerWithOverride() {
         XCTAssert(try validate(fileName: "MyStructf.swift", excludedOverride: ["MyStructf.swift"]).isEmpty)
     }
 
-    func testMainDoesTriggerWithoutOverride() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMainDoesTriggerWithoutOverride() {
         XCTAssertEqual(try validate(fileName: "main.swift", excludedOverride: []).count, 1)
     }
 
-    func testCustomSuffixPattern() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomSuffixPattern() {
         XCTAssert(try validate(fileName: "BoolExtension.swift", suffixPattern: "Extensions?").isEmpty)
         XCTAssert(try validate(fileName: "BoolExtensions.swift", suffixPattern: "Extensions?").isEmpty)
         XCTAssert(try validate(fileName: "BoolExtensionTests.swift", suffixPattern: "Extensions?|\\+.*").isEmpty)
     }
 
-    func testCustomPrefixPattern() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomPrefixPattern() {
         XCTAssert(try validate(fileName: "ExtensionBool.swift", prefixPattern: "Extensions?").isEmpty)
         XCTAssert(try validate(fileName: "ExtensionsBool.swift", prefixPattern: "Extensions?").isEmpty)
     }
 
-    func testCustomPrefixAndSuffixPatterns() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCustomPrefixAndSuffixPatterns() {
         XCTAssert(
             try validate(
                 fileName: "SLBoolExtension.swift",

--- a/Tests/SwiftLintFrameworkTests/GlobTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GlobTests.swift
@@ -1,5 +1,4 @@
 @testable import SwiftLintFramework
-import SwiftLintTestHelpers
 import XCTest
 
 final class GlobTests: XCTestCase {
@@ -7,65 +6,47 @@ final class GlobTests: XCTestCase {
         return testResourcesPath.stringByAppendingPathComponent("ProjectMock")
     }
 
-    func testOnlyGlobForWildcard() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testOnlyGlobForWildcard() {
         let files = Glob.resolveGlob("foo/bar.swift")
         XCTAssertEqual(files, ["foo/bar.swift"])
     }
 
-    func testNoMatchReturnsEmpty() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testNoMatchReturnsEmpty() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("NoFile*.swift"))
         XCTAssertTrue(files.isEmpty)
     }
 
-    func testMatchesFiles() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMatchesFiles() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level*.swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
-    func testMatchesSingleCharacter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMatchesSingleCharacter() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level?.swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
-    func testMatchesOneCharacterInBracket() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMatchesOneCharacterInBracket() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[01].swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
-    func testNoMatchOneCharacterInBracket() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testNoMatchOneCharacterInBracket() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[ab].swift"))
          XCTAssertTrue(files.isEmpty)
     }
 
-    func testMatchesCharacterInRange() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMatchesCharacterInRange() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[0-9].swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level0.swift")])
     }
 
-    func testNoMatchCharactersInRange() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testNoMatchCharactersInRange() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level[a-z].swift"))
         XCTAssertTrue(files.isEmpty)
     }
 
-    func testMatchesMultipleFiles() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMatchesMultipleFiles() {
         let expectedFiles: Set = [
             mockPath.stringByAppendingPathComponent("Level0.swift"),
             mockPath.stringByAppendingPathComponent("Directory.swift")
@@ -75,16 +56,12 @@ final class GlobTests: XCTestCase {
         XCTAssertEqual(files.sorted(), expectedFiles.sorted())
     }
 
-    func testMatchesNestedDirectory() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMatchesNestedDirectory() {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("Level1/*.swift"))
         XCTAssertEqual(files, [mockPath.stringByAppendingPathComponent("Level1/Level1.swift")])
     }
 
-    func testGlobstarSupport() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testGlobstarSupport() {
         let expectedFiles = Set(
             [
                 "Directory.swift",

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintFramework
-import SwiftLintTestHelpers
 import XCTest
 
 class ReporterTests: XCTestCase {
@@ -51,33 +50,25 @@ class ReporterTests: XCTestCase {
         ]
     }
 
-    func testXcodeReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testXcodeReporter() {
         let expectedOutput = stringFromFile("CannedXcodeReporterOutput.txt")
         let result = XcodeReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testEmojiReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testEmojiReporter() {
         let expectedOutput = stringFromFile("CannedEmojiReporterOutput.txt")
         let result = EmojiReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testGitHubActionsLoggingReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testGitHubActionsLoggingReporter() {
         let expectedOutput = stringFromFile("CannedGitHubActionsLoggingReporterOutput.txt")
         let result = GitHubActionsLoggingReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testGitLabJUnitReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testGitLabJUnitReporter() {
         let expectedOutput = stringFromFile("CannedGitLabJUnitReporterOutput.xml")
         let result = GitLabJUnitReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
@@ -95,48 +86,36 @@ class ReporterTests: XCTestCase {
     }
 
     func testJSONReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
         let expectedOutput = stringFromFile("CannedJSONReporterOutput.json")
         let result = JSONReporter.generateReport(generateViolations())
         XCTAssertEqual(try jsonValue(result), try jsonValue(expectedOutput))
     }
 
-    func testCSVReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCSVReporter() {
         let expectedOutput = stringFromFile("CannedCSVReporterOutput.csv")
         let result = CSVReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testCheckstyleReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCheckstyleReporter() {
         let expectedOutput = stringFromFile("CannedCheckstyleReporterOutput.xml")
         let result = CheckstyleReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testCodeClimateReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testCodeClimateReporter() {
         let expectedOutput = stringFromFile("CannedCodeClimateReporterOutput.json")
         let result = CodeClimateReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testJunitReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testJunitReporter() {
         let expectedOutput = stringFromFile("CannedJunitReporterOutput.xml")
         let result = JUnitReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testHTMLReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testHTMLReporter() {
         let expectedOutput = stringFromFile("CannedHTMLReporterOutput.html")
         let result = HTMLReporter.generateReport(
             generateViolations(),
@@ -146,17 +125,13 @@ class ReporterTests: XCTestCase {
         XCTAssertEqual(result, expectedOutput)
     }
 
-    func testSonarQubeReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testSonarQubeReporter() {
         let expectedOutput = stringFromFile("CannedSonarQubeReporterOutput.json")
         let result = SonarQubeReporter.generateReport(generateViolations())
         XCTAssertEqual(try jsonValue(result), try jsonValue(expectedOutput))
     }
 
-    func testMarkdownReporter() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testMarkdownReporter() {
         let expectedOutput = stringFromFile("CannedMarkdownReporterOutput.md")
         let result = MarkdownReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -47,8 +47,8 @@ class SourceKitCrashTests: XCTestCase {
                       "Expects assert handler was not called on accessing SwiftLintFile.syntaxTokensByLines")
     }
 
-    func testRulesWithFileThatCrashedSourceKitService() {
-        let file = SwiftLintFile(path: #file)!
+    func testRulesWithFileThatCrashedSourceKitService() throws {
+        let file = try XCTUnwrap(SwiftLintFile(path: "\(TestResources.path)/ProjectMock/Level0.swift"))
         file.sourcekitdFailed = true
         file.assertHandler = {
             XCTFail("If this called, rule's SourceKitFreeRule is not properly configured")

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -1,6 +1,5 @@
 @_spi(TestHelper)
 @testable import SwiftLintFramework
-import SwiftLintTestHelpers
 import XCTest
 
 class SourceKitCrashTests: XCTestCase {
@@ -48,9 +47,7 @@ class SourceKitCrashTests: XCTestCase {
                       "Expects assert handler was not called on accessing SwiftLintFile.syntaxTokensByLines")
     }
 
-    func testRulesWithFileThatCrashedSourceKitService() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
+    func testRulesWithFileThatCrashedSourceKitService() {
         let file = SwiftLintFile(path: #file)!
         file.sourcekitdFailed = true
         file.assertHandler = {

--- a/Tests/SwiftLintFrameworkTests/XCTestCase+BundlePath.swift
+++ b/Tests/SwiftLintFrameworkTests/XCTestCase+BundlePath.swift
@@ -3,7 +3,11 @@ import XCTest
 
 enum TestResources {
     static var path: String {
-        URL(fileURLWithPath: #file, isDirectory: false)
+        if let rootProjectDirectory = ProcessInfo.processInfo.environment["BUILD_WORKSPACE_DIRECTORY"] {
+            return "\(rootProjectDirectory)/Tests/SwiftLintFrameworkTests/Resources"
+        }
+
+        return URL(fileURLWithPath: #file, isDirectory: false)
             .deletingLastPathComponent()
             .appendingPathComponent("Resources")
             .path

--- a/Tests/SwiftLintFrameworkTests/YamlSwiftLintTests.swift
+++ b/Tests/SwiftLintFrameworkTests/YamlSwiftLintTests.swift
@@ -1,12 +1,9 @@
 import Foundation
-import SwiftLintTestHelpers
 import XCTest
 import Yams
 
 class YamlSwiftLintTests: XCTestCase {
     func testFlattenYaml() throws {
-        try XCTSkipIf(shouldSkipRulesXcodeprojRunFiles)
-
         do {
             guard let yamlDict = try Yams.load(yaml: try getTestYaml()) as? [String: Any] else {
                 XCTFail("Failed to load YAML from file")

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -319,11 +319,6 @@ private func addShebang(_ example: Example) -> Example {
 public extension XCTestCase {
     var isRunningWithBazel: Bool { FileManager.default.currentDirectoryPath.contains("bazel-out") }
 
-    // Enable all tests when runfiles support is added - https://github.com/buildbuddy-io/rules_xcodeproj/issues/828
-    var shouldSkipRulesXcodeprojRunFiles: Bool {
-        ProcessInfo.processInfo.environment["RUNNING_RULES_XCODEPROJ_TESTS"] != nil
-    }
-
     func verifyRule(_ ruleDescription: RuleDescription,
                     ruleConfiguration: Any? = nil,
                     commentDoesntViolate: Bool = true,


### PR DESCRIPTION
This reverts #4694: Skip tests requiring runfiles support when testing with rules_xcodeproj

Turns out we don't need runfiles support (https://github.com/buildbuddy-io/rules_xcodeproj/issues/828) since the tests run outside the sandbox in Xcode, so we can get the path to these files from the `BUILD_WORKSPACE_DIRECTORY` environment variable that `bazel test` sets.