### PR TITLE
Add new `redundant_self_in_closure` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -40,6 +40,7 @@ disabled_rules:
   - prefer_nimble
   - prefer_self_in_static_references
   - prefixed_toplevel_constant
+  - redundant_self_in_closure
   - required_deinit
   - self_binding
   - sorted_enum_cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   * Closure used in a struct declaration (`self` can always be omitted)
   * Anonymous closures that are directly called (`{ ... }()`) as they are
     definitly not escaping
+  * Weakly captured `self` with explicit unwrapping
 
   [SimplyDanny](https://github.com/SimplyDanny)
   [#59](https://github.com/realm/SwiftLint/issues/59)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 * Add `sorted_enum_cases` rule which warns when enum cases are not sorted.  
   [kimdv](https://github.com/kimdv)
 
+* Add new `redundant_self_in_closure` rule that triggers in closures on
+  explicitly used `self` when it's actually not needed due to:
+  * Strongly captured `self` (`{ [self] in ... }`)
+  * Closure used in a struct declaration (`self` can always be omitted)
+  * Anonymous closures that are directly called (`{ ... }()`) as they are
+    definitly not escaping
+
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#59](https://github.com/realm/SwiftLint/issues/59)
+
 * Extend `xct_specific_matcher` rule to check for boolean asserts on (un)equal
   comparisons. The rule can be configured with the matchers that should trigger
   rule violations. By default, all matchers trigger, but that can be limited to

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -165,6 +165,7 @@ public let builtInRules: [Rule.Type] = [
     RedundantNilCoalescingRule.self,
     RedundantObjcAttributeRule.self,
     RedundantOptionalInitializationRule.self,
+    RedundantSelfInClosureRule.self,
     RedundantSetAccessControlRule.self,
     RedundantStringEnumValueRule.self,
     RedundantTypeAnnotationRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
@@ -1,0 +1,273 @@
+import SwiftSyntax
+
+struct RedundantSelfInClosureRule: SwiftSyntaxRule, CorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = SeverityConfiguration(.warning)
+
+    static var description = RuleDescription(
+        identifier: "redundant_self_in_closure",
+        name: "Redundant Self in Closure",
+        description: "Explicit use of 'self' is not required",
+        kind: .style,
+        nonTriggeringExamples: [
+            Example("""
+                struct S {
+                    var x = 0
+                    func f(_ work: @escaping () -> Void) { work() }
+                    func g() {
+                        f {
+                            x = 1
+                            f { x = 1 }
+                            g()
+                        }
+                    }
+                }
+            """),
+            Example("""
+                class C {
+                    var x = 0
+                    func f(_ work: @escaping () -> Void) { work() }
+                    func g() {
+                        f { [weak self] in
+                            self?.x = 1
+                            self?.g()
+                        }
+                        C().f { self.x = 1 }
+                        f { [weak self] in if let self { self.x = 1 } }
+                    }
+                }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                struct S {
+                    var x = 0
+                    func f(_ work: @escaping () -> Void) { work() }
+                    func g() {
+                        f {
+                            ↓self.x = 1
+                            if ↓self.x == 1 { ↓self.g() }
+                        }
+                    }
+                }
+            """),
+            Example("""
+                class C {
+                    var x = 0
+                    func g() {
+                        {
+                            ↓self.x = 1
+                            ↓self.g()
+                        }()
+                    }
+                }
+            """),
+            Example("""
+                class C {
+                    var x = 0
+                    func f(_ work: @escaping () -> Void) { work() }
+                    func g() {
+                        f { [self] in
+                            ↓self.x = 1
+                            ↓self.g()
+                            f { self.x = 1 }
+                        }
+                    }
+                }
+            """),
+            Example("""
+                class C {
+                    var x = 0
+                    func f(_ work: @escaping () -> Void) { work() }
+                    func g() {
+                        f { [unowned self] in ↓self.x = 1 }
+                        f { [self = self] in ↓self.x = 1 }
+                        f { [s = self] in s.x = 1 }
+                    }
+                }
+            """)
+        ],
+        corrections: [
+            Example("""
+                struct S {
+                    var x = 0
+                    func f(_ work: @escaping () -> Void) { work() }
+                    func g() {
+                        f {
+                            ↓self.x = 1
+                            if ↓self.x == 1 { ↓self.g() }
+                        }
+                    }
+                }
+            """): Example("""
+                struct S {
+                    var x = 0
+                    func f(_ work: @escaping () -> Void) { work() }
+                    func g() {
+                        f {
+                            x = 1
+                            if x == 1 { g() }
+                        }
+                    }
+                }
+            """)
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        ScopeVisitor(viewMode: .sourceAccurate)
+    }
+
+    func correct(file: SwiftLintFile) -> [Correction] {
+        let ranges = ScopeVisitor(viewMode: .sourceAccurate)
+            .walk(file: file, handler: \.corrections)
+            .compactMap { file.stringView.NSRange(start: $0.start, end: $0.end) }
+            .filter { file.ruleEnabled(violatingRange: $0, for: self) != nil }
+            .reversed()
+
+        var corrections = [Correction]()
+        var contents = file.contents
+        for range in ranges {
+            let contentsNSString = contents.bridge()
+            contents = contentsNSString.replacingCharacters(in: range, with: "")
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: Self.description, location: location))
+        }
+
+        file.write(contents)
+
+        return corrections
+    }
+}
+
+private enum TypeDeclarationKind {
+    case likeStruct
+    case likeClass
+}
+
+private enum FunctionCallType {
+    case anonymousClosure
+    case function
+}
+
+private enum SelfCaptureKind {
+    case strong
+    case weak
+    case uncaptured
+}
+
+private class ScopeVisitor: ViolationsSyntaxVisitor {
+    private var typeDeclarations = [TypeDeclarationKind]()
+    private var functionCalls = [FunctionCallType]()
+    private var selfCaptures = [SelfCaptureKind]()
+
+    private(set) var corrections = [(start: AbsolutePosition, end: AbsolutePosition)]()
+
+    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .extensionsAndProtocols }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeDeclarations.append(.likeClass)
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: ActorDeclSyntax) {
+        _ = typeDeclarations.popLast()
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeDeclarations.append(.likeClass)
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: ClassDeclSyntax) {
+        _ = typeDeclarations.popLast()
+    }
+
+    override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+        if let selfItem = node.signature?.capture?.items?.first(where: \.capturesSelf) {
+            selfCaptures.append(selfItem.capturesWeakly ? .weak : .strong)
+        } else {
+            selfCaptures.append(.uncaptured)
+        }
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: ClosureExprSyntax) {
+        guard let activeTypeDeclarationKind = typeDeclarations.last,
+              let activeFunctionCallType = functionCalls.last,
+              let activeSelfCaptureKind = selfCaptures.last else {
+            return
+        }
+        let localCorrections = ExplicitSelfVisitor(
+            typeDeclarationKind: activeTypeDeclarationKind,
+            functionCallType: activeFunctionCallType,
+            selfCaptureKind: activeSelfCaptureKind
+        ).walk(tree: node.statements, handler: \.corrections)
+        violations.append(contentsOf: localCorrections.map(\.start))
+        corrections.append(contentsOf: localCorrections)
+        _ = selfCaptures.popLast()
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeDeclarations.append(.likeStruct)
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: EnumDeclSyntax) {
+        _ = typeDeclarations.popLast()
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.calledExpression.is(ClosureExprSyntax.self) {
+            functionCalls.append(.anonymousClosure)
+        } else {
+            functionCalls.append(.function)
+        }
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: FunctionCallExprSyntax) {
+        _ = functionCalls.popLast()
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        typeDeclarations.append(.likeStruct)
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: StructDeclSyntax) {
+        _ = typeDeclarations.popLast()
+    }
+}
+
+private class ExplicitSelfVisitor: ViolationsSyntaxVisitor {
+    private let typeDeclarationKind: TypeDeclarationKind
+    private let functionCallType: FunctionCallType
+    private let selfCaptureKind: SelfCaptureKind
+
+    private(set) var corrections = [(start: AbsolutePosition, end: AbsolutePosition)]()
+
+    init(typeDeclarationKind: TypeDeclarationKind,
+         functionCallType: FunctionCallType,
+         selfCaptureKind: SelfCaptureKind) {
+        self.typeDeclarationKind = typeDeclarationKind
+        self.functionCallType = functionCallType
+        self.selfCaptureKind = selfCaptureKind
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visitPost(_ node: MemberAccessExprSyntax) {
+        guard node.isSelfAccess else {
+            return
+        }
+        if typeDeclarationKind == .likeStruct || functionCallType == .anonymousClosure || selfCaptureKind == .strong {
+            corrections.append(
+                (start: node.positionAfterSkippingLeadingTrivia, end: node.dot.endPositionBeforeTrailingTrivia)
+            )
+        }
+    }
+
+    override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+        // Will be handled separately by the parent visitor.
+        .skipChildren
+    }
+}

--- a/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
@@ -328,7 +328,6 @@ public extension IntegerLiteralExprSyntax {
         guard case let .integerLiteral(number) = digits.tokenKind else {
             return false
         }
-
         return number.isZero
     }
 }
@@ -338,8 +337,29 @@ public extension FloatLiteralExprSyntax {
         guard case let .floatingLiteral(number) = floatingDigits.tokenKind else {
             return false
         }
-
         return number.isZero
+    }
+}
+
+public extension IdentifierExprSyntax {
+    var isSelf: Bool {
+        identifier.text == "self"
+    }
+}
+
+public extension MemberAccessExprSyntax {
+    var isSelfAccess: Bool {
+        base?.as(IdentifierExprSyntax.self)?.isSelf == true
+    }
+}
+
+public extension ClosureCaptureItemSyntax {
+    var capturesSelf: Bool {
+        expression.as(IdentifierExprSyntax.self)?.isSelf == true
+    }
+
+    var capturesWeakly: Bool {
+        specifier?.specifier.text == "weak"
     }
 }
 

--- a/Source/SwiftLintCore/Models/SwiftVersion.swift
+++ b/Source/SwiftLintCore/Models/SwiftVersion.swift
@@ -33,6 +33,8 @@ public extension SwiftVersion {
     static let fiveDotSix = SwiftVersion(rawValue: "5.6.0")
     /// Swift 5.7.x - https://swift.org/download/#swift-57
     static let fiveDotSeven = SwiftVersion(rawValue: "5.7.0")
+    /// Swift 5.8.x - https://swift.org/download/#swift-58
+    static let fiveDotEight = SwiftVersion(rawValue: "5.8.0")
 
     /// The current detected Swift compiler version, based on the currently accessible SourceKit version.
     ///

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -980,6 +980,12 @@ class RedundantOptionalInitializationRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class RedundantSelfInClosureRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RedundantSelfInClosureRule.description)
+    }
+}
+
 class RedundantSetAccessControlRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantSetAccessControlRule.description)


### PR DESCRIPTION
This adds the new (and long awaited by #59) `redundant_self_in_closure` rule that triggers in closures on explicitly used `self` when it's actually not needed due to:

* Strongly captured `self` (`{ [self] in ... }`) according to [SE-0269](https://github.com/apple/swift-evolution/blob/main/proposals/0269-implicit-self-explicit-capture.md)
* Closure used in a struct declaration (`self` can always be omitted)
* Anonymous closures that are directly called (`{ ... }()`) as they are
    definitly not escaping
* Weakly captured `self` with explicit unwrapping according to [SE-0365](https://github.com/apple/swift-evolution/blob/main/proposals/0365-implicit-self-weak-capture.md)

What's missing is the detection of redundant `self` in classes when the closure isn't `@escaping`. This case can only be resolved by a separate Analyzer rule that has full knowledge about the closure's type. It's not possible to implement that reliably on bare source code level only.