### PR TITLE
Add example to proof that shorthand optional binding works with `unused_declaration` rule

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -128,7 +128,7 @@ struct UnusedDeclarationRuleExamples {
           "hello"
         }
         """)
-    ] + platformSpecificNonTriggeringExamples
+    ] + platformSpecificNonTriggeringExamples + versionSpecificNonTriggeringExamples
 
     static let triggeringExamples = [
         Example("""
@@ -300,5 +300,21 @@ struct UnusedDeclarationRuleExamples {
 #else
     private static let platformSpecificNonTriggeringExamples = [Example]()
     private static let platformSpecificTriggeringExamples = [Example]()
+#endif
+
+#if compiler(>=5.8)
+    private static let versionSpecificNonTriggeringExamples = [
+        Example("""
+            struct S {
+                var i: Int? = nil
+                func f() {
+                    if let i { print(i) }
+                }
+            }
+            S().f()
+        """)
+    ]
+#else
+    private static let versionSpecificNonTriggeringExamples = [Example]()
 #endif
 }


### PR DESCRIPTION
This now only works with Swift 5.8/Xcode 14.3. Is it okay to restrict the rule to Swift 5.8 subsequently?