### PR TITLE
Fix void_return rule to support async and async throws functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,10 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4753](https://github.com/realm/SwiftLint/issues/4753)
 
+* Fix `void_return` rule to support async and async throws functions.  
+  [Mathias Schreck](https://github.com/lo1tuma)
+  [#4772](https://github.com/realm/SwiftLint/issues/4772)
+
 ## 0.50.3: Bundle of Towels
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/VoidReturnRule.swift
@@ -18,7 +18,12 @@ struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
             Example("let foo: (ConfigurationTests) -> () throws -> Void\n"),
             Example("let foo: (ConfigurationTests) ->   () throws -> Void\n"),
             Example("let foo: (ConfigurationTests) ->() throws -> Void\n"),
-            Example("let foo: (ConfigurationTests) -> () -> Void\n")
+            Example("let foo: (ConfigurationTests) -> () -> Void\n"),
+            Example("let foo: () -> () async -> Void\n"),
+            Example("let foo: () -> () async throws -> Void\n"),
+            Example("let foo: () -> () async -> Void\n"),
+            Example("func foo() -> () async throws -> Void {}\n"),
+            Example("func foo() async throws -> () async -> Void { return {} }\n")
         ],
         triggeringExamples: [
             Example("let abc: () -> ↓() = {}\n"),
@@ -27,7 +32,9 @@ struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
             Example("func foo(completion: () -> ↓())\n"),
             Example("func foo(completion: () -> ↓(   ))\n"),
             Example("func foo(completion: () -> ↓(Void))\n"),
-            Example("let foo: (ConfigurationTests) -> () throws -> ↓()\n")
+            Example("let foo: (ConfigurationTests) -> () throws -> ↓()\n"),
+            Example("func foo() async -> ↓()\n"),
+            Example("func foo() async throws -> ↓()\n")
         ],
         corrections: [
             Example("let abc: () -> ↓() = {}\n"): Example("let abc: () -> Void = {}\n"),
@@ -37,7 +44,8 @@ struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
             Example("func foo(completion: () -> ↓(   ))\n"): Example("func foo(completion: () -> Void)\n"),
             Example("func foo(completion: () -> ↓(Void))\n"): Example("func foo(completion: () -> Void)\n"),
             Example("let foo: (ConfigurationTests) -> () throws -> ↓()\n"):
-                Example("let foo: (ConfigurationTests) -> () throws -> Void\n")
+                Example("let foo: (ConfigurationTests) -> () throws -> Void\n"),
+            Example("func foo() async throws -> ↓()\n"): Example("func foo() async throws -> Void\n")
         ]
     )
 
@@ -53,7 +61,7 @@ struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
         let kinds = SyntaxKind.commentAndStringKinds
         let parensPattern = "\\(\\s*(?:Void)?\\s*\\)"
         let pattern = "->\\s*\(parensPattern)\\s*(?!->)"
-        let excludingPattern = "(\(pattern))\\s*(throws\\s+)?->"
+        let excludingPattern = "(\(pattern))\\s*(async\\s+)?(throws\\s+)?->"
 
         return file.match(pattern: pattern, excludingSyntaxKinds: kinds, excludingPattern: excludingPattern,
                           exclusionMapping: { $0.range(at: 1) }).compactMap {


### PR DESCRIPTION
This fixes #4766. I’ve noticed there is also #4158 which rewrites the whole rule to use `SwiftSyntax`, which would be also sufficient to fix the issue. But this PR adds additional test cases for the `async` and `async throws` functions, so I think we can use this fix for now and consider #4158 as a long-term solution, which should hopefully also pass the new tests.

Fixes: #4766
Refs: #4158