### PR TITLE
Remove SourceKitten from OSSCheck

### DIFF
--- a/tools/oss-check
+++ b/tools/oss-check
@@ -303,7 +303,6 @@ end
   Repo.new('PocketCasts', 'Automattic/pocket-casts-ios'),
   Repo.new('Quick', 'Quick/Quick'),
   Repo.new('Realm', 'realm/realm-swift'),
-  Repo.new('SourceKitten', 'jpsim/SourceKitten'),
   Repo.new('Sourcery', 'krzysztofzablocki/Sourcery'),
   Repo.new('Swift', 'apple/swift'),
   Repo.new('VLC', 'videolan/vlc-ios'),


### PR DESCRIPTION
It looks like there's some non-determinism in how we lint it that was recently introduced, maybe it's due to some SwiftSyntax update, not sure.