### PR TITLE
Make id and isVirtual public in SwiftLintFile

### DIFF
--- a/Source/SwiftLintCore/Models/SwiftLintFile.swift
+++ b/Source/SwiftLintCore/Models/SwiftLintFile.swift
@@ -5,6 +5,7 @@ import SourceKittenFramework
 public final class SwiftLintFile {
     /// The underlying SourceKitten file.
     public let file: File
+    /// The associated unique identifier for this file.
     public let id: UUID
     /// Whether or not this is a file generated for testing purposes.
     public private(set) var isTestFile = false

--- a/Source/SwiftLintCore/Models/SwiftLintFile.swift
+++ b/Source/SwiftLintCore/Models/SwiftLintFile.swift
@@ -5,11 +5,11 @@ import SourceKittenFramework
 public final class SwiftLintFile {
     /// The underlying SourceKitten file.
     public let file: File
-    let id: UUID
+    public let id: UUID
     /// Whether or not this is a file generated for testing purposes.
     public private(set) var isTestFile = false
     /// A file is virtual if it is not backed by a filesystem path.
-    private(set) var isVirtual = false
+    public private(set) var isVirtual = false
 
     /// Creates a `SwiftLintFile` with a SourceKitten `File`.
     ///


### PR DESCRIPTION
We're using these properties in our custom rules:

- `isVirtual`: we can replace for `path == nil`, but using it seems more idiomatic. We use that because we exclude some files from our custom rules in code, but still want the examples to be validated 
- `id`: we use to cache some computations that are file based and shared between rules