### PR TITLE
Remove `SwiftLintFramework` dependency from GeneratedTests target

### DIFF
--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -86,7 +86,6 @@ swift_library(
     srcs = ["GeneratedTests/GeneratedTests.swift"],
     module_name = "GeneratedTests",
     deps = [
-        "//:SwiftLintFramework",
         ":SwiftLintTestHelpers",
     ],
 )


### PR DESCRIPTION
Since it's available transitively from SwiftLintTestHelpers.