### PR TITLE
Allow configuring `xct_specific_matcher` with matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@
   [kimdv](https://github.com/kimdv)
 
 * Extend `xct_specific_matcher` rule to check for boolean asserts on (un)equal
-  comparisons.  
+  comparisons. The rule can be configured with the matchers that should trigger
+  rule violations. By default, all matchers trigger, but that can be limited to
+  just `single-argument` or `double-argument`.  
   [SimplyDanny](https://github.com/SimplyDanny)
+  [JP Simard](https://github.com/jpsim)
   [#3726](https://github.com/realm/SwiftLint/issues/3726)
 
 * Trigger `prefer_self_in_static_references` rule on more type references.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Extend `xct_specific_matcher` rule to check for boolean asserts on (un)equal
   comparisons. The rule can be configured with the matchers that should trigger
   rule violations. By default, all matchers trigger, but that can be limited to
-  just `single-argument` or `double-argument`.  
+  just `one-argument-asserts` or `two-argument-asserts`.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [JP Simard](https://github.com/jpsim)
   [#3726](https://github.com/realm/SwiftLint/issues/3726)

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -30,13 +30,13 @@ private extension XCTSpecificMatcherRule {
         }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            if configuration.matchers.contains(.doubleArgument),
+            if configuration.matchers.contains(.twoArgumentAsserts),
                let suggestion = TwoArgsXCTAssert.violations(in: node) {
                 violations.append(ReasonedRuleViolation(
                     position: node.positionAfterSkippingLeadingTrivia,
                     reason: "Prefer the specific matcher '\(suggestion)' instead"
                 ))
-            } else if configuration.matchers.contains(.singleArgument),
+            } else if configuration.matchers.contains(.oneArgumentAsserts),
                let suggestion = OneArgXCTAssert.violations(in: node) {
                 violations.append(ReasonedRuleViolation(
                     position: node.positionAfterSkippingLeadingTrivia,

--- a/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Idiomatic/XCTSpecificMatcherRuleExamples.swift
@@ -50,7 +50,13 @@ internal struct XCTSpecificMatcherRuleExamples {
         Example("XCTAssertEqual(foo?.bar, toto())"),
         Example("XCTAssertEqual(foo?.bar, .toto(.zoo))"),
         Example("XCTAssertEqual(toto(), foo?.bar)"),
-        Example("XCTAssertEqual(.toto(.zoo), foo?.bar)")
+        Example("XCTAssertEqual(.toto(.zoo), foo?.bar)"),
+
+        // Configurations Disabled
+        Example("XCTAssertEqual(foo, true)",
+                configuration: ["matchers": ["one-argument-asserts"]]),
+        Example("XCTAssert(foo == bar)",
+                configuration: ["matchers": ["two-argument-asserts"]])
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/XCTSpecificMatcherRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/XCTSpecificMatcherRuleConfiguration.swift
@@ -8,8 +8,8 @@ struct XCTSpecificMatcherRuleConfiguration: SeverityBasedRuleConfiguration, Equa
     }
 
     private enum ConfigurationKey: String {
-        case severity = "severity"
-        case matchers = "matchers"
+        case severity
+        case matchers
     }
 
     var consoleDescription: String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/XCTSpecificMatcherRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/XCTSpecificMatcherRuleConfiguration.swift
@@ -3,8 +3,8 @@ struct XCTSpecificMatcherRuleConfiguration: SeverityBasedRuleConfiguration, Equa
     private(set) var matchers = Set(Matcher.allCases)
 
     enum Matcher: String, Hashable, CaseIterable {
-        case singleArgument = "single-argument"
-        case doubleArgument = "double-argument"
+        case oneArgumentAsserts = "one-argument-asserts"
+        case twoArgumentAsserts = "two-argument-asserts"
     }
 
     private enum ConfigurationKey: String {

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/XCTSpecificMatcherRuleConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/XCTSpecificMatcherRuleConfiguration.swift
@@ -1,0 +1,35 @@
+struct XCTSpecificMatcherRuleConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+    private(set) var matchers = Set(Matcher.allCases)
+
+    enum Matcher: String, Hashable, CaseIterable {
+        case singleArgument = "single-argument"
+        case doubleArgument = "double-argument"
+    }
+
+    private enum ConfigurationKey: String {
+        case severity = "severity"
+        case matchers = "matchers"
+    }
+
+    var consoleDescription: String {
+        return [
+            "severity: \(severityConfiguration.consoleDescription)",
+            "\(ConfigurationKey.matchers): \(matchers.map(\.rawValue).sorted().joined(separator: ", "))"
+        ].joined(separator: ", ")
+    }
+
+    mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let severityString = configuration[ConfigurationKey.severity.rawValue] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        if let matchers = configuration[ConfigurationKey.matchers.rawValue] as? [String] {
+            self.matchers = Set(matchers.compactMap(Matcher.init(rawValue:)))
+        }
+    }
+}


### PR DESCRIPTION
So that either `one-argument-asserts` or `two-argument-asserts` or both can be enabled.

The following configuration effectively reverts back to the rule behavior prior to https://github.com/realm/SwiftLint/pull/3858:

```yaml
xct_specific_matcher:
  matchers:
    - two-argument-asserts
```