### PR TITLE
Move `excludedPaths` out of iteration loop in favor of dependency inj…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@
   [keith](https://github.com/keith)
   [#4782](https://github.com/realm/SwiftLint/issues/4782)
 
+* Move `excludedPaths` out of iteration loop in favor of dependency injection  
+  [andyyhope](https://github.com/andyyhope)
+  [#4844](https://github.com/realm/SwiftLint/issues/4844)
+
 ## 0.51.0: bzllint
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,8 @@
   [keith](https://github.com/keith)
   [#4782](https://github.com/realm/SwiftLint/issues/4782)
 
-* Move `excludedPaths(fileManager:)` operation out of linting iterations
-  in favor of dependency injection to improve build speeds for Swift Plugin.   
+* Improve lint times of SwiftLintPlugin by moving the
+  `excludedPaths(fileManager:)` operation out of the linting iterations.  
   [andyyhope](https://github.com/andyyhope)
   [#4844](https://github.com/realm/SwiftLint/issues/4844)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@
   [keith](https://github.com/keith)
   [#4782](https://github.com/realm/SwiftLint/issues/4782)
 
-* Move `excludedPaths` out of iteration loop in favor of dependency injection  
+* Move `excludedPaths(fileManager:)` operation out of linting iterations
+  in favor of dependency injection to improve build speeds for Swift Plugin.   
   [andyyhope](https://github.com/andyyhope)
   [#4844](https://github.com/realm/SwiftLint/issues/4844)
 

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -108,7 +108,7 @@ extension Configuration {
     /// - parameter fileManager: The file manager to get child paths in a given parent location.
     ///
     /// - returns: The expanded excluded file paths.
-    public func excludedPaths(fileManager: LintableFileManager) -> [String] {
+    public func excludedPaths(fileManager: LintableFileManager = FileManager.default) -> [String] {
         return excludedPaths
             .flatMap(Glob.resolveGlob)
             .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 extension Configuration {
+    public enum ExcludeBy {
+        case prefix
+        case paths(excludedPaths: [String])
+    }
+
     // MARK: Lintable Paths
     /// Returns the files that can be linted by SwiftLint in the specified parent path.
     ///
@@ -12,8 +17,8 @@ extension Configuration {
     ///
     /// - returns: Files to lint.
     public func lintableFiles(inPath path: String, forceExclude: Bool,
-                              excludeByPrefix: Bool = false) -> [SwiftLintFile] {
-        return lintablePaths(inPath: path, forceExclude: forceExclude, excludeByPrefix: excludeByPrefix)
+                              excludeBy: ExcludeBy) -> [SwiftLintFile] {
+        return lintablePaths(inPath: path, forceExclude: forceExclude, excludeBy: excludeBy)
             .compactMap(SwiftLintFile.init(pathDeferringReading:))
     }
 
@@ -30,14 +35,17 @@ extension Configuration {
     internal func lintablePaths(
         inPath path: String,
         forceExclude: Bool,
-        excludeByPrefix: Bool = false,
+        excludeBy: ExcludeBy,
         fileManager: LintableFileManager = FileManager.default
     ) -> [String] {
         if fileManager.isFile(atPath: path) {
             if forceExclude {
-                return excludeByPrefix
-                    ? filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])
-                    : filterExcludedPaths(fileManager: fileManager, in: [path.absolutePathStandardized()])
+                switch excludeBy {
+                case .prefix:
+                    return filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])
+                case .paths(let excludedPaths):
+                    return filterExcludedPaths(excludedPaths, in: [path.absolutePathStandardized()])
+                }
             }
             // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
             return [path]
@@ -48,9 +56,12 @@ extension Configuration {
             .flatMap(Glob.resolveGlob)
             .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }
 
-        return excludeByPrefix
-            ? filterExcludedPathsByPrefix(in: pathsForPath, includedPaths)
-            : filterExcludedPaths(fileManager: fileManager, in: pathsForPath, includedPaths)
+        switch excludeBy {
+        case .prefix:
+            return filterExcludedPathsByPrefix(in: pathsForPath, includedPaths)
+        case .paths(let excludedPaths):
+            return filterExcludedPaths(excludedPaths, in: pathsForPath, includedPaths)
+        }
     }
 
     /// Returns an array of file paths after removing the excluded paths as defined by this configuration.
@@ -60,7 +71,7 @@ extension Configuration {
     ///
     /// - returns: The input paths after removing the excluded paths.
     public func filterExcludedPaths(
-        fileManager: LintableFileManager = FileManager.default,
+        _ excludedPaths: [String],
         in paths: [String]...
     ) -> [String] {
         let allPaths = paths.flatMap { $0 }
@@ -71,7 +82,6 @@ extension Configuration {
         let result = NSMutableOrderedSet(array: allPaths)
         #endif
 
-        let excludedPaths = self.excludedPaths(fileManager: fileManager)
         result.minusSet(Set(excludedPaths))
         // swiftlint:disable:next force_cast
         return result.map { $0 as! String }
@@ -98,7 +108,7 @@ extension Configuration {
     /// - parameter fileManager: The file manager to get child paths in a given parent location.
     ///
     /// - returns: The expanded excluded file paths.
-    private func excludedPaths(fileManager: LintableFileManager) -> [String] {
+    public func excludedPaths(fileManager: LintableFileManager) -> [String] {
         return excludedPaths
             .flatMap(Glob.resolveGlob)
             .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -227,8 +227,7 @@ extension Configuration {
                 return filterExcludedPathsByPrefix(in: scriptInputPaths)
                     .map(SwiftLintFile.init(pathDeferringReading:))
             } else {
-                let excluded = excludedPaths(fileManager: FileManager.default)
-                return filterExcludedPaths(excluded, in: scriptInputPaths)
+                return filterExcludedPaths(excludedPaths(), in: scriptInputPaths)
                     .map(SwiftLintFile.init(pathDeferringReading:))
             }
         }
@@ -242,14 +241,13 @@ extension Configuration {
 
             queuedPrintError("\(visitor.action) Swift files \(filesInfo)")
         }
-        let excludedPaths = excludedPaths(fileManager: FileManager.default)
         return visitor.paths.flatMap {
             self.lintableFiles(
                 inPath: $0,
                 forceExclude: visitor.forceExclude,
                 excludeBy: visitor.useExcludingByPrefix
                     ? .prefix
-                    : .paths(excludedPaths: excludedPaths))
+                    : .paths(excludedPaths: excludedPaths()))
         }
     }
 

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -17,7 +17,11 @@ private let config: Configuration = {
 class IntegrationTests: SwiftLintTestCase {
     func testSwiftLintLints() {
         // This is as close as we're ever going to get to a self-hosting linter.
-        let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false)
+        let excludedPaths = config.excludedPaths(fileManager: FileManager.default)
+        let swiftFiles = config.lintableFiles(
+            inPath: "",
+            forceExclude: false,
+            excludeBy: .paths(excludedPaths: excludedPaths))
         XCTAssert(
             swiftFiles.contains(where: { #file.bridge().absolutePathRepresentation() == $0.path }),
             "current file should be included"
@@ -35,7 +39,10 @@ class IntegrationTests: SwiftLintTestCase {
     }
 
     func testSwiftLintAutoCorrects() {
-        let swiftFiles = config.lintableFiles(inPath: "", forceExclude: false)
+        let swiftFiles = config.lintableFiles(
+            inPath: "",
+            forceExclude: false,
+            excludeBy: .paths(excludedPaths: config.excludedPaths(fileManager: FileManager.default)))
         let storage = RuleStorage()
         let corrections = swiftFiles.parallelFlatMap {
             Linter(file: $0, configuration: config).collect(into: storage).correct(using: storage)

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -17,11 +17,10 @@ private let config: Configuration = {
 class IntegrationTests: SwiftLintTestCase {
     func testSwiftLintLints() {
         // This is as close as we're ever going to get to a self-hosting linter.
-        let excludedPaths = config.excludedPaths(fileManager: FileManager.default)
         let swiftFiles = config.lintableFiles(
             inPath: "",
             forceExclude: false,
-            excludeBy: .paths(excludedPaths: excludedPaths))
+            excludeBy: .paths(excludedPaths: config.excludedPaths()))
         XCTAssert(
             swiftFiles.contains(where: { #file.bridge().absolutePathRepresentation() == $0.path }),
             "current file should be included"
@@ -42,7 +41,7 @@ class IntegrationTests: SwiftLintTestCase {
         let swiftFiles = config.lintableFiles(
             inPath: "",
             forceExclude: false,
-            excludeBy: .paths(excludedPaths: config.excludedPaths(fileManager: FileManager.default)))
+            excludeBy: .paths(excludedPaths: config.excludedPaths()))
         let storage = RuleStorage()
         let corrections = swiftFiles.parallelFlatMap {
             Linter(file: $0, configuration: config).collect(into: storage).correct(using: storage)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -342,7 +342,7 @@ class ConfigurationTests: SwiftLintTestCase {
             excludedPaths: [Mock.Dir.level3.stringByAppendingPathComponent("*.swift")]
         )
 
-        let excludedPaths = configuration.excludedPaths(fileManager: FileManager.default)
+        let excludedPaths = configuration.excludedPaths()
         let lintablePaths = configuration.lintablePaths(inPath: "",
                                                         forceExclude: false,
                                                         excludeBy: .paths(excludedPaths: excludedPaths))


### PR DESCRIPTION
# Problem 
When using SwiftLint's Swift Plugin feature for moderately sized Packages (1000+ files), build times would regress considerably in comparison to the script integration - even when a cache was provided for successive builds.

### Issue
- [#4844](https://github.com/realm/SwiftLint/issues/4844)

# Cause
This build regression comes from the `excludedPaths(fileManager:)` function being called when iterating the files array for the lint process. For Swift packages, this can result in a considerably large computation time (0.33s on an M1 mac) because it can potentially return thousands of files.

# Solution
Because this doesn't appear to change between iterations, I've moved the API call up the stack and outside the iteration loop and passed it down via arguments. There are only a few call-sites which needed to be updated and it doesn't change any functionality.

To maintain code behaviour, I've created a new `enum` type `ExcludeBy`. This maintains mutual exclusivity between the types of exclusion filepaths: `filterExcludedPathsByPrefix` and `filterExcludedPaths`. This is the type that gets passed down to the linter.

# Tests
I've also updated all tests with the new API changes and they're all passing. ✅

