### PR TITLE
Implement a workaround for Swift Package build plugins consuming input files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
 
 #### Bug Fixes
 
+* Work around an issue where the Swift Package Manger build plugin would 
+  "consume" input files causing Xcode's build system to ignore them in 
+  subsequent build steps such as compilation. 
+  [Tony Arnold](https://github.com/tonyarnold)
+  [#4732](https://github.com/realm/SwiftLint/pull/4732)
+
 * Report violations in all `<scope>_length` rules when the error threshold is
   smaller than the warning threshold.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Plugins/SwiftLintPlugin/Path+Helpers.swift
+++ b/Plugins/SwiftLintPlugin/Path+Helpers.swift
@@ -45,15 +45,16 @@ extension Path {
     }
 
     public func relative(to base: Path) -> Path {
+        // This method is a reimplementation of the same method from `Path`
+        // in https://github.com/apple/swift-tools-support-core
         let result: String
         // Split the two paths into their components.
-        // FIXME: The is needs to be optimized to avoid unncessary copying.
         let pathComps = self.parents.reversed()
         let baseComps = base.parents.reversed()
 
         // It's common for the base to be an ancestor, so try that first.
         if pathComps.starts(with: baseComps) {
-            // Special case, which is a plain path without `..` components.  It
+            // Special case, which is a plain path without `..` components. It
             // might be an empty path (when self and the base are equal).
             let relComps = pathComps.dropFirst(baseComps.count).map(\.lastComponent)
 #if os(Windows)

--- a/Plugins/SwiftLintPlugin/Path+Helpers.swift
+++ b/Plugins/SwiftLintPlugin/Path+Helpers.swift
@@ -13,18 +13,7 @@ extension Path {
     /// - returns: Path to the configuration file, or nil if one cannot be found.
     func firstConfigurationFileInParentDirectories() -> Path? {
         let defaultConfigurationFileName = ".swiftlint.yml"
-        let proposedDirectory = sequence(
-            first: self,
-            next: { path in
-                guard path.stem.count > 1 else {
-                    // Check we're not at the root of this filesystem, as `removingLastComponent()`
-                    // will continually return the root from itself.
-                    return nil
-                }
-
-                return path.removingLastComponent()
-            }
-        ).first { path in
+        let proposedDirectory = parents.first { path in
             let potentialConfigurationFile = path.appending(subpath: defaultConfigurationFileName)
             return potentialConfigurationFile.isAccessible()
         }
@@ -38,5 +27,61 @@ extension Path {
         }
 
         return result == 0
+    }
+
+    private var parents: any Sequence<Path> {
+        sequence(
+            first: self,
+            next: { path in
+                guard path.stem.count > 1 else {
+                    // Check we're not at the root of this filesystem, as `removingLastComponent()`
+                    // will continually return the root from itself.
+                    return nil
+                }
+
+                return path.removingLastComponent()
+            }
+        )
+    }
+
+    public func relative(to base: Path) -> Path {
+        let result: String
+        // Split the two paths into their components.
+        // FIXME: The is needs to be optimized to avoid unncessary copying.
+        let pathComps = self.parents.reversed()
+        let baseComps = base.parents.reversed()
+
+        // It's common for the base to be an ancestor, so try that first.
+        if pathComps.starts(with: baseComps) {
+            // Special case, which is a plain path without `..` components.  It
+            // might be an empty path (when self and the base are equal).
+            let relComps = pathComps.dropFirst(baseComps.count).map(\.lastComponent)
+#if os(Windows)
+            result = Array(relComps).joined(separator: "\\")
+#else
+            result = Array(relComps).joined(separator: "/")
+#endif
+        } else {
+            // General case, in which we might well need `..` components to go
+            // "up" before we can go "down" the directory tree.
+            var newPathComps = ArraySlice(pathComps)
+            var newBaseComps = ArraySlice(baseComps)
+            while newPathComps.prefix(1) == newBaseComps.prefix(1) {
+                // First component matches, so drop it.
+                newPathComps = newPathComps.dropFirst()
+                newBaseComps = newBaseComps.dropFirst()
+            }
+            // Now construct a path consisting of as many `..`s as are in the
+            // `newBaseComps` followed by what remains in `newPathComps`.
+            var relComps = Array(repeating: "..", count: newBaseComps.count)
+            relComps.append(contentsOf: newPathComps.map(\.lastComponent))
+#if os(Windows)
+            result = relComps.joined(separator: "\\")
+#else
+            result = relComps.joined(separator: "/")
+#endif
+        }
+
+        return Path(result)
     }
 }

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -7,7 +7,7 @@ struct SwiftLintPlugin: BuildToolPlugin {
         guard let sourceTarget = target as? SourceModuleTarget else {
             return []
         }
-        return createBuildCommands(
+        return try createBuildCommands(
             inputFiles: sourceTarget.sourceFiles(withSuffix: "swift").map(\.path),
             packageDirectory: context.package.directory,
             workingDirectory: context.pluginWorkDirectory,
@@ -18,7 +18,9 @@ struct SwiftLintPlugin: BuildToolPlugin {
     private func createBuildCommands(inputFiles: [Path],
                                      packageDirectory: Path,
                                      workingDirectory: Path,
-                                     tool: PluginContext.Tool) -> [Command] {
+                                     tool: PluginContext.Tool,
+                                     preventInputFileConsumption: Bool = false
+    ) throws -> [Command] {
         if inputFiles.isEmpty {
             // Don't lint anything if there are no Swift source files in this target
             return []
@@ -37,12 +39,38 @@ struct SwiftLintPlugin: BuildToolPlugin {
         }
         arguments += inputFiles.map(\.string)
 
+        let buildCommandInputFiles: [Path]
+        if preventInputFileConsumption {
+            // This is a workaround for an issue that affects Xcode targets under Xcode 14.x (FB11835329, FB11877146):
+            // If a build tool plugin is applied to an Xcode target and lists `.swift` source files as inputs of
+            // the build commands it generates, then those `.swift` source files aren't seen by Xcode's build
+            // system (as they've been "consumed" by the plugin command).
+            //
+            // The workaround creates a new symbolic link to the project directory within the build plugin's working 
+            // directory, then references every input file via that symbolically linked directory as the input files
+            // for the build command. This prevents Xcode "consuming" the input files, and allows further processing 
+            // such as compilation.
+            let xcodeProjDirSymlink = workingDirectory.appending("ProjectDir")
+            try? FileManager.default.removeItem(atPath: xcodeProjDirSymlink.string)
+            try FileManager.default.createSymbolicLink(
+                atPath: xcodeProjDirSymlink.string,
+                withDestinationPath: packageDirectory.string
+            )
+
+            buildCommandInputFiles = inputFiles.map { inputFile in
+                let relativePath = inputFile.relative(to: packageDirectory)
+                return xcodeProjDirSymlink.appending(subpath: relativePath.string)
+            }
+        } else {
+            buildCommandInputFiles = inputFiles
+        }
+
         return [
             .buildCommand(
                 displayName: "SwiftLint",
                 executable: tool.path,
                 arguments: arguments,
-                inputFiles: inputFiles,
+                inputFiles: buildCommandInputFiles,
                 outputFiles: [workingDirectory]
             )
         ]
@@ -57,11 +85,13 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
         let inputFilePaths = target.inputFiles
             .filter { $0.type == .source && $0.path.extension == "swift" }
             .map(\.path)
-        return createBuildCommands(
+
+        return try createBuildCommands(
             inputFiles: inputFilePaths,
             packageDirectory: context.xcodeProject.directory,
             workingDirectory: context.pluginWorkDirectory,
-            tool: try context.tool(named: "swiftlint")
+            tool: try context.tool(named: "swiftlint"),
+            preventInputFileConsumption: true
         )
     }
 }

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -65,13 +65,16 @@ struct SwiftLintPlugin: BuildToolPlugin {
             buildCommandInputFiles = inputFiles
         }
 
+        let nonExistentOutputDirectory = workingDirectory.appending(UUID().uuidString)
+        try FileManager.default.createDirectory(atPath: nonExistentOutputDirectory.string, withIntermediateDirectories: false)
+
         return [
             .buildCommand(
                 displayName: "SwiftLint",
                 executable: tool.path,
                 arguments: arguments,
                 inputFiles: buildCommandInputFiles,
-                outputFiles: [workingDirectory]
+                outputFiles: [nonExistentOutputDirectory]
             )
         ]
     }


### PR DESCRIPTION
If a build tool plugin is applied to an Xcode target and lists `.swift` source files as inputs of the build commands it generates, then those `.swift` source files aren't seen by Xcode's build system (as they've been "consumed" by the plugin command). 

The workaround creates a new symbolic link to the project directory within the build plugin's working directory, then references every input file via that symbolically linked directory as the input files for the build command. This prevents Xcode "consuming" the input files, and allows further processing such as compilation.

The SwiftLint executable is still passed the unchanged input file paths. 

The workaround is only run for Xcode targets, and is unnecessary for SwiftPM targets.