### PR TITLE
Rewrite `implicit_return` rule using SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
   [mt00chikin](https://github.com/mt00chikin)
   [#3173](https://github.com/realm/SwiftLint/issues/3173)
 
+* The `implicit_return` rule now supports the kinds `subscript` and
+  `initializer` in the `included` configuration list.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Add `unneeded_override` rule to remove function overrides that only
   call super.  
   [keith](https://github.com/keith)
@@ -84,6 +88,11 @@
 
 * Document `exclude_ranges` option for `number_separator` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
+
+* Rewrite `implicit_return` rule with SwiftSyntax fixing a few false positives
+  and false negatives in the process.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5161](https://github.com/realm/SwiftLint/issues/5161)
 
 * Make sure `severity` is configurable for `type_contents_order` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -7,6 +7,8 @@ struct ImplicitReturnConfiguration: SeverityBasedRuleConfiguration, Equatable {
         case closure
         case function
         case getter
+        case `subscript`
+        case initializer
 
         func asOption() -> OptionType { .symbol(rawValue) }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
@@ -1,7 +1,6 @@
-import Foundation
-import SourceKittenFramework
+import SwiftSyntax
 
-struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule, OptInRule {
+struct ImplicitReturnRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
     var configuration = ImplicitReturnConfiguration()
 
     static let description = RuleDescription(
@@ -14,72 +13,78 @@ struct ImplicitReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRul
         corrections: ImplicitReturnRuleExamples.corrections
     )
 
-    func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violationRanges(in: file).compactMap {
-            StyleViolation(ruleDescription: Self.description,
-                           severity: configuration.severityConfiguration.severity,
-                           location: Location(file: file, characterOffset: $0.location))
-        }
-    }
-
-    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
-        return (violationRange, "")
-    }
-
-    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        let pattern = "(?:\\bin|\\{)\\s+(return\\s+)"
-        let contents = file.stringView
-
-        return file.matchesAndSyntaxKinds(matching: pattern).compactMap { result, kinds in
-            let range = result.range
-            guard kinds == [.keyword, .keyword] || kinds == [.keyword],
-                let byteRange = contents.NSRangeToByteRange(start: range.location, length: range.length),
-                case let kinds = file.structureDictionary.kinds(forByteOffset: byteRange.location),
-                let outerKindString = kinds.lastExcludingBrace()?.kind
-            else {
-                return nil
-            }
-
-            func isKindIncluded(_ kind: ImplicitReturnConfiguration.ReturnKind) -> Bool {
-                return self.configuration.isKindIncluded(kind)
-            }
-
-            if let outerKind = SwiftExpressionKind(rawValue: outerKindString),
-                isKindIncluded(.closure),
-                [.call, .argument, .closure].contains(outerKind) {
-                    return result.range(at: 1)
-            }
-
-            if let outerKind = SwiftDeclarationKind(rawValue: outerKindString),
-                (isKindIncluded(.function) && SwiftDeclarationKind.functionKinds.contains(outerKind)) ||
-                (isKindIncluded(.getter) && SwiftDeclarationKind.variableKinds.contains(outerKind)) {
-                    return result.range(at: 1)
-            }
-
-            return nil
-        }
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(config: configuration)
     }
 }
 
-private extension Array where Element == (kind: String, byteRange: ByteRange) {
-    func lastExcludingBrace() -> Element? {
-        guard SwiftVersion.current >= .fiveDotFour else {
-            return last
+private extension ImplicitReturnRule {
+    private class Visitor: ViolationsSyntaxVisitor {
+        private let config: ConfigurationType
+
+        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+
+        init(config: ConfigurationType) {
+            self.config = config
+            super.init(viewMode: .sourceAccurate)
         }
 
-        guard let last else {
-            return nil
+        override func visitPost(_ node: AccessorDeclSyntax) {
+            if config.isKindIncluded(.getter),
+               node.accessorSpecifier.tokenKind == .keyword(.get),
+               let body = node.body {
+                collectViolation(in: body.statements)
+            }
         }
 
-        guard last.kind == "source.lang.swift.stmt.brace", count > 1 else {
-            return last
+        override func visitPost(_ node: ClosureExprSyntax) {
+            if config.isKindIncluded(.closure) {
+                collectViolation(in: node.statements)
+            }
         }
 
-        let secondLast = self[endIndex - 2]
-        if SwiftExpressionKind(rawValue: secondLast.kind) == .closure {
-            return secondLast
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            if config.isKindIncluded(.function),
+               let body = node.body {
+                collectViolation(in: body.statements)
+            }
         }
 
-        return last
+        override func visitPost(_ node: InitializerDeclSyntax) {
+            if config.isKindIncluded(.initializer),
+               let body = node.body {
+                collectViolation(in: body.statements)
+            }
+        }
+
+        override func visitPost(_ node: PatternBindingSyntax) {
+            if config.isKindIncluded(.getter),
+               case let .getter(itemList) = node.accessorBlock?.accessors {
+                collectViolation(in: itemList)
+            }
+        }
+
+        override func visitPost(_ node: SubscriptDeclSyntax) {
+            if config.isKindIncluded(.subscript),
+               case let .getter(itemList) = node.accessorBlock?.accessors {
+                collectViolation(in: itemList)
+            }
+        }
+
+        private func collectViolation(in itemList: CodeBlockItemListSyntax) {
+            guard let returnStmt = itemList.onlyElement?.item.as(ReturnStmtSyntax.self) else {
+                return
+            }
+            let returnKeyword = returnStmt.returnKeyword
+            violations.append(returnKeyword.positionAfterSkippingLeadingTrivia)
+            violationCorrections.append(
+                ViolationCorrection(
+                    start: returnKeyword.positionAfterSkippingLeadingTrivia,
+                    end: returnKeyword.endPositionBeforeTrailingTrivia
+                            .advanced(by: returnStmt.expression == nil ? 0 : 1),
+                    replacement: ""
+                )
+            )
+        }
     }
 }

--- a/Source/SwiftLintCore/Models/Example.swift
+++ b/Source/SwiftLintCore/Models/Example.swift
@@ -167,4 +167,9 @@ public extension Array where Element == Example {
     func skipDisableCommandTests() -> Self {
         map { $0.skipDisableCommandTest() }
     }
+
+    /// Remove all violation markers from the examples.
+    func removingViolationMarker() -> Self {
+        map { $0.removingViolationMarkers() }
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
@@ -9,7 +9,9 @@ class ImplicitReturnConfigurationTests: SwiftLintTestCase {
             "included": [
                 "closure",
                 "function",
-                "getter"
+                "getter",
+                "initializer",
+                "subscript"
             ]
         ]
 
@@ -17,7 +19,9 @@ class ImplicitReturnConfigurationTests: SwiftLintTestCase {
         let expectedKinds: Set<ImplicitReturnConfiguration.ReturnKind> = Set([
             .closure,
             .function,
-            .getter
+            .getter,
+            .initializer,
+            .subscript
         ])
         XCTAssertEqual(configuration.severityConfiguration.severity, .error)
         XCTAssertEqual(configuration.includedKinds, expectedKinds)

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnRuleTests.swift
@@ -2,60 +2,91 @@
 
 class ImplicitReturnRuleTests: SwiftLintTestCase {
     func testOnlyClosureKindIncluded() {
-        let nonTriggeringExamples = ImplicitReturnRuleExamples.GenericExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.ClosureExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.FunctionExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.FunctionExamples.triggeringExamples +
-            ImplicitReturnRuleExamples.GetterExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.GetterExamples.triggeringExamples
-        let triggeringExamples = ImplicitReturnRuleExamples.ClosureExamples.triggeringExamples
-        let corrections = ImplicitReturnRuleExamples.ClosureExamples.corrections
+        var nonTriggeringExamples = ImplicitReturnRuleExamples.nonTriggeringExamples +
+                                    ImplicitReturnRuleExamples.triggeringExamples
+        nonTriggeringExamples.removeAll(
+            where: ImplicitReturnRuleExamples.ClosureExamples.triggeringExamples.contains
+        )
 
-        let description = ImplicitReturnRule.description
-            .with(nonTriggeringExamples: nonTriggeringExamples)
-            .with(triggeringExamples: triggeringExamples)
-            .with(corrections: corrections)
-
-        self.verifyRule(description, returnKind: .closure)
+        verifySubset(
+            nonTriggeringExamples: nonTriggeringExamples,
+            triggeringExamples: ImplicitReturnRuleExamples.ClosureExamples.triggeringExamples,
+            corrections: ImplicitReturnRuleExamples.ClosureExamples.corrections,
+            kind: .closure
+        )
     }
 
     func testOnlyFunctionKindIncluded() {
-        let nonTriggeringExamples = ImplicitReturnRuleExamples.GenericExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.ClosureExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.ClosureExamples.triggeringExamples +
-            ImplicitReturnRuleExamples.FunctionExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.GetterExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.GetterExamples.triggeringExamples
-        let triggeringExamples = ImplicitReturnRuleExamples.FunctionExamples.triggeringExamples
-        let corrections = ImplicitReturnRuleExamples.FunctionExamples.corrections
+        var nonTriggeringExamples = ImplicitReturnRuleExamples.nonTriggeringExamples +
+                                    ImplicitReturnRuleExamples.triggeringExamples
+        nonTriggeringExamples.removeAll(
+            where: ImplicitReturnRuleExamples.FunctionExamples.triggeringExamples.contains
+        )
 
-        let description = ImplicitReturnRule.description
-            .with(nonTriggeringExamples: nonTriggeringExamples)
-            .with(triggeringExamples: triggeringExamples)
-            .with(corrections: corrections)
-
-        self.verifyRule(description, returnKind: .function)
+        verifySubset(
+            nonTriggeringExamples: nonTriggeringExamples,
+            triggeringExamples: ImplicitReturnRuleExamples.FunctionExamples.triggeringExamples,
+            corrections: ImplicitReturnRuleExamples.FunctionExamples.corrections,
+            kind: .function
+        )
     }
 
     func testOnlyGetterKindIncluded() {
-        let nonTriggeringExamples = ImplicitReturnRuleExamples.GenericExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.ClosureExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.ClosureExamples.triggeringExamples +
-            ImplicitReturnRuleExamples.FunctionExamples.nonTriggeringExamples +
-            ImplicitReturnRuleExamples.FunctionExamples.triggeringExamples +
-            ImplicitReturnRuleExamples.GetterExamples.nonTriggeringExamples
-        let triggeringExamples = ImplicitReturnRuleExamples.GetterExamples.triggeringExamples
-        let corrections = ImplicitReturnRuleExamples.GetterExamples.corrections
+        var nonTriggeringExamples = ImplicitReturnRuleExamples.nonTriggeringExamples +
+                                    ImplicitReturnRuleExamples.triggeringExamples
+        nonTriggeringExamples.removeAll(
+            where: ImplicitReturnRuleExamples.GetterExamples.triggeringExamples.contains
+        )
 
+        verifySubset(
+            nonTriggeringExamples: nonTriggeringExamples,
+            triggeringExamples: ImplicitReturnRuleExamples.GetterExamples.triggeringExamples,
+            corrections: ImplicitReturnRuleExamples.GetterExamples.corrections,
+            kind: .getter
+        )
+    }
+
+    func testOnlyInitializerKindIncluded() {
+        var nonTriggeringExamples = ImplicitReturnRuleExamples.nonTriggeringExamples +
+                                    ImplicitReturnRuleExamples.triggeringExamples
+        nonTriggeringExamples.removeAll(
+            where: ImplicitReturnRuleExamples.InitializerExamples.triggeringExamples.contains
+        )
+
+        verifySubset(
+            nonTriggeringExamples: nonTriggeringExamples,
+            triggeringExamples: ImplicitReturnRuleExamples.InitializerExamples.triggeringExamples,
+            corrections: ImplicitReturnRuleExamples.InitializerExamples.corrections,
+            kind: .initializer
+        )
+    }
+
+    func testOnlySubscriptKindIncluded() {
+        var nonTriggeringExamples = ImplicitReturnRuleExamples.nonTriggeringExamples +
+                                    ImplicitReturnRuleExamples.triggeringExamples
+        nonTriggeringExamples.removeAll(
+            where: ImplicitReturnRuleExamples.SubscriptExamples.triggeringExamples.contains
+        )
+
+        verifySubset(
+            nonTriggeringExamples: nonTriggeringExamples,
+            triggeringExamples: ImplicitReturnRuleExamples.SubscriptExamples.triggeringExamples,
+            corrections: ImplicitReturnRuleExamples.SubscriptExamples.corrections,
+            kind: .subscript
+        )
+    }
+
+    private func verifySubset(
+        nonTriggeringExamples: [Example],
+        triggeringExamples: [Example],
+        corrections: [Example: Example],
+        kind: ImplicitReturnConfiguration.ReturnKind
+    ) {
         let description = ImplicitReturnRule.description
-            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(nonTriggeringExamples: nonTriggeringExamples.removingViolationMarker())
             .with(triggeringExamples: triggeringExamples)
             .with(corrections: corrections)
 
-        self.verifyRule(description, returnKind: .getter)
-    }
-
-    private func verifyRule(_ ruleDescription: RuleDescription, returnKind: ImplicitReturnConfiguration.ReturnKind) {
-        self.verifyRule(ruleDescription, ruleConfiguration: ["included": [returnKind.rawValue]])
+        self.verifyRule(description, ruleConfiguration: ["included": [kind.rawValue]])
     }
 }


### PR DESCRIPTION
Fixes #5161.