### PR TITLE
[SwiftLintCore] Make `focused()` public

### DIFF
--- a/Source/SwiftLintCore/Models/Example.swift
+++ b/Source/SwiftLintCore/Models/Example.swift
@@ -120,7 +120,7 @@ extension Example {
     }
 
     /// Makes the current example focused. This is for debugging purposes only.
-    func focused() -> Example { // swiftlint:disable:this unused_declaration
+    public func focused() -> Example { // swiftlint:disable:this unused_declaration
         var new = self
         new.isFocused = true
         return new


### PR DESCRIPTION
So it can be used from SwiftLintBuiltInRules.

I missed this when splitting the SwiftLintFramework module.
