### PR TITLE
Fix for #5075

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 
 #### Bug Fixes
 
-* None.
+* Fix false positives for the `unneeded_synthesized_initializer` rule, when
+  no argument initializers had side-effects.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5075](https://github.com/realm/SwiftLint/issues/5075)
 
 ## 0.52.3: Duplicate Hampers
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -222,7 +222,6 @@ private extension StructDeclSyntax {
         return initializerBody.statements.isEmpty
     }
 
-
     // Does the actual access level of an initializer match the access level of the synthesized
     // memberwise initializer?
     private func initializerModifiers(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -120,7 +120,8 @@ private extension StructDeclSyntax {
 
         return initializers.filter {
             self.initializerParameters($0.parameterList, match: storedProperties) &&
-            (($0.parameterList.isEmpty && hasNoSideEffects($0.body)) || initializerBody($0.body, matches: storedProperties)) &&
+            (($0.parameterList.isEmpty && hasNoSideEffects($0.body)) ||
+             initializerBody($0.body, matches: storedProperties)) &&
             initializerModifiers($0.modifiers, match: storedProperties) && !$0.isInlinable
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -120,7 +120,7 @@ private extension StructDeclSyntax {
 
         return initializers.filter {
             self.initializerParameters($0.parameterList, match: storedProperties) &&
-            ($0.parameterList.isEmpty || initializerBody($0.body, matches: storedProperties)) &&
+            (($0.parameterList.isEmpty && hasNoSideEffects($0.body)) || initializerBody($0.body, matches: storedProperties)) &&
             initializerModifiers($0.modifiers, match: storedProperties) && !$0.isInlinable
         }
     }
@@ -214,6 +214,14 @@ private extension StructDeclSyntax {
         }
         return statements.isEmpty
     }
+
+    private func hasNoSideEffects(_ initializerBody: CodeBlockSyntax?) -> Bool {
+        guard let initializerBody else {
+            return true
+        }
+        return initializerBody.statements.isEmpty
+    }
+
 
     // Does the actual access level of an initializer match the access level of the synthesized
     // memberwise initializer?

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRuleExamples.swift
@@ -180,6 +180,23 @@ enum UnneededSynthesizedInitializerRuleExamples {
                         self.bar = bar
                     }
                 }
+                """),
+        Example("""
+                struct Foo {
+                    init() {
+                        print("perform side effect")
+                    }
+                }
+                """),
+        Example("""
+                struct Foo {
+                    var bar: Int = 0
+
+                    init(bar: Int = 0) {
+                        self.bar = bar
+                        print("perform side effect")
+                    }
+                }
                 """)
     ]
 


### PR DESCRIPTION

Fixes #5075

For the no argument case, we weren't checking for side-effects.

