### PR TITLE
Add a reporters subcommand

### DIFF
--- a/.sourcery/ReportersList.stencil
+++ b/.sourcery/ReportersList.stencil
@@ -1,7 +1,6 @@
 
 /// The reporters list containing all the reporters built into SwiftLint.
 public let reportersList: [Reporter.Type] = [
-public let reportersList: [Reporter.Type] = [
 {% for reporter in types.structs where reporter.name|hasSuffix:"Reporter" %}
     {{ reporter.name }}.self{% if not forloop.last %},{% endif %}
 {% endfor %}

--- a/.sourcery/ReportersList.stencil
+++ b/.sourcery/ReportersList.stencil
@@ -1,0 +1,5 @@
+
+/// The reporters list containing all the reporters built into SwiftLint.
+public let reportersList: [Reporter.Type] = [
+{% for reporter in types.structs where reporter.name|hasSuffix:"Reporter" %}    {{ reporter.name }}.self{% if not forloop.last %},{% endif %}
+{% endfor %}]

--- a/.sourcery/ReportersList.stencil
+++ b/.sourcery/ReportersList.stencil
@@ -1,5 +1,8 @@
 
 /// The reporters list containing all the reporters built into SwiftLint.
 public let reportersList: [Reporter.Type] = [
-{% for reporter in types.structs where reporter.name|hasSuffix:"Reporter" %}    {{ reporter.name }}.self{% if not forloop.last %},{% endif %}
-{% endfor %}]
+public let reportersList: [Reporter.Type] = [
+{% for reporter in types.structs where reporter.name|hasSuffix:"Reporter" %}
+    {{ reporter.name }}.self{% if not forloop.last %},{% endif %}
+{% endfor %}
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,11 @@
   of each rule in a text table.  
   [Martin Redington](https://github.com/mildm8nnered)
 
+* Adds a new `reporters` subcommand, to improve discoverability of
+  reporters.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4819](https://github.com/realm/SwiftLint/issues/4819)
+
 #### Bug Fixes
 
 * Report violations in all `<scope>_length` rules when the error threshold is

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,15 @@ VERSION_STRING=$(shell ./tools/get-version)
 
 all: build
 
-sourcery: Source/SwiftLintFramework/Models/PrimaryRuleList.swift Tests/GeneratedTests/GeneratedTests.swift
+sourcery: Source/SwiftLintFramework/Models/PrimaryRuleList.swift Source/SwiftLintFramework/Models/ReportersList.swift Tests/GeneratedTests/GeneratedTests.swift
 
 Source/SwiftLintFramework/Models/PrimaryRuleList.swift: Source/SwiftLintFramework/Rules/**/*.swift .sourcery/PrimaryRuleList.stencil
 	sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/PrimaryRuleList.stencil --output .sourcery
 	mv .sourcery/PrimaryRuleList.generated.swift Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+
+Source/SwiftLintFramework/Models/ReportersList.swift: Source/SwiftLintFramework/Rules/*.swift .sourcery/ReportersList.stencil
+	sourcery --sources Source/SwiftLintFramework/Reporters --templates .sourcery/ReportersList.stencil --output .sourcery
+	mv .sourcery/ReportersList.generated.swift Source/SwiftLintFramework/Models/ReportersList.swift
 
 Tests/GeneratedTests/GeneratedTests.swift: Source/SwiftLintFramework/Rules/**/*.swift .sourcery/GeneratedTests.stencil
 	sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/GeneratedTests.stencil --output .sourcery

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ Source/SwiftLintFramework/Models/PrimaryRuleList.swift: Source/SwiftLintFramewor
 	sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/PrimaryRuleList.stencil --output .sourcery
 	mv .sourcery/PrimaryRuleList.generated.swift Source/SwiftLintFramework/Models/PrimaryRuleList.swift
 
-Source/SwiftLintFramework/Models/ReportersList.swift: Source/SwiftLintFramework/Rules/*.swift .sourcery/ReportersList.stencil
+Source/SwiftLintFramework/Models/ReportersList.swift: Source/SwiftLintFramework/Reporters/*.swift .sourcery/ReportersList.stencil
 	sourcery --sources Source/SwiftLintFramework/Reporters --templates .sourcery/ReportersList.stencil --output .sourcery
 	mv .sourcery/ReportersList.generated.swift Source/SwiftLintFramework/Models/ReportersList.swift
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ SUBCOMMANDS:
   docs                    Open SwiftLint documentation website in the default web browser
   generate-docs           Generates markdown documentation for all rules
   lint (default)          Print lint warnings and errors
+  reporters               Display the list of reporters and their identifiers
   rules                   Display the list of rules and their identifiers
   version                 Display the current version of SwiftLint
 

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ identifier_name:
     - id
     - URL
     - GlobalAPIKey
-reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging)
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging, summary)
 ```
 
 You can also use environment variables in your configuration file,

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 /// The rule list containing all available rules built into SwiftLint.

--- a/Source/SwiftLintFramework/Models/ReportersList.swift
+++ b/Source/SwiftLintFramework/Models/ReportersList.swift
@@ -15,5 +15,6 @@ public let reportersList: [Reporter.Type] = [
     MarkdownReporter.self,
     RelativePathReporter.self,
     SonarQubeReporter.self,
+    SummaryReporter.self,
     XcodeReporter.self
 ]

--- a/Source/SwiftLintFramework/Models/ReportersList.swift
+++ b/Source/SwiftLintFramework/Models/ReportersList.swift
@@ -1,0 +1,19 @@
+// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+/// The reporters list containing all the reporters built into SwiftLint.
+public let reportersList: [Reporter.Type] = [
+    CSVReporter.self,
+    CheckstyleReporter.self,
+    CodeClimateReporter.self,
+    EmojiReporter.self,
+    GitHubActionsLoggingReporter.self,
+    GitLabJUnitReporter.self,
+    HTMLReporter.self,
+    JSONReporter.self,
+    JUnitReporter.self,
+    MarkdownReporter.self,
+    RelativePathReporter.self,
+    SonarQubeReporter.self,
+    XcodeReporter.self
+]

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -1,11 +1,14 @@
 /// An interface for reporting violations as strings.
-public protocol Reporter: CustomStringConvertible {
+public protocol Reporter {
     /// The unique identifier for this reporter.
     static var identifier: String { get }
 
     /// Whether or not this reporter can output incrementally as violations are found or if all violations must be
     /// collected before generating the report.
     static var isRealtime: Bool { get }
+
+    /// A more detailed description of the reporter's output.
+    static var description: String { get }
 
     /// Return a string with the report for the specified violations.
     ///

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -10,7 +10,7 @@ public protocol Reporter: CustomStringConvertible {
     /// A more detailed description of the reporter's output.
     static var description: String { get }
 
-    /// For CustomStringConvertible conformance
+    /// For CustomStringConvertible conformance.
     var description: String { get }
 
     /// Return a string with the report for the specified violations.
@@ -22,6 +22,7 @@ public protocol Reporter: CustomStringConvertible {
 }
 
 public extension Reporter {
+    // For CustomStringConvertible conformance.
     var description: String { Self.description }
 }
 

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -31,37 +31,9 @@ public extension Reporter {
 /// - parameter identifier: The identifier corresponding to the reporter.
 ///
 /// - returns: The reporter type.
-public func reporterFrom(identifier: String) -> Reporter.Type { // swiftlint:disable:this cyclomatic_complexity
-    switch identifier {
-    case XcodeReporter.identifier:
-        return XcodeReporter.self
-    case JSONReporter.identifier:
-        return JSONReporter.self
-    case CSVReporter.identifier:
-        return CSVReporter.self
-    case CheckstyleReporter.identifier:
-        return CheckstyleReporter.self
-    case JUnitReporter.identifier:
-        return JUnitReporter.self
-    case HTMLReporter.identifier:
-        return HTMLReporter.self
-    case EmojiReporter.identifier:
-        return EmojiReporter.self
-    case SonarQubeReporter.identifier:
-        return SonarQubeReporter.self
-    case MarkdownReporter.identifier:
-        return MarkdownReporter.self
-    case GitHubActionsLoggingReporter.identifier:
-        return GitHubActionsLoggingReporter.self
-    case GitLabJUnitReporter.identifier:
-        return GitLabJUnitReporter.self
-    case CodeClimateReporter.identifier:
-        return CodeClimateReporter.self
-    case RelativePathReporter.identifier:
-        return RelativePathReporter.self
-    case SummaryReporter.identifier:
-        return SummaryReporter.self
-    default:
+public func reporterFrom(identifier: String) -> Reporter.Type {
+    guard let reporter = reportersList.first(where: { $0.identifier == identifier }) else {
         queuedFatalError("no reporter with identifier '\(identifier)' available.")
     }
+    return reporter
 }

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -1,5 +1,5 @@
 /// An interface for reporting violations as strings.
-public protocol Reporter {
+public protocol Reporter: CustomStringConvertible {
     /// The unique identifier for this reporter.
     static var identifier: String { get }
 
@@ -10,12 +10,19 @@ public protocol Reporter {
     /// A more detailed description of the reporter's output.
     static var description: String { get }
 
+    /// For CustomStringConvertible conformance
+    var description: String { get }
+
     /// Return a string with the report for the specified violations.
     ///
     /// - parameter violations: The violations to report.
     ///
     /// - returns: The report.
     static func generateReport(_ violations: [StyleViolation]) -> String
+}
+
+public extension Reporter {
+    var description: String { Self.description }
 }
 
 /// Returns the reporter with the specified identifier. Traps if the specified identifier doesn't correspond to any

--- a/Source/SwiftLintFramework/Protocols/Reporter.swift
+++ b/Source/SwiftLintFramework/Protocols/Reporter.swift
@@ -22,7 +22,7 @@ public protocol Reporter: CustomStringConvertible {
 }
 
 public extension Reporter {
-    // For CustomStringConvertible conformance.
+    /// For CustomStringConvertible conformance.
     var description: String { Self.description }
 }
 

--- a/Source/SwiftLintFramework/Reporters/CSVReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CSVReporter.swift
@@ -6,10 +6,7 @@ public struct CSVReporter: Reporter {
 
     public static let identifier = "csv"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations as a newline-separated string of comma-separated values (CSV)."
-    }
+    public static let description = "Reports violations as a newline-separated string of comma-separated values (CSV)."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         let keys = [

--- a/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CheckstyleReporter.swift
@@ -5,10 +5,7 @@ public struct CheckstyleReporter: Reporter {
 
     public static let identifier = "checkstyle"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations as Checkstyle XML."
-    }
+    public static let description = "Reports violations as Checkstyle XML."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return [

--- a/Source/SwiftLintFramework/Reporters/CodeClimateReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/CodeClimateReporter.swift
@@ -10,10 +10,7 @@ public struct CodeClimateReporter: Reporter {
 
     public static let identifier = "codeclimate"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations as a JSON array in Code Climate format."
-    }
+    public static let description = "Reports violations as a JSON array in Code Climate format."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return toJSON(violations.map(dictionary(for:)))

--- a/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/EmojiReporter.swift
@@ -4,10 +4,7 @@ public struct EmojiReporter: Reporter {
 
     public static let identifier = "emoji"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations in the format that's both fun and easy to read."
-    }
+    public static let description = "Reports violations in the format that's both fun and easy to read."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         violations

--- a/Source/SwiftLintFramework/Reporters/GitHubActionsLoggingReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/GitHubActionsLoggingReporter.swift
@@ -4,10 +4,7 @@ public struct GitHubActionsLoggingReporter: Reporter {
 
     public static let identifier = "github-actions-logging"
     public static let isRealtime = true
-
-    public var description: String {
-        return "Reports violations in the format GitHub-hosted virtual machine for Actions can recognize as messages."
-    }
+    public static let description = "Reports violations in the format GitHub-hosted virtual machine for Actions can recognize as messages."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return violations.map(generateForSingleViolation).joined(separator: "\n")

--- a/Source/SwiftLintFramework/Reporters/GitHubActionsLoggingReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/GitHubActionsLoggingReporter.swift
@@ -4,7 +4,8 @@ public struct GitHubActionsLoggingReporter: Reporter {
 
     public static let identifier = "github-actions-logging"
     public static let isRealtime = true
-    public static let description = "Reports violations in the format GitHub-hosted virtual machine for Actions can recognize as messages."
+    public static let description = "Reports violations in the format GitHub-hosted virtual " +
+                                    "machine for Actions can recognize as messages."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return violations.map(generateForSingleViolation).joined(separator: "\n")

--- a/Source/SwiftLintFramework/Reporters/GitLabJUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/GitLabJUnitReporter.swift
@@ -4,10 +4,7 @@ public struct GitLabJUnitReporter: Reporter {
 
     public static let identifier = "gitlab"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations as JUnit XML supported by GitLab."
-    }
+    public static let description = "Reports violations as JUnit XML supported by GitLab."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +

--- a/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/HTMLReporter.swift
@@ -12,10 +12,7 @@ public struct HTMLReporter: Reporter {
 
     public static let identifier = "html"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations as HTML."
-    }
+    public static let description = "Reports violations as HTML."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return generateReport(violations, swiftlintVersion: Version.current.value,

--- a/Source/SwiftLintFramework/Reporters/JSONReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JSONReporter.swift
@@ -7,10 +7,7 @@ public struct JSONReporter: Reporter {
 
     public static let identifier = "json"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations as a JSON array."
-    }
+    public static let description: String = "Reports violations as a JSON array."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return toJSON(violations.map(dictionary(for:)))

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -4,10 +4,7 @@ public struct JUnitReporter: Reporter {
 
     public static let identifier = "junit"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations as JUnit XML."
-    }
+    public static let description = "Reports violations as JUnit XML."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         let warningCount = violations.filter({ $0.severity == .warning }).count

--- a/Source/SwiftLintFramework/Reporters/MarkdownReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/MarkdownReporter.swift
@@ -6,10 +6,7 @@ public struct MarkdownReporter: Reporter {
 
     public static let identifier = "markdown"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations as markdown formated (with tables)."
-    }
+    public static let description = "Reports violations as markdown formated (with tables)."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         let keys = [

--- a/Source/SwiftLintFramework/Reporters/RelativePathReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/RelativePathReporter.swift
@@ -4,10 +4,7 @@ public struct RelativePathReporter: Reporter {
 
     public static let identifier = "relative-path"
     public static let isRealtime = true
-
-    public var description: String {
-        return "Reports violations with relative paths."
-    }
+    public static let description = "Reports violations with relative paths."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return violations.map(generateForSingleViolation).joined(separator: "\n")

--- a/Source/SwiftLintFramework/Reporters/SonarQubeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/SonarQubeReporter.swift
@@ -6,10 +6,7 @@ public struct SonarQubeReporter: Reporter {
 
     public static let identifier = "sonarqube"
     public static let isRealtime = false
-
-    public var description: String {
-        return "Reports violations in SonarQube import format."
-    }
+    public static let description = "Reports violations in SonarQube import format."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return toJSON(["issues": violations.map(dictionary(for:))])

--- a/Source/SwiftLintFramework/Reporters/SummaryReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/SummaryReporter.swift
@@ -8,7 +8,7 @@ public struct SummaryReporter: Reporter {
     public static let identifier = "summary"
     public static let isRealtime = false
 
-    public var description: String {
+    public static var description: String {
         return "Reports a summary table of all violations."
     }
 

--- a/Source/SwiftLintFramework/Reporters/SummaryReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/SummaryReporter.swift
@@ -8,9 +8,7 @@ public struct SummaryReporter: Reporter {
     public static let identifier = "summary"
     public static let isRealtime = false
 
-    public static var description: String {
-        return "Reports a summary table of all violations."
-    }
+    public static let description = "Reports a summary table of all violations."
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         TextTable(violations: violations).renderWithExtraSeparator()

--- a/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/XcodeReporter.swift
@@ -4,10 +4,7 @@ public struct XcodeReporter: Reporter {
 
     public static let identifier = "xcode"
     public static let isRealtime = true
-
-    public var description: String {
-        return "Reports violations in the format Xcode uses to display in the IDE. (default)"
-    }
+    public static let description = "Reports violations in the format Xcode uses to display in the IDE. (default)"
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
         return violations.map(generateForSingleViolation).joined(separator: "\n")

--- a/Source/swiftlint/Commands/Reporters.swift
+++ b/Source/swiftlint/Commands/Reporters.swift
@@ -6,24 +6,8 @@ extension SwiftLint {
     struct Reporters: ParsableCommand {
         static let configuration = CommandConfiguration(abstract: "Display the list of reporters and their identifiers")
 
-        private static let reporters: [Reporter.Type] = [
-            XcodeReporter.self,
-            JSONReporter.self,
-            CSVReporter.self,
-            CheckstyleReporter.self,
-            CodeClimateReporter.self,
-            JUnitReporter.self,
-            HTMLReporter.self,
-            EmojiReporter.self,
-            SonarQubeReporter.self,
-            MarkdownReporter.self,
-            GitHubActionsLoggingReporter.self,
-            GitLabJUnitReporter.self,
-            RelativePathReporter.self
-        ]
-
         func run() throws {
-            print(TextTable(reporters: Self.reporters).render())
+            print(TextTable(reporters: reportersList).render())
             ExitHelper.successfullyExit()
         }
     }

--- a/Source/swiftlint/Commands/Reporters.swift
+++ b/Source/swiftlint/Commands/Reporters.swift
@@ -1,0 +1,48 @@
+import ArgumentParser
+import SwiftLintFramework
+import SwiftyTextTable
+
+extension SwiftLint {
+    struct Reporters: ParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "Display the list of reporters and their identifiers")
+
+        private static let reporters: [Reporter.Type] = [
+            XcodeReporter.self,
+            JSONReporter.self,
+            CSVReporter.self,
+            CheckstyleReporter.self,
+            CodeClimateReporter.self,
+            JUnitReporter.self,
+            HTMLReporter.self,
+            EmojiReporter.self,
+            SonarQubeReporter.self,
+            MarkdownReporter.self,
+            GitHubActionsLoggingReporter.self,
+            GitLabJUnitReporter.self,
+            RelativePathReporter.self
+        ]
+
+        func run() throws {
+            print(TextTable(reporters: Self.reporters).render())
+            ExitHelper.successfullyExit()
+        }
+    }
+}
+
+// MARK: - SwiftyTextTable
+
+private extension TextTable {
+    init(reporters: [Reporter.Type]) {
+        let columns = [
+            TextTableColumn(header: "identifier"),
+            TextTableColumn(header: "description"),
+        ]
+        self.init(columns: columns)
+        for reporter in reporters {
+            addRow(values: [
+                reporter.identifier,
+                reporter.description
+            ])
+        }
+    }
+}

--- a/Source/swiftlint/Commands/Reporters.swift
+++ b/Source/swiftlint/Commands/Reporters.swift
@@ -35,7 +35,7 @@ private extension TextTable {
     init(reporters: [Reporter.Type]) {
         let columns = [
             TextTableColumn(header: "identifier"),
-            TextTableColumn(header: "description"),
+            TextTableColumn(header: "description")
         ]
         self.init(columns: columns)
         for reporter in reporters {

--- a/Source/swiftlint/Commands/SwiftLint.swift
+++ b/Source/swiftlint/Commands/SwiftLint.swift
@@ -17,6 +17,7 @@ struct SwiftLint: AsyncParsableCommand {
                 Docs.self,
                 GenerateDocs.self,
                 Lint.self,
+                Reporters.self,
                 Rules.self,
                 Version.self
             ],

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @_spi(TestHelper)
 @testable import SwiftLintFramework

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -5,23 +5,7 @@ import XCTest
 
 class ReporterTests: XCTestCase {
     func testReporterFromString() {
-        let reporters: [Reporter.Type] = [
-            CheckstyleReporter.self,
-            CodeClimateReporter.self,
-            CSVReporter.self,
-            EmojiReporter.self,
-            GitHubActionsLoggingReporter.self,
-            GitLabJUnitReporter.self,
-            HTMLReporter.self,
-            JSONReporter.self,
-            JUnitReporter.self,
-            MarkdownReporter.self,
-            RelativePathReporter.self,
-            SonarQubeReporter.self,
-            SummaryReporter.self,
-            XcodeReporter.self
-        ]
-        for reporter in reporters {
+        for reporter in reportersList {
             XCTAssertEqual(reporter.identifier, reporterFrom(identifier: reporter.identifier).identifier)
         }
     }


### PR DESCRIPTION
Adds a new `reporters` subcommand, akin to the `rules` subcommand, to improve reporter discoverability.

Right now, the various different reporters are mentioned in passing in the README, and pretty much nowhere else that I can find.

Resolves #4819 

Example output:

```
% swiftlint help
OVERVIEW: A tool to enforce Swift style and conventions.

USAGE: swiftlint <subcommand>

OPTIONS:
  --version               Show the version.
  -h, --help              Show help information.

SUBCOMMANDS:
  analyze                 Run analysis rules
  docs                    Open SwiftLint documentation website in the default web browser
  generate-docs           Generates markdown documentation for selected group of rules
  lint (default)          Print lint warnings and errors
  reporters               Display the list of reporters and their identifiers
  rules                   Display the list of rules and their identifiers
  version                 Display the current version of SwiftLint

  See 'swiftlint help <subcommand>' for detailed help.
```

```
% swiftlint help reporters
OVERVIEW: Display the list of reporters and their identifiers

USAGE: swiftlint reporters

OPTIONS:
  --version               Show the version.
  -h, --help              Show help information.
```

```
 % swiftlint reporters
+------------------------+-------------------------------------------------------------------------------------------------------+
| identifier             | description                                                                                           |
+------------------------+-------------------------------------------------------------------------------------------------------+
| csv                    | Reports violations as a newline-separated string of comma-separated values (CSV).                     |
| checkstyle             | Reports violations as Checkstyle XML.                                                                 |
| codeclimate            | Reports violations as a JSON array in Code Climate format.                                            |
| emoji                  | Reports violations in the format that's both fun and easy to read.                                    |
| github-actions-logging | Reports violations in the format GitHub-hosted virtual machine for Actions can recognize as messages. |
| gitlab                 | Reports violations as JUnit XML supported by GitLab.                                                  |
| html                   | Reports violations as HTML.                                                                           |
| json                   | Reports violations as a JSON array.                                                                   |
| junit                  | Reports violations as JUnit XML.                                                                      |
| markdown               | Reports violations as markdown formated (with tables).                                                |
| relative-path          | Reports violations with relative paths.                                                               |
| sonarqube              | Reports violations in SonarQube import format.                                                        |
| summary                | Reports a summary table of all violations.                                                            |
| xcode                  | Reports violations in the format Xcode uses to display in the IDE. (default)                          |
+------------------------+-------------------------------------------------------------------------------------------------------+
```

I changed the Reporter protocol slightly, so that the `description` property is static, and then maintained CustomStringConvertible compliance via an extension (although I couldn't actually see anywhere in the code where we utilise CustomStringConvertible compliance on Reporter).

I also added a Sourcery generated Reporters list, as there were no three separate locations in the code that required it.


