### PR TITLE
Add TypeMemberOrderRule to check order of members within a type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   subclasses.  
   [AndrewDMontgomery](https://github.com/andrewdmontgomery)
   [#4875](https://github.com/realm/SwiftLint/pull/4875)
+  
+* Add new `type_member_order` opt-in rule that checks variables and functions to
+  ensure they are in alphabetical order.
+  [Al Wold](https://github.com/alwold)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
+++ b/Source/SwiftLintFramework/Models/PrimaryRuleList.swift
@@ -201,6 +201,7 @@ let builtInRules: [Rule.Type] = [
     TrailingWhitespaceRule.self,
     TypeBodyLengthRule.self,
     TypeContentsOrderRule.self,
+    TypeMemberOrderRule.self,
     TypeNameRule.self,
     TypesafeArrayInitRule.self,
     UnavailableConditionRule.self,

--- a/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeMemberOrderConfiguration.swift
+++ b/Source/SwiftLintFramework/Rules/RuleConfigurations/TypeMemberOrderConfiguration.swift
@@ -1,0 +1,29 @@
+struct TypeMemberOrderConfiguration: RuleConfiguration, SeverityBasedRuleConfiguration, Equatable {
+    private(set) var severityConfiguration = SeverityConfiguration(.warning)
+
+    /// Indicates whether members of each type should be considered as separate groups, or if
+    /// all members should be alphabetically ordered together. If true, each different type of
+    /// member will be considered as a separate group.
+    private(set) var separateByMemberTypes = true
+
+    /// Indicates whether MARK: comments should "reset" sorting. If true, a MARK: will delineate
+    /// a new group for the purposes of ordering.
+    private(set) var separateByMarks = true
+
+    var consoleDescription: String {
+        "separateByMemberTypes: \(separateByMemberTypes), separateByMarks: \(separateByMarks)"
+    }
+
+    mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw ConfigurationError.unknownConfiguration
+        }
+
+        if let separateByMemberTypes = configuration["separate_by_member_types"] as? Bool {
+            self.separateByMemberTypes = separateByMemberTypes
+        }
+        if let separateByMarks = configuration["separate_by_marks"] as? Bool {
+            self.separateByMarks = separateByMarks
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/TypeMemberOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeMemberOrderRule.swift
@@ -1,0 +1,200 @@
+import SwiftSyntax
+
+struct TypeMemberOrderRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+    var configuration = TypeMemberOrderConfiguration()
+
+    static let description = RuleDescription(
+        identifier: "type_member_order",
+        name: "Type Member Order",
+        description: "Enforces that members (e.g. properties, methods) are in alphabetical order within a type.",
+        kind: .style,
+        nonTriggeringExamples: TypeMemberOrderRuleExamples.nonTriggeringExamples,
+        triggeringExamples: TypeMemberOrderRuleExamples.triggeringExamples
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(viewMode: .sourceAccurate, configuration: configuration)
+    }
+}
+
+private extension TypeMemberOrderRule {
+    struct TypeState {
+        let declaration: DeclSyntaxProtocol?
+        var lastIdentifier: (type: DeclarationType, name: String)?
+    }
+
+    final class Visitor: ViolationsSyntaxVisitor {
+        var states: [TypeState] = [TypeState(declaration: nil, lastIdentifier: nil)]
+        let configuration: TypeMemberOrderConfiguration
+
+        init(viewMode: SyntaxTreeViewMode, configuration: TypeMemberOrderConfiguration) {
+            self.configuration = configuration
+            super.init(viewMode: viewMode)
+        }
+
+        override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+            states.append(TypeState(declaration: node, lastIdentifier: nil))
+            return .visitChildren
+        }
+
+        override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+            states.append(TypeState(declaration: node, lastIdentifier: nil))
+            return .visitChildren
+        }
+
+        override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+            states.append(TypeState(declaration: node, lastIdentifier: nil))
+            return .visitChildren
+        }
+
+        override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+            states.append(TypeState(declaration: node, lastIdentifier: nil))
+            return .visitChildren
+        }
+
+        override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+            states.append(TypeState(declaration: node, lastIdentifier: nil))
+            return .visitChildren
+        }
+
+        override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+            states.append(TypeState(declaration: node, lastIdentifier: nil))
+            return .visitChildren
+        }
+
+        override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+            if node.leadingTrivia.hasMark == true {
+                states[states.count - 1].lastIdentifier = nil
+            }
+            return .visitChildren
+        }
+
+        override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+            if configuration.separateByMarks, node.leadingTrivia.hasMark {
+                states[states.count - 1].lastIdentifier = nil
+            }
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: IdentifierPatternSyntax) {
+            guard let variableType = node.declarationType else { return }
+
+            let identifier = normalizedIdentifier(for: node)
+            if let lastIdentifier = states.last?.lastIdentifier, identifier < lastIdentifier.name, variableType != .localVariable {
+                if variableType == lastIdentifier.type || !configuration.separateByMemberTypes {
+                    violations.append(ReasonedRuleViolation(position: node.identifier.position, reason: "\(node.identifier.text) should be before \(lastIdentifier.name)"))
+                }
+            }
+            states[states.count - 1].lastIdentifier = (type: variableType, name: identifier)
+        }
+
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            if let lastIdentifier = states.last?.lastIdentifier, node.resolvedName() < lastIdentifier.name {
+                if node.declarationType == lastIdentifier.type || !configuration.separateByMemberTypes {
+                    violations.append(ReasonedRuleViolation(position: node.identifier.position, reason: "\(node.resolvedName()) should be before \(lastIdentifier.name)"))
+                }
+            }
+            states[states.count - 1].lastIdentifier = (type: node.declarationType, name: node.resolvedName())
+        }
+
+        override func visitPost(_ node: ActorDeclSyntax) {
+            states.removeLast()
+        }
+
+        override func visitPost(_ node: ClassDeclSyntax) {
+            states.removeLast()
+        }
+
+        override func visitPost(_ node: EnumDeclSyntax) {
+            states.removeLast()
+        }
+
+        override func visitPost(_ node: ExtensionDeclSyntax) {
+            states.removeLast()
+        }
+
+        override func visitPost(_ node: ProtocolDeclSyntax) {
+            states.removeLast()
+        }
+
+        override func visitPost(_ node: StructDeclSyntax) {
+            states.removeLast()
+        }
+
+        /// Get the name of the identifier for an `IdentifierPatternSyntax`, removing any
+        /// extra backticks used to quote reserved words.
+        ///
+        /// - Parameter identifier: The `IdentifierPatternSyntax` for the identifier
+        /// - Returns: The identifier with backticks removed, or the original identifier
+        ///
+        private func normalizedIdentifier(for identifier: IdentifierPatternSyntax) -> String {
+            let text = identifier.identifier.text
+            if text.hasPrefix("`") && text.hasSuffix("`") {
+                return String(text[text.index(after: text.startIndex)...text.index(before: text.endIndex)])
+            } else {
+                return text
+            }
+        }
+    }
+}
+
+private enum DeclarationType {
+    case instanceVariable
+    case localVariable
+    case typeVariable
+    case instanceMethod
+    case typeMethod
+    case function
+}
+
+private extension IdentifierPatternSyntax {
+    var declarationType: DeclarationType? {
+        guard let variableDeclaration, let parent = variableDeclaration.parent else {
+            return nil
+        }
+        if parent.is(MemberDeclListItemSyntax.self) {
+            if variableDeclaration.isInstanceVariable {
+                return .instanceVariable
+            } else {
+                return .typeVariable
+            }
+        } else if parent.is(CodeBlockItemSyntax.self) {
+            return .localVariable
+        }
+        return nil
+    }
+
+    // If an identifier is part of a variable declaration, it should have this structure:
+    // VariableDecl -> PatternBindingList -> PatternBinding -> IdentifierPattern
+    var variableDeclaration: VariableDeclSyntax? {
+        parent?.as(PatternBindingSyntax.self)?
+            .parent?.as(PatternBindingListSyntax.self)?
+            .parent?.as(VariableDeclSyntax.self)
+    }
+}
+
+private extension FunctionDeclSyntax {
+    var declarationType: DeclarationType {
+        if parent?.is(MemberDeclListItemSyntax.self) == true {
+            if modifiers.isClass || modifiers.isStatic {
+                return .typeMethod
+            } else {
+                return .instanceMethod
+            }
+        } else {
+            return .function
+        }
+    }
+}
+
+private extension Trivia {
+    var hasMark: Bool {
+        pieces.contains {
+            if case .lineComment(let comment) = $0, comment.hasPrefix("// MARK:") {
+                return true
+            } else {
+                return false
+            }
+        }
+    }
+}

--- a/Source/SwiftLintFramework/Rules/Style/TypeMemberOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/TypeMemberOrderRuleExamples.swift
@@ -1,0 +1,78 @@
+internal struct TypeMemberOrderRuleExamples {
+    static let nonTriggeringExamples = [
+        Example("""
+        struct Car {
+            let numberOfDoors: Int
+            let `wheelSize`: Int
+        }
+        """),
+        Example("""
+        struct Car {
+            let numberOfDoors: Int
+            let wheelSize: Int
+
+            // MARK: More stuff
+            let accessories: [Accessory]
+        """),
+        Example("""
+        struct Car {
+            let numberOfDoors: Int
+            let wheelSize: Int
+
+            func accelerate() {}
+            func brake() {}
+        }
+        """),
+        Example("""
+        // with `separate_by_member_types` set to false in configuration
+        struct Car {
+            func accelerate() {}
+            func brake() {}
+            let numberOfDoors: Int
+            func rev() {}
+            let wheelSize: Int
+        }
+        """, configuration: ["separate_by_member_types": false]),
+        Example("""
+        // with `separate_by_member_types` set to false in configuration
+        struct Car {
+            func accelerate() {}
+
+            struct Wheel {
+                let wheelSize: Int
+            }
+
+            let wheelCount: Int
+        }
+        """, configuration: ["separate_by_member_types": false])
+    ]
+
+    static let triggeringExamples = [
+        Example("""
+        struct Car {
+            let wheelSize: Int
+            let ↓numberOfDoors: Int
+        }
+        """),
+        Example("""
+        struct Car {
+            let numberOfDoors: Int
+            let wheelSize: Int
+
+            func brake() {}
+            func ↓accelerate() {}
+        }
+        """),
+        Example("""
+        // with `separate_by_member_types` set to false in configuration
+        struct Car {
+            func accelerate() {}
+            func brake() {}
+            func rev() {}
+
+            let ↓numberOfDoors: Int
+            let wheelSize: Int
+        }
+        """, configuration: ["separate_by_member_types": false])
+    ]
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1190,6 +1190,12 @@ class TypeContentsOrderRuleGeneratedTests: XCTestCase {
     }
 }
 
+class TypeMemberOrderRuleGeneratedTests: XCTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(TypeMemberOrderRule.description)
+    }
+}
+
 class TypeNameRuleGeneratedTests: XCTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TypeNameRule.description)


### PR DESCRIPTION
This adds an opt-in rule to enforce alphabetical order on properties/methods in a type. The order can be enforced on "groups" of members, or on all members in the type.

This is my first rule, so feel free to rip it apart if I should do anything differently :)