### PR TITLE
Make `unhandled_throwing_task` rule opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@
 
 #### Bug Fixes
 
-* None.
+* Make `unhandled_throwing_task` opt-in instead of enabled by default. The rule
+  is still prone to false positives at this point, so this makes enabling the
+  rule a conscious decision by end-users instead of enabled by default.  
+  [JP Simard](https://github.com/jpsim)
+  [#4987](https://github.com/realm/SwiftLint/issues/4987)
 
 ## 0.52.1: Crisp Clear Pleats
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct UnhandledThrowingTaskRule: ConfigurationProviderRule, SwiftSyntaxRule {
+struct UnhandledThrowingTaskRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
     var configuration = SeverityConfiguration(.error)
 
     static let description = RuleDescription(


### PR DESCRIPTION
Because since it was included in a release a few days ago, we've had several reports of false positives and so flipping to opt-in is appropriate so users can determine for themselves if they should enable the rule.