### PR TITLE
Remove the need for rules_xcodeproj dependency for downstream consumers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,11 +4,6 @@ load(
     "swift_binary",
     "swift_library",
 )
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_schemes",
-    "xcodeproj",
-)
 
 # Targets
 
@@ -106,39 +101,6 @@ COPYFILE_DISABLE=1 tar czvfh "$${outs[0]}" \
   *
 shasum -a 256 "$${outs[0]}" > "$${outs[1]}"
     """,
-)
-
-# Xcode Integration
-
-xcodeproj(
-    name = "xcodeproj",
-    project_name = "SwiftLint",
-    schemes = [
-        xcode_schemes.scheme(
-            name = "SwiftLint",
-            launch_action = xcode_schemes.launch_action(
-                "swiftlint",
-                args = [
-                    "--progress",
-                ],
-            ),
-            test_action = xcode_schemes.test_action([
-                "//Tests:CLITests",
-                "//Tests:SwiftLintFrameworkTests",
-                "//Tests:GeneratedTests",
-                "//Tests:IntegrationTests",
-                "//Tests:ExtraRulesTests",
-            ]),
-        ),
-    ],
-    top_level_targets = [
-        "//:swiftlint",
-        "//Tests:CLITests",
-        "//Tests:SwiftLintFrameworkTests",
-        "//Tests:GeneratedTests",
-        "//Tests:IntegrationTests",
-        "//Tests:ExtraRulesTests",
-    ],
 )
 
 # Analyze

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,3 +1,45 @@
+load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
+    "xcode_schemes",
+    "xcodeproj",
+)
+
+# Xcode Integration
+
+xcodeproj(
+    name = "xcodeproj",
+    install_directory = "",
+    project_name = "SwiftLint",
+    schemes = [
+        xcode_schemes.scheme(
+            name = "SwiftLint",
+            launch_action = xcode_schemes.launch_action(
+                target = "//:swiftlint",
+                args = [
+                    "--progress",
+                ],
+            ),
+            test_action = xcode_schemes.test_action([
+                "//Tests:CLITests",
+                "//Tests:SwiftLintFrameworkTests",
+                "//Tests:GeneratedTests",
+                "//Tests:IntegrationTests",
+                "//Tests:ExtraRulesTests",
+            ]),
+        ),
+    ],
+    top_level_targets = [
+        "//:swiftlint",
+        "//Tests:CLITests",
+        "//Tests:SwiftLintFrameworkTests",
+        "//Tests:GeneratedTests",
+        "//Tests:IntegrationTests",
+        "//Tests:ExtraRulesTests",
+    ],
+)
+
+# Release Files
+
 filegroup(
     name = "release_files",
     srcs = glob(["*"]),


### PR DESCRIPTION
This was needed because the `xcodeproj` target was declared in the same
BUILD file with the `@SwiftLint//:swiftlint` target, so when users run
`bazel run @SwiftLint//:swiftlint`, bazel would try to load
`rules_xcodeproj`. `rules_xcodeproj` 1.0 allows us to specify the
location of the generated Xcode project, so we don't need this target in
the top-level BUILD file anymore.

This only fixes for non-bzlmod case now.

Fixes https://github.com/realm/SwiftLint/issues/4737
