### PR TITLE
Rename `Request.cursorInfo()` to `cursorInfoWithoutSymbolGraph()`

### DIFF
--- a/Source/SwiftLintFramework/Extensions/Request+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/Request+SwiftLint.swift
@@ -11,7 +11,7 @@ extension Request {
         return try send()
     }
 
-    static func cursorInfo(file: String, offset: ByteCount, arguments: [String]) -> Request {
+    static func cursorInfoWithoutSymbolGraph(file: String, offset: ByteCount, arguments: [String]) -> Request {
         .customRequest(request: [
             "key.request": UID("source.request.cursorinfo"),
             "key.name": file,

--- a/Source/SwiftLintFramework/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/TypesafeArrayInitRule.swift
@@ -72,7 +72,9 @@ struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
                 guard let offset = getOffset(in: file, at: violation.location) else {
                     return false
                 }
-                let cursorInfo = Request.cursorInfo(file: filePath, offset: offset, arguments: compilerArguments)
+                let cursorInfo = Request.cursorInfoWithoutSymbolGraph(
+                    file: filePath, offset: offset, arguments: compilerArguments
+                )
                 guard let request = try? cursorInfo.sendIfNotDisabled() else {
                     return false
                 }

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedDeclarationRule.swift
@@ -193,7 +193,9 @@ private extension SwiftLintFile {
     }
 
     func cursorInfo(at byteOffset: ByteCount, compilerArguments: [String]) -> SourceKittenDictionary? {
-        let request = Request.cursorInfo(file: path!, offset: byteOffset, arguments: compilerArguments)
+        let request = Request.cursorInfoWithoutSymbolGraph(
+            file: path!, offset: byteOffset, arguments: compilerArguments
+        )
         return (try? request.sendIfNotDisabled()).map(SourceKittenDictionary.init)
     }
 

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -162,8 +162,9 @@ private extension SwiftLintFile {
             if SyntaxKind.kindsWithoutModuleInfo.contains(tokenKind) {
                 continue
             }
-            let cursorInfoRequest = Request.cursorInfo(file: path!, offset: token.offset,
-                                                       arguments: compilerArguments)
+            let cursorInfoRequest = Request.cursorInfoWithoutSymbolGraph(
+                file: path!, offset: token.offset, arguments: compilerArguments
+            )
             guard let cursorInfo = (try? cursorInfoRequest.sendIfNotDisabled()).map(SourceKittenDictionary.init) else {
                 queuedPrintError("Could not get cursor info")
                 continue
@@ -215,7 +216,7 @@ private extension SwiftLintFile {
                 // Filter already processed tokens such as static methods that are not operators
                 guard !processedTokenOffsets.contains(ByteCount(offset)) else { continue }
 
-                let cursorInfoRequest = Request.cursorInfo(file: path!, offset: ByteCount(offset), arguments: arguments)
+                let cursorInfoRequest = Request.cursorInfoWithoutSymbolGraph(file: path!, offset: ByteCount(offset), arguments: arguments)
                 guard let cursorInfo = (try? cursorInfoRequest.sendIfNotDisabled())
                     .map(SourceKittenDictionary.init) else {
                     queuedPrintError("Could not get cursor info")

--- a/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintFramework/Rules/Lint/UnusedImportRule.swift
@@ -216,7 +216,9 @@ private extension SwiftLintFile {
                 // Filter already processed tokens such as static methods that are not operators
                 guard !processedTokenOffsets.contains(ByteCount(offset)) else { continue }
 
-                let cursorInfoRequest = Request.cursorInfoWithoutSymbolGraph(file: path!, offset: ByteCount(offset), arguments: arguments)
+                let cursorInfoRequest = Request.cursorInfoWithoutSymbolGraph(
+                    file: path!, offset: ByteCount(offset), arguments: arguments
+                )
                 guard let cursorInfo = (try? cursorInfoRequest.sendIfNotDisabled())
                     .map(SourceKittenDictionary.init) else {
                     queuedPrintError("Could not get cursor info")

--- a/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/ExplicitSelfRule.swift
@@ -91,8 +91,10 @@ private extension SwiftLintFile {
         -> [[String: SourceKitRepresentable]] {
         return try byteOffsets.compactMap { offset in
             if isExplicitAccess(at: offset) { return nil }
-            var cursorInfo = try Request.cursorInfo(file: self.path!, offset: offset,
-                                                    arguments: compilerArguments).sendIfNotDisabled()
+            let cursorInfoRequest = Request.cursorInfoWithoutSymbolGraph(
+                file: self.path!, offset: offset, arguments: compilerArguments
+            )
+            var cursorInfo = try cursorInfoRequest.sendIfNotDisabled()
 
             // Accessing a `projectedValue` of a property wrapper (e.g. `self.$foo`) or the property wrapper itself
             // (e.g. `self._foo`) results in an incorrect `key.length` (it does not account for the identifier


### PR DESCRIPTION
To avoid conflicting with the `cursorInfo` declared in SourceKittenFramework.
