### PR TITLE
Breaking change: Drop support for disable/enable command parsing in multiline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,9 @@
   to `false.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4843](https://github.com/realm/SwiftLint/issues/4843)
+* Removed support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * The internal module structure for SwiftLint has changed to split the
   monolithic `SwiftLintFramework` into new `SwiftLintCore` for core linter
@@ -466,10 +469,6 @@
   contain characters that must be escaped in regular expression.  
   [Moly](https://github.com/kyounh12)
   [#4655](https://github.com/realm/SwiftLint/pull/4655)
-
-* Removed support for disable and enable commands in multiline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 #### Experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -465,8 +465,8 @@
   At the same time, make it an opt-in rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4615](https://github.com/realm/SwiftLint/issues/4615)
-  
-* Interpret strings in `excluded` option of `identifier_name`, 
+
+* Interpret strings in `excluded` option of `identifier_name`,
   `type_name` and `generic_type_name` rules as regular expression. Existing
   configurations should remain working without notice as long as they don't
   contain characters that must be escaped in regular expression.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,10 @@
   declarations in classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5009](https://github.com/realm/SwiftLint/issues/5009)
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Do not trigger `prefer_self_in_static_references` rule on collection types in
   classes, but on initializers like `[C]()` in all types.  
@@ -332,10 +336,6 @@
 * Fix Bazel release tarball for compiling on macOS.  
   [JP Simard](https://github.com/jpsim)
   [#4985](https://github.com/realm/SwiftLint/issues/4985)
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 ## 0.52.0: Crisp Clear Pleats
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,9 @@
 
 #### Breaking
 
-* None.
+* Removed support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 #### Experimental
 
@@ -330,6 +332,10 @@
 * Fix Bazel release tarball for compiling on macOS.  
   [JP Simard](https://github.com/jpsim)
   [#4985](https://github.com/realm/SwiftLint/issues/4985)
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 ## 0.52.0: Crisp Clear Pleats
 
@@ -343,10 +349,6 @@
   to `false.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4843](https://github.com/realm/SwiftLint/issues/4843)
-
-* Removed support for disable and enable commands in multiline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * The internal module structure for SwiftLint has changed to split the
   monolithic `SwiftLintFramework` into new `SwiftLintCore` for core linter
@@ -435,11 +437,6 @@
 
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
-
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Do not trigger `reduce_boolean` on `reduce` methods with a first named
   argument that is different from `into`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -635,6 +635,10 @@
   by `disable` commands.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4788](https://github.com/realm/SwiftLint/issues/4788)
+* Fix false positives for superfluous_disable_command, and improved
+  command parsing in multiline strings.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Fixed correction for `trailing_comma` rule wrongly removing trailing
   comments.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,16 +133,16 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5171](https://github.com/realm/SwiftLint/issues/5171)
 
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multiline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
-
 * The `accessibility_label_for_image` rule will no longer ignore the
   `Image(systemName:)` constructor, as many system images do not
   have good accessibility labels.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5165](https://github.com/realm/SwiftLint/issues/5165)
+
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 ## 0.52.4: Lid Switch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@
   declarations in classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5009](https://github.com/realm/SwiftLint/issues/5009)
+
 * Fix false positives for superfluous_disable_command, and removed
   support for disable and enable commands in multline comments.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
   operations.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5171](https://github.com/realm/SwiftLint/issues/5171)
+
 * Fix false positives for superfluous_disable_command, and removed
   support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,7 @@
 
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
+
 * Fix false positives for superfluous_disable_command, and removed
   support for disable and enable commands in multline comments.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@
   trailing comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5081](https://github.com/realm/SwiftLint/issues/5081)
+
 * Fix false positives for superfluous_disable_command, and removed
   support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,7 @@
   to `false.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4843](https://github.com/realm/SwiftLint/issues/4843)
+
 * Removed support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
@@ -403,7 +404,7 @@
   subclasses.  
   [AndrewDMontgomery](https://github.com/andrewdmontgomery)
   [#4875](https://github.com/realm/SwiftLint/pull/4875)
-  
+
 * Prepend `warning: ` to error messages so that they show in Xcode.  
   [whiteio](https://github.com/whiteio)
   [#4923](https://github.com/realm/SwiftLint/issues/4923)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,10 @@
   trailing comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5081](https://github.com/realm/SwiftLint/issues/5081)
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Fix false positives for the `private_subject` rule when creating subjects
   inside initializers.  
@@ -265,11 +269,6 @@
   a predicate.  
   [woxtu](https://github.com/woxtu)
   [#3023](https://github.com/realm/SwiftLint/issues/3023)
-
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multiline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Work around dyld warning about duplicate SwiftSyntax classes with Xcode 15
   betas.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,15 +245,6 @@
   declarations in classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5009](https://github.com/realm/SwiftLint/issues/5009)
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
-
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Do not trigger `prefer_self_in_static_references` rule on collection types in
   classes, but on initializers like `[C]()` in all types.  
@@ -274,8 +265,9 @@
   a predicate.  
   [woxtu](https://github.com/woxtu)
   [#3023](https://github.com/realm/SwiftLint/issues/3023)
+
 * Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multiline comments.  
+  support for disable and enable commands in multline comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
@@ -415,7 +407,7 @@
   subclasses.  
   [AndrewDMontgomery](https://github.com/andrewdmontgomery)
   [#4875](https://github.com/realm/SwiftLint/pull/4875)
-
+  
 * Prepend `warning: ` to error messages so that they show in Xcode.  
   [whiteio](https://github.com/whiteio)
   [#4923](https://github.com/realm/SwiftLint/issues/4923)
@@ -474,8 +466,8 @@
   At the same time, make it an opt-in rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4615](https://github.com/realm/SwiftLint/issues/4615)
-
-* Interpret strings in `excluded` option of `identifier_name`,
+  
+* Interpret strings in `excluded` option of `identifier_name`, 
   `type_name` and `generic_type_name` rules as regular expression. Existing
   configurations should remain working without notice as long as they don't
   contain characters that must be escaped in regular expression.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   supported but is deprecated. It's recommended to use the list
   `test_parent_classes` instead which accepts names of parent test classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
+
 * Removed support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
@@ -110,11 +111,6 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5120](https://github.com/realm/SwiftLint/issues/5120)
 
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multiline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
-
 * Fix some unexpected rule enablement interactions between parent and
   child configurations.  
   [Martin Redington](https://github.com/mildm8nnered)
@@ -136,6 +132,10 @@
   operations.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5171](https://github.com/realm/SwiftLint/issues/5171)
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * The `accessibility_label_for_image` rule will no longer ignore the
   `Image(systemName:)` constructor, as many system images do not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   `test_parent_classes` instead which accepts names of parent test classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
-* Removed support for disable and enable commands in multiline comments.  
+* Remove support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
@@ -139,8 +139,7 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5165](https://github.com/realm/SwiftLint/issues/5165)
 
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multiline comments.  
+* Fix false positives for `superfluous_disable_command` rule.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   supported but is deprecated. It's recommended to use the list
   `test_parent_classes` instead which accepts names of parent test classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
+* Removed support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 #### Experimental
 
@@ -106,6 +109,10 @@
   for nested structs in classes.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5120](https://github.com/realm/SwiftLint/issues/5120)
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Fix some unexpected rule enablement interactions between parent and
   child configurations.  
@@ -139,9 +146,7 @@
 
 #### Breaking
 
-* Removed support for disable and enable commands in multiline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
+* None.
 
 #### Experimental
 
@@ -174,11 +179,6 @@
   trailing comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5081](https://github.com/realm/SwiftLint/issues/5081)
-
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multiline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Fix false positives for the `private_subject` rule when creating subjects
   inside initializers.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,10 @@
   declarations in classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5009](https://github.com/realm/SwiftLint/issues/5009)
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Fix false positives for superfluous_disable_command, and removed
   support for disable and enable commands in multline comments.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,7 @@
   [#3023](https://github.com/realm/SwiftLint/issues/3023)
 
 * Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multline comments.  
+  support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,6 +467,10 @@
   [Moly](https://github.com/kyounh12)
   [#4655](https://github.com/realm/SwiftLint/pull/4655)
 
+* Removed support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
+
 #### Experimental
 
 * None.
@@ -637,6 +641,8 @@
   [#4788](https://github.com/realm/SwiftLint/issues/4788)
 * Fix false positives for superfluous_disable_command, and improved
   command parsing in multiline strings.  
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multline comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,10 @@
 
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Do not trigger `reduce_boolean` on `reduce` methods with a first named
   argument that is different from `into`.  
@@ -638,11 +642,6 @@
   by `disable` commands.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4788](https://github.com/realm/SwiftLint/issues/4788)
-
-* Fix false positives for superfluous_disable_command, and removed
-  support for disable and enable commands in multline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Fixed correction for `trailing_comma` rule wrongly removing trailing
   comments.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,10 @@
   a predicate.  
   [woxtu](https://github.com/woxtu)
   [#3023](https://github.com/realm/SwiftLint/issues/3023)
+* Fix false positives for superfluous_disable_command, and removed
+  support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 * Work around dyld warning about duplicate SwiftSyntax classes with Xcode 15
   betas.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -639,8 +639,7 @@
   by `disable` commands.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4788](https://github.com/realm/SwiftLint/issues/4788)
-* Fix false positives for superfluous_disable_command, and improved
-  command parsing in multiline strings.  
+
 * Fix false positives for superfluous_disable_command, and removed
   support for disable and enable commands in multline comments.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
   for nested structs in classes.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5120](https://github.com/realm/SwiftLint/issues/5120)
+
 * Fix false positives for superfluous_disable_command, and removed
   support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/Source/SwiftLintCore/Visitors/CommandVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/CommandVisitor.swift
@@ -30,7 +30,7 @@ private extension Trivia {
         for trivia in self {
             triviaOffset += trivia.sourceLength
             switch trivia {
-            case .lineComment(let comment), .blockComment(let comment):
+            case .lineComment(let comment):
                 guard let lower = comment.range(of: "swiftlint:")?.lowerBound else {
                     break
                 }

--- a/Source/SwiftLintCore/Visitors/CommandVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/CommandVisitor.swift
@@ -30,7 +30,7 @@ private extension Trivia {
         for trivia in self {
             triviaOffset += trivia.sourceLength
             switch trivia {
-            case .lineComment(let comment):
+            case .lineComment(let comment), .blockComment(let comment):
                 guard let lower = comment.range(of: "swiftlint:")?.lowerBound else {
                     break
                 }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -461,8 +461,7 @@ class CommandTests: SwiftLintTestCase {
                         // swiftlint:disable identifier_name
                         let a = 0
                     */
-                    let a = 0
-
+                    
                     """)
             ),
 >>>>>>> cba23a55e (Whitespace change)

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -461,7 +461,7 @@ class CommandTests: SwiftLintTestCase {
                         // swiftlint:disable identifier_name
                         let a = 0
                     */
-                    
+
                     """)
             ),
 >>>>>>> cba23a55e (Whitespace change)

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -363,8 +363,6 @@ class CommandTests: SwiftLintTestCase {
             violations(Example("print(123)\n// swiftlint:disable:previous nesting_foo\n"))[0].reason,
             "'nesting_foo' is not a valid SwiftLint rule; remove it from the disable command"
         )
-
-        XCTAssertEqual(violations(Example("/* swiftlint:disable nesting */\n")).count, 2)
     }
 
     func testSuperfluousDisableCommandsDisabled() {
@@ -439,32 +437,6 @@ class CommandTests: SwiftLintTestCase {
 
                                """
             )),
-            []
-        )
-    }
-
-    func testSuperfluousDisableCommandsInMultilineComments() {
-<<<<<<< HEAD
-        XCTAssertEqual(
-            violations(Example("""
-                               /*
-                               // swiftlint:disable identifier_name
-                               let a = 0
-                               */
-
-                               """
-            )),
-=======
-        XCTAssertEqual(violations(
-            Example("""
-                    /*
-                        // swiftlint:disable identifier_name
-                        let a = 0
-                    */
-
-                    """)
-            ),
->>>>>>> cba23a55e (Whitespace change)
             []
         )
     }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -440,4 +440,18 @@ class CommandTests: SwiftLintTestCase {
             []
         )
     }
+
+    func testSuperfluousDisableCommandsInMultilineComments() {
+        XCTAssertEqual(
+            violations(Example("""
+                               /*
+                               // swiftlint:disable identifier_name
+                               let a = 0
+                               */
+
+                               """
+            )),
+            []
+        )
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -14,6 +14,7 @@ private extension Command {
     }
 }
 
+// swiftlint:disable:next type_body_length
 class CommandTests: SwiftLintTestCase {
     // MARK: Command Creation
 

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -444,6 +444,7 @@ class CommandTests: SwiftLintTestCase {
     }
 
     func testSuperfluousDisableCommandsInMultilineComments() {
+<<<<<<< HEAD
         XCTAssertEqual(
             violations(Example("""
                                /*
@@ -453,6 +454,18 @@ class CommandTests: SwiftLintTestCase {
 
                                """
             )),
+=======
+        XCTAssertEqual(violations(
+            Example("""
+                    /*
+                        // swiftlint:disable identifier_name
+                        let a = 0
+                    */
+                    let a = 0
+
+                    """)
+            ),
+>>>>>>> cba23a55e (Whitespace change)
             []
         )
     }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -442,4 +442,18 @@ class CommandTests: SwiftLintTestCase {
             []
         )
     }
+
+    func testSuperfluousDisableCommandsInMultilineComments() {
+        XCTAssertEqual(
+            violations(Example("""
+                               /*
+                               // swiftlint:disable identifier_name
+                               let a = 0
+                               */
+
+                               """
+            )),
+            []
+        )
+    }
 }


### PR DESCRIPTION
This PR drops support for `swiftlint:disable` and `enable` commands in multiline comments, and resolves #4798 

Command parsing is broken in multi-line comments (see for example #4798).

It would be possible to fix that particular issue (see #4799), but I think there are enough problems with commands in multi-line comments, that it is probably easier just to drop support for them completely.

1. In a multi-line comment, only the first command will be processed. later commands will be ignored. #4799 does not resolve this.

2. Only the single line comment form is documented in the README (I did consider adding a line to the README explicitly saying multi-line comments are not supported, and still may do that).

3. If disable commands in multiline comments did actually work (beyond the first one), they would just trigger a lot of `superfluous_disable_command` hits, as whatever they're suppressing would most likely not be triggering.

4. block commenting out a bunch of code is not great, but is something that people probably do a lot in real life, and they should be able to do that and just forget about it (for a while).

5. Even though it is a breaking change, for anyone relying on disable commands working in multi-line comments, it will be obvious immediately that this has happened if they also have `superfluous_disable_command` enabled.


