### PR TITLE
Add missing `assets` dir to published Jazzy docs

### DIFF
--- a/tools/push-docs
+++ b/tools/push-docs
@@ -25,8 +25,9 @@ git rm -rf .
 rm -rf Carthage
 cd ..
 
-# Copy generated docs into publishing dir
+# Copy generated docs & repo's assets into the publishing dir
 cp -a docs/. "${publishing_dir}/."
+cp -R assets "${publishing_dir}/"
 
 # Publish to GitHub Pages
 cd "$publishing_dir" || exit

--- a/tools/push-docs
+++ b/tools/push-docs
@@ -1,24 +1,32 @@
 #!/bin/bash
 
+# Install deploy ssh key, to enable pushing back to gh-pages
 mkdir -p ~/.ssh && mv $DOWNLOADSECUREFILE_SECUREFILEPATH ~/.ssh/id_rsa
 chmod 700 ~/.ssh && chmod 600 ~/.ssh/id_rsa
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
+# Get current commit hash, to include in automated commit message
 source_sha="$(git rev-parse HEAD)"
+
+# Get a second copy of the repo, pointing to the `gh-pages` branch,
+# to use for publishing to GitHub Pages
 user="swiftlintbot@jpsim.com"
 git config --global user.email "$user"
 git config --global user.name "$user"
 git clone git@github.com:realm/SwiftLint.git out
 
+# Remove all contents from publishing dir
 cd out
 git checkout gh-pages
 git rm -rf .
 rm -rf Carthage
 cd ..
 
+# Copy generated docs into publishing dir
 cp -a docs/. out/.
-cd out
 
+# Publish to GitHub Pages
+cd out
 git add -A
 git commit -m "Automated deployment to GitHub Pages: ${source_sha}" --allow-empty
 

--- a/tools/push-docs
+++ b/tools/push-docs
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+set -eEo pipefail
+
+publishing_dir='./out'
+
 # Install deploy ssh key, to enable pushing back to gh-pages
-mkdir -p ~/.ssh && mv $DOWNLOADSECUREFILE_SECUREFILEPATH ~/.ssh/id_rsa
+mkdir -p ~/.ssh && mv "$DOWNLOADSECUREFILE_SECUREFILEPATH" ~/.ssh/id_rsa
 chmod 700 ~/.ssh && chmod 600 ~/.ssh/id_rsa
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
@@ -13,21 +17,19 @@ source_sha="$(git rev-parse HEAD)"
 user="swiftlintbot@jpsim.com"
 git config --global user.email "$user"
 git config --global user.name "$user"
-git clone git@github.com:realm/SwiftLint.git out
+git clone --branch gh-pages git@github.com:realm/SwiftLint.git "$publishing_dir"
 
 # Remove all contents from publishing dir
-cd out
-git checkout gh-pages
+cd "$publishing_dir" || exit
 git rm -rf .
 rm -rf Carthage
 cd ..
 
 # Copy generated docs into publishing dir
-cp -a docs/. out/.
+cp -a docs/. "${publishing_dir}/."
 
 # Publish to GitHub Pages
-cd out
+cd "$publishing_dir" || exit
 git add -A
 git commit -m "Automated deployment to GitHub Pages: ${source_sha}" --allow-empty
-
 git push origin gh-pages


### PR DESCRIPTION
### Content
This aims to fix #3968 which results in missing images on https://realm.github.io/SwiftLint.

Additionally it adds other small improvements to the publishing script, including
- adding comments
- fixing two issues reported by shellcheck ([SC2086](https://www.shellcheck.net/wiki/SC2086), [SC2164](https://www.shellcheck.net/wiki/SC2164))

### Reviewing
For contextual grouping, a commit-by-commit review might be helpful.
The main fix is in the last commit.

### Testing
I tested the script as such locally, but as this change is mostly a CI fix, we'll only see if it actually works when it ran on CI.

:warning: Be careful when running this manually, as this script touches global git config and ssh keys! :warning: