### PR TITLE
fix configuration unit tests

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Extensions/Configuration+LintableFiles.swift
@@ -33,7 +33,7 @@ extension Configuration {
         excludeByPrefix: Bool = false,
         fileManager: LintableFileManager = FileManager.default
     ) -> [String] {
-        if path.isFile {
+        if fileManager.isFile(atPath: path) {
             if forceExclude {
                 return excludeByPrefix
                     ? filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])

--- a/Source/SwiftLintFramework/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/FileManager+SwiftLint.swift
@@ -51,17 +51,6 @@ extension FileManager: LintableFileManager {
     }
 
     public func isFile(atPath path: String) -> Bool {
-        exists(atPath: path, isDirectory: false)
-    }
-
-    private func exists(atPath path: String, isDirectory: Bool) -> Bool {
-        guard !path.isEmpty else {
-            return false
-        }
-        var isDirectoryObjC: ObjCBool = false
-        if fileExists(atPath: path, isDirectory: &isDirectoryObjC) {
-            return isDirectoryObjC.boolValue == isDirectory
-        }
-        return false
+        path.isFile
     }
 }

--- a/Source/SwiftLintFramework/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/FileManager+SwiftLint.swift
@@ -19,6 +19,13 @@ public protocol LintableFileManager {
     ///
     /// - returns: A date, if one was determined.
     func modificationDate(forFileAtPath path: String) -> Date?
+
+    /// Returns true if a file (but not a directory) exists at the specified path.
+    ///
+    /// - parameter path: The path that should be checked to see if it is a file.
+    ///
+    /// - returns: true if the specified path is a file.
+    func isFile(atPath path: String) -> Bool
 }
 
 extension FileManager: LintableFileManager {
@@ -41,5 +48,20 @@ extension FileManager: LintableFileManager {
 
     public func modificationDate(forFileAtPath path: String) -> Date? {
         return (try? attributesOfItem(atPath: path))?[.modificationDate] as? Date
+    }
+
+    public func isFile(atPath path: String) -> Bool {
+        exists(atPath: path, isDirectory: false)
+    }
+
+    private func exists(atPath path: String, isDirectory: Bool) -> Bool {
+        guard !path.isEmpty else {
+            return false
+        }
+        var isDirectoryObjC: ObjCBool = false
+        if fileExists(atPath: path, isDirectory: &isDirectoryObjC) {
+            return isDirectoryObjC.boolValue == isDirectory
+        }
+        return false
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -235,7 +235,7 @@ class ConfigurationTests: XCTestCase {
             case "directory/ExcludedFile.swift": filesToLint = ["directory/ExcludedFile.swift"]
             default: XCTFail("Should not be called with path \(path)")
             }
-            return filesToLint.map { $0.absolutePathStandardized() }
+            return filesToLint.absolutePathsStandardized()
         }
 
         func modificationDate(forFileAtPath path: String) -> Date? {
@@ -252,10 +252,7 @@ class ConfigurationTests: XCTestCase {
                                           excludedPaths: ["directory/excluded",
                                                           "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "", forceExclude: false, fileManager: TestFileManager())
-        XCTAssertEqual(
-            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
-            paths
-        )
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testForceExcludesFile() {
@@ -269,30 +266,21 @@ class ConfigurationTests: XCTestCase {
         let configuration = Configuration(includedPaths: ["directory"],
                                           excludedPaths: ["directory/ExcludedFile.swift", "directory/excluded"])
         let paths = configuration.lintablePaths(inPath: "", forceExclude: true, fileManager: TestFileManager())
-        XCTAssertEqual(
-            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
-            paths
-        )
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testForceExcludesDirectory() {
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "directory", forceExclude: true,
                                                 fileManager: TestFileManager())
-        XCTAssertEqual(
-            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
-            paths
-        )
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() {
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "directory", forceExclude: true,
                                                 fileManager: TestFileManager())
-        XCTAssertEqual(
-            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
-            paths
-        )
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testLintablePaths() {
@@ -516,5 +504,11 @@ extension ConfigurationTests {
 
         XCTAssertEqual(configuration1.cachePath, "cache/path/1")
         XCTAssertEqual(configuration2.cachePath, "cache/path/1")
+    }
+}
+
+private extension Sequence where Element == String {
+    func absolutePathsStandardized() -> [String] {
+        map { $0.absolutePathStandardized() }
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -226,20 +226,24 @@ class ConfigurationTests: XCTestCase {
 
     private class TestFileManager: LintableFileManager {
         func filesToLint(inPath path: String, rootDirectory: String? = nil) -> [String] {
+            var filesToLint: [String] = []
             switch path {
-            case "directory": return ["directory/File1.swift", "directory/File2.swift",
-                                      "directory/excluded/Excluded.swift",
-                                      "directory/ExcludedFile.swift"]
-            case "directory/excluded": return ["directory/excluded/Excluded.swift"]
-            case "directory/ExcludedFile.swift": return ["directory/ExcludedFile.swift"]
-            default: break
+            case "directory": filesToLint = ["directory/File1.swift", "directory/File2.swift",
+                                             "directory/excluded/Excluded.swift",
+                                             "directory/ExcludedFile.swift"]
+            case "directory/excluded": filesToLint = ["directory/excluded/Excluded.swift"]
+            case "directory/ExcludedFile.swift": filesToLint = ["directory/ExcludedFile.swift"]
+            default: XCTFail("Should not be called with path \(path)")
             }
-            XCTFail("Should not be called with path \(path)")
-            return []
+            return filesToLint.map { $0.absolutePathStandardized() }
         }
 
         func modificationDate(forFileAtPath path: String) -> Date? {
             return nil
+        }
+
+        func isFile(atPath path: String) -> Bool {
+            path.hasSuffix(".swift")
         }
     }
 
@@ -248,7 +252,10 @@ class ConfigurationTests: XCTestCase {
                                           excludedPaths: ["directory/excluded",
                                                           "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "", forceExclude: false, fileManager: TestFileManager())
-        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
+        XCTAssertEqual(
+            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
+            paths
+        )
     }
 
     func testForceExcludesFile() {
@@ -262,21 +269,30 @@ class ConfigurationTests: XCTestCase {
         let configuration = Configuration(includedPaths: ["directory"],
                                           excludedPaths: ["directory/ExcludedFile.swift", "directory/excluded"])
         let paths = configuration.lintablePaths(inPath: "", forceExclude: true, fileManager: TestFileManager())
-        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
+        XCTAssertEqual(
+            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
+            paths
+        )
     }
 
     func testForceExcludesDirectory() {
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "directory", forceExclude: true,
                                                 fileManager: TestFileManager())
-        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
+        XCTAssertEqual(
+            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
+            paths
+        )
     }
 
     func testForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() {
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "directory", forceExclude: true,
                                                 fileManager: TestFileManager())
-        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
+        XCTAssertEqual(
+            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
+            paths
+        )
     }
 
     func testLintablePaths() {

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -62,6 +62,10 @@ private class TestFileManager: LintableFileManager {
     fileprivate func modificationDate(forFileAtPath path: String) -> Date? {
         return stubbedModificationDateByPath[path]
     }
+
+    fileprivate func isFile(atPath path: String) -> Bool {
+        false
+    }
 }
 
 class LinterCacheTests: XCTestCase {


### PR DESCRIPTION
I was looking into making some changes to how we parse files on the command line (see #4823), when I came across some issues with the unit tests. This PR does not change behaviour at all - just addresses these unit test issues.

The initial problem test is `testForceExcludesFile` in `ConfigurationTests`, which looks like this:

```
func testForceExcludesFile() {
    let configuration = Configuration(excludedPaths: ["directory/ExcludedFile.swift"])
    let paths = configuration.lintablePaths(inPath: "directory/ExcludedFile.swift", forceExclude: true,
                                            fileManager: TestFileManager())
    XCTAssertEqual([], paths)
}
```

`TestFileManager` looks like this:

```
private class TestFileManager: LintableFileManager {
    func filesToLint(inPath path: String, rootDirectory: String? = nil) -> [String] {
        switch path {
        case "directory": return ["directory/File1.swift", "directory/File2.swift",
                                  "directory/excluded/Excluded.swift",
                                  "directory/ExcludedFile.swift"]
        case "directory/excluded": return ["directory/excluded/Excluded.swift"]
        case "directory/ExcludedFile.swift": return ["directory/ExcludedFile.swift"]
        default: break
        }
        XCTFail("Should not be called with path \(path)")
        return []
    }

    func modificationDate(forFileAtPath path: String) -> Date? {
        return nil
    }
}
```

When this test is run, in `Configuration+LintableFiles.swift`, `lintablePaths` will get called with arguments `path = directory/ExcludedFile.swift`, `forceExclude = true`, and `excludeByPrefix = false` (and the `TestFileManager`).

```
internal func lintablePaths(
    inPath path: String,
    forceExclude: Bool,
    excludeByPrefix: Bool = false,
    fileManager: LintableFileManager = FileManager.default
) -> [String] {
    if path.isFile {
        if forceExclude {
            return excludeByPrefix
                ? filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])
                : filterExcludedPaths(fileManager: fileManager, in: [path.absolutePathStandardized()])
        }
        // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
        return [path]
    }

    let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: path, rootDirectory: nil) : []
    let includedPaths = self.includedPaths
        .flatMap(Glob.resolveGlob)
        .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }

    return excludeByPrefix
        ? filterExcludedPathsByPrefix(in: pathsForPath, includedPaths)
        : filterExcludedPaths(fileManager: fileManager, in: pathsForPath, includedPaths)
}
```

`path.isFile` would be `true` on a real filesystem, but will (almost certainly) be `false` in the unit test case, so the test will fall through to the remaining code.

That code will end up returning `[]` anyway, but the test is not exercising the code that it's supposed to be.

To work around this, I added a `isFile(atPath:)` method to `LintableFileManager`, which the mock can implement to fall down the correct path.

This caused `testForceExcludesFile` to start failing.

The problem here is that in `filterExcludedPaths(fileManager: fileManager, in: [path.absolutePathStandardized()])`, for example, we'll actually pass in `/path/to/current_directory/directory/ExcludedFile.swift`, but our Mock TestFileManager will return relative paths when checking the exclusions.

In real world execution, I think all the path comparisons for exclusion are done with absolute paths.

I changed TestFileManager to return absolute paths, but this then caused other unit tests to fail until they were similarly adjusted to expect absolute paths.
