### PR TITLE
Fix crash when parsing apple/swift

### DIFF
--- a/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -66,7 +66,7 @@ private extension GenericTypeNameRule {
 
         override func visitPost(_ node: GenericParameterSyntax) {
             let name = node.name.text
-            guard !configuration.shouldExclude(name: name) else { return }
+            guard !name.isEmpty, !configuration.shouldExclude(name: name) else { return }
 
             let allowedSymbols = configuration.allowedSymbols.union(.alphanumerics)
             if !allowedSymbols.isSuperset(of: CharacterSet(charactersIn: name)) {


### PR DESCRIPTION

Fixes #4827

With especially funky files (e.g. Apple's test cases for issues that formerly crashed the compiler), `name` could end up being empty, which means that `name[name.startIndex]` will instantly crash.
