### PR TITLE
Pin Sourcery version to 2.0.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,4 +24,4 @@ steps:
       - echo "+++ Run Sourcery"
       - make --always-make sourcery
       - echo "+++ Diff Files"
-      - git diff-index --quiet HEAD
+      - git diff --quiet HEAD

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,4 +24,4 @@ steps:
       - echo "+++ Run Sourcery"
       - make --always-make sourcery
       - echo "+++ Diff Files"
-      - "! git diff -U0 | grep '^[-+][^-+]' | grep --invert-match '// Generated using Sourcery'"
+      - git diff-index --quiet HEAD

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,3 +19,9 @@ steps:
     commands:
       - echo "+++ Test"
       - bazel test --test_output=streamed --build_tests_only --features=tsan --test_timeout=1000 //Tests/...
+  - label: "Sourcery"
+    commands:
+      - echo "+++ Run Sourcery"
+      - make --always-make sourcery
+      - echo "+++ Diff Files"
+      - "! git diff -U0 | grep '^[-+][^-+]' | grep --invert-match '// Generated using Sourcery'"

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,15 @@ all: build
 sourcery: Source/SwiftLintFramework/Models/PrimaryRuleList.swift Source/SwiftLintFramework/Models/ReportersList.swift Tests/GeneratedTests/GeneratedTests.swift
 
 Source/SwiftLintFramework/Models/PrimaryRuleList.swift: Source/SwiftLintFramework/Rules/**/*.swift .sourcery/PrimaryRuleList.stencil
-	sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/PrimaryRuleList.stencil --output .sourcery
+	./tools/sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/PrimaryRuleList.stencil --output .sourcery
 	mv .sourcery/PrimaryRuleList.generated.swift Source/SwiftLintFramework/Models/PrimaryRuleList.swift
 
 Source/SwiftLintFramework/Models/ReportersList.swift: Source/SwiftLintFramework/Reporters/*.swift .sourcery/ReportersList.stencil
-	sourcery --sources Source/SwiftLintFramework/Reporters --templates .sourcery/ReportersList.stencil --output .sourcery
+	./tools/sourcery --sources Source/SwiftLintFramework/Reporters --templates .sourcery/ReportersList.stencil --output .sourcery
 	mv .sourcery/ReportersList.generated.swift Source/SwiftLintFramework/Models/ReportersList.swift
 
 Tests/GeneratedTests/GeneratedTests.swift: Source/SwiftLintFramework/Rules/**/*.swift .sourcery/GeneratedTests.stencil
-	sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/GeneratedTests.stencil --output .sourcery
+	./tools/sourcery --sources Source/SwiftLintFramework/Rules --templates .sourcery/GeneratedTests.stencil --output .sourcery
 	mv .sourcery/GeneratedTests.generated.swift Tests/GeneratedTests/GeneratedTests.swift
 
 test: clean_xcode

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 /// The rule list containing all available rules built into SwiftLint.

--- a/Source/SwiftLintFramework/Models/ReportersList.swift
+++ b/Source/SwiftLintFramework/Models/ReportersList.swift
@@ -1,5 +1,5 @@
 // Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
-// DO NOT EDIT
+// This was edited
 
 /// The reporters list containing all the reporters built into SwiftLint.
 public let reportersList: [Reporter.Type] = [

--- a/Source/SwiftLintFramework/Models/ReportersList.swift
+++ b/Source/SwiftLintFramework/Models/ReportersList.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 /// The reporters list containing all the reporters built into SwiftLint.

--- a/Source/SwiftLintFramework/Models/ReportersList.swift
+++ b/Source/SwiftLintFramework/Models/ReportersList.swift
@@ -1,5 +1,5 @@
 // Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
-// This was edited
+// DO NOT EDIT
 
 /// The reporters list containing all the reporters built into SwiftLint.
 public let reportersList: [Reporter.Type] = [

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @_spi(TestHelper)
 @testable import SwiftLintFramework

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,3 +29,22 @@ ruby_bundle(
     gemfile = "//:Gemfile",
     gemfile_lock = "//:Gemfile.lock",
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "Sourcery",
+    build_file_content = """
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+name = "Sourcery",
+src = "sourcery",
+out = "sourcery",
+visibility = ["//visibility:public"],
+)
+    """,
+    strip_prefix = "bin",
+    sha256 = "7489afb5c867efa06333a779a2430ccb52647a50f0e2280066cc78aea4532d8d",
+    url = "https://github.com/krzysztofzablocki/Sourcery/releases/download/2.0.2/Sourcery-2.0.2.zip",
+)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,15 +2,6 @@ trigger:
 - main
 
 jobs:
-- job: Sourcery
-  pool:
-    vmImage: 'macOS-12'
-  steps:
-    - script: make --always-make sourcery
-      displayName: Generate sources
-    - script: "! git diff -U0 | grep '^[-+][^-+]' | grep --invert-match '// Generated using Sourcery'"
-      displayName: Check changed files ignoring Sourcery's version
-
 - job: Linux
   pool:
     vmImage: 'ubuntu-20.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,8 +6,6 @@ jobs:
   pool:
     vmImage: 'macOS-12'
   steps:
-    - script: brew install sourcery
-      displayName: Install Sourcery
     - script: make --always-make sourcery
       displayName: Generate sources
     - script: "! git diff -U0 | grep '^[-+][^-+]' | grep --invert-match '// Generated using Sourcery'"

--- a/tools/sourcery
+++ b/tools/sourcery
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bazel run \
+  --run_under="cd $PWD && " \
+  --noshow_progress \
+  --show_result=0 \
+  --ui_event_filters=-INFO \
+  @Sourcery//:Sourcery -- "$@"


### PR DESCRIPTION
By adding a `tools/sourcery` script that downloads and runs Sourcery via Bazel.

Previously, unrelated changes might include modifications to the generated comment headers because contributors' local versions of Sourcery would be used, which we don't control.

Also move the CI job to Buildkite where the bazel server is usually already warmed up and running.