### PR TITLE
Silence duplicate symbol runtime warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@
   [woxtu](https://github.com/woxtu)
   [#3023](https://github.com/realm/SwiftLint/issues/3023)
 
+* Work around dyld warning about duplicate SwiftSyntax classes with Xcode 15
+  betas.  
+  [keith](https://github.com/keith)
+  [JP Simard](https://github.com/jpsim)
+  [#4782](https://github.com/realm/SwiftLint/issues/4782)
+
 ## 0.52.2: Crisper Clearer Pleats
 
 #### Breaking

--- a/Source/DyldWarningWorkaround/DyldWarningWorkaround.c
+++ b/Source/DyldWarningWorkaround/DyldWarningWorkaround.c
@@ -11,10 +11,6 @@ OBJC_DUPCLASS(_TtC11SwiftSyntax18ParsingSyntaxArena);
 OBJC_DUPCLASS(_TtC11SwiftSyntax23SourceLocationConverter);
 OBJC_DUPCLASS(_TtC11SwiftSyntax26IncrementalParseTransition);
 OBJC_DUPCLASS(_TtC11SwiftSyntax35IncrementalParseReusedNodeCollector);
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wexcess-initializers"
 OBJC_DUPCLASS(_TtC11SwiftParserP33_78149DB072C20084E7D780D86E26C3AF41StringLiteralExpressionIndentationChecker);
-#pragma clang diagnostic pop
 
 #endif // __APPLE__

--- a/Source/DyldWarningWorkaround/DyldWarningWorkaround.c
+++ b/Source/DyldWarningWorkaround/DyldWarningWorkaround.c
@@ -12,4 +12,9 @@ OBJC_DUPCLASS(_TtC11SwiftSyntax23SourceLocationConverter);
 OBJC_DUPCLASS(_TtC11SwiftSyntax26IncrementalParseTransition);
 OBJC_DUPCLASS(_TtC11SwiftSyntax35IncrementalParseReusedNodeCollector);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexcess-initializers"
+OBJC_DUPCLASS(_TtC11SwiftParserP33_78149DB072C20084E7D780D86E26C3AF41StringLiteralExpressionIndentationChecker);
+#pragma clang diagnostic pop
+
 #endif // __APPLE__

--- a/Source/DyldWarningWorkaround/include/objc_dupclass.h
+++ b/Source/DyldWarningWorkaround/include/objc_dupclass.h
@@ -11,7 +11,7 @@
 // Struct layout from https://github.com/apple-oss-distributions/objc4/blob/8701d5672d3fd3cd817aeb84db1077aafe1a1604/runtime/objc-abi.h#L175-L183
 #define OBJC_DUPCLASS(kclass) \
     __attribute__((used)) __attribute__((visibility("hidden"))) \
-      static struct { uint32_t version; uint32_t flags; const char name[64]; } \
+      static struct { uint32_t version; uint32_t flags; const char name[128]; } \
       const __duplicate_class_##kclass = { 0, 0, #kclass }; \
     \
     __attribute__((used)) __attribute__((visibility("hidden"))) \


### PR DESCRIPTION
Similar to #4901 but updated with a new warning from Xcode 15 beta 1.

Unfortunately this doesn't appear to work, even with this change the warning is still logged:

```
objc[18947]: Class _TtC11SwiftParserP33_78149DB072C20084E7D780D86E26C3AF41StringLiteralExpressionIndentationChecker is implemented in both /private/var/tmp/_bazel_jp/d6a0d3abed4579623f79fc46ad4a7a79/execroot/_main/bazel-out/darwin_arm64-opt/bin/swiftlint (0x1059a79a0) and /Applications/Xcode-15.0.0-Beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/libSwiftParser.dylib (0x10703da50). One of the two will be used. Which one is undefined.
```

It might have something to do with how long the symbol name is.