### PR TITLE
Ensure that configured exclusion rules are respected by the build plugin

### DIFF
--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -29,6 +29,10 @@ struct SwiftLintPlugin: BuildToolPlugin {
         var arguments = [
             "lint",
             "--quiet",
+            // We always pass all of the Swift source files in the target to the tool,
+            // so we need to ensure that any exclusion rules in the configuration are
+            // respected.
+            "--force-exclude",
             "--cache-path", "\(workingDirectory)"
         ]
 


### PR DESCRIPTION
#4680 changed the build plugin to use a `prebuildCommand` rather than a `buildCommand`. For some reason, this change altered the behaviour and configured exclusions were ignored. 

Given that we always pass all of the Swift source files in the target to the tool within the build plugin, we need to ensure that any exclusion rules in the configuration are respected. 

This PR proposes to add the `--force-exclude` option to the build plugin's invocation of the tool.