### PR TITLE
Fix false positive for `prefer_self_in_static_references` rule on class declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@
   [JP Simard](https://github.com/jpsim)
   [#4985](https://github.com/realm/SwiftLint/issues/4985)
 
+* Fix false positive for `prefer_self_in_static_references` when a class inherits from
+  another class with generic types.  
+  [kasrababaei](https://github.com/kasrababaei)
+
 ## 0.52.0: Crisp Clear Pleats
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -179,6 +179,13 @@ private class Visitor: ViolationsSyntaxVisitor {
         parentDeclScopes.pop()
     }
 
+    override func visit(_ node: GenericArgumentListSyntax) -> SyntaxVisitorContinueKind {
+        if case .likeClass = parentDeclScopes.peek() {
+            return .skipChildren
+        }
+        return .visitChildren
+    }
+
     override func visitPost(_ node: SimpleTypeIdentifierSyntax) {
         guard let parent = node.parent else {
             return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -72,6 +72,33 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 let c: C = C()
                 func f(c: C) -> KeyPath<C, Int> { \\Self.i }
             }
+        """, excludeFromDocumentation: true),
+        Example("""
+            class C1<T> {}
+            class C2: C1<C2> {}
+        """, excludeFromDocumentation: true),
+        Example("""
+                class C1<T> {}
+                class C2: C1<C2.C3> {
+                    class C3 {}
+                }
+                """, excludeFromDocumentation: true),
+        Example("""
+            class C1<T> {}
+            class C2: C1<C2.C3.C4> {
+                class C3 {
+                    class C4 {}
+                }
+            }
+        """, excludeFromDocumentation: true),
+        Example("""
+            class S1<T> {
+                class S2 {}
+                func f() {
+                    let s1 = S1<S1.S2>()
+                    let s2 = S1<S1>()
+                }
+            }
         """, excludeFromDocumentation: true)
     ]
 
@@ -184,6 +211,14 @@ enum PreferSelfInStaticReferencesRuleExamples {
                     return f
                 }
                 func g(a: [↓S]) -> [↓S] { a }
+            }
+        """, excludeFromDocumentation: true),
+        Example("""
+            class T {
+                let child: T
+                init(input: Any) {
+                    child = (input as! T).child
+                }
             }
         """, excludeFromDocumentation: true)
     ]


### PR DESCRIPTION
### Description of changes:

The `prefer_self_in_static_references` rule triggers a warning for class `Movie` in the following example:

```Swift
class Movie<Genre> {
    let genre: Genre
    
    init(genre: Genre) {
        self.genre = genre
    }
}

class StarWars: Movie<StarWars.Genre> { // <- triggers a warning
    enum Genre {
        case sciFi
    }
}
```

However, changing `class StarWars: Movie<StarWars.Genre>` to `class StarWars: Movie<Self.Genre>` would throw the following compile time error:

> Covariant 'Self' or 'Self?' can only appear as the type of a property, subscript or method result; did you mean 'StarWars'?
> Replace 'Self' with 'StarWars'

I think the issue is the grand parent syntax isn't used to checked to see if it's a `GenericArgumentSyntax` or not.

Maybe there's a better solution, and I'm open to suggestions, but this one didn't break any tests and is working.