### PR TITLE
Fix/improve command parsing in multiline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
+
 * Fix false positives for superfluous_disable_command, and improved
   command parsing in multiline strings.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,10 @@
   by `disable` commands.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4788](https://github.com/realm/SwiftLint/issues/4788)
+* Fix false positives for superfluous_disable_command, and improved
+  command parsing in multiline strings.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Fixed correction for `trailing_comma` rule wrongly removing trailing
   comments.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@
   by `disable` commands.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4788](https://github.com/realm/SwiftLint/issues/4788)
+
 * Fix false positives for superfluous_disable_command, and improved
   command parsing in multiline strings.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@
 
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
+* Fix false positives for superfluous_disable_command, and improved
+  command parsing in multiline strings.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Do not trigger `reduce_boolean` on `reduce` methods with a first named
   argument that is different from `into`.  
@@ -253,11 +257,6 @@
   by `disable` commands.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4788](https://github.com/realm/SwiftLint/issues/4788)
-
-* Fix false positives for superfluous_disable_command, and improved
-  command parsing in multiline strings.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Fixed correction for `trailing_comma` rule wrongly removing trailing
   comments.  

--- a/Source/SwiftLintCore/Visitors/CommandVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/CommandVisitor.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftSyntax
 
 // MARK: - CommandVisitor
@@ -37,11 +36,12 @@ private extension TriviaPiece {
             }
         case .blockComment(let comment):
             if let lower = comment.range(of: commandString)?.lowerBound {
-                var contentsEnd: Int = 0
-                let location = comment.distance(from: comment.startIndex, to: lower)
-                let range = NSRange(location: location, length: commandString.count)
-                (comment as NSString).getLineStart(nil, end: nil, contentsEnd: &contentsEnd, for: range)
-                let actionString = comment[lower..<comment.index(comment.startIndex, offsetBy: contentsEnd)]
+                var start = comment.startIndex
+                var end = comment.startIndex
+                var contentsEnd = comment.startIndex
+                let endOfCommand = comment.index(lower, offsetBy: commandString.count)
+                comment.getLineStart(&start, end: &end, contentsEnd: &contentsEnd, for: lower..<endOfCommand)
+                let actionString = comment[lower..<contentsEnd]
                 return String(actionString)
             }
         default:

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -15,6 +15,7 @@ private extension Command {
 }
 
 class CommandTests: SwiftLintTestCase {
+// swiftlint:disable:next type_body_length
     // MARK: Command Creation
 
     func testNoCommandsInEmptyFile() {
@@ -447,7 +448,7 @@ class CommandTests: SwiftLintTestCase {
         XCTAssertEqual(violations(
             Example("""
                     /*
-                        // swiftlint:disable identifier_name
+                        // swiftlint:disable:next identifier_name
                         let a = 0
                     */
                     let a = 0

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -427,7 +427,7 @@ class CommandTests: SwiftLintTestCase {
                                // swiftlint:enable non_existent_rule_name
                                // swiftlint:enable all
                                """
-            )),
+                              )),
             []
         )
         XCTAssertEqual(
@@ -439,6 +439,21 @@ class CommandTests: SwiftLintTestCase {
 
                                """
             )),
+            []
+        )
+    }
+
+    func testSuperfluousDisableCommandsInMultilineComments() {
+        XCTAssertEqual(violations(
+            Example("""
+                    /*
+                        // swiftlint:disable identifier_name
+                        let a = 0
+                    */
+                    let a = 0
+                    
+                    """)
+            ),
             []
         )
     }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -14,8 +14,8 @@ private extension Command {
     }
 }
 
-class CommandTests: SwiftLintTestCase {
 // swiftlint:disable:next type_body_length
+class CommandTests: SwiftLintTestCase {
     // MARK: Command Creation
 
     func testNoCommandsInEmptyFile() {

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -451,7 +451,7 @@ class CommandTests: SwiftLintTestCase {
                         let a = 0
                     */
                     let a = 0
-                    
+
                     """)
             ),
             []


### PR DESCRIPTION

Fixes #4798 

The easiest fix for this problem would be to ignore commands in block comments. With both the existing code, and with the changes proposed here, only the first command within a block comment will be detected in any case.

I guess there could be some people relying on commands working in block comments, and dropping that would definitely be a breaking change for them.

What I've done here is, in block comments, is to only parse the command up to the end of the line, instead of up to the end of the block comment, which preserves the current behaviour without the bugs.

I used the annoyingly verbose Swift String getLineStart() API to get the end of the lines while accounting for all possible line separators, but there is probably a better way to do that.

Of course, if we can just drop block comment support altogether, this PR would be a lot lot simpler ...

