### PR TITLE
Fix `lower_acl_than_parent` rule rewriter by preserving leading whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
 
 #### Bug Fixes
 
-* None.
+* Fix `lower_acl_than_parent` rule rewriter by preserving leading whitespace.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4860](https://github.com/realm/SwiftLint/issues/4860)
 
 ## 0.51.0: bzllint
 

--- a/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/LowerACLThanParentRule.swift
@@ -68,7 +68,17 @@ struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, SwiftSyntax
             Example("class Foo { ↓public func bar() {} }"):
                 Example("class Foo { func bar() {} }"),
             Example("actor Foo { ↓public func bar() {} }"):
-                Example("actor Foo { func bar() {} }")
+                Example("actor Foo { func bar() {} }"),
+            Example("""
+                struct Foo {
+                    ↓public func bar() {}
+                }
+                """):
+                Example("""
+                struct Foo {
+                    func bar() {}
+                }
+                """)
         ]
     )
 
@@ -120,7 +130,10 @@ private extension LowerACLThanParentRule {
                     trailingTrivia: .space
                 )
             } else {
-                newNode = DeclModifierSyntax(name: .keyword(.internal, presence: .missing))
+                newNode = DeclModifierSyntax(
+                    leadingTrivia: node.leadingTrivia ?? .zero,
+                    name: .identifier("")
+                )
             }
 
             return super.visit(newNode)


### PR DESCRIPTION
Fixes #4860.