### PR TITLE
Apply small formatting fixes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,7 +24,7 @@ swift_library(
         "@com_github_jpsim_sourcekitten//:SourceKittenFramework",
         "@com_github_apple_swift_syntax//:optlibs",
         "@sourcekitten_com_github_jpsim_yams//:Yams",
-        "@swiftlint_com_github_scottrhoyt_swifty_text_table//:SwiftyTextTable",	
+        "@swiftlint_com_github_scottrhoyt_swifty_text_table//:SwiftyTextTable",
     ] + select({
         "@platforms//os:linux": ["@com_github_krzyzanowskim_cryptoswift//:CryptoSwift"],
         "//conditions:default": [],

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let frameworkDependencies: [Target.Dependency] = [
     .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
     .product(name: "SwiftParser", package: "swift-syntax"),
     .product(name: "SwiftOperators", package: "swift-syntax"),
+    "SwiftyTextTable",
     "Yams",
 ]
 + (addCryptoSwift ? ["CryptoSwift"] : [])
@@ -61,7 +62,7 @@ let package = Package(
         ),
         .target(
             name: "SwiftLintFramework",
-            dependencies: frameworkDependencies + ["SwiftyTextTable"]
+            dependencies: frameworkDependencies
         ),
         .target(
             name: "SwiftLintTestHelpers",

--- a/README.md
+++ b/README.md
@@ -484,9 +484,8 @@ Rule inclusion:
 
 * `disabled_rules`: Disable rules from the default enabled set.
 * `opt_in_rules`: Enable rules that are not part of the default set. The
-   special `all` rule will enable all opt in rules, except the rules
-   listed in `disabled_rules`. Analyzer rules will not be enabled by
-   `all`, but can be listed explicitly.
+   special `all` identifier will enable all opt in linter rules, except the ones
+   listed in `disabled_rules`.
 * `only_rules`: Only the rules specified in this list will be enabled.
    Cannot be specified alongside `disabled_rules` or `opt_in_rules`.
 * `analyzer_rules`: This is an entirely separate list of rules that are only

--- a/Source/SwiftLintFramework/Models/Configuration.swift
+++ b/Source/SwiftLintFramework/Models/Configuration.swift
@@ -178,7 +178,6 @@ public struct Configuration {
         ignoreParentAndChildConfigs: Bool = false,
         mockedNetworkResults: [String: String] = [:],
         useDefaultConfigOnFailure: Bool? = nil // swiftlint:disable:this discouraged_optional_boolean
-
     ) {
         // Handle mocked network results if needed
         Self.FileGraph.FilePath.mockedNetworkResults = mockedNetworkResults

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -44,7 +44,7 @@ class ReporterTests: XCTestCase {
                            severity: .error,
                            location: location,
                            reason: "Shorthand syntactic sugar should be used" +
-                           ", i.e. [Int] instead of Array<Int>"),
+                                   ", i.e. [Int] instead of Array<Int>"),
             StyleViolation(ruleDescription: ColonRule.description,
                            severity: .error,
                            location: Location(file: nil),


### PR DESCRIPTION
* Trim excess trailing and vertical whitespace
* Move `SwiftyTextTable` dependency into `frameworkDependencies`
* Adjust wording in README around analyzer rules in the `opt_in_rules` section, since analyzer rules can only go in the `analyzer_rules` section.