### PR TITLE
Add example verifying that `trailing_semicolon` works with trailing comments

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -16,7 +16,8 @@ struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule, ConfigurationProviderR
         ],
         triggeringExamples: [
             Example("let a = 0↓;\n"),
-            Example("let a = 0↓;\nlet b = 1\n")
+            Example("let a = 0↓;\nlet b = 1\n"),
+            Example("let a = 0↓; // a comment\n")
         ],
         corrections: [
             Example("let a = 0↓;\n"): Example("let a = 0\n"),


### PR DESCRIPTION
This proofs #3217 to be resolved which was fixed by #4296.