### PR TITLE
Rely on pre-defined issues and allow to print them directly to the console

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -2,10 +2,7 @@ import SwiftSyntax
 
 // TODO: [09/07/2024] Remove deprecation warning after ~2 years.
 private let warnDeprecatedOnceImpl: Void = {
-    queuedPrintError("""
-        warning: The `anyobject_protocol` rule is now deprecated and will be completely removed in a future release.
-        """
-    )
+    Issue.ruleDeprecated(ruleID: AnyObjectProtocolRule.description.identifier).print()
 }()
 
 private func warnDeprecatedOnce() {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
@@ -263,10 +263,7 @@ private extension SwiftLintFile {
             let path = self.path,
             let response = try? Request.index(file: path, arguments: compilerArguments).sendIfNotDisabled()
         else {
-            queuedPrintError("""
-                warning: Could not index file at path '\(self.path ?? "...")' with the \
-                \(CaptureVariableRule.description.identifier) rule.
-                """)
+            Issue.indexingError(path: path, ruleID: CaptureVariableRule.description.identifier).print()
             return nil
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
@@ -2,11 +2,7 @@ import SwiftSyntax
 
 // TODO: [12/23/2024] Remove deprecation warning after ~2 years.
 private let warnDeprecatedOnceImpl: Void = {
-    queuedPrintError("""
-        warning: The `\(InertDeferRule.description.identifier)` rule is now deprecated and will be \
-        completely removed in a future release due to an equivalent warning issued by the Swift compiler.
-        """
-    )
+    Issue.ruleDeprecated(ruleID: InertDeferRule.description.identifier).print()
 }()
 
 private func warnDeprecatedOnce() {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -61,10 +61,7 @@ struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
             return []
         }
         guard compilerArguments.isNotEmpty else {
-            queuedPrintError("""
-                warning: Attempted to lint file at path '\(file.path ?? "...")' with the \
-                \(Self.description.identifier) rule without any compiler arguments.
-                """)
+            Issue.missingCompilerArguments(path: file.path, ruleID: Self.description.identifier).print()
             return []
         }
         return Self.parentRule.validate(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
@@ -2,11 +2,7 @@ import SwiftSyntax
 
 // TODO: [12/22/2024] Remove deprecation warning after ~2 years.
 private let warnDeprecatedOnceImpl: Void = {
-    queuedPrintError("""
-        warning: The `\(UnusedCaptureListRule.description.identifier)` rule is now deprecated and will be completely \
-        removed in a future release due to an equivalent warning issued by the Swift compiler.
-        """
-    )
+    Issue.ruleDeprecated(ruleID: UnusedCaptureListRule.description.identifier).print()
 }()
 
 private func warnDeprecatedOnce() {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -34,27 +34,18 @@ struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, Collectin
 
     func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> UnusedDeclarationRule.FileUSRs {
         guard compilerArguments.isNotEmpty else {
-            queuedPrintError("""
-                warning: Attempted to lint file at path '\(file.path ?? "...")' with the \
-                \(Self.description.identifier) rule without any compiler arguments.
-                """)
+            Issue.missingCompilerArguments(path: file.path, ruleID: Self.description.identifier).print()
             return .empty
         }
 
         guard let index = file.index(compilerArguments: compilerArguments), index.value.isNotEmpty else {
-            queuedPrintError("""
-                warning: Could not index file at path '\(file.path ?? "...")' with the \
-                \(Self.description.identifier) rule.
-                """)
+            Issue.indexingError(path: file.path, ruleID: Self.description.identifier).print()
             return .empty
         }
 
         guard let editorOpen = (try? Request.editorOpen(file: file.file).sendIfNotDisabled())
                 .map(SourceKittenDictionary.init) else {
-            queuedPrintError("""
-                warning: Could not open file at path '\(file.path ?? "...")' with the \
-                \(Self.description.identifier) rule.
-                """)
+            Issue.fileNotReadable(path: file.path, ruleID: Self.description.identifier).print()
             return .empty
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -85,10 +85,7 @@ struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRul
 
     private func importUsage(in file: SwiftLintFile, compilerArguments: [String]) -> [ImportUsage] {
         guard compilerArguments.isNotEmpty else {
-            queuedPrintError("""
-                warning: Attempted to lint file at path '\(file.path ?? "...")' with the \
-                \(Self.description.identifier) rule without any compiler arguments.
-                """)
+            Issue.missingCompilerArguments(path: file.path, ruleID: Self.description.identifier).print()
             return []
         }
 
@@ -166,7 +163,7 @@ private extension SwiftLintFile {
                 file: path!, offset: token.offset, arguments: compilerArguments
             )
             guard let cursorInfo = (try? cursorInfoRequest.sendIfNotDisabled()).map(SourceKittenDictionary.init) else {
-                queuedPrintError("Could not get cursor info")
+                Issue.missingCursorInfo(path: path, ruleID: UnusedImportRule.description.identifier).print()
                 continue
             }
             if nextIsModuleImport {
@@ -198,7 +195,7 @@ private extension SwiftLintFile {
     func operatorImports(arguments: [String], processedTokenOffsets: Set<ByteCount>) -> Set<String> {
         guard let index = (try? Request.index(file: path!, arguments: arguments).sendIfNotDisabled())
             .map(SourceKittenDictionary.init) else {
-            queuedPrintError("Could not get index")
+            Issue.indexingError(path: path, ruleID: UnusedImportRule.description.identifier).print()
             return []
         }
 
@@ -221,7 +218,7 @@ private extension SwiftLintFile {
                 )
                 guard let cursorInfo = (try? cursorInfoRequest.sendIfNotDisabled())
                     .map(SourceKittenDictionary.init) else {
-                    queuedPrintError("Could not get cursor info")
+                    Issue.missingCursorInfo(path: path, ruleID: UnusedImportRule.description.identifier).print()
                     continue
                 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -71,12 +71,15 @@ struct NameConfiguration: RuleConfiguration, Equatable {
             try severity.apply(configuration: validatesStartWithLowercase)
             self.validatesStartWithLowercase = severity
         } else if let validatesStartWithLowercase = configurationDict["validates_start_with_lowercase"] as? Bool {
+            // TODO: [05/10/2025] Remove deprecation warning after ~2 years.
             self.validatesStartWithLowercase = validatesStartWithLowercase ? .error : nil
-            queuedPrintError("""
-                warning: The \"validates_start_with_lowercase\" configuration now expects a severity (warning or \
+            Issue.genericWarning(
+                """
+                The \"validates_start_with_lowercase\" configuration now expects a severity (warning or \
                 error). The boolean value 'true' will still enable it as an error. It is now deprecated and will be \
                 removed in a future release.
-                """)
+                """
+            ).print()
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
@@ -42,10 +42,7 @@ struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRul
 
     private func violationRanges(in file: SwiftLintFile, compilerArguments: [String]) -> [NSRange] {
         guard compilerArguments.isNotEmpty else {
-            queuedPrintError("""
-                warning: Attempted to lint file at path '\(file.path ?? "...")' with the \
-                \(Self.description.identifier) rule without any compiler arguments.
-                """)
+            Issue.missingCompilerArguments(path: file.path, ruleID: Self.description.identifier).print()
             return []
         }
 
@@ -72,7 +69,7 @@ struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRul
 
         return cursorsMissingExplicitSelf.compactMap { cursorInfo in
             guard let byteOffset = (cursorInfo["swiftlint.offset"] as? Int64).flatMap(ByteCount.init) else {
-                queuedPrintError("couldn't convert offsets")
+                Issue.genericWarning("Cannot convert offsets in '\(Self.description.identifier)' rule.").print()
                 return nil
             }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Cache.swift
@@ -92,7 +92,7 @@ extension Configuration {
         do {
             try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true, attributes: nil)
         } catch {
-            queuedPrintError("Error while creating cache: " + error.localizedDescription)
+            Issue.genericWarning("Cannot create cache: " + error.localizedDescription).print()
         }
 
         return folder

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -41,7 +41,7 @@ public extension Configuration {
                     let duplicateRules = identifiers.reduce(into: [String: Int]()) { $0[$1, default: 0] += 1 }
                         .filter { $0.1 > 1 }
                     for duplicateRule in duplicateRules {
-                        queuedPrintError("warning: '\(duplicateRule.0)' is listed \(duplicateRule.1) times")
+                        Issue.listedMultipleTime(ruleID: duplicateRule.0, times: duplicateRule.1).print()
                     }
                 }
             }

--- a/Source/SwiftLintCore/Helpers/Glob.swift
+++ b/Source/SwiftLintCore/Helpers/Glob.swift
@@ -60,7 +60,7 @@ struct Glob {
             }
         } catch {
             directories = []
-            queuedPrintError("Error parsing file system item: \(error)")
+            Issue.genericWarning("Error parsing file system item: \(error)").print()
         }
 
         // Check the base directory for the glob star as well.

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -5,6 +5,18 @@ public enum Issue: LocalizedError, Equatable {
     /// The configuration didn't match internal expectations.
     case unknownConfiguration
 
+    /// Rule is listed multiple times in the configuration.
+    case listedMultipleTime(ruleID: String, times: Int)
+
+    /// An identifier `old` has been renamed to `new`.
+    case renamedIdentifier(old: String, new: String)
+
+    /// Configuration for a rule is invalid.
+    case invalidConfiguration(ruleID: String)
+
+    /// Some configuration keys are invalid.
+    case invalidConfigurationKeys([String])
+
     /// A generic warning specified by a string.
     case genericWarning(String)
 
@@ -12,10 +24,25 @@ public enum Issue: LocalizedError, Equatable {
     case genericError(String)
 
     /// A deprecation warning for a rule.
-    case deprecation(ruleID: String)
+    case ruleDeprecated(ruleID: String)
 
     /// The initial configuration file was not found.
     case initialFileNotFound(path: String)
+
+    /// The file at `path` is not readable or cannot be opened.
+    case fileNotReadable(path: String?, ruleID: String)
+
+    /// The file at `path` is not writable.
+    case fileNotWritable(path: String)
+
+    /// The file at `path` cannot be indexed by a specific rule.
+    case indexingError(path: String?, ruleID: String)
+
+    /// No arguments were provided to compile a file at `path` within a specific rule.
+    case missingCompilerArguments(path: String?, ruleID: String)
+
+    /// Cursor information cannot be extracted from a specific location.
+    case missingCursorInfo(path: String?, ruleID: String)
 
     /// An error that occurred when parsing YAML.
     case yamlParsing(String)
@@ -26,10 +53,7 @@ public enum Issue: LocalizedError, Equatable {
     ///
     /// - returns: A `SwiftLintError.genericWarning` containig the message of the `error` argument.
     static func wrap(error: Error) -> Self {
-        if let this = error as? Issue {
-            return this
-        }
-        return Self.genericWarning(error.localizedDescription)
+        error as? Issue ?? Self.genericWarning(error.localizedDescription)
     }
 
     /// Make this issue an error.
@@ -49,20 +73,46 @@ public enum Issue: LocalizedError, Equatable {
         }
     }
 
+    /// Print the issue to the console.
+    public func print() {
+        queuedPrintError(errorDescription)
+    }
+
     private var message: String {
         switch self {
         case .unknownConfiguration:
             return "Invalid configuration. Falling back to default."
-        case .genericWarning(let message), .genericError(let message):
+        case let .listedMultipleTime(id, times):
+            return "'\(id)' is listed \(times) times in the configuration."
+        case let .renamedIdentifier(old, new):
+            return "'\(old)' has been renamed to '\(new)' and will be completely removed in a future release."
+        case let .invalidConfiguration(id):
+            return "Invalid configuration for '\(id)'. Falling back to default."
+        case let .invalidConfigurationKeys(keys):
+            return "Configuration contains invalid keys \(keys.joined(separator: ", "))."
+        case let .genericWarning(message), let .genericError(message):
             return message
-        case .deprecation(let ruleID):
+        case let .ruleDeprecated(id):
             return """
-                The `\(ruleID)` rule is now deprecated and will be \
+                The `\(id)` rule is now deprecated and will be \
                 completely removed in a future release.
                 """
-        case .initialFileNotFound(let path):
-            return "Could not read file at path \(path)."
-        case .yamlParsing(let message):
+        case let .initialFileNotFound(path):
+            return "Could not read file at path '\(path)'."
+        case let .fileNotReadable(path, id):
+            return "Cannot open or read file at path '\(path ?? "...")' within '\(id)' rule."
+        case let .fileNotWritable(path):
+            return "Cannot write to file at path '\(path)'."
+        case let .indexingError(path, id):
+            return "Cannot index file at path '\(path ?? "...")' within '\(id)' rule."
+        case let .missingCompilerArguments(path, id):
+            return """
+                Attempted to lint file at path '\(path ?? "...")' within '\(id)' rule \
+                without any compiler arguments.
+                """
+        case let .missingCursorInfo(path, id):
+            return "Cannot get cursor info from file at path '\(path ?? "...")' within '\(id)' rule."
+        case let .yamlParsing(message):
             return "Cannot parse YAML file: \(message)"
         }
     }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 
 private let warnSourceKitFailedOnceImpl: Void = {
-    queuedPrintError("warning: SourceKit-based rules will be skipped because sourcekitd has failed.")
+    Issue.genericWarning("SourceKit-based rules will be skipped because sourcekitd has failed.").print()
 }()
 
 private func warnSourceKitFailedOnce() {
@@ -245,8 +245,7 @@ public struct CollectedLinter {
         }
 
         for (deprecatedIdentifier, identifier) in deprecatedToValidIdentifier {
-            queuedPrintError("warning: '\(deprecatedIdentifier)' rule has been renamed to '\(identifier)' and " +
-                "will be completely removed in a future release.")
+            Issue.renamedIdentifier(old: deprecatedIdentifier, new: identifier).print()
         }
 
         // Free some memory used for this file's caches. They shouldn't be needed after this point.

--- a/Source/SwiftLintCore/Models/RuleList.swift
+++ b/Source/SwiftLintCore/Models/RuleList.swift
@@ -56,7 +56,7 @@ public struct RuleList {
                     initializedWithNonEmptyConfiguration: isConfigured
                 )
             } catch {
-                queuedPrintError("warning: Invalid configuration for '\(identifier)'. Falling back to default.")
+                Issue.invalidConfiguration(ruleID: identifier).print()
                 rules[identifier] = (ruleType.init(), false)
             }
         }

--- a/Source/SwiftLintCore/Protocols/Reporter.swift
+++ b/Source/SwiftLintCore/Protocols/Reporter.swift
@@ -34,7 +34,7 @@ public extension Reporter {
 /// - returns: The reporter type.
 public func reporterFrom(identifier: String) -> Reporter.Type {
     guard let reporter = reportersList.first(where: { $0.identifier == identifier }) else {
-        queuedFatalError("no reporter with identifier '\(identifier)' available.")
+        queuedFatalError("No reporter with identifier '\(identifier)' available.")
     }
     return reporter
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -23,7 +23,7 @@ struct CustomRulesConfiguration: RuleConfiguration, Equatable, CacheDescriptionP
             do {
                 try ruleConfiguration.apply(configuration: value)
             } catch {
-                queuedPrintError("warning: Invalid configuration for custom rule '\(key)'.")
+                Issue.invalidConfiguration(ruleID: key).print()
                 continue
             }
 

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -22,9 +22,9 @@ extension SwiftLint {
             let allPaths: [String]
             if let path {
                 // TODO: [06/14/2024] Remove deprecation warning after ~2 years.
-                queuedPrintError("""
-                    warning: The --path option is deprecated. Pass the path(s) to analyze last to the swiftlint command.
-                    """)
+                Issue.genericWarning(
+                    "The --path option is deprecated. Pass the path(s) to analyze last to the swiftlint command."
+                ).print()
                 allPaths = [path] + paths
             } else if !paths.isEmpty {
                 allPaths = paths

--- a/Source/swiftlint/Commands/Docs.swift
+++ b/Source/swiftlint/Commands/Docs.swift
@@ -15,7 +15,7 @@ extension SwiftLint {
             var subPage = ""
             if let ruleID {
                 if RuleRegistry.shared.rule(forID: ruleID) == nil {
-                    queuedPrintError("warning: There is no rule named '\(ruleID)'. Opening rule directory instead.")
+                    Issue.genericWarning("There is no rule named '\(ruleID)'. Opening rule directory instead.").print()
                     subPage = "rule-directory.html"
                 } else {
                     subPage = ruleID + ".html"

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -26,9 +26,9 @@ extension SwiftLint {
             let allPaths: [String]
             if let path {
                 // TODO: [06/14/2024] Remove deprecation warning after ~2 years.
-                queuedPrintError("""
-                    warning: The --path option is deprecated. Pass the path(s) to lint last to the swiftlint command.
-                    """)
+                Issue.genericWarning(
+                    "The --path option is deprecated. Pass the path(s) to lint last to the swiftlint command."
+                ).print()
                 allPaths = [path] + paths
             } else if !paths.isEmpty {
                 allPaths = paths

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -154,10 +154,12 @@ extension Configuration {
                     let outputFilename = self.outputFilename(for: filePath, duplicateFileNames: duplicateFileNames)
                     let collected = await counter.next()
                     if skipFile {
-                        queuedPrintError("""
-                            warning: Skipping '\(outputFilename)' (\(collected)/\(total)) \
+                        Issue.genericWarning(
+                            """
+                            Skipping '\(outputFilename)' (\(collected)/\(total)) \
                             because its compiler arguments could not be found
-                            """)
+                            """
+                        ).print()
                     } else {
                         queuedPrintError("Collecting '\(outputFilename)' (\(collected)/\(total))")
                     }

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -274,7 +274,7 @@ private class LintOrAnalyzeResultBuilder {
             do {
                 try Data().write(to: URL(fileURLWithPath: outFile))
             } catch {
-                queuedPrintError("warning: Could not write to file at path \(outFile)")
+                Issue.fileNotWritable(path: outFile).print()
             }
         }
     }
@@ -303,7 +303,7 @@ private extension LintOrAnalyzeOptions {
             fileUpdater.write(Data((string + "\n").utf8))
             fileUpdater.closeFile()
         } catch {
-            queuedPrintError("warning: Could not write to file at path \(outFile)")
+            Issue.fileNotWritable(path: outFile).print()
         }
     }
 }


### PR DESCRIPTION
Advantages of having typical errors at a common place:
* Error message styling can be harmonized
* Existing messages can be reused
* Overview of prefixes (`error: `, `warning: `)
* Manage how to print them to the console