### PR TITLE
Improve performance of excluded files filter

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -89,6 +89,7 @@ swift_library(
         ":SourceKittenFramework.wrapper",
         "@sourcekitten_com_github_jpsim_yams//:Yams",
         "@swiftlint_com_github_scottrhoyt_swifty_text_table//:SwiftyTextTable",
+        "@com_github_ileitch_swift-filename-matcher//:FilenameMatcher"
     ] + select({
         "@platforms//os:linux": ["@com_github_krzyzanowskim_cryptoswift//:CryptoSwift"],
         "//conditions:default": [":DyldWarningWorkaround"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
   is enabled by default.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Improve performance when exclude patterns resolve to a large set of files.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5018](https://github.com/realm/SwiftLint/issues/5018)
+
 #### Bug Fixes
 
 * Ignore super calls with trailing closures in `unneeded_override` rule.  

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,7 @@ bazel_dep(name = "sourcekitten", version = "0.36.0", repo_name = "com_github_jps
 bazel_dep(name = "swift-syntax", version = "600.0.0", repo_name = "SwiftSyntax")
 bazel_dep(name = "swift_argument_parser", version = "1.3.1.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "yams", version = "5.1.3", repo_name = "sourcekitten_com_github_jpsim_yams")
+bazel_dep(name = "swift-filename-matcher", version = "2.0.0", repo_name = "com_github_ileitch_swift-filename-matcher")
 
 swiftlint_repos = use_extension("//bazel:repos.bzl", "swiftlint_repos_bzlmod")
 use_repo(

--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "swift-filename-matcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ileitch/swift-filename-matcher",
+      "state" : {
+        "revision" : "516ff95f6a06c7a9eff8e944e989c7af076c5cdb",
+        "version" : "2.0.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit.git", from: "0.2.0"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.8.4")),
+        .package(url: "https://github.com/ileitch/swift-filename-matcher", .upToNextMinor(from: "2.0.0")),
     ],
     targets: [
         .plugin(
@@ -85,6 +86,7 @@ let package = Package(
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
                 .product(name: "SwiftyTextTable", package: "SwiftyTextTable"),
                 .product(name: "Yams", package: "Yams"),
+                .product(name: "FilenameMatcher", package: "swift-filename-matcher"),
                 "SwiftLintCoreMacros",
             ],
             swiftSettings: swiftFeatures + strictConcurrency

--- a/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
@@ -68,9 +68,18 @@ public extension String {
 
     /// Returns a new string, converting the path to a canonical absolute path.
     ///
+    /// > Important: This method might use an incorrect working directory internally. This can cause test failures
+    /// in Bazel builds but does not seem to cause trouble in production.
+    ///
     /// - returns: A new `String`.
     func absolutePathStandardized() -> String {
         bridge().absolutePathRepresentation().bridge().standardizingPath
+    }
+
+    /// Like ``absolutePathStandardized()`` but with the working directory that's used everywhere else.
+    var normalized: String {
+        let cwd = FileManager.default.currentDirectoryPath.bridge().standardizingPath
+        return bridge().absolutePathRepresentation(rootDirectory: cwd)
     }
 
     var isFile: Bool {

--- a/Source/SwiftLintFramework/Configuration+CommandLine.swift
+++ b/Source/SwiftLintFramework/Configuration+CommandLine.swift
@@ -257,15 +257,12 @@ extension Configuration {
             guard options.forceExclude else {
                 return files
             }
-
             let scriptInputPaths = files.compactMap(\.path)
-
-            if options.useExcludingByPrefix {
-                return filterExcludedPathsByPrefix(in: scriptInputPaths)
-                    .map(SwiftLintFile.init(pathDeferringReading:))
-            }
-            return filterExcludedPaths(excludedPaths(), in: scriptInputPaths)
-                .map(SwiftLintFile.init(pathDeferringReading:))
+            return (
+                visitor.options.useExcludingByPrefix
+                    ? filterExcludedPathsByPrefix(in: scriptInputPaths)
+                    : filterExcludedPaths(in: scriptInputPaths)
+            ).map(SwiftLintFile.init(pathDeferringReading:))
         }
         if !options.quiet {
             let filesInfo: String
@@ -277,14 +274,12 @@ extension Configuration {
 
             queuedPrintError("\(options.capitalizedVerb) Swift files \(filesInfo)")
         }
-        let excludeLintableFilesBy = options.useExcludingByPrefix
-                    ? Configuration.ExcludeBy.prefix
-                    : .paths(excludedPaths: excludedPaths())
-        return options.paths.flatMap {
+        return visitor.options.paths.flatMap {
             self.lintableFiles(
                 inPath: $0,
-                forceExclude: options.forceExclude,
-                excludeBy: excludeLintableFilesBy)
+                forceExclude: visitor.options.forceExclude,
+                excludeByPrefix: visitor.options.useExcludingByPrefix
+            )
         }
     }
 

--- a/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
@@ -38,8 +38,8 @@ extension Configuration {
         if fileManager.isFile(atPath: path) {
             if forceExclude {
                 return excludeByPrefix
-                    ? filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])
-                    : filterExcludedPaths(in: [path.absolutePathStandardized()])
+                    ? filterExcludedPathsByPrefix(in: [path.normalized])
+                    : filterExcludedPaths(in: [path.normalized])
             }
             // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
             return [path]
@@ -77,8 +77,8 @@ extension Configuration {
     public func filterExcludedPathsByPrefix(in paths: [String]...) -> [String] {
         let allPaths = paths.flatMap { $0 }
         let excludedPaths = self.excludedPaths
-            .parallelFlatMap { @Sendable in Glob.resolveGlob($0) }
-            .map { $0.absolutePathStandardized() }
+            .parallelFlatMap { Glob.resolveGlob($0) }
+            .map(\.normalized)
         return allPaths.filter { path in
             !excludedPaths.contains { path.hasPrefix($0) }
         }

--- a/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
@@ -61,11 +61,17 @@ extension Configuration {
     ///
     /// - returns: The input paths after removing the excluded paths.
     public func filterExcludedPaths(in paths: [String]...) -> [String] {
+        let allPaths = paths.flatMap { $0 }
+        #if os(Linux)
+        let result = NSMutableOrderedSet(capacity: allPaths.count)
+        result.addObjects(from: allPaths)
+        #else
+        let result = NSMutableOrderedSet(array: allPaths)
+        #endif
         let exclusionPatterns = self.excludedPaths.map { Glob.createFilenameMatcher(root: rootDirectory, pattern: $0) }
-        let pathsWithoutExclusions = paths
-            .flatMap { $0 }
+        return result
+            .map { $0 as! String } // swiftlint:disable:this force_cast
             .filter { !exclusionPatterns.anyMatch(filename: $0) }
-        return pathsWithoutExclusions.unique
     }
 
     /// Returns the file paths that are excluded by this configuration using filtering by absolute path prefix.

--- a/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
@@ -1,25 +1,21 @@
 import Foundation
 
 extension Configuration {
-    public enum ExcludeBy {
-        case prefix
-        case paths(excludedPaths: [String])
-    }
-
     // MARK: Lintable Paths
+
     /// Returns the files that can be linted by SwiftLint in the specified parent path.
     ///
     /// - parameter path:            The parent path in which to search for lintable files. Can be a directory or a
     ///                              file.
     /// - parameter forceExclude:    Whether or not excludes defined in this configuration should be applied even if
     ///                              `path` is an exact match.
-    /// - parameter excludeByPrefix: Whether or not uses excluding by prefix algorithm.
+    /// - parameter excludeByPrefix: Whether or not it uses the exclude-by-prefix algorithm.
     ///
     /// - returns: Files to lint.
     public func lintableFiles(inPath path: String,
                               forceExclude: Bool,
-                              excludeBy: ExcludeBy) -> [SwiftLintFile] {
-        lintablePaths(inPath: path, forceExclude: forceExclude, excludeBy: excludeBy)
+                              excludeByPrefix: Bool) -> [SwiftLintFile] {
+        lintablePaths(inPath: path, forceExclude: forceExclude, excludeByPrefix: excludeByPrefix)
             .compactMap(SwiftLintFile.init(pathDeferringReading:))
     }
 
@@ -29,24 +25,21 @@ extension Configuration {
     ///                              file.
     /// - parameter forceExclude:    Whether or not excludes defined in this configuration should be applied even if
     ///                              `path` is an exact match.
-    /// - parameter excludeByPrefix: Whether or not uses excluding by prefix algorithm.
+    /// - parameter excludeByPrefix: Whether or not it uses the exclude-by-prefix algorithm.
     /// - parameter fileManager:     The lintable file manager to use to search for lintable files.
     ///
     /// - returns: Paths for files to lint.
     internal func lintablePaths(
         inPath path: String,
         forceExclude: Bool,
-        excludeBy: ExcludeBy,
+        excludeByPrefix: Bool,
         fileManager: some LintableFileManager = FileManager.default
     ) -> [String] {
         if fileManager.isFile(atPath: path) {
             if forceExclude {
-                switch excludeBy {
-                case .prefix:
-                    return filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])
-                case .paths(let excludedPaths):
-                    return filterExcludedPaths(excludedPaths, in: [path.absolutePathStandardized()])
-                }
+                return excludeByPrefix
+                    ? filterExcludedPathsByPrefix(in: [path.absolutePathStandardized()])
+                    : filterExcludedPaths(in: [path.absolutePathStandardized()])
             }
             // If path is a file and we're not forcing excludes, skip filtering with excluded/included paths
             return [path]
@@ -57,35 +50,22 @@ extension Configuration {
             .flatMap(Glob.resolveGlob)
             .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }
 
-        switch excludeBy {
-        case .prefix:
-            return filterExcludedPathsByPrefix(in: pathsForPath, includedPaths)
-        case .paths(let excludedPaths):
-            return filterExcludedPaths(excludedPaths, in: pathsForPath, includedPaths)
-        }
+        return excludeByPrefix
+            ? filterExcludedPathsByPrefix(in: pathsForPath, includedPaths)
+            : filterExcludedPaths(in: pathsForPath, includedPaths)
     }
 
     /// Returns an array of file paths after removing the excluded paths as defined by this configuration.
     ///
-    /// - parameter fileManager: The lintable file manager to use to expand the excluded paths into all matching paths.
-    /// - parameter paths:       The input paths to filter.
+    /// - parameter paths: The input paths to filter.
     ///
     /// - returns: The input paths after removing the excluded paths.
-    public func filterExcludedPaths(
-        _ excludedPaths: [String],
-        in paths: [String]...
-    ) -> [String] {
-        let allPaths = paths.flatMap { $0 }
-        #if os(Linux)
-        let result = NSMutableOrderedSet(capacity: allPaths.count)
-        result.addObjects(from: allPaths)
-        #else
-        let result = NSMutableOrderedSet(array: allPaths)
-        #endif
-
-        result.minusSet(Set(excludedPaths))
-        // swiftlint:disable:next force_cast
-        return result.map { $0 as! String }
+    public func filterExcludedPaths(in paths: [String]...) -> [String] {
+        let exclusionPatterns = self.excludedPaths.compactMap { Glob.toRegex($0, rootPath: rootDirectory) }
+        let pathsWithoutExclusions = paths
+            .flatMap { $0 }
+            .filter { path in !exclusionPatterns.contains { $0.firstMatch(in: path, range: path.fullNSRange) != nil } }
+        return pathsWithoutExclusions.unique
     }
 
     /// Returns the file paths that are excluded by this configuration using filtering by absolute path prefix.
@@ -102,17 +82,5 @@ extension Configuration {
         return allPaths.filter { path in
             !excludedPaths.contains { path.hasPrefix($0) }
         }
-    }
-
-    /// Returns the file paths that are excluded by this configuration after expanding them using the specified file
-    /// manager.
-    ///
-    /// - parameter fileManager: The file manager to get child paths in a given parent location.
-    ///
-    /// - returns: The expanded excluded file paths.
-    public func excludedPaths(fileManager: some LintableFileManager = FileManager.default) -> [String] {
-        excludedPaths
-            .flatMap(Glob.resolveGlob)
-            .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }
     }
 }

--- a/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
@@ -61,10 +61,10 @@ extension Configuration {
     ///
     /// - returns: The input paths after removing the excluded paths.
     public func filterExcludedPaths(in paths: [String]...) -> [String] {
-        let exclusionPatterns = self.excludedPaths.compactMap { Glob.toRegex($0, rootPath: rootDirectory) }
+        let exclusionPatterns = self.excludedPaths.map { Glob.createFilenameMatcher(root: rootDirectory, pattern: $0) }
         let pathsWithoutExclusions = paths
             .flatMap { $0 }
-            .filter { path in !exclusionPatterns.contains { $0.firstMatch(in: path, range: path.fullNSRange) != nil } }
+            .filter { !exclusionPatterns.anyMatch(filename: $0) }
         return pathsWithoutExclusions.unique
     }
 

--- a/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
@@ -68,7 +68,9 @@ extension Configuration {
         #else
         let result = NSMutableOrderedSet(array: allPaths)
         #endif
-        let exclusionPatterns = self.excludedPaths.map { Glob.createFilenameMatcher(root: rootDirectory, pattern: $0) }
+        let exclusionPatterns = self.excludedPaths.flatMap {
+            Glob.createFilenameMatchers(root: rootDirectory, pattern: $0)
+        }
         return result
             .map { $0 as! String } // swiftlint:disable:this force_cast
             .filter { !exclusionPatterns.anyMatch(filename: $0) }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -19,7 +19,7 @@ final class IntegrationTests: SwiftLintTestCase {
         let swiftFiles = config.lintableFiles(
             inPath: "",
             forceExclude: false,
-            excludeBy: .paths(excludedPaths: config.excludedPaths()))
+            excludeByPrefix: false)
         XCTAssert(
             swiftFiles.contains(where: { #filePath.bridge().absolutePathRepresentation() == $0.path }),
             "current file should be included"
@@ -40,7 +40,7 @@ final class IntegrationTests: SwiftLintTestCase {
         let swiftFiles = config.lintableFiles(
             inPath: "",
             forceExclude: false,
-            excludeBy: .paths(excludedPaths: config.excludedPaths()))
+            excludeByPrefix: false)
         let storage = RuleStorage()
         let corrections = swiftFiles.parallelFlatMap {
             Linter(file: $0, configuration: config).collect(into: storage).correct(using: storage)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -288,10 +288,9 @@ final class ConfigurationTests: SwiftLintTestCase {
             excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"]
         )
 
-        let excludedPaths = configuration.excludedPaths(fileManager: fileManager)
         let paths = configuration.lintablePaths(inPath: "",
                                                 forceExclude: false,
-                                                excludeBy: .paths(excludedPaths: excludedPaths),
+                                                excludeByPrefix: false,
                                                 fileManager: fileManager)
         XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
@@ -299,10 +298,9 @@ final class ConfigurationTests: SwiftLintTestCase {
     func testForceExcludesFile() {
         let fileManager = TestFileManager()
         let configuration = Configuration(excludedPaths: ["directory/ExcludedFile.swift"])
-        let excludedPaths = configuration.excludedPaths(fileManager: fileManager)
         let paths = configuration.lintablePaths(inPath: "directory/ExcludedFile.swift",
                                                 forceExclude: true,
-                                                excludeBy: .paths(excludedPaths: excludedPaths),
+                                                excludeByPrefix: false,
                                                 fileManager: fileManager)
         XCTAssertEqual([], paths)
     }
@@ -311,10 +309,9 @@ final class ConfigurationTests: SwiftLintTestCase {
         let fileManager = TestFileManager()
         let configuration = Configuration(includedPaths: ["directory"],
                                           excludedPaths: ["directory/ExcludedFile.swift", "directory/excluded"])
-        let excludedPaths = configuration.excludedPaths(fileManager: fileManager)
         let paths = configuration.lintablePaths(inPath: "",
                                                 forceExclude: true,
-                                                excludeBy: .paths(excludedPaths: excludedPaths),
+                                                excludeByPrefix: false,
                                                 fileManager: fileManager)
         XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
@@ -322,10 +319,9 @@ final class ConfigurationTests: SwiftLintTestCase {
     func testForceExcludesDirectory() {
         let fileManager = TestFileManager()
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
-        let excludedPaths = configuration.excludedPaths(fileManager: fileManager)
         let paths = configuration.lintablePaths(inPath: "directory",
                                                 forceExclude: true,
-                                                excludeBy: .paths(excludedPaths: excludedPaths),
+                                                excludeByPrefix: false,
                                                 fileManager: fileManager)
         XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
@@ -333,19 +329,17 @@ final class ConfigurationTests: SwiftLintTestCase {
     func testForceExcludesDirectoryThatIsNotInExcludedButHasChildrenThatAre() {
         let fileManager = TestFileManager()
         let configuration = Configuration(excludedPaths: ["directory/excluded", "directory/ExcludedFile.swift"])
-        let excludedPaths = configuration.excludedPaths(fileManager: fileManager)
         let paths = configuration.lintablePaths(inPath: "directory",
                                                 forceExclude: true,
-                                                excludeBy: .paths(excludedPaths: excludedPaths),
+                                                excludeByPrefix: false,
                                                 fileManager: fileManager)
         XCTAssertEqual(["directory/File1.swift", "directory/File2.swift"].absolutePathsStandardized(), paths)
     }
 
     func testLintablePaths() {
-        let excluded = Configuration.default.excludedPaths(fileManager: TestFileManager())
         let paths = Configuration.default.lintablePaths(inPath: Mock.Dir.level0,
                                                         forceExclude: false,
-                                                        excludeBy: .paths(excludedPaths: excluded))
+                                                        excludeByPrefix: false)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         let expectedFilenames = [
             "DirectoryLevel1.swift",
@@ -361,7 +355,7 @@ final class ConfigurationTests: SwiftLintTestCase {
         let configuration = Configuration(includedPaths: ["**/Level2"])
         let paths = configuration.lintablePaths(inPath: Mock.Dir.level0,
                                                 forceExclude: true,
-                                                excludeBy: .paths(excludedPaths: configuration.excludedPaths))
+                                                excludeByPrefix: false)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         let expectedFilenames = ["Level2.swift", "Level3.swift"]
 
@@ -374,10 +368,9 @@ final class ConfigurationTests: SwiftLintTestCase {
             excludedPaths: [Mock.Dir.level3.stringByAppendingPathComponent("*.swift")]
         )
 
-        let excludedPaths = configuration.excludedPaths()
         let lintablePaths = configuration.lintablePaths(inPath: "",
                                                         forceExclude: false,
-                                                        excludeBy: .paths(excludedPaths: excludedPaths))
+                                                        excludeByPrefix: false)
         XCTAssertEqual(lintablePaths, [])
     }
 
@@ -492,7 +485,7 @@ extension ConfigurationTests {
         )
         let paths = configuration.lintablePaths(inPath: Mock.Dir.level0,
                                                 forceExclude: false,
-                                                excludeBy: .prefix)
+                                                excludeByPrefix: true)
         let filenames = paths.map { $0.bridge().lastPathComponent }
         XCTAssertEqual(filenames, ["Level2.swift"])
     }
@@ -502,7 +495,7 @@ extension ConfigurationTests {
         let configuration = Configuration(excludedPaths: ["Level1/Level2/Level3/Level3.swift"])
         let paths = configuration.lintablePaths(inPath: "Level1/Level2/Level3/Level3.swift",
                                                 forceExclude: true,
-                                                excludeBy: .prefix)
+                                                excludeByPrefix: true)
         XCTAssertEqual([], paths)
     }
 
@@ -512,7 +505,7 @@ extension ConfigurationTests {
                                           excludedPaths: ["Level1/Level1.swift"])
         let paths = configuration.lintablePaths(inPath: "Level1",
                                                 forceExclude: true,
-                                                excludeBy: .prefix)
+                                                excludeByPrefix: true)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         XCTAssertEqual(["Level2.swift", "Level3.swift"], filenames)
     }
@@ -526,7 +519,7 @@ extension ConfigurationTests {
         )
         let paths = configuration.lintablePaths(inPath: ".",
                                                 forceExclude: true,
-                                                excludeBy: .prefix)
+                                                excludeByPrefix: true)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         XCTAssertEqual(["Level0.swift", "Level1.swift"], filenames)
     }
@@ -540,7 +533,7 @@ extension ConfigurationTests {
         )
         let paths = configuration.lintablePaths(inPath: ".",
                                                 forceExclude: true,
-                                                excludeBy: .prefix)
+                                                excludeByPrefix: true)
         let filenames = paths.map { $0.bridge().lastPathComponent }
         XCTAssertEqual(["Level0.swift"], filenames)
     }
@@ -552,7 +545,7 @@ extension ConfigurationTests {
             excludedPaths: ["Level1/*/*.swift", "Level1/*/*/*.swift"])
         let paths = configuration.lintablePaths(inPath: "Level1",
                                                 forceExclude: false,
-                                                excludeBy: .prefix)
+                                                excludeByPrefix: true)
         let filenames = paths.map { $0.bridge().lastPathComponent }.sorted()
         XCTAssertEqual(filenames, ["Level1.swift"])
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -599,7 +599,7 @@ extension ConfigurationTests {
 
 private extension Sequence where Element == String {
     func absolutePathsStandardized() -> [String] {
-        map { $0.absolutePathStandardized() }
+        map(\.normalized)
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/GlobTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GlobTests.swift
@@ -83,18 +83,30 @@ final class GlobTests: SwiftLintTestCase {
         XCTAssertEqual(files.sorted(), expectedFiles.sorted())
     }
 
-    func testCreateFilenameMatcher() {
-        XCTAssert(Glob.createFilenameMatcher(root: "/a/b/", pattern: "c/*.swift").match(filename: "/a/b/c/d.swift"))
-        XCTAssert(Glob.createFilenameMatcher(root: "/a", pattern: "**/*.swift").match(filename: "/a/b/c/d.swift"))
-        XCTAssert(Glob.createFilenameMatcher(root: "/a/b", pattern: "/a/b/c/*.swift").match(filename: "/a/b/c/d.swift"))
-        XCTAssert(Glob.createFilenameMatcher(root: "/a/", pattern: "/a/b/c/*.swift").match(filename: "/a/b/c/d.swift"))
+    func testCreateFilenameMatchers() {
+        func assertGlobMatch(root: String, pattern: String, filename: String) {
+            let matchers = Glob.createFilenameMatchers(root: root, pattern: pattern)
+            XCTAssert(matchers.anyMatch(filename: filename))
+        }
 
-        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/a/b/c").match(filename: "/a/b/c/d.swift"))
-        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/a/b/c/").match(filename: "/a/b/c/d.swift"))
-        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/a/b/c/*.swift").match(filename: "/a/b/c/d.swift"))
-        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/d.swift/*.swift").match(filename: "/d.swift/e.swift"))
-        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/a/**").match(filename: "/a/b/c/d.swift"))
+        assertGlobMatch(root: "/a/b/", pattern: "c/*.swift", filename: "/a/b/c/d.swift")
+        assertGlobMatch(root: "/a", pattern: "**/*.swift", filename: "/a/b/c/d.swift")
+        assertGlobMatch(root: "/a", pattern: "**/*.swift", filename: "/a/b.swift")
+        assertGlobMatch(root: "", pattern: "**/*.swift", filename: "/a/b.swift")
+        assertGlobMatch(root: "", pattern: "a/**/b.swift", filename: "a/b.swift")
+        assertGlobMatch(root: "", pattern: "a/**/b.swift", filename: "a/c/b.swift")
+        assertGlobMatch(root: "", pattern: "**/*.swift", filename: "a.swift")
+        assertGlobMatch(root: "", pattern: "a/**/*.swift", filename: "a/b/c.swift")
+        assertGlobMatch(root: "", pattern: "a/**/*.swift", filename: "a/b.swift")
+        assertGlobMatch(root: "/a/b", pattern: "/a/b/c/*.swift", filename: "/a/b/c/d.swift")
+        assertGlobMatch(root: "/a/", pattern: "/a/b/c/*.swift", filename: "/a/b/c/d.swift")
 
-        XCTAssertFalse(Glob.createFilenameMatcher(root: "/a/", pattern: "**/*.swift").match(filename: "/a/b.swift"))
+        assertGlobMatch(root: "", pattern: "/a/b/c", filename: "/a/b/c/d.swift")
+        assertGlobMatch(root: "", pattern: "/a/b/c/", filename: "/a/b/c/d.swift")
+        assertGlobMatch(root: "", pattern: "/a/b/c/*.swift", filename: "/a/b/c/d.swift")
+        assertGlobMatch(root: "", pattern: "/d.swift/*.swift", filename: "/d.swift/e.swift")
+        assertGlobMatch(root: "", pattern: "/a/**", filename: "/a/b/c/d.swift")
+        assertGlobMatch(root: "", pattern: "**/*Test*", filename: "/a/b/c/MyTest2.swift")
+        assertGlobMatch(root: "", pattern: "**/*Test*", filename: "/a/b/MyTests/c.swift")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/GlobTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GlobTests.swift
@@ -82,4 +82,19 @@ final class GlobTests: SwiftLintTestCase {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("**/*.swift"))
         XCTAssertEqual(files.sorted(), expectedFiles.sorted())
     }
+
+    func testToRegex() {
+        XCTAssertEqual(Glob.toRegex("*?.(**)")?.pattern, "^[^/]*.\\.\\(.*\\).*$")
+        XCTAssertEqual(Glob.toRegex("a/b/c")?.pattern, "^a/b/c.*$")
+        XCTAssertEqual(Glob.toRegex("a//b")?.pattern, "^a/b.*$")
+        XCTAssertEqual(Glob.toRegex("/a/b/*")?.pattern, "^/a/b/[^/]*$")
+        XCTAssertEqual(Glob.toRegex("a/*.swift")?.pattern, "^a/[^/]*\\.swift.*$")
+        XCTAssertEqual(Glob.toRegex("**/a/*.swift")?.pattern, "^.*a/[^/]*\\.swift.*$")
+        XCTAssertEqual(Glob.toRegex("**/*.swift")?.pattern, "^.*\\.swift.*$")
+
+        XCTAssertEqual(Glob.toRegex("a/b", rootPath: "/tmp/")?.pattern, "^/tmp/a/b.*$")
+        XCTAssertEqual(Glob.toRegex("/tmp/a/b", rootPath: "/tmp/")?.pattern, "^/tmp/a/b.*$")
+        XCTAssertEqual(Glob.toRegex("/a/b", rootPath: "/tmp")?.pattern, "^/tmp/a/b.*$")
+        XCTAssertEqual(Glob.toRegex("**/*.swift", rootPath: "/tmp")?.pattern, "^/tmp/.*\\.swift.*$")
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/GlobTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GlobTests.swift
@@ -83,18 +83,18 @@ final class GlobTests: SwiftLintTestCase {
         XCTAssertEqual(files.sorted(), expectedFiles.sorted())
     }
 
-    func testToRegex() {
-        XCTAssertEqual(Glob.toRegex("*?.(**)")?.pattern, "^[^/]*.\\.\\(.*\\).*$")
-        XCTAssertEqual(Glob.toRegex("a/b/c")?.pattern, "^a/b/c.*$")
-        XCTAssertEqual(Glob.toRegex("a//b")?.pattern, "^a/b.*$")
-        XCTAssertEqual(Glob.toRegex("/a/b/*")?.pattern, "^/a/b/[^/]*$")
-        XCTAssertEqual(Glob.toRegex("a/*.swift")?.pattern, "^a/[^/]*\\.swift.*$")
-        XCTAssertEqual(Glob.toRegex("**/a/*.swift")?.pattern, "^.*a/[^/]*\\.swift.*$")
-        XCTAssertEqual(Glob.toRegex("**/*.swift")?.pattern, "^.*\\.swift.*$")
+    func testCreateFilenameMatcher() {
+        XCTAssert(Glob.createFilenameMatcher(root: "/a/b/", pattern: "c/*.swift").match(filename: "/a/b/c/d.swift"))
+        XCTAssert(Glob.createFilenameMatcher(root: "/a", pattern: "**/*.swift").match(filename: "/a/b/c/d.swift"))
+        XCTAssert(Glob.createFilenameMatcher(root: "/a/b", pattern: "/a/b/c/*.swift").match(filename: "/a/b/c/d.swift"))
+        XCTAssert(Glob.createFilenameMatcher(root: "/a/", pattern: "/a/b/c/*.swift").match(filename: "/a/b/c/d.swift"))
 
-        XCTAssertEqual(Glob.toRegex("a/b", rootPath: "/tmp/")?.pattern, "^/tmp/a/b.*$")
-        XCTAssertEqual(Glob.toRegex("/tmp/a/b", rootPath: "/tmp/")?.pattern, "^/tmp/a/b.*$")
-        XCTAssertEqual(Glob.toRegex("/a/b", rootPath: "/tmp")?.pattern, "^/tmp/a/b.*$")
-        XCTAssertEqual(Glob.toRegex("**/*.swift", rootPath: "/tmp")?.pattern, "^/tmp/.*\\.swift.*$")
+        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/a/b/c").match(filename: "/a/b/c/d.swift"))
+        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/a/b/c/").match(filename: "/a/b/c/d.swift"))
+        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/a/b/c/*.swift").match(filename: "/a/b/c/d.swift"))
+        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/d.swift/*.swift").match(filename: "/d.swift/e.swift"))
+        XCTAssert(Glob.createFilenameMatcher(root: "", pattern: "/a/**").match(filename: "/a/b/c/d.swift"))
+
+        XCTAssertFalse(Glob.createFilenameMatcher(root: "/a/", pattern: "**/*.swift").match(filename: "/a/b.swift"))
     }
 }

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -64,6 +64,13 @@ def swiftlint_repos(bzlmod = False):
         url = "https://github.com/krzyzanowskim/CryptoSwift/archive/refs/tags/1.8.4.tar.gz",
     )
 
+    http_archive(
+        name = "com_github_ileitch_swift-filename-matcher",
+        sha256 = "1adbb1eb042910f996689827f7dee217bebf7c5178f34178bcfe468b5b3268a2",
+        strip_prefix = "swift-filename-matcher-2.0.0",
+        url = "https://github.com/ileitch/swift-filename-matcher/archive/refs/tags/2.0.0.tar.gz",
+    )
+
 def _swiftlint_repos_bzlmod(_):
     swiftlint_repos(bzlmod = True)
 

--- a/tools/oss-check
+++ b/tools/oss-check
@@ -45,6 +45,7 @@ end.parse!
 class Repo
   attr_accessor :name
   attr_accessor :github_location
+  attr_accessor :keep_config
   attr_accessor :config
   attr_accessor :commit_hash
   attr_accessor :branch_exit_value
@@ -52,9 +53,10 @@ class Repo
   attr_accessor :main_exit_value
   attr_accessor :main_duration
 
-  def initialize(name, github_location, config=nil)
+  def initialize(name, github_location, keep_config=false, config=nil)
     @name = name
     @github_location = github_location
+    @keep_config = keep_config
     @config = config
   end
 
@@ -140,7 +142,9 @@ def setup_repos
     puts "Cloning #{repo}"
     perform("git clone #{repo.git_url} --depth 1 #{dir} 2> /dev/null")
     swiftlint_config = "#{dir}/.swiftlint.yml"
-    FileUtils.rm_rf(swiftlint_config)
+    if !repo.keep_config
+      FileUtils.rm_rf(swiftlint_config)
+    end
     if repo.config
       File.open(swiftlint_config, 'a') do |file|
         file.puts(repo.config)
@@ -292,7 +296,7 @@ end
 @repos = [
   Repo.new('Aerial', 'JohnCoates/Aerial'),
   Repo.new('Alamofire', 'Alamofire/Alamofire'),
-  Repo.new('Brave', 'brave/brave-ios'),
+  Repo.new('Brave', 'brave/brave-ios', true),
   Repo.new('DuckDuckGo', 'duckduckgo/iOS'),
   Repo.new('Firefox', 'mozilla-mobile/firefox-ios'),
   Repo.new('Kickstarter', 'kickstarter/ios-oss'),
@@ -303,9 +307,9 @@ end
   Repo.new('Quick', 'Quick/Quick'),
   Repo.new('Realm', 'realm/realm-swift'),
   Repo.new('Sourcery', 'krzysztofzablocki/Sourcery'),
-  Repo.new('Swift', 'apple/swift', 'included: stdlib'),
+  Repo.new('Swift', 'apple/swift', false, 'included: stdlib'),
   Repo.new('VLC', 'videolan/vlc-ios'),
-  Repo.new('Wire', 'wireapp/wire-ios', 'excluded: wire-ios/Templates/Viper'),
+  Repo.new('Wire', 'wireapp/wire-ios', false, 'excluded: wire-ios/Templates/Viper'),
   Repo.new('WordPress', 'wordpress-mobile/WordPress-iOS')
 ]
 


### PR DESCRIPTION
The current algorithm is like "collect all included files and subtract all excluded files". Collecting all included and all excluded files relies on the file system. This can become slow when the patterns used to exclude files resolve to a large number of files.

The new approach only collects all lintable files and checks them against the exclude patterns. This can be done by in-memory string-regex-match and does therefore not require file system accesses.

The most critical part is the conversion of glob patterns to regular expressions. I might have missed cases.

Fixes #5018.