### PR TITLE
feat: add new mode `weak_except_iboutlets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,8 +228,9 @@
   `unallowed_symbols_severity`. It accepts the two values `warning` and `error`
   (default) as usual.  
   [SimplyDanny](https://github.com/SimplyDanny)
-* Extend `implicitly_unwrapped_optional` rule with a new mode `weak_except_iboutlets`
-  that only checks `weak` variable with force-unwrapping operator.
+
+* Extend `implicitly_unwrapped_optional` rule with the new mode
+  `weak_except_iboutlets` that only checks `weak` variables.  
   [Ricky Tan](https://github.com/rickytan)
 
 * Mention a rule's identifier in the console message that is printed when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,10 @@
 
 #### Enhancements
 
+* Extend `implicitly_unwrapped_optional` rule with a new mode `weak_except_iboutlets`
+  that only checks `weak` variable with force-unwrapping operator.
+  [Ricky Tan](https://github.com/rickytan)
+
 * Add new `superfluous_else` rule that triggers on `if`-statements when an
   attached `else`-block can be removed, because all branches of the previous
   `if`-block(s) would certainly exit the current scope already.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,9 @@
   `unallowed_symbols_severity`. It accepts the two values `warning` and `error`
   (default) as usual.  
   [SimplyDanny](https://github.com/SimplyDanny)
+* Extend `implicitly_unwrapped_optional` rule with a new mode `weak_except_iboutlets`
+  that only checks `weak` variable with force-unwrapping operator.
+  [Ricky Tan](https://github.com/rickytan)
 
 * Mention a rule's identifier in the console message that is printed when the
   rule's associated configuration entry contains invalid values.  
@@ -386,10 +389,6 @@
 * None.
 
 #### Enhancements
-
-* Extend `implicitly_unwrapped_optional` rule with a new mode `weak_except_iboutlets`
-  that only checks `weak` variable with force-unwrapping operator.
-  [Ricky Tan](https://github.com/rickytan)
 
 * Add new `superfluous_else` rule that triggers on `if`-statements when an
   attached `else`-block can be removed, because all branches of the previous

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -65,6 +65,8 @@ private extension ImplicitlyUnwrappedOptionalRule {
                 return .visitChildren
             case .allExceptIBOutlets:
                 return node.isIBOutlet ? .skipChildren : .visitChildren
+            case .weakExceptIBOutlets:
+                return (node.isIBOutlet || node.weakOrUnownedModifier == nil) ? .skipChildren : .visitChildren
             }
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -7,6 +7,7 @@ struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration,
     enum ImplicitlyUnwrappedOptionalModeConfiguration: String, AcceptableByConfigurationElement {
         case all = "all"
         case allExceptIBOutlets = "all_except_iboutlets"
+        case weakExceptIBOutlets = "weak_except_iboutlets"
 
         init(value: Any) throws {
             if let string = (value as? String)?.lowercased(),

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -33,7 +33,6 @@ class ImplicitlyUnwrappedOptionalRuleTests: SwiftLintTestCase {
         ]
 
         let nonTriggeringExamples = [
-            Example("if !boolean {}"),
             Example("@IBOutlet private var label: UILabel!"),
             Example("@IBOutlet var label: UILabel!"),
             Example("@IBOutlet weak var label: UILabel!"),

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -27,9 +27,9 @@ class ImplicitlyUnwrappedOptionalRuleTests: SwiftLintTestCase {
     func testImplicitlyUnwrappedOptionalRuleWarnsOnOutletsInWeakMode() {
         let baseDescription = ImplicitlyUnwrappedOptionalRule.description
         let triggeringExamples = [
-            Example("private weak var label: UILabel!"),
-            Example("weak var label: UILabel!"),
-            Example("@objc weak var label: UILabel!")
+            Example("private weak var label: UILabel↓!"),
+            Example("weak var label: UILabel↓!"),
+            Example("@objc weak var label: UILabel↓!")
         ]
 
         let nonTriggeringExamples = [

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -27,9 +27,9 @@ class ImplicitlyUnwrappedOptionalRuleTests: SwiftLintTestCase {
     func testImplicitlyUnwrappedOptionalRuleWarnsOnOutletsInWeakMode() {
         let baseDescription = ImplicitlyUnwrappedOptionalRule.description
         let triggeringExamples = [
-            Example("private weak var label: UILabel↓!"),
-            Example("weak var label: UILabel↓!"),
-            Example("@objc weak var label: UILabel↓!")
+            Example("private weak var label: ↓UILabel!"),
+            Example("weak var label: ↓UILabel!"),
+            Example("@objc weak var label: ↓UILabel!")
         ]
 
         let nonTriggeringExamples = [

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -23,25 +23,27 @@ class ImplicitlyUnwrappedOptionalRuleTests: SwiftLintTestCase {
         verifyRule(description, ruleConfiguration: ["mode": "all"],
                    commentDoesntViolate: true, stringDoesntViolate: true)
     }
-    
+
     func testImplicitlyUnwrappedOptionalRuleWarnsOnOutletsInWeakMode() {
         let baseDescription = ImplicitlyUnwrappedOptionalRule.description
         let triggeringExamples = [
             Example("private weak var label: UILabel!"),
             Example("weak var label: UILabel!"),
-            Example("@objc weak var label: UILabel!"),
+            Example("@objc weak var label: UILabel!")
         ]
-        
+
         let nonTriggeringExamples = [
             Example("if !boolean {}"),
             Example("@IBOutlet private var label: UILabel!"),
             Example("@IBOutlet var label: UILabel!"),
             Example("@IBOutlet weak var label: UILabel!"),
+            Example("var label: UILabel!"),
             Example("let int: Int!")
         ]
+
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
             .with(triggeringExamples: triggeringExamples)
-        
+
         verifyRule(description, ruleConfiguration: ["mode": "weak_except_iboutlets"],
                    commentDoesntViolate: true, stringDoesntViolate: true)
     }

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -23,4 +23,26 @@ class ImplicitlyUnwrappedOptionalRuleTests: SwiftLintTestCase {
         verifyRule(description, ruleConfiguration: ["mode": "all"],
                    commentDoesntViolate: true, stringDoesntViolate: true)
     }
+    
+    func testImplicitlyUnwrappedOptionalRuleWarnsOnOutletsInWeakMode() {
+        let baseDescription = ImplicitlyUnwrappedOptionalRule.description
+        let triggeringExamples = [
+            Example("private weak var label: UILabel!"),
+            Example("weak var label: UILabel!"),
+            Example("@objc weak var label: UILabel!"),
+        ]
+        
+        let nonTriggeringExamples = [
+            Example("if !boolean {}"),
+            Example("@IBOutlet private var label: UILabel!"),
+            Example("@IBOutlet var label: UILabel!"),
+            Example("@IBOutlet weak var label: UILabel!"),
+            Example("let int: Int!")
+        ]
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+        
+        verifyRule(description, ruleConfiguration: ["mode": "weak_except_iboutlets"],
+                   commentDoesntViolate: true, stringDoesntViolate: true)
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -43,7 +43,6 @@ class ImplicitlyUnwrappedOptionalRuleTests: SwiftLintTestCase {
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
             .with(triggeringExamples: triggeringExamples)
 
-        verifyRule(description, ruleConfiguration: ["mode": "weak_except_iboutlets"],
-                   commentDoesntViolate: true, stringDoesntViolate: true)
+        verifyRule(description, ruleConfiguration: ["mode": "weak_except_iboutlets"])
     }
 }


### PR DESCRIPTION
This PR add a new mode for `ImplicitlyUnwrappedOptionalRule`, which only checks weak or unowned variable with implicitly unwrap