### PR TITLE
Mark rules_xcodeproj as a `dev_dependency`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,11 +4,6 @@ load(
     "swift_binary",
     "swift_library",
 )
-load(
-    "@rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_schemes",
-    "xcodeproj",
-)
 
 # Targets
 
@@ -162,39 +157,6 @@ COPYFILE_DISABLE=1 tar czvfh "$${outs[0]}" \
   *
 shasum -a 256 "$${outs[0]}" > "$${outs[1]}"
     """,
-)
-
-# Xcode Integration
-
-xcodeproj(
-    name = "xcodeproj",
-    project_name = "SwiftLint",
-    schemes = [
-        xcode_schemes.scheme(
-            name = "SwiftLint",
-            launch_action = xcode_schemes.launch_action(
-                "swiftlint",
-                args = [
-                    "--progress",
-                ],
-            ),
-            test_action = xcode_schemes.test_action([
-                "//Tests:CLITests",
-                "//Tests:SwiftLintFrameworkTests",
-                "//Tests:GeneratedTests",
-                "//Tests:IntegrationTests",
-                "//Tests:ExtraRulesTests",
-            ]),
-        ),
-    ],
-    top_level_targets = [
-        "//:swiftlint",
-        "//Tests:CLITests",
-        "//Tests:SwiftLintFrameworkTests",
-        "//Tests:GeneratedTests",
-        "//Tests:IntegrationTests",
-        "//Tests:ExtraRulesTests",
-    ],
 )
 
 # Analyze

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 * Make sure `severity` is configurable for `type_contents_order` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Bazel: mark `rules_xcodeproj` as a dev dependency.  
+  [Thi Doãn](https://github.com/thii)
+  [JP Simard](https://github.com/jpsim)
+  [#4737](https://github.com/realm/SwiftLint/issues/4737)
+
 ## 0.52.4: Lid Switch
 
 #### Breaking

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,6 @@ bazel_dep(name = "bazel_skylib", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "rules_apple", version = "2.4.1", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_swift", version = "1.9.1", repo_name = "build_bazel_rules_swift")
-bazel_dep(name = "rules_xcodeproj", version = "1.7.1")
 bazel_dep(name = "sourcekitten", version = "0.34.1", repo_name = "com_github_jpsim_sourcekitten")
 bazel_dep(name = "swift_argument_parser", version = "1.2.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "yams", version = "5.0.6", repo_name = "sourcekitten_com_github_jpsim_yams")
@@ -25,3 +24,7 @@ use_repo(
 
 extra_rules = use_extension("//bazel:extensions.bzl", "extra_rules")
 use_repo(extra_rules, "swiftlint_extra_rules")
+
+# Dev Dependencies
+
+bazel_dep(name = "rules_xcodeproj", version = "1.7.1", dev_dependency = True)

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,3 +1,45 @@
+load(
+    "@rules_xcodeproj//xcodeproj:defs.bzl",
+    "xcode_schemes",
+    "xcodeproj",
+)
+
+# Xcode Integration
+
+xcodeproj(
+    name = "xcodeproj",
+    install_directory = "",
+    project_name = "SwiftLint",
+    schemes = [
+        xcode_schemes.scheme(
+            name = "SwiftLint",
+            launch_action = xcode_schemes.launch_action(
+                "//:swiftlint",
+                args = [
+                    "--progress",
+                ],
+            ),
+            test_action = xcode_schemes.test_action([
+                "//Tests:CLITests",
+                "//Tests:SwiftLintFrameworkTests",
+                "//Tests:GeneratedTests",
+                "//Tests:IntegrationTests",
+                "//Tests:ExtraRulesTests",
+            ]),
+        ),
+    ],
+    top_level_targets = [
+        "//:swiftlint",
+        "//Tests:CLITests",
+        "//Tests:SwiftLintFrameworkTests",
+        "//Tests:GeneratedTests",
+        "//Tests:IntegrationTests",
+        "//Tests:ExtraRulesTests",
+    ],
+)
+
+# Release Files
+
 filegroup(
     name = "release_files",
     srcs = glob(["*"]),


### PR DESCRIPTION
To do this, the `xcodeproj` definition needs to move out of the main `BUILD` file, so it's now moved to `bazel/BUILD`.

The command to generate the Bazel Xcode project is now

```
bazel run //bazel:xcodeproj
```