### PR TITLE
Fix false positives for the private_subject rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5081](https://github.com/realm/SwiftLint/issues/5081)
 
+* Fix false positives for the `private_subject` rule when creating subjects
+  inside initializers.  
+  [kasrababaei](https://github.com/kasrababaei)
+
 ## 0.52.3: Duplicate Hampers
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
@@ -22,7 +22,7 @@ private extension PrivateSubjectRule {
         private let subjectTypes: Set<String> = ["PassthroughSubject", "CurrentValueSubject"]
 
         override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
-            [FunctionDeclSyntax.self, VariableDeclSyntax.self, SubscriptDeclSyntax.self]
+            [FunctionDeclSyntax.self, VariableDeclSyntax.self, SubscriptDeclSyntax.self, InitializerDeclSyntax.self]
         }
 
         override func visitPost(_ node: VariableDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRuleExamples.swift
@@ -102,6 +102,17 @@ internal struct PrivateSubjectRuleExamples {
             """#
         ),
         Example(
+            #"""
+            final class Foobar {
+                private let goodSubject: CurrentValueSubject<Bool, Never>
+                init() {
+                    let goodSubject = CurrentValueSubject<Bool, Never>(true)
+                    self.goosSubject = goodSubject
+                }
+            }
+            """#
+        ),
+        Example(
             """
             func foo() {
                 let goodSubject = PassthroughSubject<Bool, Never>(true)

--- a/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
@@ -42,6 +42,10 @@ open class ViolationsSyntaxVisitor: SyntaxVisitor {
     override open func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         skippableDeclarations.contains { $0 == StructDeclSyntax.self } ? .skipChildren : .visitChildren
     }
+
+    override open func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+        skippableDeclarations.contains { $0 == InitializerDeclSyntax.self } ? .skipChildren : .visitChildren
+    }
 }
 
 public extension Array where Element == DeclSyntaxProtocol.Type {


### PR DESCRIPTION
The `private_subject` rule triggers a warning when creating a subject inside of an initializer. 

Triggering example:
```Swift
class Foo {
    let isEnabled: AnyPublisher<Bool, Never>

    init() {
        let isEnabled = PassthroughSubject<Bool, Never>() // This triggers a warning but it shouldn't
        self.isEnabled = isEnabled.eraseToAnyPublisher()
    }
}
```