### PR TITLE
Add rule suggesting static immutable property

### DIFF
--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -183,6 +183,7 @@ public let builtInRules: [Rule.Type] = [
     SortedFirstLastRule.self,
     SortedImportsRule.self,
     StatementPositionRule.self,
+    StaticImmutablePropertiesRule.self,
     StaticOperatorRule.self,
     StrictFilePrivateRule.self,
     StrongIBOutletRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/StaticImmutablePropertiesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/StaticImmutablePropertiesRule.swift
@@ -1,0 +1,114 @@
+import SwiftSyntax
+
+struct StaticImmutablePropertiesRule: ConfigurationProviderRule, SwiftSyntaxRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "static_immutable_properties",
+        name: "Static immutable properies",
+        description: "Prefer making initialized immutable properties static",
+        kind: .style,
+        nonTriggeringExamples: nonTriggeringExamples,
+        triggeringExamples: triggeringExamples
+    )
+
+    init() {}
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(viewMode: .sourceAccurate)
+    }
+}
+
+private extension StaticImmutablePropertiesRule {
+    final class Visitor: ViolationsSyntaxVisitor {
+        override func visitPost(_ node: MemberDeclListSyntax) {
+            let nonStaticProperties: [VariableDeclSyntax] = node.compactMap({ item in
+                guard item.decl.kind == .variableDecl else {
+                    // need variable decls
+                    return nil
+                }
+                guard let variableSyntax = item.decl.as(VariableDeclSyntax.self) else {
+                    return nil
+                }
+                let modifiers = variableSyntax.modifiers ?? []
+                guard modifiers.allSatisfy({ modifier in
+                    return modifier.name.tokenKind != .keyword(.static)
+                }) else {
+                    // no static modifier
+                    return nil
+                }
+                guard variableSyntax.as(TokenSyntax.self)?.tokenKind == .keyword(.let) else {
+                    // should be an immutable property
+                    return nil
+                }
+                guard variableSyntax.bindings.contains(where: { syntax in
+                    return syntax.initializer?.kind == .initializerClause
+                }) else {
+                    // should be an initialisation clause
+                    return nil
+                }
+                return variableSyntax
+            })
+            // and report positions of the lets
+            let allPositions = nonStaticProperties.map { syntax in
+                return syntax.positionAfterSkippingLeadingTrivia
+            }
+            self.violations.append(contentsOf: allPositions)
+        }
+    }
+}
+
+private extension StaticImmutablePropertiesRule {
+    static let nonTriggeringExamples: [Example] = [
+        Example("""
+        class Foo {
+            static let constant: Int = 1
+            var variable: Int = 2
+        }
+        """),
+        Example("""
+        struct Foo {
+            static let constant: Int = 1
+        }
+        """),
+        Example("""
+        enum InstFooance {
+            static let constant = 1
+        }
+        """),
+        Example("""
+        struct Foo {
+            let property1
+            let property2
+            init(property1: Int, property2: String) {
+                self.property1 = property1
+                self.property2 = property2
+            }
+        }
+        """)
+    ]
+
+    static let triggeringExamples: [Example] = [
+        Example("""
+        class Foo {
+            static let one = 32
+            ↓let constant: Int = 1
+        }
+        """),
+        Example("""
+        struct Foo {
+            ↓let constant: Int = 1
+        }
+        """),
+        Example("""
+        enum Foo {
+            ↓let constant: Int = 1
+        }
+        """),
+        Example("""
+        enum Foo {
+            ↓let constant = "Xddd"
+        }
+        """)
+    ]
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1088,6 +1088,12 @@ class StatementPositionRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class StaticImmutablePropertiesRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(StaticImmutablePropertiesRule.description)
+    }
+}
+
 class StaticOperatorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StaticOperatorRule.description)


### PR DESCRIPTION
Adds a rule that suggests to use a static modifier for immutable initialized properties.

So this:
```
struct Foo {
   let property = 2
}
```
is suggested to be:
```
struct Foo {
   static let property = 2
}
```