### PR TITLE
Make `Correction` and `CorrectableRule` declarations public

### DIFF
--- a/Source/SwiftLintFramework/Models/Correction.swift
+++ b/Source/SwiftLintFramework/Models/Correction.swift
@@ -1,5 +1,4 @@
 /// A value describing a SwiftLint violation that was corrected.
-@_spi(TestHelper)
 public struct Correction: Equatable {
     /// The description of the rule for which this correction was applied.
     public let ruleDescription: RuleDescription

--- a/Source/SwiftLintFramework/Models/Correction.swift
+++ b/Source/SwiftLintFramework/Models/Correction.swift
@@ -10,10 +10,11 @@ public struct Correction: Equatable {
         return "\(location) Corrected \(ruleDescription.name)"
     }
 
-    public init (
-        ruleDescription: RuleDescription,
-        location: Location
-    ) {
+    /// Memberwise initializer.
+    ///
+    /// - parameter ruleDescription: The description of the rule for which this correction was applied.
+    /// - parameter location:        The location of the original violation that was corrected.
+    public init(ruleDescription: RuleDescription, location: Location) {
         self.ruleDescription = ruleDescription
         self.location = location
     }

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -281,7 +281,6 @@ public struct CollectedLinter {
     /// - parameter storage: The storage object containing all collected info.
     ///
     /// - returns: All corrections that were applied.
-    @_spi(TestHelper)
     public func correct(using storage: RuleStorage) -> [Correction] {
         if let violations = cachedStyleViolations()?.0, violations.isEmpty {
             return []

--- a/Source/SwiftLintFramework/Protocols/Rule.swift
+++ b/Source/SwiftLintFramework/Protocols/Rule.swift
@@ -101,7 +101,6 @@ public protocol ConfigurationProviderRule: Rule {
 }
 
 /// A rule that can correct violations.
-@_spi(TestHelper)
 public protocol CorrectableRule: Rule {
     /// Attempts to correct the violations to this rule in the specified file.
     ///

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -7,7 +7,6 @@ import Glibc
 #error("Unsupported platform")
 #endif
 import Foundation
-@_spi(TestHelper)
 import SwiftLintFramework
 import SwiftyTextTable
 

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -1,6 +1,5 @@
 import Dispatch
 import Foundation
-@_spi(TestHelper)
 import SwiftLintFramework
 
 enum LintOrAnalyzeMode {

--- a/Source/swiftlint/Helpers/RulesFilter.swift
+++ b/Source/swiftlint/Helpers/RulesFilter.swift
@@ -1,4 +1,3 @@
-@_spi(TestHelper)
 import SwiftLintFramework
 
 extension RulesFilter {


### PR DESCRIPTION
The CLI target shouldn't be importing SwiftLintFramework with `@_spi(TestHelper)`. If the CLI target needs to access something in SwiftLintFramework, that declaration should be `public`.