### PR TITLE
Add new `non_overridable_class_declaration` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 * Rewrite `control_statement` rule using SwiftSyntax.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Add new `non_overridable_class_declaration` rule that triggers on `class`
+  function and variable declarations in final classes that are not final
+  themselves or private.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * The Homebrew formula for SwiftLint now also installs completion scripts for
   Bash, Zsh and fish.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -130,6 +130,7 @@ public let builtInRules: [Rule.Type] = [
     NoGroupingExtensionRule.self,
     NoMagicNumbersRule.self,
     NoSpaceInMethodCallRule.self,
+    NonOverridableClassDeclarationRule.self,
     NotificationCenterDetachmentRule.self,
     NumberSeparatorRule.self,
     ObjectLiteralRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NonOverridableClassDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NonOverridableClassDeclarationConfiguration.swift
@@ -1,0 +1,34 @@
+import SwiftLintCore
+
+// swiftlint:disable:next type_name
+struct NonOverridableClassDeclarationConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    typealias Parent = NonOverridableClassDeclarationRule
+
+    enum FinalClassModifier: String, AcceptableByConfigurationElement {
+        case finalClass = "final class"
+        case `static` = "static"
+
+        func asOption() -> OptionType { .symbol(rawValue) }
+    }
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
+    @ConfigurationElement(key: "final_class_modifier")
+    private(set) var finalClassModifier = FinalClassModifier.finalClass
+
+    mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+        }
+        if let severityString = configuration[$severityConfiguration] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+        if let value = configuration[$finalClassModifier] as? String {
+            if let modifier = FinalClassModifier(rawValue: value) {
+                finalClassModifier = modifier
+            } else {
+                throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            }
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
@@ -1,0 +1,170 @@
+import SwiftSyntax
+
+struct NonOverridableClassDeclarationRule: SwiftSyntaxRule, CorrectableRule, ConfigurationProviderRule, OptInRule {
+    var configuration = NonOverridableClassDeclarationConfiguration()
+
+    static var description = RuleDescription(
+        identifier: "non_overridable_class_declaration",
+        name: "Class Declaration in Final Class",
+        description: """
+            Class methods and properties in final classes should themselves be final, just as if the declarations
+            are private. In both cases, they cannot be overriden. Using `final class` or `static` makes this explicit.
+        """,
+        kind: .style,
+        nonTriggeringExamples: [
+            Example("""
+            final class C {
+                final class var b: Bool { true }
+                final class func f() {}
+            }
+            """),
+            Example("""
+            class C {
+                final class var b: Bool { true }
+                final class func f() {}
+            }
+            """),
+            Example("""
+            class C {
+                class var b: Bool { true }
+                class func f() {}
+            }
+            """),
+            Example("""
+            class C {
+                static var b: Bool { true }
+                static func f() {}
+            }
+            """),
+            Example("""
+            final class C {
+                static var b: Bool { true }
+                static func f() {}
+            }
+            """),
+            Example("""
+            final class C {
+                class D {
+                    class var b: Bool { true }
+                    class func f() {}
+                }
+            }
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+            final class C {
+                ↓class var b: Bool { true }
+                ↓class func f() {}
+            }
+            """),
+            Example("""
+            class C {
+                final class D {
+                    ↓class var b: Bool { true }
+                    ↓class func f() {}
+                }
+            }
+            """),
+            Example("""
+            class C {
+                private ↓class var b: Bool { true }
+                private ↓class func f() {}
+            }
+            """)
+        ],
+        corrections: [
+            Example("""
+            final class C {
+                class func f() {}
+            }
+            """): Example("""
+                final class C {
+                    final class func f() {}
+                }
+                """),
+            Example("""
+            final class C {
+                class var b: Bool { true }
+            }
+            """, configuration: ["final_class_modifier": "static"]): Example("""
+                final class C {
+                    static var b: Bool { true }
+                }
+                """)
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(severity: configuration.severity)
+    }
+
+    func correct(file: SwiftLintFile) -> [Correction] {
+        let ranges = Visitor(severity: configuration.severity)
+            .walk(file: file, handler: \.corrections)
+            .compactMap { file.stringView.NSRange(start: $0.start, end: $0.end) }
+            .filter { file.ruleEnabled(violatingRange: $0, for: self) != nil }
+            .reversed()
+
+        var corrections = [Correction]()
+        var contents = file.contents
+        for range in ranges {
+            let contentsNSString = contents.bridge()
+            contents = contentsNSString.replacingCharacters(in: range, with: configuration.finalClassModifier.rawValue)
+            let location = Location(file: file, characterOffset: range.location)
+            corrections.append(Correction(ruleDescription: Self.description, location: location))
+        }
+
+        file.write(contents)
+
+        return corrections
+    }
+}
+
+private class Visitor: ViolationsSyntaxVisitor {
+    private let severity: ViolationSeverity
+
+    private var finalClassScope = Stack<Bool>()
+    private(set) var corrections = [(start: AbsolutePosition, end: AbsolutePosition)]()
+
+    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+
+    init(severity: ViolationSeverity) {
+        self.severity = severity
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        finalClassScope.push(node.modifiers.isFinal)
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: ClassDeclSyntax) {
+        _ = finalClassScope.pop()
+    }
+
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        checkViolations(for: node.modifiers, type: "methods")
+    }
+
+    override func visitPost(_ node: VariableDeclSyntax) {
+        checkViolations(for: node.modifiers, type: "properties")
+    }
+
+    private func checkViolations(for modifiers: ModifierListSyntax?, type: String) {
+        guard !modifiers.isFinal, let classKeyword = modifiers?.first(where: { $0.name.text == "class" }),
+              case let inFinalClass = finalClassScope.peek() == true, inFinalClass || modifiers.isPrivate else {
+            return
+        }
+        violations.append(ReasonedRuleViolation(
+            position: classKeyword.positionAfterSkippingLeadingTrivia,
+            reason: inFinalClass
+                ? "Class \(type) in final classes should themselves be final"
+                : "Private class methods and properties should be declared final",
+            severity: severity
+        ))
+        corrections.append(
+            (classKeyword.positionAfterSkippingLeadingTrivia, classKeyword.endPositionBeforeTrailingTrivia)
+        )
+    }
+}

--- a/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
@@ -136,11 +136,18 @@ public extension ModifierListSyntax? {
         contains(tokenKind: .keyword(.fileprivate))
     }
 
+    var isPrivate: Bool {
+        contains(tokenKind: .keyword(.private))
+    }
+
+    var isFinal: Bool {
+        contains(tokenKind: .keyword(.final))
+    }
+
     var isPrivateOrFileprivate: Bool {
         guard let modifiers = self else {
             return false
         }
-
         return modifiers.contains { elem in
             (elem.name.tokenKind == .keyword(.private) || elem.name.tokenKind == .keyword(.fileprivate)) &&
                 elem.detail == nil
@@ -148,11 +155,7 @@ public extension ModifierListSyntax? {
     }
 
     private func contains(tokenKind: TokenKind) -> Bool {
-        guard let modifiers = self else {
-            return false
-        }
-
-        return modifiers.contains { $0.name.tokenKind == tokenKind }
+        self?.contains { $0.name.tokenKind == tokenKind } ?? false
     }
 }
 

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -770,6 +770,12 @@ class NoSpaceInMethodCallRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class NonOverridableClassDeclarationRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NonOverridableClassDeclarationRule.description)
+    }
+}
+
 class NotificationCenterDetachmentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NotificationCenterDetachmentRule.description)


### PR DESCRIPTION
The idea stems from [this post](https://forums.swift.org/t/is-it-right-to-call-class-func-from-final-class/66525) in the Swift forums.