### PR TITLE
Extract `EnumDeclSyntax.supportsRawValues` helper

### DIFF
--- a/Source/SwiftLintFramework/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/SwiftSyntax+SwiftLint.swift
@@ -177,6 +177,30 @@ extension VariableDeclSyntax {
     }
 }
 
+public extension EnumDeclSyntax {
+    /// True if this enum supports raw values
+    var supportsRawValues: Bool {
+        guard let inheritedTypeCollection = inheritanceClause?.inheritedTypeCollection else {
+            return false
+        }
+
+        let rawValueTypes: Set<String> = [
+            "Int", "Int8", "Int16", "Int32", "Int64",
+            "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+            "Double", "Float", "Float80", "Decimal", "NSNumber",
+            "NSDecimalNumber", "NSInteger", "String", "CGFloat"
+        ]
+
+        return inheritedTypeCollection.contains { element in
+            guard let identifier = element.typeName.as(SimpleTypeIdentifierSyntax.self)?.name.text else {
+                return false
+            }
+
+            return rawValueTypes.contains(identifier)
+        }
+    }
+}
+
 extension FunctionDeclSyntax {
     var isIBAction: Bool {
         attributes?.contains { attr in

--- a/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -89,42 +89,19 @@ private extension ExplicitEnumRawValueRule {
         override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: EnumCaseElementSyntax) {
-            if node.rawValue == nil,
-               let enclosingEnum = Syntax(node).enclosingEnum(),
-               let inheritance = enclosingEnum.inheritanceClause,
-               inheritance.supportsRawValue {
+            if node.rawValue == nil, node.enclosingEnum()?.supportsRawValues == true {
                 violations.append(node.identifier.positionAfterSkippingLeadingTrivia)
             }
         }
     }
 }
 
-private extension Syntax {
+private extension SyntaxProtocol {
     func enclosingEnum() -> EnumDeclSyntax? {
         if let node = self.as(EnumDeclSyntax.self) {
             return node
         }
 
         return parent?.enclosingEnum()
-    }
-}
-
-private extension TypeInheritanceClauseSyntax {
-    var supportsRawValue: Bool {
-        // Check if it's an enum which supports raw values
-        let implicitRawValueSet: Set<String> = [
-            "Int", "Int8", "Int16", "Int32", "Int64",
-            "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
-            "Double", "Float", "Float80", "Decimal", "NSNumber",
-            "NSDecimalNumber", "NSInteger", "String"
-        ]
-
-        return inheritedTypeCollection.contains { element in
-            guard let identifier = element.typeName.as(SimpleTypeIdentifierSyntax.self)?.name.text else {
-                return false
-            }
-
-            return implicitRawValueSet.contains(identifier)
-        }
     }
 }


### PR DESCRIPTION
I'll want to use this elsewhere shortly.

Also adds `CGFloat` to the raw value types since we were missing that one.