### PR TITLE
Disable `no_fallthrough_only` in favor of simultaneously active `fallthrough`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -35,6 +35,7 @@ disabled_rules:
   - multiline_parameters
   - multiline_parameters_brackets
   - no_extension_access_modifier
+  - no_fallthrough_only
   - no_grouping_extension
   - no_magic_numbers
   - prefer_nimble


### PR DESCRIPTION
Avoids two violation when using `fallthrough`.