### PR TITLE
Adds test verifying that the file_header rule can require an empty file header

### DIFF
--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -190,6 +190,7 @@ class FileHeaderRuleTests: XCTestCase {
 
         // Non triggering tests
         XCTAssert(try validate(fileName: "FileHeaderEmpty.swift", using: configuration).isEmpty)
+        XCTAssert(try validate(fileName: "DocumentedType.swift", using: configuration).isEmpty)
 
         // Triggering tests
         XCTAssertEqual(try validate(fileName: "FileNameCaseMismatch.swift", using: configuration).count, 1)

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -184,4 +184,16 @@ class FileHeaderRuleTests: XCTestCase {
         XCTAssertEqual(try validate(fileName: "FileNameMatchingSimple.swift", using: configuration1).count, 1)
         XCTAssertEqual(try validate(fileName: "FileNameMatchingComplex.swift", using: configuration2).count, 1)
     }
+
+    func testFileHeaderShouldBeEmpty() {
+        let configuration = ["forbidden_pattern": "."]
+
+        // Non triggering tests
+        XCTAssert(try validate(fileName: "FileHeaderEmpty.swift", using: configuration).isEmpty)
+
+        // Triggering tests
+        XCTAssertEqual(try validate(fileName: "FileNameCaseMismatch.swift", using: configuration).count, 1)
+        XCTAssertEqual(try validate(fileName: "FileNameMismatch.swift", using: configuration).count, 1)
+        XCTAssertEqual(try validate(fileName: "FileNameMissing.swift", using: configuration).count, 1)
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/DocumentedType.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/DocumentedType.swift
@@ -1,0 +1,2 @@
+/// This is the documentation for struct A.
+struct A {}

--- a/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileHeaderEmpty.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileHeaderRuleFixtures/FileHeaderEmpty.swift
@@ -1,0 +1,1 @@
+struct A {}


### PR DESCRIPTION
This PR adds a test to the FileHeaderRuleTests to verify that the `file_header` rule can be used to require an empty file header using `forbidden_pattern: .`.

For the longest time I have been wanting a SwiftLint rule to require empty file headers and only now did I realize that I can use the `file_header` rule and it's `forbidden_pattern` to achieve this. I thought I wanted to add a unit test to document this behavior and ensure that it doesn't break in future updates.

The two tests ensures that:

1. The configuration `forbidden_pattern: .` detects non-empty file headers.
2. Documentation for a type does not count as a file header.