### PR TITLE
[CI] Use rbenv to manage Ruby

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,10 +11,10 @@ steps:
       - swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
   - label: "Danger"
     commands:
-      - echo "--- Build Danger"
-      - bazel build //tools:danger
+      - echo "--- Bundle Install"
+      - bundle install
       - echo "+++ Run Danger"
-      - ./bazel-bin/tools/danger --verbose
+      - bundle exec danger --verbose
   - label: "TSan Tests"
     commands:
       - echo "+++ Test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,8 @@ steps:
       - swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
   - label: "Danger"
     commands:
+      - echo "--- Install Bundler"
+      - gem install bundler
       - echo "--- Bundle Install"
       - bundle install
       - echo "+++ Run Danger"

--- a/.buildkite/pre-command
+++ b/.buildkite/pre-command
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+export PATH="$HOME/.rbenv/bin:$PATH"
+
+eval "$(rbenv init -)"

--- a/.buildkite/pre-command
+++ b/.buildkite/pre-command
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-export PATH="$HOME/.rbenv/bin:$PATH"
-
-eval "$(rbenv init -)"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
     repo_name = "SwiftLint",
 )
 
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "rules_apple", version = "2.2.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_swift", version = "1.7.1", repo_name = "build_bazel_rules_swift")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ load(
 
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "2.7.5")
+rules_ruby_select_sdk(version = "host")
 
 load(
     "@bazelruby_rules_ruby//ruby:defs.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ load(
 
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "host")
+rules_ruby_select_sdk(version = "2.7.5")
 
 load(
     "@bazelruby_rules_ruby//ruby:defs.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,35 +1,5 @@
 workspace(name = "SwiftLint")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "bazelruby_rules_ruby",
-    commit = "cc2f5ce961f7fa34557264dd05c7597e634f31e1",
-    remote = "https://github.com/bazelruby/rules_ruby.git",
-    shallow_since = "1679251731 -0700",
-)
-
-load(
-    "@bazelruby_rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
-
-rules_ruby_dependencies()
-
-rules_ruby_select_sdk(version = "host")
-
-load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
-    "ruby_bundle",
-)
-
-ruby_bundle(
-    name = "bundle",
-    gemfile = "//:Gemfile",
-    gemfile_lock = "//:Gemfile.lock",
-)
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,9 +1,1 @@
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_binary")
-
 exports_files(["test-analyze.sh"])
-
-ruby_binary(
-    name = "danger",
-    main = "@bundle//:bin/danger",
-    deps = ["@bundle//:bin"],
-)


### PR DESCRIPTION
And pin the Ruby version to 2.7.5. rbenv was installed on all CI machines using Homebrew, with Ruby 2.7.5 installed and set as the global version. The `pre-command` script was also updated on all agents to add rbenv binaries to the path and run `rbenv init`.

Remove rules_ruby integration and just use rbenv and ruby directly.