### PR TITLE
Fixes warning about configurations for rules that are not enabled, when they are enabled in a parent config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## MainOAA
+## Main
 
 #### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,8 @@
 
 * Add new `non_optional_string_data_conversion` rule to enforce 
   non-failable conversions of UTF-8 `String` <-> `Data`.    
+* Add new `non_optional_string_data_conversion` rule to enforce
+  non-failable conversions of UTF-8 `String` <-> `Data`.  
   [Ben P](https://github.com/ben-p-commits)
   [#5263](https://github.com/realm/SwiftLint/issues/5263)
 
@@ -194,7 +196,7 @@
   are defined in a tuple like `let (a, b) = (5, 10)` or `let a = (2, 3)`.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5305](https://github.com/realm/SwiftLint/pull/5305)
-  
+
 * Silence `pattern_matching_keywords` rule when an identifier is referenced
   in the argument list of a matching enum case.  
   [SimplyDanny](https://github.com/SimplyDanny)
@@ -277,7 +279,6 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5277](https://github.com/realm/SwiftLint/issues/5277)
 
-* Fix false positive in `unused_import` rule that triggered on 
 * Fix false positive in `unused_import` rule that triggered on
   `@_exported` imports which could break downstream modules if removed.  
   [jszumski](https://github.com/jszumski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Main
+## MainOAA
 
 #### Breaking
 
@@ -457,18 +457,14 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4798](https://github.com/realm/SwiftLint/issues/4798)
 
+* Fix false positive in the `test_case_accessibility` rule.  
+  [gibachan](https://github.com/gibachan)
+  [#5211](https://github.com/realm/SwiftLint/issues/5211)
+
 * Fixes superfluous warnings about configurations for rules that were not
   enabled, when the rules were enabled in a parent configuration.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4858](https://github.com/realm/SwiftLint/issues/4858)
-
-* Fix false positives for `superfluous_disable_command` rule.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4798](https://github.com/realm/SwiftLint/issues/4798)
-
-* Fix false positive in the `test_case_accessibility` rule.  
-  [gibachan](https://github.com/gibachan)
-  [#5211](https://github.com/realm/SwiftLint/issues/5211)
 
 ## 0.52.4: Lid Switch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,7 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5277](https://github.com/realm/SwiftLint/issues/5277)
 
+* Fix false positive in `unused_import` rule that triggered on 
 * Fix false positive in `unused_import` rule that triggered on
   `@_exported` imports which could break downstream modules if removed.  
   [jszumski](https://github.com/jszumski)
@@ -281,6 +282,7 @@
   defined in a transitive module.  
   [jszumski](https://github.com/jszumski)
   [#5246](https://github.com/realm/SwiftLint/pull/5246)
+
 * Fixes superfluous warnings about configurations for rules that were not
   enabled, when the rules were enabled in a parent configuration.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,10 @@
   defined in a transitive module.  
   [jszumski](https://github.com/jszumski)
   [#5246](https://github.com/realm/SwiftLint/pull/5246)
+* Fixes superfluous warnings about configurations for rules that were not
+  enabled, when the rules were enabled in a parent configuration.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 ## 0.53.0: Laundry List
 
@@ -460,11 +464,6 @@
 * Fix false positive in the `test_case_accessibility` rule.  
   [gibachan](https://github.com/gibachan)
   [#5211](https://github.com/realm/SwiftLint/issues/5211)
-
-* Fixes superfluous warnings about configurations for rules that were not
-  enabled, when the rules were enabled in a parent configuration.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 ## 0.52.4: Lid Switch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -453,6 +453,10 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5165](https://github.com/realm/SwiftLint/issues/5165)
 
+* Fix false positives for `superfluous_disable_command` rule.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4798](https://github.com/realm/SwiftLint/issues/4798)
+
 * Fixes superfluous warnings about configurations for rules that were not
   enabled, when the rules were enabled in a parent configuration.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,7 @@
   in the argument list of a matching enum case.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#3852](https://github.com/realm/SwiftLint/pull/3852)
+
 * Fixes superfluous warnings about configurations for rules that were not
   enabled, when the rules were enabled in a parent configuration.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,7 @@
   have good accessibility labels.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5165](https://github.com/realm/SwiftLint/issues/5165)
+
 * Fixes superfluous warnings about configurations for rules that were not
   enabled, when the rules were enabled in a parent configuration.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,8 +119,6 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5418](https://github.com/realm/SwiftLint/pull/5418)
 
-* Add new `non_optional_string_data_conversion` rule to enforce 
-  non-failable conversions of UTF-8 `String` <-> `Data`.    
 * Add new `non_optional_string_data_conversion` rule to enforce
   non-failable conversions of UTF-8 `String` <-> `Data`.  
   [Ben P](https://github.com/ben-p-commits)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,10 +436,6 @@
   extension are in the same source file.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5137](https://github.com/realm/SwiftLint/issues/5137)
-* Fixes superfluous warnings about configurations for rules that were not
-  enabled, when the rules were enabled in a parent configuration.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 * Fix false positive in the `ns_number_init_as_function_reference` rule
   when calling `NSNumber.init(value:)` directly.  
@@ -456,6 +452,10 @@
   have good accessibility labels.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5165](https://github.com/realm/SwiftLint/issues/5165)
+* Fixes superfluous warnings about configurations for rules that were not
+  enabled, when the rules were enabled in a parent configuration.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 * Fix false positives for `superfluous_disable_command` rule.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,10 +419,6 @@
   [Thi Doãn](https://github.com/thii)
   [JP Simard](https://github.com/jpsim)
   [#4737](https://github.com/realm/SwiftLint/issues/4737)
-* Fixes superfluous warnings about configurations for rules that were not
-  enabled, when the rules were enabled in a parent configuration.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 * Fix false negatives for the `unneeded_synthesized_initializer` rule
   for nested structs in classes.  
@@ -440,6 +436,10 @@
   extension are in the same source file.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5137](https://github.com/realm/SwiftLint/issues/5137)
+* Fixes superfluous warnings about configurations for rules that were not
+  enabled, when the rules were enabled in a parent configuration.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 * Fix false positive in the `ns_number_init_as_function_reference` rule
   when calling `NSNumber.init(value:)` directly.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,10 @@
   in the argument list of a matching enum case.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#3852](https://github.com/realm/SwiftLint/pull/3852)
+* Fixes superfluous warnings about configurations for rules that were not
+  enabled, when the rules were enabled in a parent configuration.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 * Don't trigger the `return_value_from_void_function` warning from initializers.  
   [mrbkap](https://github.com/mrbkap)
@@ -282,11 +286,6 @@
   defined in a transitive module.  
   [jszumski](https://github.com/jszumski)
   [#5246](https://github.com/realm/SwiftLint/pull/5246)
-
-* Fixes superfluous warnings about configurations for rules that were not
-  enabled, when the rules were enabled in a parent configuration.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 ## 0.53.0: Laundry List
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,6 +419,10 @@
   [Thi Doãn](https://github.com/thii)
   [JP Simard](https://github.com/jpsim)
   [#4737](https://github.com/realm/SwiftLint/issues/4737)
+* Fixes superfluous warnings about configurations for rules that were not
+  enabled, when the rules were enabled in a parent configuration.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 * Fix false negatives for the `unneeded_synthesized_initializer` rule
   for nested structs in classes.  
@@ -750,11 +754,6 @@
 * Fix `lower_acl_than_parent` rule rewriter by preserving leading whitespace.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4860](https://github.com/realm/SwiftLint/issues/4860)
-
-* Fixes superfluous warnings about configurations for rules that were not
-  enabled, when the rules were enabled in a parent configuration.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
 * Ignore block comments in `let_var_whitespace` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,13 +202,13 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#3852](https://github.com/realm/SwiftLint/pull/3852)
 
+* Don't trigger the `return_value_from_void_function` warning from initializers.  
+  [mrbkap](https://github.com/mrbkap)
+
 * Fixes superfluous warnings about configurations for rules that were not
   enabled, when the rules were enabled in a parent configuration.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4858](https://github.com/realm/SwiftLint/issues/4858)
-
-* Don't trigger the `return_value_from_void_function` warning from initializers.  
-  [mrbkap](https://github.com/mrbkap)
 
 ## 0.54.0: Macro-Economic Forces
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
@@ -8,7 +8,7 @@ extension Configuration {
     // MARK: - Methods: Merging
     package func merged(
         withChild childConfiguration: Configuration,
-        rootDirectory: String
+        rootDirectory: String = ""
     ) -> Configuration {
         let mergedIncludedAndExcluded = self.mergedIncludedAndExcluded(
             with: childConfiguration,

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -218,7 +218,7 @@ extension Configuration {
     ) -> Issue? {
         var enabledInParentRules: Set<String> = []
         var disabledInParentRules: Set<String> = []
-        
+
         if let parentConfiguration {
             switch parentConfiguration.rulesMode {
             case .allEnabled:
@@ -235,14 +235,14 @@ extension Configuration {
                 disabledInParentRules = parentDisabledRules
             }
         }
-        
+
         var allEnabledRules: Set<String> = enabledInParentRules
         allEnabledRules.subtract(disabledInParentRules)
         allEnabledRules.formUnion(optInRules)
         allEnabledRules.subtract(disabledRules)
-        
+
         let allIdentifiers = ruleType.description.allIdentifiers
-        
+
         if allEnabledRules.isDisjoint(with: allIdentifiers) {
             if Set(disabledRules).isDisjoint(with: allIdentifiers) == false {
                 return Issue.genericWarning("\(message), but it is disabled on " +
@@ -250,7 +250,7 @@ extension Configuration {
             } else if Set(disabledInParentRules).isDisjoint(with: allIdentifiers) == false {
                 return Issue.genericWarning("\(message), but it is disabled in a parent configuration.")
             }
-            
+
             if ruleType is OptInRule.Type {
                 if Set(enabledInParentRules.union(optInRules)).isDisjoint(with: allIdentifiers) {
                     return Issue.genericWarning("\(message), but it is not enabled on " +
@@ -258,7 +258,7 @@ extension Configuration {
                 }
             }
         }
-                    
+
         return nil
     }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -248,10 +248,10 @@ extension Configuration {
             }
         }
 
-        var allEnabledRules: Set<String> = enabledInParentRules
-        allEnabledRules.subtract(disabledInParentRules)
-        allEnabledRules.formUnion(optInRules)
-        allEnabledRules.subtract(disabledRules)
+        var allEnabledRules = enabledInParentRules
+            .subtracting(disabledInParentRules)
+            .union(optInRules)
+            .subtracting(disabledRules)
 
         let allIdentifiers = ruleType.description.allIdentifiers
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -167,10 +167,7 @@ extension Configuration {
             case .allEnabled:
                 return
             case .only(let onlyRules):
-                let issue = validateConfiguredRuleIsEnabled(
-                    onlyRules: onlyRules,
-                    ruleType: ruleType
-                )
+                let issue = validateConfiguredRuleIsEnabled(onlyRules: onlyRules, ruleType: ruleType)
                 issue?.print()
             case let .default(disabled: disabledRules, optIn: optInRules):
                 if rule is any OptInRule.Type, Set(optInRules).isDisjoint(with: rule.description.allIdentifiers) {

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -1,6 +1,3 @@
-// swiftlint:disable:next blanket_disable_command
-// swiftlint:disable inclusive_language - To ease migration from `whitelist_rules`
-
 extension Configuration {
     // MARK: - Subtypes
     internal enum Key: String, CaseIterable {
@@ -12,10 +9,8 @@ extension Configuration {
         case optInRules = "opt_in_rules"
         case reporter = "reporter"
         case swiftlintVersion = "swiftlint_version"
-        case useNestedConfigs = "use_nested_configs" // deprecated, always enabled
         case warningThreshold = "warning_threshold"
         case onlyRules = "only_rules"
-        case whitelistRules = "whitelist_rules" // deprecated in favor of onlyRules
         case indentation = "indentation"
         case analyzerRules = "analyzer_rules"
         case allowZeroLintableFiles = "allow_zero_lintable_files"
@@ -32,6 +27,7 @@ extension Configuration {
     // MARK: - Initializers
     /// Creates a Configuration value based on the specified parameters.
     ///
+    /// - parameter parentConfiguration           The parent configuration, if any
     /// - parameter dict:                   The untyped dictionary to serve as the input for this typed configuration.
     ///                                     Typically generated from a YAML-formatted file.
     /// - parameter ruleList:               The list of rules to be available to this configuration.
@@ -51,8 +47,7 @@ extension Configuration {
         let optInRules = defaultStringArray(dict[Key.optInRules.rawValue] ?? dict[Key.enabledRules.rawValue])
         let disabledRules = defaultStringArray(dict[Key.disabledRules.rawValue])
 
-        // Use either the new 'only_rules' or fallback to the deprecated 'whitelist_rules'
-        let onlyRules = defaultStringArray(dict[Key.onlyRules.rawValue] ?? dict[Key.whitelistRules.rawValue])
+        let onlyRules = defaultStringArray(dict[Key.onlyRules.rawValue])
         let analyzerRules = defaultStringArray(dict[Key.analyzerRules.rawValue])
 
         Self.warnAboutInvalidKeys(configurationDictionary: dict, ruleList: ruleList)
@@ -68,7 +63,7 @@ extension Configuration {
         } catch let RuleListError.duplicatedConfigurations(ruleType) {
             let aliases = ruleType.description.deprecatedAliases.map { "'\($0)'" }.joined(separator: ", ")
             let identifier = ruleType.description.identifier
-            throw ConfigurationError.generic(
+            throw Issue.genericWarning(
                 "Multiple configurations found for '\(identifier)'. Check for any aliases: \(aliases)."
             )
         }
@@ -114,8 +109,7 @@ extension Configuration {
             if let indentationStyle = Self.IndentationStyle(rawIndentation) {
                 return indentationStyle
             }
-
-            queuedPrintError("Invalid configuration for '\(Key.indentation)'. Falling back to default.")
+            Issue.invalidConfiguration(ruleID: Key.indentation.rawValue).print()
             return .default
         }
 
@@ -131,23 +125,7 @@ extension Configuration {
     ) {
         // Deprecation warning for "enabled_rules"
         if dict[Key.enabledRules.rawValue] != nil {
-            queuedPrintError("warning: '\(Key.enabledRules.rawValue)' has been renamed to " +
-                "'\(Key.optInRules.rawValue)' and will be completely removed in a " +
-                "future release.")
-        }
-
-        // Deprecation warning for "use_nested_configs"
-        if dict[Key.useNestedConfigs.rawValue] != nil {
-            queuedPrintError("warning: Support for '\(Key.useNestedConfigs.rawValue)' has " +
-                "been deprecated and its value is now ignored. Nested configuration files are " +
-                "now always considered.")
-        }
-
-        // Deprecation warning for "whitelist_rules"
-        if dict[Key.whitelistRules.rawValue] != nil {
-            queuedPrintError("'\(Key.whitelistRules.rawValue)' has been renamed to " +
-                "'\(Key.onlyRules.rawValue)' and will be completely removed in a " +
-                "future release.")
+            Issue.renamedIdentifier(old: Key.enabledRules.rawValue, new: Key.optInRules.rawValue).print()
         }
 
         // Deprecation warning for rules
@@ -161,10 +139,7 @@ extension Configuration {
         }
 
         for (deprecatedIdentifier, identifier) in deprecatedUsages {
-            queuedPrintError(
-                "warning: '\(deprecatedIdentifier)' rule has been renamed to '\(identifier)' and will be "
-                    + "completely removed in a future release."
-            )
+            Issue.renamedIdentifier(old: deprecatedIdentifier, new: identifier).print()
         }
     }
 
@@ -188,7 +163,7 @@ extension Configuration {
                     continue
             }
 
-            let message = "warning: Found a configuration for '\(identifier)' rule"
+            let message = "Found a configuration for '\(identifier)' rule"
 
             switch rulesMode {
             case .allEnabled:
@@ -196,8 +171,7 @@ extension Configuration {
 
             case .only(let onlyRules):
                 if Set(onlyRules).isDisjoint(with: ruleType.description.allIdentifiers) {
-                    queuedPrintError("\(message), but it is not present on " +
-                        "'\(Key.onlyRules.rawValue)'.")
+                    Issue.genericWarning("\(message), but it is not present on '\(Key.onlyRules.rawValue)'.").print()
                 }
 
             case let .default(disabled: disabledRules, optIn: optInRules):
@@ -259,14 +233,14 @@ extension Configuration {
         let allIdentifiers = ruleType.description.allIdentifiers
         if ruleType is OptInRule.Type {
             if Set(allOptInRules).isDisjoint(with: allIdentifiers) {
-                queuedPrintError("\(message), but it is not enabled on " +
-                                 "'\(Key.optInRules.rawValue)'.")
+                Issue.genericWarning("\(message), but it is not enabled on " +
+                                     "'\(Key.optInRules.rawValue)'.").print()
             }
         } else if Set(disabledRules).isSuperset(of: allIdentifiers) {
-            queuedPrintError("\(message), but it is disabled on " +
-                             "'\(Key.disabledRules.rawValue)'.")
+            Issue.genericWarning("\(message), but it is disabled on " +
+                                 "'\(Key.disabledRules.rawValue)'.").print()
         } else if Set(allDisabledRules.subtracting(disabledRules)).isSuperset(of: allIdentifiers) {
-            queuedPrintError("\(message), but it is disabled in a parent configuration.")
+            Issue.genericWarning("\(message), but it is disabled in a parent configuration.").print()
         }
     }
 
@@ -277,10 +251,12 @@ extension Configuration {
         Set(analyzerRules).intersection(optInRules)
             .sorted()
             .forEach {
-                queuedPrintError("""
-                    warning: '\($0)' should be listed in the 'analyzer_rules' configuration section \
-                    for more clarity as it is only run by 'swiftlint analyze'
-                    """)
+                Issue.genericWarning(
+                    """
+                    '\($0)' should be listed in the 'analyzer_rules' configuration section \
+                    for more clarity as it is only run by 'swiftlint analyze'.
+                    """
+                ).print()
             }
     }
 }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -207,7 +207,7 @@ extension Configuration {
         ruleType: any Rule.Type
     ) -> Issue? {
         if onlyRules.isDisjoint(with: ruleType.description.allIdentifiers) {
-            return Issue.configurationForRuleNotPresentInOnlyRules(ruleID: ruleType.identifier)
+            return Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)
         }
         return nil
     }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -27,7 +27,7 @@ extension Configuration {
     // MARK: - Initializers
     /// Creates a Configuration value based on the specified parameters.
     ///
-    /// - parameter parentConfiguration:    The parent configuration, if any
+    /// - parameter parentConfiguration:    The parent configuration, if any.
     /// - parameter dict:                   The untyped dictionary to serve as the input for this typed configuration.
     ///                                     Typically generated from a YAML-formatted file.
     /// - parameter ruleList:               The list of rules to be available to this configuration.

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -209,7 +209,7 @@ extension Configuration {
         }
     }
 
-    private static func validateConfiguredRuleIsEnabled(
+    static func validateConfiguredRuleIsEnabled(
         message: String,
         parentConfiguration: Configuration?,
         disabledRules: Set<String>,

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -243,10 +243,10 @@ extension Configuration {
         let allIdentifiers = ruleType.description.allIdentifiers
 
         if allEnabledRules.isDisjoint(with: allIdentifiers) {
-            if disabledRules.isDisjoint(with: allIdentifiers) == false {
+            if !disabledRules.isDisjoint(with: allIdentifiers) {
                 return Issue.ruleDisabledInDisabledRules(ruleID: ruleType.identifier)
             }
-            if disabledInParentRules.isDisjoint(with: allIdentifiers) == false {
+            if !disabledInParentRules.isDisjoint(with: allIdentifiers) {
                 return Issue.ruleDisabledInParentConfiguration(ruleID: ruleType.identifier)
             }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -246,14 +246,14 @@ extension Configuration {
         let allIdentifiers = ruleType.description.allIdentifiers
 
         if allEnabledRules.isDisjoint(with: allIdentifiers) {
-            if Set(disabledRules).isDisjoint(with: allIdentifiers) == false {
+            if disabledRules.isDisjoint(with: allIdentifiers) == false {
                 return Issue.ruleDisabledInDisabledRules(ruleID: ruleType.identifier)
-            } else if Set(disabledInParentRules).isDisjoint(with: allIdentifiers) == false {
+            } else if disabledInParentRules.isDisjoint(with: allIdentifiers) == false {
                 return Issue.ruleDisabledInParentConfiguration(ruleID: ruleType.identifier)
             }
 
             if ruleType is OptInRule.Type {
-                if Set(enabledInParentRules.union(optInRules)).isDisjoint(with: allIdentifiers) {
+                if enabledInParentRules.union(optInRules).isDisjoint(with: allIdentifiers) {
                     return Issue.ruleNotEnabledInOptInRules(ruleID: ruleType.identifier)
                 }
             }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -165,7 +165,7 @@ extension Configuration {
         if case .default(let disabledRules, let optInRules) = rulesMode {
             if case .only(let onlyRules) = parentConfiguration?.rulesMode {
                 enabledInParentRules = onlyRules
-            } else if case .default(let parentDisabledRules, let parentOptInRules) = parentConfiguration?.rulesMode{
+            } else if case .default(let parentDisabledRules, let parentOptInRules) = parentConfiguration?.rulesMode {
                 enabledInParentRules = parentOptInRules
                 disabledInParentRules = parentDisabledRules
             }
@@ -234,6 +234,7 @@ extension Configuration {
         return nil
     }
 
+    // swiftlint:disable:next function_parameter_count
     static func validateConfiguredRuleIsEnabled(
         parentConfiguration: Configuration?,
         enabledInParentRules: Set<String>,

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -213,6 +213,7 @@ extension Configuration {
         return nil
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     static func validateConfiguredRuleIsEnabled(
         parentConfiguration: Configuration?,
         disabledRules: Set<String>,
@@ -256,6 +257,9 @@ extension Configuration {
                 if enabledInParentRules.union(optInRules).isDisjoint(with: allIdentifiers) {
                     return Issue.ruleNotEnabledInOptInRules(ruleID: ruleType.identifier)
                 }
+            } else if case .only(let enabledInParentRules) = parentConfiguration?.rulesMode,
+                      enabledInParentRules.isDisjoint(with: allIdentifiers) {
+                return Issue.ruleNotEnabledInParentOnlyRules(ruleID: ruleType.identifier)
             }
         }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -168,12 +168,13 @@ extension Configuration {
             switch rulesMode {
             case .allEnabled:
                 return
-
             case .only(let onlyRules):
-                if Set(onlyRules).isDisjoint(with: ruleType.description.allIdentifiers) {
-                    Issue.genericWarning("\(message), but it is not present on '\(Key.onlyRules.rawValue)'.").print()
-                }
-
+                let issue = validateConfiguredRuleIsEnabled(
+                    message: message,
+                    onlyRules: onlyRules,
+                    ruleType: ruleType
+                )
+                issue?.print()
             case let .default(disabled: disabledRules, optIn: optInRules):
                 if rule is any OptInRule.Type, Set(optInRules).isDisjoint(with: rule.description.allIdentifiers) {
                     Issue.genericWarning("\(message), but it is not enabled on '\(Key.optInRules.rawValue)'.").print()
@@ -207,6 +208,17 @@ extension Configuration {
                 issue?.print()
             }
         }
+    }
+
+    static func validateConfiguredRuleIsEnabled(
+        message: String,
+        onlyRules: Set<String>,
+        ruleType: Rule.Type
+    ) -> Issue? {
+        if onlyRules.isDisjoint(with: ruleType.description.allIdentifiers) {
+            return Issue.genericWarning("\(message), but it is not present on '\(Key.onlyRules.rawValue)'.")
+        }
+        return nil
     }
 
     static func validateConfiguredRuleIsEnabled(

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -236,9 +236,8 @@ extension Configuration {
         if case .allEnabled = parentConfiguration?.rulesMode {
             if disabledRules.contains(ruleType.identifier) {
                 return Issue.ruleDisabledInDisabledRules(ruleID: ruleType.identifier)
-            } else {
-                return nil
             }
+            return nil
         }
 
         let allIdentifiers = ruleType.description.allIdentifiers
@@ -246,7 +245,8 @@ extension Configuration {
         if allEnabledRules.isDisjoint(with: allIdentifiers) {
             if disabledRules.isDisjoint(with: allIdentifiers) == false {
                 return Issue.ruleDisabledInDisabledRules(ruleID: ruleType.identifier)
-            } else if disabledInParentRules.isDisjoint(with: allIdentifiers) == false {
+            }
+            if disabledInParentRules.isDisjoint(with: allIdentifiers) == false {
                 return Issue.ruleDisabledInParentConfiguration(ruleID: ruleType.identifier)
             }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -204,7 +204,7 @@ extension Configuration {
         ruleType: any Rule.Type
     ) -> Issue? {
         if onlyRules.isDisjoint(with: ruleType.description.allIdentifiers) {
-            return Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)
+            return Issue.configurationForRuleNotPresentInOnlyRules(ruleID: ruleType.identifier)
         }
         return nil
     }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -254,7 +254,7 @@ extension Configuration {
 
             if ruleType is OptInRule.Type {
                 if Set(enabledInParentRules.union(optInRules)).isDisjoint(with: allIdentifiers) {
-                    return Issue.ruleIsNotEnabledInOptInRules(ruleID: ruleType.identifier)
+                    return Issue.ruleNotEnabledInOptInRules(ruleID: ruleType.identifier)
                 }
             }
         }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -176,7 +176,10 @@ extension Configuration {
 
                 if case .only(let onlyRules) = parentConfiguration?.rulesMode {
                     enabledInParentRules = onlyRules
-                } else if case .default(let parentDisabledRules, let parentOptInRules) = parentConfiguration?.rulesMode {
+                } else if case .default(
+                    let parentDisabledRules,
+                    let parentOptInRules
+                ) = parentConfiguration?.rulesMode {
                     enabledInParentRules = parentOptInRules
                     disabledInParentRules = parentDisabledRules
                 }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -188,28 +188,6 @@ extension Configuration {
                 let issue = validateConfiguredRuleIsEnabled(onlyRules: onlyRules, ruleType: ruleType)
                 issue?.print()
             case let .default(disabled: disabledRules, optIn: optInRules):
-                if rule is any OptInRule.Type, Set(optInRules).isDisjoint(with: rule.description.allIdentifiers) {
-                    Issue.genericWarning("\(message), but it is not enabled on '\(Key.optInRules.rawValue)'.").print()
-
-                    if rule is OptInRule.Type {
-                    var allOptInRules = optInRules
-                    if let parentConfiguration {
-                        switch parentConfiguration.rulesMode {
-                        case .allEnabled:
-                            return
-                        case .only(let parentOnlyRules):
-                            allOptInRules.formUnion(parentOnlyRules)
-                        case let .default(disabled: _, optIn: parentOptInRules):
-                            allOptInRules.formUnion(parentOptInRules)
-                        }
-                    }
-                    if Set(allOptInRules).isDisjoint(with: rule.description.allIdentifiers) {
-                        queuedPrintError("\(message), but it is not enabled on " +
-                                         "'\(Key.optInRules.rawValue)'.")
-                    }
-                } else if Set(disabledRules).isSuperset(of: rule.description.allIdentifiers) {
-                    Issue.genericWarning("\(message), but it is disabled on '\(Key.disabledRules.rawValue)'.").print()
-
                 let issue = validateConfiguredRuleIsEnabled(
                     parentConfiguration: parentConfiguration,
                     enabledInParentRules: enabledInParentRules,
@@ -226,7 +204,7 @@ extension Configuration {
 
     static func validateConfiguredRuleIsEnabled(
         onlyRules: Set<String>,
-        ruleType: Rule.Type
+        ruleType: any Rule.Type
     ) -> Issue? {
         if onlyRules.isDisjoint(with: ruleType.description.allIdentifiers) {
             return Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)
@@ -242,7 +220,7 @@ extension Configuration {
         disabledRules: Set<String>,
         optInRules: Set<String>,
         allEnabledRules: Set<String>,
-        ruleType: Rule.Type
+        ruleType: any Rule.Type
     ) -> Issue? {
         if case .allEnabled = parentConfiguration?.rulesMode {
             if disabledRules.contains(ruleType.identifier) {
@@ -261,7 +239,7 @@ extension Configuration {
                 return Issue.ruleDisabledInParentConfiguration(ruleID: ruleType.identifier)
             }
 
-            if ruleType is OptInRule.Type {
+            if ruleType is any OptInRule.Type {
                 if enabledInParentRules.union(optInRules).isDisjoint(with: allIdentifiers) {
                     return Issue.ruleNotEnabledInOptInRules(ruleID: ruleType.identifier)
                 }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -157,24 +157,6 @@ extension Configuration {
         ruleList: RuleList,
         rulesMode: RulesMode
     ) {
-        var enabledInParentRules: Set<String> = []
-        var disabledInParentRules: Set<String> = []
-        var allEnabledRules: Set<String> = []
-
-        // If our configuration is the default, precalculate some values
-        if case .default(let disabledRules, let optInRules) = rulesMode {
-            if case .only(let onlyRules) = parentConfiguration?.rulesMode {
-                enabledInParentRules = onlyRules
-            } else if case .default(let parentDisabledRules, let parentOptInRules) = parentConfiguration?.rulesMode {
-                enabledInParentRules = parentOptInRules
-                disabledInParentRules = parentDisabledRules
-            }
-            allEnabledRules = enabledInParentRules
-                .subtracting(disabledInParentRules)
-                .union(optInRules)
-                .subtracting(disabledRules)
-        }
-
         for key in dict.keys where !validGlobalKeys.contains(key) {
             guard let identifier = ruleList.identifier(for: key),
                 let ruleType = ruleList.list[identifier] else {
@@ -188,6 +170,21 @@ extension Configuration {
                 let issue = validateConfiguredRuleIsEnabled(onlyRules: onlyRules, ruleType: ruleType)
                 issue?.print()
             case let .default(disabled: disabledRules, optIn: optInRules):
+                var enabledInParentRules: Set<String> = []
+                var disabledInParentRules: Set<String> = []
+                var allEnabledRules: Set<String> = []
+
+                if case .only(let onlyRules) = parentConfiguration?.rulesMode {
+                    enabledInParentRules = onlyRules
+                } else if case .default(let parentDisabledRules, let parentOptInRules) = parentConfiguration?.rulesMode {
+                    enabledInParentRules = parentOptInRules
+                    disabledInParentRules = parentDisabledRules
+                }
+                allEnabledRules = enabledInParentRules
+                    .subtracting(disabledInParentRules)
+                    .union(optInRules)
+                    .subtracting(disabledRules)
+
                 let issue = validateConfiguredRuleIsEnabled(
                     parentConfiguration: parentConfiguration,
                     enabledInParentRules: enabledInParentRules,

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -218,7 +218,8 @@ extension Configuration {
     ) -> Issue? {
         var allOptInRules = optInRules
         var allDisabledRules = disabledRules
-
+        var allEnabledRules: Set<String> = []
+        
         if let parentConfiguration {
             switch parentConfiguration.rulesMode {
             case .allEnabled:
@@ -228,22 +229,32 @@ extension Configuration {
             case let .default(disabled: parentDisabledRules, optIn: parentOptInRules):
                 allOptInRules.formUnion(parentOptInRules)
                 allDisabledRules.formUnion(parentDisabledRules)
+                allEnabledRules.formUnion(parentOptInRules)
+                allEnabledRules.subtract(parentDisabledRules)
             }
-        }
-
-        let allIdentifiers = ruleType.description.allIdentifiers
-        if ruleType is OptInRule.Type {
-            if Set(allOptInRules).isDisjoint(with: allIdentifiers) {
-                return Issue.genericWarning("\(message), but it is not enabled on " +
-                                     "'\(Key.optInRules.rawValue)'.")
-            }
-        } else if Set(disabledRules).isSuperset(of: allIdentifiers) {
-            return Issue.genericWarning("\(message), but it is disabled on " +
-                                 "'\(Key.disabledRules.rawValue)'.")
-        } else if Set(allDisabledRules.subtracting(disabledRules)).isSuperset(of: allIdentifiers) {
-            return Issue.genericWarning("\(message), but it is disabled in a parent configuration.")
         }
         
+        allEnabledRules.formUnion(optInRules)
+        allEnabledRules.subtract(disabledRules)
+
+        let allIdentifiers = ruleType.description.allIdentifiers
+        
+        if allEnabledRules.contains(ruleType.identifier) == false {
+            if Set(disabledRules).isSuperset(of: allIdentifiers) {
+                return Issue.genericWarning("\(message), but it is disabled on " +
+                                            "'\(Key.disabledRules.rawValue)'.")
+            } else if Set(allDisabledRules.subtracting(disabledRules)).isSuperset(of: allIdentifiers) {
+                return Issue.genericWarning("\(message), but it is disabled in a parent configuration.")
+            }
+            
+            if ruleType is OptInRule.Type {
+                if Set(allOptInRules).isDisjoint(with: allIdentifiers) {
+                    return Issue.genericWarning("\(message), but it is not enabled on " +
+                                                "'\(Key.optInRules.rawValue)'.")
+                }
+            }
+        }
+                    
         return nil
     }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -170,36 +170,47 @@ extension Configuration {
                 let issue = validateConfiguredRuleIsEnabled(onlyRules: onlyRules, ruleType: ruleType)
                 issue?.print()
             case let .default(disabled: disabledRules, optIn: optInRules):
-                var enabledInParentRules: Set<String> = []
-                var disabledInParentRules: Set<String> = []
-                var allEnabledRules: Set<String> = []
-
-                if case .only(let onlyRules) = parentConfiguration?.rulesMode {
-                    enabledInParentRules = onlyRules
-                } else if case .default(
-                    let parentDisabledRules,
-                    let parentOptInRules
-                ) = parentConfiguration?.rulesMode {
-                    enabledInParentRules = parentOptInRules
-                    disabledInParentRules = parentDisabledRules
-                }
-                allEnabledRules = enabledInParentRules
-                    .subtracting(disabledInParentRules)
-                    .union(optInRules)
-                    .subtracting(disabledRules)
-
                 let issue = validateConfiguredRuleIsEnabled(
                     parentConfiguration: parentConfiguration,
-                    enabledInParentRules: enabledInParentRules,
-                    disabledInParentRules: disabledInParentRules,
                     disabledRules: disabledRules,
                     optInRules: optInRules,
-                    allEnabledRules: allEnabledRules,
                     ruleType: ruleType
                 )
                 issue?.print()
             }
         }
+    }
+
+    static func validateConfiguredRuleIsEnabled(
+        parentConfiguration: Configuration?,
+        disabledRules: Set<String>,
+        optInRules: Set<String>,
+        ruleType: any Rule.Type
+    ) -> Issue? {
+        var enabledInParentRules: Set<String> = []
+        var disabledInParentRules: Set<String> = []
+        var allEnabledRules: Set<String> = []
+
+        if case .only(let onlyRules) = parentConfiguration?.rulesMode {
+            enabledInParentRules = onlyRules
+        } else if case .default(let parentDisabledRules, let parentOptInRules) = parentConfiguration?.rulesMode {
+            enabledInParentRules = parentOptInRules
+            disabledInParentRules = parentDisabledRules
+        }
+        allEnabledRules = enabledInParentRules
+            .subtracting(disabledInParentRules)
+            .union(optInRules)
+            .subtracting(disabledRules)
+
+        return validateConfiguredRuleIsEnabled(
+            parentConfiguration: parentConfiguration,
+            enabledInParentRules: enabledInParentRules,
+            disabledInParentRules: disabledInParentRules,
+            disabledRules: disabledRules,
+            optInRules: optInRules,
+            allEnabledRules: allEnabledRules,
+            ruleType: ruleType
+        )
     }
 
     static func validateConfiguredRuleIsEnabled(

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -27,7 +27,7 @@ extension Configuration {
     // MARK: - Initializers
     /// Creates a Configuration value based on the specified parameters.
     ///
-    /// - parameter parentConfiguration           The parent configuration, if any
+    /// - parameter parentConfiguration:    The parent configuration, if any
     /// - parameter dict:                   The untyped dictionary to serve as the input for this typed configuration.
     ///                                     Typically generated from a YAML-formatted file.
     /// - parameter ruleList:               The list of rules to be available to this configuration.

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -222,7 +222,12 @@ extension Configuration {
         if let parentConfiguration {
             switch parentConfiguration.rulesMode {
             case .allEnabled:
-                return nil
+                if disabledRules.contains(ruleType.identifier) {
+                    return Issue.genericWarning("\(message), but it is disabled on " +
+                                                "'\(Key.disabledRules.rawValue)'.")
+                } else {
+                    return nil
+                }
             case .only(let parentOnlyRules):
                 enabledInParentRules = parentOnlyRules
             case let .default(disabled: parentDisabledRules, optIn: parentOptInRules):
@@ -238,11 +243,11 @@ extension Configuration {
         
         let allIdentifiers = ruleType.description.allIdentifiers
         
-        if allEnabledRules.contains(ruleType.identifier) == false {
-            if Set(disabledRules).isSuperset(of: allIdentifiers) {
+        if allEnabledRules.isDisjoint(with: allIdentifiers) {
+            if Set(disabledRules).isDisjoint(with: allIdentifiers) == false {
                 return Issue.genericWarning("\(message), but it is disabled on " +
                                             "'\(Key.disabledRules.rawValue)'.")
-            } else if Set(disabledInParentRules).isSuperset(of: allIdentifiers) {
+            } else if Set(disabledInParentRules).isDisjoint(with: allIdentifiers) == false {
                 return Issue.genericWarning("\(message), but it is disabled in a parent configuration.")
             }
             

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -238,7 +238,7 @@ extension Configuration {
             }
         }
 
-        var allEnabledRules = enabledInParentRules
+        let allEnabledRules = enabledInParentRules
             .subtracting(disabledInParentRules)
             .union(optInRules)
             .subtracting(disabledRules)

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -17,7 +17,7 @@ public extension Configuration {
     }
 
     /// Represents how a Configuration object can be configured with regards to rules.
-    enum RulesMode {
+    enum RulesMode: Equatable {
         /// The default rules mode, which will enable all rules that aren't defined as being opt-in
         /// (conforming to the `OptInRule` protocol), minus the rules listed in `disabled`, plus the rules listed in
         /// `optIn`.

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -285,7 +285,8 @@ extension Configuration: Hashable {
             lhs.rules == rhs.rules &&
             lhs.fileGraph == rhs.fileGraph &&
             lhs.allowZeroLintableFiles == rhs.allowZeroLintableFiles &&
-            lhs.strict == rhs.strict
+            lhs.strict == rhs.strict &&
+            lhs.rulesMode == rhs.rulesMode
     }
 }
 

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -21,8 +21,7 @@ public enum Issue: LocalizedError, Equatable {
     case invalidRuleIDs(Set<String>)
 
     /// Found a rule configuration for a rule that is not present in `only_rules`.
-    case configurationForRuleNotPresentInOnlyRules(ruleID: String)
-    // swiftlint:disable:previous identifier_name
+    case ruleNotPresentInOnlyRules(ruleID: String)
 
     /// Found a rule configuration for a rule that is disabled.
     case ruleDisabledInDisabledRules(ruleID: String)
@@ -120,7 +119,7 @@ public enum Issue: LocalizedError, Equatable {
             return "Configuration for '\(id)' rule contains the invalid key(s) \(keys.formatted)."
         case let .invalidRuleIDs(ruleIDs):
             return "The key(s) \(ruleIDs.formatted) used as rule identifier(s) is/are invalid."
-        case let .configurationForRuleNotPresentInOnlyRules(id):
+        case let .ruleNotPresentInOnlyRules(id):
             return "Found a configuration for '\(id)' rule, but it is not present in " +
                    "'\(Configuration.Key.onlyRules.rawValue)'."
         case let .ruleDisabledInDisabledRules(id):

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -30,7 +30,7 @@ public enum Issue: LocalizedError, Equatable {
     case ruleDisabledInParentConfiguration(ruleID: String)
 
     /// Found a rule configuration for a rule that is not enabled in opt_in_rules
-    case ruleIsNotEnabledInOptInRules(ruleID: String)
+    case ruleNotEnabledInOptInRules(ruleID: String)
 
     /// A generic warning specified by a string.
     case genericWarning(String)
@@ -124,7 +124,7 @@ public enum Issue: LocalizedError, Equatable {
                    "'\(Configuration.Key.disabledRules.rawValue)'."
         case let .ruleDisabledInParentConfiguration(id):
             return "Found a configuration for '\(id)' rule, but it is disabled in a parent configuration."
-        case let .ruleIsNotEnabledInOptInRules(id):
+        case let .ruleNotEnabledInOptInRules(id):
             return "Found a configuration for '\(id)' rule, but it is not enabled on " +
                    "'\(Configuration.Key.optInRules.rawValue)'."
         case let .genericWarning(message), let .genericError(message):

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -32,6 +32,9 @@ public enum Issue: LocalizedError, Equatable {
     /// Found a rule configuration for a rule that is not enabled in opt_in_rules
     case ruleNotEnabledInOptInRules(ruleID: String)
 
+    /// Found a rule configuration for a rule that is not enabled in parent only_rules.
+    case ruleNotEnabledInParentOnlyRules(ruleID: String)
+
     /// A generic warning specified by a string.
     case genericWarning(String)
 
@@ -127,6 +130,9 @@ public enum Issue: LocalizedError, Equatable {
         case let .ruleNotEnabledInOptInRules(id):
             return "Found a configuration for '\(id)' rule, but it is not enabled on " +
                    "'\(Configuration.Key.optInRules.rawValue)'."
+        case let .ruleNotEnabledInParentOnlyRules(id):
+            return "Found a configuration for '\(id)' rule, but it is not present in the parent " +
+                   "'\(Configuration.Key.onlyRules.rawValue)'."
         case let .genericWarning(message), let .genericError(message):
             return message
         case let .ruleDeprecated(id):

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -21,7 +21,7 @@ public enum Issue: LocalizedError, Equatable {
     case invalidRuleIDs(Set<String>)
 
     /// Found a rule configuration for a rule that is not present in only_rules.
-    case ruleNotPresentInOnlyRules(ruleID: String)
+    case configurationForRuleNotPresentInOnlyRules(ruleID: String)
 
     /// Found a rule configuration for a rule that is disabled.
     case ruleDisabledInDisabledRules(ruleID: String)
@@ -119,7 +119,7 @@ public enum Issue: LocalizedError, Equatable {
             return "Configuration for '\(id)' rule contains the invalid key(s) \(keys.formatted)."
         case let .invalidRuleIDs(ruleIDs):
             return "The key(s) \(ruleIDs.formatted) used as rule identifier(s) is/are invalid."
-        case let .ruleNotPresentInOnlyRules(id):
+        case let .configurationForRuleNotPresentInOnlyRules(id):
             return "Found a configuration for '\(id)' rule, but it is not present on " +
                    "'\(Configuration.Key.onlyRules.rawValue)'."
         case let .ruleDisabledInDisabledRules(id):

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -20,6 +20,18 @@ public enum Issue: LocalizedError, Equatable {
     /// Used rule IDs are invalid.
     case invalidRuleIDs(Set<String>)
 
+    /// Found a rule configuration for a rule that is not present in only_rules.
+    case ruleNotPresentInOnlyRules(ruleID: String)
+
+    /// Found a rule configuration for a rule that is disabled.
+    case ruleDisabledInDisabledRules(ruleID: String)
+
+    /// Found a rule configuration for a rule that is disabled in the parent configuration
+    case ruleDisabledInParentConfiguration(ruleID: String)
+
+    /// Found a rule configuration for a rule that is not enabled in opt_in_rules
+    case ruleIsNotEnabledInOptInRules(ruleID: String)
+
     /// A generic warning specified by a string.
     case genericWarning(String)
 
@@ -104,6 +116,14 @@ public enum Issue: LocalizedError, Equatable {
             return "Configuration for '\(id)' rule contains the invalid key(s) \(keys.formatted)."
         case let .invalidRuleIDs(ruleIDs):
             return "The key(s) \(ruleIDs.formatted) used as rule identifier(s) is/are invalid."
+        case let .ruleNotPresentInOnlyRules(id):
+            return "Found a configuration for '\(id)' rule, but it is not present on '\(Configuration.Key.onlyRules.rawValue)'."
+        case let .ruleDisabledInDisabledRules(id):
+            return "Found a configuration for '\(id)' rule, but it is disabled on '\(Configuration.Key.disabledRules.rawValue)'."
+        case let .ruleDisabledInParentConfiguration(id):
+            return "Found a configuration for '\(id)' rule, but it is disabled in a parent configuration."
+        case let .ruleIsNotEnabledInOptInRules(id):
+            return "Found a configuration for '\(id)' rule, but it is not enabled on '\(Configuration.Key.optInRules.rawValue)'."
         case let .genericWarning(message), let .genericError(message):
             return message
         case let .ruleDeprecated(id):

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -90,7 +90,7 @@ public enum Issue: LocalizedError, Equatable {
         queuedPrintError(errorDescription)
     }
 
-    private var message: String {
+    var message: String {
         switch self {
         case let .invalidConfiguration(id):
             return "Invalid configuration for '\(id)' rule. Falling back to default."

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -20,19 +20,19 @@ public enum Issue: LocalizedError, Equatable {
     /// Used rule IDs are invalid.
     case invalidRuleIDs(Set<String>)
 
-    /// Found a rule configuration for a rule that is not present in only_rules.
+    /// Found a rule configuration for a rule that is not present in `only_rules`.
     case configurationForRuleNotPresentInOnlyRules(ruleID: String)
 
     /// Found a rule configuration for a rule that is disabled.
     case ruleDisabledInDisabledRules(ruleID: String)
 
-    /// Found a rule configuration for a rule that is disabled in the parent configuration
+    /// Found a rule configuration for a rule that is disabled in the parent configuration.
     case ruleDisabledInParentConfiguration(ruleID: String)
 
-    /// Found a rule configuration for a rule that is not enabled in opt_in_rules
+    /// Found a rule configuration for a rule that is not enabled in `opt_in_rules`.
     case ruleNotEnabledInOptInRules(ruleID: String)
 
-    /// Found a rule configuration for a rule that is not enabled in parent only_rules.
+    /// Found a rule configuration for a rule that is not enabled in parent `only_rules`.
     case ruleNotEnabledInParentOnlyRules(ruleID: String)
 
     /// A generic warning specified by a string.

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -102,7 +102,7 @@ public enum Issue: LocalizedError, Equatable {
         queuedPrintError(errorDescription)
     }
 
-    var message: String {
+    private var message: String {
         switch self {
         case let .invalidConfiguration(id):
             return "Invalid configuration for '\(id)' rule. Falling back to default."
@@ -117,13 +117,16 @@ public enum Issue: LocalizedError, Equatable {
         case let .invalidRuleIDs(ruleIDs):
             return "The key(s) \(ruleIDs.formatted) used as rule identifier(s) is/are invalid."
         case let .ruleNotPresentInOnlyRules(id):
-            return "Found a configuration for '\(id)' rule, but it is not present on '\(Configuration.Key.onlyRules.rawValue)'."
+            return "Found a configuration for '\(id)' rule, but it is not present on " +
+                   "'\(Configuration.Key.onlyRules.rawValue)'."
         case let .ruleDisabledInDisabledRules(id):
-            return "Found a configuration for '\(id)' rule, but it is disabled on '\(Configuration.Key.disabledRules.rawValue)'."
+            return "Found a configuration for '\(id)' rule, but it is disabled on " +
+                   "'\(Configuration.Key.disabledRules.rawValue)'."
         case let .ruleDisabledInParentConfiguration(id):
             return "Found a configuration for '\(id)' rule, but it is disabled in a parent configuration."
         case let .ruleIsNotEnabledInOptInRules(id):
-            return "Found a configuration for '\(id)' rule, but it is not enabled on '\(Configuration.Key.optInRules.rawValue)'."
+            return "Found a configuration for '\(id)' rule, but it is not enabled on " +
+                   "'\(Configuration.Key.optInRules.rawValue)'."
         case let .genericWarning(message), let .genericError(message):
             return message
         case let .ruleDeprecated(id):

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -22,6 +22,7 @@ public enum Issue: LocalizedError, Equatable {
 
     /// Found a rule configuration for a rule that is not present in `only_rules`.
     case configurationForRuleNotPresentInOnlyRules(ruleID: String)
+    // swiftlint:disable:previous identifier_name
 
     /// Found a rule configuration for a rule that is disabled.
     case ruleDisabledInDisabledRules(ruleID: String)

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -120,15 +120,15 @@ public enum Issue: LocalizedError, Equatable {
         case let .invalidRuleIDs(ruleIDs):
             return "The key(s) \(ruleIDs.formatted) used as rule identifier(s) is/are invalid."
         case let .configurationForRuleNotPresentInOnlyRules(id):
-            return "Found a configuration for '\(id)' rule, but it is not present on " +
+            return "Found a configuration for '\(id)' rule, but it is not present in " +
                    "'\(Configuration.Key.onlyRules.rawValue)'."
         case let .ruleDisabledInDisabledRules(id):
-            return "Found a configuration for '\(id)' rule, but it is disabled on " +
+            return "Found a configuration for '\(id)' rule, but it is disabled in " +
                    "'\(Configuration.Key.disabledRules.rawValue)'."
         case let .ruleDisabledInParentConfiguration(id):
             return "Found a configuration for '\(id)' rule, but it is disabled in a parent configuration."
         case let .ruleNotEnabledInOptInRules(id):
-            return "Found a configuration for '\(id)' rule, but it is not enabled on " +
+            return "Found a configuration for '\(id)' rule, but it is not enabled in " +
                    "'\(Configuration.Key.optInRules.rawValue)'."
         case let .ruleNotEnabledInParentOnlyRules(id):
             return "Found a configuration for '\(id)' rule, but it is not present in the parent's " +

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -131,7 +131,7 @@ public enum Issue: LocalizedError, Equatable {
             return "Found a configuration for '\(id)' rule, but it is not enabled on " +
                    "'\(Configuration.Key.optInRules.rawValue)'."
         case let .ruleNotEnabledInParentOnlyRules(id):
-            return "Found a configuration for '\(id)' rule, but it is not present in the parent " +
+            return "Found a configuration for '\(id)' rule, but it is not present in the parent's " +
                    "'\(Configuration.Key.onlyRules.rawValue)'."
         case let .genericWarning(message), let .genericError(message):
             return message

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -484,12 +484,20 @@ extension ConfigurationTests {
     }
 
     func testOnlyConfigurationDisabledRulesWarnings() {
+        let optInRuleType = ImplicitReturnRule.self
+        XCTAssertTrue((optInRuleType as Any) is OptInRule.Type)
+        testOnlyConfigurationDisabledRulesWarnings(ruleType: optInRuleType)
+
+        let defaultRuleType = BlockBasedKVORule.self
+        XCTAssertFalse((defaultRuleType as Any) is OptInRule.Type)
+        testOnlyConfigurationDisabledRulesWarnings(ruleType: defaultRuleType)
+    }
+
+    private func testOnlyConfigurationDisabledRulesWarnings(ruleType: Rule.Type) {
         struct TestCase: Equatable {
             let onlyRules: Set<String>
             let expectedIssue: Issue?
         }
-        let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue((ruleType as Any) is OptInRule.Type)
 
         let testCases: [TestCase] = [
             TestCase(onlyRules: [], expectedIssue: Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)),

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -422,36 +422,40 @@ extension ConfigurationTests {
             let parentConfiguration: Configuration?
             let disabledRules: Set<String>
             let optInRules: Set<String>
-            let expectedIssueMessage: String?
+            let expectedMessage: String?
         }
         let ruleType = ImplicitReturnRule.self
         let ruleIdentifier = ruleType.description.identifier
 
-        let noneNoneConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: []))
+        let emptyConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: []))
         let optInConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier]))
         let optInDisabledConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [ruleIdentifier]))
         let disabledConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
-
+        
+        let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not enabled on 'opt_in_rules'."
+        let disabledInParentMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled in a parent configuration."
+        let disabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled on 'disabled_rules'."
+        
         let testCases: [TestCase] = [
-            TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: nil),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: ""),
+            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
+            TestCase(parentConfiguration: optInConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
+            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [], expectedMessage: disabledInParentMessage),
+            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [], optInRules: [], expectedMessage: disabledInParentMessage),
 
-            TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssueMessage: nil),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssueMessage: nil),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssueMessage: nil),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssueMessage: nil),
+            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: optInConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
 
-            TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: ""),
+            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
 
-            TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: ""),
+            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
         ]
 
         for testCase in testCases {
@@ -460,7 +464,7 @@ extension ConfigurationTests {
                 parentConfiguration: testCase.parentConfiguration,
                 disabledRules: testCase.disabledRules,
                 optInRules: testCase.optInRules,
-                expectedIssueMessage: testCase.expectedIssueMessage
+                expectedMessage: testCase.expectedMessage
             )
         }
     }
@@ -479,7 +483,7 @@ extension ConfigurationTests {
             parentConfiguration: Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier])),
             disabledRules: [ruleIdentifier],
             optInRules: [ruleIdentifier],
-            expectedIssueMessage: ""
+            expectedMessage: ""
         )
     }
     
@@ -488,7 +492,7 @@ extension ConfigurationTests {
         parentConfiguration: Configuration?,
         disabledRules: Set<String>,
         optInRules: Set<String>,
-        expectedIssueMessage: String? = nil
+        expectedMessage: String? = nil
     ) {
         let ruleIdentifier = ruleType.description.identifier
         let message = "Found a configuration for '\(ruleIdentifier)' rule"
@@ -499,8 +503,12 @@ extension ConfigurationTests {
             optInRules: optInRules,
             ruleType: ruleType
         )
-        if let expectedIssueMessage {
-            XCTAssertNotNil(issue)
+        if let expectedMessage {
+            if let issue {
+                XCTAssertEqual(issue.message, expectedMessage)
+            } else {
+                XCTFail("issue was nil")
+            }
         } else {
             XCTAssertNil(issue)
         }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -500,7 +500,6 @@ extension ConfigurationTests {
     }
 
     func testOnlyConfigurationDisabledRulesWarnings() {
-        // swiftlint:disable:previous function_body_length
         struct TestCase: Equatable {
             let onlyRules: Set<String>
             let expectedIssue: Issue?
@@ -511,7 +510,7 @@ extension ConfigurationTests {
 
         let testCases: [TestCase] = [
             TestCase(onlyRules: [], expectedIssue: notEnabledIssue),
-            TestCase(onlyRules: [ruleType.identifier], expectedIssue: nil),
+            TestCase(onlyRules: [ruleType.identifier], expectedIssue: nil)
         ]
 
         for testCase in testCases {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -426,6 +426,7 @@ extension ConfigurationTests {
             let expectedIssue: Issue?
         }
         let ruleType = ImplicitReturnRule.self
+        XCTAssertTrue((ruleType as Any) is OptInRule.Type)
         let ruleIdentifier = ruleType.identifier
 
         // swiftlint:disable line_length
@@ -505,6 +506,7 @@ extension ConfigurationTests {
             let expectedIssue: Issue?
         }
         let ruleType = ImplicitReturnRule.self
+        XCTAssertTrue((ruleType as Any) is OptInRule.Type)
         let notEnabledIssue = Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)
 
         let testCases: [TestCase] = [

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -547,7 +547,10 @@ extension ConfigurationTests {
         }
 
         let testCases = [
-            TestCase(onlyRules: [], expectedIssue: Issue.configurationForRuleNotPresentInOnlyRules(ruleID: ruleType.identifier)),
+            TestCase(
+                onlyRules: [],
+                expectedIssue: Issue.configurationForRuleNotPresentInOnlyRules(ruleID: ruleType.identifier)
+            ),
             TestCase(onlyRules: [ruleType.identifier], expectedIssue: nil)
         ]
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -455,38 +455,6 @@ extension ConfigurationTests {
         }
     }
 
-    private func validateConfiguredRuleIsEnabled(
-        parentConfiguration: Configuration?,
-        disabledRules: Set<String>,
-        optInRules: Set<String>,
-        ruleType: any Rule.Type
-    ) -> Issue? {
-        var enabledInParentRules: Set<String> = []
-        var disabledInParentRules: Set<String> = []
-        var allEnabledRules: Set<String> = []
-
-        if case .only(let onlyRules) = parentConfiguration?.rulesMode {
-            enabledInParentRules = onlyRules
-        } else if case .default(let parentDisabledRules, let parentOptInRules) = parentConfiguration?.rulesMode {
-            enabledInParentRules = parentOptInRules
-            disabledInParentRules = parentDisabledRules
-        }
-        allEnabledRules = enabledInParentRules
-            .subtracting(disabledInParentRules)
-            .union(optInRules)
-            .subtracting(disabledRules)
-
-        return Configuration.validateConfiguredRuleIsEnabled(
-            parentConfiguration: parentConfiguration,
-            enabledInParentRules: enabledInParentRules,
-            disabledInParentRules: disabledInParentRules,
-            disabledRules: disabledRules,
-            optInRules: optInRules,
-            allEnabledRules: allEnabledRules,
-            ruleType: ruleType
-        )
-    }
-
     private func testParentConfiguration(
         _ parentConfiguration: Configuration?,
         configuration: Configuration,
@@ -495,7 +463,7 @@ extension ConfigurationTests {
         if case .default(let disabledRules, let optInRules) = configuration.rulesMode {
             let mergedConfiguration = parentConfiguration?.merged(withChild: configuration) ?? configuration
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
-            let issue = validateConfiguredRuleIsEnabled(
+            let issue = Configuration.validateConfiguredRuleIsEnabled(
                 parentConfiguration: parentConfiguration,
                 disabledRules: disabledRules,
                 optInRules: optInRules,

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -470,31 +470,32 @@ extension ConfigurationTests {
                 ruleType: ruleType
             )
             XCTAssertEqual(isEnabled, issue == nil)
-            if let issue {
-                let ruleIdentifier = ruleType.identifier
-                if disabledRules.isEmpty, optInRules.isEmpty {
-                    if parentConfiguration == nil ||
-                        parentConfiguration == Configuration.emptyDefaultConfiguration() {
-                        XCTAssertEqual(issue, Issue.ruleNotEnabledInOptInRules(ruleID: ruleIdentifier))
-                        return
-                    }
-
-                    if parentConfiguration == Configuration.emptyOnlyConfiguration() {
-                        if ruleType is any OptInRule.Type {
-                            XCTAssertEqual(issue, Issue.ruleNotEnabledInOptInRules(ruleID: ruleIdentifier))
-                        } else {
-                            XCTAssertEqual(issue, Issue.ruleNotEnabledInParentOnlyRules(ruleID: ruleIdentifier))
-                        }
-                        return
-                    }
-                    if parentConfiguration == Configuration.optInDisabledDefaultConfiguration(ruleIdentifier) ||
-                        parentConfiguration == Configuration.disabledDefaultConfiguration(ruleIdentifier) {
-                        XCTAssertEqual(issue, Issue.ruleDisabledInParentConfiguration(ruleID: ruleIdentifier))
-                        return
-                    }
-                }
-                XCTAssertEqual(issue, Issue.ruleDisabledInDisabledRules(ruleID: ruleIdentifier))
+            guard let issue else {
+                return
             }
+            let ruleIdentifier = ruleType.identifier
+            if disabledRules.isEmpty, optInRules.isEmpty {
+                if parentConfiguration == nil ||
+                    parentConfiguration == Configuration.emptyDefaultConfiguration() {
+                    XCTAssertEqual(issue, Issue.ruleNotEnabledInOptInRules(ruleID: ruleIdentifier))
+                    return
+                }
+
+                if parentConfiguration == Configuration.emptyOnlyConfiguration() {
+                    if ruleType is any OptInRule.Type {
+                        XCTAssertEqual(issue, Issue.ruleNotEnabledInOptInRules(ruleID: ruleIdentifier))
+                    } else {
+                        XCTAssertEqual(issue, Issue.ruleNotEnabledInParentOnlyRules(ruleID: ruleIdentifier))
+                    }
+                    return
+                }
+                if parentConfiguration == Configuration.optInDisabledDefaultConfiguration(ruleIdentifier) ||
+                    parentConfiguration == Configuration.disabledDefaultConfiguration(ruleIdentifier) {
+                    XCTAssertEqual(issue, Issue.ruleDisabledInParentConfiguration(ruleID: ruleIdentifier))
+                    return
+                }
+            }
+            XCTAssertEqual(issue, Issue.ruleDisabledInDisabledRules(ruleID: ruleIdentifier))
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -417,7 +417,17 @@ extension ConfigurationTests {
     }
 
     // MARK: Warnings about configurations for disabled rules
-    func testDefaultConfigurationDisabledOptInRuleWarnings() {
+    func testDefaultConfigurationDisabledRuleWarnings() {
+        let optInRuleType = ImplicitReturnRule.self
+        XCTAssertTrue((optInRuleType as Any) is OptInRule.Type)
+        testDefaultConfigurationDisabledRuleWarnings(for: optInRuleType)
+
+        let defaultRuleType = BlockBasedKVORule.self
+        XCTAssertFalse((defaultRuleType as Any) is OptInRule.Type)
+        testDefaultConfigurationDisabledRuleWarnings(for: defaultRuleType)
+    }
+
+    private func testDefaultConfigurationDisabledRuleWarnings(for ruleType: Rule.Type) {
         let ruleType = ImplicitReturnRule.self
         XCTAssertTrue((ruleType as Any) is OptInRule.Type)
         let ruleIdentifier = ruleType.identifier
@@ -437,30 +447,6 @@ extension ConfigurationTests {
             Configuration(rulesMode: .default(disabled: [], optIn: [])),
             Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier])),
             Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [ruleIdentifier])),
-            Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
-        ]
-
-        for parentConfiguration in parentConfigurations {
-            testParentConfiguration(parentConfiguration, configurations: configurations, ruleType: ruleType)
-        }
-    }
-
-    func testDefaultConfigurationDisabledDefaultRuleWarnings() {
-        let ruleType = BlockBasedKVORule.self
-        XCTAssertFalse((ruleType as Any) is OptInRule.Type)
-        let ruleIdentifier = ruleType.identifier
-
-        let parentConfigurations = [
-            nil,
-            Configuration.emptyDefaultConfiguration(),
-            Configuration.disabledDefaultConfiguration(ruleIdentifier),
-            Configuration.emptyOnlyConfiguration(),
-            Configuration.enabledOnlyConfiguration(ruleIdentifier),
-            Configuration.allEnabledConfiguration()
-        ]
-
-        let configurations = [
-            Configuration(rulesMode: .default(disabled: [], optIn: [])),
             Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
         ]
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -418,7 +418,6 @@ extension ConfigurationTests {
 
     // MARK: Warnings about configurations for disabled rules
     func testDefaultConfigurationDisabledRulesWarnings() {
-        // swiftlint:disable:previous function_body_length
         let ruleType = ImplicitReturnRule.self
         XCTAssertTrue((ruleType as Any) is OptInRule.Type)
         let ruleIdentifier = ruleType.identifier
@@ -451,9 +450,8 @@ extension ConfigurationTests {
                 Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
             ]
             for configuration in configurations {
-                let mergedConfiguration = parentConfiguration?.merged(withChild: configuration) ?? configuration
-
                 if case .default(let disabledRules, let optInRules) = configuration.rulesMode {
+                    let mergedConfiguration = parentConfiguration?.merged(withChild: configuration) ?? configuration
                     let isEnabled = mergedConfiguration.contains(rule: ruleType)
                     let issue = Configuration.validateConfiguredRuleIsEnabled(
                         parentConfiguration: parentConfiguration,
@@ -482,9 +480,7 @@ extension ConfigurationTests {
             }
         }
 
-        for parentConfiguration in parentConfigurations {
-            testParentConfiguration(parentConfiguration)
-        }
+        parentConfigurations.forEach { testParentConfiguration($0) }
     }
 
     func testOnlyConfigurationDisabledRulesWarnings() {
@@ -494,10 +490,9 @@ extension ConfigurationTests {
         }
         let ruleType = ImplicitReturnRule.self
         XCTAssertTrue((ruleType as Any) is OptInRule.Type)
-        let notEnabledIssue = Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)
 
         let testCases: [TestCase] = [
-            TestCase(onlyRules: [], expectedIssue: notEnabledIssue),
+            TestCase(onlyRules: [], expectedIssue: Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)),
             TestCase(onlyRules: [ruleType.identifier], expectedIssue: nil)
         ]
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -549,7 +549,7 @@ extension ConfigurationTests {
         }
 
         let testCases = [
-            TestCase(onlyRules: [], expectedIssue: Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)),
+            TestCase(onlyRules: [], expectedIssue: Issue.configurationForRuleNotPresentInOnlyRules(ruleID: ruleType.identifier)),
             TestCase(onlyRules: [ruleType.identifier], expectedIssue: nil)
         ]
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -509,26 +509,11 @@ extension ConfigurationTests {
     }
 
     private func testOnlyConfigurationDisabledRulesWarnings(ruleType: any Rule.Type) {
-        struct TestCase: Equatable {
-            let onlyRules: Set<String>
-            let expectedIssue: Issue?
-        }
-
-        let testCases = [
-            TestCase(
-                onlyRules: [],
-                expectedIssue: Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)
-            ),
-            TestCase(onlyRules: [ruleType.identifier], expectedIssue: nil)
-        ]
-
-        for testCase in testCases {
-            let issue = Configuration.validateConfiguredRuleIsEnabled(
-                onlyRules: testCase.onlyRules,
-                ruleType: ruleType
-            )
-            XCTAssertEqual(issue, testCase.expectedIssue)
-        }
+        let issue = Configuration.validateConfiguredRuleIsEnabled(onlyRules: [], ruleType: ruleType)
+        XCTAssertEqual(issue, Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier))
+        XCTAssertNil(
+            Configuration.validateConfiguredRuleIsEnabled(onlyRules: [ruleType.identifier], ruleType: ruleType)
+        )
     }
 
     // MARK: - Remote Configs

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -417,22 +417,27 @@ extension ConfigurationTests {
     }
 
     // MARK: Warnings about configurations for disabled rules
-    private struct TestCase: Equatable {
-        let parentConfiguration: Configuration?
-        let disabledRules: Set<String>
-        let optInRules: Set<String>
-        let expectedMessage: String?
-    }
-
-    func testOptInRulesWithDefaultConfigurationWarnings() {
+    func testDefaultConfigurationDisabledConfiguredRulesWarnings() {
+        // swiftlint:disable:previous function_body_length
+        struct TestCase: Equatable {
+            let parentConfiguration: Configuration?
+            let disabledRules: Set<String>
+            let optInRules: Set<String>
+            let expectedMessage: String?
+        }
         let ruleType = ImplicitReturnRule.self
         let ruleIdentifier = ruleType.identifier
 
         // swiftlint:disable line_length
-        let emptyConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: []))
-        let optInConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier]))
-        let optInDisabledConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [ruleIdentifier]))
-        let disabledConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
+        let emptyDefaultConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: []))
+        let optInDefaultConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier]))
+        let optInDisabledDefaultConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [ruleIdentifier]))
+        let disabledDefaultConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
+
+        let emptyOnlyConfiguration = Configuration(rulesMode: .only([]))
+        let enabledOnlyConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
+
+        let allEnabledConfiguration = Configuration(rulesMode: .allEnabled)
 
         let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not enabled on 'opt_in_rules'."
         let disabledInParentMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled in a parent configuration."
@@ -440,85 +445,49 @@ extension ConfigurationTests {
 
         let testCases: [TestCase] = [
             TestCase(parentConfiguration: nil, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
-            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [], expectedMessage: disabledInParentMessage),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [], optInRules: [], expectedMessage: disabledInParentMessage),
+            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
+            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
+            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [], optInRules: [], expectedMessage: disabledInParentMessage),
+            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [], optInRules: [], expectedMessage: disabledInParentMessage),
 
             TestCase(parentConfiguration: nil, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
 
             TestCase(parentConfiguration: nil, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
 
             TestCase(parentConfiguration: nil, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage)
+            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+
+            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
+            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
+
+            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+
+            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+
+            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+
+            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
+            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage)
         ]
         // swiftlint:enable line_length
 
-        test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
-    }
-
-    func testOptInRulesWithOnlyConfigurationWarnings() {
-        let ruleType = ImplicitReturnRule.self
-        let ruleIdentifier = ruleType.identifier
-
-        let emptyConfiguration = Configuration(rulesMode: .only([]))
-        let enabledConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
-
-        // swiftlint:disable line_length
-        let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not enabled on 'opt_in_rules'."
-        let disabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled on 'disabled_rules'."
-
-        let testCases: [TestCase] = [
-            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
-            TestCase(parentConfiguration: enabledConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
-
-            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: enabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-
-            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: enabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-
-            TestCase(parentConfiguration: emptyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: enabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage)
-        ]
-        // swiftlint:enable line_length
-
-        test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
-    }
-
-    func testOptInRulesWithAllConfigurationWarnings() {
-        let ruleType = ImplicitReturnRule.self
-        let ruleIdentifier = ruleType.identifier
-
-        let configuration = Configuration(rulesMode: .allEnabled)
-
-        // swiftlint:disable line_length
-        let disabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled on 'disabled_rules'."
-
-        let testCases: [TestCase] = [
-            TestCase(parentConfiguration: configuration, disabledRules: [], optInRules: [], expectedMessage: nil),
-            TestCase(parentConfiguration: configuration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: configuration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: configuration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage)
-        ]
-        // swiftlint:enable line_length
-
-        test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
-    }
-
-    private func test(cases: [TestCase], ruleType: Rule.Type, ruleIdentifier: String) {
-        for testCase in cases {
+        for testCase in testCases {
             testConfiguredRuleValidation(
                 ruleType: ruleType,
                 ruleIdentifier: ruleIdentifier,

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -422,7 +422,7 @@ extension ConfigurationTests {
         XCTAssertTrue((ruleType as Any) is OptInRule.Type)
         let ruleIdentifier = ruleType.identifier
 
-        let parentConfigurations: [Configuration?] = [
+        let parentConfigurations = [
             nil,
             Configuration.emptyDefaultConfiguration(),
             Configuration.optInDefaultConfiguration(ruleIdentifier),
@@ -450,7 +450,7 @@ extension ConfigurationTests {
         XCTAssertFalse((ruleType as Any) is OptInRule.Type)
         let ruleIdentifier = ruleType.identifier
 
-        let parentConfigurations: [Configuration?] = [
+        let parentConfigurations = [
             nil,
             Configuration.emptyDefaultConfiguration(),
             Configuration.disabledDefaultConfiguration(ruleIdentifier),
@@ -490,7 +490,7 @@ extension ConfigurationTests {
             .union(optInRules)
             .subtracting(disabledRules)
 
-        let issue = Configuration.validateConfiguredRuleIsEnabled(
+        return Configuration.validateConfiguredRuleIsEnabled(
             parentConfiguration: parentConfiguration,
             enabledInParentRules: enabledInParentRules,
             disabledInParentRules: disabledInParentRules,
@@ -499,7 +499,6 @@ extension ConfigurationTests {
             allEnabledRules: allEnabledRules,
             ruleType: ruleType
         )
-        return issue
     }
 
     private func testParentConfiguration(
@@ -563,7 +562,7 @@ extension ConfigurationTests {
             let expectedIssue: Issue?
         }
 
-        let testCases: [TestCase] = [
+        let testCases = [
             TestCase(onlyRules: [], expectedIssue: Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)),
             TestCase(onlyRules: [ruleType.identifier], expectedIssue: nil)
         ]

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -465,7 +465,7 @@ extension ConfigurationTests {
                             if parentConfiguration == nil ||
                                parentConfiguration == emptyDefaultConfiguration ||
                                parentConfiguration == emptyOnlyConfiguration {
-                                XCTAssertEqual(issue, Issue.ruleIsNotEnabledInOptInRules(ruleID: ruleIdentifier))
+                                XCTAssertEqual(issue, Issue.ruleNotEnabledInOptInRules(ruleID: ruleIdentifier))
                                 continue
                             }
                             if parentConfiguration == optInDisabledDefaultConfiguration ||

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -491,10 +491,11 @@ extension ConfigurationTests {
                         if parentConfiguration == nil ||
                             parentConfiguration == Configuration.emptyDefaultConfiguration() {
                             XCTAssertEqual(issue, Issue.ruleNotEnabledInOptInRules(ruleID: ruleIdentifier))
+                            continue
                         }
 
                         if parentConfiguration == Configuration.emptyOnlyConfiguration() {
-                            if ruleType is OptInRule {
+                            if ruleType is OptInRule.Type {
                                 XCTAssertEqual(issue, Issue.ruleNotEnabledInOptInRules(ruleID: ruleIdentifier))
                             } else {
                                 XCTAssertEqual(issue, Issue.ruleNotEnabledInParentOnlyRules(ruleID: ruleIdentifier))

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -428,7 +428,6 @@ extension ConfigurationTests {
     }
 
     private func testDefaultConfigurationDisabledRuleWarnings(for ruleType: any Rule.Type) {
-        XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
         let ruleIdentifier = ruleType.identifier
 
         let parentConfigurations = [

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -417,13 +417,13 @@ extension ConfigurationTests {
     }
 
     // MARK: Warnings about configurations for disabled rules
-    func testDefaultConfigurationDisabledConfiguredRulesWarnings() {
+    func testDefaultConfigurationDisabledRulesWarnings() {
         // swiftlint:disable:previous function_body_length
         struct TestCase: Equatable {
             let parentConfiguration: Configuration?
             let disabledRules: Set<String>
             let optInRules: Set<String>
-            let expectedMessage: String?
+            let expectedIssue: Issue?
         }
         let ruleType = ImplicitReturnRule.self
         let ruleIdentifier = ruleType.identifier
@@ -439,51 +439,51 @@ extension ConfigurationTests {
 
         let allEnabledConfiguration = Configuration(rulesMode: .allEnabled)
 
-        let notEnabledMessage = Issue.ruleIsNotEnabledInOptInRules(ruleID: ruleIdentifier).message
-        let disabledInParentMessage = Issue.ruleDisabledInParentConfiguration(ruleID: ruleIdentifier).message
-        let disabledMessage = Issue.ruleDisabledInDisabledRules(ruleID: ruleIdentifier).message
+        let notEnabledIssue = Issue.ruleIsNotEnabledInOptInRules(ruleID: ruleIdentifier)
+        let disabledInParentIssue = Issue.ruleDisabledInParentConfiguration(ruleID: ruleIdentifier)
+        let disabledIssue = Issue.ruleDisabledInDisabledRules(ruleID: ruleIdentifier)
 
         let testCases: [TestCase] = [
-            TestCase(parentConfiguration: nil, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
-            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
-            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
-            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [], optInRules: [], expectedMessage: disabledInParentMessage),
-            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [], optInRules: [], expectedMessage: disabledInParentMessage),
+            TestCase(parentConfiguration: nil, disabledRules: [], optInRules: [], expectedIssue: notEnabledIssue),
+            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [], optInRules: [], expectedIssue: notEnabledIssue),
+            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [], optInRules: [], expectedIssue: nil),
+            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [], optInRules: [], expectedIssue: disabledInParentIssue),
+            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [], optInRules: [], expectedIssue: disabledInParentIssue),
 
-            TestCase(parentConfiguration: nil, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: nil, disabledRules: [], optInRules: [ruleIdentifier], expectedIssue: nil),
+            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssue: nil),
+            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssue: nil),
+            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssue: nil),
+            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssue: nil),
 
-            TestCase(parentConfiguration: nil, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: nil, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssue: disabledIssue),
 
-            TestCase(parentConfiguration: nil, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: nil, disabledRules: [ruleIdentifier], optInRules: [], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: emptyDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: optInDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: optInDisabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: disabledDefaultConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssue: disabledIssue),
 
-            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
-            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
+            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [], optInRules: [], expectedIssue: notEnabledIssue),
+            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [], optInRules: [], expectedIssue: nil),
 
-            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssue: nil),
+            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssue: nil),
 
-            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssue: disabledIssue),
 
-            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: emptyOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: enabledOnlyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssue: disabledIssue),
 
-            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
-            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
-            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage)
+            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [], optInRules: [], expectedIssue: nil),
+            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssue: nil),
+            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssue: disabledIssue),
+            TestCase(parentConfiguration: allEnabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssue: disabledIssue)
         ]
         // swiftlint:enable line_length
 
@@ -494,25 +494,22 @@ extension ConfigurationTests {
                 optInRules: testCase.optInRules,
                 ruleType: ruleType
             )
-            XCTAssertEqual(issue?.message, testCase.expectedMessage)
+            XCTAssertEqual(issue, testCase.expectedIssue)
         }
     }
 
-    func testOnlyConfigurationDisabledConfiguredRulesWarnings() {
+    func testOnlyConfigurationDisabledRulesWarnings() {
         // swiftlint:disable:previous function_body_length
         struct TestCase: Equatable {
             let onlyRules: Set<String>
-            let expectedMessage: String?
+            let expectedIssue: Issue?
         }
         let ruleType = ImplicitReturnRule.self
-        let ruleIdentifier = ruleType.identifier
-
-        // swiftlint:disable:next line_length
-        let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not present on 'only_rules'."
+        let notEnabledIssue = Issue.ruleNotPresentInOnlyRules(ruleID: ruleType.identifier)
 
         let testCases: [TestCase] = [
-            TestCase(onlyRules: [], expectedMessage: notEnabledMessage),
-            TestCase(onlyRules: [ruleIdentifier], expectedMessage: nil),
+            TestCase(onlyRules: [], expectedIssue: notEnabledIssue),
+            TestCase(onlyRules: [ruleType.identifier], expectedIssue: nil),
         ]
 
         for testCase in testCases {
@@ -520,7 +517,7 @@ extension ConfigurationTests {
                 onlyRules: testCase.onlyRules,
                 ruleType: ruleType
             )
-            XCTAssertEqual(issue?.message, testCase.expectedMessage)
+            XCTAssertEqual(issue, testCase.expectedIssue)
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -13,7 +13,7 @@ private extension Configuration {
 extension ConfigurationTests {
     // MARK: - Rules Merging
     func testMerge() {
-        let config0Merge2 = Mock.Config._0.merged(withChild: Mock.Config._2, rootDirectory: "")
+        let config0Merge2 = Mock.Config._0.merged(withChild: Mock.Config._2)
 
         XCTAssertFalse(Mock.Config._0.contains(rule: ForceCastRule.self))
         XCTAssertTrue(Mock.Config._2.contains(rule: ForceCastRule.self))
@@ -25,7 +25,7 @@ extension ConfigurationTests {
 
         XCTAssertFalse(Mock.Config._3.contains(rule: TodoRule.self))
         XCTAssertFalse(
-            config0Merge2.merged(withChild: Mock.Config._3, rootDirectory: "").contains(rule: TodoRule.self)
+            config0Merge2.merged(withChild: Mock.Config._3).contains(rule: TodoRule.self)
         )
     }
 
@@ -38,16 +38,16 @@ extension ConfigurationTests {
             )
         }
         XCTAssertEqual(configuration(forWarningThreshold: 3)
-            .merged(withChild: configuration(forWarningThreshold: 2), rootDirectory: "").warningThreshold,
+            .merged(withChild: configuration(forWarningThreshold: 2)).warningThreshold,
                        2)
         XCTAssertEqual(configuration(forWarningThreshold: nil)
-            .merged(withChild: configuration(forWarningThreshold: 2), rootDirectory: "").warningThreshold,
+            .merged(withChild: configuration(forWarningThreshold: 2)).warningThreshold,
                        2)
         XCTAssertEqual(configuration(forWarningThreshold: 3)
-            .merged(withChild: configuration(forWarningThreshold: nil), rootDirectory: "").warningThreshold,
+            .merged(withChild: configuration(forWarningThreshold: nil)).warningThreshold,
                        3)
         XCTAssertNil(configuration(forWarningThreshold: nil)
-            .merged(withChild: configuration(forWarningThreshold: nil), rootDirectory: "").warningThreshold)
+            .merged(withChild: configuration(forWarningThreshold: nil)).warningThreshold)
     }
 
     func testOnlyRulesMerging() {
@@ -59,12 +59,12 @@ extension ConfigurationTests {
         XCTAssertEqual(onlyConfiguration.rules.count, 1)
         XCTAssertTrue(onlyConfiguration.rules[0] is TodoRule)
 
-        let mergedConfiguration1 = baseConfiguration.merged(withChild: onlyConfiguration, rootDirectory: "")
+        let mergedConfiguration1 = baseConfiguration.merged(withChild: onlyConfiguration)
         XCTAssertEqual(mergedConfiguration1.rules.count, 1)
         XCTAssertTrue(mergedConfiguration1.rules[0] is TodoRule)
 
         // Also test the other way around
-        let mergedConfiguration2 = onlyConfiguration.merged(withChild: baseConfiguration, rootDirectory: "")
+        let mergedConfiguration2 = onlyConfiguration.merged(withChild: baseConfiguration)
         XCTAssertEqual(mergedConfiguration2.rules.count, 3) // 2 opt-ins + 1 from the only rules
         XCTAssertTrue(mergedConfiguration2.contains(rule: TodoRule.self))
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceCastRule.self))
@@ -347,7 +347,7 @@ extension ConfigurationTests {
                 disabled: testCase.disabledInChild ? [ruleIdentifier] : [],
                 optIn: testCase.optedInInChild ? [ruleIdentifier] : []
             ))
-            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
+            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration)
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
             XCTAssertEqual(isEnabled, testCase.isEnabled, testCase.message)
         }
@@ -379,7 +379,7 @@ extension ConfigurationTests {
             let childConfiguration = Configuration(
                 rulesMode: .default(disabled: testCase.disabledInChild ? [ruleIdentifier] : [], optIn: [])
             )
-            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
+            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration)
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
             XCTAssertEqual(isEnabled, testCase.isEnabled, testCase.message)
         }
@@ -410,7 +410,7 @@ extension ConfigurationTests {
                 disabled: testCase.disabledInChild ? [ruleIdentifier] : [],
                 optIn: testCase.optedInInChild ? [ruleIdentifier] : []
             ))
-            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration, rootDirectory: "")
+            let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration)
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
             XCTAssertEqual(isEnabled, testCase.isEnabled, testCase.message)
         }
@@ -451,12 +451,7 @@ extension ConfigurationTests {
                 Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
             ]
             for configuration in configurations {
-                let mergedConfiguration: Configuration
-                if let parentConfiguration {
-                    mergedConfiguration = parentConfiguration.merged(withChild: configuration, rootDirectory: "")
-                } else {
-                    mergedConfiguration = configuration
-                }
+                let mergedConfiguration = parentConfiguration?.merged(withChild: configuration) ?? configuration
 
                 if case .default(let disabledRules, let optInRules) = configuration.rulesMode {
                     let isEnabled = mergedConfiguration.contains(rule: ruleType)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -488,40 +488,15 @@ extension ConfigurationTests {
         // swiftlint:enable line_length
 
         for testCase in testCases {
-            testConfiguredRuleValidation(
-                ruleType: ruleType,
+            let message = "Found a configuration for '\(ruleIdentifier)' rule"
+            let issue = Configuration.validateConfiguredRuleIsEnabled(
+                message: message,
                 parentConfiguration: testCase.parentConfiguration,
                 disabledRules: testCase.disabledRules,
                 optInRules: testCase.optInRules,
-                expectedMessage: testCase.expectedMessage
+                ruleType: ruleType
             )
-        }
-    }
-
-    private func testConfiguredRuleValidation(
-        ruleType: Rule.Type,
-        parentConfiguration: Configuration?,
-        disabledRules: Set<String>,
-        optInRules: Set<String>,
-        expectedMessage: String? = nil
-    ) {
-        let ruleIdentifier = ruleType.identifier
-        let message = "Found a configuration for '\(ruleIdentifier)' rule"
-        let issue = Configuration.validateConfiguredRuleIsEnabled(
-            message: message,
-            parentConfiguration: parentConfiguration,
-            disabledRules: disabledRules,
-            optInRules: optInRules,
-            ruleType: ruleType
-        )
-        if let expectedMessage {
-            if let issue {
-                XCTAssertEqual(issue.message, expectedMessage)
-            } else {
-                XCTFail("issue was nil")
-            }
-        } else {
-            XCTAssertNil(issue)
+            XCTAssertEqual(issue?.message, testCase.expectedMessage)
         }
     }
 
@@ -543,34 +518,13 @@ extension ConfigurationTests {
         ]
 
         for testCase in testCases {
-            testConfiguredRuleValidation(
-                ruleType: ruleType,
+            let message = "Found a configuration for '\(ruleIdentifier)' rule"
+            let issue = Configuration.validateConfiguredRuleIsEnabled(
+                message: message,
                 onlyRules: testCase.onlyRules,
-                expectedMessage: testCase.expectedMessage
+                ruleType: ruleType
             )
-        }
-    }
-
-    private func testConfiguredRuleValidation(
-        ruleType: Rule.Type,
-        onlyRules: Set<String>,
-        expectedMessage: String? = nil
-    ) {
-        let ruleIdentifier = ruleType.identifier
-        let message = "Found a configuration for '\(ruleIdentifier)' rule"
-        let issue = Configuration.validateConfiguredRuleIsEnabled(
-            message: message,
-            onlyRules: onlyRules,
-            ruleType: ruleType
-        )
-        if let expectedMessage {
-            if let issue {
-                XCTAssertEqual(issue.message, expectedMessage)
-            } else {
-                XCTFail("issue was nil")
-            }
-        } else {
-            XCTAssertNil(issue)
+            XCTAssertEqual(issue?.message, testCase.expectedMessage)
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -439,9 +439,9 @@ extension ConfigurationTests {
 
         let allEnabledConfiguration = Configuration(rulesMode: .allEnabled)
 
-        let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not enabled on 'opt_in_rules'."
-        let disabledInParentMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled in a parent configuration."
-        let disabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled on 'disabled_rules'."
+        let notEnabledMessage = Issue.ruleIsNotEnabledInOptInRules(ruleID: ruleIdentifier).message
+        let disabledInParentMessage = Issue.ruleDisabledInParentConfiguration(ruleID: ruleIdentifier).message
+        let disabledMessage = Issue.ruleDisabledInDisabledRules(ruleID: ruleIdentifier).message
 
         let testCases: [TestCase] = [
             TestCase(parentConfiguration: nil, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
@@ -488,9 +488,7 @@ extension ConfigurationTests {
         // swiftlint:enable line_length
 
         for testCase in testCases {
-            let message = "Found a configuration for '\(ruleIdentifier)' rule"
             let issue = Configuration.validateConfiguredRuleIsEnabled(
-                message: message,
                 parentConfiguration: testCase.parentConfiguration,
                 disabledRules: testCase.disabledRules,
                 optInRules: testCase.optInRules,
@@ -518,9 +516,7 @@ extension ConfigurationTests {
         ]
 
         for testCase in testCases {
-            let message = "Found a configuration for '\(ruleIdentifier)' rule"
             let issue = Configuration.validateConfiguredRuleIsEnabled(
-                message: message,
                 onlyRules: testCase.onlyRules,
                 ruleType: ruleType
             )

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -507,8 +507,8 @@ extension ConfigurationTests {
                             XCTAssertEqual(issue, Issue.ruleDisabledInParentConfiguration(ruleID: ruleIdentifier))
                             continue
                         }
-                        XCTAssertEqual(issue, Issue.ruleDisabledInDisabledRules(ruleID: ruleIdentifier))
                     }
+                    XCTAssertEqual(issue, Issue.ruleDisabledInDisabledRules(ruleID: ruleIdentifier))
                 }
             }
         }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -427,7 +427,7 @@ extension ConfigurationTests {
     func testOptInRulesWithDefaultConfigurationWarnings() {
         let ruleType = ImplicitReturnRule.self
         let ruleIdentifier = ruleType.identifier
-
+        
         let emptyConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: []))
         let optInConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier]))
         let optInDisabledConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [ruleIdentifier]))
@@ -463,7 +463,7 @@ extension ConfigurationTests {
             TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
         ]
 
-        test(cases: testCases, ruleType: ruleType)
+        test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
     }
     
     func testOptInRulesWithOnlyConfigurationWarnings() {
@@ -490,7 +490,7 @@ extension ConfigurationTests {
             TestCase(parentConfiguration: enabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
         ]
         
-        test(cases: testCases, ruleType: ruleType)
+        test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
     }
     
     func testOptInRulesWithAllConfigurationWarnings() {
@@ -499,7 +499,6 @@ extension ConfigurationTests {
 
         let configuration = Configuration(rulesMode: .allEnabled)
         
-        let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not enabled on 'opt_in_rules'."
         let disabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled on 'disabled_rules'."
 
         let testCases: [TestCase] = [
@@ -509,17 +508,30 @@ extension ConfigurationTests {
             TestCase(parentConfiguration: configuration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
         ]
 
-        test(cases: testCases, ruleType: ruleType)
+        test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
     }
-    
+
+    private func test(cases: [TestCase], ruleType: Rule.Type, ruleIdentifier: String) {
+        for testCase in cases {
+            testConfiguredRuleValidation(
+                ruleType: ruleType,
+                ruleIdentifier: ruleIdentifier,
+                parentConfiguration: testCase.parentConfiguration,
+                disabledRules: testCase.disabledRules,
+                optInRules: testCase.optInRules,
+                expectedMessage: testCase.expectedMessage
+            )
+        }
+    }
+
     private func testConfiguredRuleValidation(
         ruleType: Rule.Type,
+        ruleIdentifier: String,
         parentConfiguration: Configuration?,
         disabledRules: Set<String>,
         optInRules: Set<String>,
         expectedMessage: String? = nil
     ) {
-        let ruleIdentifier = ruleType.description.identifier
         let message = "Found a configuration for '\(ruleIdentifier)' rule"
         let issue = Configuration.validateConfiguredRuleIsEnabled(
             message: message,
@@ -536,18 +548,6 @@ extension ConfigurationTests {
             }
         } else {
             XCTAssertNil(issue)
-        }
-    }
-
-    private func test(cases: [TestCase], ruleType: Rule.Type) {
-        for testCase in cases {
-            testConfiguredRuleValidation(
-                ruleType: ruleType,
-                parentConfiguration: testCase.parentConfiguration,
-                disabledRules: testCase.disabledRules,
-                optInRules: testCase.optInRules,
-                expectedMessage: testCase.expectedMessage
-            )
         }
     }
     

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -490,7 +490,6 @@ extension ConfigurationTests {
         for testCase in testCases {
             testConfiguredRuleValidation(
                 ruleType: ruleType,
-                ruleIdentifier: ruleIdentifier,
                 parentConfiguration: testCase.parentConfiguration,
                 disabledRules: testCase.disabledRules,
                 optInRules: testCase.optInRules,
@@ -501,12 +500,12 @@ extension ConfigurationTests {
 
     private func testConfiguredRuleValidation(
         ruleType: Rule.Type,
-        ruleIdentifier: String,
         parentConfiguration: Configuration?,
         disabledRules: Set<String>,
         optInRules: Set<String>,
         expectedMessage: String? = nil
     ) {
+        let ruleIdentifier = ruleType.identifier
         let message = "Found a configuration for '\(ruleIdentifier)' rule"
         let issue = Configuration.validateConfiguredRuleIsEnabled(
             message: message,
@@ -546,7 +545,6 @@ extension ConfigurationTests {
         for testCase in testCases {
             testConfiguredRuleValidation(
                 ruleType: ruleType,
-                ruleIdentifier: ruleIdentifier,
                 onlyRules: testCase.onlyRules,
                 expectedMessage: testCase.expectedMessage
             )
@@ -555,10 +553,10 @@ extension ConfigurationTests {
 
     private func testConfiguredRuleValidation(
         ruleType: Rule.Type,
-        ruleIdentifier: String,
         onlyRules: Set<String>,
         expectedMessage: String? = nil
     ) {
+        let ruleIdentifier = ruleType.identifier
         let message = "Found a configuration for '\(ruleIdentifier)' rule"
         let issue = Configuration.validateConfiguredRuleIsEnabled(
             message: message,

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -428,7 +428,6 @@ extension ConfigurationTests {
     }
 
     private func testDefaultConfigurationDisabledRuleWarnings(for ruleType: any Rule.Type) {
-        let ruleType = ImplicitReturnRule.self
         XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
         let ruleIdentifier = ruleType.identifier
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -526,6 +526,56 @@ extension ConfigurationTests {
         }
     }
 
+    func testOnlyConfigurationDisabledConfiguredRulesWarnings() {
+        // swiftlint:disable:previous function_body_length
+        struct TestCase: Equatable {
+            let onlyRules: Set<String>
+            let expectedMessage: String?
+        }
+        let ruleType = ImplicitReturnRule.self
+        let ruleIdentifier = ruleType.identifier
+
+        // swiftlint:disable:next line_length
+        let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not present on 'only_rules'."
+
+        let testCases: [TestCase] = [
+            TestCase(onlyRules: [], expectedMessage: notEnabledMessage),
+            TestCase(onlyRules: [ruleIdentifier], expectedMessage: nil),
+        ]
+
+        for testCase in testCases {
+            testConfiguredRuleValidation(
+                ruleType: ruleType,
+                ruleIdentifier: ruleIdentifier,
+                onlyRules: testCase.onlyRules,
+                expectedMessage: testCase.expectedMessage
+            )
+        }
+    }
+
+    private func testConfiguredRuleValidation(
+        ruleType: Rule.Type,
+        ruleIdentifier: String,
+        onlyRules: Set<String>,
+        expectedMessage: String? = nil
+    ) {
+        let message = "Found a configuration for '\(ruleIdentifier)' rule"
+        let issue = Configuration.validateConfiguredRuleIsEnabled(
+            message: message,
+            onlyRules: onlyRules,
+            ruleType: ruleType
+        )
+        if let expectedMessage {
+            if let issue {
+                XCTAssertEqual(issue.message, expectedMessage)
+            } else {
+                XCTFail("issue was nil")
+            }
+        } else {
+            XCTAssertNil(issue)
+        }
+    }
+
     // MARK: - Remote Configs
     func testValidRemoteChildConfig() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.remoteConfigChild)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -419,17 +419,17 @@ extension ConfigurationTests {
     // MARK: Warnings about configurations for disabled rules
     func testDefaultConfigurationDisabledRuleWarnings() {
         let optInRuleType = ImplicitReturnRule.self
-        XCTAssertTrue((optInRuleType as Any) is OptInRule.Type)
+        XCTAssertTrue((optInRuleType as Any) is any OptInRule.Type)
         testDefaultConfigurationDisabledRuleWarnings(for: optInRuleType)
 
         let defaultRuleType = BlockBasedKVORule.self
-        XCTAssertFalse((defaultRuleType as Any) is OptInRule.Type)
+        XCTAssertFalse((defaultRuleType as Any) is any OptInRule.Type)
         testDefaultConfigurationDisabledRuleWarnings(for: defaultRuleType)
     }
 
-    private func testDefaultConfigurationDisabledRuleWarnings(for ruleType: Rule.Type) {
+    private func testDefaultConfigurationDisabledRuleWarnings(for ruleType: any Rule.Type) {
         let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue((ruleType as Any) is OptInRule.Type)
+        XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
         let ruleIdentifier = ruleType.identifier
 
         let parentConfigurations = [
@@ -459,7 +459,7 @@ extension ConfigurationTests {
         parentConfiguration: Configuration?,
         disabledRules: Set<String>,
         optInRules: Set<String>,
-        ruleType: Rule.Type
+        ruleType: any Rule.Type
     ) -> Issue? {
         var enabledInParentRules: Set<String> = []
         var disabledInParentRules: Set<String> = []
@@ -490,7 +490,7 @@ extension ConfigurationTests {
     private func testParentConfiguration(
         _ parentConfiguration: Configuration?,
         configurations: [Configuration],
-        ruleType: Rule.Type
+        ruleType: any Rule.Type
     ) {
         for configuration in configurations {
             if case .default(let disabledRules, let optInRules) = configuration.rulesMode {
@@ -513,7 +513,7 @@ extension ConfigurationTests {
                         }
 
                         if parentConfiguration == Configuration.emptyOnlyConfiguration() {
-                            if ruleType is OptInRule.Type {
+                            if ruleType is any OptInRule.Type {
                                 XCTAssertEqual(issue, Issue.ruleNotEnabledInOptInRules(ruleID: ruleIdentifier))
                             } else {
                                 XCTAssertEqual(issue, Issue.ruleNotEnabledInParentOnlyRules(ruleID: ruleIdentifier))
@@ -534,15 +534,15 @@ extension ConfigurationTests {
 
     func testOnlyConfigurationDisabledRulesWarnings() {
         let optInRuleType = ImplicitReturnRule.self
-        XCTAssertTrue((optInRuleType as Any) is OptInRule.Type)
+        XCTAssertTrue((optInRuleType as Any) is any OptInRule.Type)
         testOnlyConfigurationDisabledRulesWarnings(ruleType: optInRuleType)
 
         let defaultRuleType = BlockBasedKVORule.self
-        XCTAssertFalse((defaultRuleType as Any) is OptInRule.Type)
+        XCTAssertFalse((defaultRuleType as Any) is any OptInRule.Type)
         testOnlyConfigurationDisabledRulesWarnings(ruleType: defaultRuleType)
     }
 
-    private func testOnlyConfigurationDisabledRulesWarnings(ruleType: Rule.Type) {
+    private func testOnlyConfigurationDisabledRulesWarnings(ruleType: any Rule.Type) {
         struct TestCase: Equatable {
             let onlyRules: Set<String>
             let expectedIssue: Issue?

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -460,7 +460,7 @@ extension ConfigurationTests {
         configuration: Configuration,
         ruleType: any Rule.Type
     ) {
-        guard let case .default(let disabledRules, let optInRules) = configuration.rulesMode else {
+        guard case .default(let disabledRules, let optInRules) = configuration.rulesMode else {
             XCTFail("Configuration rulesMode was not the default")
             return
         }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -435,7 +435,7 @@ extension ConfigurationTests {
         let testCases: [TestCase] = [
             TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: ""),
             TestCase(parentConfiguration: optInConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: nil),
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: nil), // wrong - should be an error
+            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: ""),
             TestCase(parentConfiguration: disabledConfiguration, disabledRules: [], optInRules: [], expectedIssueMessage: ""),
 
             TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssueMessage: nil),
@@ -443,14 +443,14 @@ extension ConfigurationTests {
             TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssueMessage: nil),
             TestCase(parentConfiguration: disabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedIssueMessage: nil),
 
-            TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: nil), // wrong - should be an error
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: nil), // wrong - should be an error
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: nil), // wrong - should be an error
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: nil), // wrong - should be an error
+            TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: ""),
+            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: ""),
+            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: ""),
+            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedIssueMessage: ""),
 
             TestCase(parentConfiguration: noneNoneConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: ""),
-            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: nil), // wrong - should be an error
-            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: nil), // wrong - should be an error
+            TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: ""),
+            TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: ""),
             TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedIssueMessage: ""),
         ]
 
@@ -504,7 +504,6 @@ extension ConfigurationTests {
         } else {
             XCTAssertNil(issue)
         }
-
     }
     
     // MARK: - Remote Configs

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -427,16 +427,17 @@ extension ConfigurationTests {
     func testOptInRulesWithDefaultConfigurationWarnings() {
         let ruleType = ImplicitReturnRule.self
         let ruleIdentifier = ruleType.identifier
-        
+
+        // swiftlint:disable line_length
         let emptyConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: []))
         let optInConfiguration = Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier]))
         let optInDisabledConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [ruleIdentifier]))
         let disabledConfiguration = Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
-        
+
         let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not enabled on 'opt_in_rules'."
         let disabledInParentMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled in a parent configuration."
         let disabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled on 'disabled_rules'."
-        
+
         let testCases: [TestCase] = [
             TestCase(parentConfiguration: nil, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
             TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
@@ -460,26 +461,28 @@ extension ConfigurationTests {
             TestCase(parentConfiguration: emptyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
             TestCase(parentConfiguration: optInConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
             TestCase(parentConfiguration: optInDisabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: disabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage)
         ]
+        // swiftlint:enable line_length
 
         test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
     }
-    
+
     func testOptInRulesWithOnlyConfigurationWarnings() {
         let ruleType = ImplicitReturnRule.self
         let ruleIdentifier = ruleType.identifier
 
         let emptyConfiguration = Configuration(rulesMode: .only([]))
         let enabledConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
-        
+
+        // swiftlint:disable line_length
         let notEnabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is not enabled on 'opt_in_rules'."
         let disabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled on 'disabled_rules'."
 
         let testCases: [TestCase] = [
             TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [], expectedMessage: notEnabledMessage),
             TestCase(parentConfiguration: enabledConfiguration, disabledRules: [], optInRules: [], expectedMessage: nil),
-            
+
             TestCase(parentConfiguration: emptyConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
             TestCase(parentConfiguration: enabledConfiguration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
 
@@ -487,26 +490,29 @@ extension ConfigurationTests {
             TestCase(parentConfiguration: enabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
 
             TestCase(parentConfiguration: emptyConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: enabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: enabledConfiguration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage)
         ]
-        
+        // swiftlint:enable line_length
+
         test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
     }
-    
+
     func testOptInRulesWithAllConfigurationWarnings() {
         let ruleType = ImplicitReturnRule.self
         let ruleIdentifier = ruleType.identifier
 
         let configuration = Configuration(rulesMode: .allEnabled)
-        
+
+        // swiftlint:disable line_length
         let disabledMessage = "Found a configuration for '\(ruleIdentifier)' rule, but it is disabled on 'disabled_rules'."
 
         let testCases: [TestCase] = [
             TestCase(parentConfiguration: configuration, disabledRules: [], optInRules: [], expectedMessage: nil),
             TestCase(parentConfiguration: configuration, disabledRules: [], optInRules: [ruleIdentifier], expectedMessage: nil),
             TestCase(parentConfiguration: configuration, disabledRules: [ruleIdentifier], optInRules: [ruleIdentifier], expectedMessage: disabledMessage),
-            TestCase(parentConfiguration: configuration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage),
+            TestCase(parentConfiguration: configuration, disabledRules: [ruleIdentifier], optInRules: [], expectedMessage: disabledMessage)
         ]
+        // swiftlint:enable line_length
 
         test(cases: testCases, ruleType: ruleType, ruleIdentifier: ruleIdentifier)
     }
@@ -550,7 +556,7 @@ extension ConfigurationTests {
             XCTAssertNil(issue)
         }
     }
-    
+
     // MARK: - Remote Configs
     func testValidRemoteChildConfig() {
         FileManager.default.changeCurrentDirectoryPath(Mock.Dir.remoteConfigChild)


### PR DESCRIPTION
Fixes #4858

The problem here is configurations like this:

```
included:
  - Plugins
  - Source
  - Tests
excluded:
  - Tests/SwiftLintFrameworkTests/Resources
opt_in_rules:
  - implicit_return
disabled_rules:
  - type_body_length
  - function_body_length
  - large_tuple

implicit_return:
  included:
    - closure
```

with child configurations like this:

```
parent_config: .swiftlint-parent.yml

implicit_return:
  included:
    - closure
    - function
    - getter
```

SwiftLint will report `warning: Found a configuration for 'implicit_return' rule, but it is not enabled on 'opt_in_rules'.` for the child config, even though it will correctly apply the new config.

We now pass in the parent configuration when validating rule configurations for the child, and do not complain about configurations where that rule is enabled in the parent.

There should be no change in behaviour at all here - just a change in the warnings.

Getting this correct turned out to be quite complex, but after this PR, it should be the case that whenever, and only when, a rule is disabled in the parent or "child" config, a warning message will be printed, and the exact warning will vary somewhat, depending on whether the rule is disabled in the parent or "child", or not enabled at all.

There is a separate issue with `child_config` that this PR does not attempt to address - See #5251 
