### PR TITLE
Add no_default_switch_in_operators rule

### DIFF
--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -125,6 +125,7 @@ public let builtInRules: [Rule.Type] = [
     NSObjectPreferIsEqualRule.self,
     NestingRule.self,
     NimbleOperatorRule.self,
+    NoDefaultSwitchInOperatorsRule.self,
     NoExtensionAccessModifierRule.self,
     NoFallthroughOnlyRule.self,
     NoGroupingExtensionRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NoDefaultSwitchInOperatorsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NoDefaultSwitchInOperatorsRule.swift
@@ -1,0 +1,47 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+struct NoDefaultSwitchInOperatorsRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "no_default_switch_in_operators",
+        name: "Don't use 'default' in operators",
+        description: "Don't use default in operator definitions to avoid the risk of forgetting to add new cases",
+        kind: .lint,
+        nonTriggeringExamples: NoDefaultSwitchInOperatorsRuleExamples.nonTriggeringExamples,
+        triggeringExamples: NoDefaultSwitchInOperatorsRuleExamples.triggeringExamples
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(viewMode: .sourceAccurate)
+    }
+}
+
+private final class Visitor: ViolationsSyntaxVisitor {
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        guard case .binaryOperator = node.identifier.tokenKind else {
+            return
+        }
+
+        let defaultCaseVisitor = HasDefaultCaseVisitor()
+        defaultCaseVisitor.walk(node)
+        for location in defaultCaseVisitor.defaultCaseLocations {
+            self.violations.append(location)
+        }
+    }
+}
+
+private final class HasDefaultCaseVisitor: SyntaxVisitor {
+    var defaultCaseLocations: [AbsolutePosition] = []
+
+    init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visitPost(_ node: SwitchCaseSyntax) {
+        if node.unknownAttr == nil && node.label.as(SwitchDefaultLabelSyntax.self) != nil {
+            defaultCaseLocations.append(node.positionAfterSkippingLeadingTrivia)
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NoDefaultSwitchInOperatorsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NoDefaultSwitchInOperatorsRuleExamples.swift
@@ -1,0 +1,56 @@
+struct NoDefaultSwitchInOperatorsRuleExamples {
+    static let nonTriggeringExamples = [
+        Example("""
+func foo() {}
+"""),
+        Example("""
+func foo(lhs: Bar, rhs: Bar) -> Bool {
+    return lhs == rhs
+}
+"""),
+
+        Example("""
+func ==(lhs: Bar, rhs: Bar) -> Bool {
+    switch (lhs, rhs) {
+    case (.baz, .baz):
+        return true
+    case (.baz, _), (.qux, _):
+        return false
+    }
+}
+"""),
+        Example("""
+func ==(lhs: Bar, rhs: Bar) -> Bool {
+    switch (lhs, rhs) {
+    case (.baz, .baz):
+        return true
+    @unknown default:
+        return false
+    }
+}
+""")
+    ]
+
+    static let triggeringExamples = [
+        Example("""
+func ==(lhs: Bar, rhs: Bar) -> Bool {
+    switch (lhs, rhs) {
+    case (.baz, .baz):
+        return true
+    default:
+        return false
+    }
+}
+"""),
+        Example("""
+func >(lhs: Bar, rhs: Bar) -> Bool {
+    switch (lhs, rhs) {
+    case (.baz, .baz):
+        return true
+    default:
+        return false
+    }
+}
+""")
+    ]
+}

--- a/Source/SwiftLintCore/Models/Location.swift
+++ b/Source/SwiftLintCore/Models/Location.swift
@@ -98,7 +98,7 @@ private extension Optional where Wrapped: Comparable {
             return lhs < rhs
         case (nil, _?):
             return true
-        default:
+        case (_, _):
             return false
         }
     }

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -740,6 +740,12 @@ class NimbleOperatorRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class NoDefaultSwitchInOperatorsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NoDefaultSwitchInOperatorsRule.description)
+    }
+}
+
 class NoExtensionAccessModifierRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NoExtensionAccessModifierRule.description)


### PR DESCRIPTION
This rule validates that `default` is not used in switch cases in
operator definitions. This could be expanded to do more than operator
definitions but operators feel a bit special in that forgetting to add
your case to them as you add new cases probably leads to more subtle
bugs than other areas.
