### PR TITLE
[Update] Add Code Line in README_KR.md

### DIFF
--- a/README_KR.md
+++ b/README_KR.md
@@ -75,7 +75,10 @@ fi
 그 이유는, 애플 실리콘 기반 맥에서 Homebrew는 기본적으로 바이너리들을 `/opt/homebrew/bin`에 저장하기 때문입니다. SwiftLint가 어디 있는지 찾는 것을 Xcode에 알려주기 위해, build phase에서 `/opt/homebrew/bin`를 `PATH` 환경 변수에 동시에 추가하여야 합니다.
 
 ```bash
-export PATH="$PATH:/opt/homebrew/bin"
+if [[ "$(uname -m)" == arm64 ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+fi
+
 if which swiftlint > /dev/null; then
   swiftlint
 else


### PR DESCRIPTION
Add Code Line in README_KR.md for Korean users who are using Apple Silicon(M1/M2) MacBooks. (based-on README.md)

애플 실리콘 기반의 맥북을 사용하고 계신 한국 유저들에게 도움을 주기 위하여, README_KR.md 문서에 코드를 추가하였습니다. (README.md 파일을 기반으로 수정하였습니다.)