### PR TITLE
Use Ubuntu 20.04 to release Linux binaries

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
   
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Using the latest version of Ubuntu leads to incompatibilities with `glibc` versions from LTS versions.