### PR TITLE
Fix for `trailing_semicolon` rule wrongly also removing trailing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4788](https://github.com/realm/SwiftLint/issues/4788)
 
+* Fixed correction for `trailing_comma` rule wrongly removing trailing
+  comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4814](https://github.com/realm/SwiftLint/issues/4814)
+
 ## 0.50.3: Bundle of Towels
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -66,7 +66,6 @@ private extension TrailingSemicolonRule {
             }
 
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-            // Keep the trailing trivia
             return ("" as TokenSyntax).with(\.trailingTrivia, node.trailingTrivia ?? .zero)
         }
     }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -66,7 +66,7 @@ private extension TrailingSemicolonRule {
             }
 
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-            return ("" as TokenSyntax).with(\.trailingTrivia, node.trailingTrivia ?? .zero)
+            return .unknown("").with(\.trailingTrivia, node.trailingTrivia ?? .zero)
         }
     }
 }

--- a/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -21,7 +21,8 @@ struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule, ConfigurationProviderR
         ],
         corrections: [
             Example("let a = 0↓;\n"): Example("let a = 0\n"),
-            Example("let a = 0↓;\nlet b = 1\n"): Example("let a = 0\nlet b = 1\n")
+            Example("let a = 0↓;\nlet b = 1\n"): Example("let a = 0\nlet b = 1\n"),
+            Example("let foo = 12↓;  // comment\n"): Example("let foo = 12  // comment\n")
         ]
     )
 
@@ -65,8 +66,8 @@ private extension TrailingSemicolonRule {
             }
 
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-            // Is there a better way to remove a node? Should we somehow keep trailing trivia?
-            return super.visit(TokenSyntax(.semicolon, presence: .missing))
+            // Keep the trailing trivia
+            return ("" as TokenSyntax).with(\.trailingTrivia, node.trailingTrivia ?? .zero)
         }
     }
 }


### PR DESCRIPTION
Resolves #4817

When replacing the semi-colon, preserve the trailing trivia.

Ironically, the original comment read 

`// Is there a better way to remove a node? Should we somehow keep trailing trivia?`
