### PR TITLE
Handle static `spec` methods in `quick_discouraged_call` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 #### Enhancements
 
-* None.
+* Handle static `spec` methods in `quick_discouraged_call` rule. The method
+  type changed from an instance method to a class method in Quick 7.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5072](https://github.com/realm/SwiftLint/issues/5072)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -20,10 +20,11 @@ struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule {
         }
 
         let specDeclarations = testClasses.flatMap { classDict in
-            return classDict.substructure.filter {
-                return $0.name == "spec()" && $0.enclosedVarParameters.isEmpty &&
-                    $0.declarationKind == .functionMethodInstance &&
-                    $0.enclosedSwiftAttributes.contains(.override)
+            classDict.substructure.filter { structure in
+                   structure.name == "spec()"
+                && structure.enclosedVarParameters.isEmpty
+                && [.functionMethodInstance, .functionMethodStatic].contains(structure.declarationKind)
+                && structure.enclosedSwiftAttributes.contains(.override)
             }
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
@@ -187,6 +187,15 @@ internal struct QuickDiscouragedCallRuleExamples {
         """),
         Example("""
         class TotoTests: QuickSpec {
+           override static func spec() {
+               describe("foo") {
+                   let foo = ↓Foo()
+               }
+           }
+        }
+        """),
+        Example("""
+        class TotoTests: QuickSpec {
            override func spec() {
                describe("foo") {
                    let foo = ↓Foo()

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRuleExamples.swift
@@ -1,6 +1,15 @@
 internal struct QuickDiscouragedCallRuleExamples {
     static let nonTriggeringExamples: [Example] = [
         Example("""
+        class TotoTests {
+           override func spec() {
+               describe("foo") {
+                   let foo = Foo()
+               }
+           }
+        }
+        """),
+        Example("""
         class TotoTests: QuickSpec {
            override func spec() {
                describe("foo") {
@@ -168,13 +177,6 @@ internal struct QuickDiscouragedCallRuleExamples {
 
     static let triggeringExamples: [Example] = [
         Example("""
-        class TotoTests {
-           override func spec() {
-               describe("foo") {
-                   let foo = Foo()
-               }
-           }
-        }
         class TotoTests: QuickSpec {
            override func spec() {
                describe("foo") {


### PR DESCRIPTION
Fixes #5072.