### PR TITLE
Move extra rules into its own module

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,15 +29,28 @@ swift_library(
 )
 
 swift_library(
+    name = "SwiftLintExtraRules",
+    srcs = [
+        "Source/SwiftLintExtraRules/Exports.swift",
+        "@swiftlint_extra_rules//:extra_rules",
+    ],
+    module_name = "SwiftLintExtraRules",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":SwiftLintCore",
+    ],
+)
+
+swift_library(
     name = "SwiftLintFramework",
     srcs = glob(
         ["Source/SwiftLintFramework/**/*.swift"],
-        exclude = ["Source/SwiftLintFramework/Rules/ExcludedFromBazel/ExtraRules.swift"],
-    ) + ["@swiftlint_extra_rules//:extra_rules"],
+    ),
     module_name = "SwiftLintFramework",
     visibility = ["//visibility:public"],
     deps = [
         ":SwiftLintCore",
+        ":SwiftLintExtraRules",
     ],
 )
 

--- a/Package.swift
+++ b/Package.swift
@@ -58,8 +58,12 @@ let package = Package(
             ]
         ),
         .target(
-            name: "SwiftLintFramework",
+            name: "SwiftLintExtraRules",
             dependencies: ["SwiftLintCore"]
+        ),
+        .target(
+            name: "SwiftLintFramework",
+            dependencies: ["SwiftLintCore", "SwiftLintExtraRules"]
         ),
         .target(name: "DyldWarningWorkaround"),
         .target(

--- a/Source/SwiftLintExtraRules/Exports.swift
+++ b/Source/SwiftLintExtraRules/Exports.swift
@@ -1,0 +1,1 @@
+@_exported import SwiftLintCore

--- a/Source/SwiftLintExtraRules/ExtraRules.swift
+++ b/Source/SwiftLintExtraRules/ExtraRules.swift
@@ -3,4 +3,4 @@
 /// This is an extension point for custom native rules for Bazel.
 ///
 /// - returns: Extra rules that are compiled with Bazel.
-func extraRules() -> [Rule.Type] { [] }
+public func extraRules() -> [Rule.Type] { [] }

--- a/Source/SwiftLintFramework/Exports.swift
+++ b/Source/SwiftLintFramework/Exports.swift
@@ -1,4 +1,5 @@
 @_exported import SwiftLintCore
+import SwiftLintExtraRules
 
 private let _registerAllRulesOnceImpl: Void = {
     RuleRegistry.shared.register(rules: builtInRules + coreRules + extraRules())

--- a/Tests/ExtraRulesTests/ExtraRulesTests.swift
+++ b/Tests/ExtraRulesTests/ExtraRulesTests.swift
@@ -1,4 +1,4 @@
-@testable import SwiftLintFramework
+@testable import SwiftLintExtraRules
 import SwiftLintTestHelpers
 
 final class ExtraRulesTests: SwiftLintTestCase {

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -3,7 +3,7 @@ load("@com_github_jpsim_sourcekitten//bazel:repos.bzl", "sourcekitten_repos")
 
 def _extra_swift_sources_impl(ctx):
     ctx.file("WORKSPACE", "")
-    ctx.file("empty.swift", "func extraRules() -> [Rule.Type] { [] }")
+    ctx.file("empty.swift", "public func extraRules() -> [Rule.Type] { [] }")
     label = ":empty"
     if ctx.attr.srcs:
         label = ctx.attr.srcs


### PR DESCRIPTION
This will decouple building extra rules from built-in rules so that
making changes in one of those modules doesn't rebuild the other.
