### PR TITLE
Include `MODULE.bazel` in bazel release archive

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -79,6 +79,7 @@ filegroup(
 filegroup(
     name = "release_files",
     srcs = [
+        "MODULE.bazel",
         "BUILD",
         "LICENSE",
         "//:LintInputs",


### PR DESCRIPTION
So it can be used with bzlmod.