### PR TITLE
Fix some `unhandled_throwing_task` false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 * Make `unhandled_throwing_task` opt-in instead of enabled by default. The rule
   is still prone to false positives at this point, so this makes enabling the
-  rule a conscious decision by end-users instead of enabled by default.  
+  rule a conscious decision by end-users.  
   [JP Simard](https://github.com/jpsim)
   [#4987](https://github.com/realm/SwiftLint/issues/4987)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   [JP Simard](https://github.com/jpsim)
   [#4987](https://github.com/realm/SwiftLint/issues/4987)
 
+* Fix `unhandled_throwing_task` false positives when the `Task` is returned.  
+  [JP Simard](https://github.com/jpsim)
+  [#4987](https://github.com/realm/SwiftLint/issues/4987)
+
 ## 0.52.1: Crisp Clear Pleats
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
   [JP Simard](https://github.com/jpsim)
   [#4987](https://github.com/realm/SwiftLint/issues/4987)
 
-* Fix `unhandled_throwing_task` false positives when the `Task` is returned.  
+* Fix `unhandled_throwing_task` false positives when the `Task` is returned or
+  where the throwing code is handled in a `Result` initializer.  
   [JP Simard](https://github.com/jpsim)
   [#4987](https://github.com/realm/SwiftLint/issues/4987)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
@@ -173,6 +173,13 @@ struct UnhandledThrowingTaskRule: ConfigurationProviderRule, SwiftSyntaxRule, Op
                 throw BarError()
               }
             }
+            """),
+            Example("""
+            func doTask() {
+              ↓Task {
+                try await someThrowingFunction()
+              }
+            }
             """)
         ]
     )
@@ -320,11 +327,15 @@ private extension SyntaxProtocol {
         // 2nd parent:   | CodeBlockItemList
         // 1st parent:     | CodeBlockItem
         // Current node:     | FunctionDeclSyntax
-        guard let possibleFunctionDecl = parent?.parent?.parent?.parent?.as(FunctionDeclSyntax.self) else {
+        guard
+            let parentFunctionDecl = parent?.parent?.parent?.parent?.as(FunctionDeclSyntax.self),
+            parentFunctionDecl.body?.statements.count == 1,
+            parentFunctionDecl.signature.output != nil
+        else {
             return false
         }
 
-        return possibleFunctionDecl.body?.statements.count == 1
+        return true
     }
 
     var isReturnValue: Bool {


### PR DESCRIPTION
Fixes some of the cases reported in https://github.com/realm/SwiftLint/issues/4987