### PR TITLE
Add automatic architecture detection to Xcode script configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,14 @@ folder by default. To instruct Xcode where to find SwiftLint, you can either add
 `/opt/homebrew/bin` to the `PATH` environment variable in your build phase
 
 ```bash
-export PATH="$PATH:/opt/homebrew/bin"
-if which swiftlint > /dev/null; then
-  swiftlint
+if [[ "$(uname -m)" = x86_64* ]]; then
+  prefie="/usr/local/bin/"
+else
+  prefie="/opt/homebrew/bin/"    
+fi
+
+if which $prefie/swiftformat >/dev/null; then
+  $prefie/swiftlint
 else
   echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
 fi

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ folder by default. To instruct Xcode where to find SwiftLint, you can either add
 if [[ "$(uname -m)" = x86_64* ]]; then
   prefie="/usr/local/bin/"
 else
-  prefie="/opt/homebrew/bin/"    
+  prefie="/opt/homebrew/bin/"
 fi
 
-if which $prefie/swiftformat >/dev/null; then
+if which $prefie/swiftlint >/dev/null; then
   $prefie/swiftlint
 else
   echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"

--- a/README.md
+++ b/README.md
@@ -158,14 +158,12 @@ folder by default. To instruct Xcode where to find SwiftLint, you can either add
 `/opt/homebrew/bin` to the `PATH` environment variable in your build phase
 
 ```bash
-if [[ "$(uname -m)" = x86_64* ]]; then
-  prefie="/usr/local/bin/"
-else
-  prefie="/opt/homebrew/bin/"
+if [[ "$(uname -m)" == arm64 ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
 fi
 
-if which $prefie/swiftlint >/dev/null; then
-  $prefie/swiftlint
+if which swiftlint > /dev/null; then
+  swiftlint
 else
   echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
 fi


### PR DESCRIPTION
This pull request adds automatic detection of the current architecture (Apple or Intel) to the Xcode script configuration. With this change, the script will now use the appropriate path for the swiftlint executable based on the current architecture.

The updated code replaces the hard-coded `/opt/homebrew/bin` path with a conditional statement that sets the `prefie` variable to the appropriate path based on the current architecture. If the current architecture is `x86_64*`, the `prefie` variable is set to `/usr/local/bin/`, otherwise it is set to `/opt/homebrew/bin/`.
