### PR TITLE
Add new `disallow_top_level_variables` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,7 @@ disabled_rules:
   - closure_body_length
   - conditional_returns_on_newline
   - convenience_type
+  - disallow_top_level_variables
   - discouraged_optional_collection
   - explicit_acl
   - explicit_enum_raw_value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 * Trigger `prefer_self_in_static_references` rule on more type references.
   [SimplyDanny](https://github.com/SimplyDanny)
+  
+* Add new `disallow_top_level_variables` rule that disallows declaring variables
+  and constants as the top-level declarations.
+  [Andrii Zinoviev](https://github.com/shivatinker)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -37,6 +37,7 @@ let builtInRules: [Rule.Type] = [
     CyclomaticComplexityRule.self,
     DeploymentTargetRule.self,
     DirectReturnRule.self,
+    DisallowTopLevelVariablesRule.self,
     DiscardedNotificationCenterObserverRule.self,
     DiscouragedAssertRule.self,
     DiscouragedDirectInitRule.self,

--- a/Source/SwiftLintFramework/Rules/Style/DisallowTopLevelVariablesRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/DisallowTopLevelVariablesRule.swift
@@ -1,0 +1,64 @@
+import SwiftSyntax
+
+struct DisallowTopLevelVariablesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+    var configuration: SeverityConfiguration = .init(.warning)
+
+    static let description: RuleDescription = .init(
+        identifier: "disallow_top_level_variables",
+        name: "Disallow Top-Level Variables",
+        description: "Top-Level variables and constants should be avoided",
+        kind: .style,
+        nonTriggeringExamples: [
+            Example(
+                """
+                struct A {
+                    public var a: Int = 12
+                }
+                """
+            )
+        ],
+        triggeringExamples: [
+            Example("var ↓a: Int = 11"),
+            Example("let ↓a: Int = 11"),
+            Example("private var ↓a: Int = 11"),
+            Example("public var ↓a: String?"),
+            Example("public var ↓b: Int { return 42 }")
+        ])
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor()
+    }
+}
+
+private extension DisallowTopLevelVariablesRule {
+    final class Visitor: ViolationsSyntaxVisitor {
+        init() {
+            super.init(viewMode: .sourceAccurate)
+        }
+
+        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+
+        override func visitPost(_ node: VariableDeclSyntax) {
+            let kind = node.bindingKeyword.tokenKind
+            guard kind == .keyword(.let) || kind == .keyword(.var) else {
+                return
+            }
+
+            for binding in node.bindings {
+                guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
+                    continue
+                }
+
+                violations.append(pattern.positionAfterSkippingLeadingTrivia)
+            }
+        }
+
+        override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @_spi(TestHelper)
 @testable import SwiftLintFramework
@@ -203,6 +203,12 @@ class DeploymentTargetRuleGeneratedTests: XCTestCase {
 class DirectReturnRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DirectReturnRule.description)
+    }
+}
+
+class DisallowTopLevelVariablesRuleGeneratedTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(DisallowTopLevelVariablesRule.description)
     }
 }
 


### PR DESCRIPTION
Added new `disallow_top_level_variables` rule, that we want to use in our team. For now, we are using `prefixed_toplevel_constant` rule to locate global constants and move them to scopes (enums/classes/structs). 

Feel free to ask any questions or suggest improvements. 