### PR TITLE
Fix for #4788 - when disabled, `superfluous_disable_command` should not fire, even for invalid rule identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,11 @@
   with keypath arguments.  
   [JP Simard](https://github.com/jpsim)
 
+* Fix for `superfluous_disable_command` not being completely disabled
+  by `disable` commands.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4788](https://github.com/realm/SwiftLint/issues/4788)
+
 ## 0.50.3: Bundle of Towels
 
 #### Breaking

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -332,9 +332,14 @@ public struct CollectedLinter {
             .configuration.customRuleConfigurations.map { RuleIdentifier($0.identifier) } ?? []
         let allRuleIdentifiers = primaryRuleList.allValidIdentifiers().map { RuleIdentifier($0) }
         let allValidIdentifiers = Set(allCustomIdentifiers + allRuleIdentifiers + [.all])
+        let superfluousRuleIdentifier = RuleIdentifier(SuperfluousDisableCommandRule.description.identifier)
 
         return regions.flatMap { region in
-            region.disabledRuleIdentifiers.filter({ !allValidIdentifiers.contains($0) }).map { id in
+            region.disabledRuleIdentifiers.filter({
+                !allValidIdentifiers.contains($0) &&
+                !region.disabledRuleIdentifiers.contains(.all) &&
+                !region.disabledRuleIdentifiers.contains(superfluousRuleIdentifier)
+            }).map { id in
                 return StyleViolation(
                     ruleDescription: type(of: superfluousDisableCommandRule).description,
                     severity: superfluousDisableCommandRule.configuration.severity,

--- a/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
@@ -11,7 +11,17 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKi
             SwiftLint 'disable' commands are superfluous when the disabled rule would not have triggered a violation \
             in the disabled region. Use " - " if you wish to document a command.
             """,
-        kind: .lint
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+            // swiftlint:disable all
+            // swiftlint:disable non_existent_rule_name
+            """),
+            Example("""
+            // swiftlint:disable superfluous_disable_command
+            // swiftlint:disable non_existent_rule_name
+            """)
+        ]
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {

--- a/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/SuperfluousDisableCommandRule.swift
@@ -11,17 +11,7 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKi
             SwiftLint 'disable' commands are superfluous when the disabled rule would not have triggered a violation \
             in the disabled region. Use " - " if you wish to document a command.
             """,
-        kind: .lint,
-        nonTriggeringExamples: [
-            Example("""
-            // swiftlint:disable all
-            // swiftlint:disable non_existent_rule_name
-            """),
-            Example("""
-            // swiftlint:disable superfluous_disable_command
-            // swiftlint:disable non_existent_rule_name
-            """)
-        ]
+        kind: .lint
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 import SourceKittenFramework
 @_spi(TestHelper)
@@ -391,14 +392,17 @@ class CommandTests: XCTestCase {
             []
         )
     }
-    
+
     func testSuperfluousDisableCommandsDisabledWhenAllRulesDisabled() {
         XCTAssertEqual(
             violations(Example("// swiftlint:disable all\n// swiftlint:disable non_existent_rule_name\n")),
             []
         )
         XCTAssertEqual(
-            violations(Example("// swiftlint:disable superfluous_disable_command\n// swiftlint:disable non_existent_rule_name\n")),
+            violations(Example(
+                "// swiftlint:disable superfluous_disable_command\n" +
+                "// swiftlint:disable non_existent_rule_name\n"
+            )),
             []
         )
     }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -395,7 +395,10 @@ class CommandTests: XCTestCase {
 
     func testSuperfluousDisableCommandsDisabledWhenAllRulesDisabled() {
         XCTAssertEqual(
-            violations(Example("// swiftlint:disable all\n// swiftlint:disable non_existent_rule_name\n")),
+            violations(Example("""
+                // swiftlint:disable all
+                // swiftlint:disable non_existent_rule_name
+            """)),
             []
         )
         XCTAssertEqual(

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -396,9 +396,10 @@ class CommandTests: XCTestCase {
     func testSuperfluousDisableCommandsDisabledWhenAllRulesDisabled() {
         XCTAssertEqual(
             violations(Example("""
-                // swiftlint:disable all
-                // swiftlint:disable non_existent_rule_name
-            """)),
+                               // swiftlint:disable all
+                               // swiftlint:disable non_existent_rule_name
+                               """
+            )),
             []
         )
         XCTAssertEqual(

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -391,4 +391,15 @@ class CommandTests: XCTestCase {
             []
         )
     }
+    
+    func testSuperfluousDisableCommandsDisabledWhenAllRulesDisabled() {
+        XCTAssertEqual(
+            violations(Example("// swiftlint:disable all\n// swiftlint:disable non_existent_rule_name\n")),
+            []
+        )
+        XCTAssertEqual(
+            violations(Example("// swiftlint:disable superfluous_disable_command\n// swiftlint:disable non_existent_rule_name\n")),
+            []
+        )
+    }
 }


### PR DESCRIPTION
Fixes #4788

When `superfluous_disable_command` is disabled, it should not fire, even for invalid rule identifiers.

Also fixes #4798 for Aerial - see the `This PR fixed a violation in Aerial` messages below, but only accidentally. See #4799 for more details, and a proper fix for #4798
