### PR TITLE
Added default.profraw, and deleted obsolete instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Xcode
 #
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
 ## Build generated
 build/
@@ -22,6 +21,7 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+default.profraw
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION

I have code-coverage enabled locally, and it's really annoying to always see `default.profraw` show up in git

At the top of `.gitignore`, there were the following instructions:

`gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore`

I couldn't find any other `*.gitignore` in the tree, so I assume that instruction is obsolete, and have removed it.
