### PR TITLE
Rules.Idomatic: update switch for new `macro` enumerator

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitACLRule.swift
@@ -184,7 +184,8 @@ private extension SwiftDeclarationKind {
              .varGlobal, .varInstance, .varStatic, .typealias, .functionAccessorModify, .functionAccessorRead,
              .functionConstructor, .functionDestructor, .functionFree, .functionMethodClass,
              .functionMethodInstance, .functionMethodStatic, .functionOperator, .functionOperatorInfix,
-             .functionOperatorPostfix, .functionOperatorPrefix, .functionSubscript, .protocol, .opaqueType:
+             .functionOperatorPostfix, .functionOperatorPrefix, .functionSubscript, .protocol, .opaqueType,
+             .macro:
             return true
         case .actor, .class, .enum, .extension, .extensionClass, .extensionEnum,
              .extensionProtocol, .extensionStruct, .struct:


### PR DESCRIPTION
The introduction of the `macro` enumerator in the enumeration causes a build break due to an uncovered switch.  Conservatively treat the macros as being exempt from the ACLing.