### PR TITLE
Remove checks for setUp/tearDown from `overridden_super_call` lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   Violations within test classes will now be ignored by default.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4896](https://github.com/realm/SwiftLint/issues/4896)
+
 * Stop enforcing calls to super from the override functions `setUp()`,
   `tearDown()`, `setUpWithError()`, and `tearDownWithError()` in `XCTestCase`
   subclasses.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
   [#4896](https://github.com/realm/SwiftLint/issues/4896)
 * Stop enforcing calls to super from the override functions `setUp()`,
   `tearDown()`, `setUpWithError()`, and `tearDownWithError()` in `XCTestCase`
-  subclasses.
+  subclasses.  
   [AndrewDMontgomery](https://github.com/andrewdmontgomery)
   [#4875](https://github.com/realm/SwiftLint/pull/4875)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
   Violations within test classes will now be ignored by default.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#4896](https://github.com/realm/SwiftLint/issues/4896)
+* Stop enforcing calls to super from the override functions `setUp()`,
+  `tearDown()`, `setUpWithError()`, and `tearDownWithError()` in `XCTestCase`
+  subclasses.
+  [AndrewDMontgomery](https://github.com/andrewdmontgomery)
+  [#4875](https://github.com/realm/SwiftLint/pull/4875)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRuleExamples.swift
@@ -14,30 +14,6 @@ internal struct TestCaseAccessibilityRuleExamples {
                 return nestedMember
             }
 
-            override static func setUp() {
-                super.setUp()
-            }
-
-            override func setUp() {
-                super.setUp()
-            }
-
-            override func setUpWithError() throws {
-                try super.setUpWithError()
-            }
-
-            override static func tearDown() {
-                super.tearDown()
-            }
-
-            override func tearDown() {
-                super.tearDown()
-            }
-
-            override func tearDownWithError() {
-                try super.tearDownWithError()
-            }
-
             override func someFutureXCTestFunction() {
                 super.someFutureXCTestFunction()
             }

--- a/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TestCaseAccessibilityRuleExamples.swift
@@ -14,6 +14,18 @@ internal struct TestCaseAccessibilityRuleExamples {
                 return nestedMember
             }
 
+            override static func setUp() {}
+
+            override func setUp() {}
+
+            override func setUpWithError() throws {}
+
+            override static func tearDown() {}
+
+            override func tearDown() {}
+
+            override func tearDownWithError() {}
+
             override func someFutureXCTestFunction() {
                 super.someFutureXCTestFunction()
             }

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -26,12 +26,7 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
         "viewDidDisappear(_:)",
         "viewDidLoad()",
         "viewWillAppear(_:)",
-        "viewWillDisappear(_:)",
-        // XCTestCase
-        "setUp()",
-        "setUpWithError()",
-        "tearDown()",
-        "tearDownWithError()"
+        "viewWillDisappear(_:)"
     ]
 
     private(set) var severityConfiguration = SeverityConfiguration(.warning)


### PR DESCRIPTION
Apple has recently updated its documentation [Set Up and Tear Down State in Your Tests](https://developer.apple.com/documentation/xctest/xctestcase/set_up_and_tear_down_state_in_your_tests) to remove calls to `super` from within the override functions for setting up and tearing down state in unit tests.

Apple also [acknowledged in the developer forums](https://developer.apple.com/forums/thread/113314) that the superclass implementation of the various `setUp()` and `tearDown()` functions of XCTestCase are (and have always been) no-ops, and that this change in the documentation was due to bug reports asking for clarification since it was observed that the ObjC documentation for these functions isn't annotated with the call to `super` being required.

Lastly, they have also stopped including calls to super in their boilerplate when creating a new XCTestCase file.  I can confirm this is true from at least Xcode 14.2.  The thread above says that the boilerplate change goes back to at least Xcode 10.1.

```swift
final class MyTestCase: XCTestCase {

    override func setUpWithError() throws {
        // Put setup code here. This method is called before the invocation of each test method in the class.

        // In UI tests it is usually best to stop immediately when a failure occurs.
        continueAfterFailure = false

        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
    }

    override func tearDownWithError() throws {
        // Put teardown code here. This method is called after the invocation of each test method in the class.
    }

    func testExample() throws {
        // UI tests must launch the application that they test.
        let app = XCUIApplication()
        app.launch()

        // Use XCTAssert and related functions to verify your tests produce the correct results.
    }

    func testLaunchPerformance() throws {
        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
            // This measures how long it takes to launch your application.
            measure(metrics: [XCTApplicationLaunchMetric()]) {
                XCUIApplication().launch()
            }
        }
    }
}
```

Since Apple updated their docs, and the boilerplate no longer includes these calls to `super`, let's stop enforcing them with this rule.
