### PR TITLE
Ignore initializers of computed properties in `prefer_self_in_static_references` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 #### Bug Fixes
 
+* Fix bug in `prefer_self_in_static_references` rule that triggered on
+  initializers of computed properties in classes when the property had an
+  accessor block.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5118](https://github.com/realm/SwiftLint/issues/5118)
+
 * Document `exclude_ranges` option for `number_separator` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -72,6 +72,13 @@ private class Visitor: ViolationsSyntaxVisitor {
         parentDeclScopes.pop()
     }
 
+    override func visit(_ node: AttributeSyntax) -> SyntaxVisitorContinueKind {
+        if case .skipReferences = variableDeclScopes.peek() {
+            return .skipChildren
+        }
+        return .visitChildren
+    }
+
     override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         parentDeclScopes.push(.likeClass(name: node.identifier.text))
         return .visitChildren
@@ -125,6 +132,13 @@ private class Visitor: ViolationsSyntaxVisitor {
             return
         }
         addViolation(on: node.identifier)
+    }
+
+    override func visit(_ node: InitializerClauseSyntax) -> SyntaxVisitorContinueKind {
+        if case .skipReferences = variableDeclScopes.peek() {
+            return .skipChildren
+        }
+        return .visitChildren
     }
 
     override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
@@ -218,17 +232,6 @@ private class Visitor: ViolationsSyntaxVisitor {
             {
                 return .visitChildren
             }
-        }
-        return .skipChildren
-    }
-
-    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-        if node.bindings.onlyElement?.accessor != nil {
-            // Variable declaration is a computed property.
-            return .visitChildren
-        }
-        if case .handleReferences = variableDeclScopes.peek() {
-            return .visitChildren
         }
         return .skipChildren
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -28,7 +28,8 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 static private(set) var i = 0, j = C.i
                 static let k = { C.i }()
                 let h = C.i
-                @GreaterThan(C.j) var k: Int
+                var n: Int = C.k { didSet { m += 1 } }
+                @GreaterThan(C.j) var m: Int
             }
         """, excludeFromDocumentation: true),
         Example("""


### PR DESCRIPTION
Fixes #5118.