### PR TITLE
Fix redundant objc attribute false alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,10 @@
 * Fix correction on `lower_acl_than_parent` rule for `open` declarations.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4753](https://github.com/realm/SwiftLint/issues/4753)
+* Fix false positives on `redundant_objc_attribute` rule for enums
+  and private members.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4633](https://github.com/realm/SwiftLint/issues/4633)
 
 * Fix `void_return` rule to support async and async throws functions.  
   [Mathias Schreck](https://github.com/lo1tuma)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@
 * Fix Bazel release tarball for compiling on macOS.  
   [JP Simard](https://github.com/jpsim)
   [#4985](https://github.com/realm/SwiftLint/issues/4985)
+* Fix false positives on `redundant_objc_attribute` rule for enums
+  and private members.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4633](https://github.com/realm/SwiftLint/issues/4633)
 
 ## 0.52.0: Crisp Clear Pleats
 
@@ -198,11 +202,6 @@
 
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
-
-* Fix false positives on `redundant_objc_attribute` rule for enums
-  and private members.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4633](https://github.com/realm/SwiftLint/issues/4633)
 
 * Do not trigger `reduce_boolean` on `reduce` methods with a first named
   argument that is different from `into`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   declarations in classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5009](https://github.com/realm/SwiftLint/issues/5009)
+* Fix false positives on `redundant_objc_attribute` rule for enums
+  and private members.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4633](https://github.com/realm/SwiftLint/issues/4633)
 
 * Fix autocorrect for `CGIntersectionRect` in `legacy_cggeometry_functions`
   rule.  
@@ -97,10 +101,6 @@
 * Fix Bazel release tarball for compiling on macOS.  
   [JP Simard](https://github.com/jpsim)
   [#4985](https://github.com/realm/SwiftLint/issues/4985)
-* Fix false positives on `redundant_objc_attribute` rule for enums
-  and private members.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4633](https://github.com/realm/SwiftLint/issues/4633)
 
 ## 0.52.0: Crisp Clear Pleats
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   declarations in classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5009](https://github.com/realm/SwiftLint/issues/5009)
+
 * Fix false positives on `redundant_objc_attribute` rule for enums
   and private members.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,7 @@
 * Fix correction on `lower_acl_than_parent` rule for `open` declarations.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4753](https://github.com/realm/SwiftLint/issues/4753)
+
 * Fix false positives on `redundant_objc_attribute` rule for enums
   and private members.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,10 @@
 
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
+* Fix false positives on `redundant_objc_attribute` rule for enums
+  and private members.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4633](https://github.com/realm/SwiftLint/issues/4633)
 
 * Do not trigger `reduce_boolean` on `reduce` methods with a first named
   argument that is different from `into`.  
@@ -389,11 +393,6 @@
 * Fix correction on `lower_acl_than_parent` rule for `open` declarations.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4753](https://github.com/realm/SwiftLint/issues/4753)
-
-* Fix false positives on `redundant_objc_attribute` rule for enums
-  and private members.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4633](https://github.com/realm/SwiftLint/issues/4633)
 
 * Fix `void_return` rule to support async and async throws functions.  
   [Mathias Schreck](https://github.com/lo1tuma)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@
 
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
+
 * Fix false positives on `redundant_objc_attribute` rule for enums
   and private members.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -89,9 +89,7 @@ private extension AttributeListSyntax {
                   let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
                   parentClassDecl.attributes?.hasObjCMembers == true {
             if let functionDeclSyntax = parent?.as(FunctionDeclSyntax.self) {
-                if functionDeclSyntax.modifiers.isPrivateOrFileprivate == false {
-                    return objcAttribute
-                }
+                return functionDeclSyntax.modifiers.isPrivateOrFileprivate ? nil : objcAttribute
             } else {
                 return objcAttribute
             }
@@ -101,8 +99,6 @@ private extension AttributeListSyntax {
         } else {
             return nil
         }
-
-        return nil
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -75,6 +75,15 @@ private extension Syntax {
             return false
         }
     }
+
+    var functionOrVariableModifiers: ModifierListSyntax? {
+        if let functionDecl = self.as(FunctionDeclSyntax.self) {
+            return functionDecl.modifiers
+        } else if let variableDecl = self.as(VariableDeclSyntax.self) {
+            return variableDecl.modifiers
+        }
+        return nil
+    }
 }
 
 private extension AttributeListSyntax {
@@ -88,10 +97,8 @@ private extension AttributeListSyntax {
         } else if parent?.isFunctionOrStoredProperty == true,
                   let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
                   parentClassDecl.attributes?.hasObjCMembers == true {
-            if let functionDecl = parent?.as(FunctionDeclSyntax.self) {
-                return functionDecl.modifiers.isPrivateOrFileprivate ? nil : objcAttribute
-            } else if let variableDecl = parent?.as(VariableDeclSyntax.self) {
-                return variableDecl.modifiers.isPrivateOrFileprivate ? nil : objcAttribute
+            if parent?.functionOrVariableModifiers.isPrivateOrFileprivate == true {
+                return nil
             } else {
                 return objcAttribute
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -97,7 +97,7 @@ private extension AttributeListSyntax {
             }
         } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
                   parentExtensionDecl.attributes?.objCAttribute != nil {
-            return objcAttribute
+            return parent?.as(EnumDeclSyntax.self) != nil ? nil : objcAttribute
         } else {
             return nil
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -94,17 +94,15 @@ private extension AttributeListSyntax {
 
         if hasAttributeImplyingObjC, parent?.is(ExtensionDeclSyntax.self) != true {
             return objcAttribute
+        } else if parent?.is(EnumDeclSyntax.self) == true {
+            return nil
         } else if parent?.isFunctionOrStoredProperty == true,
                   let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
                   parentClassDecl.attributes?.hasObjCMembers == true {
-            if parent?.functionOrVariableModifiers.isPrivateOrFileprivate == true {
-                return nil
-            } else {
-                return objcAttribute
-            }
+            return parent?.functionOrVariableModifiers.isPrivateOrFileprivate == true ? nil : objcAttribute
         } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
                   parentExtensionDecl.attributes?.objCAttribute != nil {
-            return parent?.as(EnumDeclSyntax.self) != nil ? nil : objcAttribute
+            return objcAttribute
         } else {
             return nil
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -40,22 +40,15 @@ struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule,
 }
 
 private extension AttributeListSyntax {
-    var hasObjCMembers: Bool {
-        contains { $0.as(AttributeSyntax.self)?.attributeName.tokenKind == .identifier("objcMembers") }
-    }
-
     var objCAttribute: AttributeSyntax? {
         lazy
             .compactMap { $0.as(AttributeSyntax.self) }
-            .first { attribute in
-                attribute.attributeName.tokenKind == .contextualKeyword("objc") &&
-                    attribute.argument == nil
-            }
+            .first { $0.attributeNameText == "objc" && $0.argument == nil }
     }
 
     var hasAttributeImplyingObjC: Bool {
         contains { element in
-            guard case let .identifier(attributeName) = element.as(AttributeSyntax.self)?.attributeName.tokenKind else {
+            guard let attributeName = element.as(AttributeSyntax.self)?.attributeNameText else {
                 return false
             }
 
@@ -98,7 +91,7 @@ private extension AttributeListSyntax {
             return nil
         } else if parent?.isFunctionOrStoredProperty == true,
                   let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
-                  parentClassDecl.attributes?.hasObjCMembers == true {
+                  parentClassDecl.attributes.contains(attributeNamed: "objcMembers") {
             return parent?.functionOrVariableModifiers.isPrivateOrFileprivate == true ? nil : objcAttribute
         } else if let parentExtensionDecl = parent?.parent?.parent?.parent?.parent?.as(ExtensionDeclSyntax.self),
                   parentExtensionDecl.attributes?.objCAttribute != nil {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -88,8 +88,10 @@ private extension AttributeListSyntax {
         } else if parent?.isFunctionOrStoredProperty == true,
                   let parentClassDecl = parent?.parent?.parent?.parent?.parent?.as(ClassDeclSyntax.self),
                   parentClassDecl.attributes?.hasObjCMembers == true {
-            if let functionDeclSyntax = parent?.as(FunctionDeclSyntax.self) {
-                return functionDeclSyntax.modifiers.isPrivateOrFileprivate ? nil : objcAttribute
+            if let functionDecl = parent?.as(FunctionDeclSyntax.self) {
+                return functionDecl.modifiers.isPrivateOrFileprivate ? nil : objcAttribute
+            } else if let variableDecl = parent?.as(VariableDeclSyntax.self) {
+                return variableDecl.modifiers.isPrivateOrFileprivate ? nil : objcAttribute
             } else {
                 return objcAttribute
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -1,6 +1,6 @@
 struct RedundantObjcAttributeRuleExamples {
     static let nonTriggeringExamples = [
-        Example("@objc private var foo: String? {}"),
+        Example("@objc private var foo: String? {}"), // nope
         Example("@IBInspectable private var foo: String? {}"),
         Example("@objc private func foo(_ sender: Any) {}"),
         Example("@IBAction private func foo(_ sender: Any) {}"),
@@ -13,7 +13,7 @@ struct RedundantObjcAttributeRuleExamples {
         class Foo {
             var bar: Any?
             @objc
-            class Bar {
+            class Bar: NSObject {
                 @objc
                 var foo: Any?
             }
@@ -59,14 +59,15 @@ struct RedundantObjcAttributeRuleExamples {
         Example("""
         @objcMembers
         class Foo {
+            @objc
             class Bar: NSObject {
-                @objc var foo: Any
+                @objc var foo: Any?
             }
         }
         """),
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             @objc class Bar {}
         }
         """),
@@ -78,7 +79,7 @@ struct RedundantObjcAttributeRuleExamples {
         """),
         Example("""
         @objcMembers
-        public class Foo {
+        public class Foo: NSObject {
             @objc
             private func handler(_ notification: Notification) {
             }
@@ -120,6 +121,14 @@ struct RedundantObjcAttributeRuleExamples {
                 value(forKey: "baz")
             }
         }
+        """),
+        Example("""
+        @objcMembers
+        class Foo: NSObject {
+            @objc enum Bar: Int {
+               case bar
+            }
+        }
         """)
     ]
 
@@ -135,13 +144,13 @@ struct RedundantObjcAttributeRuleExamples {
         Example("↓@objc @IBDesignable class Foo {}"),
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             ↓@objc var bar: Any?
         }
         """),
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             ↓@objc var bar: Any?
             ↓@objc var foo: Any?
             @objc
@@ -171,7 +180,7 @@ struct RedundantObjcAttributeRuleExamples {
         """),
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             @objcMembers
             class Bar: NSObject {
                 ↓@objc var foo: Any
@@ -205,23 +214,23 @@ struct RedundantObjcAttributeRuleExamples {
         Example("↓@objc @IBDesignable class Foo {}"): Example("@IBDesignable class Foo {}"),
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             ↓@objc var bar: Any?
         }
         """):
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             var bar: Any?
         }
         """),
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             ↓@objc var bar: Any?
             ↓@objc var foo: Any?
             @objc
-            class Bar {
+            class Bar: NSObject {
                 @objc
                 var foo2: Any?
             }
@@ -229,11 +238,11 @@ struct RedundantObjcAttributeRuleExamples {
         """):
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             var bar: Any?
             var foo: Any?
             @objc
-            class Bar {
+            class Bar: NSObject {
                 @objc
                 var foo2: Any?
             }
@@ -275,7 +284,7 @@ struct RedundantObjcAttributeRuleExamples {
         """),
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             @objcMembers
             class Bar: NSObject {
                 ↓@objc var foo: Any
@@ -284,7 +293,7 @@ struct RedundantObjcAttributeRuleExamples {
         """):
         Example("""
         @objcMembers
-        class Foo {
+        class Foo: NSObject {
             @objcMembers
             class Bar: NSObject {
                 var foo: Any

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -87,6 +87,17 @@ struct RedundantObjcAttributeRuleExamples {
                 NotificationCenter.default.addObserver(self, selector: #selector(handler(_:)), name: nil, object: nil)
             }
         }
+        """),
+        Example("""
+        class Foo: NSObject { }
+
+        @objc extension Foo {
+            @objc enum Bar: Int {
+               case bar
+            }
+
+            var bar: Bar { .bar }
+        }
         """)
     ]
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -75,6 +75,18 @@ struct RedundantObjcAttributeRuleExamples {
             @objc(addElementsObject:)
             @NSManaged public func addToElements(_ value: BlockEditorSettingElement)
         }
+        """),
+        Example("""
+        @objcMembers
+        public class Foo {
+            @objc
+            private func handler(_ notification: Notification) {
+            }
+
+            func registerForNotifications() {
+                NotificationCenter.default.addObserver(self, selector: #selector(handler(_:)), name: nil, object: nil)
+            }
+        }
         """)
     ]
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -104,11 +104,11 @@ struct RedundantObjcAttributeRuleExamples {
         class Foo: NSObject { }
 
         @objc extension Foo {
-          @objc private enum Baz: Int {
-            case baz
-          }
+            @objc private enum Baz: Int {
+              case baz
+            }
 
-          private var baz: Baz { .baz }
+            private var baz: Baz { .baz }
         }
         """),
         Example("""

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -110,17 +110,17 @@ struct RedundantObjcAttributeRuleExamples {
           private var baz: Baz { .baz }
         }
         """),
-       Example("""
-       @objcMembers
-       internal class Foo: NSObject {
-           @objc
-           private var baz: Int = 1
+        Example("""
+        @objcMembers
+        internal class Foo: NSObject {
+            @objc
+            private var baz: Int = 1
 
-           var x: Any? {
-               value(forKey: "baz")
-           }
-       }
-       """)
+            var x: Any? {
+                value(forKey: "baz")
+            }
+        }
+        """)
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -109,7 +109,18 @@ struct RedundantObjcAttributeRuleExamples {
 
           private var baz: Baz { .baz }
         }
-        """)
+        """),
+       Example("""
+       @objcMembers
+       internal class Foo: NSObject {
+           @objc
+           private var baz: Int = 1
+
+           var x: Any? {
+               value(forKey: "baz")
+           }
+       }
+       """)
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -1,6 +1,6 @@
 struct RedundantObjcAttributeRuleExamples {
     static let nonTriggeringExamples = [
-        Example("@objc private var foo: String? {}"), // nope
+        Example("@objc private var foo: String? {}"),
         Example("@IBInspectable private var foo: String? {}"),
         Example("@objc private func foo(_ sender: Any) {}"),
         Example("@IBAction private func foo(_ sender: Any) {}"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRuleExamples.swift
@@ -98,6 +98,17 @@ struct RedundantObjcAttributeRuleExamples {
 
             var bar: Bar { .bar }
         }
+        """),
+        Example("""
+        class Foo: NSObject { }
+
+        @objc extension Foo {
+          @objc private enum Baz: Int {
+            case baz
+          }
+
+          private var baz: Baz { .baz }
+        }
         """)
     ]
 


### PR DESCRIPTION
Fixes some false alarms in the redundant_objc_attribute that seem to have come in around 0.50.1

Resolves https://github.com/realm/SwiftLint/issues/4633

We've seen a few of these in our own codebase.

I picked this up and fixed most of it, when I noticed @Cyberbeni 's branch. My final solution is a mix of my original, and some stuff I cribbed from his fixes at https://github.com/realm/SwiftLint/pull/4642

I also patched up some of the examples that weren't valid Swift code or didn't make sense.

These are the examples that were triggering false alarms:

```
        @objcMembers
        public class Foo: NSObject {
            @objc
            private func handler(_ notification: Notification) {
            }
            func registerForNotifications() {
                NotificationCenter.default.addObserver(self, selector: #selector(handler(_:)), name: nil, object: nil)
            }
        }
```

```
        class Foo: NSObject { }
        @objc extension Foo {
            @objc enum Bar: Int {
               case bar
            }
            var bar: Bar { .bar }
        }
```

```
        class Foo: NSObject { }
        @objc extension Foo {
          @objc private enum Baz: Int {
            case baz
          }
          private var baz: Baz { .baz }
        }
```


```
        @objcMembers
        internal class Foo: NSObject {
            @objc
            private var baz: Int = 1
            var x: Any? {
                value(forKey: "baz")
            }
        }
```

```
        @objcMembers
        class Foo: NSObject {
            @objc enum Bar: Int {
               case bar
            }
        }
```

