### PR TITLE
Add new `duplicate_conditions` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Add `duplicate_conditions` rule which warns when a condition is duplicated
   in separate branches of the same branching statement (if-else, or switch).  
   [1in1](https://github.com/1in1)
-  [#issue_number](https://github.com/realm/SwiftLint/issues/4666)
+  [#4666](https://github.com/realm/SwiftLint/issues/4666)
 
 * Add local links to rule descriptions to every rule listed
   in `Rule Directory.md`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 
 #### Enhancements
 
+* Add `duplicate_conditions` rule which warns when a condition is duplicated
+  in separate branches of the same branching statement (if-else, or switch).  
+  [1in1](https://github.com/1in1)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/4666)
+
 * Add local links to rule descriptions to every rule listed
   in `Rule Directory.md`.  
   [kattouf](https://github.com/kattouf)

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -43,6 +43,7 @@ let builtInRules: [Rule.Type] = [
     DiscouragedObjectLiteralRule.self,
     DiscouragedOptionalBooleanRule.self,
     DiscouragedOptionalCollectionRule.self,
+    DuplicateConditionsRule.self,
     DuplicateEnumCasesRule.self,
     DuplicateImportsRule.self,
     DuplicatedKeyInDictionaryLiteralRule.self,

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
@@ -203,20 +203,20 @@ private extension DuplicateConditionsRule {
         private func extract(_ node: ConditionElementSyntax) -> String {
             let text: String
             switch node.condition {
-            case .availability(let node):
-                text = node.debugDescription(includeChildren: true, includeTrivia: false)
-            case .expression(let node):
-                text = node.debugDescription(includeChildren: true, includeTrivia: false)
-            case .matchingPattern(let node):
-                text = node.debugDescription(includeChildren: true, includeTrivia: false)
-            case .optionalBinding(let node):
-                text = node.debugDescription(includeChildren: true, includeTrivia: false)
+            case .availability(let innerNode):
+                text = innerNode.debugDescription(includeChildren: true, includeTrivia: false)
+            case .expression(let innerNode):
+                text = innerNode.debugDescription(includeChildren: true, includeTrivia: false)
+            case .matchingPattern(let innerNode):
+                text = innerNode.debugDescription(includeChildren: true, includeTrivia: false)
+            case .optionalBinding(let innerNode):
+                text = innerNode.debugDescription(includeChildren: true, includeTrivia: false)
             }
 
             return text
         }
 
-        private func addViolations(_ positionsByCondition: any Collection<[AbsolutePosition]>) {
+        private func addViolations(_ positionsByCondition: some Collection<[AbsolutePosition]>) {
             let duplicatedPositions = positionsByCondition
                 .filter { $0.count > 1 }
                 .flatMap { $0 }

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 struct DuplicateConditionsRule: SwiftSyntaxRule, ConfigurationProviderRule {
-    var configuration = SeverityConfiguration(.warning)
+    var configuration = SeverityConfiguration(.error)
 
     init() {}
 
@@ -67,6 +67,11 @@ struct DuplicateConditionsRule: SwiftSyntaxRule, ConfigurationProviderRule {
                   foo()
                 } else if case .q = x {
                   bar()
+                }
+            """),
+            Example("""
+                if true {
+                  if true { foo() }
                 }
             """)
         ],
@@ -143,6 +148,11 @@ struct DuplicateConditionsRule: SwiftSyntaxRule, ConfigurationProviderRule {
                 } else if ↓case .p = x {
                   bar()
                 }
+            """),
+            Example("""
+                if ↓x < 5 {}
+                else if ↓x < 5 {}
+                else if ↓x < 5 {}
             """)
         ]
     )

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
@@ -179,7 +179,9 @@ private extension DuplicateConditionsRule {
 
             let positionsByConditions = statementChain
                 .reduce(into: [Set<String>: [AbsolutePosition]]()) { acc, elt in
-                    let conditions = elt.conditions.map(extract)
+                    let conditions = elt.conditions.map {
+                        $0.condition.debugDescription(includeChildren: true, includeTrivia: false)
+                    }
                     let location = elt.conditions.positionAfterSkippingLeadingTrivia
                     acc[Set(conditions), default: []].append(location)
                 }
@@ -208,22 +210,6 @@ private extension DuplicateConditionsRule {
                 }
 
             addViolations(Array(positionsByCondition.values))
-        }
-
-        private func extract(_ node: ConditionElementSyntax) -> String {
-            let text: String
-            switch node.condition {
-            case .availability(let innerNode):
-                text = innerNode.debugDescription(includeChildren: true, includeTrivia: false)
-            case .expression(let innerNode):
-                text = innerNode.debugDescription(includeChildren: true, includeTrivia: false)
-            case .matchingPattern(let innerNode):
-                text = innerNode.debugDescription(includeChildren: true, includeTrivia: false)
-            case .optionalBinding(let innerNode):
-                text = innerNode.debugDescription(includeChildren: true, includeTrivia: false)
-            }
-
-            return text
         }
 
         private func addViolations(_ positionsByCondition: [[AbsolutePosition]]) {

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
@@ -1,0 +1,176 @@
+import SwiftSyntax
+
+struct DuplicateConditionsRule: SwiftSyntaxRule, ConfigurationProviderRule {
+    var configuration = SeverityConfiguration(.warning)
+
+    init() {}
+
+    static let description = RuleDescription(
+        identifier: "duplicate_conditions",
+        name: "Duplicate Conditions",
+        description: "Duplicate conditions in the same branching statement should be avoided",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+                if x < 5 {
+                  foo()
+                } else if y == "s" {
+                  bar()
+                }
+            """),
+            Example("""
+                if x < 5 {
+                  foo()
+                }
+                if x < 5 {
+                  bar()
+                }
+            """),
+            Example("""
+                switch x {
+                case \"a\":
+                  foo()
+                  bar()
+                }
+            """),
+            Example("""
+                if let x = maybeAbc {
+                  foo()
+                } else if let x = maybePqr {
+                  bar()
+                }
+            """),
+            Example("""
+                if case .p = x {
+                  foo()
+                } else if case .q = x {
+                  bar()
+                }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                if ↓x < 5 {
+                  foo()
+                } else if y == "s" {
+                  bar()
+                } else if ↓x < 5 { 
+                  baz()
+                }
+            """),
+            Example("""
+                if x < 5, ↓y == "s" {
+                  foo()
+                } else if x < 10 {
+                  bar()
+                } else if ↓y == "s", x < 15 {
+                  baz()
+                }
+            """),
+            Example("""
+                switch x {
+                case ↓\"a\", \"b\":
+                  foo()
+                case \"c\", ↓\"a\":
+                  bar()
+                }
+            """),
+            Example("""
+                if ↓let xyz = maybeXyz {
+                  foo()
+                } else if ↓let xyz = maybeXyz {
+                  bar()
+                }
+            """),
+            Example("""
+                if ↓#available(macOS 10.15, *) {
+                  foo()
+                } else if ↓#available(macOS 10.15, *) {
+                  bar()
+                }
+            """),
+            Example("""
+                if ↓case .p = x {
+                  foo()
+                } else if ↓case .p = x {
+                  bar()
+                }
+            """)
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(viewMode: .sourceAccurate)
+    }
+}
+
+private extension DuplicateConditionsRule {
+    final class Visitor: ViolationsSyntaxVisitor {
+        override func visitPost(_ node: IfStmtSyntax) {
+            if let prevToken = node.previousToken,
+               prevToken.tokenKind == .elseKeyword {
+                // We can skip these cases - they will be picked up when we visit the top level `if`
+                return
+            }
+
+            var maybeCurr: IfStmtSyntax? = node
+            var statementChain: [IfStmtSyntax] = []
+            while let curr = maybeCurr {
+                statementChain.append(curr)
+                maybeCurr = curr.elseBody?.as(IfStmtSyntax.self)
+            }
+
+            let positionsByCondition = statementChain
+                .flatMap { $0.conditions }
+                .compactMap(extract)
+                .reduce(into: [[UInt8]: [AbsolutePosition]](), { xs, x in
+                    xs[x.text, default: []].append(x.location)
+                })
+
+            addViolations(positionsByCondition)
+        }
+
+        override func visitPost(_ node: SwitchCaseListSyntax) {
+            let switchCases = node.compactMap { $0.as(SwitchCaseSyntax.self) }
+
+            let positionsByCondition = switchCases
+                .reduce(into: [[UInt8]: [AbsolutePosition]]()) { xs, x in
+                    // Defaults don't have a condition to worry about
+                    guard case let .case(caseLabel) = x.label else { return }
+                    for item in caseLabel.caseItems {
+                        let pattern = item.pattern.withoutTrivia().syntaxTextBytes
+                        let location = item.positionAfterSkippingLeadingTrivia
+                        xs[pattern, default: []].append(location)
+                    }
+                }
+
+            addViolations(positionsByCondition)
+        }
+
+        private func extract(_ node: ConditionElementSyntax) -> (text: [UInt8], location: AbsolutePosition)? {
+            let text: [UInt8]
+            switch node.condition {
+            case .availability(let node):
+                text = node.withoutTrivia().syntaxTextBytes
+            case .expression(let node):
+                text = node.withoutTrivia().syntaxTextBytes
+            case .matchingPattern(let node):
+                text = node.withoutTrivia().syntaxTextBytes
+            case .optionalBinding(let node):
+                text = node.withoutTrivia().syntaxTextBytes
+            default:
+                return nil
+            }
+
+            return (text: text, location: node.positionAfterSkippingLeadingTrivia)
+        }
+
+        private func addViolations(_ positionsByCondition: [[UInt8]: [AbsolutePosition]]) {
+            let duplicatedPositions = positionsByCondition
+                .filter { $0.value.count > 1 }
+                .flatMap { $0.value }
+
+            violations.append(contentsOf: duplicatedPositions)
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/DuplicateConditionsRule.swift
@@ -174,7 +174,7 @@ private extension DuplicateConditionsRule {
                     acc[Set(conditions), default: []].append(location)
                 }
 
-            addViolations(positionsByConditions.values)
+            addViolations(Array(positionsByConditions.values))
         }
 
         override func visitPost(_ node: SwitchCaseListSyntax) {
@@ -197,7 +197,7 @@ private extension DuplicateConditionsRule {
                     }
                 }
 
-            addViolations(positionsByCondition.values)
+            addViolations(Array(positionsByCondition.values))
         }
 
         private func extract(_ node: ConditionElementSyntax) -> String {
@@ -216,7 +216,7 @@ private extension DuplicateConditionsRule {
             return text
         }
 
-        private func addViolations(_ positionsByCondition: some Collection<[AbsolutePosition]>) {
+        private func addViolations(_ positionsByCondition: [[AbsolutePosition]]) {
             let duplicatedPositions = positionsByCondition
                 .filter { $0.count > 1 }
                 .flatMap { $0 }

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -259,6 +259,12 @@ class DuplicatedKeyInDictionaryLiteralRuleGeneratedTests: XCTestCase {
     }
 }
 
+class DuplicateConditionsRuleTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(DuplicateConditionsRule.description)
+    }
+}
+
 class DynamicInlineRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DynamicInlineRule.description)

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @_spi(TestHelper)
 @testable import SwiftLintFramework
@@ -241,6 +241,12 @@ class DiscouragedOptionalCollectionRuleGeneratedTests: XCTestCase {
     }
 }
 
+class DuplicateConditionsRuleGeneratedTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(DuplicateConditionsRule.description)
+    }
+}
+
 class DuplicateEnumCasesRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DuplicateEnumCasesRule.description)
@@ -256,12 +262,6 @@ class DuplicateImportsRuleGeneratedTests: XCTestCase {
 class DuplicatedKeyInDictionaryLiteralRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DuplicatedKeyInDictionaryLiteralRule.description)
-    }
-}
-
-class DuplicateConditionsRuleTests: XCTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(DuplicateConditionsRule.description)
     }
 }
 


### PR DESCRIPTION
Long time user, first time contributor - let me know if anything's wrong!

__I can't run Sourcery at the moment__ (I don't have access to a mac for a while, this change was made on a linux box -- Sourcery is... non-trivial to install, shall we say); so if that's required for this change, and a maintainer is able to help with that when this is otherwise ready, I'd be appreciative!

This PR adds the `duplicate_conditions` rule described [here](https://github.com/realm/SwiftLint/issues/4666)

`if-else` and `switch` branching statements are considered. Compiler directives are not considered. The behaviour is very slightly different between `if-else` and `switch` statements:
- For `if-else` statements, a violation is triggered if the conditions of one branch are the same as the conditions of another branch, ignoring ordering. 
  - I considered flagging individual conditions, but I think something like the following is reasonable stylistically, in some scenarios, and so should not be a violation:
```
if x < 5, y == "s" { foo() }
else if x < 5 { bar() }
```
Additionally, to cover this case generally, some reasonably complicated special casing would be needed to prevent the following from being a violation:
```
if let x = maybeX1, y = x.p { foo() }
else if let x = maybeX2, y = x.p { bar() }
```
- For `switch` statements, a violation is triggered if any of the conditions (including `when` clause, if applicable) in any of the case labels match


See the examples for more :)