### PR TITLE
Silence `xct_specific_matcher` rule on types and tuples used in "one argument asserts"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 #### Enhancements
 
-* None.
+* Silence `xct_specific_matcher` rule on "one argument asserts" if there are
+  potential types or tuples involved in the comparison as types and tuples do
+  not conform to `Equatable`.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4990](https://github.com/realm/SwiftLint/issues/4990)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRuleExamples.swift
@@ -58,7 +58,12 @@ internal struct XCTSpecificMatcherRuleExamples {
                 excludeFromDocumentation: true),
         Example("XCTAssert(foo == bar)",
                 configuration: ["matchers": ["two-argument-asserts"]],
-                excludeFromDocumentation: true)
+                excludeFromDocumentation: true),
+
+        // Skip if one operand might be a type or a tuple
+        Example("XCTAssert(foo.self == bar)"),
+        Example("XCTAssertTrue(type(of: foo) != Int.self)"),
+        Example("XCTAssertTrue(a == (1, 3, 5)")
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
Fixes #4990. 