### PR TITLE
Ignore `no_magic_numbers` violations if they are in an extension of a test class (only works in the same file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4876](https://github.com/realm/SwiftLint/issues/4876)
 
+* The `no_magic_numbers` rule will not trigger for violations in an
+  extension, if the extended class inherits from one of the specified
+  `test_parent_classes`, as long as the class declaration and the
+  extension are in the same source file.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5137](https://github.com/realm/SwiftLint/issues/5137)
+
 ## 0.52.4: Lid Switch
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -9,80 +9,80 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
         description: "Magic numbers should be replaced by named constants",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            Example("var foo = 123"),
-            Example("static let bar: Double = 0.123"),
-            Example("let a = b + 1.0"),
-            Example("array[0] + array[1] "),
-            Example("let foo = 1_000.000_01"),
-            Example("// array[1337]"),
-            Example("baz(\"9999\")"),
-            Example("""
+            "var foo = 123",
+            "static let bar: Double = 0.123",
+            "let a = b + 1.0",
+            "array[0] + array[1] ",
+            "let foo = 1_000.000_01",
+            "// array[1337]",
+            "baz(\"9999\")",
+            """
             func foo() {
                 let x: Int = 2
                 let y = 3
                 let vector = [x, y, -1]
             }
-            """),
-            Example("""
+            """,
+            """
             class A {
                 var foo: Double = 132
                 static let bar: Double = 0.98
             }
-            """),
-            Example("""
+            """,
+            """
             @available(iOS 13, *)
             func version() {
                 if #available(iOS 13, OSX 10.10, *) {
                     return
                 }
             }
-            """),
-            Example("""
+            """,
+            """
             enum Example: Int {
                 case positive = 2
                 case negative = -2
             }
-            """),
-            Example("""
+            """,
+            """
             class FooTests: XCTestCase {
                 let array: [Int] = []
                 let bar = array[42]
             }
-            """),
-            Example("""
+            """,
+            """
             class FooTests: XCTestCase {
                 class Bar {
                     let array: [Int] = []
                     let bar = array[42]
                 }
             }
-            """),
-            Example("""
+            """,
+            """
             class MyTest: XCTestCase {}
             extension MyTest {
                 let a = Int(3)
             }
-            """),
-            Example("""
+            """,
+            """
             extension MyTest {
                 let a = Int(3)
             }
             class MyTest: XCTestCase {}
-            """)
+            """,
         ],
         triggeringExamples: [
-            Example("foo(↓321)"),
-            Example("bar(↓1_000.005_01)"),
-            Example("array[↓42]"),
-            Example("let box = array[↓12 + ↓14]"),
-            Example("let a = b + ↓2.0"),
-            Example("Color.primary.opacity(isAnimate ? ↓0.1 : ↓1.5)"),
-            Example("""
+            "foo(↓321)",
+            "bar(↓1_000.005_01)",
+            "array[↓42]",
+            "let box = array[↓12 + ↓14]",
+            "let a = b + ↓2.0",
+            "Color.primary.opacity(isAnimate ? ↓0.1 : ↓1.5)",
+            """
                     class MyTest: XCTestCase {}
                     extension NSObject {
                         let a = Int(↓3)
                     }
-            """)
+            """,
         ]
     )
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -172,7 +172,8 @@ private extension NoMagicNumbersRule {
             guard let possibleViolationsForClass = possibleViolations[className] else {
                 return
             }
-            violations.removeAll { possibleViolationsForClass.contains($0) }
+            let violationsToRemove = Set(possibleViolationsForClass)
+            violations.removeAll { violationsToRemove.contains($0) }
             possibleViolations[className] = nil
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -133,13 +133,13 @@ private extension NoMagicNumbersRule {
             guard !node.isMemberOfATestClass(testParentClasses) else {
                 return
             }
-            if let extendedClassName = node.extendedClassName() {
-                if testClasses.contains(extendedClassName) == false {
+            if let extendedTypeName = node.extendedTypeName() {
+                if testClasses.contains(extendedTypeName) == false {
                     violations.append(violation)
-                    if nonTestClasses.contains(extendedClassName) == false {
-                        var possibleViolationsForClass = possibleViolations[extendedClassName] ?? []
+                    if nonTestClasses.contains(extendedTypeName) == false {
+                        var possibleViolationsForClass = possibleViolations[extendedTypeName] ?? []
                         possibleViolationsForClass.insert(violation)
-                        possibleViolations[extendedClassName] = possibleViolationsForClass
+                        possibleViolations[extendedTypeName] = possibleViolationsForClass
                     }
                 }
             } else {
@@ -188,7 +188,7 @@ private extension ExprSyntaxProtocol {
         return false
     }
 
-    func extendedClassName() -> String? {
+    func extendedTypeName() -> String? {
         var parent = parent
         while parent != nil {
             if let extensionDecl = parent?.as(ExtensionDeclSyntax.self) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -88,11 +88,11 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
             Example("let a = b + ↓2.0"),
             Example("Color.primary.opacity(isAnimate ? ↓0.1 : ↓1.5)"),
             Example("""
-            extension AVAsset {
-                enum VideoOrientation {
+            extension Foo {
+                enum Orientation {
                     case right, up, left, down
 
-                    static func fromVideoWithAngle(ofDegree degree: CGFloat) -> VideoOrientation? {
+                    static func fromAngle(ofDegree degree: CGFloat) -> Orientation? {
                         switch Int(degree) {
                         case 0: return .right
                         case ↓90: return .up
@@ -128,7 +128,7 @@ private extension NoMagicNumbersRule {
             let className = node.identifier.text
             if node.isXCTestCase(testParentClasses) {
                 testClasses.insert(className)
-                processPossibleViolations(forClassName: className)
+                removeViolations(forClassName: className)
             } else {
                 nonTestClasses.insert(className)
             }
@@ -154,13 +154,13 @@ private extension NoMagicNumbersRule {
             guard !node.isMemberOfATestClass(testParentClasses) else {
                 return
             }
-            if let extendedTypeName = node.extendedClassname() {
-                if testClasses.contains(extendedTypeName) == false {
+            if let extendedClassName = node.extendedClassName() {
+                if testClasses.contains(extendedClassName) == false {
                     violations.append(violation)
-                    if nonTestClasses.contains(extendedTypeName) == false {
-                        var possibleViolationsForClass = possibleViolations[extendedTypeName] ?? []
+                    if nonTestClasses.contains(extendedClassName) == false {
+                        var possibleViolationsForClass = possibleViolations[extendedClassName] ?? []
                         possibleViolationsForClass.append(violation)
-                        possibleViolations[extendedTypeName] = possibleViolationsForClass
+                        possibleViolations[extendedClassName] = possibleViolationsForClass
                     }
                 }
             } else {
@@ -168,13 +168,11 @@ private extension NoMagicNumbersRule {
             }
         }
 
-        private func processPossibleViolations(forClassName className: String) {
+        private func removeViolations(forClassName className: String) {
             guard let possibleViolationsForClass = possibleViolations[className] else {
                 return
             }
-            if testClasses.contains(className) {
-                violations.removeAll { possibleViolationsForClass.contains($0) }
-            }
+            violations.removeAll { possibleViolationsForClass.contains($0) }
             possibleViolations[className] = nil
         }
     }
@@ -211,7 +209,7 @@ private extension ExprSyntaxProtocol {
         return false
     }
 
-    func extendedClassname() -> String? {
+    func extendedClassName() -> String? {
         var parent = parent
         while parent != nil {
             if let extensionDecl = parent?.as(ExtensionDeclSyntax.self) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -68,7 +68,7 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
                 let a = Int(3)
             }
             class MyTest: XCTestCase {}
-            """),
+            """)
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -82,7 +82,7 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
                     extension NSObject {
                         let a = Int(↓3)
                     }
-            """),
+            """)
         ]
     )
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -9,80 +9,80 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
         description: "Magic numbers should be replaced by named constants",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            "var foo = 123",
-            "static let bar: Double = 0.123",
-            "let a = b + 1.0",
-            "array[0] + array[1] ",
-            "let foo = 1_000.000_01",
-            "// array[1337]",
-            "baz(\"9999\")",
-            """
+            Example("var foo = 123"),
+            Example("static let bar: Double = 0.123"),
+            Example("let a = b + 1.0"),
+            Example("array[0] + array[1] "),
+            Example("let foo = 1_000.000_01"),
+            Example("// array[1337]"),
+            Example("baz(\"9999\")"),
+            Example("""
             func foo() {
                 let x: Int = 2
                 let y = 3
                 let vector = [x, y, -1]
             }
-            """,
-            """
+            """),
+            Example("""
             class A {
                 var foo: Double = 132
                 static let bar: Double = 0.98
             }
-            """,
-            """
+            """),
+            Example("""
             @available(iOS 13, *)
             func version() {
                 if #available(iOS 13, OSX 10.10, *) {
                     return
                 }
             }
-            """,
-            """
+            """),
+            Example("""
             enum Example: Int {
                 case positive = 2
                 case negative = -2
             }
-            """,
-            """
+            """),
+            Example("""
             class FooTests: XCTestCase {
                 let array: [Int] = []
                 let bar = array[42]
             }
-            """,
-            """
+            """),
+            Example("""
             class FooTests: XCTestCase {
                 class Bar {
                     let array: [Int] = []
                     let bar = array[42]
                 }
             }
-            """,
-            """
+            """),
+            Example("""
             class MyTest: XCTestCase {}
             extension MyTest {
                 let a = Int(3)
             }
-            """,
-            """
+            """),
+            Example("""
             extension MyTest {
                 let a = Int(3)
             }
             class MyTest: XCTestCase {}
-            """,
+            """)
         ],
         triggeringExamples: [
-            "foo(↓321)",
-            "bar(↓1_000.005_01)",
-            "array[↓42]",
-            "let box = array[↓12 + ↓14]",
-            "let a = b + ↓2.0",
-            "Color.primary.opacity(isAnimate ? ↓0.1 : ↓1.5)",
-            """
+            Example("foo(↓321)"),
+            Example("bar(↓1_000.005_01)"),
+            Example("array[↓42]"),
+            Example("let box = array[↓12 + ↓14]"),
+            Example("let a = b + ↓2.0"),
+            Example("Color.primary.opacity(isAnimate ? ↓0.1 : ↓1.5)"),
+            Example("""
                     class MyTest: XCTestCase {}
                     extension NSObject {
                         let a = Int(↓3)
                     }
-            """,
+            """)
         ]
     )
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -58,27 +58,17 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
             }
             """),
             Example("""
-            class FooTests: XCTestCase {
-                let baz: [Int] = Array(repeating: 0, count: 10)
-            }
-
-            extension FooTests {
-                class Bar {
-                   let baz: [Int] = Array(repeating: 0, count: 10)
-                }
+            class MyTest: XCTestCase {}
+            extension MyTest {
+                let a = Int(3)
             }
             """),
             Example("""
-            extension FooTests {
-                class Bar {
-                   let baz: [Int] = Array(repeating: 0, count: 10)
-                }
+            extension MyTest {
+                let a = Int(3)
             }
-
-            class FooTests: XCTestCase {
-                let baz: [Int] = Array(repeating: 0, count: 10)
-            }
-            """)
+            class MyTest: XCTestCase {}
+            """),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -88,22 +78,11 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
             Example("let a = b + ↓2.0"),
             Example("Color.primary.opacity(isAnimate ? ↓0.1 : ↓1.5)"),
             Example("""
-            extension Foo {
-                enum Orientation {
-                    case right, up, left, down
-
-                    static func fromAngle(ofDegree degree: CGFloat) -> Orientation? {
-                        switch Int(degree) {
-                        case 0: return .right
-                        case ↓90: return .up
-                        case ↓180: return .left
-                        case -↓90: return .down
-                        default: return nil
-                        }
+                    class MyTest: XCTestCase {}
+                    extension NSObject {
+                        let a = Int(↓3)
                     }
-                }
-            }
-            """)
+            """),
         ]
     )
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -96,7 +96,7 @@ private extension NoMagicNumbersRule {
         private let testParentClasses: Set<String>
         private var testClasses: Set<String> = []
         private var nonTestClasses: Set<String> = []
-        private var possibleViolations: [String: Set<ReasonedRuleViolation>] = [:]
+        private var possibleViolations: [String: Set<AbsolutePosition>] = [:]
 
         init(viewMode: SyntaxTreeViewMode, testParentClasses: Set<String>) {
             self.testParentClasses = testParentClasses
@@ -145,9 +145,10 @@ private extension NoMagicNumbersRule {
         }
 
         private func removeViolations(forClassName className: String) {
-            guard let violationsToRemove = possibleViolations[className] else {
+            guard let possibleViolationsForClass = possibleViolations[className] else {
                 return
             }
+            let violationsToRemove = Set(possibleViolationsForClass.map { ReasonedRuleViolation(position: $0) })
             violations.removeAll { violationsToRemove.contains($0) }
             possibleViolations.removeValue(forKey: className)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -136,9 +136,7 @@ private extension NoMagicNumbersRule {
                 if testClasses.contains(extendedTypeName) == false {
                     violations.append(violation)
                     if nonTestClasses.contains(extendedTypeName) == false {
-                        var possibleViolationsForClass = possibleViolations[extendedTypeName] ?? []
-                        possibleViolationsForClass.insert(violation)
-                        possibleViolations[extendedTypeName] = possibleViolationsForClass
+                        possibleViolations[extendedTypeName, default: []].insert(violation)
                     }
                 }
             } else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -96,7 +96,7 @@ private extension NoMagicNumbersRule {
         private let testParentClasses: Set<String>
         private var testClasses: Set<String> = []
         private var nonTestClasses: Set<String> = []
-        private var possibleViolations: [String: [ReasonedRuleViolation]] = [:]
+        private var possibleViolations: [String: Set<ReasonedRuleViolation>] = [:]
 
         init(viewMode: SyntaxTreeViewMode, testParentClasses: Set<String>) {
             self.testParentClasses = testParentClasses
@@ -138,7 +138,7 @@ private extension NoMagicNumbersRule {
                     violations.append(violation)
                     if nonTestClasses.contains(extendedClassName) == false {
                         var possibleViolationsForClass = possibleViolations[extendedClassName] ?? []
-                        possibleViolationsForClass.append(violation)
+                        possibleViolationsForClass.insert(violation)
                         possibleViolations[extendedClassName] = possibleViolationsForClass
                     }
                 }
@@ -148,12 +148,11 @@ private extension NoMagicNumbersRule {
         }
 
         private func removeViolations(forClassName className: String) {
-            guard let possibleViolationsForClass = possibleViolations[className] else {
+            guard let violationsToRemove = possibleViolations[className] else {
                 return
             }
-            let violationsToRemove = Set(possibleViolationsForClass)
             violations.removeAll { violationsToRemove.contains($0) }
-            possibleViolations[className] = nil
+            possibleViolations.removeValue(forKey: className)
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -133,9 +133,9 @@ private extension NoMagicNumbersRule {
             }
             let violation = node.positionAfterSkippingLeadingTrivia
             if let extendedTypeName = node.extendedTypeName() {
-                if testClasses.contains(extendedTypeName) == false {
+                if !testClasses.contains(extendedTypeName) {
                     violations.append(violation)
-                    if nonTestClasses.contains(extendedTypeName) == false {
+                    if !nonTestClasses.contains(extendedTypeName) {
                         possibleViolations[extendedTypeName, default: []].insert(violation)
                     }
                 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -67,7 +67,7 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
                    let baz: [Int] = Array(repeating: 0, count: 10)
                 }
             }
-            """).focused(),
+            """),
             Example("""
             extension FooTests {
                 class Bar {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -117,22 +117,21 @@ private extension NoMagicNumbersRule {
             guard node.floatingDigits.isMagicNumber else {
                 return
             }
-            let violation = node.floatingDigits.positionAfterSkippingLeadingTrivia
-            process(violation: violation, forNode: node)
+            collectViolation(forNode: node)
         }
 
         override func visitPost(_ node: IntegerLiteralExprSyntax) {
             guard node.digits.isMagicNumber else {
                 return
             }
-            let violation = node.digits.positionAfterSkippingLeadingTrivia
-            process(violation: violation, forNode: node)
+            collectViolation(forNode: node)
         }
 
-        private func process(violation: AbsolutePosition, forNode node: ExprSyntaxProtocol) {
-            guard !node.isMemberOfATestClass(testParentClasses) else {
+        private func collectViolation(forNode node: ExprSyntaxProtocol) {
+            if node.isMemberOfATestClass(testParentClasses) {
                 return
             }
+            let violation = node.positionAfterSkippingLeadingTrivia
             if let extendedTypeName = node.extendedTypeName() {
                 if testClasses.contains(extendedTypeName) == false {
                     violations.append(violation)

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
@@ -138,4 +138,3 @@ public extension Set where Element == ReasonedRuleViolation {
         insert(ReasonedRuleViolation(position: position))
     }
 }
-

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
@@ -86,7 +86,7 @@ public extension SwiftSyntaxRule {
 }
 
 /// A violation produced by `ViolationsSyntaxVisitor`s.
-public struct ReasonedRuleViolation: Comparable {
+public struct ReasonedRuleViolation: Comparable, Hashable {
     /// The violation's position.
     public let position: AbsolutePosition
     /// A specific reason for the violation.

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
@@ -127,14 +127,3 @@ public extension Array where Element == ReasonedRuleViolation {
         append(contentsOf: positions.map { ReasonedRuleViolation(position: $0) })
     }
 }
-
-/// Extension for sets of `ReasonedRuleViolation`s that provides the automatic conversion of
-/// `AbsolutePosition`s into `ReasonedRuleViolation`s (without a specific reason).
-public extension Set where Element == ReasonedRuleViolation {
-    /// Insert a minimal violation for the specified position.
-    ///
-    /// - parameter position: The position for the violation to be inserted.
-    mutating func insert(_ position: AbsolutePosition) {
-        insert(ReasonedRuleViolation(position: position))
-    }
-}

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
@@ -127,3 +127,15 @@ public extension Array where Element == ReasonedRuleViolation {
         append(contentsOf: positions.map { ReasonedRuleViolation(position: $0) })
     }
 }
+
+/// Extension for sets of `ReasonedRuleViolation`s that provides the automatic conversion of
+/// `AbsolutePosition`s into `ReasonedRuleViolation`s (without a specific reason).
+public extension Set where Element == ReasonedRuleViolation {
+    /// Insert a minimal violation for the specified position.
+    ///
+    /// - parameter position: The position for the violation to be inserted.
+    mutating func insert(_ position: AbsolutePosition) {
+        insert(ReasonedRuleViolation(position: position))
+    }
+}
+


### PR DESCRIPTION
Ignores violations if they are present in an extension, if that extension extends a child of the specified `testParentClasses`, as long as the class declaration is in the same source file.

Partially resolves #5137

This was harder that I thought, and also more useful than expected, given the number of violations this (apparently correctly) fixes in the OSS tests.

We now keep track of class declarations, and whether they inherit from `testParentClasses` or not.

When we see a violation in an extension, unless we already know that it extends a test class, we add it to the violations.

If later in the file, we see the class declaration, and it extends one of the `testParentClasses`, we remove the violations from the list.

This should work no matter where in the file the class declaration occurs.
