### PR TITLE
Breaking change: paths specified on the command line should take precedence over configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [JP Simard](https://github.com/jpsim)
 
+* When files and directories are specified on the command line, any paths
+  specified in the configuration will be ignored. Previously this was not
+  true in every case.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4849](https://github.com/realm/SwiftLint/issues/4849)
+
 #### Experimental
 
 * None.
@@ -95,12 +101,6 @@
 * Remove support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
-
-* When files and directories are specified on the command line, any paths
-  specified in the configuration will be ignored. Previously this was not
-  true in every case.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4849](https://github.com/realm/SwiftLint/issues/4849)
 
 #### Experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
   supported but is deprecated. It's recommended to use the list
   `test_parent_classes` instead which accepts names of parent test classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
+
 * When files and directories are specified on the command line, any paths
   specified in the configuration will be ignored. Previously this was not
   true in every case.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,15 +92,15 @@
   `test_parent_classes` instead which accepts names of parent test classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Remove support for disable and enable commands in multiline comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
+
 * When files and directories are specified on the command line, any paths
   specified in the configuration will be ignored. Previously this was not
   true in every case.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4849](https://github.com/realm/SwiftLint/issues/4849)
-
-* Remove support for disable and enable commands in multiline comments.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
 #### Experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,11 @@
   supported but is deprecated. It's recommended to use the list
   `test_parent_classes` instead which accepts names of parent test classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
+* When files and directories are specified on the command line, any paths
+  specified in the configuration will be ignored. Previously this was not
+  true in every case.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4849](https://github.com/realm/SwiftLint/issues/4849)
 
 * Remove support for disable and enable commands in multiline comments.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -48,11 +48,10 @@ extension Configuration {
         }
 
         if path.isEmpty {
-            var pathsForPath = includedPaths
-            if pathsForPath.isEmpty {
-                pathsForPath = fileManager.filesToLint(inPath: path, rootDirectory: nil)
+            if includedPaths.isEmpty {
+                return excludePaths(from: fileManager.filesToLint(inPath: "", rootDirectory: rootDirectory))
             }
-            let includedPaths = pathsForPath
+            let includedPaths = includedPaths
                 .flatMap(Glob.resolveGlob)
                 .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }
             return excludePaths(from: includedPaths)

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -70,6 +70,8 @@ extension Configuration {
             let pathsForPath = fileManager.filesToLint(inPath: path, rootDirectory: nil)
             return excludePaths(from: pathsForPath)
         }
+
+        Issue.noSuchFileOrDirectory(path: path).print()
         return []
     }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -34,7 +34,10 @@ extension Configuration {
         fileManager: some LintableFileManager = FileManager.default
     ) -> [String] {
         if path.isEmpty {
-            let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: path, rootDirectory: nil) : includedPaths
+            var pathsForPath = includedPaths
+            if pathsForPath.isEmpty {
+                pathsForPath = fileManager.filesToLint(inPath: path, rootDirectory: nil)
+            }
             let includedPaths = pathsForPath
                 .flatMap(Glob.resolveGlob)
                 .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -34,10 +34,10 @@ extension Configuration {
         fileManager: some LintableFileManager = FileManager.default
     ) -> [String] {
         if path.isEmpty {
-            let includedPaths = self.includedPaths
+            let pathsForPath = includedPaths.isEmpty ? fileManager.filesToLint(inPath: path, rootDirectory: nil) : includedPaths
+            let includedPaths = pathsForPath
                 .flatMap(Glob.resolveGlob)
                 .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }
-
             return excludeByPrefix
                 ? filterExcludedPathsByPrefix(in: includedPaths)
                 : filterExcludedPaths(fileManager: fileManager, in: includedPaths)

--- a/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
@@ -51,6 +51,17 @@ extension FileManager: LintableFileManager {
     }
 
     public func isFile(atPath path: String) -> Bool {
-        path.isFile
+        exists(atPath: path, isDirectory: false)
+    }
+
+    private func exists(atPath path: String, isDirectory: Bool) -> Bool {
+        guard !path.isEmpty else {
+            return false
+        }
+        var isDirectoryObjC: ObjCBool = false
+        if fileExists(atPath: path, isDirectory: &isDirectoryObjC) {
+            return isDirectoryObjC.boolValue == isDirectory
+        }
+        return false
     }
 }

--- a/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
@@ -75,4 +75,8 @@ extension FileManager: LintableFileManager {
     public func isDirectory(atPath path: String) -> Bool {
         path.isDirectory
     }
+
+    public func isDirectory(atPath path: String) -> Bool {
+        path.isDirectory
+    }
 }

--- a/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
@@ -58,7 +58,18 @@ extension FileManager: LintableFileManager {
     }
 
     public func isFile(atPath path: String) -> Bool {
-        path.isFile
+        exists(atPath: path, isDirectory: false)
+    }
+
+    private func exists(atPath path: String, isDirectory: Bool) -> Bool {
+        guard !path.isEmpty else {
+            return false
+        }
+        var isDirectoryObjC: ObjCBool = false
+        if fileExists(atPath: path, isDirectory: &isDirectoryObjC) {
+            return isDirectoryObjC.boolValue == isDirectory
+        }
+        return false
     }
 
     public func isDirectory(atPath path: String) -> Bool {

--- a/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
@@ -62,6 +62,6 @@ extension FileManager: LintableFileManager {
     }
 
     public func isDirectory(atPath path: String) -> Bool {
-          path.isDirectory
+        path.isDirectory
     }
 }

--- a/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
@@ -58,25 +58,10 @@ extension FileManager: LintableFileManager {
     }
 
     public func isFile(atPath path: String) -> Bool {
-        exists(atPath: path, isDirectory: false)
-    }
-
-    private func exists(atPath path: String, isDirectory: Bool) -> Bool {
-        guard !path.isEmpty else {
-            return false
-        }
-        var isDirectoryObjC: ObjCBool = false
-        if fileExists(atPath: path, isDirectory: &isDirectoryObjC) {
-            return isDirectoryObjC.boolValue == isDirectory
-        }
-        return false
+        path.isFile
     }
 
     public func isDirectory(atPath path: String) -> Bool {
-        path.isDirectory
-    }
-
-    public func isDirectory(atPath path: String) -> Bool {
-        path.isDirectory
+          path.isDirectory
     }
 }

--- a/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
@@ -26,6 +26,13 @@ public protocol LintableFileManager {
     ///
     /// - returns: true if the specified path is a file.
     func isFile(atPath path: String) -> Bool
+
+    /// Returns true if a directory exists at the specified path.
+    ///
+    /// - parameter path: The path that should be checked to see if it is a directory.
+    ///
+    /// - returns: true if the specified path is a directory.
+    func isDirectory(atPath path: String) -> Bool
 }
 
 extension FileManager: LintableFileManager {
@@ -52,5 +59,9 @@ extension FileManager: LintableFileManager {
 
     public func isFile(atPath path: String) -> Bool {
         path.isFile
+    }
+
+    public func isDirectory(atPath path: String) -> Bool {
+        path.isDirectory
     }
 }

--- a/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
@@ -51,17 +51,6 @@ extension FileManager: LintableFileManager {
     }
 
     public func isFile(atPath path: String) -> Bool {
-        exists(atPath: path, isDirectory: false)
-    }
-
-    private func exists(atPath path: String, isDirectory: Bool) -> Bool {
-        guard !path.isEmpty else {
-            return false
-        }
-        var isDirectoryObjC: ObjCBool = false
-        if fileExists(atPath: path, isDirectory: &isDirectoryObjC) {
-            return isDirectoryObjC.boolValue == isDirectory
-        }
-        return false
+        path.isFile
     }
 }

--- a/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-extension String {
-    internal func hasTrailingWhitespace() -> Bool {
+public extension String {
+    func hasTrailingWhitespace() -> Bool {
         if isEmpty {
             return false
         }
@@ -14,20 +14,12 @@ extension String {
         return false
     }
 
-    internal func isUppercase() -> Bool {
+    func isUppercase() -> Bool {
         return self == uppercased()
     }
 
-    internal func isLowercase() -> Bool {
+    func isLowercase() -> Bool {
         return self == lowercased()
-    }
-
-    internal func nameStrippingLeadingUnderscoreIfPrivate(_ dict: SourceKittenDictionary) -> String {
-        if let acl = dict.accessibility,
-            acl.isPrivate && first == "_" {
-            return String(self[index(after: startIndex)...])
-        }
-        return self
     }
 
     private subscript (range: Range<Int>) -> String {
@@ -39,21 +31,21 @@ extension String {
         queuedFatalError("invalid range")
     }
 
-    internal func substring(from: Int, length: Int? = nil) -> String {
+    func substring(from: Int, length: Int? = nil) -> String {
         if let length {
             return self[from..<from + length]
         }
         return String(self[index(startIndex, offsetBy: from, limitedBy: endIndex)!...])
     }
 
-    internal func lastIndex(of search: String) -> Int? {
+    func lastIndex(of search: String) -> Int? {
         if let range = range(of: search, options: [.literal, .backwards]) {
             return distance(from: startIndex, to: range.lowerBound)
         }
         return nil
     }
 
-    internal func nsrangeToIndexRange(_ nsrange: NSRange) -> Range<Index>? {
+    func nsrangeToIndexRange(_ nsrange: NSRange) -> Range<Index>? {
         guard nsrange.location != NSNotFound else {
             return nil
         }
@@ -70,22 +62,22 @@ extension String {
         return fromIndex..<toIndex
     }
 
-    internal var fullNSRange: NSRange {
+    var fullNSRange: NSRange {
         return NSRange(location: 0, length: utf16.count)
     }
 
     /// Returns a new string, converting the path to a canonical absolute path.
     ///
     /// - returns: A new `String`.
-    public func absolutePathStandardized() -> String {
+    func absolutePathStandardized() -> String {
         return bridge().absolutePathRepresentation().bridge().standardizingPath
     }
 
-    internal var isFile: Bool {
+    var isFile: Bool {
         exists(isDirectory: false)
     }
 
-    internal var isDirectory: Bool {
+    var isDirectory: Bool {
         exists(isDirectory: true)
     }
 
@@ -103,14 +95,14 @@ extension String {
     /// Count the number of occurrences of the given character in `self`
     /// - Parameter character: Character to count
     /// - Returns: Number of times `character` occurs in `self`
-    public func countOccurrences(of character: Character) -> Int {
+    func countOccurrences(of character: Character) -> Int {
         return self.reduce(0, {
             $1 == character ? $0 + 1 : $0
         })
     }
 
     /// If self is a path, this method can be used to get a path expression relative to a root directory
-    public func path(relativeTo rootDirectory: String) -> String {
+    func path(relativeTo rootDirectory: String) -> String {
         let normalizedRootDir = rootDirectory.bridge().standardizingPath
         let normalizedSelf = bridge().standardizingPath
         if normalizedRootDir.isEmpty {
@@ -131,7 +123,7 @@ extension String {
         }
     }
 
-    internal func deletingPrefix(_ prefix: String) -> String {
+    func deletingPrefix(_ prefix: String) -> String {
         guard hasPrefix(prefix) else { return self }
         return String(dropFirst(prefix.count))
     }

--- a/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SourceKittenFramework
 
-public extension String {
-    func hasTrailingWhitespace() -> Bool {
+extension String {
+    internal func hasTrailingWhitespace() -> Bool {
         if isEmpty {
             return false
         }
@@ -14,12 +14,20 @@ public extension String {
         return false
     }
 
-    func isUppercase() -> Bool {
+    internal func isUppercase() -> Bool {
         return self == uppercased()
     }
 
-    func isLowercase() -> Bool {
+    internal func isLowercase() -> Bool {
         return self == lowercased()
+    }
+
+    internal func nameStrippingLeadingUnderscoreIfPrivate(_ dict: SourceKittenDictionary) -> String {
+        if let acl = dict.accessibility,
+            acl.isPrivate && first == "_" {
+            return String(self[index(after: startIndex)...])
+        }
+        return self
     }
 
     private subscript (range: Range<Int>) -> String {
@@ -31,21 +39,21 @@ public extension String {
         queuedFatalError("invalid range")
     }
 
-    func substring(from: Int, length: Int? = nil) -> String {
+    internal func substring(from: Int, length: Int? = nil) -> String {
         if let length {
             return self[from..<from + length]
         }
         return String(self[index(startIndex, offsetBy: from, limitedBy: endIndex)!...])
     }
 
-    func lastIndex(of search: String) -> Int? {
+    internal func lastIndex(of search: String) -> Int? {
         if let range = range(of: search, options: [.literal, .backwards]) {
             return distance(from: startIndex, to: range.lowerBound)
         }
         return nil
     }
 
-    func nsrangeToIndexRange(_ nsrange: NSRange) -> Range<Index>? {
+    internal func nsrangeToIndexRange(_ nsrange: NSRange) -> Range<Index>? {
         guard nsrange.location != NSNotFound else {
             return nil
         }
@@ -62,22 +70,22 @@ public extension String {
         return fromIndex..<toIndex
     }
 
-    var fullNSRange: NSRange {
+    internal var fullNSRange: NSRange {
         return NSRange(location: 0, length: utf16.count)
     }
 
     /// Returns a new string, converting the path to a canonical absolute path.
     ///
     /// - returns: A new `String`.
-    func absolutePathStandardized() -> String {
+    public func absolutePathStandardized() -> String {
         return bridge().absolutePathRepresentation().bridge().standardizingPath
     }
 
-    var isFile: Bool {
+    internal var isFile: Bool {
         exists(isDirectory: false)
     }
 
-    var isDirectory: Bool {
+    internal var isDirectory: Bool {
         exists(isDirectory: true)
     }
 
@@ -95,14 +103,14 @@ public extension String {
     /// Count the number of occurrences of the given character in `self`
     /// - Parameter character: Character to count
     /// - Returns: Number of times `character` occurs in `self`
-    func countOccurrences(of character: Character) -> Int {
+    public func countOccurrences(of character: Character) -> Int {
         return self.reduce(0, {
             $1 == character ? $0 + 1 : $0
         })
     }
 
     /// If self is a path, this method can be used to get a path expression relative to a root directory
-    func path(relativeTo rootDirectory: String) -> String {
+    public func path(relativeTo rootDirectory: String) -> String {
         let normalizedRootDir = rootDirectory.bridge().standardizingPath
         let normalizedSelf = bridge().standardizingPath
         if normalizedRootDir.isEmpty {
@@ -123,7 +131,7 @@ public extension String {
         }
     }
 
-    func deletingPrefix(_ prefix: String) -> String {
+    internal func deletingPrefix(_ prefix: String) -> String {
         guard hasPrefix(prefix) else { return self }
         return String(dropFirst(prefix.count))
     }

--- a/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
@@ -81,6 +81,10 @@ public extension String {
         exists(isDirectory: true)
     }
 
+    var exists: Bool {
+        FileManager.default.fileExists(atPath: self)
+    }
+
     private func exists(isDirectory: Bool) -> Bool {
         if self.isEmpty {
             return false

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -113,7 +113,7 @@ public enum Issue: LocalizedError, Equatable {
         case let .fileNotWritable(path):
             return "Cannot write to file at path '\(path)'."
         case let .noSuchFileOrDirectory(path):
-            return "No file or directory found at '\(path)'."
+            return "No file or directory found at path '\(path)'."
         case let .indexingError(path, id):
             return "Cannot index file at path '\(path ?? "...")' within '\(id)' rule."
         case let .missingCompilerArguments(path, id):

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -35,6 +35,9 @@ public enum Issue: LocalizedError, Equatable {
     /// The file at `path` is not writable.
     case fileNotWritable(path: String)
 
+    /// No file or directory found at `path`.
+    case noSuchFileOrDirectory(path: String)
+
     /// The file at `path` cannot be indexed by a specific rule.
     case indexingError(path: String?, ruleID: String)
 
@@ -109,6 +112,8 @@ public enum Issue: LocalizedError, Equatable {
             return "Cannot open or read file at path '\(path ?? "...")' within '\(id)' rule."
         case let .fileNotWritable(path):
             return "Cannot write to file at path '\(path)'."
+        case let .noSuchFileOrDirectory(path):
+            return "No file or directory found at '\(path)'."
         case let .indexingError(path, id):
             return "Cannot index file at path '\(path ?? "...")' within '\(id)' rule."
         case let .missingCompilerArguments(path, id):

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -236,7 +236,7 @@ extension Configuration {
         if !visitor.quiet {
             let filesInfo: String
             if visitor.paths.isEmpty || visitor.paths == [""] {
-                if self != Self.default, includedPaths.isNotEmpty {
+                if includedPaths.isNotEmpty {
                     filesInfo = "specified in the configuration"
                 } else {
                     filesInfo = "in current working directory"

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -236,7 +236,11 @@ extension Configuration {
         if !visitor.quiet {
             let filesInfo: String
             if visitor.paths.isEmpty || visitor.paths == [""] {
-                filesInfo = "in current working directory"
+                if self != Self.default, includedPaths.isNotEmpty {
+                    filesInfo = "specified in the configuration"
+                } else {
+                    filesInfo = "in current working directory"
+                }
             } else {
                 filesInfo = "at paths \(visitor.paths.joined(separator: ", "))"
             }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -250,6 +250,10 @@ class ConfigurationTests: SwiftLintTestCase {
         func isFile(atPath path: String) -> Bool {
             path.hasSuffix(".swift")
         }
+
+        func isDirectory(atPath path: String) -> Bool {
+            path == "directory" || path == "directory/excluded"
+        }
     }
 
     func testExcludedPaths() {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -240,7 +240,7 @@ class ConfigurationTests: SwiftLintTestCase {
             case "directory/ExcludedFile.swift": filesToLint = ["directory/ExcludedFile.swift"]
             default: XCTFail("Should not be called with path \(path)")
             }
-            return filesToLint.absolutePathsStandardized()
+            return filesToLint.map { $0.absolutePathStandardized() }
         }
 
         func modificationDate(forFileAtPath path: String) -> Date? {
@@ -261,7 +261,10 @@ class ConfigurationTests: SwiftLintTestCase {
                                           excludedPaths: ["directory/excluded",
                                                           "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "", forceExclude: false, fileManager: TestFileManager())
-        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
+        XCTAssertEqual(
+            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
+            paths
+        )
     }
 
     func testForceExcludesFile() {
@@ -275,21 +278,30 @@ class ConfigurationTests: SwiftLintTestCase {
         let configuration = Configuration(includedPaths: ["directory"],
                                           excludedPaths: ["directory/ExcludedFile.swift", "directory/excluded"])
         let paths = configuration.lintablePaths(inPath: "", forceExclude: true, fileManager: TestFileManager())
-        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
+        XCTAssertEqual(
+            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
+            paths
+        )
     }
 
     func testForceExcludesDirectory() {
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "directory", forceExclude: true,
                                                 fileManager: TestFileManager())
-        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
+        XCTAssertEqual(
+            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
+            paths
+        )
     }
 
     func testForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() {
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "directory", forceExclude: true,
                                                 fileManager: TestFileManager())
-        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
+        XCTAssertEqual(
+            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
+            paths
+        )
     }
 
     func testLintablePaths() {
@@ -543,11 +555,5 @@ extension ConfigurationTests {
 
         XCTAssertEqual(configuration1.cachePath, "cache/path/1")
         XCTAssertEqual(configuration2.cachePath, "cache/path/1")
-    }
-}
-
-private extension Sequence where Element == String {
-    func absolutePathsStandardized() -> [String] {
-        map { $0.absolutePathStandardized() }
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -304,6 +304,13 @@ class ConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(Set(expectedFilenames), Set(filenames))
     }
 
+    func testLintablePathsWithDirectory() {
+        let paths = Configuration.default.lintablePaths(inPath: Mock.Dir.level1, forceExclude: false)
+        let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
+        let expectedFilenames = ["Level1.swift", "Level2.swift", "Level3.swift"]
+        XCTAssertEqual(Set(expectedFilenames), Set(filenames))
+    }
+
     func testGlobIncludePaths() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.level0)
         let configuration = Configuration(includedPaths: ["**/Level2"])

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -309,8 +309,17 @@ class ConfigurationTests: SwiftLintTestCase {
         let configuration = Configuration(includedPaths: ["**/Level2"])
         let paths = configuration.lintablePaths(inPath: Mock.Dir.level0, forceExclude: true)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
-        let expectedFilenames = ["Level2.swift", "Level3.swift"]
+        let expectedFilenames = [
+            "DirectoryLevel1.swift",
+            "Level0.swift",
+            "Level1.swift",
+            "Level2.swift",
+            "Level3.swift",
+            "Main.swift",
+            "Sub.swift",
+        ].sorted()
 
+        // Because a directory was passed, we should ignore the configuration
         XCTAssertEqual(Set(expectedFilenames), Set(filenames))
     }
 
@@ -412,8 +421,15 @@ extension ConfigurationTests {
         let paths = configuration.lintablePaths(inPath: Mock.Dir.level0,
                                                 forceExclude: false,
                                                 excludeByPrefix: true)
-        let filenames = paths.map { $0.bridge().lastPathComponent }
-        XCTAssertEqual(filenames, ["Level2.swift"])
+        let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
+        let expectedFilenames = [
+            "DirectoryLevel1.swift",
+            "Level0.swift",
+            "Level2.swift",
+            "Main.swift",
+            "Sub.swift",
+        ].sorted()
+        XCTAssertEqual(filenames, expectedFilenames)
     }
 
     func testExcludeByPrefixForceExcludesFile() {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -323,7 +323,7 @@ class ConfigurationTests: SwiftLintTestCase {
             "Level2.swift",
             "Level3.swift",
             "Main.swift",
-            "Sub.swift",
+            "Sub.swift"
         ].sorted()
 
         // Because a directory was passed, we should ignore the configuration
@@ -434,7 +434,7 @@ extension ConfigurationTests {
             "Level0.swift",
             "Level2.swift",
             "Main.swift",
-            "Sub.swift",
+            "Sub.swift"
         ].sorted()
         XCTAssertEqual(filenames, expectedFilenames)
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -240,7 +240,7 @@ class ConfigurationTests: SwiftLintTestCase {
             case "directory/ExcludedFile.swift": filesToLint = ["directory/ExcludedFile.swift"]
             default: XCTFail("Should not be called with path \(path)")
             }
-            return filesToLint.map { $0.absolutePathStandardized() }
+            return filesToLint.absolutePathsStandardized()
         }
 
         func modificationDate(forFileAtPath path: String) -> Date? {
@@ -257,10 +257,7 @@ class ConfigurationTests: SwiftLintTestCase {
                                           excludedPaths: ["directory/excluded",
                                                           "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "", forceExclude: false, fileManager: TestFileManager())
-        XCTAssertEqual(
-            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
-            paths
-        )
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testForceExcludesFile() {
@@ -274,30 +271,21 @@ class ConfigurationTests: SwiftLintTestCase {
         let configuration = Configuration(includedPaths: ["directory"],
                                           excludedPaths: ["directory/ExcludedFile.swift", "directory/excluded"])
         let paths = configuration.lintablePaths(inPath: "", forceExclude: true, fileManager: TestFileManager())
-        XCTAssertEqual(
-            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
-            paths
-        )
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testForceExcludesDirectory() {
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "directory", forceExclude: true,
                                                 fileManager: TestFileManager())
-        XCTAssertEqual(
-            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
-            paths
-        )
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() {
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
         let paths = configuration.lintablePaths(inPath: "directory", forceExclude: true,
                                                 fileManager: TestFileManager())
-        XCTAssertEqual(
-            ["directory/File1.swift", "directory/File2.swift"].map { $0.absolutePathStandardized() },
-            paths
-        )
+        XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testLintablePaths() {
@@ -528,5 +516,11 @@ extension ConfigurationTests {
 
         XCTAssertEqual(configuration1.cachePath, "cache/path/1")
         XCTAssertEqual(configuration2.cachePath, "cache/path/1")
+    }
+}
+
+private extension Sequence where Element == String {
+    func absolutePathsStandardized() -> [String] {
+        map { $0.absolutePathStandardized() }
     }
 }

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -66,6 +66,10 @@ private class TestFileManager: LintableFileManager {
     fileprivate func isFile(atPath path: String) -> Bool {
         false
     }
+
+    fileprivate func isDirectory(atPath path: String) -> Bool {
+        false
+    }
 }
 
 class LinterCacheTests: SwiftLintTestCase {


### PR DESCRIPTION

This PR changes how SwiftLint treats files or directories passed as command line arguments, and resolves  #4823

Typically, one would expect that paths explicitly supplied on the command line would take precedence over paths specified in a configuration file.

SwiftLint behaves like this in most cases, but there are some scenarios where the existing behavior is not intuitive or expected.

I'll enumerate some scenarios below (some of which have not changed at all).

1. `swiftlint` - if there is a configuration file present, this will be attended to. Otherwise, lint all `.swift` files under the current directory - unchanged

2. `swiftlint /relative/or/absolute/path/to/some/file` - the specified file(s) will be linted - unchanged

3. `swiftlint /relative/or/absolute/path/to/some/file /relative/or/absolute/path/to/some/file_that_does_not_actually exist`

     Old behaviour: SwiftLint would lint the file that exists, and then scan all files and directories specified in the configuration file if one was present. If no configuration file was present, SwiftLint would just lint the existing file.

    New behaviour: SwiftLint will ignore the configuration's specified files and directories, and lint any specified files that actually do exist. A warning will be printed for any path supplied on the command line that does not exist:

    `warning: No file or directory found at '/tmp/Z.swift'.`

4. `swiftlint /relative/or/absolute/path/to/some/directory`

    Old behaviour - if a configuration file was detected, and specified any directories to scan, the configuration file's specification of which files/directories to scan would be used, and the command line directory (or directories) would be ignored. If no configuration file was present, or if it specified no paths to scan, then the directory specified on the command line would be scanned.

    New behaviour - the directory or directories specified on the command line will be scanned. Any directories specified in a configuration file will be ignored. The remainder of the configuration file, if any, for example, exclusions, rule enablement or disablement, will be respected.

#### Messaging

If there is no configuration file, or no paths are specified in the configuration file, then SwiftLint will print

`Linting Swift files in current working directory`

as before. However if a configuration file is specified, or the default is present, and any paths are specified in the configuration, then SwiftLint will now print

`Linting Swift files specified in the configuration`

instead.
