### PR TITLE
Improve StyleViolation reason formatting validation

### DIFF
--- a/Source/SwiftLintFramework/Models/StyleViolation.swift
+++ b/Source/SwiftLintFramework/Models/StyleViolation.swift
@@ -42,7 +42,7 @@ public struct StyleViolation: CustomStringConvertible, Equatable, Codable {
         self.reason = reason ?? ruleDescription.description
         #if DEBUG
         if self.reason.trimmingTrailingCharacters(in: .whitespaces).last == ".",
-           builtInRules.contains(where: { rule in rule.description.identifier == self.ruleIdentifier }) {
+           RuleRegistry.shared.rule(forID: self.ruleIdentifier) != nil {
             queuedFatalError("""
                 Reasons shall not end with a period. Got "\(self.reason)". Either rewrite the rule's description \
                 or set a custom reason in the StyleViolation's constructor.


### PR DESCRIPTION
So it checks violations for all rules in the registry, not just the built-in rules.