### PR TITLE
feat: add implicitly_unwrapped_weak rule

### DIFF
--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -86,6 +86,7 @@ public let builtInRules: [Rule.Type] = [
     IdentifierNameRule.self,
     ImplicitGetterRule.self,
     ImplicitReturnRule.self,
+    ImplicitlyUnwrapWeakVariableRule.self,
     ImplicitlyUnwrappedOptionalRule.self,
     InclusiveLanguageRule.self,
     IndentationWidthRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ImplicitlyUnwrapWeakVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ImplicitlyUnwrapWeakVariableRule.swift
@@ -1,0 +1,59 @@
+
+import SwiftSyntax
+import SourceKittenFramework
+
+struct ImplicitlyUnwrapWeakVariableRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+    
+    var configuration = SeverityConfiguration(.warning)
+    
+    static var description = RuleDescription(
+        identifier: "implicitly_unwrapped_weak",
+        name: "Implicitly Unwrapped Weak Variable",
+        description: "Implicitly unwrapped weak variable should be avoided, use ? instead",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+            class Foo {
+              weak var bar: SomeObject?
+            }
+            """),
+            Example("""
+            class Foo {
+              @IBOutlet
+              weak var button: UIButton!
+            }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+            class Foo {
+              weak var bar: SomeObject!↓
+            }
+            """),
+            Example("""
+            struct Foo {
+              weak var bar: SomeObject!↓
+            }
+            """)
+        ]
+    )
+    
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(viewMode: .sourceAccurate)
+    }
+}
+
+private extension ImplicitlyUnwrapWeakVariableRule {
+    final class Visitor: ViolationsSyntaxVisitor {
+        
+        override func visitPost(_ node: VariableDeclSyntax) {
+            guard !node.isIBOutlet, node.weakOrUnownedModifier != nil else {
+                return
+            }
+            
+            if node.bindings.first?.typeAnnotation?.type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) != nil {
+                violations.append(node.endPositionBeforeTrailingTrivia)
+            }
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ImplicitlyUnwrapWeakVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ImplicitlyUnwrapWeakVariableRule.swift
@@ -1,11 +1,9 @@
-
-import SwiftSyntax
 import SourceKittenFramework
+import SwiftSyntax
 
 struct ImplicitlyUnwrapWeakVariableRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
-    
     var configuration = SeverityConfiguration(.warning)
-    
+
     static var description = RuleDescription(
         identifier: "implicitly_unwrapped_weak",
         name: "Implicitly Unwrapped Weak Variable",
@@ -37,7 +35,7 @@ struct ImplicitlyUnwrapWeakVariableRule: ConfigurationProviderRule, SwiftSyntaxR
             """)
         ]
     )
-    
+
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
         Visitor(viewMode: .sourceAccurate)
     }
@@ -45,12 +43,11 @@ struct ImplicitlyUnwrapWeakVariableRule: ConfigurationProviderRule, SwiftSyntaxR
 
 private extension ImplicitlyUnwrapWeakVariableRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        
         override func visitPost(_ node: VariableDeclSyntax) {
             guard !node.isIBOutlet, node.weakOrUnownedModifier != nil else {
                 return
             }
-            
+
             if node.bindings.first?.typeAnnotation?.type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) != nil {
                 violations.append(node.endPositionBeforeTrailingTrivia)
             }

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -506,6 +506,12 @@ class ImplicitReturnRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class ImplicitlyUnwrapWeakVariableRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(ImplicitlyUnwrapWeakVariableRule.description)
+    }
+}
+
 class ImplicitlyUnwrappedOptionalRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ImplicitlyUnwrappedOptionalRule.description)


### PR DESCRIPTION
This rule checks dangerous usage of force unwrapping weak member, such as:
```swift
class MyClass {
  weak var bar: SomeObject!
}
```

Except `@IBOutlet` member