### PR TITLE
Fix false positives on `sorted_first_last` rule when `first`/`last` have a predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@
   [Haoocen](https://github.com/Haoocen)
   [#5023](https://github.com/realm/SwiftLint/pull/5023)
 
+* Fix false positives on `sorted_first_last` rule when `first`/`last` have
+  a predicate.
+  [woxtu](https://github.com/woxtu)
+  [#3023](https://github.com/realm/SwiftLint/issues/3023)
+
 ## 0.52.2: Crisper Clearer Pleats
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
@@ -21,7 +21,11 @@ struct SortedFirstLastRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRul
             Example("myList.sorted().firstIndex(where: someFunction)"),
             Example("myList.sorted().lastIndex(where: someFunction)"),
             Example("myList.sorted().firstIndex { $0 == key }"),
-            Example("myList.sorted().lastIndex { $0 == key }")
+            Example("myList.sorted().lastIndex { $0 == key }"),
+            Example("myList.sorted().first(where: someFunction)"),
+            Example("myList.sorted().last(where: someFunction)"),
+            Example("myList.sorted().first { $0 == key }"),
+            Example("myList.sorted().last { $0 == key }")
         ],
         triggeringExamples: [
             Example("↓myList.sorted().first\n"),
@@ -50,6 +54,7 @@ private extension SortedFirstLastRule {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
                 node.name.text == "first" || node.name.text == "last",
+                node.parent?.is(FunctionCallExprSyntax.self) != true,
                 let firstBase = node.base?.asFunctionCall,
                 let firstBaseCalledExpression = firstBase.calledExpression.as(MemberAccessExprSyntax.self),
                 firstBaseCalledExpression.name.text == "sorted",


### PR DESCRIPTION
Hi,

This PR fixes false positives on `sorted_first_last` rule when `first`/`last` have a predicate.
Resolve #3023.