### PR TITLE
Add new option to `attributes` rule to influence its behavior for attributes with arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 #### Breaking
 
-* None.
+* The `attributes` rule now expects attributes with arguments to be placed
+  on their own line above the declaration they are supposed to influence.
+  This applies to attributes with any kinds of arguments including single
+  key path arguments which were previously handled in a different way. This
+  behavior can be turned off by setting `attributes_with_arguments_always_on_line_above`
+  to `false.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4843](https://github.com/realm/SwiftLint/issues/4843)
 
 #### Experimental
 
@@ -47,6 +54,14 @@
 * Prepend `warning: ` to error messages so that they show in Xcode.  
   [whiteio](https://github.com/whiteio)
   [#4923](https://github.com/realm/SwiftLint/issues/4923)
+
+* The `attributes` rule received a new boolean option
+  `attributes_with_arguments_always_on_line_above` which is `true` by default.
+  Setting it to `false` ensures that attributes with arguments like
+  `@Persisted(primaryKey: true)` don't violate the rule if they are on the same
+  line with the variable declaration.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4843](https://github.com/realm/SwiftLint/issues/4843)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -1,5 +1,6 @@
 struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var attributesWithArgumentsAlwaysOnNewLine = true
     private(set) var alwaysOnSameLine = Set<String>()
     private(set) var alwaysOnNewLine = Set<String>()
 
@@ -18,6 +19,11 @@ struct AttributesConfiguration: SeverityBasedRuleConfiguration, Equatable {
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
             throw ConfigurationError.unknownConfiguration
+        }
+
+        if let attributesWithArgumentsAlwaysOnNewLine
+                = configuration["attributes_with_arguments_always_on_line_above"] as? Bool {
+            self.attributesWithArgumentsAlwaysOnNewLine = attributesWithArgumentsAlwaysOnNewLine
         }
 
         if let alwaysOnSameLine = configuration["always_on_same_line"] as? [String] {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -157,7 +157,7 @@ private extension AttributeListSyntax {
                     return (attribute, .sameLineAsDeclaration)
                 } else if configuration.alwaysOnNewLine.contains(atPrefixedName) {
                     return (attribute, .dedicatedLine)
-                } else if attribute.argument != nil {
+                } else if attribute.argument != nil, configuration.attributesWithArgumentsAlwaysOnNewLine {
                     return (attribute, .dedicatedLine)
                 }
 
@@ -165,20 +165,9 @@ private extension AttributeListSyntax {
             }
     }
 
-    var hasAttributeWithKeypathArgument: Bool {
-        contains { element in
-            switch element {
-            case .attribute(let attribute):
-                return attribute.hasKeypathArgument
-            case .ifConfigDecl:
-                return false
-            }
-        }
-    }
-
     // swiftlint:disable:next cyclomatic_complexity
     func makeHelper(locationConverter: SourceLocationConverter) -> RuleHelper? {
-        guard let parent, !hasAttributeWithKeypathArgument else {
+        guard let parent else {
             return nil
         }
 
@@ -224,11 +213,5 @@ private extension AttributeListSyntax {
             keywordLine: keywordLine,
             shouldBeOnSameLine: shouldBeOnSameLine
         )
-    }
-}
-
-private extension AttributeSyntax {
-    var hasKeypathArgument: Bool {
-        argument?.as(TupleExprElementListSyntax.self)?.first?.expression.is(KeyPathExprSyntax.self) == true
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRuleExamples.swift
@@ -82,15 +82,15 @@ internal struct AttributesRuleExamples {
         final class AppDelegate: NSAppDelegate {}
         """),
         Example(#"""
+        @_spi(Private) import SomeFramework
+
+        @_spi(Private)
         final class MyView: View {
-          @SwiftUI.Environment(\.colorScheme) var colorScheme: ColorScheme
+            @SwiftUI.Environment(\.colorScheme) var first: ColorScheme
+            @Environment(\.colorScheme) var second: ColorScheme
+            @Persisted(primaryKey: true) var id: Int
         }
-        """#),
-        Example(#"""
-        final class MyView: View {
-          @Environment(\.colorScheme) var colorScheme: ColorScheme
-        }
-        """#)
+        """#, configuration: ["attributes_with_arguments_always_on_line_above": false], excludeFromDocumentation: true)
     ]
 
     static let triggeringExamples = [
@@ -124,6 +124,16 @@ internal struct AttributesRuleExamples {
         Example("@GKInspectable\n ↓var maxSpeed: Float"),
         Example("@discardableResult ↓func a() -> Int"),
         Example("@objc\n @discardableResult ↓func a() -> Int"),
-        Example("@objc\n\n @discardableResult\n ↓func a() -> Int")
+        Example("@objc\n\n @discardableResult\n ↓func a() -> Int"),
+        Example(#"""
+        struct S: View {
+            @Environment(\.colorScheme) ↓var first: ColorScheme
+            @Persisted var id: Int
+            @FetchRequest(
+                  animation: nil
+            )
+            var entities: FetchedResults
+        }
+        """#, excludeFromDocumentation: true)
     ]
 }


### PR DESCRIPTION
Fixes #4843 by adding a new option `attributes_with_arguments_always_on_line_above` which can be set to `false` if attributes with arguments on the same line like the variable declaration shall be allowed.