### PR TITLE
Improving attributes error message

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -9,7 +9,7 @@ struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
         description: """
             Attributes should be on their own lines in functions and types, but on the same line as variables and \
             imports except when they have properties and attributes_with_arguments_always_on_line_above is true \
-            which is the default.
+            which is the default
             """,
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -52,7 +52,10 @@ private extension AttributesRule {
 
             switch hasViolation {
             case .argumentsAlwaysOnNewLineViolation:
-                let reason = "Attributes with arguments or inside always_on_line_above must be on a new line instead of the same line"
+                let reason = """
+                    Attributes with arguments or inside always_on_line_above must be on a new line \
+                    instead of the same line
+                    """
 
                 violations.append(
                     ReasonedRuleViolation(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -3,12 +3,15 @@ import SwiftSyntax
 struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     var configuration = AttributesConfiguration()
 
+    let attributeWithParametersString = configuration.attributesWithArgumentsAlwaysOnNewLine ?
+        ", variables with attributes " : ""
+
     static let description = RuleDescription(
         identifier: "attributes",
         name: "Attributes",
         description: """
-            Attributes should be on their own lines in functions and types, but on the same line as variables and \
-            imports
+            Attributes should be on their own lines in functions \(attributesWithParametersString)and types, but on\
+            the same line as variables and imports
             """,
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -49,7 +49,7 @@ private extension AttributesRule {
                 attributesAndPlacements: attributesAndPlacements,
                 attributesWithArgumentsAlwaysOnNewLine: configuration.attributesWithArgumentsAlwaysOnNewLine
             )
-            
+
             switch hasViolation {
             case .argumentsAlwaysOnNewLineViolation:
                 let reason = "Attributes with arguments or inside always_on_line_above must be on a new line instead of the same line"

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -3,9 +3,6 @@ import SwiftSyntax
 struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     var configuration = AttributesConfiguration()
 
-    let attributeWithParametersString = configuration.attributesWithArgumentsAlwaysOnNewLine ?
-        "" : ""
-
     static let description = RuleDescription(
         identifier: "attributes",
         name: "Attributes",

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -10,7 +10,7 @@ struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
         identifier: "attributes",
         name: "Attributes",
         description: """
-            Attributes should be on their own lines in functions \(attributesWithParametersString)and types, but on\
+            Attributes should be on their own lines in functions \(attributeWithParametersString)and types, but on\
             the same line as variables and imports
             """,
         kind: .style,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -83,7 +83,7 @@ private extension AttributesRule {
 
                 violations.append(
                     ReasonedRuleViolation(
-                        position: node.funcKeyword.positionAfterSkippingLeadingTrivia,
+                        position: helper.violationPosition,
                         reason: reason,
                         severity: configuration.severityConfiguration.severity
                     )

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -8,8 +8,7 @@ struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
         name: "Attributes",
         description: """
             Attributes should be on their own lines in functions and types, but on the same line as variables and \
-            imports except when they have properties and attributes_with_arguments_always_on_line_above is true \
-            which is the default
+            imports
             """,
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,
@@ -77,6 +76,18 @@ private extension AttributesRule {
             if hasMultipleNewlines {
                 violations.append(helper.violationPosition)
                 return
+            }
+
+            if configuration.attributesWithArgumentsAlwaysOnNewLine {
+                let reason = "Attributes with arguments must be on a new line instead of the same line"
+
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: node.funcKeyword.positionAfterSkippingLeadingTrivia,
+                        reason: reason,
+                        severity: configuration.severityConfiguration.severity
+                    )
+                )
             }
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -4,14 +4,15 @@ struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     var configuration = AttributesConfiguration()
 
     let attributeWithParametersString = configuration.attributesWithArgumentsAlwaysOnNewLine ?
-        ", variables with attributes " : ""
+        "" : ""
 
     static let description = RuleDescription(
         identifier: "attributes",
         name: "Attributes",
         description: """
-            Attributes should be on their own lines in functions \(attributeWithParametersString)and types, but on\
-            the same line as variables and imports
+            Attributes should be on their own lines in functions and types, but on the same line as variables and \
+            imports except when they have properties and attributes_with_arguments_always_on_line_above is true \
+            which is the default.
             """,
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,

--- a/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
@@ -101,7 +101,10 @@ class AttributesRuleTests: SwiftLintTestCase {
             Example("@Environment(\\.presentationMode) private var presentationMode")
         ]
         let triggeringExamples = [
-            Example("@Environment(\\.presentationMode)\nprivate var presentationMode")
+            Example("""
+            @Environment(\\.presentationMode)
+            private ↓var presentationMode
+            """)
         ]
 
         let argumentsAlwaysOnLineDescription = AttributesRule.description
@@ -117,7 +120,7 @@ class AttributesRuleTests: SwiftLintTestCase {
             Example("@Environment(\\.presentationMode)\nprivate var presentationMode")
         ]
         let triggeringExamples = [
-            Example("@Environment(\\.presentationMode) private var presentationMode")
+            Example("@Environment(\\.presentationMode) private ↓var presentationMode")
         ]
 
         let argumentsAlwaysOnLineDescription = AttributesRule.description

--- a/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
@@ -95,4 +95,36 @@ class AttributesRuleTests: SwiftLintTestCase {
                    ruleConfiguration: ["always_on_same_line": ["@discardableResult", "@objc",
                                                                "@IBAction", "@IBDesignable"]])
     }
+    
+    func testAttributesWithArgumentsAlwaysOnLineAboveFalse() {
+        let nonTriggeringExamples = [
+            Example("@Environment(\\.presentationMode) private var presentationMode"),
+        ]
+        let triggeringExamples = [
+            Example("@Environment(\\.presentationMode)\nprivate var presentationMode"),
+        ]
+
+        let argumentsAlwaysOnLineAboveFalseDescription = AttributesRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+        
+        verifyRule(argumentsAlwaysOnLineAboveFalseDescription,
+                   ruleConfiguration: ["attributes_with_arguments_always_on_line_above": false])
+    }
+
+    func testAttributesWithArgumentsAlwaysOnLineAboveTrue() {
+        let nonTriggeringExamples = [
+            Example("@Environment(\\.presentationMode)\nprivate var presentationMode"),
+        ]
+        let triggeringExamples = [
+            Example("@Environment(\\.presentationMode) private var presentationMode"),
+        ]
+
+        let argumentsAlwaysOnLineAboveFalseDescription = AttributesRule.description
+            .with(triggeringExamples: triggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+        
+        verifyRule(argumentsAlwaysOnLineAboveFalseDescription,
+                   ruleConfiguration: ["attributes_with_arguments_always_on_line_above": true])
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
@@ -95,36 +95,36 @@ class AttributesRuleTests: SwiftLintTestCase {
                    ruleConfiguration: ["always_on_same_line": ["@discardableResult", "@objc",
                                                                "@IBAction", "@IBDesignable"]])
     }
-    
+
     func testAttributesWithArgumentsAlwaysOnLineAboveFalse() {
         let nonTriggeringExamples = [
-            Example("@Environment(\\.presentationMode) private var presentationMode"),
+            Example("@Environment(\\.presentationMode) private var presentationMode")
         ]
         let triggeringExamples = [
-            Example("@Environment(\\.presentationMode)\nprivate var presentationMode"),
+            Example("@Environment(\\.presentationMode)\nprivate var presentationMode")
         ]
 
-        let argumentsAlwaysOnLineAboveFalseDescription = AttributesRule.description
+        let argumentsAlwaysOnLineDescription = AttributesRule.description
             .with(triggeringExamples: triggeringExamples)
             .with(nonTriggeringExamples: nonTriggeringExamples)
-        
-        verifyRule(argumentsAlwaysOnLineAboveFalseDescription,
+
+        verifyRule(argumentsAlwaysOnLineDescription,
                    ruleConfiguration: ["attributes_with_arguments_always_on_line_above": false])
     }
 
     func testAttributesWithArgumentsAlwaysOnLineAboveTrue() {
         let nonTriggeringExamples = [
-            Example("@Environment(\\.presentationMode)\nprivate var presentationMode"),
+            Example("@Environment(\\.presentationMode)\nprivate var presentationMode")
         ]
         let triggeringExamples = [
-            Example("@Environment(\\.presentationMode) private var presentationMode"),
+            Example("@Environment(\\.presentationMode) private var presentationMode")
         ]
 
-        let argumentsAlwaysOnLineAboveFalseDescription = AttributesRule.description
+        let argumentsAlwaysOnLineDescription = AttributesRule.description
             .with(triggeringExamples: triggeringExamples)
             .with(nonTriggeringExamples: nonTriggeringExamples)
-        
-        verifyRule(argumentsAlwaysOnLineAboveFalseDescription,
+
+        verifyRule(argumentsAlwaysOnLineDescription,
                    ruleConfiguration: ["attributes_with_arguments_always_on_line_above": true])
     }
 }


### PR DESCRIPTION
The value of attributesWithArgumentsAlwaysOnNewLine is true by default. But the current error is not intuitive enough.

This is an improvement that came from this issue:
https://github.com/realm/SwiftLint/issues/5103