### PR TITLE
Add imports for typealias dependencies

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Dictionary+SwiftLint.swift
@@ -103,6 +103,11 @@ public struct SourceKittenDictionary {
         return value["key.typename"] as? String
     }
 
+    /// Type USR.
+    var typeUSR: String? {
+        return value["key.typeusr"] as? String
+    }
+
     /// Documentation length.
     var docLength: ByteCount? {
         return (value["key.doclength"] as? Int64).flatMap(ByteCount.init)

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -273,6 +273,24 @@ private extension SwiftLintFile {
                 )
             }
         }
+
+        if cursorInfo.kind == "source.lang.swift.ref.typealias",
+            let typeUSR = cursorInfo.typeUSR, typeUSR.hasPrefix("$s") {
+            // The format of the string is '$s<N><module>' where N is the length of the module name
+            let moduleNameLength = typeUSR.substring(from: 2).prefix(while: { $0.isNumber })
+            guard let moduleNameLengthInt = Int(moduleNameLength) else {
+                return
+            }
+
+            let moduleName = typeUSR.substring(from: moduleNameLength.count + 2, length: moduleNameLengthInt)
+            usrFragments.insert(moduleName)
+
+            if moduleName == moduleToLog, let filePath = path {
+                queuedPrintError(
+                    "[SWIFTLINT_LOG_MODULE_USAGE] \(moduleName) referenced by USR '\(typeUSR)' in file '\(filePath)'"
+                )
+            }
+        }
     }
 
     /// Returns whether or not the file contains any attributes that require the Foundation module.


### PR DESCRIPTION
Starting with Swift 5.8 there is a warning if you use a typealias that
aliases a type from a module that you don't import. This handles that
case by extracting the module name from the type alias' type.

Example:

```
// Module A
public struct Foo { ... }
```

```
// Module B
import A
public typealias Bar = Foo
```

```
// Module C
import B

func baz(arg: Bar) { ... }
```

In this example module C must now `import A` in order to avoid this
warning.
