### PR TITLE
Added include multiline strings option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * Improve `identifier_name` documentation.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4767](https://github.com/realm/SwiftLint/issues/4767)
+
 * Adds `include_multiline_strings` option to `indentation_width` rule.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4248](https://github.com/realm/SwiftLint/issues/4248)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 * Make forceExclude work with directly specified files.  
   [jimmya](https://github.com/jimmya)
-  [#issue_number](https://github.com/realm/SwiftLint/issues/4609)
+  [#4609](https://github.com/realm/SwiftLint/issues/4609)
 
 * Separate analyzer rules as an independent section in the rule directory of
   the reference.  
@@ -86,6 +86,9 @@
 * Improve `identifier_name` documentation.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4767](https://github.com/realm/SwiftLint/issues/4767)
+* Adds `include_multiline_strings` option to `indentation_width` rule.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4248](https://github.com/realm/SwiftLint/issues/4248)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -4,23 +4,27 @@ struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
             + "indentation_width: \(indentationWidth), "
             + "include_comments: \(includeComments), "
             + "include_compiler_directives: \(includeCompilerDirectives)"
+            + "include_multiline_strings: \(includeMultilineStrings)"
     }
 
     private(set) var severityConfiguration: SeverityConfiguration
     private(set) var indentationWidth: Int
     private(set) var includeComments: Bool
     private(set) var includeCompilerDirectives: Bool
+    private(set) var includeMultilineStrings: Bool
 
     init(
         severity: ViolationSeverity,
         indentationWidth: Int,
         includeComments: Bool,
-        includeCompilerDirectives: Bool
+        includeCompilerDirectives: Bool,
+        includeMultilineStrings: Bool
     ) {
         self.severityConfiguration = SeverityConfiguration(severity)
         self.indentationWidth = indentationWidth
         self.includeComments = includeComments
         self.includeCompilerDirectives = includeCompilerDirectives
+        self.includeMultilineStrings = includeMultilineStrings
     }
 
     mutating func apply(configuration: Any) throws {
@@ -42,6 +46,10 @@ struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
 
         if let includeCompilerDirectives = configurationDict["include_compiler_directives"] as? Bool {
             self.includeCompilerDirectives = includeCompilerDirectives
+        }
+        
+        if let includeMultilineStrings = configurationDict["include_multiline_strings"] as? Bool {
+            self.includeMultilineStrings = includeMultilineStrings
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -47,7 +47,7 @@ struct IndentationWidthConfiguration: RuleConfiguration, Equatable {
         if let includeCompilerDirectives = configurationDict["include_compiler_directives"] as? Bool {
             self.includeCompilerDirectives = includeCompilerDirectives
         }
-        
+
         if let includeMultilineStrings = configurationDict["include_multiline_strings"] as? Bool {
             self.includeMultilineStrings = includeMultilineStrings
         }

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -60,9 +60,7 @@ struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
             let indentationCharacterCount = line.content.countOfLeadingCharacters(in: CharacterSet(charactersIn: " \t"))
             if line.content.count == indentationCharacterCount { continue }
 
-            if ignoreComment(line: line, in: file) { continue }
-
-            if ignoreMultilineStrings(line: line, in: file) { continue }
+            if ignoreComment(line: line, in: file) || ignoreMultilineStrings(line: line, in: file) { continue }
 
             // Get space and tab count in prefix
             let prefix = String(line.content.prefix(indentationCharacterCount))
@@ -170,7 +168,7 @@ struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
         }
         return false
     }
-    
+
     private func ignoreMultilineStrings(line: Line, in file: SwiftLintFile) -> Bool {
         if configuration.includeMultilineStrings {
             return false

--- a/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/IndentationWidthRule.swift
@@ -35,7 +35,6 @@ struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
             Example("firstLine\n\tsecondLine\n\t\tthirdLine\n\n\t\tfourthLine"),
             Example("firstLine\n\tsecondLine\n\t\tthirdLine\n\t//test\n\t\tfourthLine"),
             Example("firstLine\n    secondLine\n        thirdLine\nfourthLine")
-//            Example("let x = \"\"\"\nstring1\n    string2\n  string3\n\"\"\"\n")
         ],
         triggeringExamples: [
             Example("↓    firstLine", testMultiByteOffsets: false, testDisableCommand: false),

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -196,12 +196,27 @@ class IndentationWidthRuleTests: XCTestCase {
             """, includeCompilerDirectives: true)
     }
 
+    func testIgnoredMultilineStrings() {
+        assertNoViolation(
+            in: "let x = \"\"\"\nstring1\n    string2\n  string3\n\"\"\"\n",
+            includeMultilineStrings: false
+        )
+        assert1Violation(
+            in: "let x = \"\"\"\nstring1\n    string2\n  string3\n\"\"\"\n"
+        )
+        assertViolations(
+            in: "let x = \"\"\"\nstring1\n    string2\n  string3\n string4\n\"\"\"\n",
+            equals: 2
+        )
+    }
+
     // MARK: Helpers
     private func countViolations(
         in example: Example,
         indentationWidth: Int? = nil,
         includeComments: Bool? = nil,
         includeCompilerDirectives: Bool? = nil,
+        includeMultilineStrings: Bool? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) -> Int {
@@ -214,6 +229,9 @@ class IndentationWidthRuleTests: XCTestCase {
         }
         if let includeCompilerDirectives {
             configDict["include_compiler_directives"] = includeCompilerDirectives
+        }
+        if let includeMultilineStrings {
+            configDict["include_multiline_strings"] = includeMultilineStrings
         }
 
         guard let config = makeConfig(configDict, IndentationWidthRule.description.identifier) else {
@@ -230,6 +248,7 @@ class IndentationWidthRuleTests: XCTestCase {
         indentationWidth: Int? = nil,
         includeComments: Bool? = nil,
         includeCompilerDirectives: Bool? = nil,
+        includeMultilineStrings: Bool? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -239,6 +258,7 @@ class IndentationWidthRuleTests: XCTestCase {
                 indentationWidth: indentationWidth,
                 includeComments: includeComments,
                 includeCompilerDirectives: includeCompilerDirectives,
+                includeMultilineStrings: includeMultilineStrings,
                 file: file,
                 line: line
             ),
@@ -253,6 +273,7 @@ class IndentationWidthRuleTests: XCTestCase {
         indentationWidth: Int? = nil,
         includeComments: Bool? = nil,
         includeCompilerDirectives: Bool? = nil,
+        includeMultilineStrings: Bool? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -262,6 +283,7 @@ class IndentationWidthRuleTests: XCTestCase {
             indentationWidth: indentationWidth,
             includeComments: includeComments,
             includeCompilerDirectives: includeCompilerDirectives,
+            includeMultilineStrings: includeMultilineStrings,
             file: file,
             line: line
         )
@@ -272,6 +294,7 @@ class IndentationWidthRuleTests: XCTestCase {
         indentationWidth: Int? = nil,
         includeComments: Bool? = nil,
         includeCompilerDirectives: Bool? = nil,
+        includeMultilineStrings: Bool? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -281,6 +304,7 @@ class IndentationWidthRuleTests: XCTestCase {
             indentationWidth: indentationWidth,
             includeComments: includeComments,
             includeCompilerDirectives: includeCompilerDirectives,
+            includeMultilineStrings: includeMultilineStrings,
             file: file,
             line: line
         )


### PR DESCRIPTION
Fixes #4248 

Adds an `include_multiline_strings` configuration parameter to the `indentation_width` rule, `true` by default.

If set to false, violations of the `indentation_width` rule within multiline strings will be ignored.

