### PR TITLE
Improved `identifier_name` documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,10 +141,6 @@
 
 * Fix false positives in `attributes` rule when using property wrappers
   with keypath arguments.  
-  [JP Simard](https://github.com/jpsim)
-
-* Fix false positives in `attributes` rule when using property wrappers
-  with keypath arguments.  
   [JP Simard](https://github.com/jpsim)	
 
 ## 0.50.3: Bundle of Towels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@
 * Catch more valid `no_magic_numbers` violations.  
   [JP Simard](https://github.com/jpsim)
 
+* Improve `identifier_name` documentation.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4767](https://github.com/realm/SwiftLint/issues/4767)
+
 #### Bug Fixes
 
 * Report violations in all `<scope>_length` rules when the error threshold is
@@ -138,6 +142,10 @@
 * Fix false positives in `attributes` rule when using property wrappers
   with keypath arguments.  
   [JP Simard](https://github.com/jpsim)
+
+* Fix false positives in `attributes` rule when using property wrappers
+  with keypath arguments.  
+  [JP Simard](https://github.com/jpsim)	
 
 ## 0.50.3: Bundle of Towels
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@
 
 * Fix false positives in `attributes` rule when using property wrappers
   with keypath arguments.  
-  [JP Simard](https://github.com/jpsim)	
+  [JP Simard](https://github.com/jpsim)
 
 ## 0.50.3: Bundle of Towels
 

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRule.swift
@@ -16,7 +16,7 @@ struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
         description: "Identifier names should only contain alphanumeric characters and " +
             "start with a lowercase character or should only contain capital letters. " +
             "In an exception to the above, variable names may start with a capital letter " +
-            "when they are declared static and immutable. Variable names should not be too " +
+            "when they are declared as static. Variable names should not be too " +
             "long or too short.",
         kind: .style,
         nonTriggeringExamples: IdentifierNameRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintFramework/Rules/Style/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IdentifierNameRuleExamples.swift
@@ -13,7 +13,17 @@ internal struct IdentifierNameRuleExamples {
         Example("func == (lhs: SyntaxToken, rhs: SyntaxToken) -> Bool"),
         Example("override func IsOperator(name: String) -> Bool"),
         Example("enum Foo { case `private` }"),
-        Example("enum Foo { case value(String) }")
+        Example("enum Foo { case value(String) }"),
+        Example("""
+                class Foo {
+                   static let Bar = 0
+                }
+                """),
+        Example("""
+                class Foo {
+                   static var Bar = 0
+                }
+                """)
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
Resolves #4767 

I added a few more examples, and removed the reference to `immutable` in the documentation.

It still does seem a bit weird that

`static let Bar = 0` (outside a class) will trigger the identifier_name rule, but that 

```
class Foo {
    static let Bar = 0
}
```

Does not. 



