### PR TITLE
Remove unused _SwiftSyntaxMacros library

### DIFF
--- a/bazel/SwiftSyntax.BUILD
+++ b/bazel/SwiftSyntax.BUILD
@@ -90,18 +90,6 @@ swift_library(
 )
 
 swift_library(
-    name = "_SwiftSyntaxMacros",
-    srcs = glob(["Sources/_SwiftSyntaxMacros/**/*.swift"]),
-    module_name = "_SwiftSyntaxMacros",
-    deps = [
-        ":SwiftDiagnostics",
-        ":SwiftParser",
-        ":SwiftSyntax",
-        ":SwiftSyntaxBuilder",
-    ],
-)
-
-swift_library(
     name = "IDEUtils",
     srcs = glob(["Sources/IDEUtils/**/*.swift"]),
     module_name = "IDEUtils",


### PR DESCRIPTION
This one was actually renamed to not have the underscore but it's not
used so we might as well drop it.
