### PR TITLE
Allow shortening output in Terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
   [David Steinacher](https://github.com/stonko1994)
   [#4626](https://github.com/realm/SwiftLint/issues/4626)
   
-* Add `relative-path` reporter to generate reports with relative paths
+* Add `relative-path` reporter to generate reports with relative file paths.  
   [Roya1v](https://github.com/roya1v)
   [#4660](https://github.com/realm/SwiftLint/issues/4660)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   `quick_discouraged_call`.  
   [David Steinacher](https://github.com/stonko1994)
   [#4626](https://github.com/realm/SwiftLint/issues/4626)
+  
+* Add `relative-path` reporter to generate reports with relative paths
+  [Roya1v](https://github.com/roya1v)
+  [#4660](https://github.com/realm/SwiftLint/issues/4660)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -47,6 +47,8 @@ public func reporterFrom(identifier: String) -> Reporter.Type { // swiftlint:dis
         return GitLabJUnitReporter.self
     case CodeClimateReporter.identifier:
         return CodeClimateReporter.self
+    case RelativePathReporter.identifier:
+        return RelativePathReporter.self
     default:
         queuedFatalError("no reporter with identifier '\(identifier)' available.")
     }

--- a/Source/SwiftLintFramework/Reporters/RelativePathReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/RelativePathReporter.swift
@@ -1,4 +1,4 @@
-/// Reports violations in a format similar to the one Xcode uses to display in the IDE but with relative paths.
+/// Reports violations with relative paths.
 public struct RelativePathReporter: Reporter {
     // MARK: - Reporter Conformance
 
@@ -6,7 +6,7 @@ public struct RelativePathReporter: Reporter {
     public static let isRealtime = true
 
     public var description: String {
-        return "Reports violations in a format similar to the one Xcode uses to display in the IDE but with relative paths."
+        return "Reports violations with relative paths."
     }
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {

--- a/Source/SwiftLintFramework/Reporters/RelativePathReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/RelativePathReporter.swift
@@ -1,0 +1,34 @@
+/// Reports violations in a format similar to the one Xcode uses to display in the IDE but with relative paths.
+public struct RelativePathReporter: Reporter {
+    // MARK: - Reporter Conformance
+
+    public static let identifier = "relative-path"
+    public static let isRealtime = true
+
+    public var description: String {
+        return "Reports violations in a format similar to the one Xcode uses to display in the IDE but with relative paths."
+    }
+
+    public static func generateReport(_ violations: [StyleViolation]) -> String {
+        return violations.map(generateForSingleViolation).joined(separator: "\n")
+    }
+
+    /// Generates a report for a single violation.
+    ///
+    /// - parameter violation: The violation to report.
+    ///
+    /// - returns: The report for a single violation.
+    internal static func generateForSingleViolation(_ violation: StyleViolation) -> String {
+        // {relative_path_to_file}{:line}{:character}: {error,warning}: {content}
+
+        return [
+            "\(violation.location.relativeFile ?? "<nopath>")",
+            ":\(violation.location.line ?? 1)",
+            ":\(violation.location.character ?? 1): ",
+            "\(violation.severity.rawValue): ",
+            "\(violation.ruleName) Violation: ",
+            violation.reason,
+            " (\(violation.ruleIdentifier))"
+        ].joined()
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -143,4 +143,16 @@ class ReporterTests: XCTestCase {
         let result = RelativePathReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
+
+    func testRelativePathReporterPaths() {
+        let relativePath = "filename"
+        let absolutePath = FileManager.default.currentDirectoryPath + "/" + relativePath
+        let location = Location(file: absolutePath, line: 1, character: 2)
+        let violation = StyleViolation(ruleDescription: LineLengthRule.description,
+                                       location: location,
+                                       reason: "Violation Reason")
+        let result = RelativePathReporter.generateReport([violation])
+        XCTAssertFalse(result.contains(absolutePath))
+        XCTAssertTrue(result.contains(relativePath))
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -17,7 +17,8 @@ class ReporterTests: XCTestCase {
             SonarQubeReporter.self,
             MarkdownReporter.self,
             GitHubActionsLoggingReporter.self,
-            GitLabJUnitReporter.self
+            GitLabJUnitReporter.self,
+            RelativePathReporter.self
         ]
         for reporter in reporters {
             XCTAssertEqual(reporter.identifier, reporterFrom(identifier: reporter.identifier).identifier)
@@ -134,6 +135,12 @@ class ReporterTests: XCTestCase {
     func testMarkdownReporter() {
         let expectedOutput = stringFromFile("CannedMarkdownReporterOutput.md")
         let result = MarkdownReporter.generateReport(generateViolations())
+        XCTAssertEqual(result, expectedOutput)
+    }
+
+    func testRelativePathReporter() {
+        let expectedOutput = stringFromFile("CannedRelativePathReporterOutput.txt")
+        let result = RelativePathReporter.generateReport(generateViolations())
         XCTAssertEqual(result, expectedOutput)
     }
 }

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedRelativePathReporterOutput.txt
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedRelativePathReporterOutput.txt
@@ -1,0 +1,4 @@
+filename:1:2: warning: Line Length Violation: Violation Reason (line_length)
+filename:1:2: error: Line Length Violation: Violation Reason (line_length)
+filename:1:2: error: Syntactic Sugar Violation: Shorthand syntactic sugar should be used, i.e. [Int] instead of Array<Int> (syntactic_sugar)
+<nopath>:1:1: error: Colon Spacing Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals (colon)


### PR DESCRIPTION
Added a new reporter that uses relative paths. As described in #4660. 
I've updated the unit tests but not sure that they make a lot of sense as with the current mocked location the output is identical to the xcode reporter