### PR TITLE
Improves correction for cases with trailing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5075](https://github.com/realm/SwiftLint/issues/5075)
 
+* Fix auto-correction for the `direct_return` rule, when statements have
+  trailing comments.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5081](https://github.com/realm/SwiftLint/issues/5081)
+
 ## 0.52.3: Duplicate Hampers
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
@@ -146,6 +146,26 @@ struct DirectReturnRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, 
                 }
             """),
             Example("""
+                func f() -> UIView {
+                    let view = instantiateView() as! UIView // swiftlint:disable:this force_cast
+                    return view
+                }
+            """): Example("""
+                func f() -> UIView {
+                    return instantiateView() as! UIView // swiftlint:disable:this force_cast
+                }
+            """),
+            Example("""
+                func f() -> UIView {
+                    let view = instantiateView() as! UIView // swiftlint:disable:this force_cast
+                    return view // return the view
+                }
+            """): Example("""
+                func f() -> UIView {
+                    return instantiateView() as! UIView // swiftlint:disable:this force_cast // return the view
+                }
+            """),
+            Example("""
                 func f() -> Bool {
                     let b  :  Bool  =  true
                     return b
@@ -244,8 +264,10 @@ private class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
             ))
         } else {
             let leadingTrivia = varDecl.leadingTrivia.withoutTrailingIndentation +
-                varDecl.trailingTrivia +
                 returnStmt.leadingTrivia.withFirstEmptyLineRemoved
+            let trailingTrivia = varDecl.trailingTrivia.withoutTrailingIndentation +
+                returnStmt.trailingTrivia
+
             newStmtList.append(
                 CodeBlockItemSyntax(
                     item: .stmt(
@@ -253,6 +275,7 @@ private class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
                             returnStmt
                                 .with(\.expression, initExpression)
                                 .with(\.leadingTrivia, leadingTrivia)
+                                .with(\.trailingTrivia, trailingTrivia)
                         )
                     )
                 )


### PR DESCRIPTION

Fixes #5081

Appends the trailing trivia from the variable declaration and the return statement to the new return statement.

This works great for the case reported in the report:

```
func f() -> UIView {
    let view = instantiateView() as! UIView // swiftlint:disable:this force_cast
    return view
}
 ```

becomes

```
func f() -> UIView {
    return instantiateView() as! UIView // swiftlint:disable:this force_cast
}
```

When both have trailing comments, it's not so great, but not completely awful, and certainly a lot better than what we had before.

```
func f() -> UIView {
    let view = instantiateView() as! UIView // swiftlint:disable:this force_cast
    return view // return the view
}
```

now becomes

```
func f() -> UIView {
   return instantiateView() as! UIView // swiftlint:disable:this force_cast // return the view
}
```

as opposed to (on 0.52.2), somewhat crazily

```
func f() -> UIView {
 // swiftlint:disable:this force_cast    return instantiateView() as! UIView // swiftlint:disable:this force_cast
}
```
