### PR TITLE
Add 5.9 to Swift version tests

### DIFF
--- a/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
@@ -5,6 +5,8 @@ final class SwiftVersionTests: SwiftLintTestCase {
     func testDetectSwiftVersion() {
 #if compiler(>=6.0.0)
         let version = "6.0.0"
+#elseif compiler(>=5.9.0)
+        let version = "5.9.0"
 #elseif compiler(>=5.8.1)
         let version = "5.8.1"
 #elseif compiler(>=5.8.0)


### PR DESCRIPTION
This gets all tests passing with Xcode 15 beta 1.
