### PR TITLE
Allow one-line statements for the uncuddled mode in the `statement_position` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@
   subclasses.  
   [AndrewDMontgomery](https://github.com/andrewdmontgomery)
   [#4875](https://github.com/realm/SwiftLint/pull/4875)
+  
+* Allow one-line statements for the uncuddled mode 
+  in the `statement_position` rule.  
+  [enebin](https://github.com/enebin)
+  [#4632](https://github.com/realm/SwiftLint/issues/4632)
 
 #### Bug Fixes
 


### PR DESCRIPTION
- Fixes #4632

#### Changes
- Before, because of the `equal indentation check`, one-line statement in `uncuddled mode` violated the rule.
- So, changed regex pattern to capture preceding non-whitespace characters and then ignore the `eqaul indentation check` if any non-whitespace character is present.