### PR TITLE
Fix false positive in rule `indentation_width`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4860](https://github.com/realm/SwiftLint/issues/4860)
 
+* Fix false positives in `indentation_width` rule.  
+  [Sven Münnich](https://github.com/svenmuennich)
+
 ## 0.51.0: bzllint
 
 #### Breaking

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -196,18 +196,57 @@ class IndentationWidthRuleTests: XCTestCase {
             """, includeCompilerDirectives: true)
     }
 
-    func testIgnoredMultilineStrings() {
-        assertNoViolation(
-            in: "let x = \"\"\"\nstring1\n    string2\n  string3\n\"\"\"\n",
-            includeMultilineStrings: false
-        )
-        assert1Violation(
-            in: "let x = \"\"\"\nstring1\n    string2\n  string3\n\"\"\"\n"
-        )
-        assertViolations(
-            in: "let x = \"\"\"\nstring1\n    string2\n  string3\n string4\n\"\"\"\n",
-            equals: 2
-        )
+    func testIncludeMultilineStrings() {
+        let example0 = #"""
+            let x = """
+                string1
+                    string2
+                  string3
+                """
+            """#
+        assertNoViolation(in: example0, includeMultilineStrings: false)
+        assert1Violation(in: example0, includeMultilineStrings: true)
+
+        let example1 = #"""
+            let x = """
+                string1
+                    string2
+                  string3
+                 string4
+                """
+            """#
+        assertNoViolation(in: example1, includeMultilineStrings: false)
+        assertViolations(in: example1, equals: 2, includeMultilineStrings: true)
+
+        let example2 = ##"""
+            let x = #"""
+                string1
+               """#
+            """##
+        assert1Violation(in: example2, includeMultilineStrings: false)
+        assert1Violation(in: example2, includeMultilineStrings: true)
+
+        let example3 = """
+            let x = [
+                "key": [
+                    ["nestedKey": "string"],
+                ],
+            ]
+            """
+        assertNoViolation(in: example3, includeMultilineStrings: false)
+        assertNoViolation(in: example3, includeMultilineStrings: true)
+
+        let example4 = #"""
+            func test() -> String {
+                """
+                ▿ Type:
+                  - property: \(123) + \(456)
+                \(true)
+                """
+            }
+            """#
+        assertNoViolation(in: example4, includeMultilineStrings: false)
+        assert1Violation(in: example4, includeMultilineStrings: true)
     }
 
     // MARK: Helpers


### PR DESCRIPTION
We noticed a lot of false positives for rule `indentation_width` when setting the newly introduced option `include_multiline_strings` to `false`. 

Here's an example where this would produce a false positive:
```swift
let x = [
    "key": [
        ["nestedKey": "string"],
    ],
]
```

This PR fixes the rule's detection of lines belonging to a multiline line string by considering only this lines that represent the content of the string, not its delimiters.

The indentation of the closing delimiter of a multiline string is always tested for rule violations (independently from `include_multiline_strings`), as IMHO the delimiter acts more like a closing brace than a string. Hence the following example always produces a violation:
```swift
let x = """
    content
   """
```