### PR TITLE
Disabled rules in child configs are no longer automatically ignored if they are opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5120](https://github.com/realm/SwiftLint/issues/5120)
 
+* Fix some unexpected rule enablement interactions between parent and
+  child configurations.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4876](https://github.com/realm/SwiftLint/issues/4876)
+
 ## 0.52.4: Lid Switch
 
 #### Breaking

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -259,7 +259,7 @@ internal extension Configuration {
                 // Allow parent only rules that weren't disabled via the child config
                 // & opt-ins from the child config
                 return .only(Set(
-                    childOptIn + onlyRules.filter { !childDisabled.contains($0) }
+                    childOptIn.union(onlyRules).filter { !childDisabled.contains($0) }
                 ))
 
             case .allEnabled:

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -233,10 +233,7 @@ internal extension Configuration {
 
                 // Only use parent disabled / optIn if child config doesn't tell the opposite
                 return .default(
-                    disabled: Set(childDisabled).union(Set(disabled.filter { !childOptIn.contains($0) }))
-                        .filter {
-                            !isOptInRule($0, allRulesWrapped: newAllRulesWrapped)
-                        },
+                    disabled: Set(childDisabled).union(Set(disabled.filter { !childOptIn.contains($0) })),
                     optIn: Set(childOptIn).union(Set(optIn.filter { !childDisabled.contains($0) }))
                         .filter {
                             isOptInRule($0, allRulesWrapped: newAllRulesWrapped)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -302,6 +302,25 @@ extension ConfigurationTests {
     }
     
     func testParentChildOptInAndDisable() {
+        func isEnabledInChild(
+            ruleType: Rule.Type,
+            enabledInParent: Bool,
+            disabledInParent: Bool,
+            enabledInChild: Bool,
+            disabledInChild: Bool
+        ) -> Bool {
+            let ruleIdentifier = ruleType.description.identifier
+            let parentConfiguration = Configuration(rulesMode: .default(
+                disabled: disabledInParent ? [ruleIdentifier] : [],
+                optIn: enabledInParent ? [ruleIdentifier] : []
+            ))
+            let childConfiguration = Configuration(rulesMode: .default(
+                disabled: disabledInChild ? [ruleIdentifier] : [],
+                optIn: enabledInChild ? [ruleIdentifier] : []
+            ))
+            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
+            return mergedConfiguration.contains(rule: ruleType)
+        }
 //        let expectedResults = "0101111100001111"
         let expectedResults = "0100111100000000"
         XCTAssertEqual(expectedResults.count, 4 * 4)
@@ -325,25 +344,6 @@ extension ConfigurationTests {
             XCTAssertEqual(expectedResult, result)
         }
     }
-
-    private func isEnabledInChild(
-        ruleType: Rule.Type,
-        enabledInParent: Bool,
-        disabledInParent: Bool,
-        enabledInChild: Bool,
-        disabledInChild: Bool
-    ) -> Bool {
-        let ruleIdentifier = ruleType.description.identifier
-        let parentConfiguration = Configuration(rulesMode: .default(
-            disabled: disabledInParent ? [ruleIdentifier] : [],
-            optIn: enabledInParent ? [ruleIdentifier] : []
-        ))
-        let childConfiguration = Configuration(rulesMode: .default(
-            disabled: disabledInChild ? [ruleIdentifier] : [],
-            optIn: enabledInChild ? [ruleIdentifier] : []
-        ))
-        let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
-        return mergedConfiguration.contains(rule: ruleType)
     }
     
     // MARK: - Remote Configs

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -337,7 +337,8 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 4 * 4)
         let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue(ruleType is OptInRule)
+        let isOptIn = ruleType is OptInRule.Type
+        XCTAssertTrue(isOptIn)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(rulesMode: .default(
@@ -371,7 +372,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = BlanketDisableCommandRule.self
-        XCTAssertFalse(ruleType is OptInRule)
+        XCTAssertFalse(ruleType is OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(
@@ -403,7 +404,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue(ruleType is OptInRule)
+        XCTAssertTrue(ruleType is OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
         let parentConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
         for testCase in testCases {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -304,19 +304,19 @@ extension ConfigurationTests {
     func testParentChildOptInAndDisable() {
         func isEnabledInChild(
             ruleType: Rule.Type,
-            enabledInParent: Bool,
+            optedInInParent: Bool,
             disabledInParent: Bool,
-            enabledInChild: Bool,
+            optedInInChild: Bool,
             disabledInChild: Bool
         ) -> Bool {
             let ruleIdentifier = ruleType.description.identifier
             let parentConfiguration = Configuration(rulesMode: .default(
                 disabled: disabledInParent ? [ruleIdentifier] : [],
-                optIn: enabledInParent ? [ruleIdentifier] : []
+                optIn: optedInInParent ? [ruleIdentifier] : []
             ))
             let childConfiguration = Configuration(rulesMode: .default(
                 disabled: disabledInChild ? [ruleIdentifier] : [],
-                optIn: enabledInChild ? [ruleIdentifier] : []
+                optIn: optedInInChild ? [ruleIdentifier] : []
             ))
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
             return mergedConfiguration.contains(rule: ruleType)
@@ -332,18 +332,18 @@ extension ConfigurationTests {
             (value ? " " : "") + " \(value)"
         }
         for i in 0..<expectedResults.count {
-            let enabledInParent = i & 1 == 1
+            let optedInInParent = i & 1 == 1
             let disabledInParent = i & 2 == 2
-            let enabledInChild = i & 4 == 4
+            let optedInInChild = i & 4 == 4
             let disabledInChild = i & 8 == 8
             let result = isEnabledInChild(
                 ruleType: ImplicitReturnRule.self,
-                enabledInParent: enabledInParent,
+                optedInInParent: optedInInParent,
                 disabledInParent: disabledInParent,
-                enabledInChild: enabledInChild,
+                optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            // print(">>>> \(i) \(format(enabledInParent)) \(format(disabledInParent)) \(format(enabledInChild)) \(format(disabledInChild)) \(format(result))")
+            // print(">>>> \(i) \(format(optedInInParent)) \(format(disabledInParent)) \(format(optedInInChild)) \(format(disabledInChild)) \(format(result))")
             XCTAssertEqual(expectedResults[i], result)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -340,7 +340,7 @@ extension ConfigurationTests {
                 optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            XCTAssertEqual(expectedResults[index], result)
+            XCTAssertEqual(result, expectedResults[index])
         }
     }
 
@@ -369,7 +369,7 @@ extension ConfigurationTests {
                 optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            XCTAssertEqual(expectedResults[index], result)
+            XCTAssertEqual(result, expectedResults[index])
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -337,8 +337,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 4 * 4)
         let ruleType = ImplicitReturnRule.self
-        let isOptIn = ruleType is OptInRule.Type
-        XCTAssertTrue(isOptIn)
+        XCTAssertTrue(ruleType.isOptInRule)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(rulesMode: .default(
@@ -404,7 +403,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue(ruleType is OptInRule.Type)
+        XCTAssertTrue(ruleType.isOptInRule)
         let ruleIdentifier = ruleType.description.identifier
         let parentConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
         for testCase in testCases {
@@ -525,3 +524,10 @@ extension ConfigurationTests {
         XCTAssertEqual(Set(configuration1.excludedPaths), Set(configuration2.excludedPaths))
     }
 }
+
+private extension Rule {
+    static var isOptInRule: Bool {
+        self is OptInRule
+    }
+}
+

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -337,7 +337,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 4 * 4)
         let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue(ruleType.isOptInRule)
+        XCTAssertTrue((ruleType as Any) is OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(rulesMode: .default(
@@ -403,7 +403,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue(ruleType.isOptInRule)
+        XCTAssertTrue((ruleType as Any) is OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
         let parentConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
         for testCase in testCases {
@@ -522,11 +522,5 @@ extension ConfigurationTests {
         XCTAssertEqual(Set(configuration1.includedPaths), Set(configuration2.includedPaths))
 
         XCTAssertEqual(Set(configuration1.excludedPaths), Set(configuration2.excludedPaths))
-    }
-}
-
-private extension Rule {
-    static var isOptInRule: Bool {
-        self is OptInRule
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -344,6 +344,39 @@ extension ConfigurationTests {
             XCTAssertEqual(expectedResult, result)
         }
     }
+
+    func testParentChildOnlyRulesAndDisable() {
+        func isEnabledInChild(
+            ruleType: Rule.Type,
+            enabledInChild: Bool,
+            disabledInChild: Bool
+        ) -> Bool {
+            let ruleIdentifier = ruleType.description.identifier
+            let parentConfiguration = Configuration(rulesMode:.only([ruleIdentifier]))
+            let childConfiguration = Configuration(rulesMode: .default(
+                disabled: disabledInChild ? [ruleIdentifier] : [],
+                optIn: enabledInChild ? [ruleIdentifier] : []
+            ))
+            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
+            return mergedConfiguration.contains(rule: ruleType)
+        }
+        let expectedResults = "1100"
+        XCTAssertEqual(expectedResults.count, 2 * 2)
+        func format(_ value: Bool) -> String {
+            (value ? " " : "") + " \(value)"
+        }
+        for i in 0..<expectedResults.count {
+            let enabledInChild = i & 1 == 1
+            let disabledInChild = i & 2 == 2
+            let result = isEnabledInChild(
+                ruleType: ImplicitReturnRule.self,
+                enabledInChild: enabledInChild,
+                disabledInChild: disabledInChild
+            )
+            print(">>>> \(i) \(format(enabledInChild)) \(format(disabledInChild)) \(format(result))")
+            let expectedResult = expectedResults[expectedResults.index(expectedResults.startIndex, offsetBy: i)] == "1"
+            XCTAssertEqual(expectedResult, result)
+        }
     }
     
     // MARK: - Remote Configs

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -322,7 +322,11 @@ extension ConfigurationTests {
             return mergedConfiguration.contains(rule: ruleType)
         }
 //        let expectedResults = "0101111100001111"
-        let expectedResults = "0100111100000000"
+//        let expectedResults = "0100111100000000"
+        let expectedResults = [
+            false, true, false, false, true, true, true, true,
+            false, false, false, false, false, false, false, false,
+        ]
         XCTAssertEqual(expectedResults.count, 4 * 4)
         func format(_ value: Bool) -> String {
             (value ? " " : "") + " \(value)"
@@ -340,8 +344,7 @@ extension ConfigurationTests {
                 disabledInChild: disabledInChild
             )
             // print(">>>> \(i) \(format(enabledInParent)) \(format(disabledInParent)) \(format(enabledInChild)) \(format(disabledInChild)) \(format(result))")
-            let expectedResult = expectedResults[expectedResults.index(expectedResults.startIndex, offsetBy: i)] == "1"
-            XCTAssertEqual(expectedResult, result)
+            XCTAssertEqual(expectedResults[i], result)
         }
     }
 
@@ -360,7 +363,7 @@ extension ConfigurationTests {
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
             return mergedConfiguration.contains(rule: ruleType)
         }
-        let expectedResults = "1100"
+        let expectedResults = [ true, true, false, false ]
         XCTAssertEqual(expectedResults.count, 2 * 2)
         func format(_ value: Bool) -> String {
             (value ? " " : "") + " \(value)"
@@ -374,8 +377,7 @@ extension ConfigurationTests {
                 disabledInChild: disabledInChild
             )
             print(">>>> \(i) \(format(enabledInChild)) \(format(disabledInChild)) \(format(result))")
-            let expectedResult = expectedResults[expectedResults.index(expectedResults.startIndex, offsetBy: i)] == "1"
-            XCTAssertEqual(expectedResult, result)
+            XCTAssertEqual(expectedResults[i], result)
         }
     }
     

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -303,8 +303,6 @@ extension ConfigurationTests {
 
     func testParentChildOptInAndDisable() {
         let ruleType = ImplicitReturnRule.self
-        //        let expectedResults = "0101111100001111"
-        //        let expectedResults = "0100111100000000"
         let expectedResults = [
             false, true, false, false, true, true, true, true,
             false, false, false, false, false, false, false, false
@@ -314,8 +312,6 @@ extension ConfigurationTests {
 
     func testParentChildOptInAndDisableForDefaultRule() {
         let ruleType = BlanketDisableCommandRule.self
-        //        let expectedResults = "0101111100001111"
-        //        let expectedResults = "0100111100000000"
         let expectedResults = [
             true, true, false, false, true, true, true, true,
             false, false, false, false, false, false, false, false
@@ -324,7 +320,7 @@ extension ConfigurationTests {
     }
 
     private func testParentChildOptInAndDisable(ruleType: Rule.Type, expectedResults: [Bool]) {
-        func isEnabledInChild(
+        func isEnabledInMergedConfiguration(
             ruleType: Rule.Type,
             optedInInParent: Bool,
             disabledInParent: Bool,
@@ -349,7 +345,7 @@ extension ConfigurationTests {
             let disabledInParent = index & 2 != 0
             let optedInInChild = index & 4 != 0
             let disabledInChild = index & 8 != 0
-            let result = isEnabledInChild(
+            let result = isEnabledInMergedConfiguration(
                 ruleType: ruleType,
                 optedInInParent: optedInInParent,
                 disabledInParent: disabledInParent,
@@ -363,7 +359,7 @@ extension ConfigurationTests {
     }
 
     func testParentChildOnlyRulesAndDisable() {
-        func isEnabledInChild(
+        func isEnabledInMergedConfiguration(
             ruleType: Rule.Type,
             optedInInChild: Bool,
             disabledInChild: Bool
@@ -382,12 +378,13 @@ extension ConfigurationTests {
         for index in 0..<expectedResults.count {
             let optedInInChild = index & 1 != 0
             let disabledInChild = index & 2 != 0
-            let result = isEnabledInChild(
+            let result = isEnabledInMergedConfiguration(
                 ruleType: ImplicitReturnRule.self,
                 optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            XCTAssertEqual(result, expectedResults[index])
+            let message = "optedInInChild = \(optedInInChild), disabledInChild = \(disabledInChild)"
+            XCTAssertEqual(result, expectedResults[index], message)
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -302,6 +302,28 @@ extension ConfigurationTests {
     }
 
     func testParentChildOptInAndDisable() {
+        let ruleType = ImplicitReturnRule.self
+        //        let expectedResults = "0101111100001111"
+        //        let expectedResults = "0100111100000000"
+        let expectedResults = [
+            false, true, false, false, true, true, true, true,
+            false, false, false, false, false, false, false, false
+        ]
+        testParentChildOptInAndDisable(ruleType: ruleType, expectedResults: expectedResults)
+    }
+
+    func testParentChildOptInAndDisableForDefaultRule() {
+        let ruleType = BlanketDisableCommandRule.self
+        //        let expectedResults = "0101111100001111"
+        //        let expectedResults = "0100111100000000"
+        let expectedResults = [
+            true, true, false, false, true, true, true, true,
+            false, false, false, false, false, false, false, false
+        ]
+        testParentChildOptInAndDisable(ruleType: ruleType, expectedResults: expectedResults)
+    }
+
+    private func testParentChildOptInAndDisable(ruleType: Rule.Type, expectedResults: [Bool]) {
         func isEnabledInChild(
             ruleType: Rule.Type,
             optedInInParent: Bool,
@@ -321,12 +343,6 @@ extension ConfigurationTests {
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
             return mergedConfiguration.contains(rule: ruleType)
         }
-//        let expectedResults = "0101111100001111"
-//        let expectedResults = "0100111100000000"
-        let expectedResults = [
-            false, true, false, false, true, true, true, true,
-            false, false, false, false, false, false, false, false
-        ]
         XCTAssertEqual(expectedResults.count, 4 * 4)
         for index in 0..<expectedResults.count {
             let optedInInParent = index & 1 != 0
@@ -334,13 +350,15 @@ extension ConfigurationTests {
             let optedInInChild = index & 4 != 0
             let disabledInChild = index & 8 != 0
             let result = isEnabledInChild(
-                ruleType: ImplicitReturnRule.self,
+                ruleType: ruleType,
                 optedInInParent: optedInInParent,
                 disabledInParent: disabledInParent,
                 optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            XCTAssertEqual(result, expectedResults[index])
+            let message = "optedInInParent = \(optedInInParent), disabledInParent = \(disabledInParent), " +
+                          "optedInInChild = \(optedInInChild), disabledInChild = \(disabledInChild)"
+            XCTAssertEqual(result, expectedResults[index], message)
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -530,4 +530,3 @@ private extension Rule {
         self is OptInRule
     }
 }
-

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -351,14 +351,14 @@ extension ConfigurationTests {
     func testParentChildOnlyRulesAndDisable() {
         func isEnabledInChild(
             ruleType: Rule.Type,
-            enabledInChild: Bool,
+            optedInInChild: Bool,
             disabledInChild: Bool
         ) -> Bool {
             let ruleIdentifier = ruleType.description.identifier
             let parentConfiguration = Configuration(rulesMode:.only([ruleIdentifier]))
             let childConfiguration = Configuration(rulesMode: .default(
                 disabled: disabledInChild ? [ruleIdentifier] : [],
-                optIn: enabledInChild ? [ruleIdentifier] : []
+                optIn: optedInInChild ? [ruleIdentifier] : []
             ))
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
             return mergedConfiguration.contains(rule: ruleType)
@@ -369,14 +369,14 @@ extension ConfigurationTests {
             (value ? " " : "") + " \(value)"
         }
         for i in 0..<expectedResults.count {
-            let enabledInChild = i & 1 == 1
+            let optedInInChild = i & 1 == 1
             let disabledInChild = i & 2 == 2
             let result = isEnabledInChild(
                 ruleType: ImplicitReturnRule.self,
-                enabledInChild: enabledInChild,
+                optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            print(">>>> \(i) \(format(enabledInChild)) \(format(disabledInChild)) \(format(result))")
+            print(">>>> \(i) \(format(optedInInChild)) \(format(disabledInChild)) \(format(result))")
             XCTAssertEqual(expectedResults[i], result)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -302,33 +302,34 @@ extension ConfigurationTests {
     }
 
     func testParentChildOptInAndDisable() {
-        // swiftlint:disable:next large_tuple
-        typealias TestCase = (
-            optedInInParent: Bool,
-            disabledInParent: Bool,
-            optedInInChild: Bool,
-            disabledInChild: Bool,
-            isEnabled: Bool
-        )
+        struct TestCase: Equatable {
+            let optedInInParent: Bool
+            let disabledInParent: Bool
+            let optedInInChild: Bool
+            let disabledInChild: Bool
+            let isEnabled: Bool
+        }
         let testCases: [TestCase] = [
-            (false, false, false, false, false),
-            (true, false, false, false, true),
-            (false, true, false, false, false),
-            (true, true, false, false, false),
-            (false, false, true, false, true),
-            (true, false, true, false, true),
-            (false, true, true, false, true),
-            (true, true, true, false, true),
-            (false, false, false, true, false),
-            (true, false, false, true, false),
-            (false, true, false, true, false),
-            (true, true, false, true, false),
-            (false, false, true, true, false),
-            (true, false, true, true, false),
-            (false, true, true, true, false),
-            (true, true, true, true, false)
+            // swiftlint:disable line_length
+            TestCase(optedInInParent: false, disabledInParent: false, optedInInChild: false, disabledInChild: false, isEnabled: false),
+            TestCase(optedInInParent: true, disabledInParent: false, optedInInChild: false, disabledInChild: false, isEnabled: true),
+            TestCase(optedInInParent: false, disabledInParent: true, optedInInChild: false, disabledInChild: false, isEnabled: false),
+            TestCase(optedInInParent: true, disabledInParent: true, optedInInChild: false, disabledInChild: false, isEnabled: false),
+            TestCase(optedInInParent: false, disabledInParent: false, optedInInChild: true, disabledInChild: false, isEnabled: true),
+            TestCase(optedInInParent: true, disabledInParent: false, optedInInChild: true, disabledInChild: false, isEnabled: true),
+            TestCase(optedInInParent: false, disabledInParent: true, optedInInChild: true, disabledInChild: false, isEnabled: true),
+            TestCase(optedInInParent: true, disabledInParent: true, optedInInChild: true, disabledInChild: false, isEnabled: true),
+            TestCase(optedInInParent: false, disabledInParent: false, optedInInChild: false, disabledInChild: true, isEnabled: false),
+            TestCase(optedInInParent: true, disabledInParent: false, optedInInChild: false, disabledInChild: true, isEnabled: false),
+            TestCase(optedInInParent: false, disabledInParent: true, optedInInChild: false, disabledInChild: true, isEnabled: false),
+            TestCase(optedInInParent: true, disabledInParent: true, optedInInChild: false, disabledInChild: true, isEnabled: false),
+            TestCase(optedInInParent: false, disabledInParent: false, optedInInChild: true, disabledInChild: true, isEnabled: false),
+            TestCase(optedInInParent: true, disabledInParent: false, optedInInChild: true, disabledInChild: true, isEnabled: false),
+            TestCase(optedInInParent: false, disabledInParent: true, optedInInChild: true, disabledInChild: true, isEnabled: false),
+            TestCase(optedInInParent: true, disabledInParent: true, optedInInChild: true, disabledInChild: true, isEnabled: false)
+            // swiftlint:enable line_length
         ]
-        XCTAssertEqual(testCases.count, 4 * 4)
+        XCTAssertEqual(testCases.unique.count, 4 * 4)
         let ruleType = ImplicitReturnRule.self
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
@@ -350,18 +351,18 @@ extension ConfigurationTests {
     }
 
     func testParentChildDisableForDefaultRule() {
-        typealias TestCase = (
-            disabledInParent: Bool,
-            disabledInChild: Bool,
-            isEnabled: Bool
-        )
+        struct TestCase: Equatable {
+            let disabledInParent: Bool
+            let disabledInChild: Bool
+            let isEnabled: Bool
+        }
         let testCases: [TestCase] = [
-            (false, false, true),
-            (true, false, false),
-            (false, true, false),
-            (true, true, false)
+            TestCase(disabledInParent: false, disabledInChild: false, isEnabled: true),
+            TestCase(disabledInParent: true, disabledInChild: false, isEnabled: false),
+            TestCase(disabledInParent: false, disabledInChild: true, isEnabled: false),
+            TestCase(disabledInParent: true, disabledInChild: true, isEnabled: false)
         ]
-        XCTAssertEqual(testCases.count, 2 * 2)
+        XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = BlanketDisableCommandRule.self
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
@@ -379,19 +380,20 @@ extension ConfigurationTests {
         }
     }
 
-    private typealias OptedInAndDisabledInChildTestCase = (
-        optedInInChild: Bool,
-        disabledInChild: Bool,
-        isEnabled: Bool
-    )
+    private struct OptedInAndDisabledInChildTestCase: Equatable {
+        let optedInInChild: Bool
+        let disabledInChild: Bool
+        let isEnabled: Bool
+    }
 
     func testParentOnlyRulesAndChildOptInAndDisabled() {
         let testCases: [OptedInAndDisabledInChildTestCase] = [
-            (false, false, true),
-            (true, false, true),
-            (false, true, false),
-            (true, true, false)
+            OptedInAndDisabledInChildTestCase(optedInInChild: false, disabledInChild: false, isEnabled: true),
+            OptedInAndDisabledInChildTestCase(optedInInChild: true, disabledInChild: false, isEnabled: true),
+            OptedInAndDisabledInChildTestCase(optedInInChild: false, disabledInChild: true, isEnabled: false),
+            OptedInAndDisabledInChildTestCase(optedInInChild: true, disabledInChild: true, isEnabled: false)
         ]
+        XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
         let parentConfiguration = Configuration(rulesMode: .only([ruleType.description.identifier]))
         testParentConfigurationAndChildOptInAndDisabled(
@@ -401,11 +403,12 @@ extension ConfigurationTests {
 
     func testParentAllRulesAndChildOptInAndDisabled() {
         let testCases: [OptedInAndDisabledInChildTestCase] = [
-            (false, false, true),
-            (true, false, true),
-            (false, true, false),
-            (true, true, false)
+            OptedInAndDisabledInChildTestCase(optedInInChild: false, disabledInChild: false, isEnabled: true),
+            OptedInAndDisabledInChildTestCase(optedInInChild: true, disabledInChild: false, isEnabled: true),
+            OptedInAndDisabledInChildTestCase(optedInInChild: false, disabledInChild: true, isEnabled: false),
+            OptedInAndDisabledInChildTestCase(optedInInChild: true, disabledInChild: true, isEnabled: false)
         ]
+        XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
         let parentConfiguration = Configuration(rulesMode: .allEnabled)
         testParentConfigurationAndChildOptInAndDisabled(

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -380,48 +380,22 @@ extension ConfigurationTests {
         }
     }
 
-    private struct OptedInAndDisabledInChildTestCase: Equatable {
-        let optedInInChild: Bool
-        let disabledInChild: Bool
-        let isEnabled: Bool
-    }
-
     func testParentOnlyRulesAndChildOptInAndDisabled() {
-        let testCases: [OptedInAndDisabledInChildTestCase] = [
-            OptedInAndDisabledInChildTestCase(optedInInChild: false, disabledInChild: false, isEnabled: true),
-            OptedInAndDisabledInChildTestCase(optedInInChild: true, disabledInChild: false, isEnabled: true),
-            OptedInAndDisabledInChildTestCase(optedInInChild: false, disabledInChild: true, isEnabled: false),
-            OptedInAndDisabledInChildTestCase(optedInInChild: true, disabledInChild: true, isEnabled: false)
+        struct TestCase: Equatable {
+            let optedInInChild: Bool
+            let disabledInChild: Bool
+            let isEnabled: Bool
+        }
+        let testCases: [TestCase] = [
+            TestCase(optedInInChild: false, disabledInChild: false, isEnabled: true),
+            TestCase(optedInInChild: true, disabledInChild: false, isEnabled: true),
+            TestCase(optedInInChild: false, disabledInChild: true, isEnabled: false),
+            TestCase(optedInInChild: true, disabledInChild: true, isEnabled: false)
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
-        let parentConfiguration = Configuration(rulesMode: .only([ruleType.description.identifier]))
-        testParentConfigurationAndChildOptInAndDisabled(
-            parentConfiguration, ruleType: ruleType, testCases: testCases
-        )
-    }
-
-    func testParentAllRulesAndChildOptInAndDisabled() {
-        let testCases: [OptedInAndDisabledInChildTestCase] = [
-            OptedInAndDisabledInChildTestCase(optedInInChild: false, disabledInChild: false, isEnabled: true),
-            OptedInAndDisabledInChildTestCase(optedInInChild: true, disabledInChild: false, isEnabled: true),
-            OptedInAndDisabledInChildTestCase(optedInInChild: false, disabledInChild: true, isEnabled: false),
-            OptedInAndDisabledInChildTestCase(optedInInChild: true, disabledInChild: true, isEnabled: false)
-        ]
-        XCTAssertEqual(testCases.unique.count, 2 * 2)
-        let ruleType = ImplicitReturnRule.self
-        let parentConfiguration = Configuration(rulesMode: .allEnabled)
-        testParentConfigurationAndChildOptInAndDisabled(
-            parentConfiguration, ruleType: ruleType, testCases: testCases
-        )
-    }
-
-    private func testParentConfigurationAndChildOptInAndDisabled(
-        _ parentConfiguration: Configuration,
-        ruleType: Rule.Type,
-        testCases: [OptedInAndDisabledInChildTestCase]
-    ) {
         let ruleIdentifier = ruleType.description.identifier
+        let parentConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
         for testCase in testCases {
             let childConfiguration = Configuration(rulesMode: .default(
                 disabled: testCase.disabledInChild ? [ruleIdentifier] : [],
@@ -429,7 +403,7 @@ extension ConfigurationTests {
             ))
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
-            let message = "optedInInChild = \(testCase.optedInInChild), disabledInChild = \(testCase.disabledInChild)"
+            let message = "optedInInChild = \(testCase.optedInInChild) disabledInChild = \(testCase.disabledInChild)"
             XCTAssertEqual(isEnabled, testCase.isEnabled, message)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -308,6 +308,12 @@ extension ConfigurationTests {
             let optedInInChild: Bool
             let disabledInChild: Bool
             let isEnabled: Bool
+            var message: String {
+                "optedInInParent = \(optedInInParent) " +
+                "disabledInParent = \(disabledInParent) " +
+                "optedInInChild = \(optedInInChild) " +
+                "disabledInChild = \(disabledInChild)"
+            }
         }
         let testCases: [TestCase] = [
             // swiftlint:disable line_length
@@ -344,10 +350,7 @@ extension ConfigurationTests {
             ))
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
-            let message = "optedInInParent = \(testCase.optedInInParent) " +
-                          "disabledInParent = \(testCase.disabledInParent), " +
-            "optedInInChild = \(testCase.optedInInChild), disabledInChild = \(testCase.disabledInChild)"
-            XCTAssertEqual(isEnabled, testCase.isEnabled, message)
+            XCTAssertEqual(isEnabled, testCase.isEnabled, testCase.message)
         }
     }
 
@@ -356,6 +359,9 @@ extension ConfigurationTests {
             let disabledInParent: Bool
             let disabledInChild: Bool
             let isEnabled: Bool
+            var message: String {
+                "disabledInParent = \(disabledInParent) disabledInChild = \(disabledInChild)"
+            }
         }
         let testCases: [TestCase] = [
             TestCase(disabledInParent: false, disabledInChild: false, isEnabled: true),
@@ -376,9 +382,7 @@ extension ConfigurationTests {
             )
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
-            let message = "disabledInParent = \(testCase.disabledInParent) " +
-                          "disabledInChild = \(testCase.disabledInChild)"
-            XCTAssertEqual(isEnabled, testCase.isEnabled, message)
+            XCTAssertEqual(isEnabled, testCase.isEnabled, testCase.message)
         }
     }
 
@@ -387,6 +391,9 @@ extension ConfigurationTests {
             let optedInInChild: Bool
             let disabledInChild: Bool
             let isEnabled: Bool
+            var message: String {
+                "optedInInChild = \(optedInInChild) disabledInChild = \(disabledInChild)"
+            }
         }
         let testCases: [TestCase] = [
             TestCase(optedInInChild: false, disabledInChild: false, isEnabled: true),
@@ -406,8 +413,7 @@ extension ConfigurationTests {
             ))
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
-            let message = "optedInInChild = \(testCase.optedInInChild) disabledInChild = \(testCase.disabledInChild)"
-            XCTAssertEqual(isEnabled, testCase.isEnabled, message)
+            XCTAssertEqual(isEnabled, testCase.isEnabled, testCase.message)
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -332,10 +332,10 @@ extension ConfigurationTests {
             (value ? " " : "") + " \(value)"
         }
         for i in 0..<expectedResults.count {
-            let optedInInParent = i & 1 == 1
-            let disabledInParent = i & 2 == 2
-            let optedInInChild = i & 4 == 4
-            let disabledInChild = i & 8 == 8
+            let optedInInParent = i & 1 != 0
+            let disabledInParent = i & 2 != 0
+            let optedInInChild = i & 4 != 0
+            let disabledInChild = i & 8 != 0
             let result = isEnabledInChild(
                 ruleType: ImplicitReturnRule.self,
                 optedInInParent: optedInInParent,
@@ -369,8 +369,8 @@ extension ConfigurationTests {
             (value ? " " : "") + " \(value)"
         }
         for i in 0..<expectedResults.count {
-            let optedInInChild = i & 1 == 1
-            let disabledInChild = i & 2 == 2
+            let optedInInChild = i & 1 != 0
+            let disabledInChild = i & 2 != 0
             let result = isEnabledInChild(
                 ruleType: ImplicitReturnRule.self,
                 optedInInChild: optedInInChild,

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -328,11 +328,11 @@ extension ConfigurationTests {
             false, false, false, false, false, false, false, false
         ]
         XCTAssertEqual(expectedResults.count, 4 * 4)
-        for i in 0..<expectedResults.count {
-            let optedInInParent = i & 1 != 0
-            let disabledInParent = i & 2 != 0
-            let optedInInChild = i & 4 != 0
-            let disabledInChild = i & 8 != 0
+        for index in 0..<expectedResults.count {
+            let optedInInParent = index & 1 != 0
+            let disabledInParent = index & 2 != 0
+            let optedInInChild = index & 4 != 0
+            let disabledInChild = index & 8 != 0
             let result = isEnabledInChild(
                 ruleType: ImplicitReturnRule.self,
                 optedInInParent: optedInInParent,
@@ -340,7 +340,7 @@ extension ConfigurationTests {
                 optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            XCTAssertEqual(expectedResults[i], result)
+            XCTAssertEqual(expectedResults[index], result)
         }
     }
 
@@ -361,15 +361,15 @@ extension ConfigurationTests {
         }
         let expectedResults = [ true, true, false, false ]
         XCTAssertEqual(expectedResults.count, 2 * 2)
-        for i in 0..<expectedResults.count {
-            let optedInInChild = i & 1 != 0
-            let disabledInChild = i & 2 != 0
+        for index in 0..<expectedResults.count {
+            let optedInInChild = index & 1 != 0
+            let disabledInChild = index & 2 != 0
             let result = isEnabledInChild(
                 ruleType: ImplicitReturnRule.self,
                 optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            XCTAssertEqual(expectedResults[i], result)
+            XCTAssertEqual(expectedResults[index], result)
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -300,7 +300,7 @@ extension ConfigurationTests {
             Configuration()
         )
     }
-    
+
     func testParentChildOptInAndDisable() {
         func isEnabledInChild(
             ruleType: Rule.Type,
@@ -325,12 +325,9 @@ extension ConfigurationTests {
 //        let expectedResults = "0100111100000000"
         let expectedResults = [
             false, true, false, false, true, true, true, true,
-            false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false
         ]
         XCTAssertEqual(expectedResults.count, 4 * 4)
-        func format(_ value: Bool) -> String {
-            (value ? " " : "") + " \(value)"
-        }
         for i in 0..<expectedResults.count {
             let optedInInParent = i & 1 != 0
             let disabledInParent = i & 2 != 0
@@ -343,7 +340,6 @@ extension ConfigurationTests {
                 optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            // print(">>>> \(i) \(format(optedInInParent)) \(format(disabledInParent)) \(format(optedInInChild)) \(format(disabledInChild)) \(format(result))")
             XCTAssertEqual(expectedResults[i], result)
         }
     }
@@ -355,7 +351,7 @@ extension ConfigurationTests {
             disabledInChild: Bool
         ) -> Bool {
             let ruleIdentifier = ruleType.description.identifier
-            let parentConfiguration = Configuration(rulesMode:.only([ruleIdentifier]))
+            let parentConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
             let childConfiguration = Configuration(rulesMode: .default(
                 disabled: disabledInChild ? [ruleIdentifier] : [],
                 optIn: optedInInChild ? [ruleIdentifier] : []
@@ -365,9 +361,6 @@ extension ConfigurationTests {
         }
         let expectedResults = [ true, true, false, false ]
         XCTAssertEqual(expectedResults.count, 2 * 2)
-        func format(_ value: Bool) -> String {
-            (value ? " " : "") + " \(value)"
-        }
         for i in 0..<expectedResults.count {
             let optedInInChild = i & 1 != 0
             let disabledInChild = i & 2 != 0
@@ -376,11 +369,10 @@ extension ConfigurationTests {
                 optedInInChild: optedInInChild,
                 disabledInChild: disabledInChild
             )
-            print(">>>> \(i) \(format(optedInInChild)) \(format(disabledInChild)) \(format(result))")
             XCTAssertEqual(expectedResults[i], result)
         }
     }
-    
+
     // MARK: - Remote Configs
     func testValidRemoteChildConfig() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.remoteConfigChild)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -331,6 +331,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 4 * 4)
         let ruleType = ImplicitReturnRule.self
+        XCTAssertTrue(ruleType is OptInRule)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(rulesMode: .default(
@@ -394,6 +395,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
+        XCTAssertTrue(ruleType is OptInRule)
         let ruleIdentifier = ruleType.description.identifier
         let parentConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
         for testCase in testCases {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -365,6 +365,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = BlanketDisableCommandRule.self
+        XCTAssertFalse(ruleType is OptInRule)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -307,21 +307,7 @@ extension ConfigurationTests {
             false, true, false, false, true, true, true, true,
             false, false, false, false, false, false, false, false
         ]
-        testParentChildOptInAndDisable(ruleType: ruleType, expectedResults: expectedResults)
-    }
-
-    func testParentChildOptInAndDisableForDefaultRule() {
-        let ruleType = BlanketDisableCommandRule.self
-        let expectedResults = [
-            true, true, false, false, true, true, true, true,
-            false, false, false, false, false, false, false, false
-        ]
-        testParentChildOptInAndDisable(ruleType: ruleType, expectedResults: expectedResults)
-    }
-
-    private func testParentChildOptInAndDisable(ruleType: Rule.Type, expectedResults: [Bool]) {
         func isEnabledInMergedConfiguration(
-            ruleType: Rule.Type,
             optedInInParent: Bool,
             disabledInParent: Bool,
             optedInInChild: Bool,
@@ -346,7 +332,6 @@ extension ConfigurationTests {
             let optedInInChild = index & 4 != 0
             let disabledInChild = index & 8 != 0
             let result = isEnabledInMergedConfiguration(
-                ruleType: ruleType,
                 optedInInParent: optedInInParent,
                 disabledInParent: disabledInParent,
                 optedInInChild: optedInInChild,
@@ -354,6 +339,36 @@ extension ConfigurationTests {
             )
             let message = "optedInInParent = \(optedInInParent), disabledInParent = \(disabledInParent), " +
                           "optedInInChild = \(optedInInChild), disabledInChild = \(disabledInChild)"
+            XCTAssertEqual(result, expectedResults[index], message)
+        }
+    }
+
+    func testParentChildDisableForDefaultRule() {
+        let ruleType = BlanketDisableCommandRule.self
+        let expectedResults = [true, false, false, false]
+        func isEnabledInMergedConfiguration(
+            disabledInParent: Bool,
+            disabledInChild: Bool
+        ) -> Bool {
+            let ruleIdentifier = ruleType.description.identifier
+            let parentConfiguration = Configuration(
+                rulesMode: .default(disabled: disabledInParent ? [ruleIdentifier] : [], optIn: [])
+            )
+            let childConfiguration = Configuration(
+                rulesMode: .default(disabled: disabledInChild ? [ruleIdentifier] : [], optIn: [])
+            )
+            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
+            return mergedConfiguration.contains(rule: ruleType)
+        }
+        XCTAssertEqual(expectedResults.count, 2 * 2)
+        for index in 0..<expectedResults.count {
+            let disabledInParent = index & 1 != 0
+            let disabledInChild = index & 2 != 0
+            let result = isEnabledInMergedConfiguration(
+                disabledInParent: disabledInParent,
+                disabledInChild: disabledInChild
+            )
+            let message = "disabledInParent = \(disabledInParent), disabledInChild = \(disabledInChild)"
             XCTAssertEqual(result, expectedResults[index], message)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/ChildConfig/Test2/expected.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/ChildConfig/Test2/expected.yml
@@ -2,7 +2,10 @@ opt_in_rules:
   - private_action
 
 disabled_rules:
+  - empty_count
   - force_cast
+  - private_outlet
+  - trailing_closure
 
 line_length: 80
 

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/ParentConfig/Test2/expected.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/ParentConfig/Test2/expected.yml
@@ -2,7 +2,10 @@ opt_in_rules:
   - private_action
 
 disabled_rules:
+  - empty_count
   - force_cast
+  - private_outlet
+  - trailing_closure
 
 line_length: 80
 


### PR DESCRIPTION
Fixes some unexpected behaviors in the interaction between parent and child configurations.

For example, if a rule is enabled and disabled in the parent config, and not mentioned in the child config (case 3 below), currently the rule will become re-enabled in the merged configuration.

Resolves #4876, which documents the unexpected behaviors.

Below is the truth table for whether an optin rule is enabled in the child configuration, as a function of whether it is listed in the `opt_in_rules`, and/or the `disabled_rules` sections of the parent and child configuration.

`current` is the value for `main`/`0.51.0`, and `new` is the value produced by this branch.

asterisked rows have changed.

```
        parent    parent      child      child
        opt_in   disabled    opt_in     disabled    current       new

0       false      false      false      false       false       false
1        true      false      false      false        true        true
2       false       true      false      false       false       false
3        true       true      false      false        true       false *
4       false      false       true      false        true        true
5        true      false       true      false        true        true
6       false       true       true      false        true        true
7        true       true       true      false        true        true
8       false      false      false       true       false       false
9        true      false      false       true       false       false
10      false       true      false       true       false       false
11       true       true      false       true       false       false
12      false      false       true       true        true       false *
13       true      false       true       true        true       false *
14      false       true       true       true        true       false *
15       true       true       true       true        true       false *
```

To take case 3 in detail, if an optin rule is listed in opt_in_rules and disabled_rules in the parent configuration, and not mentioned in the child, then currently (in `main`/`0.51.0`) the rule will be disabled for the parent configuration, but **enabled** in the child.

parent.yml:

```
opt_in_rules:
  - implicit_return
disabled_rules:
  - implicit_return
```

child.yml:

```
parent_config: parent.yml
```

checking enablement:

```
% swiftlint rules  --config parent.yml | grep implicit_return
| implicit_return                          | yes    | yes         | NO                     | style       | no       | yes            | severity: ... |
```

```
% swiftlint rules  --config child.yml | grep implicit_return
| implicit_return                          | yes    | yes         | YES                    | style       | no       | yes            | severity: ... |
```

and actual behaviour, given:

```
class ImplicitReturn {
   var foo: Int {
       return 0
   }
}
```

```
 % swiftlint lint  --config parent.yml ImplicitReturn.swift 
Linting Swift files at paths ImplicitReturn.swift
Linting 'ImplicitReturn.swift' (1/1)
Done linting! Found 0 violations, 0 serious in 1 file.
%
% swiftlint lint --config child.yml ImplicitReturn.swift 
Linting Swift files at paths ImplicitReturn.swift
Linting 'ImplicitReturn.swift' (1/1)
/Users/martin.redington/Documents/Hudl/Source/SwiftLint/ImplicitReturn.swift:3:8: warning: Implicit Return Violation: Prefer implicit returns in closures, functions and getters (implicit_return)
Done linting! Found 1 violation, 0 serious in 1 file.
```

Similarly, in cases 12 through 15, the rule is both mentioned in the child's `opt_in_rules`, and `disabled_rules`, which should surely mean the rule ends up disabled in the child, no matter what the parent says.

This PR changes the processing of these configurations, to produce the truth values shown in the `new` column above, which seem more sensible than the current values.

There is a related issue when the parent has only rules, and the child has a default configuration.

Here is the truth table for this case:

```
       child       child
       optin     disabled    current     new

0      false      false       true       true
1       true      false       true       true
2      false       true      false      false
3       true       true       true      false *
```

Examining case 3

parent.yml:

```
only_rules:
   - implicit_return
```

and child.yml:

```
parent_config: parent.yml

opt_in_rules:
  - implicit_return
disabled_rules:
  - implicit_return
```

Currently (in `main`/`0.51.0`) the rule would end up enabled for the child, even though it is explicitly disabled in the child configuration.
