### PR TITLE
Prepend `warning: ` to error messages so that they show in Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   subclasses.  
   [AndrewDMontgomery](https://github.com/andrewdmontgomery)
   [#4875](https://github.com/realm/SwiftLint/pull/4875)
+  
+* Prepend `warning: ` to error messages so that they show in Xcode.  
+  [whiteio](https://github.com/whiteio)
+  [#4923](https://github.com/realm/SwiftLint/issues/4923)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 private let warnDeprecatedOnceImpl: Void = {
     queuedPrintError("""
-        The `anyobject_protocol` rule is now deprecated and will be completely removed in a future release.
+        warning: The `anyobject_protocol` rule is now deprecated and will be completely removed in a future release.
         """
     )
 }()

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
@@ -264,7 +264,7 @@ private extension SwiftLintFile {
             let response = try? Request.index(file: path, arguments: compilerArguments).sendIfNotDisabled()
         else {
             queuedPrintError("""
-                Could not index file at path '\(self.path ?? "...")' with the \
+                warning: Could not index file at path '\(self.path ?? "...")' with the \
                 \(CaptureVariableRule.description.identifier) rule.
                 """)
             return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
@@ -2,8 +2,8 @@ import SwiftSyntax
 
 private let warnDeprecatedOnceImpl: Void = {
     queuedPrintError("""
-        The `\(InertDeferRule.description.identifier)` rule is now deprecated and will be completely \
-        removed in a future release due to an equivalent warning issued by the Swift compiler.
+        warning: The `\(InertDeferRule.description.identifier)` rule is now deprecated and will be \
+        completely removed in a future release due to an equivalent warning issued by the Swift compiler.
         """
     )
 }()

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -62,7 +62,7 @@ struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
         }
         guard compilerArguments.isNotEmpty else {
             queuedPrintError("""
-                Attempted to lint file at path '\(file.path ?? "...")' with the \
+                warning: Attempted to lint file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule without any compiler arguments.
                 """)
             return []

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 private let warnDeprecatedOnceImpl: Void = {
     queuedPrintError("""
-        The `\(UnusedCaptureListRule.description.identifier)` rule is now deprecated and will be completely \
+        warning: The `\(UnusedCaptureListRule.description.identifier)` rule is now deprecated and will be completely \
         removed in a future release due to an equivalent warning issued by the Swift compiler.
         """
     )

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -35,7 +35,7 @@ struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, Collectin
     func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> UnusedDeclarationRule.FileUSRs {
         guard compilerArguments.isNotEmpty else {
             queuedPrintError("""
-                Attempted to lint file at path '\(file.path ?? "...")' with the \
+                warning: Attempted to lint file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule without any compiler arguments.
                 """)
             return .empty
@@ -43,7 +43,7 @@ struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, Collectin
 
         guard let index = file.index(compilerArguments: compilerArguments), index.value.isNotEmpty else {
             queuedPrintError("""
-                Could not index file at path '\(file.path ?? "...")' with the \
+                warning: Could not index file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule.
                 """)
             return .empty
@@ -52,7 +52,7 @@ struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, Collectin
         guard let editorOpen = (try? Request.editorOpen(file: file.file).sendIfNotDisabled())
                 .map(SourceKittenDictionary.init) else {
             queuedPrintError("""
-                Could not open file at path '\(file.path ?? "...")' with the \
+                warning: Could not open file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule.
                 """)
             return .empty

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -86,7 +86,7 @@ struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRul
     private func importUsage(in file: SwiftLintFile, compilerArguments: [String]) -> [ImportUsage] {
         guard compilerArguments.isNotEmpty else {
             queuedPrintError("""
-                Attempted to lint file at path '\(file.path ?? "...")' with the \
+                warning: Attempted to lint file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule without any compiler arguments.
                 """)
             return []

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -67,7 +67,7 @@ struct NameConfiguration: RuleConfiguration, Equatable {
             self.validatesStartWithLowercase = validatesStartWithLowercase
         } else if let validatesStartWithLowercase = configurationDict["validates_start_lowercase"] as? Bool {
             self.validatesStartWithLowercase = validatesStartWithLowercase
-            queuedPrintError("\"validates_start_lowercase\" configuration was renamed to " +
+            queuedPrintError("warning: \"validates_start_lowercase\" configuration was renamed to " +
                 "\"validates_start_with_lowercase\" and will be removed in a future release.")
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -36,8 +36,8 @@ struct NestingConfiguration: RuleConfiguration, Equatable {
         } else if let statementLevelConfiguration = configurationDict["statement_level"] {
             queuedPrintError(
                 """
-                'statement_level' has been renamed to 'function_level' and will be completely removed in a future \
-                release.
+                warning: 'statement_level' has been renamed to 'function_level' and will be completely removed \
+                in a future release.
                 """
             )
             try functionLevel.apply(configuration: statementLevelConfiguration)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
@@ -43,7 +43,7 @@ struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRul
     private func violationRanges(in file: SwiftLintFile, compilerArguments: [String]) -> [NSRange] {
         guard compilerArguments.isNotEmpty else {
             queuedPrintError("""
-                Attempted to lint file at path '\(file.path ?? "...")' with the \
+                warning: Attempted to lint file at path '\(file.path ?? "...")' with the \
                 \(Self.description.identifier) rule without any compiler arguments.
                 """)
             return []

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -109,7 +109,7 @@ extension Configuration {
                 return indentationStyle
             }
 
-            queuedPrintError("Invalid configuration for '\(Key.indentation)'. Falling back to default.")
+            queuedPrintError("warning: Invalid configuration for '\(Key.indentation)'. Falling back to default.")
             return .default
         }
 
@@ -139,7 +139,7 @@ extension Configuration {
 
         // Deprecation warning for "whitelist_rules"
         if dict[Key.whitelistRules.rawValue] != nil {
-            queuedPrintError("'\(Key.whitelistRules.rawValue)' has been renamed to " +
+            queuedPrintError("warning: '\(Key.whitelistRules.rawValue)' has been renamed to " +
                 "'\(Key.onlyRules.rawValue)' and will be completely removed in a " +
                 "future release.")
         }

--- a/Source/SwiftLintCore/Extensions/Configuration+Remote.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Remote.swift
@@ -170,7 +170,9 @@ internal extension Configuration.FileGraph.FilePath {
 
     private mutating func handleFileWriteFailure(urlString: String, cachedFilePath: String?) throws -> String {
         if let cachedFilePath {
-            queuedPrintError("Unable to cache remote config from \"\(urlString)\". Using cached version as a fallback.")
+            queuedPrintError(
+                "warning: Unable to cache remote config from \"\(urlString)\". Using cached version as a fallback."
+            )
             self = .existing(path: cachedFilePath)
             return cachedFilePath
         } else {

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -134,7 +134,7 @@ public struct Configuration {
     ) {
         if let pinnedVersion, pinnedVersion != Version.current.value {
             queuedPrintError(
-                "Currently running SwiftLint \(Version.current.value) but " +
+                "warning: Currently running SwiftLint \(Version.current.value) but " +
                 "configuration specified version \(pinnedVersion)."
             )
             exit(2)

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 
 private let warnSourceKitFailedOnceImpl: Void = {
-    queuedPrintError("SourceKit-based rules will be skipped because sourcekitd has failed.")
+    queuedPrintError("warning: SourceKit-based rules will be skipped because sourcekitd has failed.")
 }()
 
 private func warnSourceKitFailedOnce() {
@@ -245,8 +245,8 @@ public struct CollectedLinter {
         }
 
         for (deprecatedIdentifier, identifier) in deprecatedToValidIdentifier {
-            queuedPrintError("'\(deprecatedIdentifier)' rule has been renamed to '\(identifier)' and will be " +
-                "completely removed in a future release.")
+            queuedPrintError("warning: '\(deprecatedIdentifier)' rule has been renamed to '\(identifier)' and " +
+                "will be completely removed in a future release.")
         }
 
         // Free some memory used for this file's caches. They shouldn't be needed after this point.
@@ -288,7 +288,7 @@ public struct CollectedLinter {
 
         if let parserDiagnostics = file.parserDiagnostics, parserDiagnostics.isNotEmpty {
             queuedPrintError(
-                "Skipping correcting file because it produced Swift parser errors: \(file.path ?? "<nopath>")"
+                "warning: Skipping correcting file because it produced Swift parser errors: \(file.path ?? "<nopath>")"
             )
             queuedPrintError(toJSON(["diagnostics": parserDiagnostics]))
             return []

--- a/Source/SwiftLintCore/Models/RuleList.swift
+++ b/Source/SwiftLintCore/Models/RuleList.swift
@@ -56,7 +56,7 @@ public struct RuleList {
                     initializedWithNonEmptyConfiguration: isConfigured
                 )
             } catch {
-                queuedPrintError("Invalid configuration for '\(identifier)'. Falling back to default.")
+                queuedPrintError("warning: Invalid configuration for '\(identifier)'. Falling back to default.")
                 rules[identifier] = (ruleType.init(), false)
             }
         }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -23,7 +23,7 @@ struct CustomRulesConfiguration: RuleConfiguration, Equatable, CacheDescriptionP
             do {
                 try ruleConfiguration.apply(configuration: value)
             } catch {
-                queuedPrintError("Invalid configuration for custom rule '\(key)'.")
+                queuedPrintError("warning: Invalid configuration for custom rule '\(key)'.")
                 continue
             }
 

--- a/Source/swiftlint/Commands/Docs.swift
+++ b/Source/swiftlint/Commands/Docs.swift
@@ -15,7 +15,7 @@ extension SwiftLint {
             var subPage = ""
             if let ruleID {
                 if RuleRegistry.shared.rule(forID: ruleID) == nil {
-                    queuedPrintError("There is no rule named '\(ruleID)'. Opening rule directory instead.")
+                    queuedPrintError("warning: There is no rule named '\(ruleID)'. Opening rule directory instead.")
                     subPage = "rule-directory.html"
                 } else {
                     subPage = ruleID + ".html"

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -155,7 +155,7 @@ extension Configuration {
                     let collected = await counter.next()
                     if skipFile {
                         queuedPrintError("""
-                            Skipping '\(outputFilename)' (\(collected)/\(total)) \
+                            warning: Skipping '\(outputFilename)' (\(collected)/\(total)) \
                             because its compiler arguments could not be found
                             """)
                     } else {

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -273,7 +273,7 @@ private class LintOrAnalyzeResultBuilder {
             do {
                 try Data().write(to: URL(fileURLWithPath: outFile))
             } catch {
-                queuedPrintError("Could not write to file at path \(outFile)")
+                queuedPrintError("warning: Could not write to file at path \(outFile)")
             }
         }
     }
@@ -302,7 +302,7 @@ private extension LintOrAnalyzeOptions {
             fileUpdater.write(Data((string + "\n").utf8))
             fileUpdater.closeFile()
         } catch {
-            queuedPrintError("Could not write to file at path \(outFile)")
+            queuedPrintError("warning: Could not write to file at path \(outFile)")
         }
     }
 }


### PR DESCRIPTION
Some error messages aren't being shown in Xcode, `warning: ` should be prepended to these warning messages so that they will show in Xcode.

Fixes https://github.com/realm/SwiftLint/issues/4923