### PR TITLE
Add consider_default_literal_types_redundant option to RedundantTypeAnnotationRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 * Add `consider_default_literal_types_redundant` option to the
   `redundant_type_annotation` rule supporting `Bool`, `Double`, `Int` and
   `String`. Setting the option to `true` lets the rule consider said types in
-  declarations like `let i: Int = 1` or `let s: String = ""` as redundant.  
+  declarations like `let i: Int = 1` or `let s: String = ""` as redundant.
+  Note that `Bool` literals will no longer be considered redundant by default.  
   [Garric Nahapetian](https://github.com/garricn)
 
 #### Experimental

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,10 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4792](https://github.com/realm/SwiftLint/issues/4792)
 
-* Add `consider_default_literal_types_redundant` option to the
-  `redundant_type_annotation` rule supporting `Bool`, `Double`, `Int` and
-  `String`. Setting the option to `true` lets the rule consider said types in
-  declarations like `let i: Int = 1` or `let s: String = ""` as redundant.
-  Note that `Bool` literals will no longer be considered redundant by default.  
+* With the introduction of the `consider_default_literal_types_redundant`
+  option to the `redundant_type_annotation` rule, `Bool` literals will no
+  longer be considered redundant by default. Set this option to true to
+  preserve the previous behavior.  
   [Garric Nahapetian](https://github.com/garricn)
 
 #### Experimental
@@ -194,6 +193,14 @@
   `list.enumerated().map { $1 }`.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5470](https://github.com/realm/SwiftLint/issues/5470)
+
+* Include `Double`, `Int` and `String` to the exiting redundant type validation
+  check of `Bool` in the `redundant_type_annotation` rule. Add
+  `consider_default_literal_types_redundant` option supporting `Bool`,
+  `Double`, `Int` and `String`. Setting this option to `true` lets the rule
+  consider said types in declarations like `let i: Int = 1` or
+  `let s: String = ""` as redundant.  
+  [Garric Nahapetian](https://github.com/garricn)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4792](https://github.com/realm/SwiftLint/issues/4792)
 
+* Add `consider_default_literal_types_redundant` option to
+  `RedundantTypeAnnotationRule` supporting `Bool`, `Double`, `Int` and `String`.
+  Note that this option must be set to `true` to maintain the previous behavior.
+  [Garric Nahapetian](https://github.com/garricn)
+  [#4756](https://github.com/realm/SwiftLint/pull/4756)
+
 #### Experimental
 
 * Add two new options to the `lint` and `analyze` commands: `--write-baseline`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4792](https://github.com/realm/SwiftLint/issues/4792)
 
-* Add `consider_default_literal_types_redundant` option to
-  `RedundantTypeAnnotationRule` supporting `Bool`, `Double`, `Int` and `String`.
-  Note that this option must be set to `true` to maintain the previous behavior.
+* Add `consider_default_literal_types_redundant` option to the
+  `redundant_type_annotation` rule supporting `Bool`, `Double`, `Int` and
+  `String`. Setting the option to `true` lets the rule consider said types in
+  declarations like `let i: Int = 1` or `let s: String = ""` as redundant.  
   [Garric Nahapetian](https://github.com/garricn)
-  [#4756](https://github.com/realm/SwiftLint/pull/4756)
 
 #### Experimental
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -234,20 +234,25 @@ private extension TypeAnnotationSyntax {
         // Consider the type annotation redundant if `considerLiteralsRedundant` is true and the expression is one of
         // the supported compiler-inferred literals.
         if considerLiteralsRedundant {
-            return switch initializer {
-            case let expr where expr.is(BooleanLiteralExprSyntax.self):
-                type.trimmedDescription == "Bool"
-            case let expr where expr.is(FloatLiteralExprSyntax.self):
-                type.trimmedDescription == "Double"
-            case let expr where expr.is(IntegerLiteralExprSyntax.self):
-                type.trimmedDescription == "Int"
-            case let expr where expr.is(StringLiteralExprSyntax.self):
-                type.trimmedDescription == "String"
-            default:
-                false
-            }
+            return isCompilerInferredLiteral(expression: initializer)
         }
         return initializer.accessedNames.contains(type.trimmedDescription)
+    }
+
+    // Returns true if the expression is one of the supported compiler-inferred literals.
+    private func isCompilerInferredLiteral(expression: ExprSyntax) -> Bool {
+        return switch expression {
+        case let expr where expr.is(BooleanLiteralExprSyntax.self):
+            type.trimmedDescription == "Bool"
+        case let expr where expr.is(FloatLiteralExprSyntax.self):
+            type.trimmedDescription == "Double"
+        case let expr where expr.is(IntegerLiteralExprSyntax.self):
+            type.trimmedDescription == "Int"
+        case let expr where expr.is(StringLiteralExprSyntax.self):
+            type.trimmedDescription == "String"
+        default:
+            false
+        }
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -221,32 +221,6 @@ private extension RedundantTypeAnnotationRule {
     }
 }
 
-private extension SyntaxKind {
-    var compilerInferredLiteralType: String? {
-        switch self {
-        case .booleanLiteralExpr:
-            "Bool"
-        case .floatLiteralExpr:
-            "Double"
-        case .integerLiteralExpr:
-            "Int"
-        case .stringLiteralExpr:
-            "String"
-        default:
-            nil
-        }
-    }
-
-    func isLiteralExpression() -> Bool {
-        switch self {
-        case .booleanLiteralExpr, .floatLiteralExpr, .integerLiteralExpr, .stringLiteralExpr:
-            true
-        default:
-            false
-        }
-    }
-}
-
 private extension ExprSyntax {
     /// An expression can represent an access to an identifier in one or another way depending on the exact underlying
     /// expression type. E.g. the expression `A` accesses `A` while `f()` accesses `f` and `a.b.c` accesses `a` in the
@@ -277,5 +251,31 @@ private extension ExprSyntax {
             expr = forceUnwrap.expression
         }
         return expr.accessedNames.contains(type.trimmedDescription)
+    }
+}
+
+private extension SyntaxKind {
+    var compilerInferredLiteralType: String? {
+        switch self {
+        case .booleanLiteralExpr:
+            "Bool"
+        case .floatLiteralExpr:
+            "Double"
+        case .integerLiteralExpr:
+            "Int"
+        case .stringLiteralExpr:
+            "String"
+        default:
+            nil
+        }
+    }
+
+    func isLiteralExpression() -> Bool {
+        switch self {
+        case .booleanLiteralExpr, .floatLiteralExpr, .integerLiteralExpr, .stringLiteralExpr:
+            true
+        default:
+            false
+        }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -242,7 +242,7 @@ private extension ExprSyntax {
     }
 
     func hasRedundantLiteralType(_ type: TypeSyntax) -> Bool {
-        kind.isLiteralExpression() && kind.compilerInferredLiteralType == type.trimmedDescription
+        kind.isLiteralExpression() && type.trimmedDescription == kind.compilerInferredLiteralType 
     }
 
     func hasRedundantType(_ type: TypeSyntax) -> Bool {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -242,7 +242,7 @@ private extension ExprSyntax {
     }
 
     func hasRedundantLiteralType(_ type: TypeSyntax) -> Bool {
-        kind.isLiteralExpression() && type.trimmedDescription == kind.compilerInferredLiteralType 
+        type.trimmedDescription == kind.compilerInferredLiteralType
     }
 
     func hasRedundantType(_ type: TypeSyntax) -> Bool {
@@ -267,15 +267,6 @@ private extension SyntaxKind {
             "String"
         default:
             nil
-        }
-    }
-
-    func isLiteralExpression() -> Bool {
-        switch self {
-        case .booleanLiteralExpr, .floatLiteralExpr, .integerLiteralExpr, .stringLiteralExpr:
-            true
-        default:
-            false
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -234,14 +234,14 @@ private extension TypeAnnotationSyntax {
         // Consider the type annotation redundant if `considerLiteralsRedundant` is true and the expression is one of
         // the supported compiler-inferred literals.
         if considerLiteralsRedundant {
-            return isCompilerInferredLiteral(expression: initializer)
+            return isCompilerInferredLiteral(initializer)
         }
         return initializer.accessedNames.contains(type.trimmedDescription)
     }
 
     // Returns true if the expression is one of the supported compiler-inferred literals.
-    private func isCompilerInferredLiteral(expression: ExprSyntax) -> Bool {
-        return switch expression {
+    private func isCompilerInferredLiteral(_ expr: ExprSyntax) -> Bool {
+        switch expr {
         case let expr where expr.is(BooleanLiteralExprSyntax.self):
             type.trimmedDescription == "Bool"
         case let expr where expr.is(FloatLiteralExprSyntax.self):

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
@@ -8,4 +8,6 @@ struct RedundantTypeAnnotationConfiguration: SeverityBasedRuleConfiguration {
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "ignore_attributes")
     var ignoreAttributes = Set<String>(["IBInspectable"])
+    @ConfigurationElement(key: "consider_default_literal_types_redundant")
+    private(set) var considerDefaultLiteralTypesRedundant = false
 }

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -457,6 +457,7 @@ redundant_string_enum_value:
 redundant_type_annotation:
   severity: warning
   ignore_attributes: ["IBInspectable"]
+  consider_default_literal_types_redundant: false
 redundant_void_return:
   severity: warning
   include_closures: true


### PR DESCRIPTION
- Add `consider_default_literal_types_redundant` option to `RedundantTypeAnnotationConfiguration`
- Add examples in rule description
- Improve control flow in `visitPost` methods
- Refactor `isRedundant` method to include and use `considerLiteralsRedundant` for `Bool`, `Double`, `Int` and `String`

By default, literals for `Bool`, `Double`, `Int` and `String` will be considered **not** redundant. For example: `var isEnabled: Bool = true`. This is an intentional change in behavior. See the comments below for additional details.

> [!IMPORTANT]
> The `consider_default_literal_types_redundant ` option must be set to `true` to maintain the previous behavior.