### PR TITLE
Disable Violation Test Inline Error Highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,6 @@
   [keith](https://github.com/keith)
   [5139](https://github.com/realm/SwiftLint/pull/5139)
 
-* Tests now highlight disable and superfluous failures inline in example code  
-  [mredig](https://github.com/mredig)
-  [5149](https://github.com/realm/SwiftLint/pull/5149)
-
 #### Bug Fixes
 
 * Fix false positive in `control_statement` rule that triggered on conditions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
   [keith](https://github.com/keith)
   [5139](https://github.com/realm/SwiftLint/pull/5139)
 
+* Tests now highlight disable and superfluous failures inline in example code  
+  [mredig](https://github.com/mredig)
+  [5149](https://github.com/realm/SwiftLint/pull/5149)
+
 #### Bug Fixes
 
 * Fix false positive in `control_statement` rule that triggered on conditions

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -414,21 +414,23 @@ public extension XCTestCase {
 
         // Disabled rule doesn't violate and disable command isn't superfluous
         for command in disableCommands {
-			let disabledTriggers = triggers
+            let disabledTriggers = triggers
                 .filter { $0.testDisableCommand }
                 .map { $0.with(code: command + $0.code) }
 
-			for trigger in disabledTriggers {
-				let violationsPartionedByType = makeViolations(trigger)
-					.partitioned { $0.ruleIdentifier == SuperfluousDisableCommandRule.description.identifier }
+            for trigger in disabledTriggers {
+                let violationsPartionedByType = makeViolations(trigger)
+                    .partitioned { $0.ruleIdentifier == SuperfluousDisableCommandRule.description.identifier }
 
-				XCTAssert(violationsPartionedByType.first.isEmpty,
-						  "Violation(s) still triggered although rule was disabled",
-						  file: trigger.file, line: trigger.line)
-				XCTAssert(violationsPartionedByType.second.isEmpty,
-						  "Disable command was superfluous since no violations(s) triggered",
-						  file: trigger.file, line: trigger.line)
-			}
+                XCTAssert(violationsPartionedByType.first.isEmpty,
+                          "Violation(s) still triggered although rule was disabled",
+                          file: trigger.file,
+                          line: trigger.line)
+                XCTAssert(violationsPartionedByType.second.isEmpty,
+                          "Disable command was superfluous since no violations(s) triggered",
+                          file: trigger.file,
+                          line: trigger.line)
+            }
         }
     }
 

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -414,17 +414,21 @@ public extension XCTestCase {
 
         // Disabled rule doesn't violate and disable command isn't superfluous
         for command in disableCommands {
-            let violationsPartionedByType = triggers
+			let disabledTriggers = triggers
                 .filter { $0.testDisableCommand }
                 .map { $0.with(code: command + $0.code) }
-                .flatMap { makeViolations($0) }
-                .partitioned { $0.ruleIdentifier == SuperfluousDisableCommandRule.description.identifier }
-            XCTAssert(violationsPartionedByType.first.isEmpty,
-                      "Violation(s) still triggered although rule was disabled",
-                      file: (file), line: line)
-            XCTAssert(violationsPartionedByType.second.isEmpty,
-                      "Disable command was superfluous since no violations(s) triggered",
-                      file: (file), line: line)
+
+			for trigger in disabledTriggers {
+				let violationsPartionedByType = makeViolations(trigger)
+					.partitioned { $0.ruleIdentifier == SuperfluousDisableCommandRule.description.identifier }
+
+				XCTAssert(violationsPartionedByType.first.isEmpty,
+						  "Violation(s) still triggered although rule was disabled",
+						  file: trigger.file, line: trigger.line)
+				XCTAssert(violationsPartionedByType.second.isEmpty,
+						  "Disable command was superfluous since no violations(s) triggered",
+						  file: trigger.file, line: trigger.line)
+			}
         }
     }
 


### PR DESCRIPTION
When creating examples, most test failures highlight *in* the example code, which is very helpful. However, if a rule fails to enable or disable according to `// swiftlint:disable` commands, the test failure unhelpfully just highlights in the generic unit test code.

This PR just refactors the location of the error highlighting to point to the failing example, just as the other test failures do. 