### PR TITLE
Updated JUnit reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4121](https://github.com/realm/SwiftLint/issues/4121)
 
+* Updated JUnit reporter to output error count and warning count.
+  [patricks](https://github.com/patricks)
+  [#4725](https://github.com/realm/SwiftLint/pull/4725)
+
 ## 0.50.3: Bundle of Towels
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4121](https://github.com/realm/SwiftLint/issues/4121)
 
-* Updated JUnit reporter to output error count and warning count.
+* Updated JUnit reporter to output error count and warning count.  
   [patricks](https://github.com/patricks)
   [#4725](https://github.com/realm/SwiftLint/pull/4725)
 

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -10,17 +10,30 @@ public struct JUnitReporter: Reporter {
     }
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
-        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +
-            violations.map({ violation -> String in
-                let fileName = (violation.location.file ?? "<nopath>").escapedForXML()
-                let severity = violation.severity.rawValue + ":\n"
-                let message = severity + "Line:" + String(violation.location.line ?? 0) + " "
-                let reason = violation.reason.escapedForXML()
-                return [
-                    "\n\t<testcase classname='Formatting Test' name='\(fileName)\'>\n",
-                    "<failure message='\(reason)\'>" + message + "</failure>",
-                    "\t</testcase>"
-                ].joined()
-            }).joined() + "\n</testsuite></testsuites>"
+        let warningCount = violations.filter({ $0.severity == .warning }).count
+        let errorCount = violations.filter({ $0.severity == .error }).count
+
+        return [
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
+            "<testsuites failures=\"\(warningCount)\" errors=\"\(errorCount)\">\n",
+            "\t<testsuite failures=\"\(warningCount)\" errors=\"\(errorCount)\">",
+            violations.map({ testCase(for: $0) }).joined(),
+            "\n\t</testsuite>\n",
+            "</testsuites>"
+        ].joined()
+    }
+
+    private static func testCase(for violation: StyleViolation) -> String {
+        let fileName = (violation.location.file ?? "<nopath>").escapedForXML()
+        let reason = violation.reason.escapedForXML()
+        let severity = violation.severity.rawValue.capitalized
+        let lineNumber = String(violation.location.line ?? 0)
+        let message = severity + ":" + "Line:" + lineNumber
+
+        return [
+            "\n\t\t<testcase classname='Formatting Test' name='\(fileName)\'>",
+            "\n\t\t\t<failure message='\(reason)\'>" + message + "</failure>",
+            "\n\t\t</testcase>"
+        ].joined()
     }
 }

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedJunitReporterOutput.xml
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedJunitReporterOutput.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<testsuites><testsuite>
-	<testcase classname='Formatting Test' name='filename'>
-<failure message='Violation Reason'>warning:
-Line:1 </failure>	</testcase>
-	<testcase classname='Formatting Test' name='filename'>
-<failure message='Violation Reason'>error:
-Line:1 </failure>	</testcase>
-	<testcase classname='Formatting Test' name='filename'>
-<failure message='Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;'>error:
-Line:1 </failure>	</testcase>
-	<testcase classname='Formatting Test' name='&lt;nopath&gt;'>
-<failure message='Colons should be next to the identifier when specifying a type and next to the key in dictionary literals'>error:
-Line:0 </failure>	</testcase>
-</testsuite></testsuites>
+<testsuites failures="1" errors="3">
+	<testsuite failures="1" errors="3">
+		<testcase classname='Formatting Test' name='filename'>
+			<failure message='Violation Reason'>Warning:Line:1</failure>
+		</testcase>
+		<testcase classname='Formatting Test' name='filename'>
+			<failure message='Violation Reason'>Error:Line:1</failure>
+		</testcase>
+		<testcase classname='Formatting Test' name='filename'>
+			<failure message='Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;'>Error:Line:1</failure>
+		</testcase>
+		<testcase classname='Formatting Test' name='&lt;nopath&gt;'>
+			<failure message='Colons should be next to the identifier when specifying a type and next to the key in dictionary literals'>Error:Line:0</failure>
+		</testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
Some JUnit XML parsers require, that the warnings and errors count is set per test suite. Bitbucket Pipelines require this otherwise the errors / warnings are not recognized. I updated to code that these values are also provided. Another important value would be the total tests count (successful count + warnings count + errors count). But I couldn't figure out an easy way to get this value. I also update the format of the output.

Previous generated file output format:
```
<?xml version="1.0" encoding="utf-8"?>
<testsuites><testsuite>
	<testcase classname='Formatting Test' name='File.swift'>
<failure message='Lines should not have trailing whitespace.'>warning:
Line:15 </failure>	</testcase>
</testsuite></testsuites>
```

New file output format:
```
<?xml version="1.0" encoding="utf-8"?>
<testsuites failures="1" errors="0">
	<testsuite failures="1" errors="0">
		<testcase classname='Formatting Test' name='File.swift'>
			<failure message='Lines should not have trailing whitespace'>Warning:Line:15</failure>
		</testcase>
	</testsuite>
</testsuites>
```

