### PR TITLE
[CI] Stop running "Analyze" job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,10 +15,6 @@ steps:
       - bazel build //tools:danger
       - echo "+++ Run Danger"
       - ./bazel-bin/tools/danger --verbose
-  - label: "Analyze"
-    commands:
-      - echo "+++ Analyze"
-      - bazel test -c opt --test_output=streamed --test_timeout=3600 --spawn_strategy=local analyze
   - label: "TSan Tests"
     commands:
       - echo "+++ Test"


### PR DESCRIPTION
it's extremely time-consuming, taking 25 minutes lately, and we'll hopefully have a better solution soon with the upcoming improvements to dead code detection, taking less than 1 second to run.

```
(1/4) Collecting units and records (0.25s)
(2/4) Collecting protocol conformances (0.26s)
(3/4) Collecting declarations and references (0.04s)
(4/4) Calculating unused declarations (0.05s)
Source/SwiftLintFramework/Extensions/Configuration+IndentationStyle.swift:16:18: error: Unused declaration named 'init(_:)'
Source/SwiftLintFramework/Models/LinterCache.swift:53:13: error: Unused declaration named 'init(cache:location:fileManager:swiftVersion:)'
Source/SwiftLintFramework/Models/SwiftVersion.swift:25:16: error: Unused declaration named 'fiveDotTwo'
Source/SwiftLintFramework/Models/SwiftVersion.swift:27:16: error: Unused declaration named 'fiveDotThree'
Source/SwiftLintFramework/Models/SwiftVersion.swift:31:16: error: Unused declaration named 'fiveDotFive'
Source/SwiftLintFramework/Rules/Lint/CompilerProtocolInitRule.swift:85:5: error: Unused declaration named 'init(protocolName:types:arguments:)'
Found 6 unused declarations (0.61s)
```