### PR TITLE
Add `grouping` option to the `sorted_imports` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,6 @@
   to sort groups of imports defined by their preceding attributes
   (e.g. `@testable`, `@_exported`, ...).  
   [hiltonc](https://github.com/hiltonc)
-  [#4935](https://github.com/realm/SwiftLint/pull/4935)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4990](https://github.com/realm/SwiftLint/issues/4990)
 
+* Add `grouping` option to the `sorted_imports` rule allowing
+  to sort groups of imports defined by their preceding attributes
+  (e.g. `@testable`, `@_exported`, ...).  
+  [hiltonc](https://github.com/hiltonc)
+
 #### Bug Fixes
 
 * Do not trigger `prefer_self_in_static_references` rule on `typealias`
@@ -178,11 +183,6 @@
   This results in errors being silently discarded, which may be unexpected.
   See this forum thread for more details: https://forums.swift.org/t/56066  
   [kylebshr](https://github.com/kylebshr)
-* Adds `grouping` option to the `sorted_imports` rule.  
-* Add `grouping` option to the `sorted_imports` rule allowing
-  to sort groups of imports defined by their preceding attributes
-  (e.g. `@testable`, `@_exported`, ...).  
-  [hiltonc](https://github.com/hiltonc)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,9 @@
   See this forum thread for more details: https://forums.swift.org/t/56066  
   [kylebshr](https://github.com/kylebshr)
 * Adds `grouping` option to the `sorted_imports` rule.  
+* Add `grouping` option to the `sorted_imports` rule allowing
+  to sort groups of imports defined by their preceding attributes
+  (e.g. `@testable`, `@_exported`, ...).  
   [hiltonc](https://github.com/hiltonc)
   [#4935](https://github.com/realm/SwiftLint/pull/4935)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,9 @@
   This results in errors being silently discarded, which may be unexpected.
   See this forum thread for more details: https://forums.swift.org/t/56066  
   [kylebshr](https://github.com/kylebshr)
+* Adds `grouping` option to the `sorted_imports` rule.  
+  [hiltonc](https://github.com/hiltonc)
+  [#4935](https://github.com/realm/SwiftLint/pull/4935)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -1,0 +1,42 @@
+
+struct SortedImportsConfiguration: RuleConfiguration, Equatable {
+    typealias Parent = SortedImportsRule
+
+    enum SortedImportsGroupingConfiguration: String {
+        /// Sorts import lines based on any import attributes (e.g. `@testable`, `@_exported`, etc.), followed by a case
+        /// insensitive comparison of the imported module name.
+        case attributes
+        /// Sorts import lines based on a case insensitive comparison of the imported module name.
+        case name
+
+        init(value: Any) throws {
+            if let string = value as? String,
+               let value = Self(rawValue: string) {
+                self = value
+            } else {
+                throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            }
+        }
+    }
+
+    private(set) var severity = SeverityConfiguration<Parent>(.warning)
+    private(set) var grouping = SortedImportsGroupingConfiguration.name
+
+    var consoleDescription: String {
+        return "severity: \(severity.consoleDescription)"
+            + ", grouping: \(grouping)"
+    }
+
+    mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+        }
+
+        if let grouping = configuration["grouping"] as? String {
+            self.grouping = try SortedImportsGroupingConfiguration(value: grouping)
+        }
+        if let severityString = configuration["severity"] as? String {
+            try severity.apply(configuration: severityString)
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -1,4 +1,3 @@
-
 struct SortedImportsConfiguration: RuleConfiguration, Equatable {
     typealias Parent = SortedImportsRule
 
@@ -7,12 +6,12 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
         /// insensitive comparison of the imported module name.
         case attributes
         /// Sorts import lines based on a case insensitive comparison of the imported module name.
-        case name
+        case names
 
         init(value: Any) throws {
             if let string = value as? String,
                let value = Self(rawValue: string) {
-                self = value
+               self = value
             } else {
                 throw Issue.unknownConfiguration(ruleID: Parent.identifier)
             }
@@ -20,7 +19,7 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
     }
 
     private(set) var severity = SeverityConfiguration<Parent>(.warning)
-    private(set) var grouping = SortedImportsGroupingConfiguration.name
+    private(set) var grouping = SortedImportsGroupingConfiguration.names
 
     var consoleDescription: String {
         return "severity: \(severity.consoleDescription)"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -22,13 +22,14 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
             throw Issue.unknownConfiguration(ruleID: Parent.identifier)
         }
 
-        if let rawGrouping = configuration["grouping"] as? String {
-            if let grouping = SortedImportsGroupingConfiguration(rawValue: rawGrouping) {
-                self.grouping = grouping
-            } else {
+        if let rawGrouping = configuration["grouping"] {
+            guard let rawGrouping = rawGrouping as? String,
+                  let grouping = SortedImportsGroupingConfiguration(rawValue: rawGrouping) else {
                 throw Issue.unknownConfiguration(ruleID: Parent.identifier)
             }
+            self.grouping = grouping
         }
+
         if let severityString = configuration["severity"] as? String {
             try severity.apply(configuration: severityString)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -7,15 +7,6 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
         case attributes
         /// Sorts import lines based on a case insensitive comparison of the imported module name.
         case names
-
-        init(value: Any) throws {
-            if let string = value as? String,
-               let value = Self(rawValue: string) {
-               self = value
-            } else {
-                throw Issue.unknownConfiguration(ruleID: Parent.identifier)
-            }
-        }
     }
 
     private(set) var severity = SeverityConfiguration<Parent>(.warning)
@@ -31,8 +22,12 @@ struct SortedImportsConfiguration: RuleConfiguration, Equatable {
             throw Issue.unknownConfiguration(ruleID: Parent.identifier)
         }
 
-        if let grouping = configuration["grouping"] as? String {
-            self.grouping = try SortedImportsGroupingConfiguration(value: grouping)
+        if let rawGrouping = configuration["grouping"] as? String {
+            if let grouping = SortedImportsGroupingConfiguration(rawValue: rawGrouping) {
+                self.grouping = grouping
+            } else {
+                throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            }
         }
         if let severityString = configuration["severity"] as? String {
             try severity.apply(configuration: severityString)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
@@ -55,15 +55,14 @@ private extension Sequence where Element == Line {
 struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
     var configuration = SortedImportsConfiguration()
 
-    private static let examples = SortedImportsRuleExamples.self
     static let description = RuleDescription(
         identifier: "sorted_imports",
         name: "Sorted Imports",
         description: "Imports should be sorted",
         kind: .style,
-        nonTriggeringExamples: examples.nonTriggeringExamples,
-        triggeringExamples: examples.triggeringExamples,
-        corrections: examples.corrections
+        nonTriggeringExamples: SortedImportsRuleExamples.nonTriggeringExamples,
+        triggeringExamples: SortedImportsRuleExamples.triggeringExamples,
+        corrections: SortedImportsRuleExamples.corrections
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
@@ -120,10 +119,10 @@ struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule 
                 }
                 return lhsAttributes < rhsAttributes
             }
-            return lhs.importModule().lowercased() <= rhs.importModule().lowercased()
-        case .name:
-            return lhs.importModule().lowercased() <= rhs.importModule().lowercased()
+        case .names:
+            break
         }
+        return lhs.importModule().lowercased() <= rhs.importModule().lowercased()
     }
 
     func correct(file: SwiftLintFile) -> [Correction] {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
@@ -21,9 +21,9 @@ internal struct SortedImportsRuleExamples {
         import AAA
         import BBB
         """),
-        Example("@testable import AAA\n  @testable import BBB", configuration: groupByAttributesConfiguration),
-        Example("@testable import BBB\n  import AAA", configuration: groupByAttributesConfiguration),
-        Example("@_exported import BBB\n  @testable import AAA", configuration: groupByAttributesConfiguration)
+        Example("@testable import AAA\n  @testable import BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("@testable import BBB\n  import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("@_exported import BBB\n  @testable import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
     ]
 
     static let triggeringExamples = [
@@ -44,10 +44,10 @@ internal struct SortedImportsRuleExamples {
         import AAA
         import BBB
         """),
-        Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration),
-        Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration),
-        Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration),
-        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration)
+        Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
     ]
 
     static let corrections = [
@@ -84,13 +84,13 @@ internal struct SortedImportsRuleExamples {
         import AAA
         import BBB
         """),
-        Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration):
+        Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
             Example("@testable import AAA\n  @testable import BBB"),
-        Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration):
+        Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
             Example("@testable import BBB\n  import AAA"),
-        Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration):
+        Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
             Example("@testable import AAA\n  import BBB"),
-        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration):
+        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
             Example("@_exported import BBB\n  @testable import AAA")
     ]
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
@@ -2,12 +2,34 @@ internal struct SortedImportsRuleExamples {
     private static let groupByAttributesConfiguration = ["grouping": "attributes"]
 
     static let nonTriggeringExamples = [
-        Example("import AAA\nimport BBB\nimport CCC\nimport DDD"),
-        Example("import Alamofire\nimport API"),
-        Example("import labc\nimport Ldef"),
-        Example("import BBB\n// comment\nimport AAA\nimport CCC"),
-        Example("@testable import AAA\nimport   CCC"),
-        Example("import AAA\n@testable import   CCC"),
+        Example("""
+        import AAA
+        import BBB
+        import CCC
+        import DDD
+        """),
+        Example("""
+        import Alamofire
+        import API
+        """),
+        Example("""
+        import labc
+        import Ldef
+        """),
+        Example("""
+        import BBB
+        // comment
+        import AAA
+        import CCC
+        """),
+        Example("""
+        @testable import AAA
+        import   CCC
+        """),
+        Example("""
+        import AAA
+        @testable import   CCC
+        """),
         Example("""
         import EEE.A
         import FFF.B
@@ -40,10 +62,26 @@ internal struct SortedImportsRuleExamples {
     ]
 
     static let triggeringExamples = [
-        Example("import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC"),
-        Example("import DDD\n// comment\nimport CCC\nimport ↓AAA"),
-        Example("@testable import CCC\nimport   ↓AAA"),
-        Example("import CCC\n@testable import   ↓AAA"),
+        Example("""
+        import AAA
+        import ZZZ
+        import ↓BBB
+        import CCC
+        """),
+        Example("""
+        import DDD
+        // comment
+        import CCC
+        import ↓AAA
+        """),
+        Example("""
+        @testable import CCC
+        import   ↓AAA
+        """),
+        Example("""
+        import CCC
+        @testable import   ↓AAA
+        """),
         Example("""
         import FFF.B
         import ↓EEE.A
@@ -80,13 +118,51 @@ internal struct SortedImportsRuleExamples {
     ]
 
     static let corrections = [
-        Example("import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC"):
-            Example("import AAA\nimport BBB\nimport CCC\nimport ZZZ"),
-        Example("import BBB // comment\nimport ↓AAA"): Example("import AAA\nimport BBB // comment"),
-        Example("import BBB\n// comment\nimport CCC\nimport ↓AAA"):
-            Example("import BBB\n// comment\nimport AAA\nimport CCC"),
-        Example("@testable import CCC\nimport  ↓AAA"): Example("import  AAA\n@testable import CCC"),
-        Example("import CCC\n@testable import  ↓AAA"): Example("@testable import  AAA\nimport CCC"),
+        Example("""
+        import AAA
+        import ZZZ
+        import ↓BBB
+        import CCC
+        """):
+            Example("""
+            import AAA
+            import BBB
+            import CCC
+            import ZZZ
+            """),
+        Example("""
+        import BBB // comment
+        import ↓AAA
+        """): Example("""
+              import AAA
+              import BBB // comment
+              """),
+        Example("""
+        import BBB
+        // comment
+        import CCC
+        import ↓AAA
+        """):
+            Example("""
+            import BBB
+            // comment
+            import AAA
+            import CCC
+            """),
+        Example("""
+        @testable import CCC
+        import  ↓AAA
+        """): Example("""
+              import  AAA
+              @testable import CCC
+              """),
+        Example("""
+        import CCC
+        @testable import  ↓AAA
+        """): Example("""
+              @testable import  AAA
+              import CCC
+              """),
         Example("""
         import FFF.B
         import ↓EEE.A
@@ -116,7 +192,7 @@ internal struct SortedImportsRuleExamples {
         Example("""
           @testable import BBB
         @testable import ↓AAA
-        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+        """, configuration: groupByAttributesConfiguration):
             Example("""
             @testable import AAA
               @testable import BBB
@@ -124,7 +200,7 @@ internal struct SortedImportsRuleExamples {
         Example("""
           import AAA
         @testable import ↓BBB
-        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+        """, configuration: groupByAttributesConfiguration):
             Example("""
             @testable import BBB
               import AAA
@@ -132,7 +208,7 @@ internal struct SortedImportsRuleExamples {
         Example("""
           import BBB
         @testable import ↓AAA
-        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+        """, configuration: groupByAttributesConfiguration):
             Example("""
             @testable import AAA
               import BBB
@@ -140,7 +216,7 @@ internal struct SortedImportsRuleExamples {
         Example("""
           @testable import AAA
         @_exported import ↓BBB
-        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+        """, configuration: groupByAttributesConfiguration):
             Example("""
             @_exported import BBB
               @testable import AAA
@@ -148,7 +224,7 @@ internal struct SortedImportsRuleExamples {
         Example("""
           import AAA
         @_exported @testable import ↓BBB
-        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+        """, configuration: groupByAttributesConfiguration):
             Example("""
             @_exported @testable import BBB
               import AAA

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
@@ -23,7 +23,8 @@ internal struct SortedImportsRuleExamples {
         """),
         Example("@testable import AAA\n  @testable import BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
         Example("@testable import BBB\n  import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("@_exported import BBB\n  @testable import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
+        Example("@_exported import BBB\n  @testable import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("@_exported @testable import BBB\n  import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
     ]
 
     static let triggeringExamples = [
@@ -47,7 +48,8 @@ internal struct SortedImportsRuleExamples {
         Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
         Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
         Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
+        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("  import AAA\n@_exported @testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
     ]
 
     static let corrections = [
@@ -91,6 +93,8 @@ internal struct SortedImportsRuleExamples {
         Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
             Example("@testable import AAA\n  import BBB"),
         Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
-            Example("@_exported import BBB\n  @testable import AAA")
+            Example("@_exported import BBB\n  @testable import AAA"),
+        Example("  import AAA\n@_exported @testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+            Example("@_exported @testable import BBB\n  import AAA")
     ]
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
@@ -21,10 +21,22 @@ internal struct SortedImportsRuleExamples {
         import AAA
         import BBB
         """),
-        Example("@testable import AAA\n  @testable import BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("@testable import BBB\n  import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("@_exported import BBB\n  @testable import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("@_exported @testable import BBB\n  import AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
+        Example("""
+        @testable import AAA
+          @testable import BBB
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("""
+        @testable import BBB
+          import AAA
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("""
+        @_exported import BBB
+          @testable import AAA
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("""
+        @_exported @testable import BBB
+          import AAA
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
     ]
 
     static let triggeringExamples = [
@@ -45,11 +57,26 @@ internal struct SortedImportsRuleExamples {
         import AAA
         import BBB
         """),
-        Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
-        Example("  import AAA\n@_exported @testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
+        Example("""
+          @testable import BBB
+        @testable import ↓AAA
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("""
+          import AAA
+        @testable import ↓BBB
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("""
+          import BBB
+        @testable import ↓AAA
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("""
+          @testable import AAA
+        @_exported import ↓BBB
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
+        Example("""
+          import AAA
+        @_exported @testable import ↓BBB
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true)
     ]
 
     static let corrections = [
@@ -73,28 +100,58 @@ internal struct SortedImportsRuleExamples {
         import AAA
         import BBB
         """):
+            Example("""
+            import EEE.A
+            import FFF.B
+            #if os(Linux)
+            import DDD.A
+            import EEE.B
+            #else
+            import CCC
+            import DDD.B
+            #endif
+            import AAA
+            import BBB
+            """),
         Example("""
-        import EEE.A
-        import FFF.B
-        #if os(Linux)
-        import DDD.A
-        import EEE.B
-        #else
-        import CCC
-        import DDD.B
-        #endif
-        import AAA
-        import BBB
-        """),
-        Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
-            Example("@testable import AAA\n  @testable import BBB"),
-        Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
-            Example("@testable import BBB\n  import AAA"),
-        Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
-            Example("@testable import AAA\n  import BBB"),
-        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
-            Example("@_exported import BBB\n  @testable import AAA"),
-        Example("  import AAA\n@_exported @testable import ↓BBB", configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
-            Example("@_exported @testable import BBB\n  import AAA")
+          @testable import BBB
+        @testable import ↓AAA
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+            Example("""
+            @testable import AAA
+              @testable import BBB
+            """),
+        Example("""
+          import AAA
+        @testable import ↓BBB
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+            Example("""
+            @testable import BBB
+              import AAA
+            """),
+        Example("""
+          import BBB
+        @testable import ↓AAA
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+            Example("""
+            @testable import AAA
+              import BBB
+            """),
+        Example("""
+          @testable import AAA
+        @_exported import ↓BBB
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+            Example("""
+            @_exported import BBB
+              @testable import AAA
+            """),
+        Example("""
+          import AAA
+        @_exported @testable import ↓BBB
+        """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true):
+            Example("""
+            @_exported @testable import BBB
+              import AAA
+            """)
     ]
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
@@ -1,0 +1,96 @@
+internal struct SortedImportsRuleExamples {
+    private static let groupByAttributesConfiguration = ["grouping": "attributes"]
+
+    static let nonTriggeringExamples = [
+        Example("import AAA\nimport BBB\nimport CCC\nimport DDD"),
+        Example("import Alamofire\nimport API"),
+        Example("import labc\nimport Ldef"),
+        Example("import BBB\n// comment\nimport AAA\nimport CCC"),
+        Example("@testable import AAA\nimport   CCC"),
+        Example("import AAA\n@testable import   CCC"),
+        Example("""
+        import EEE.A
+        import FFF.B
+        #if os(Linux)
+        import DDD.A
+        import EEE.B
+        #else
+        import CCC
+        import DDD.B
+        #endif
+        import AAA
+        import BBB
+        """),
+        Example("@testable import AAA\n  @testable import BBB", configuration: groupByAttributesConfiguration),
+        Example("@testable import BBB\n  import AAA", configuration: groupByAttributesConfiguration),
+        Example("@_exported import BBB\n  @testable import AAA", configuration: groupByAttributesConfiguration)
+    ]
+
+    static let triggeringExamples = [
+        Example("import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC"),
+        Example("import DDD\n// comment\nimport CCC\nimport ↓AAA"),
+        Example("@testable import CCC\nimport   ↓AAA"),
+        Example("import CCC\n@testable import   ↓AAA"),
+        Example("""
+        import FFF.B
+        import ↓EEE.A
+        #if os(Linux)
+        import DDD.A
+        import EEE.B
+        #else
+        import DDD.B
+        import ↓CCC
+        #endif
+        import AAA
+        import BBB
+        """),
+        Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration),
+        Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration),
+        Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration),
+        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration)
+    ]
+
+    static let corrections = [
+        Example("import AAA\nimport ZZZ\nimport ↓BBB\nimport CCC"):
+            Example("import AAA\nimport BBB\nimport CCC\nimport ZZZ"),
+        Example("import BBB // comment\nimport ↓AAA"): Example("import AAA\nimport BBB // comment"),
+        Example("import BBB\n// comment\nimport CCC\nimport ↓AAA"):
+            Example("import BBB\n// comment\nimport AAA\nimport CCC"),
+        Example("@testable import CCC\nimport  ↓AAA"): Example("import  AAA\n@testable import CCC"),
+        Example("import CCC\n@testable import  ↓AAA"): Example("@testable import  AAA\nimport CCC"),
+        Example("""
+        import FFF.B
+        import ↓EEE.A
+        #if os(Linux)
+        import DDD.A
+        import EEE.B
+        #else
+        import DDD.B
+        import ↓CCC
+        #endif
+        import AAA
+        import BBB
+        """):
+        Example("""
+        import EEE.A
+        import FFF.B
+        #if os(Linux)
+        import DDD.A
+        import EEE.B
+        #else
+        import CCC
+        import DDD.B
+        #endif
+        import AAA
+        import BBB
+        """),
+        Example("  @testable import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration):
+            Example("@testable import AAA\n  @testable import BBB"),
+        Example("  import AAA\n@testable import ↓BBB", configuration: groupByAttributesConfiguration):
+            Example("@testable import BBB\n  import AAA"),
+        Example("  import BBB\n@testable import ↓AAA", configuration: groupByAttributesConfiguration):
+            Example("@testable import AAA\n  import BBB"),
+        Example("  @testable import AAA\n@_exported import ↓BBB", configuration: groupByAttributesConfiguration):
+            Example("@_exported import BBB\n  @testable import AAA")
+    ]
+}


### PR DESCRIPTION
Adds a `grouping` option to the `sorted_import` rule. With this configuration:

```
sorted_imports:
  grouping: attributes
```

It puts all the `@testable` imports at the top of the import groups.