### PR TITLE
Mark `bazel_skylib` as `dev_dependency = True`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
     repo_name = "SwiftLint",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "bazel_skylib", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "rules_apple", version = "2.2.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_swift", version = "1.7.1", repo_name = "build_bazel_rules_swift")


### PR DESCRIPTION
So folks who integrate SwiftLint with Bazel don't need to match this exact version.