### PR TITLE
Document the case-sensitivity of included and excluded parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,9 +506,9 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
 analyzer_rules: # Rules run by `swiftlint analyze`
   - explicit_self
 
-included: # paths to include during linting. `--path` is ignored if present.
+included: # case-sensitive paths to include during linting. `--path` is ignored if present.
   - Source
-excluded: # paths to ignore during linting. Takes precedence over `included`.
+excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - Pods
   - Source/ExcludedFolder

--- a/README.md
+++ b/README.md
@@ -496,24 +496,24 @@ disabled_rules: # rule identifiers turned on by default to exclude from running
   - comma
   - control_statement
 opt_in_rules: # some rules are turned off by default, so you need to opt-in
-  - empty_count # Find all the available rules by running: `swiftlint rules`
+  - empty_count # find all the available rules by running: `swiftlint rules`
 
 # Alternatively, specify all rules explicitly by uncommenting this option:
 # only_rules: # delete `disabled_rules` & `opt_in_rules` if using this
 #   - empty_parameters
 #   - vertical_whitespace
 
-analyzer_rules: # Rules run by `swiftlint analyze`
+analyzer_rules: # rules run by `swiftlint analyze`
   - explicit_self
 
-included: # case-sensitive paths to include during linting. `--path` is ignored if present.
+included: # case-sensitive paths to include during linting. `--path` is ignored if present
   - Source
-excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`.
+excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`
   - Carthage
   - Pods
   - Source/ExcludedFolder
   - Source/ExcludedFile.swift
-  - Source/*/ExcludedFile.swift # Exclude files with a wildcard
+  - Source/*/ExcludedFile.swift # exclude files with a wildcard
 
 # If true, SwiftLint will not fail if no lintable files are found.
 allow_zero_lintable_files: false


### PR DESCRIPTION
Because git is case-insensitive, I was able to rename a folder long ago without having my colleague notice it, and after that, I added some include and exclude rules which didn't apply to him the same way they did for me. So, after an ~1h long debugging, we finally figured out the cause, and I thought of making sure that others notice this earlier.