### PR TITLE
Check first argument label in `reduce_boolean` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@
 * Fix false positives in `indentation_width` rule.  
   [Sven Münnich](https://github.com/svenmuennich)
 
+* Do not trigger `reduce_boolean` on `reduce` methods with a first named
+  argument that is different from `into`.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4894](https://github.com/realm/SwiftLint/issues/4894)
+
 ## 0.51.0: bzllint
 
 #### Breaking

--- a/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
+++ b/Source/SwiftLintFramework/Rules/Performance/ReduceBooleanRule.swift
@@ -12,7 +12,8 @@ struct ReduceBooleanRule: SwiftSyntaxRule, ConfigurationProviderRule {
         kind: .performance,
         nonTriggeringExamples: [
             Example("nums.reduce(0) { $0.0 + $0.1 }"),
-            Example("nums.reduce(0.0) { $0.0 + $0.1 }")
+            Example("nums.reduce(0.0) { $0.0 + $0.1 }"),
+            Example("nums.reduce(initial: true) { $0.0 && $0.1 == 3 }")
         ],
         triggeringExamples: [
             Example("let allNines = nums.↓reduce(true) { $0.0 && $0.1 == 9 }"),
@@ -22,7 +23,8 @@ struct ReduceBooleanRule: SwiftSyntaxRule, ConfigurationProviderRule {
             Example("let allNines = nums.↓reduce(true, { $0.0 && $0.1 == 9 })"),
             Example("let anyNines = nums.↓reduce(false, { $0.0 || $0.1 == 9 })"),
             Example("let allValid = validators.↓reduce(true, { $0 && $1(input) })"),
-            Example("let anyValid = validators.↓reduce(false, { $0 || $1(input) })")
+            Example("let anyValid = validators.↓reduce(false, { $0 || $1(input) })"),
+            Example("nums.reduce(into: true) { (r: inout Bool, s) in r = r && (s == 3) }")
         ]
     )
 
@@ -38,6 +40,7 @@ private extension ReduceBooleanRule {
                 let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),
                 calledExpression.name.text == "reduce",
                 let firstArgument = node.argumentList.first,
+                firstArgument.label?.text ?? "into" == "into",
                 let bool = firstArgument.expression.as(BooleanLiteralExprSyntax.self)
             else {
                 return


### PR DESCRIPTION
It's impossible to avoid all false-positives reported by this rule due to missing type information. This PR fixes #4894, but there are definitely more problematic cases.

It's also questionable if code like `a.reduce(true)` is enough information to conclude that the attached closure simply `&&`'s all conditions working on the elements.