### PR TITLE
Ignore `switch` expressions assigned to variables in `switch_case_alignment` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5075](https://github.com/realm/SwiftLint/issues/5075)
 
+* Ignore `switch` expressions assigned to variables in `switch_case_alignment`
+  rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5080](https://github.com/realm/SwiftLint/issues/5080)
+
 * Fix auto-correction for the `direct_return` rule, when statements have
   trailing comments.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -33,7 +33,13 @@ struct SwitchCaseAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
                 }
               }
             }
-            """, excludeFromDocumentation: true)
+            """, excludeFromDocumentation: true),
+            Example("""
+            let a = switch i {
+                case 1: 1
+                default: 2
+            }
+            """)
         ],
         triggeringExamples: Examples(indentedCases: false).triggeringExamples
     )
@@ -55,6 +61,9 @@ extension SwitchCaseAlignmentRule {
         }
 
         override func visitPost(_ node: SwitchExprSyntax) {
+            if node.parent?.is(InitializerClauseSyntax.self) == true {
+                return
+            }
             let switchPosition = node.switchKeyword.positionAfterSkippingLeadingTrivia
             let switchColumn = locationConverter.location(for: switchPosition).column
             guard node.cases.isNotEmpty,


### PR DESCRIPTION
Fixes #5080 by just ignoring `switch` expressions assigned to variables.

It's clear that not all users would like the same rules that apply to freestanding `switch` expressions to apply to `switch` expression used for initialization as well. For the moment, ignoring them might be sufficient. It's also conceivable to extend the rule's configuration to support another `indented_cases` option for "real" `switch` expressions. Another option would be to enforce the indented style for them without configuration.