### PR TITLE
Do not trigger `prefer_self_in_static_references` rule on `typealias` in classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@
 
 #### Bug Fixes
 
-* None.
+* Do not trigger `prefer_self_in_static_references` rule on `typealias`
+  declarations in classes.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5009](https://github.com/realm/SwiftLint/issues/5009)
 
 ## 0.52.2: Crisper Clearer Pleats
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -190,6 +190,13 @@ private class Visitor: ViolationsSyntaxVisitor {
         }
     }
 
+    override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+        if case .likeClass = parentDeclScopes.peek() {
+            return .skipChildren
+        }
+        return .visitChildren
+    }
+
     override func visit(_ node: TypeAnnotationSyntax) -> SyntaxVisitorContinueKind {
         guard case .likeStruct = parentDeclScopes.peek() else {
             return .skipChildren

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -146,6 +146,7 @@ enum PreferSelfInStaticReferencesRuleExamples {
         """, excludeFromDocumentation: true),
         Example("""
             class C {
+                typealias A = C
                 let d: C? = nil
                 var c: C { C() }
                 init() {}
@@ -155,6 +156,7 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 }
             }
             final class D {
+                typealias A = D
                 let c: D? = nil
                 var d: D { D() }
                 init() {}
@@ -164,6 +166,7 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 }
             }
             struct S {
+                typealias A = ↓S
                 // let s: S? = nil // Struct cannot contain itself
                 var t: ↓S { ↓S() }
                 init() {}


### PR DESCRIPTION
Fixes #5009.