### PR TITLE
Fix README.md example for custom_rules#{in,ex}cluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,10 +568,8 @@ following syntax:
 ```yaml
 custom_rules:
   pirates_beat_ninjas: # rule identifier
-    included: 
-      - ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: 
-      - ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
+    included: ".*\\.swift" # regex that defines paths to include during linting. optional.
+    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
     name: "Pirates Beat Ninjas" # rule name. optional.
     regex: "([nN]inja)" # matching pattern
     capture_group: 0 # number of regex capture group to highlight the rule violation at. optional.


### PR DESCRIPTION
Firstly, thanks for maintaining this tool!

There's an error in `README.md` in depicting how to use `{in,ex}cluded` with `custom_rules`. Specifically, it suggests that `{in,ex}cluded` should key to a list of values, but the implementation expects a string type.

`README_KR.md`'s example is correct.

`README_CN.md` is missing this example entirely, and while I'd like to add it now I wouldn't be able to add an appropriate comment and so I did not do so here.