### PR TITLE
Add instructions for disabling Xcode package validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,14 @@ Select `SwiftLintPlugin` from the list and add it to the project.
 
 ![](assets/select-swiftlint-plugin.png)
 
-For unattended use (eg CI) you can disable the package validation dialog by:
+For unattended use (e.g. on CI), you can disable the package validation dialog by
 
-* Individually passing `-skipPackagePluginValidation` to `xcodebuild`
-* Globally setting `defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES` for that user
+* individually passing `-skipPackagePluginValidation` to `xcodebuild` or
+* globally setting `defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES` 
+  for that user.
 
-_Note: this implicitly trusts all Xcode package plugins and bypasses Xcode's package validation dialog, which has security implications._
+_Note: This implicitly trusts all Xcode package plugins and bypasses Xcode's package validation
+       dialogs, which has security implications._
 
 #### Swift Package
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ there is currently no way to pass any additional options to the SwiftLint execut
 
 #### Xcode
 
-You can integrate SwiftLint as a Xcode Build Tool Plug-in if you're working
+You can integrate SwiftLint as an Xcode Build Tool Plug-in if you're working
 with a project in Xcode.
 
 Add SwiftLint as a package dependency to your project without linking any of the

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ Select `SwiftLintPlugin` from the list and add it to the project.
 
 ![](assets/select-swiftlint-plugin.png)
 
+For unattended use (eg CI) you can disable the package validation dialog by:
+
+* Individually passing `-skipPackagePluginValidation` to `xcodebuild`
+* Globally setting `defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES` for that user
+
+_Note: this implicitly trusts all Xcode package plugins and bypasses Xcode's package validation dialog, which has security implications._
+
 #### Swift Package
 
 You can integrate SwiftLint as a Swift Package Manager Plug-in if you're working with


### PR DESCRIPTION
Useful for unattended/CI installations. Also fixes a minor typo in the readme.