### PR TITLE
Make the `rule_id` rule work correctly

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -82,7 +82,7 @@ type_body_length: 400
 
 custom_rules:
   rule_id:
-    included: Source/SwiftLintFramework/Rules/.+/\w+\.swift
+    included: Source/SwiftLintBuiltInRules/Rules/.+/\w+\.swift
     name: Rule ID
     message: Rule IDs must be all lowercase, snake case and not end with `rule`
     regex: ^\s+identifier:\s*("\w+_rule"|"\S*[^a-z_]\S*")


### PR DESCRIPTION
Hi,

This PR fixes a path to the rules directory to make the `rule_id` rule work correctly.