### PR TITLE
Vertical whitespace between functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   is involved.  
   [chrisngabp](https://github.com/chrisngabp)
   [5103](https://github.com/realm/SwiftLint/issues/5103)
+* Add `max_empty_lines_between_functions` configuration option to
+  `vertical_whitespace` rule. With the option set, the rule will use this value
+  instead of `max_empty_lines` for empty lines adjacent to functions.  
+  [bunnyhero](https://github.com/bunnyhero)
+  [#2526](https://github.com/realm/SwiftLint/issues/2526)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -7,6 +7,8 @@ struct VerticalWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatabl
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "max_empty_lines")
     private(set) var maxEmptyLines = 1
+    @ConfigurationElement(key: "max_empty_lines_between_functions")
+    private(set) var maxEmptyLinesBetweenFunctions = 1
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
@@ -15,6 +17,12 @@ struct VerticalWhitespaceConfiguration: SeverityBasedRuleConfiguration, Equatabl
 
         if let maxEmptyLines = configuration[$maxEmptyLines] as? Int {
             self.maxEmptyLines = maxEmptyLines
+        }
+
+        if let maxEmptyLinesBetweenFunctions = configuration[$maxEmptyLinesBetweenFunctions] as? Int {
+            self.maxEmptyLinesBetweenFunctions = maxEmptyLinesBetweenFunctions
+        } else {
+            maxEmptyLinesBetweenFunctions = maxEmptyLines
         }
 
         if let severityString = configuration[$severityConfiguration] as? String {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
@@ -47,7 +47,7 @@ struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
                 ruleDescription: Self.description,
                 severity: configuration.severityConfiguration.severity,
                 location: Location(file: file.path, line: eachLineSection.lastLine.index),
-                reason: configuredDescriptionReason + "; currently \(eachLineSection.linesToRemove + 1) adj test: \(eachLineSection.isFunctionAdjacent)"
+                reason: configuredDescriptionReason + "; currently \(eachLineSection.linesToRemove + 1)"
             )
         }
     }
@@ -120,7 +120,9 @@ struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
         return blankLinesSections
     }
 
-    private func findFunctionLineExtents(in file: SwiftLintFile, dictionary: SourceKittenDictionary) -> [ClosedRange<Int>] {
+    private func findFunctionLineExtents(
+        in file: SwiftLintFile, dictionary: SourceKittenDictionary
+    ) -> [ClosedRange<Int>] {
         let substructureExtents = dictionary.substructure.flatMap {
             findFunctionLineExtents(in: file, dictionary: $0)
         }
@@ -151,8 +153,7 @@ struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
             return false
         }
         return functionLineExtents.first(where: {
-            lastBlankLineIndex == $0.lowerBound - 1 ||
-            firstBlankLineIndex - 1 == $0.upperBound + 1
+            lastBlankLineIndex == $0.lowerBound - 1 || firstBlankLineIndex - 1 == $0.upperBound + 1
         }) != nil
     }
 
@@ -163,7 +164,8 @@ struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
         var indexOfLinesToDelete = [Int]()
 
         for section in linesSections {
-            let linesToRemove = section.linesToRemove - configuration.maxEmptyLines(isFunctionAdjacent: section.isFunctionAdjacent) + 1
+            let linesToRemove =
+                section.linesToRemove - configuration.maxEmptyLines(isFunctionAdjacent: section.isFunctionAdjacent) + 1
             let start = section.lastLine.index - linesToRemove
             indexOfLinesToDelete.append(contentsOf: start..<section.lastLine.index)
         }
@@ -198,7 +200,6 @@ struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
         return []
     }
 }
-
 
 private extension VerticalWhitespaceConfiguration {
     func maxEmptyLines(isFunctionAdjacent: Bool) -> Int {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
@@ -152,9 +152,9 @@ struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
         else {
             return false
         }
-        return functionLineExtents.first(where: {
+        return functionLineExtents.contains(where: {
             lastBlankLineIndex == $0.lowerBound - 1 || firstBlankLineIndex - 1 == $0.upperBound + 1
-        }) != nil
+        })
     }
 
     func correct(file: SwiftLintFile) -> [Correction] {

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -73,7 +73,8 @@ class VerticalWhitespaceRuleTests: SwiftLintTestCase {
             .with(triggeringExamples: [])
             .with(corrections: [
                 Example("let b = 0\n\n↓\n↓\n↓\n\nfunc aaa() {}\n"): Example("let b = 0\n\n\nfunc aaa() {}\n"),
-                Example("let b = 0\n\n\nfunc aaa() {}\n"): Example("let b = 0\n\n\nfunc aaa() {}\n")
+                Example("let b = 0\n\n\nfunc aaa() {}\n"): Example("let b = 0\n\n\nfunc aaa() {}\n"),
+                Example("let b = 0\n↓\n↓\n↓\n\nclass AAA {}\n"): Example("let b = 0\n\nclass AAA {}\n")
             ])
 
         verifyRule(maxEmptyLinesBetweenFunctionsDescription,

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -66,4 +66,17 @@ class VerticalWhitespaceRuleTests: SwiftLintTestCase {
         verifyRule(maxEmptyLinesBetweenFunctionsDescription,
                    ruleConfiguration: ["max_empty_lines_between_functions": 2])
     }
+
+    func testAutoCorrectionWithMaxEmptyLinesBetweenFunctions() {
+        let maxEmptyLinesBetweenFunctionsDescription = VerticalWhitespaceRule.description
+            .with(nonTriggeringExamples: [])
+            .with(triggeringExamples: [])
+            .with(corrections: [
+                Example("let b = 0\n\n↓\n↓\n↓\n\nfunc aaa() {}\n"): Example("let b = 0\n\n\nfunc aaa() {}\n"),
+                Example("let b = 0\n\n\nfunc aaa() {}\n"): Example("let b = 0\n\n\nfunc aaa() {}\n")
+            ])
+
+        verifyRule(maxEmptyLinesBetweenFunctionsDescription,
+                   ruleConfiguration: ["max_empty_lines_between_functions": 2])
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -79,4 +79,22 @@ class VerticalWhitespaceRuleTests: SwiftLintTestCase {
         verifyRule(maxEmptyLinesBetweenFunctionsDescription,
                    ruleConfiguration: ["max_empty_lines_between_functions": 2])
     }
+
+    func testViolationMessageWithMaxEmptyLinesBetweenFunctions() {
+        guard let config = makeConfig(["max_empty_lines_between_functions": 2], ruleID) else {
+            XCTFail("Failed to create configuration")
+            return
+        }
+        let allViolations = violations(Example("func aaaa() {}\n\n\n\nlet bbb = 2\n"), config: config)
+
+        let verticalWhiteSpaceViolation = allViolations.first { $0.ruleIdentifier == ruleID }
+        if let violation = verticalWhiteSpaceViolation {
+            XCTAssertEqual(
+                violation.reason,
+                "Limit vertical whitespace between functions to maximum 2 empty lines; currently 3"
+            )
+        } else {
+            XCTFail("A vertical whitespace violation should have been triggered!")
+        }
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -52,4 +52,18 @@ class VerticalWhitespaceRuleTests: SwiftLintTestCase {
             XCTFail("A vertical whitespace violation should have been triggered!")
         }
     }
+
+    func testAttributesWithMaxEmptyLinesBetweenFunctions() {
+        // Test with custom `max_empty_lines_between_functions`
+        let maxEmptyLinesBetweenFunctionsDescription = VerticalWhitespaceRule.description
+            .with(nonTriggeringExamples: [Example("let aaaa = 0\n\n\nfunc bbb() {\n}")])
+            .with(triggeringExamples: [
+                Example("func aaa() {\n}\n\n\n\nstruct BBBB {}"),
+                Example("let aaaa = 0\n\n\n")
+            ])
+            .with(corrections: [:])
+
+        verifyRule(maxEmptyLinesBetweenFunctionsDescription,
+                   ruleConfiguration: ["max_empty_lines_between_functions": 2])
+    }
 }


### PR DESCRIPTION
As requested in https://github.com/realm/SwiftLint/issues/2526, adds a configuration option to `vertical_whitespace` rule that allows specifying a separate value for the maximum number of empty lines between functions.

Notes:

- The new option is named `max_empty_lines_between_functions`. If the option is absent, then its value defaults to the value of `max_empty_lines`. I was uncertain of the best way to handle this, and if there's a simple way to note how this works in the generated documentation.
- I use a linear search to detect whether a section of empty lines is adjacent to a function. Obviously this isn't very efficient. I haven't benchmarked this however.
