### PR TITLE
Update SwiftSyntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "67c5007099d9ffdd292f421f81f4efe5ee42963e",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-09-a"
+        "revision" : "e42bece52df2496d60b1b2a762fee9ffde7fc205",
+        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-07-a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.1")),
-        .package(url: "https://github.com/apple/swift-syntax.git", exact: "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-09-a"),
+        .package(url: "https://github.com/apple/swift-syntax.git", exact: "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-07-a"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.34.1")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.6"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),

--- a/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
+++ b/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
@@ -54,7 +54,7 @@ enum LegacyFunctionRuleHelper {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard
                 node.isLegacyFunctionExpression(legacyFunctions: legacyFunctions),
-                let funcName = node.calledExpression.as(IdentifierExprSyntax.self)?.identifier.text,
+                let funcName = node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
                 !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter)
             else {
                 return super.visit(node)
@@ -62,7 +62,7 @@ enum LegacyFunctionRuleHelper {
 
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
 
-            let trimmedArguments = node.argumentList.map { $0.trimmingTrailingComma() }
+            let trimmedArguments = node.arguments.map { $0.trimmingTrailingComma() }
             let rewriteStrategy = legacyFunctions[funcName]
 
             let expr: ExprSyntax
@@ -91,9 +91,9 @@ enum LegacyFunctionRuleHelper {
 private extension FunctionCallExprSyntax {
     func isLegacyFunctionExpression(legacyFunctions: [String: LegacyFunctionRuleHelper.RewriteStrategy]) -> Bool {
         guard
-            let calledExpression = calledExpression.as(IdentifierExprSyntax.self),
-            let rewriteStrategy = legacyFunctions[calledExpression.identifier.text],
-            argumentList.count == rewriteStrategy.expectedInitialArguments
+            let calledExpression = calledExpression.as(DeclReferenceExprSyntax.self),
+            let rewriteStrategy = legacyFunctions[calledExpression.baseName.text],
+            arguments.count == rewriteStrategy.expectedInitialArguments
         else {
             return false
         }
@@ -102,8 +102,8 @@ private extension FunctionCallExprSyntax {
     }
 }
 
-private extension TupleExprElementSyntax {
-    func trimmingTrailingComma() -> TupleExprElementSyntax {
+private extension LabeledExprSyntax {
+    func trimmingTrailingComma() -> LabeledExprSyntax {
         self.trimmed.with(\.trailingComma, nil).trimmed
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -51,8 +51,8 @@ private extension AnonymousArgumentInMultilineClosureRule {
             return startLocation.line == endLocation.line ? .skipChildren : .visitChildren
         }
 
-        override func visitPost(_ node: IdentifierExprSyntax) {
-            if case .dollarIdentifier = node.identifier.tokenKind {
+        override func visitPost(_ node: DeclReferenceExprSyntax) {
+            if case .dollarIdentifier = node.baseName.tokenKind {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -42,9 +42,9 @@ private extension BlockBasedKVORule {
     private final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionDeclSyntax) {
             guard node.modifiers.containsOverride,
-                  case let parameterList = node.signature.input.parameterList,
+                  case let parameterList = node.signature.parameterClause.parameters,
                   parameterList.count == 4,
-                  node.identifier.text == "observeValue",
+                  node.name.text == "observeValue",
                   parameterList.map(\.firstName.text) == ["forKeyPath", "of", "change", "context"]
             else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -144,9 +144,9 @@ private extension ConvenienceTypeRule {
             }
         }
 
-        private func hasViolation(inheritance: TypeInheritanceClauseSyntax?,
+        private func hasViolation(inheritance: InheritanceClauseSyntax?,
                                   attributes: AttributeListSyntax?,
-                                  members: MemberDeclBlockSyntax) -> Bool {
+                                  members: MemberBlockSyntax) -> Bool {
             guard inheritance.isNilOrEmpty,
                   !attributes.containsObjcMembers,
                   !attributes.containsObjc,
@@ -196,9 +196,9 @@ private class ConvenienceTypeCheckVisitor: ViolationsSyntaxVisitor {
     }
 }
 
-private extension TypeInheritanceClauseSyntax? {
+private extension InheritanceClauseSyntax? {
     var isNilOrEmpty: Bool {
-        self?.inheritedTypeCollection.isEmpty ?? true
+        self?.inheritedTypes.isEmpty ?? true
     }
 }
 
@@ -220,12 +220,12 @@ private extension AttributeListSyntax? {
 
         return attrs.contains { elem in
             guard let attr = elem.as(AttributeSyntax.self),
-                  let arguments = attr.argument?.as(AvailabilitySpecListSyntax.self) else {
+                  let arguments = attr.arguments?.as(AvailabilityArgumentListSyntax.self) else {
                 return false
             }
 
             return attr.attributeNameText == "available" && arguments.contains { arg in
-                arg.entry.as(TokenSyntax.self)?.tokenKind.isUnavailableKeyword == true
+                arg.argument.as(TokenSyntax.self)?.tokenKind.isUnavailableKeyword == true
             }
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -31,11 +31,11 @@ struct DiscouragedAssertRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderR
 private extension DiscouragedAssertRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            guard node.calledExpression.as(IdentifierExprSyntax.self)?.identifier.text == "assert",
-                  let firstArg = node.argumentList.first,
+            guard node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text == "assert",
+                  let firstArg = node.arguments.first,
                   firstArg.label == nil,
                   let boolExpr = firstArg.expression.as(BooleanLiteralExprSyntax.self),
-                  boolExpr.booleanLiteral.tokenKind == .keyword(.false) else {
+                  boolExpr.literal.tokenKind == .keyword(.false) else {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedNoneNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedNoneNameRule.swift
@@ -185,8 +185,8 @@ struct DiscouragedNoneNameRule: SwiftSyntaxRule, OptInRule, ConfigurationProvide
 private extension DiscouragedNoneNameRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: EnumCaseElementSyntax) {
-            let emptyParams = node.associatedValue?.parameterList.isEmpty ?? true
-            if emptyParams, node.identifier.isNone {
+            let emptyParams = node.parameterClause?.parameters.isEmpty ?? true
+            if emptyParams, node.name.isNone {
                 violations.append(ReasonedRuleViolation(
                     position: node.positionAfterSkippingLeadingTrivia,
                     reason: reason(type: "`case`")

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -38,7 +38,7 @@ private extension DiscouragedObjectLiteralRule {
 
         override func visitPost(_ node: MacroExpansionExprSyntax) {
             guard
-                case let .identifier(identifierText) = node.macro.tokenKind,
+                case let .identifier(identifierText) = node.macroName.tokenKind,
                 ["colorLiteral", "imageLiteral"].contains(identifierText)
             else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -20,13 +20,13 @@ struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRule, Swi
 private extension DiscouragedOptionalBooleanRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: OptionalTypeSyntax) {
-            if node.wrappedType.as(SimpleTypeIdentifierSyntax.self)?.typeName == "Bool" {
+            if node.wrappedType.as(IdentifierTypeSyntax.self)?.typeName == "Bool" {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }
 
         override func visitPost(_ node: OptionalChainingExprSyntax) {
-            if node.expression.as(IdentifierExprSyntax.self)?.identifier.text == "Bool" {
+            if node.expression.as(DeclReferenceExprSyntax.self)?.baseName.text == "Bool" {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }
@@ -34,11 +34,11 @@ private extension DiscouragedOptionalBooleanRule {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
                 let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),
-                let singleArgument = node.argumentList.onlyElement,
+                let singleArgument = node.arguments.onlyElement,
                 singleArgument.expression.is(BooleanLiteralExprSyntax.self),
-                let base = calledExpression.base?.as(IdentifierExprSyntax.self),
-                base.identifier.text == "Optional",
-                calledExpression.name.text == "some"
+                let base = calledExpression.base?.as(DeclReferenceExprSyntax.self),
+                base.baseName.text == "Optional",
+                calledExpression.declName.baseName.text == "some"
             else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -88,7 +88,7 @@ private extension ExplicitEnumRawValueRule {
 
         override func visitPost(_ node: EnumCaseElementSyntax) {
             if node.rawValue == nil, node.enclosingEnum()?.supportsRawValues == true {
-                violations.append(node.identifier.positionAfterSkippingLeadingTrivia)
+                violations.append(node.name.positionAfterSkippingLeadingTrivia)
             }
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -224,7 +224,7 @@ private extension ExplicitInitRule {
 
 private extension MemberAccessExprSyntax {
     var explicitInitPosition: AbsolutePosition? {
-        if let base, base.isTypeReferenceLike, name.text == "init" {
+        if let base, base.isTypeReferenceLike, declName.baseName.text == "init" {
             return base.endPositionBeforeTrailingTrivia
         } else {
             return nil
@@ -235,13 +235,13 @@ private extension MemberAccessExprSyntax {
 private extension ExprSyntax {
     /// `String` or `Nested.Type`.
     var isTypeReferenceLike: Bool {
-        if let expr = self.as(IdentifierExprSyntax.self), expr.identifier.text.startsWithUppercase {
+        if let expr = self.as(DeclReferenceExprSyntax.self), expr.baseName.text.startsWithUppercase {
             return true
         } else if let expr = self.as(MemberAccessExprSyntax.self),
                   expr.description.split(separator: ".").allSatisfy(\.startsWithUppercase) {
             return true
-        } else if let expr = self.as(SpecializeExprSyntax.self)?.expression.as(IdentifierExprSyntax.self),
-                  expr.identifier.text.startsWithUppercase {
+        } else if let expr = self.as(GenericSpecializationExprSyntax.self)?.expression.as(DeclReferenceExprSyntax.self),
+                  expr.baseName.text.startsWithUppercase {
             return true
         } else {
             return false

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -67,7 +67,7 @@ private extension ExplicitTopLevelACLRule {
             }
         }
 
-        override func visitPost(_ node: TypealiasDeclSyntax) {
+        override func visitPost(_ node: TypeAliasDeclSyntax) {
             if hasViolation(modifiers: node.modifiers) {
                 violations.append(node.typealiasKeyword.positionAfterSkippingLeadingTrivia)
             }
@@ -81,7 +81,7 @@ private extension ExplicitTopLevelACLRule {
 
         override func visitPost(_ node: VariableDeclSyntax) {
             if hasViolation(modifiers: node.modifiers) {
-                violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+                violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
             }
         }
 
@@ -93,7 +93,7 @@ private extension ExplicitTopLevelACLRule {
             .skipChildren
         }
 
-        private func hasViolation(modifiers: ModifierListSyntax?) -> Bool {
+        private func hasViolation(modifiers: DeclModifierListSyntax?) -> Bool {
             guard let modifiers else {
                 return true
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -93,7 +93,7 @@ private class Visitor: ViolationsSyntaxVisitor {
             if configuration.allowedKinds.contains(.static) {
                 checkViolation(node)
             }
-        } else if node.parent?.is(MemberDeclListItemSyntax.self) == true {
+        } else if node.parent?.is(MemberBlockItemSyntax.self) == true {
             if configuration.allowedKinds.contains(.instance) {
                 checkViolation(node)
             }
@@ -130,7 +130,7 @@ private extension InitializerClauseSyntax {
     }
 
     var isTypeReference: Bool {
-        value.as(MemberAccessExprSyntax.self)?.name.tokenKind == .keyword(.self)
+        value.as(MemberAccessExprSyntax.self)?.declName.baseName.tokenKind == .keyword(.self)
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FallthroughRule.swift
@@ -35,7 +35,7 @@ struct FallthroughRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
 
 private extension FallthroughRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override func visitPost(_ node: FallthroughStmtSyntax) {
+        override func visitPost(_ node: FallThroughStmtSyntax) {
             violations.append(node.positionAfterSkippingLeadingTrivia)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -42,9 +42,9 @@ struct FatalErrorMessageRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInR
 private extension FatalErrorMessageRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            guard let expression = node.calledExpression.as(IdentifierExprSyntax.self),
-                  expression.identifier.text == "fatalError",
-                node.argumentList.isEmptyOrEmptyString else {
+            guard let expression = node.calledExpression.as(DeclReferenceExprSyntax.self),
+                  expression.baseName.text == "fatalError",
+                  node.arguments.isEmptyOrEmptyString else {
                 return
             }
 
@@ -53,7 +53,7 @@ private extension FatalErrorMessageRule {
     }
 }
 
-private extension TupleExprElementListSyntax {
+private extension LabeledExprListSyntax {
     var isEmptyOrEmptyString: Bool {
         if isEmpty {
             return true

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FileNameRule.swift
@@ -55,27 +55,27 @@ private class TypeNameCollectingVisitor: SyntaxVisitor {
     private(set) var names: Set<String> = []
 
     override func visitPost(_ node: ClassDeclSyntax) {
-        names.insert(node.identifier.text)
+        names.insert(node.name.text)
     }
 
     override func visitPost(_ node: ActorDeclSyntax) {
-        names.insert(node.identifier.text)
+        names.insert(node.name.text)
     }
 
     override func visitPost(_ node: StructDeclSyntax) {
-        names.insert(node.identifier.text)
+        names.insert(node.name.text)
     }
 
-    override func visitPost(_ node: TypealiasDeclSyntax) {
-        names.insert(node.identifier.text)
+    override func visitPost(_ node: TypeAliasDeclSyntax) {
+        names.insert(node.name.text)
     }
 
     override func visitPost(_ node: EnumDeclSyntax) {
-        names.insert(node.identifier.text)
+        names.insert(node.name.text)
     }
 
     override func visitPost(_ node: ProtocolDeclSyntax) {
-        names.insert(node.identifier.text)
+        names.insert(node.name.text)
     }
 
     override func visitPost(_ node: ExtensionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForWhereRule.swift
@@ -130,7 +130,7 @@ private extension ForWhereRule {
             super.init(viewMode: .sourceAccurate)
         }
 
-        override func visitPost(_ node: ForInStmtSyntax) {
+        override func visitPost(_ node: ForStmtSyntax) {
             guard node.whereClause == nil,
                   let onlyExprStmt = node.body.statements.onlyElement?.item.as(ExpressionStmtSyntax.self),
                   let ifExpr = onlyExprStmt.expression.as(IfExprSyntax.self),
@@ -183,7 +183,7 @@ private extension ConditionElementSyntax {
             }
 
             let operators: Set = ["&&", "||"]
-            return operators.contains(binaryExpr.operatorToken.text)
+            return operators.contains(binaryExpr.operator.text)
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceCastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceCastRule.swift
@@ -22,13 +22,13 @@ struct ForceCastRule: ConfigurationProviderRule, SwiftSyntaxRule {
 private final class ForceCastRuleVisitor: ViolationsSyntaxVisitor {
     override func visitPost(_ node: AsExprSyntax) {
         if node.questionOrExclamationMark?.tokenKind == .exclamationMark {
-            violations.append(node.asTok.positionAfterSkippingLeadingTrivia)
+            violations.append(node.asKeyword.positionAfterSkippingLeadingTrivia)
         }
     }
 
     override func visitPost(_ node: UnresolvedAsExprSyntax) {
         if node.questionOrExclamationMark?.tokenKind == .exclamationMark {
-            violations.append(node.asTok.positionAfterSkippingLeadingTrivia)
+            violations.append(node.asKeyword.positionAfterSkippingLeadingTrivia)
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -71,7 +71,7 @@ struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRul
 }
 
 private final class ForceUnwrappingVisitor: ViolationsSyntaxVisitor {
-    override func visitPost(_ node: ForcedValueExprSyntax) {
+    override func visitPost(_ node: ForceUnwrapExprSyntax) {
         violations.append(node.exclamationMark.positionAfterSkippingLeadingTrivia)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -76,7 +76,7 @@ private extension FunctionDefaultParameterAtEndRule {
 
 private extension FunctionSignatureSyntax {
     var containsViolation: Bool {
-        let params = input.parameterList.filter { param in
+        let params = parameterClause.parameters.filter { param in
             !param.isClosure
         }
 
@@ -85,7 +85,7 @@ private extension FunctionSignatureSyntax {
         }
 
         let defaultParams = params.filter { param in
-            param.defaultArgument != nil
+            param.defaultValue != nil
         }
         guard defaultParams.isNotEmpty else {
             return false
@@ -93,7 +93,7 @@ private extension FunctionSignatureSyntax {
 
         let lastParameters = params.suffix(defaultParams.count)
         let lastParametersWithDefaultValue = lastParameters.filter { param in
-            param.defaultArgument != nil
+            param.defaultValue != nil
         }
 
         return lastParameters.count != lastParametersWithDefaultValue.count

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/IsDisjointRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/IsDisjointRule.swift
@@ -29,15 +29,15 @@ private extension IsDisjointRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
-                node.name.text == "isEmpty",
+                node.declName.baseName.text == "isEmpty",
                 let firstBase = node.base?.asFunctionCall,
                 let firstBaseCalledExpression = firstBase.calledExpression.as(MemberAccessExprSyntax.self),
-                firstBaseCalledExpression.name.text == "intersection"
+                firstBaseCalledExpression.declName.baseName.text == "intersection"
             else {
                 return
             }
 
-            violations.append(firstBaseCalledExpression.name.positionAfterSkippingLeadingTrivia)
+            violations.append(firstBaseCalledExpression.declName.baseName.positionAfterSkippingLeadingTrivia)
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -74,7 +74,7 @@ private extension JoinedDefaultParameterRule {
             }
 
             correctionPositions.append(violationPosition)
-            let newNode = node.with(\.argumentList, [])
+            let newNode = node.with(\.arguments, [])
             return super.visit(newNode)
         }
     }
@@ -82,9 +82,9 @@ private extension JoinedDefaultParameterRule {
 
 private extension FunctionCallExprSyntax {
     var violationPosition: AbsolutePosition? {
-        guard let argument = argumentList.first,
+        guard let argument = arguments.first,
               let memberExp = calledExpression.as(MemberAccessExprSyntax.self),
-              memberExp.name.text == "joined",
+              memberExp.declName.baseName.text == "joined",
               argument.label?.text == "separator",
               let strLiteral = argument.expression.as(StringLiteralExprSyntax.self),
               strLiteral.isEmptyString else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyHashingRule.swift
@@ -82,18 +82,18 @@ extension LegacyHashingRule {
     private final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: VariableDeclSyntax) {
             guard
-                node.parent?.is(MemberDeclListItemSyntax.self) == true,
-                node.bindingKeyword.tokenKind == .keyword(.var),
+                node.parent?.is(MemberBlockItemSyntax.self) == true,
+                node.bindingSpecifier.tokenKind == .keyword(.var),
                 let binding = node.bindings.onlyElement,
                 let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
                 identifier.identifier.text == "hashValue",
-                let returnType = binding.typeAnnotation?.type.as(SimpleTypeIdentifierSyntax.self),
+                let returnType = binding.typeAnnotation?.type.as(IdentifierTypeSyntax.self),
                 returnType.name.text == "Int"
             else {
                 return
             }
 
-            violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+            violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -49,10 +49,10 @@ struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule
 private extension LegacyMultipleRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
-            guard let operatorNode = node.operatorOperand.as(BinaryOperatorExprSyntax.self),
-                  operatorNode.operatorToken.tokenKind == .binaryOperator("%"),
+            guard let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),
+                  operatorNode.operator.tokenKind == .binaryOperator("%"),
                   let parent = node.parent?.as(InfixOperatorExprSyntax.self),
-                  let parentOperatorNode = parent.operatorOperand.as(BinaryOperatorExprSyntax.self),
+                  let parentOperatorNode = parent.operator.as(BinaryOperatorExprSyntax.self),
                   parentOperatorNode.isEqualityOrInequalityOperator else {
                 return
             }
@@ -71,14 +71,14 @@ private extension LegacyMultipleRule {
                 return
             }
 
-            violations.append(node.operatorOperand.positionAfterSkippingLeadingTrivia)
+            violations.append(node.operator.positionAfterSkippingLeadingTrivia)
         }
     }
 }
 
 private extension BinaryOperatorExprSyntax {
     var isEqualityOrInequalityOperator: Bool {
-        operatorToken.tokenKind == .binaryOperator("==") ||
-            operatorToken.tokenKind == .binaryOperator("!=")
+        `operator`.tokenKind == .binaryOperator("==") ||
+        `operator`.tokenKind == .binaryOperator("!=")
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -73,20 +73,20 @@ struct LegacyObjcTypeRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
 
 private extension LegacyObjcTypeRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override func visitPost(_ node: SimpleTypeIdentifierSyntax) {
+        override func visitPost(_ node: IdentifierTypeSyntax) {
             if let typeName = node.typeName, legacyObjcTypes.contains(typeName) {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }
 
-        override func visitPost(_ node: IdentifierExprSyntax) {
-            if legacyObjcTypes.contains(node.identifier.text) {
-                violations.append(node.identifier.positionAfterSkippingLeadingTrivia)
+        override func visitPost(_ node: DeclReferenceExprSyntax) {
+            if legacyObjcTypes.contains(node.baseName.text) {
+                violations.append(node.baseName.positionAfterSkippingLeadingTrivia)
             }
         }
 
-        override func visitPost(_ node: MemberTypeIdentifierSyntax) {
-            guard node.baseType.as(SimpleTypeIdentifierSyntax.self)?.typeName == "Foundation",
+        override func visitPost(_ node: MemberTypeSyntax) {
+            guard node.baseType.as(IdentifierTypeSyntax.self)?.typeName == "Foundation",
                legacyObjcTypes.contains(node.name.text)
             else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyRandomRule.swift
@@ -34,7 +34,7 @@ private extension LegacyRandomRule {
         ]
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            if let function = node.calledExpression.as(IdentifierExprSyntax.self)?.identifier.text,
+            if let function = node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
                Self.legacyRandomFunctions.contains(function) {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -24,11 +24,11 @@ private extension NoFallthroughOnlyRule {
 
             let localViolations = cases.enumerated()
                 .compactMap { index, element -> AbsolutePosition? in
-                    if let fallthroughStmt = element.statements.onlyElement?.item.as(FallthroughStmtSyntax.self) {
+                    if let fallthroughStmt = element.statements.onlyElement?.item.as(FallThroughStmtSyntax.self) {
                         if case let nextCaseIndex = cases.index(after: index),
                            nextCaseIndex < cases.endIndex,
                            case let nextCase = cases[nextCaseIndex],
-                           nextCase.unknownAttr != nil {
+                           nextCase.attribute != nil {
                             return nil
                         }
                         return fallthroughStmt.positionAfterSkippingLeadingTrivia

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -108,7 +108,7 @@ private extension NoMagicNumbersRule {
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {
-            let className = node.identifier.text
+            let className = node.name.text
             if node.isXCTestCase(testParentClasses) {
                 testClasses.insert(className)
                 removeViolations(forClassName: className)
@@ -118,14 +118,14 @@ private extension NoMagicNumbersRule {
         }
 
         override func visitPost(_ node: FloatLiteralExprSyntax) {
-            guard node.floatingDigits.isMagicNumber else {
+            guard node.literal.isMagicNumber else {
                 return
             }
             collectViolation(forNode: node)
         }
 
         override func visitPost(_ node: IntegerLiteralExprSyntax) {
-            guard node.digits.isMagicNumber else {
+            guard node.literal.isMagicNumber else {
                 return
             }
             collectViolation(forNode: node)
@@ -213,7 +213,7 @@ private extension ExprSyntaxProtocol {
         }
 
         let operatorIndex = siblings.index(after: siblings.startIndex)
-        if let tokenKind = siblings[operatorIndex].as(BinaryOperatorExprSyntax.self)?.operatorToken.tokenKind {
+        if let tokenKind = siblings[operatorIndex].as(BinaryOperatorExprSyntax.self)?.operator.tokenKind {
             return tokenKind == .binaryOperator("<<") || tokenKind == .binaryOperator(">>")
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -62,8 +62,8 @@ private extension ObjectLiteralRule {
 
         private func isImageNamedInit(node: FunctionCallExprSyntax, name: String) -> Bool {
             guard inits(forClasses: ["UIImage", "NSImage"]).contains(name),
-                  node.argumentList.compactMap(\.label?.text) == ["named"],
-                  let argument = node.argumentList.first?.expression.as(StringLiteralExprSyntax.self),
+                  node.arguments.compactMap(\.label?.text) == ["named"],
+                  let argument = node.arguments.first?.expression.as(StringLiteralExprSyntax.self),
                   argument.isConstantString else {
                 return false
             }
@@ -73,12 +73,12 @@ private extension ObjectLiteralRule {
 
         private func isColorInit(node: FunctionCallExprSyntax, name: String) -> Bool {
             guard inits(forClasses: ["UIColor", "NSColor"]).contains(name),
-                case let argumentsNames = node.argumentList.compactMap(\.label?.text),
+                  case let argumentsNames = node.arguments.compactMap(\.label?.text),
                 argumentsNames == ["red", "green", "blue", "alpha"] || argumentsNames == ["white", "alpha"] else {
                     return false
             }
 
-            return node.argumentList.allSatisfy { elem in
+            return node.arguments.allSatisfy { elem in
                 elem.expression.canBeExpressedAsColorLiteralParams
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferNimbleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferNimbleRule.swift
@@ -30,8 +30,8 @@ struct PreferNimbleRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
 private extension PreferNimbleRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            if let expr = node.calledExpression.as(IdentifierExprSyntax.self),
-               expr.identifier.text.starts(with: "XCTAssert") {
+            if let expr = node.calledExpression.as(DeclReferenceExprSyntax.self),
+               expr.baseName.text.starts(with: "XCTAssert") {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -125,19 +125,19 @@ private extension FunctionCallExprSyntax {
     }
 
     var name: String? {
-        guard let expr = calledExpression.as(IdentifierExprSyntax.self) else {
+        guard let expr = calledExpression.as(DeclReferenceExprSyntax.self) else {
             return nil
         }
 
-        return expr.identifier.text
+        return expr.baseName.text
     }
 
     var argumentNames: [String?] {
-        argumentList.map(\.label?.text)
+        arguments.map(\.label?.text)
     }
 
     var argumentsAreAllZero: Bool {
-        argumentList.allSatisfy { arg in
+        arguments.allSatisfy { arg in
             if let intExpr = arg.expression.as(IntegerLiteralExprSyntax.self) {
                 return intExpr.isZero
             } else if let floatExpr = arg.expression.as(FloatLiteralExprSyntax.self) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -125,7 +125,7 @@ private extension PrivateOverFilePrivateRule {
             return .skipChildren
         }
 
-        override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+        override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
             if let privateModifier = node.modifiers.fileprivateModifier {
                 violations.append(privateModifier.positionAfterSkippingLeadingTrivia)
             }
@@ -230,7 +230,7 @@ private extension PrivateOverFilePrivateRule {
             return DeclSyntax(newNode)
         }
 
-        override func visit(_ node: TypealiasDeclSyntax) -> DeclSyntax {
+        override func visit(_ node: TypeAliasDeclSyntax) -> DeclSyntax {
             guard let modifier = node.modifiers.fileprivateModifier,
                   let modifierIndex = node.modifiers.fileprivateModifierIndex,
                   !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) else {
@@ -244,8 +244,8 @@ private extension PrivateOverFilePrivateRule {
     }
 }
 
-private extension ModifierListSyntax? {
-    var fileprivateModifierIndex: ModifierListSyntax.Index? {
+private extension DeclModifierListSyntax? {
+    var fileprivateModifierIndex: DeclModifierListSyntax.Index? {
         self?.firstIndex(where: { $0.name.tokenKind == .keyword(.fileprivate) })
     }
 
@@ -254,12 +254,12 @@ private extension ModifierListSyntax? {
     }
 }
 
-private extension ModifierListSyntax {
-    func replacing(fileprivateModifierIndex: ModifierListSyntax.Index) -> ModifierListSyntax? {
+private extension DeclModifierListSyntax {
+    func replacing(fileprivateModifierIndex: DeclModifierListSyntax.Index) -> DeclModifierListSyntax? {
         let fileprivateModifier = self[fileprivateModifierIndex]
-        return replacing(
-            childAt: self.distance(from: self.startIndex, to: fileprivateModifierIndex),
-            with: fileprivateModifier.with(
+        return with(
+            \.[fileprivateModifierIndex],
+            fileprivateModifier.with(
                 \.name,
                 .keyword(
                     .private,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -16,7 +16,7 @@ struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule, Config
             Example("var myVar: Int? = nil; myVar ↓?? nil")
         ],
         corrections: [
-            Example("var myVar: Int? = nil; let foo = myVar↓ ?? nil"):
+            Example("var myVar: Int? = nil; let foo = myVar ↓?? nil"):
                 Example("var myVar: Int? = nil; let foo = myVar")
         ]
     )
@@ -59,14 +59,14 @@ private extension RedundantNilCoalescingRule {
                 let lastExpression = node.last,
                 lastExpression.is(NilLiteralExprSyntax.self),
                 let secondToLastExpression = node.dropLast().last?.as(BinaryOperatorExprSyntax.self),
-                secondToLastExpression.operatorToken.tokenKind.isNilCoalescingOperator,
+                secondToLastExpression.operator.tokenKind.isNilCoalescingOperator,
                 !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter)
             else {
                 return super.visit(node)
             }
 
-            let newNode = node.removingLast().removingLast().with(\.trailingTrivia, [])
-            correctionPositions.append(newNode.endPosition)
+            let newNode = ExprListSyntax(node.dropLast(2)).with(\.trailingTrivia, [])
+            correctionPositions.append(secondToLastExpression.operator.positionAfterSkippingLeadingTrivia)
             return super.visit(newNode)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -43,7 +43,7 @@ private extension AttributeListSyntax {
     var objCAttribute: AttributeSyntax? {
         lazy
             .compactMap { $0.as(AttributeSyntax.self) }
-            .first { $0.attributeNameText == "objc" && $0.argument == nil }
+            .first { $0.attributeNameText == "objc" && $0.arguments == nil }
     }
 
     var hasAttributeImplyingObjC: Bool {
@@ -62,14 +62,14 @@ private extension Syntax {
         if self.is(FunctionDeclSyntax.self) {
             return true
         } else if let variableDecl = self.as(VariableDeclSyntax.self),
-                  variableDecl.bindings.allSatisfy({ $0.accessor == nil }) {
+                  variableDecl.bindings.allSatisfy({ $0.accessorBlock == nil }) {
             return true
         } else {
             return false
         }
     }
 
-    var functionOrVariableModifiers: ModifierListSyntax? {
+    var functionOrVariableModifiers: DeclModifierListSyntax? {
         if let functionDecl = self.as(FunctionDeclSyntax.self) {
             return functionDecl.modifiers
         } else if let variableDecl = self.as(VariableDeclSyntax.self) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -119,7 +119,7 @@ struct RedundantOptionalInitializationRule: SwiftSyntaxCorrectableRule, Configur
 private extension RedundantOptionalInitializationRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: VariableDeclSyntax) {
-            guard node.bindingKeyword.tokenKind == .keyword(.var),
+            guard node.bindingSpecifier.tokenKind == .keyword(.var),
                   !node.modifiers.containsLazy else {
                 return
             }
@@ -139,7 +139,7 @@ private extension RedundantOptionalInitializationRule {
         }
 
         override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
-            guard node.bindingKeyword.tokenKind == .keyword(.var),
+            guard node.bindingSpecifier.tokenKind == .keyword(.var),
                   !node.modifiers.containsLazy else {
                 return super.visit(node)
             }
@@ -164,7 +164,7 @@ private extension RedundantOptionalInitializationRule {
                     return binding
                 }
                 let newBinding = binding.with(\.initializer, nil)
-                if newBinding.accessor != nil {
+                if newBinding.accessorBlock != nil {
                     return newBinding
                 }
                 if binding.trailingComma != nil {
@@ -203,7 +203,7 @@ private extension TypeAnnotationSyntax {
             return true
         }
 
-        if let type = type.as(SimpleTypeIdentifierSyntax.self), let genericClause = type.genericArgumentClause {
+        if let type = type.as(IdentifierTypeSyntax.self), let genericClause = type.genericArgumentClause {
             return genericClause.arguments.count == 1 && type.name.text == "Optional"
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -121,26 +121,26 @@ private extension SyntaxProtocol {
 }
 
 private extension DeclSyntax {
-    var modifiers: ModifierListSyntax? {
+    var modifiers: DeclModifierListSyntax? {
         if let decl = self.as(ClassDeclSyntax.self) {
-            return decl.modifiers ?? ModifierListSyntax([])
+            return decl.modifiers ?? DeclModifierListSyntax([])
         } else if let decl = self.as(ActorDeclSyntax.self) {
-            return decl.modifiers ?? ModifierListSyntax([])
+            return decl.modifiers ?? DeclModifierListSyntax([])
         } else if let decl = self.as(StructDeclSyntax.self) {
-            return decl.modifiers ?? ModifierListSyntax([])
+            return decl.modifiers ?? DeclModifierListSyntax([])
         } else if let decl = self.as(ProtocolDeclSyntax.self) {
-            return decl.modifiers ?? ModifierListSyntax([])
+            return decl.modifiers ?? DeclModifierListSyntax([])
         } else if let decl = self.as(ExtensionDeclSyntax.self) {
-            return decl.modifiers ?? ModifierListSyntax([])
+            return decl.modifiers ?? DeclModifierListSyntax([])
         } else if let decl = self.as(EnumDeclSyntax.self) {
-            return decl.modifiers ?? ModifierListSyntax([])
+            return decl.modifiers ?? DeclModifierListSyntax([])
         }
 
         return nil
     }
 }
 
-private extension ModifierListSyntax {
+private extension DeclModifierListSyntax {
     var setAccessor: DeclModifierSyntax? {
         first { $0.detail?.detail.tokenKind == .identifier("set") }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -85,7 +85,7 @@ private extension RedundantStringEnumValueRule {
                 .compactMap { element -> AbsolutePosition? in
                     guard let stringExpr = element.rawValue?.value.as(StringLiteralExprSyntax.self),
                           let segment = stringExpr.segments.onlyElement?.as(StringSegmentSyntax.self),
-                          segment.content.text == element.identifier.text else {
+                          segment.content.text == element.name.text else {
                         return nil
                     }
 
@@ -105,8 +105,8 @@ private extension EnumDeclSyntax {
             return false
         }
 
-        return inheritanceClause.inheritedTypeCollection.contains { elem in
-            elem.typeName.as(SimpleTypeIdentifierSyntax.self)?.typeName == "String"
+        return inheritanceClause.inheritedTypes.contains { elem in
+            elem.type.as(IdentifierTypeSyntax.self)?.typeName == "String"
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -44,10 +44,10 @@ private extension Syntax {
 
 private extension FunctionDeclSyntax {
     var returnsVoid: Bool {
-        if let type = signature.output?.returnType.as(SimpleTypeIdentifierSyntax.self) {
+        if let type = signature.returnClause?.type.as(IdentifierTypeSyntax.self) {
             return type.name.text == "Void"
         }
 
-        return signature.output?.returnType == nil
+        return signature.returnClause?.type == nil
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
@@ -94,7 +94,7 @@ struct ShorthandOptionalBindingRule: OptInRule, SwiftSyntaxCorrectableRule, Conf
 private class Visitor: ViolationsSyntaxVisitor {
     override func visitPost(_ node: OptionalBindingConditionSyntax) {
         if node.isShadowingOptionalBinding {
-            violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+            violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
         }
     }
 }
@@ -128,8 +128,8 @@ private class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
 private extension OptionalBindingConditionSyntax {
     var isShadowingOptionalBinding: Bool {
         if let id = pattern.as(IdentifierPatternSyntax.self),
-           let value = initializer?.value.as(IdentifierExprSyntax.self),
-           id.identifier.text == value.identifier.text {
+           let value = initializer?.value.as(DeclReferenceExprSyntax.self),
+           id.identifier.text == value.baseName.text {
             return true
         }
         return false

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
@@ -99,7 +99,7 @@ private extension FunctionDeclSyntax {
     }
 
     var isOperator: Bool {
-        switch identifier.tokenKind {
+        switch name.tokenKind {
         case .binaryOperator:
             return true
         default:

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
@@ -61,25 +61,21 @@ private extension ToggleBoolRule {
         }
 
         override func visit(_ node: ExprListSyntax) -> ExprListSyntax {
-            guard
-                node.hasToggleBoolViolation,
-                !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter)
-            else {
+            guard node.hasToggleBoolViolation,
+                  !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter),
+                  let firstExpr = node.first, let index = node.index(of: firstExpr) else {
                 return super.visit(node)
             }
-
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-
-            let newNode = node
-                .replacing(
-                    childAt: 0,
-                    with: "\(node.first!.trimmed).toggle()"
+            let elements = node
+                .with(
+                    \.[index],
+                    "\(firstExpr.trimmed).toggle()"
                 )
-                .removingLast()
-                .removingLast()
+                .dropLast(2)
+            let newNode = ExprListSyntax(elements)
                 .with(\.leadingTrivia, node.leadingTrivia)
                 .with(\.trailingTrivia, node.trailingTrivia)
-
             return super.visit(newNode)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
@@ -32,56 +32,56 @@ private extension TypeNameRule {
         }
 
         override func visitPost(_ node: StructDeclSyntax) {
-            if let violation = violation(identifier: node.identifier, modifiers: node.modifiers,
-                                         inheritedTypes: node.inheritanceClause?.inheritedTypeCollection) {
+            if let violation = violation(identifier: node.name, modifiers: node.modifiers,
+                                         inheritedTypes: node.inheritanceClause?.inheritedTypes) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {
-            if let violation = violation(identifier: node.identifier, modifiers: node.modifiers,
-                                         inheritedTypes: node.inheritanceClause?.inheritedTypeCollection) {
+            if let violation = violation(identifier: node.name, modifiers: node.modifiers,
+                                         inheritedTypes: node.inheritanceClause?.inheritedTypes) {
                 violations.append(violation)
             }
         }
 
-        override func visitPost(_ node: TypealiasDeclSyntax) {
-            if let violation = violation(identifier: node.identifier, modifiers: node.modifiers, inheritedTypes: nil) {
+        override func visitPost(_ node: TypeAliasDeclSyntax) {
+            if let violation = violation(identifier: node.name, modifiers: node.modifiers, inheritedTypes: nil) {
                 violations.append(violation)
             }
         }
 
-        override func visitPost(_ node: AssociatedtypeDeclSyntax) {
-            if let violation = violation(identifier: node.identifier, modifiers: node.modifiers,
-                                         inheritedTypes: node.inheritanceClause?.inheritedTypeCollection) {
+        override func visitPost(_ node: AssociatedTypeDeclSyntax) {
+            if let violation = violation(identifier: node.name, modifiers: node.modifiers,
+                                         inheritedTypes: node.inheritanceClause?.inheritedTypes) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: EnumDeclSyntax) {
-            if let violation = violation(identifier: node.identifier, modifiers: node.modifiers,
-                                         inheritedTypes: node.inheritanceClause?.inheritedTypeCollection) {
+            if let violation = violation(identifier: node.name, modifiers: node.modifiers,
+                                         inheritedTypes: node.inheritanceClause?.inheritedTypes) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: ActorDeclSyntax) {
-            if let violation = violation(identifier: node.identifier, modifiers: node.modifiers,
-                                         inheritedTypes: node.inheritanceClause?.inheritedTypeCollection) {
+            if let violation = violation(identifier: node.name, modifiers: node.modifiers,
+                                         inheritedTypes: node.inheritanceClause?.inheritedTypes) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: ProtocolDeclSyntax) {
             if configuration.validateProtocols,
-               let violation = violation(identifier: node.identifier, modifiers: node.modifiers,
-                                         inheritedTypes: node.inheritanceClause?.inheritedTypeCollection) {
+               let violation = violation(identifier: node.name, modifiers: node.modifiers,
+                                         inheritedTypes: node.inheritanceClause?.inheritedTypes) {
                 violations.append(violation)
             }
         }
 
         private func violation(identifier: TokenSyntax,
-                               modifiers: ModifierListSyntax?,
+                               modifiers: DeclModifierListSyntax?,
                                inheritedTypes: InheritedTypeListSyntax?) -> ReasonedRuleViolation? {
             let originalName = identifier.text
             let nameConfiguration = configuration.nameConfiguration
@@ -135,7 +135,7 @@ private extension String {
         return substring(from: 0, length: lastPreviewsIndex)
     }
 
-    func strippingLeadingUnderscoreIfPrivate(modifiers: ModifierListSyntax?) -> String {
+    func strippingLeadingUnderscoreIfPrivate(modifiers: DeclModifierListSyntax?) -> String {
         if first == "_", modifiers.isPrivateOrFileprivate {
             return String(self[index(after: startIndex)...])
         }
@@ -145,6 +145,6 @@ private extension String {
 
 private extension InheritedTypeListSyntax {
     var typeNames: Set<String> {
-        Set(compactMap { $0.typeName.as(SimpleTypeIdentifierSyntax.self) }.map(\.name.text))
+        Set(compactMap { $0.type.as(IdentifierTypeSyntax.self) }.map(\.name.text))
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableConditionRule.swift
@@ -116,9 +116,9 @@ private final class UnavailableConditionRuleVisitor: ViolationsSyntaxVisitor {
 
     private func reason(for condition: AvailabilityConditionSyntax) -> String {
         switch condition.availabilityKeyword.tokenKind {
-        case .poundAvailableKeyword:
+        case .poundAvailable:
             return "Use #unavailable instead of #available with an empty body"
-        case .poundUnavailableKeyword:
+        case .poundUnavailable:
             return "Use #available instead of #unavailable with an empty body"
         default:
             queuedFatalError("Unknown availability check type.")

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -102,7 +102,7 @@ private extension UnavailableFunctionRule {
 
 private extension FunctionDeclSyntax {
     var returnsNever: Bool {
-        if let expr = signature.output?.returnType.as(SimpleTypeIdentifierSyntax.self) {
+        if let expr = signature.returnClause?.type.as(IdentifierTypeSyntax.self) {
             return expr.name.text == "Never"
         }
         return false
@@ -117,13 +117,13 @@ private extension AttributeListSyntax? {
 
         return attrs.contains { elem in
             guard let attr = elem.as(AttributeSyntax.self),
-                    let arguments = attr.argument?.as(AvailabilitySpecListSyntax.self) else {
+                  let arguments = attr.arguments?.as(AvailabilityArgumentListSyntax.self) else {
                 return false
             }
 
             let attributeName = attr.attributeNameText
             return attributeName == "available" && arguments.contains { arg in
-                arg.entry.as(TokenSyntax.self)?.tokenKind.isUnavailableKeyword == true
+                arg.argument.as(TokenSyntax.self)?.tokenKind.isUnavailableKeyword == true
             }
         }
     }
@@ -143,11 +143,11 @@ private extension CodeBlockSyntax? {
 
         return statements.contains { item in
             guard let function = item.item.as(FunctionCallExprSyntax.self),
-                  let identifierExpr = function.calledExpression.as(IdentifierExprSyntax.self) else {
+                  let identifierExpr = function.calledExpression.as(DeclReferenceExprSyntax.self) else {
                 return false
             }
 
-            return terminatingFunctions.contains(identifierExpr.identifier.text)
+            return terminatingFunctions.contains(identifierExpr.baseName.text)
         }
     }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -104,15 +104,15 @@ private extension CatchItemSyntax {
         }
 
         if let pattern = pattern?.as(ValueBindingPatternSyntax.self) {
-            return pattern.valuePattern.is(IdentifierPatternSyntax.self)
+            return pattern.pattern.is(IdentifierPatternSyntax.self)
         }
 
         if let pattern = pattern?.as(ExpressionPatternSyntax.self),
            let tupleExpr = pattern.expression.as(TupleExprSyntax.self),
-           let tupleElement = tupleExpr.elementList.onlyElement,
-           let unresolvedPattern = tupleElement.expression.as(UnresolvedPatternExprSyntax.self),
+           let tupleElement = tupleExpr.elements.onlyElement,
+           let unresolvedPattern = tupleElement.expression.as(PatternExprSyntax.self),
            let valueBindingPattern = unresolvedPattern.pattern.as(ValueBindingPatternSyntax.self) {
-            return valueBindingPattern.valuePattern.is(IdentifierPatternSyntax.self)
+            return valueBindingPattern.pattern.is(IdentifierPatternSyntax.self)
         }
 
         return false

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -34,10 +34,10 @@ struct UnusedEnumeratedRule: SwiftSyntaxRule, ConfigurationProviderRule {
 
 private extension UnusedEnumeratedRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override func visitPost(_ node: ForInStmtSyntax) {
+        override func visitPost(_ node: ForStmtSyntax) {
             guard let tuplePattern = node.pattern.as(TuplePatternSyntax.self),
                   tuplePattern.elements.count == 2,
-                  let functionCall = node.sequenceExpr.asFunctionCall,
+                  let functionCall = node.sequence.asFunctionCall,
                   functionCall.isEnumerated,
                   let firstElement = tuplePattern.elements.first,
                   let secondElement = tuplePattern.elements.last,
@@ -66,7 +66,7 @@ private extension FunctionCallExprSyntax {
     var isEnumerated: Bool {
         guard let memberAccess = calledExpression.as(MemberAccessExprSyntax.self),
               memberAccess.base != nil,
-              memberAccess.name.text == "enumerated",
+              memberAccess.declName.baseName.text == "enumerated",
               hasNoArguments else {
             return false
         }
@@ -77,7 +77,7 @@ private extension FunctionCallExprSyntax {
     var hasNoArguments: Bool {
         trailingClosure == nil &&
             (additionalTrailingClosures?.isEmpty ?? true) &&
-            argumentList.isEmpty
+        arguments.isEmpty
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -113,8 +113,8 @@ struct VoidFunctionInTernaryConditionRule: ConfigurationProviderRule, SwiftSynta
 
 private class VoidFunctionInTernaryConditionVisitor: ViolationsSyntaxVisitor {
     override func visitPost(_ node: TernaryExprSyntax) {
-        guard node.firstChoice.is(FunctionCallExprSyntax.self),
-              node.secondChoice.is(FunctionCallExprSyntax.self),
+        guard node.thenExpression.is(FunctionCallExprSyntax.self),
+              node.elseExpression.is(FunctionCallExprSyntax.self),
               let parent = node.parent?.as(ExprListSyntax.self),
               !parent.containsAssignment,
               let grandparent = parent.parent,
@@ -128,7 +128,7 @@ private class VoidFunctionInTernaryConditionVisitor: ViolationsSyntaxVisitor {
     }
 
     override func visitPost(_ node: UnresolvedTernaryExprSyntax) {
-        guard node.firstChoice.is(FunctionCallExprSyntax.self),
+        guard node.thenExpression.is(FunctionCallExprSyntax.self),
               let parent = node.parent?.as(ExprListSyntax.self),
               parent.last?.is(FunctionCallExprSyntax.self) == true,
               !parent.containsAssignment,
@@ -204,21 +204,21 @@ private extension CodeBlockItemSyntax {
 
 private extension FunctionSignatureSyntax {
      var allowsImplicitReturns: Bool {
-         output?.allowsImplicitReturns ?? false
+         returnClause?.allowsImplicitReturns ?? false
      }
 }
 
 private extension SubscriptDeclSyntax {
     var allowsImplicitReturns: Bool {
-        result.allowsImplicitReturns
+        returnClause.allowsImplicitReturns
     }
 }
 
 private extension ReturnClauseSyntax {
     var allowsImplicitReturns: Bool {
-        if let simpleType = returnType.as(SimpleTypeIdentifierSyntax.self) {
+        if let simpleType = type.as(IdentifierTypeSyntax.self) {
             return simpleType.name.text != "Void" && simpleType.name.text != "Never"
-        } else if let tupleType = returnType.as(TupleTypeSyntax.self) {
+        } else if let tupleType = type.as(TupleTypeSyntax.self) {
             return !tupleType.elements.isEmpty
         } else {
             return true

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -43,9 +43,9 @@ private extension XCTFailMessageRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
-                let expression = node.calledExpression.as(IdentifierExprSyntax.self),
-                expression.identifier.text == "XCTFail",
-                node.argumentList.isEmptyOrEmptyString
+                let expression = node.calledExpression.as(DeclReferenceExprSyntax.self),
+                expression.baseName.text == "XCTFail",
+                node.arguments.isEmptyOrEmptyString
             else {
                 return
             }
@@ -55,7 +55,7 @@ private extension XCTFailMessageRule {
     }
 }
 
-private extension TupleExprElementListSyntax {
+private extension LabeledExprListSyntax {
     var isEmptyOrEmptyString: Bool {
         if isEmpty {
             return true

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -69,7 +69,7 @@ private extension AnyObjectProtocolRule {
         }
 
         override func visit(_ node: InheritedTypeSyntax) -> InheritedTypeSyntax {
-            let typeName = node.typeName
+            let typeName = node.type
             guard
                 typeName.is(ClassRestrictionTypeSyntax.self),
                 !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter)
@@ -80,9 +80,9 @@ private extension AnyObjectProtocolRule {
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
             return super.visit(
                 node.with(
-                    \.typeName,
+                    \.type,
                     TypeSyntax(
-                        SimpleTypeIdentifierSyntax(name: .identifier("AnyObject"), genericArgumentClause: nil)
+                        IdentifierTypeSyntax(name: .identifier("AnyObject"), genericArgumentClause: nil)
                             .with(\.leadingTrivia, typeName.leadingTrivia)
                             .with(\.trailingTrivia, typeName.trailingTrivia)
                     )

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -132,7 +132,7 @@ private extension BalancedXCTestLifecycleRule {
                 return
             }
 
-            violations.append(node.identifier.positionAfterSkippingLeadingTrivia)
+            violations.append(node.name.positionAfterSkippingLeadingTrivia)
         }
     }
 
@@ -141,8 +141,8 @@ private extension BalancedXCTestLifecycleRule {
         private(set) var methods: Set<XCTMethod> = []
 
         override func visitPost(_ node: FunctionDeclSyntax) {
-            if let method = XCTMethod(node.identifier.description),
-               node.signature.input.parameterList.isEmpty {
+            if let method = XCTMethod(node.name.description),
+               node.signature.parameterClause.parameters.isEmpty {
                 methods.insert(method)
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -41,7 +41,7 @@ private extension ClassDelegateProtocolRule {
         }
 
         override func visitPost(_ node: ProtocolDeclSyntax) {
-            if node.identifier.text.hasSuffix("Delegate") &&
+            if node.name.text.hasSuffix("Delegate") &&
                 !node.hasObjCAttribute() &&
                 !node.isClassRestricted() &&
                 !node.inheritsFromObjectOrDelegate() {
@@ -57,34 +57,34 @@ private extension ProtocolDeclSyntax {
     }
 
     func isClassRestricted() -> Bool {
-        inheritanceClause?.inheritedTypeCollection.contains { $0.typeName.is(ClassRestrictionTypeSyntax.self) } == true
+        inheritanceClause?.inheritedTypes.contains { $0.type.is(ClassRestrictionTypeSyntax.self) } == true
     }
 
     func inheritsFromObjectOrDelegate() -> Bool {
-        if inheritanceClause?.inheritedTypeCollection.contains(where: { $0.typeName.isObjectOrDelegate() }) == true {
+        if inheritanceClause?.inheritedTypes.contains(where: { $0.type.isObjectOrDelegate() }) == true {
             return true
         }
 
-        guard let requirementList = genericWhereClause?.requirementList else {
+        guard let requirementList = genericWhereClause?.requirements else {
             return false
         }
 
         return requirementList.contains { requirement in
-            guard let conformanceRequirement = requirement.body.as(ConformanceRequirementSyntax.self),
-                  let simpleLeftType = conformanceRequirement.leftTypeIdentifier.as(SimpleTypeIdentifierSyntax.self),
+            guard let conformanceRequirement = requirement.requirement.as(ConformanceRequirementSyntax.self),
+                  let simpleLeftType = conformanceRequirement.leftType.as(IdentifierTypeSyntax.self),
                   simpleLeftType.typeName == "Self"
             else {
                 return false
             }
 
-            return conformanceRequirement.rightTypeIdentifier.isObjectOrDelegate()
+            return conformanceRequirement.rightType.isObjectOrDelegate()
         }
     }
 }
 
 private extension TypeSyntax {
     func isObjectOrDelegate() -> Bool {
-        guard let typeName = self.as(SimpleTypeIdentifierSyntax.self)?.typeName else {
+        guard let typeName = self.as(IdentifierTypeSyntax.self)?.typeName else {
             return false
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CompilerProtocolInitRule.swift
@@ -33,7 +33,7 @@ private extension CompilerProtocolInitRule {
                 return
             }
 
-            let arguments = node.argumentList.compactMap(\.label)
+            let arguments = node.arguments.compactMap(\.label)
             guard ExpressibleByCompiler.possibleNumberOfArguments.contains(arguments.count) else {
                 return
             }
@@ -63,11 +63,11 @@ private extension CompilerProtocolInitRule {
 private extension FunctionCallExprSyntax {
     // doing this instead of calling `.description` as it's faster
     var functionName: String? {
-        if let expr = calledExpression.as(IdentifierExprSyntax.self) {
-            return expr.identifier.text
+        if let expr = calledExpression.as(DeclReferenceExprSyntax.self) {
+            return expr.baseName.text
         } else if let expr = calledExpression.as(MemberAccessExprSyntax.self),
-                  let base = expr.base?.as(IdentifierExprSyntax.self) {
-            return base.identifier.text + "." + expr.name.text
+                  let base = expr.base?.as(DeclReferenceExprSyntax.self) {
+            return base.baseName.text + "." + expr.declName.baseName.text
         }
 
         // we don't care about other possible expressions as they wouldn't match the calls we're interested in

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
@@ -60,12 +60,12 @@ private extension DeploymentTargetRule {
         }
 
         override func visitPost(_ node: AttributeSyntax) {
-            guard let argument = node.argument?.as(AvailabilitySpecListSyntax.self) else {
+            guard let argument = node.arguments?.as(AvailabilityArgumentListSyntax.self) else {
                 return
             }
 
             for arg in argument {
-                guard let entry = arg.entry.as(AvailabilityVersionRestrictionSyntax.self),
+                guard let entry = arg.argument.as(PlatformVersionSyntax.self),
                       let versionString = entry.version?.description,
                       case let platform = entry.platform,
                       let reason = reason(platform: platform, version: versionString, violationType: .attribute) else {
@@ -74,7 +74,7 @@ private extension DeploymentTargetRule {
 
                 violations.append(
                     ReasonedRuleViolation(
-                        position: node.atSignToken.positionAfterSkippingLeadingTrivia,
+                        position: node.atSign.positionAfterSkippingLeadingTrivia,
                         reason: reason
                     )
                 )
@@ -84,16 +84,16 @@ private extension DeploymentTargetRule {
         override func visitPost(_ node: AvailabilityConditionSyntax) {
             let violationType: AvailabilityType
             switch node.availabilityKeyword.tokenKind {
-            case .poundUnavailableKeyword:
+            case .poundUnavailable:
                 violationType = .negativeCondition
-            case .poundAvailableKeyword:
+            case .poundAvailable:
                 violationType = .condition
             default:
                 queuedFatalError("Unknown availability check type.")
             }
 
-            for elem in node.availabilitySpec {
-                guard let restriction = elem.entry.as(AvailabilityVersionRestrictionSyntax.self),
+            for elem in node.availabilityArguments {
+                guard let restriction = elem.argument.as(PlatformVersionSyntax.self),
                       let versionString = restriction.version?.description,
                       let reason = reason(platform: restriction.platform, version: versionString,
                                           violationType: violationType) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -66,8 +66,8 @@ private extension DiscardedNotificationCenterObserverRule {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
                 let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),
-                case .identifier("addObserver") = calledExpression.name.tokenKind,
-                case let argumentLabels = node.argumentList.map({ $0.label?.text }),
+                case .identifier("addObserver") = calledExpression.declName.baseName.tokenKind,
+                case let argumentLabels = node.arguments.map({ $0.label?.text }),
                 argumentLabels.starts(with: ["forName", "object", "queue"])
             else {
                 return
@@ -82,7 +82,7 @@ private extension DiscardedNotificationCenterObserverRule {
                 !fifthParent.attributes.hasDiscardableResultAttribute
             {
                 return // result is returned from a function
-            } else if node.parent?.is(TupleExprElementSyntax.self) == true {
+            } else if node.parent?.is(LabeledExprSyntax.self) == true {
                 return // result is passed as an argument to a function
             } else if node.parent?.is(ArrayElementSyntax.self) == true {
                 return // result is an array literal element

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -50,7 +50,7 @@ private extension DiscouragedDirectInitRule {
         }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            guard node.argumentList.isEmpty, node.trailingClosure == nil,
+            guard node.arguments.isEmpty, node.trailingClosure == nil,
                 discouragedInits.contains(node.calledExpression.trimmedDescription) else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -73,7 +73,7 @@ private extension DuplicateEnumCasesRule {
                 }
 
             let elementsByName = enumElements.reduce(into: [String: [AbsolutePosition]]()) { elements, element in
-                let name = String(element.identifier.text)
+                let name = String(element.name.text)
                 elements[name, default: []].append(element.positionAfterSkippingLeadingTrivia)
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
@@ -85,7 +85,7 @@ struct DuplicatedKeyInDictionaryLiteralRule: SwiftSyntaxRule, ConfigurationProvi
 private extension DuplicatedKeyInDictionaryLiteralRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ list: DictionaryElementListSyntax) {
-            let keys = list.map(\.keyExpression).compactMap { expr -> DictionaryKey? in
+            let keys = list.map(\.key).compactMap { expr -> DictionaryKey? in
                 expr.stringContent.map {
                     DictionaryKey(position: expr.positionAfterSkippingLeadingTrivia, content: $0)
                 }
@@ -127,8 +127,8 @@ private extension ExprSyntax {
             return float.description
         } else if let memberAccess = self.as(MemberAccessExprSyntax.self) {
             return memberAccess.description
-        } else if let identifier = self.as(IdentifierExprSyntax.self) {
-            return identifier.identifier.text
+        } else if let identifier = self.as(DeclReferenceExprSyntax.self) {
+            return identifier.baseName.text
         }
 
         return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DynamicInlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DynamicInlineRule.swift
@@ -46,6 +46,6 @@ private extension DynamicInlineRule {
 private extension AttributeSyntax {
     var isInlineAlways: Bool {
         attributeNameText == "inline" &&
-            argument?.firstToken(viewMode: .sourceAccurate)?.tokenKind == .identifier("__always")
+        arguments?.firstToken(viewMode: .sourceAccurate)?.tokenKind == .identifier("__always")
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -46,6 +46,6 @@ private extension FunctionDeclSyntax {
     }
 
     var isTestMethod: Bool {
-        identifier.text.hasPrefix("test") && signature.input.parameterList.isEmpty
+        name.text.hasPrefix("test") && signature.parameterClause.parameters.isEmpty
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
@@ -81,8 +81,8 @@ struct IdenticalOperandsRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInR
 private extension IdenticalOperandsRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
-            guard let operatorNode = node.operatorOperand.as(BinaryOperatorExprSyntax.self),
-                  IdenticalOperandsRule.operators.contains(operatorNode.operatorToken.text) else {
+            guard let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),
+                  IdenticalOperandsRule.operators.contains(operatorNode.operator.text) else {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
@@ -61,7 +61,7 @@ private extension LocalDocCommentRule {
                 return
             }
 
-            let violatingRange = docCommentRanges.first { $0.intersects(body.byteRange) }
+            let violatingRange = docCommentRanges.first { $0.intersects(body.totalByteRange) }
             if let violatingRange {
                 violations.append(AbsolutePosition(utf8Offset: violatingRange.offset))
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
@@ -206,7 +206,7 @@ private extension Syntax {
         self.is(ExtensionDeclSyntax.self)
     }
 
-    var modifiers: ModifierListSyntax? {
+    var modifiers: DeclModifierListSyntax? {
         if let node = self.as(StructDeclSyntax.self) {
             return node.modifiers
         } else if let node = self.as(ClassDeclSyntax.self) {
@@ -223,7 +223,7 @@ private extension Syntax {
     }
 }
 
-private extension ModifierListSyntax? {
+private extension DeclModifierListSyntax? {
     var isPrivate: Bool {
         self?.contains(where: { $0.name.tokenKind == .keyword(.private) }) == true
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringKeyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringKeyRule.swift
@@ -39,16 +39,16 @@ struct NSLocalizedStringKeyRule: SwiftSyntaxRule, OptInRule, ConfigurationProvid
 private extension NSLocalizedStringKeyRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            guard node.calledExpression.as(IdentifierExprSyntax.self)?.identifier.text == "NSLocalizedString" else {
+            guard node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text == "NSLocalizedString" else {
                 return
             }
 
-            if let keyArgument = node.argumentList.first(where: { $0.label == nil })?.expression,
+            if let keyArgument = node.arguments.first(where: { $0.label == nil })?.expression,
                keyArgument.hasViolation {
                 violations.append(keyArgument.positionAfterSkippingLeadingTrivia)
             }
 
-            if let commentArgument = node.argumentList.first(where: { $0.label?.text == "comment" })?.expression,
+            if let commentArgument = node.arguments.first(where: { $0.label?.text == "comment" })?.expression,
                commentArgument.hasViolation {
                 violations.append(commentArgument.positionAfterSkippingLeadingTrivia)
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -48,16 +48,16 @@ struct NSLocalizedStringRequireBundleRule: SwiftSyntaxRule, OptInRule, Configura
 private extension NSLocalizedStringRequireBundleRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            if let identifierExpr = node.calledExpression.as(IdentifierExprSyntax.self),
-               identifierExpr.identifier.tokenKind == .identifier("NSLocalizedString"),
-               !node.argumentList.containsArgument(named: "bundle") {
+            if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self),
+               identifierExpr.baseName.tokenKind == .identifier("NSLocalizedString"),
+               !node.arguments.containsArgument(named: "bundle") {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }
     }
 }
 
-private extension TupleExprElementListSyntax {
+private extension LabeledExprListSyntax {
     func containsArgument(named name: String) -> Bool {
         contains { arg in
             arg.label?.tokenKind == .identifier(name)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSNumberInitAsFunctionReferenceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSNumberInitAsFunctionReferenceRule.swift
@@ -31,10 +31,10 @@ struct NSNumberInitAsFunctionReferenceRule: SwiftSyntaxRule, ConfigurationProvid
 private extension NSNumberInitAsFunctionReferenceRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: MemberAccessExprSyntax) {
-            guard node.declNameArguments.isEmptyOrNil,
-                  node.name.text == "init",
+            guard node.declName.argumentNames.isEmptyOrNil,
+                  node.declName.baseName.text == "init",
                   node.parent?.as(FunctionCallExprSyntax.self) == nil,
-                  let baseText = node.base?.as(IdentifierExprSyntax.self)?.identifier.text,
+                  let baseText = node.base?.as(DeclReferenceExprSyntax.self)?.baseName.text,
                   baseText == "NSNumber" || baseText == "NSDecimalNumber" else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -35,11 +35,11 @@ private extension ClassDeclSyntax {
             return true
         }
 
-        guard let inheritanceList = inheritanceClause?.inheritedTypeCollection else {
+        guard let inheritanceList = inheritanceClause?.inheritedTypes else {
             return false
         }
         return inheritanceList.contains { type in
-            type.typeName.as(SimpleTypeIdentifierSyntax.self)?.name.text == "NSObject"
+            type.type.as(IdentifierTypeSyntax.self)?.name.text == "NSObject"
         }
     }
 }
@@ -48,9 +48,9 @@ private extension FunctionDeclSyntax {
     var isSelfEqualFunction: Bool {
         guard
             modifiers.isStatic,
-            identifier.text == "==",
+            name.text == "==",
             returnsBool,
-            case let parameterList = signature.input.parameterList,
+            case let parameterList = signature.parameterClause.parameters,
             parameterList.count == 2,
             let lhs = parameterList.first,
             let rhs = parameterList.last,
@@ -65,7 +65,7 @@ private extension FunctionDeclSyntax {
     }
 
     var returnsBool: Bool {
-        signature.output?.returnType.as(SimpleTypeIdentifierSyntax.self)?.name.text == "Bool"
+        signature.returnClause?.type.as(IdentifierTypeSyntax.self)?.name.text == "Bool"
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NotificationCenterDetachmentRule.swift
@@ -21,10 +21,10 @@ private extension NotificationCenterDetachmentRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.isNotificationCenterDettachmentCall,
-                  let arg = node.argumentList.first,
+                  let arg = node.arguments.first,
                   arg.label == nil,
-                  let expr = arg.expression.as(IdentifierExprSyntax.self),
-                  expr.identifier.tokenKind == .keyword(.self) else {
+                  let expr = arg.expression.as(DeclReferenceExprSyntax.self),
+                  expr.baseName.tokenKind == .keyword(.self) else {
                 return
             }
 
@@ -40,12 +40,12 @@ private extension NotificationCenterDetachmentRule {
 private extension FunctionCallExprSyntax {
     var isNotificationCenterDettachmentCall: Bool {
         guard trailingClosure == nil,
-              argumentList.count == 1,
+              arguments.count == 1,
               let expr = calledExpression.as(MemberAccessExprSyntax.self),
-              expr.name.text == "removeObserver",
+              expr.declName.baseName.text == "removeObserver",
               let baseExpr = expr.base?.as(MemberAccessExprSyntax.self),
-              baseExpr.name.text == "default",
-              baseExpr.base?.as(IdentifierExprSyntax.self)?.identifier.text == "NotificationCenter" else {
+              baseExpr.declName.baseName.text == "default",
+              baseExpr.base?.as(DeclReferenceExprSyntax.self)?.baseName.text == "NotificationCenter" else {
             return false
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
@@ -59,12 +59,12 @@ private extension OverrideInExtensionRule {
 
         override func visitPost(_ node: VariableDeclSyntax) {
             if node.modifiers.containsOverride {
-                violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+                violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
             }
         }
 
         override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-            guard let type = node.extendedType.as(SimpleTypeIdentifierSyntax.self),
+            guard let type = node.extendedType.as(IdentifierTypeSyntax.self),
                   !allowedExtensions.contains(type.name.text) else {
                 return .skipChildren
             }
@@ -80,6 +80,6 @@ private class ClassNameCollectingVisitor: ViolationsSyntaxVisitor {
     override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
 
     override func visitPost(_ node: ClassDeclSyntax) {
-        classNames.insert(node.identifier.text)
+        classNames.insert(node.name.text)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
@@ -90,7 +90,7 @@ private extension PrivateOutletRule {
             super.init(viewMode: .sourceAccurate)
         }
 
-        override func visitPost(_ node: MemberDeclListItemSyntax) {
+        override func visitPost(_ node: MemberBlockItemSyntax) {
             guard
                 let decl = node.decl.as(VariableDeclSyntax.self),
                 decl.attributes.contains(attributeNamed: "IBOutlet"),
@@ -103,12 +103,12 @@ private extension PrivateOutletRule {
                 return
             }
 
-            violations.append(decl.bindingKeyword.positionAfterSkippingLeadingTrivia)
+            violations.append(decl.bindingSpecifier.positionAfterSkippingLeadingTrivia)
         }
     }
 }
 
-private extension ModifierListSyntax {
+private extension DeclModifierListSyntax {
     var isPrivateOrFilePrivate: Bool {
         contains(where: \.isPrivateOrFilePrivate)
     }
@@ -118,7 +118,7 @@ private extension ModifierListSyntax {
     }
 }
 
-private extension ModifierListSyntax.Element {
+private extension DeclModifierListSyntax.Element {
     var isPrivateOrFilePrivate: Bool {
         (name.text == "private" || name.text == "fileprivate") && detail == nil
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
@@ -38,7 +38,7 @@ private extension PrivateSubjectRule {
                 // * `let subject: PassthroughSubject<Bool, Never> = .init()`
                 // * `let subject: CurrentValueSubject<Bool, Never>`
                 // * `let subject: CurrentValueSubject<String, Never> = .init("toto")`
-                if let type = binding.typeAnnotation?.type.as(SimpleTypeIdentifierSyntax.self),
+                if let type = binding.typeAnnotation?.type.as(IdentifierTypeSyntax.self),
                    subjectTypes.contains(type.name.text) {
                     violations.append(binding.pattern.positionAfterSkippingLeadingTrivia)
                     continue
@@ -49,9 +49,9 @@ private extension PrivateSubjectRule {
                 // * `let subject = PassthroughSubject<Bool, Never>()`
                 // * `let subject = CurrentValueSubject<String, Never>("toto")`
                 if let functionCall = binding.initializer?.value.as(FunctionCallExprSyntax.self),
-                   let specializeExpr = functionCall.calledExpression.as(SpecializeExprSyntax.self),
-                   let identifierExpr = specializeExpr.expression.as(IdentifierExprSyntax.self),
-                   subjectTypes.contains(identifierExpr.identifier.text) {
+                   let specializeExpr = functionCall.calledExpression.as(GenericSpecializationExprSyntax.self),
+                   let identifierExpr = specializeExpr.expression.as(DeclReferenceExprSyntax.self),
+                   subjectTypes.contains(identifierExpr.baseName.text) {
                     violations.append(binding.pattern.positionAfterSkippingLeadingTrivia)
                 }
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -27,7 +27,7 @@ private extension ProhibitedInterfaceBuilderRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: VariableDeclSyntax) {
             if node.isIBOutlet {
-                violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+                violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
             }
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -22,8 +22,8 @@ private extension QuickDiscouragedFocusedTestRule {
         override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            if let identifierExpr = node.calledExpression.as(IdentifierExprSyntax.self),
-               case let name = identifierExpr.identifier.text,
+            if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self),
+               case let name = identifierExpr.baseName.text,
                QuickFocusedCallKind(rawValue: name) != nil {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
@@ -41,7 +41,7 @@ private extension QuickDiscouragedFocusedTestRule {
 
 private extension ClassDeclSyntax {
     var containsInheritance: Bool {
-        guard let inheritanceList = inheritanceClause?.inheritedTypeCollection else {
+        guard let inheritanceList = inheritanceClause?.inheritedTypes else {
             return false
         }
 
@@ -51,8 +51,8 @@ private extension ClassDeclSyntax {
 
 private extension FunctionDeclSyntax {
     var isSpecFunction: Bool {
-        return identifier.tokenKind == .identifier("spec") &&
-            signature.input.parameterList.isEmpty &&
+        return name.tokenKind == .identifier("spec") &&
+        signature.parameterClause.parameters.isEmpty &&
             modifiers.containsOverride
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -22,8 +22,8 @@ private extension QuickDiscouragedPendingTestRule {
         override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            if let identifierExpr = node.calledExpression.as(IdentifierExprSyntax.self),
-               case let name = identifierExpr.identifier.text,
+            if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self),
+               case let name = identifierExpr.baseName.text,
                QuickPendingCallKind(rawValue: name) != nil {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
@@ -41,7 +41,7 @@ private extension QuickDiscouragedPendingTestRule {
 
 private extension ClassDeclSyntax {
     var containsInheritance: Bool {
-        guard let inheritanceList = inheritanceClause?.inheritedTypeCollection else {
+        guard let inheritanceList = inheritanceClause?.inheritedTypes else {
             return false
         }
 
@@ -51,8 +51,8 @@ private extension ClassDeclSyntax {
 
 private extension FunctionDeclSyntax {
     var isSpecFunction: Bool {
-        return identifier.tokenKind == .identifier("spec") &&
-            signature.input.parameterList.isEmpty &&
+        return name.tokenKind == .identifier("spec") &&
+        signature.parameterClause.parameters.isEmpty &&
             modifiers.containsOverride
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -101,7 +101,7 @@ private extension RawValueForCamelCasedCodableEnumRule {
         private let codableTypes = Set(["Codable", "Decodable", "Encodable"])
 
         override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-            guard let inheritedTypes = node.inheritanceClause?.inheritedTypeCollection.typeNames,
+            guard let inheritedTypes = node.inheritanceClause?.inheritedTypes.typeNames,
                   !inheritedTypes.isDisjoint(with: codableTypes),
                   inheritedTypes.contains("String") else {
                 return .skipChildren
@@ -112,7 +112,7 @@ private extension RawValueForCamelCasedCodableEnumRule {
 
         override func visitPost(_ node: EnumCaseElementSyntax) {
             guard node.rawValue == nil,
-                  case let name = node.identifier.text,
+                  case let name = node.name.text,
                   !name.isUppercase(),
                   !name.isLowercase() else {
                 return
@@ -125,6 +125,6 @@ private extension RawValueForCamelCasedCodableEnumRule {
 
 private extension InheritedTypeListSyntax {
     var typeNames: Set<String> {
-        Set(compactMap { $0.typeName.as(SimpleTypeIdentifierSyntax.self) }.map(\.name.text))
+        Set(compactMap { $0.type.as(IdentifierTypeSyntax.self) }.map(\.name.text))
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
@@ -183,7 +183,7 @@ private extension EnumDeclSyntax {
                     return []
                 }
 
-                return enumCaseDecl.elements.map(\.identifier.text)
+                return enumCaseDecl.elements.map(\.name.text)
             }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/SelfInPropertyInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/SelfInPropertyInitializationRule.swift
@@ -112,7 +112,7 @@ private extension SelfInPropertyInitializationRule {
                     continue
                 }
 
-                violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+                violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
             }
         }
     }
@@ -126,8 +126,8 @@ private extension SelfInPropertyInitializationRule {
             super.init(viewMode: .sourceAccurate)
         }
 
-        override func visitPost(_ node: IdentifierExprSyntax) {
-            if node.identifier.tokenKind == identifier {
+        override func visitPost(_ node: DeclReferenceExprSyntax) {
+            if node.baseName.tokenKind == identifier, node.keyPathInParent != \MemberAccessExprSyntax.declName {
                 isTokenUsed = true
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
@@ -67,7 +67,7 @@ private extension StrongIBOutletRule {
                 return super.visit(node)
             }
 
-            let newModifiers = ModifierListSyntax(modifiers.filter { $0 != weakOrUnownedModifier })
+            let newModifiers = modifiers.filter { $0 != weakOrUnownedModifier }
             let newNode = node.with(\.modifiers, newModifiers)
             correctionPositions.append(violationPosition)
             return super.visit(newNode)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -80,13 +80,13 @@ private extension TestCaseAccessibilityRule {
                     continue
                 }
 
-                violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+                violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
                 return
             }
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {
-            guard hasViolation(modifiers: node.modifiers, identifierToken: node.identifier),
+            guard hasViolation(modifiers: node.modifiers, identifierToken: node.name),
                   !XCTestHelpers.isXCTestFunction(node) else {
                 return
             }
@@ -95,36 +95,36 @@ private extension TestCaseAccessibilityRule {
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {
-            if hasViolation(modifiers: node.modifiers, identifierToken: node.identifier) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
                 violations.append(node.classKeyword.positionAfterSkippingLeadingTrivia)
             }
         }
 
         override func visitPost(_ node: EnumDeclSyntax) {
-            if hasViolation(modifiers: node.modifiers, identifierToken: node.identifier) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
                 violations.append(node.enumKeyword.positionAfterSkippingLeadingTrivia)
             }
         }
 
         override func visitPost(_ node: StructDeclSyntax) {
-            if hasViolation(modifiers: node.modifiers, identifierToken: node.identifier) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
                 violations.append(node.structKeyword.positionAfterSkippingLeadingTrivia)
             }
         }
 
         override func visitPost(_ node: ActorDeclSyntax) {
-            if hasViolation(modifiers: node.modifiers, identifierToken: node.identifier) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
                 violations.append(node.actorKeyword.positionAfterSkippingLeadingTrivia)
             }
         }
 
-        override func visitPost(_ node: TypealiasDeclSyntax) {
-            if hasViolation(modifiers: node.modifiers, identifierToken: node.identifier) {
+        override func visitPost(_ node: TypeAliasDeclSyntax) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
                 violations.append(node.typealiasKeyword.positionAfterSkippingLeadingTrivia)
             }
         }
 
-        private func hasViolation(modifiers: ModifierListSyntax?, identifierToken: TokenSyntax) -> Bool {
+        private func hasViolation(modifiers: DeclModifierListSyntax?, identifierToken: TokenSyntax) -> Bool {
             guard !modifiers.isPrivateOrFileprivate else {
                 return false
             }
@@ -136,8 +136,8 @@ private extension TestCaseAccessibilityRule {
 
 private extension ClassDeclSyntax {
     var inheritedTypes: [String] {
-        inheritanceClause?.inheritedTypeCollection.compactMap { type in
-            type.typeName.as(SimpleTypeIdentifierSyntax.self)?.name.text
+        inheritanceClause?.inheritedTypes.compactMap { type in
+            type.type.as(IdentifierTypeSyntax.self)?.name.text
         } ?? []
     }
 }
@@ -153,8 +153,8 @@ private enum XCTestHelpers {
         }
 
         return !function.modifiers.containsStaticOrClass &&
-            function.identifier.text.hasPrefix("test") &&
-            function.signature.input.parameterList.isEmpty
+        function.name.text.hasPrefix("test") &&
+        function.signature.parameterClause.parameters.isEmpty
     }
 
     static func isXCTestVariable(_ variable: VariableDeclSyntax) -> Bool {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -102,20 +102,20 @@ private func isUnneededOverride(_ node: FunctionDeclSyntax) -> Bool {
         return false
     }
 
-    let overridenFunctionName = node.identifier.text
+    let overridenFunctionName = node.name.text
     guard let call = extractFunctionCallSyntax(statement.item),
         let member = call.calledExpression.as(MemberAccessExprSyntax.self),
-        member.base?.is(SuperRefExprSyntax.self) == true,
-        member.name.text == overridenFunctionName else {
+          member.base?.is(SuperExprSyntax.self) == true,
+          member.declName.baseName.text == overridenFunctionName else {
         return false
     }
 
     // Assume any change in arguments passed means behavior was changed
-    let expectedArguments = node.signature.input.parameterList.map {
+    let expectedArguments = node.signature.parameterClause.parameters.map {
         ($0.firstName.text == "_" ? "" : $0.firstName.text, $0.secondName?.text ?? $0.firstName.text)
     }
-    let actualArguments = call.argumentList.map {
-        ($0.label?.text ?? "", $0.expression.as(IdentifierExprSyntax.self)?.identifier.text ?? "")
+    let actualArguments = call.arguments.map {
+        ($0.label?.text ?? "", $0.expression.as(DeclReferenceExprSyntax.self)?.baseName.text ?? "")
     }
 
     guard expectedArguments.count == actualArguments.count else {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -39,7 +39,7 @@ struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule, ConfigurationProv
 
 private final class UnownedVariableCaptureRuleVisitor: ViolationsSyntaxVisitor {
     override func visitPost(_ node: TokenSyntax) {
-        if case .keyword(.unowned) = node.tokenKind, node.parent?.is(ClosureCaptureItemSpecifierSyntax.self) == true {
+        if case .keyword(.unowned) = node.tokenKind, node.parent?.is(ClosureCaptureSpecifierSyntax.self) == true {
             violations.append(node.positionAfterSkippingLeadingTrivia)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
@@ -159,23 +159,23 @@ private extension UnusedCaptureListRule {
             }
 
             let captureItemsWithNames = captureItems
-                .compactMap { item -> (name: String, item: ClosureCaptureItemSyntax)? in
+                .compactMap { item -> (name: String, item: ClosureCaptureSyntax)? in
                     if let name = item.name {
                         return (name.text, item)
-                    } else if let expr = item.expression.as(IdentifierExprSyntax.self) {
+                    } else if let expr = item.expression.as(DeclReferenceExprSyntax.self) {
                         // allow "[unowned self]"
-                        if expr.identifier.tokenKind == .keyword(.self),
+                        if expr.baseName.tokenKind == .keyword(.self),
                            item.specifier?.specifier.tokenKind == .keyword(.unowned) {
                             return nil
                         }
 
                         // allow "[self]" capture (SE-0269)
-                        if expr.identifier.tokenKind == .keyword(.self),
+                        if expr.baseName.tokenKind == .keyword(.self),
                            item.specifier == nil {
                             return nil
                         }
 
-                        return (expr.identifier.text, item)
+                        return (expr.baseName.text, item)
                     }
 
                     return nil
@@ -210,8 +210,8 @@ private final class IdentifierReferenceVisitor: SyntaxVisitor {
         super.init(viewMode: .sourceAccurate)
     }
 
-    override func visitPost(_ node: IdentifierExprSyntax) {
-        collectReference(by: node.identifier)
+    override func visitPost(_ node: DeclReferenceExprSyntax) {
+        collectReference(by: node.baseName)
     }
 
     override func visitPost(_ node: IdentifierPatternSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRuleExamples.swift
@@ -72,6 +72,7 @@ enum UnusedClosureParameterRuleExamples {
         Example("[1, 2].map { ↓number in\n return 3 \"number\" }"),
         Example("[1, 2].something { number, ↓idx in\n return number }"),
         Example("genericsFunc { (↓number: TypeA, idx: TypeB) in return idx }"),
+        Example("let c: (Int) -> Void = { foo in _ = .foo }"),
         Example("""
         hoge(arg: num) { ↓num in
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -131,11 +131,11 @@ private extension LabeledStmtSyntax {
     var violationPosition: AbsolutePosition? {
         let visitor = BreakAndContinueLabelCollector(viewMode: .sourceAccurate)
         let labels = visitor.walk(tree: self, handler: \.labels)
-        guard !labels.contains(labelName.text) else {
+        guard !labels.contains(label.text) else {
             return nil
         }
 
-        return labelName.positionAfterSkippingLeadingTrivia
+        return label.positionAfterSkippingLeadingTrivia
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
@@ -137,11 +137,11 @@ private extension UnusedSetterValueRule {
         override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: AccessorDeclSyntax) {
-            guard node.accessorKind.tokenKind == .keyword(.set) else {
+            guard node.accessorSpecifier.tokenKind == .keyword(.set) else {
                 return
             }
 
-            let variableName = node.parameter?.name.text ?? "newValue"
+            let variableName = node.parameters?.name.text ?? "newValue"
             let visitor = NewValueUsageVisitor(variableName: variableName)
             if !visitor.walk(tree: node, handler: \.isVariableUsed) {
                 if (Syntax(node).closestVariableOrSubscript()?.modifiers).containsOverride,
@@ -163,8 +163,8 @@ private extension UnusedSetterValueRule {
             super.init(viewMode: .sourceAccurate)
         }
 
-        override func visitPost(_ node: IdentifierExprSyntax) {
-            if node.identifier.text == variableName {
+        override func visitPost(_ node: DeclReferenceExprSyntax) {
+            if node.baseName.text == variableName {
                 isVariableUsed = true
             }
         }
@@ -189,7 +189,7 @@ private enum Either<L, R> {
 }
 
 private extension Either<SubscriptDeclSyntax, VariableDeclSyntax> {
-    var modifiers: ModifierListSyntax? {
+    var modifiers: DeclModifierListSyntax? {
         switch self {
         case .left(let left):
             return left.modifiers

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ValidIBInspectableRule.swift
@@ -160,7 +160,7 @@ private extension ValidIBInspectableRule {
 
         override func visitPost(_ node: VariableDeclSyntax) {
             if node.isInstanceVariable, node.isIBInspectable, node.hasViolation {
-                violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+                violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
             }
         }
     }
@@ -176,12 +176,12 @@ private extension VariableDeclSyntax {
     }
 
     var isReadOnlyProperty: Bool {
-        if bindingKeyword.tokenKind == .keyword(.let) {
+        if bindingSpecifier.tokenKind == .keyword(.let) {
             return true
         }
 
         let computedProperty = bindings.contains { binding in
-            binding.accessor != nil
+            binding.accessorBlock != nil
         }
 
         if !computedProperty {
@@ -189,7 +189,7 @@ private extension VariableDeclSyntax {
         }
 
         return bindings.allSatisfy { binding in
-            guard let accessorBlock = binding.accessor?.as(AccessorBlockSyntax.self) else {
+            guard let accessorBlock = binding.accessorBlock?.as(AccessorBlockSyntax.self) else {
                 return true
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
@@ -88,7 +88,7 @@ private extension WeakDelegateRule {
                 return
             }
 
-            violations.append(node.bindingKeyword.positionAfterSkippingLeadingTrivia)
+            violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
         }
     }
 }
@@ -118,17 +118,10 @@ private extension VariableDeclSyntax {
 
     var hasComputedBody: Bool {
         bindings.allSatisfy { binding in
-            guard let accessor = binding.accessor else {
-                return false
-            }
-
-            if accessor.is(CodeBlockSyntax.self) {
-                return true
-            } else if accessor.as(AccessorBlockSyntax.self)?.getAccessor != nil {
+            if case .getter = binding.accessorBlock?.accessors {
                 return true
             }
-
-            return false
+            return binding.accessorBlock?.specifiesGetAccessor == true
         }
     }
 
@@ -141,7 +134,7 @@ private extension VariableDeclSyntax {
 
         return attributes?.contains { attr in
             guard case let .attribute(customAttr) = attr,
-                  let typeIdentifier = customAttr.attributeName.as(SimpleTypeIdentifierSyntax.self) else {
+                  let typeIdentifier = customAttr.attributeName.as(IdentifierTypeSyntax.self) else {
                 return false
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -51,8 +51,8 @@ private extension EnumCaseAssociatedValuesLengthRule {
         }
 
         override func visitPost(_ node: EnumCaseElementSyntax) {
-            guard let associatedValue = node.associatedValue,
-                  case let enumCaseAssociatedValueCount = associatedValue.parameterList.count,
+            guard let associatedValue = node.parameterClause,
+                  case let enumCaseAssociatedValueCount = associatedValue.parameters.count,
                   enumCaseAssociatedValueCount >= configuration.warning else {
                 return
             }
@@ -65,7 +65,7 @@ private extension EnumCaseAssociatedValuesLengthRule {
                 violationSeverity = .warning
             }
 
-            let reason = "Enum case \(node.identifier.text) should contain "
+            let reason = "Enum case \(node.name.text) should contain "
                 + "less than \(configuration.warning) associated values: "
                 + "currently contains \(enumCaseAssociatedValueCount)"
             violations.append(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionParameterCountRule.swift
@@ -54,7 +54,7 @@ private extension FunctionParameterCountRule {
                 return
             }
 
-            let parameterList = node.signature.input.parameterList
+            let parameterList = node.signature.parameterClause.parameters
             guard let minThreshold = configuration.severityConfiguration.params.map(\.value).min(by: <) else {
                 return
             }
@@ -66,7 +66,7 @@ private extension FunctionParameterCountRule {
 
             var parameterCount = allParameterCount
             if configuration.ignoresDefaultParameters {
-                parameterCount -= parameterList.filter { $0.defaultArgument != nil }.count
+                parameterCount -= parameterList.filter { $0.defaultValue != nil }.count
             }
 
             for parameter in configuration.severityConfiguration.params where parameterCount > parameter.value {

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -43,10 +43,10 @@ private extension ContainsOverFilterCountRule {
                 let second = node.dropFirst().first,
                 second.firstToken(viewMode: .sourceAccurate)?.tokenKind.isZeroComparison == true,
                 let first = node.first?.as(MemberAccessExprSyntax.self),
-                first.name.text == "count",
+                first.declName.baseName.text == "count",
                 let firstBase = first.base?.asFunctionCall,
                 let firstBaseCalledExpression = firstBase.calledExpression.as(MemberAccessExprSyntax.self),
-                firstBaseCalledExpression.name.text == "filter"
+                firstBaseCalledExpression.declName.baseName.text == "filter"
             else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -35,10 +35,10 @@ private extension ContainsOverFilterIsEmptyRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
-                node.name.text == "isEmpty",
+                node.declName.baseName.text == "isEmpty",
                 let firstBase = node.base?.asFunctionCall,
                 let firstBaseCalledExpression = firstBase.calledExpression.as(MemberAccessExprSyntax.self),
-                firstBaseCalledExpression.name.text == "filter"
+                firstBaseCalledExpression.declName.baseName.text == "filter"
             else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -40,20 +40,18 @@ struct ContainsOverFirstNotNilRule: SwiftSyntaxRule, OptInRule, ConfigurationPro
 private extension ContainsOverFirstNotNilRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
-            guard
-                let operatorNode = node.operatorOperand.as(BinaryOperatorExprSyntax.self),
-                operatorNode.operatorToken.tokenKind.isEqualityComparison,
-                node.rightOperand.is(NilLiteralExprSyntax.self),
-                let first = node.leftOperand.asFunctionCall,
-                let calledExpression = first.calledExpression.as(MemberAccessExprSyntax.self),
-                calledExpression.name.text == "first" || calledExpression.name.text == "firstIndex"
-            else {
+            guard let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),
+                  operatorNode.operator.tokenKind.isEqualityComparison,
+                  node.rightOperand.is(NilLiteralExprSyntax.self),
+                  let first = node.leftOperand.asFunctionCall,
+                  let calledExpression = first.calledExpression.as(MemberAccessExprSyntax.self),
+                  ["first", "firstIndex"].contains(calledExpression.declName.baseName.text) else {
                 return
             }
 
             let violation = ReasonedRuleViolation(
                 position: first.positionAfterSkippingLeadingTrivia,
-                reason: "Prefer `contains` over `\(calledExpression.name.text)(where:) != nil`"
+                reason: "Prefer `contains` over `\(calledExpression.declName.baseName.text)(where:) != nil`"
             )
             violations.append(violation)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -34,13 +34,13 @@ private extension ContainsOverRangeNilComparisonRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
             guard
-                let operatorNode = node.operatorOperand.as(BinaryOperatorExprSyntax.self),
-                operatorNode.operatorToken.tokenKind.isEqualityComparison,
+                let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),
+                operatorNode.operator.tokenKind.isEqualityComparison,
                 node.rightOperand.is(NilLiteralExprSyntax.self),
                 let first = node.leftOperand.asFunctionCall,
-                first.argumentList.onlyElement?.label?.text == "of",
+                first.arguments.onlyElement?.label?.text == "of",
                 let calledExpression = first.calledExpression.as(MemberAccessExprSyntax.self),
-                calledExpression.name.text == "range"
+                calledExpression.declName.baseName.text == "range"
             else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCollectionLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCollectionLiteralRule.swift
@@ -38,9 +38,9 @@ private extension EmptyCollectionLiteralRule {
                 node.tokenKind.isEqualityComparison,
                 let violationPosition = node.previousToken(viewMode: .sourceAccurate)?.endPositionBeforeTrailingTrivia,
                 let expectedLeftSquareBracketToken = node.nextToken(viewMode: .sourceAccurate),
-                expectedLeftSquareBracketToken.tokenKind == .leftSquareBracket,
+                expectedLeftSquareBracketToken.tokenKind == .leftSquare,
                 let expectedColonToken = expectedLeftSquareBracketToken.nextToken(viewMode: .sourceAccurate),
-                expectedColonToken.tokenKind == .colon || expectedColonToken.tokenKind == .rightSquareBracket
+                expectedColonToken.tokenKind == .colon || expectedColonToken.tokenKind == .rightSquare
             else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
@@ -54,8 +54,8 @@ private extension EmptyCountRule {
         private let operators: Set = ["==", "!=", ">", ">=", "<", "<="]
 
         override func visitPost(_ node: InfixOperatorExprSyntax) {
-            guard let operatorNode = node.operatorOperand.as(BinaryOperatorExprSyntax.self),
-                  let binaryOperator = operatorNode.operatorToken.binaryOperator,
+            guard let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),
+                  let binaryOperator = operatorNode.operator.binaryOperator,
                   operators.contains(binaryOperator) else {
                 return
             }
@@ -78,15 +78,15 @@ private extension EmptyCountRule {
 private extension ExprSyntax {
     func countCallPosition(onlyAfterDot: Bool) -> AbsolutePosition? {
         if let expr = self.as(MemberAccessExprSyntax.self) {
-            if expr.declNameArguments == nil && expr.name.tokenKind == .identifier("count") {
-                return expr.name.positionAfterSkippingLeadingTrivia
+            if expr.declName.argumentNames == nil && expr.declName.baseName.tokenKind == .identifier("count") {
+                return expr.declName.baseName.positionAfterSkippingLeadingTrivia
             }
 
             return nil
         }
 
-        if !onlyAfterDot, let expr = self.as(IdentifierExprSyntax.self) {
-            return expr.identifier.tokenKind == .identifier("count") ? expr.positionAfterSkippingLeadingTrivia : nil
+        if !onlyAfterDot, let expr = self.as(DeclReferenceExprSyntax.self) {
+            return expr.baseName.tokenKind == .identifier("count") ? expr.positionAfterSkippingLeadingTrivia : nil
         }
 
         return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyStringRule.swift
@@ -32,7 +32,7 @@ private extension EmptyStringRule {
         override func visitPost(_ node: StringLiteralExprSyntax) {
             guard
                 // Empty string literal: `""`, `#""#`, etc.
-                node.segments.onlyElement?.contentLength == .zero,
+                node.segments.onlyElement?.trimmedLength == .zero,
                 let previousToken = node.previousToken(viewMode: .sourceAccurate),
                 // On the rhs of an `==` or `!=` operator
                 previousToken.tokenKind.isEqualityComparison,

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FirstWhereRule.swift
@@ -39,11 +39,11 @@ private extension FirstWhereRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
-                node.name.text == "first",
+                node.declName.baseName.text == "first",
                 let functionCall = node.base?.asFunctionCall,
                 let calledExpression = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
-                calledExpression.name.text == "filter",
-                !functionCall.argumentList.contains(where: \.expression.shouldSkip)
+                calledExpression.declName.baseName.text == "filter",
+                !functionCall.arguments.contains(where: \.expression.shouldSkip)
             else {
                 return
             }
@@ -58,8 +58,8 @@ private extension ExprSyntax {
         if self.is(StringLiteralExprSyntax.self) {
             return true
         } else if let functionCall = self.as(FunctionCallExprSyntax.self),
-                  let calledExpression = functionCall.calledExpression.as(IdentifierExprSyntax.self),
-                  calledExpression.identifier.text == "NSPredicate" {
+                  let calledExpression = functionCall.calledExpression.as(DeclReferenceExprSyntax.self),
+                  calledExpression.baseName.text == "NSPredicate" {
             return true
         } else {
             return false

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FlatMapOverMapReduceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FlatMapOverMapReduceRule.swift
@@ -27,12 +27,12 @@ private extension FlatMapOverMapReduceRule {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
                 let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self),
-                memberAccess.name.text == "reduce",
-                node.argumentList.count == 2,
-                let firstArgument = node.argumentList.first?.expression.as(ArrayExprSyntax.self),
+                memberAccess.declName.baseName.text == "reduce",
+                node.arguments.count == 2,
+                let firstArgument = node.arguments.first?.expression.as(ArrayExprSyntax.self),
                 firstArgument.elements.isEmpty,
-                let secondArgument = node.argumentList.last?.expression.as(IdentifierExprSyntax.self),
-                secondArgument.identifier.text == "+"
+                let secondArgument = node.arguments.last?.expression.as(DeclReferenceExprSyntax.self),
+                secondArgument.baseName.text == "+"
             else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/LastWhereRule.swift
@@ -35,11 +35,11 @@ private extension LastWhereRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
-                node.name.text == "last",
+                node.declName.baseName.text == "last",
                 let functionCall = node.base?.asFunctionCall,
                 let calledExpression = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
-                calledExpression.name.text == "filter",
-                !functionCall.argumentList.contains(where: \.expression.shouldSkip)
+                calledExpression.declName.baseName.text == "filter",
+                !functionCall.arguments.contains(where: \.expression.shouldSkip)
             else {
                 return
             }
@@ -54,8 +54,8 @@ private extension ExprSyntax {
         if self.is(StringLiteralExprSyntax.self) {
             return true
         } else if let functionCall = self.as(FunctionCallExprSyntax.self),
-                  let calledExpression = functionCall.calledExpression.as(IdentifierExprSyntax.self),
-                  calledExpression.identifier.text == "NSPredicate" {
+                  let calledExpression = functionCall.calledExpression.as(DeclReferenceExprSyntax.self),
+                  calledExpression.baseName.text == "NSPredicate" {
             return true
         } else {
             return false

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceBooleanRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceBooleanRule.swift
@@ -36,18 +36,18 @@ private extension ReduceBooleanRule {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
                 let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),
-                calledExpression.name.text == "reduce",
-                let firstArgument = node.argumentList.first,
+                calledExpression.declName.baseName.text == "reduce",
+                let firstArgument = node.arguments.first,
                 firstArgument.label?.text ?? "into" == "into",
                 let bool = firstArgument.expression.as(BooleanLiteralExprSyntax.self)
             else {
                 return
             }
 
-            let suggestedFunction = bool.booleanLiteral.tokenKind == .keyword(.true) ? "allSatisfy" : "contains"
+            let suggestedFunction = bool.literal.tokenKind == .keyword(.true) ? "allSatisfy" : "contains"
             violations.append(
                 ReasonedRuleViolation(
-                    position: calledExpression.name.positionAfterSkippingLeadingTrivia,
+                    position: calledExpression.declName.baseName.positionAfterSkippingLeadingTrivia,
                     reason: "Use `\(suggestedFunction)` instead"
                 )
             )

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
@@ -53,12 +53,12 @@ private extension SortedFirstLastRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
-                node.name.text == "first" || node.name.text == "last",
+                node.declName.baseName.text == "first" || node.declName.baseName.text == "last",
                 node.parent?.is(FunctionCallExprSyntax.self) != true,
                 let firstBase = node.base?.asFunctionCall,
                 let firstBaseCalledExpression = firstBase.calledExpression.as(MemberAccessExprSyntax.self),
-                firstBaseCalledExpression.name.text == "sorted",
-                case let argumentLabels = firstBase.argumentList.map({ $0.label?.text }),
+                firstBaseCalledExpression.declName.baseName.text == "sorted",
+                case let argumentLabels = firstBase.arguments.map({ $0.label?.text }),
                 argumentLabels.isEmpty || argumentLabels == ["by"]
             else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -186,7 +186,7 @@ private extension AttributeListSyntax {
                     return (attribute, .sameLineAsDeclaration)
                 } else if configuration.alwaysOnNewLine.contains(atPrefixedName) {
                     return (attribute, .dedicatedLine)
-                } else if attribute.argument != nil, configuration.attributesWithArgumentsAlwaysOnNewLine {
+                } else if attribute.arguments != nil, configuration.attributesWithArgumentsAlwaysOnNewLine {
                     return (attribute, .dedicatedLine)
                 }
 
@@ -223,10 +223,10 @@ private extension AttributeListSyntax {
         } else if let protocolKeyword = parent.as(ProtocolDeclSyntax.self)?.protocolKeyword {
             keyword = protocolKeyword
             shouldBeOnSameLine = false
-        } else if let importTok = parent.as(ImportDeclSyntax.self)?.importTok {
+        } else if let importTok = parent.as(ImportDeclSyntax.self)?.importKeyword {
             keyword = importTok
             shouldBeOnSameLine = true
-        } else if let letOrVarKeyword = parent.as(VariableDeclSyntax.self)?.bindingKeyword {
+        } else if let letOrVarKeyword = parent.as(VariableDeclSyntax.self)?.bindingSpecifier {
             keyword = letOrVarKeyword
             shouldBeOnSameLine = true
         } else {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
@@ -132,10 +132,10 @@ private extension ClosureSignatureSyntax {
             positions.append(contentsOf: captureItems.map(\.expression.positionAfterSkippingLeadingTrivia))
         }
 
-        if let input = input?.as(ClosureParamListSyntax.self) {
+        if let input = parameterClause?.as(ClosureShorthandParameterListSyntax.self) {
             positions.append(contentsOf: input.map(\.positionAfterSkippingLeadingTrivia))
-        } else if let input = input?.as(ClosureParameterClauseSyntax.self) {
-            positions.append(contentsOf: input.parameterList.map(\.positionAfterSkippingLeadingTrivia))
+        } else if let input = parameterClause?.as(ClosureParameterClauseSyntax.self) {
+            positions.append(contentsOf: input.parameters.map(\.positionAfterSkippingLeadingTrivia))
         }
 
         return positions

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
@@ -151,7 +151,7 @@ private extension ClosureExprSyntax {
     }
 
     func shouldCheckForClosureSpacingRule(locationConverter: SourceLocationConverter) -> Bool {
-        guard parent?.is(PostfixUnaryExprSyntax.self) == false, // Workaround for Regex literals
+        guard parent?.is(PostfixOperatorExprSyntax.self) == false, // Workaround for Regex literals
               (rightBrace.position.utf8Offset - leftBrace.position.utf8Offset) > 1, // Allow '{}'
               case let startLine = startLocation(converter: locationConverter).line,
               case let endLine = endLocation(converter: locationConverter).line,
@@ -209,21 +209,21 @@ private extension TokenSyntax {
 
     var hasAllowedNoSpaceLeftToken: Bool {
         let previousTokenKind = parent?.previousToken(viewMode: .sourceAccurate)?.tokenKind
-        return previousTokenKind == .leftParen || previousTokenKind == .leftSquareBracket
+        return previousTokenKind == .leftParen || previousTokenKind == .leftSquare
     }
 
     var hasAllowedNoSpaceRightToken: Bool {
         let allowedKinds = [
             TokenKind.colon,
             .comma,
-            .eof,
+            .endOfFile,
             .exclamationMark,
             .leftParen,
-            .leftSquareBracket,
+            .leftSquare,
             .period,
             .postfixQuestionMark,
             .rightParen,
-            .rightSquareBracket,
+            .rightSquare,
             .semicolon
         ]
         if case .newlines = trailingTrivia.first {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
@@ -38,7 +38,7 @@ private extension CollectionAlignmentRule {
         override func visitPost(_ node: DictionaryElementListSyntax) {
             let locations = node.map { element in
                 let position = alignColons ? element.colon.positionAfterSkippingLeadingTrivia :
-                                             element.keyExpression.positionAfterSkippingLeadingTrivia
+                element.key.positionAfterSkippingLeadingTrivia
                 return locationConverter.location(for: position)
             }
             violations.append(contentsOf: validate(keyLocations: locations))

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ColonRule.swift
@@ -43,8 +43,8 @@ struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule, Source
                 }
 
                 // [:]
-                if previous.tokenKind == .leftSquareBracket,
-                   next.tokenKind == .rightSquareBracket,
+                if previous.tokenKind == .leftSquare,
+                   next.tokenKind == .rightSquare,
                    previous.trailingTrivia.isEmpty,
                    current.leadingTrivia.isEmpty,
                    current.trailingTrivia.isEmpty,
@@ -95,7 +95,7 @@ private final class ColonRuleVisitor: SyntaxVisitor {
     var caseStatementPositions: [AbsolutePosition] = []
 
     override func visitPost(_ node: TernaryExprSyntax) {
-        positionsToSkip.append(node.colonMark.position)
+        positionsToSkip.append(node.colon.position)
     }
 
     override func visitPost(_ node: DeclNameArgumentsSyntax) {
@@ -117,7 +117,7 @@ private final class ColonRuleVisitor: SyntaxVisitor {
     }
 
     override func visitPost(_ node: UnresolvedTernaryExprSyntax) {
-        positionsToSkip.append(node.colonMark.position)
+        positionsToSkip.append(node.colon.position)
     }
 
     override func visitPost(_ node: DictionaryElementSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRule.swift
@@ -30,7 +30,7 @@ private final class ComputedAccessorsOrderRuleVisitor: ViolationsSyntaxVisitor {
     }
 
     override func visitPost(_ node: AccessorBlockSyntax) {
-        guard let firstAccessor = node.accessors.first,
+        guard let firstAccessor = node.accessorsList.first,
               let order = node.order,
               order != expectedOrder else {
             return
@@ -60,11 +60,11 @@ private final class ComputedAccessorsOrderRuleVisitor: ViolationsSyntaxVisitor {
 
 private extension AccessorBlockSyntax {
     var order: ComputedAccessorsOrderConfiguration.Order? {
-        guard accessors.count == 2, accessors.map(\.body).allSatisfy({ $0 != nil }) else {
+        guard accessorsList.count == 2, accessorsList.map(\.body).allSatisfy({ $0 != nil }) else {
             return nil
         }
 
-        let tokens = accessors.map(\.accessorKind.tokenKind)
+        let tokens = accessorsList.map(\.accessorSpecifier.tokenKind)
         if tokens == [.keyword(.get), .keyword(.set)] {
             return .getSet
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
@@ -104,7 +104,7 @@ private final class Visitor: ViolationsSyntaxVisitor {
     }
 
     override func visitPost(_ node: SwitchExprSyntax) {
-        if node.expression.unwrapped != nil {
+        if node.subject.unwrapped != nil {
             violations.append(node.positionAfterSkippingLeadingTrivia)
         }
     }
@@ -164,13 +164,13 @@ private final class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
 
     override func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
         guard !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter),
-              let tupleElement = node.expression.unwrapped else {
+              let tupleElement = node.subject.unwrapped else {
             return super.visit(node)
         }
         correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
         let node = node
             .with(\.switchKeyword, node.switchKeyword.with(\.trailingTrivia, .space))
-            .with(\.expression, tupleElement.with(\.trailingTrivia, .space))
+            .with(\.subject, tupleElement.with(\.trailingTrivia, .space))
         return super.visit(node)
     }
 
@@ -203,7 +203,7 @@ private class TrailingClosureFinder: SyntaxTransformVisitor {
 
 private extension ExprSyntax {
     var unwrapped: ExprSyntax? {
-        if let expr = self.as(TupleExprSyntax.self)?.elementList.onlyElement?.expression {
+        if let expr = self.as(TupleExprSyntax.self)?.elements.onlyElement?.expression {
             return TrailingClosureFinder().visit(expr) ? nil : expr
         }
         return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
@@ -204,7 +204,7 @@ private extension CodeBlockItemListSyntax {
     var violation: (PatternBindingSyntax, ReturnStmtSyntax)? {
         guard count >= 2, let last = last?.item,
               let returnStmt = last.as(ReturnStmtSyntax.self),
-              let identifier = returnStmt.expression?.as(IdentifierExprSyntax.self)?.identifier.text,
+              let identifier = returnStmt.expression?.as(DeclReferenceExprSyntax.self)?.baseName.text,
               let varDecl = dropLast().last?.item.as(VariableDeclSyntax.self) else {
             return nil
         }
@@ -250,8 +250,8 @@ private class Rewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
             initExpression = ExprSyntax(
                 fromProtocol: AsExprSyntax(
                     expression: initExpression.trimmed,
-                    asTok: .keyword(.as).with(\.leadingTrivia, .space).with(\.trailingTrivia, .space),
-                    typeName: type.trimmed
+                    asKeyword: .keyword(.as).with(\.leadingTrivia, .space).with(\.trailingTrivia, .space),
+                    type: type.trimmed
                 )
             )
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
@@ -73,7 +73,7 @@ private extension EmptyParametersRule {
             }
 
             correctionPositions.append(violationPosition)
-            return super.visit(node.with(\.arguments, TupleTypeElementListSyntax([])))
+            return super.visit(node.with(\.parameters, TupleTypeElementListSyntax([])))
         }
     }
 }
@@ -81,10 +81,10 @@ private extension EmptyParametersRule {
 private extension FunctionTypeSyntax {
     var emptyParametersViolationPosition: AbsolutePosition? {
         guard
-            let argument = arguments.onlyElement,
+            let argument = parameters.onlyElement,
             leftParen.presence == .present,
             rightParen.presence == .present,
-            let simpleType = argument.type.as(SimpleTypeIdentifierSyntax.self),
+            let simpleType = argument.type.as(IdentifierTypeSyntax.self),
             simpleType.typeName == "Void"
         else {
             return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -99,7 +99,7 @@ private extension FunctionCallExprSyntax {
     var violationPosition: AbsolutePosition? {
         guard trailingClosure != nil,
               let leftParen,
-              argumentList.isEmpty else {
+              arguments.isEmpty else {
             return nil
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/InclusiveLanguageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/InclusiveLanguageRule.swift
@@ -38,37 +38,37 @@ private extension InclusiveLanguageRule {
         }
 
         override func visitPost(_ node: StructDeclSyntax) {
-            if let violation = violation(for: node.identifier) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: ProtocolDeclSyntax) {
-            if let violation = violation(for: node.identifier) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {
-            if let violation = violation(for: node.identifier) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: EnumDeclSyntax) {
-            if let violation = violation(for: node.identifier) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: ActorDeclSyntax) {
-            if let violation = violation(for: node.identifier) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
 
-        override func visitPost(_ node: TypealiasDeclSyntax) {
-            if let violation = violation(for: node.identifier) {
+        override func visitPost(_ node: TypeAliasDeclSyntax) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
@@ -79,14 +79,14 @@ private extension InclusiveLanguageRule {
             }
         }
 
-        override func visitPost(_ node: AssociatedtypeDeclSyntax) {
-            if let violation = violation(for: node.identifier) {
+        override func visitPost(_ node: AssociatedTypeDeclSyntax) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {
-            if let violation = violation(for: node.identifier) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
@@ -102,12 +102,12 @@ private extension InclusiveLanguageRule {
         }
 
         override func visitPost(_ node: EnumCaseElementSyntax) {
-            if let violation = violation(for: node.identifier) {
+            if let violation = violation(for: node.name) {
                 violations.append(violation)
             }
         }
 
-        override func visitPost(_ node: AccessorParameterSyntax) {
+        override func visitPost(_ node: AccessorParametersSyntax) {
             if let violation = violation(for: node.name) {
                 violations.append(violation)
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -164,14 +164,14 @@ struct MultilineArgumentsBracketsRule: SwiftSyntaxRule, OptInRule, Configuration
 private extension MultilineArgumentsBracketsRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            guard let firstArgument = node.argumentList.first,
+            guard let firstArgument = node.arguments.first,
                   let leftParen = node.leftParen,
                   let rightParen = node.rightParen else {
                 return
             }
 
             let hasMultilineFirstArgument = hasLeadingNewline(firstArgument)
-            let hasMultilineArgument = node.argumentList
+            let hasMultilineArgument = node.arguments
                 .contains { argument in
                     hasLeadingNewline(argument)
                 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRule.swift
@@ -37,13 +37,13 @@ private extension MultilineArgumentsRule {
         }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            guard node.argumentList.count > 1 else {
+            guard node.arguments.count > 1 else {
                 return
             }
 
             let functionCallPosition = node.calledExpression.positionAfterSkippingLeadingTrivia
             let functionCallLine = locationConverter.location(for: functionCallPosition).line
-            let wrappedArguments: [Argument] = node.argumentList
+            let wrappedArguments: [Argument] = node.arguments
                 .enumerated()
                 .compactMap { idx, argument in
                     Argument(element: argument, locationConverter: locationConverter, index: idx)
@@ -115,7 +115,7 @@ private struct Argument {
     let index: Int
     let expression: ExprSyntax
 
-    init?(element: TupleExprElementSyntax, locationConverter: SourceLocationConverter, index: Int) {
+    init?(element: LabeledExprSyntax, locationConverter: SourceLocationConverter, index: Int) {
         self.offset = element.positionAfterSkippingLeadingTrivia
         self.line = locationConverter.location(for: offset).line
         self.index = index

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
@@ -30,7 +30,7 @@ private extension MultilineParametersRule {
 
         override func visitPost(_ node: FunctionDeclSyntax) {
             if containsViolation(for: node.signature) {
-                violations.append(node.identifier.positionAfterSkippingLeadingTrivia)
+                violations.append(node.name.positionAfterSkippingLeadingTrivia)
             }
         }
 
@@ -41,7 +41,7 @@ private extension MultilineParametersRule {
         }
 
         private func containsViolation(for signature: FunctionSignatureSyntax) -> Bool {
-            let parameterPositions = signature.input.parameterList.map(\.positionAfterSkippingLeadingTrivia)
+            let parameterPositions = signature.parameterClause.parameters.map(\.positionAfterSkippingLeadingTrivia)
             guard parameterPositions.isNotEmpty else {
                 return false
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -59,7 +59,7 @@ private extension FunctionCallExprSyntax {
             return false
         }
 
-        return argumentList.contains { elem in
+        return arguments.contains { elem in
             elem.expression.is(ClosureExprSyntax.self)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
@@ -151,7 +151,7 @@ private class Visitor: ViolationsSyntaxVisitor {
         checkViolations(for: node.modifiers, type: "properties")
     }
 
-    private func checkViolations(for modifiers: ModifierListSyntax?, type: String) {
+    private func checkViolations(for modifiers: DeclModifierListSyntax?, type: String) {
         guard !modifiers.isFinal, let classKeyword = modifiers?.first(where: { $0.name.text == "class" }),
               case let inFinalClass = finalClassScope.peek() == true, inFinalClass || modifiers.isPrivate else {
             return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
@@ -48,13 +48,13 @@ private extension NumberSeparatorRule {
         }
 
         override func visitPost(_ node: FloatLiteralExprSyntax) {
-            if let violation = violation(token: node.floatingDigits) {
+            if let violation = violation(token: node.literal) {
                 violations.append(ReasonedRuleViolation(position: violation.position, reason: violation.reason))
             }
         }
 
         override func visitPost(_ node: IntegerLiteralExprSyntax) {
-            if let violation = violation(token: node.digits) {
+            if let violation = violation(token: node.literal) {
                 violations.append(ReasonedRuleViolation(position: violation.position, reason: violation.reason))
             }
         }
@@ -76,27 +76,32 @@ private extension NumberSeparatorRule {
 
         override func visit(_ node: FloatLiteralExprSyntax) -> ExprSyntax {
             guard
-                let violation = violation(token: node.floatingDigits),
+                let violation = violation(token: node.literal),
                 !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter)
             else {
                 return super.visit(node)
             }
 
-            let newNode = node.with(\.floatingDigits,
-                                    node.floatingDigits.with(\.tokenKind, .floatingLiteral(violation.correction)))
+            let newNode = node.with(
+                \.literal,
+                node.literal.with(
+                    \.tokenKind,
+                    .floatLiteral(violation.correction)
+                )
+            )
             correctionPositions.append(violation.position)
             return super.visit(newNode)
         }
 
         override func visit(_ node: IntegerLiteralExprSyntax) -> ExprSyntax {
             guard
-                let violation = violation(token: node.digits),
+                let violation = violation(token: node.literal),
                 !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter)
             else {
                 return super.visit(node)
             }
 
-            let newNode = node.with(\.digits, node.digits.with(\.tokenKind, .integerLiteral(violation.correction)))
+            let newNode = node.with(\.literal, node.literal.with(\.tokenKind, .integerLiteral(violation.correction)))
             correctionPositions.append(violation.position)
             return super.visit(newNode)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OperatorFunctionWhitespaceRule.swift
@@ -42,7 +42,7 @@ private extension OperatorFunctionWhitespaceRule {
 
 private extension FunctionDeclSyntax {
     var isOperatorDeclaration: Bool {
-        switch identifier.tokenKind {
+        switch name.tokenKind {
         case .binaryOperator:
             return true
         default:
@@ -51,6 +51,6 @@ private extension FunctionDeclSyntax {
     }
 
     var hasWhitespaceViolation: Bool {
-        !identifier.trailingTrivia.isSingleSpace || !funcKeyword.trailingTrivia.isSingleSpace
+        !name.trailingTrivia.isSingleSpace || !funcKeyword.trailingTrivia.isSingleSpace
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -128,7 +128,7 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
     }
 
     override func visitPost(_ node: BinaryOperatorExprSyntax) {
-        if let violation = violation(operatorToken: node.operatorToken) {
+        if let violation = violation(operatorToken: node.operator) {
             violationRanges.append(violation)
         }
     }
@@ -146,13 +146,13 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
     }
 
     override func visitPost(_ node: AssignmentExprSyntax) {
-        if let violation = violation(operatorToken: node.assignToken) {
+        if let violation = violation(operatorToken: node.equal) {
             violationRanges.append(violation)
         }
     }
 
     override func visitPost(_ node: TernaryExprSyntax) {
-        if let violation = violation(operatorToken: node.colonMark) {
+        if let violation = violation(operatorToken: node.colon) {
             violationRanges.append(violation)
         }
 
@@ -162,7 +162,7 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
     }
 
     override func visitPost(_ node: UnresolvedTernaryExprSyntax) {
-        if let violation = violation(operatorToken: node.colonMark) {
+        if let violation = violation(operatorToken: node.colon) {
             violationRanges.append(violation)
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -173,6 +173,10 @@ enum PreferSelfInStaticReferencesRuleExamples {
                         get { ↓C.i }
                         set { ↓C.i = newValue }
                     }
+                    var l: Int {
+                        let ii = ↓C.i
+                        return ii
+                    }
                 }
             }
         """, excludeFromDocumentation: true),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -145,7 +145,7 @@ private extension PreferSelfTypeOverTypeOfSelfRule {
 
             correctionPositions.append(function.positionAfterSkippingLeadingTrivia)
 
-            let base = IdentifierExprSyntax(identifier: "Self")
+            let base = DeclReferenceExprSyntax(baseName: "Self")
             let baseWithTrivia = base
                 .with(\.leadingTrivia, function.leadingTrivia)
                 .with(\.trailingTrivia, function.trailingTrivia)
@@ -157,16 +157,16 @@ private extension PreferSelfTypeOverTypeOfSelfRule {
 private extension FunctionCallExprSyntax {
     var hasViolation: Bool {
         return isTypeOfSelfCall &&
-            argumentList.map(\.label?.text) == ["of"] &&
-            argumentList.first?.expression.as(IdentifierExprSyntax.self)?.identifier.tokenKind == .keyword(.self)
+        arguments.map(\.label?.text) == ["of"] &&
+        arguments.first?.expression.as(DeclReferenceExprSyntax.self)?.baseName.tokenKind == .keyword(.self)
     }
 
     var isTypeOfSelfCall: Bool {
-        if let identifierExpr = calledExpression.as(IdentifierExprSyntax.self) {
-            return identifierExpr.identifier.text == "type"
+        if let identifierExpr = calledExpression.as(DeclReferenceExprSyntax.self) {
+            return identifierExpr.baseName.text == "type"
         } else if let memberAccessExpr = calledExpression.as(MemberAccessExprSyntax.self) {
-            return memberAccessExpr.name.text == "type" &&
-                memberAccessExpr.base?.as(IdentifierExprSyntax.self)?.identifier.text == "Swift"
+            return memberAccessExpr.declName.baseName.text == "type" &&
+            memberAccessExpr.base?.as(DeclReferenceExprSyntax.self)?.baseName.text == "Swift"
         }
         return false
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -97,7 +97,7 @@ private extension PrefixedTopLevelConstantRule {
         override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: VariableDeclSyntax) {
-            guard node.bindingKeyword.tokenKind == .keyword(.let) else {
+            guard node.bindingSpecifier.tokenKind == .keyword(.let) else {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -69,9 +69,9 @@ private extension ProtocolPropertyAccessorsOrderRule {
 
             correctionPositions.append(node.accessors.positionAfterSkippingLeadingTrivia)
 
-            let reversedAccessors = AccessorListSyntax(Array(node.accessors.reversed()))
+            let reversedAccessors = AccessorDeclListSyntax(Array(node.accessorsList.reversed()))
             return super.visit(
-                node.with(\.accessors, reversedAccessors)
+                node.with(\.accessors, .accessors(reversedAccessors))
             )
         }
     }
@@ -79,12 +79,9 @@ private extension ProtocolPropertyAccessorsOrderRule {
 
 private extension AccessorBlockSyntax {
     var hasViolation: Bool {
-        guard accessors.count == 2,
-              accessors.allSatisfy({ $0.body == nil }),
-              accessors.first?.accessorKind.tokenKind == .keyword(.set) else {
-            return false
-        }
-
-        return true
+        let accessorsList = accessorsList
+        return accessorsList.count == 2
+            && accessorsList.allSatisfy({ $0.body == nil })
+            && accessorsList.first?.accessorSpecifier.tokenKind == .keyword(.set)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -67,8 +67,8 @@ private extension RedundantDiscardableLetRule {
 
             correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
             let newNode = node
-                .with(\.bindingKeyword, .keyword(.let, presence: .missing))
-                .with(\.bindings, node.bindings.with(\.leadingTrivia, node.bindingKeyword.leadingTrivia))
+                .with(\.bindingSpecifier, .keyword(.let, presence: .missing))
+                .with(\.bindings, node.bindings.with(\.leadingTrivia, node.bindingSpecifier.leadingTrivia))
             return super.visit(newNode)
         }
     }
@@ -76,7 +76,7 @@ private extension RedundantDiscardableLetRule {
 
 private extension VariableDeclSyntax {
     var hasRedundantDiscardableLetViolation: Bool {
-        bindingKeyword.tokenKind == .keyword(.let) &&
+        bindingSpecifier.tokenKind == .keyword(.let) &&
             bindings.count == 1 &&
             bindings.first!.pattern.is(WildcardPatternSyntax.self) &&
             bindings.first!.typeAnnotation == nil &&

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
@@ -158,9 +158,9 @@ private class ExplicitSelfVisitor: DeclaredIdentifiersTrackingVisitor {
     }
 
     override func visitPost(_ node: MemberAccessExprSyntax) {
-        if !hasSeenDeclaration(for: node.name.text), node.isBaseSelf, isSelfRedundant {
+        if !hasSeenDeclaration(for: node.declName.baseName.text), node.isBaseSelf, isSelfRedundant {
             corrections.append(
-                (start: node.positionAfterSkippingLeadingTrivia, end: node.dot.endPositionBeforeTrailingTrivia)
+                (start: node.positionAfterSkippingLeadingTrivia, end: node.period.endPositionBeforeTrailingTrivia)
             )
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -91,7 +91,7 @@ private extension ReturnArrowWhitespaceRule {
         private(set) var corrections: [ArrowViolation] = []
 
         override func visitPost(_ node: FunctionTypeSyntax) {
-            guard let violation = node.output.arrow.arrowViolation else {
+            guard let violation = node.returnClause.arrow.arrowViolation else {
                 return
             }
 
@@ -100,7 +100,7 @@ private extension ReturnArrowWhitespaceRule {
         }
 
         override func visitPost(_ node: FunctionSignatureSyntax) {
-            guard let output = node.output, let violation = output.arrow.arrowViolation else {
+            guard let output = node.returnClause, let violation = output.arrow.arrowViolation else {
                 return
             }
 
@@ -109,7 +109,7 @@ private extension ReturnArrowWhitespaceRule {
         }
 
         override func visitPost(_ node: ClosureSignatureSyntax) {
-            guard let output = node.output, let violation = output.arrow.arrowViolation else {
+            guard let output = node.returnClause, let violation = output.arrow.arrowViolation else {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
@@ -73,8 +73,8 @@ private final class SelfBindingRuleVisitor: ViolationsSyntaxVisitor {
         if let identifierPattern = node.pattern.as(IdentifierPatternSyntax.self),
            identifierPattern.identifier.text != bindIdentifier {
             var hasViolation = false
-            if let initializerIdentifier = node.initializer?.value.as(IdentifierExprSyntax.self) {
-                hasViolation = initializerIdentifier.identifier.text == "self"
+            if let initializerIdentifier = node.initializer?.value.as(DeclReferenceExprSyntax.self) {
+                hasViolation = initializerIdentifier.baseName.text == "self"
             } else if node.initializer == nil {
                 hasViolation = identifierPattern.identifier.text == "self" && bindIdentifier != "self"
             }
@@ -114,8 +114,8 @@ private final class SelfBindingRuleRewriter: SyntaxRewriter, ViolationsSyntaxRew
             return super.visit(node)
         }
 
-        if let initializerIdentifier = node.initializer?.value.as(IdentifierExprSyntax.self),
-           initializerIdentifier.identifier.text == "self" {
+        if let initializerIdentifier = node.initializer?.value.as(DeclReferenceExprSyntax.self),
+           initializerIdentifier.baseName.text == "self" {
             correctionPositions.append(identifierPattern.positionAfterSkippingLeadingTrivia)
 
             let newPattern = PatternSyntax(
@@ -136,8 +136,8 @@ private final class SelfBindingRuleRewriter: SyntaxRewriter, ViolationsSyntaxRew
             )
 
             let newInitializer = InitializerClauseSyntax(
-                value: IdentifierExprSyntax(
-                    identifier: .keyword(
+                value: DeclReferenceExprSyntax(
+                    baseName: .keyword(
                         .`self`,
                         leadingTrivia: .space,
                         trailingTrivia: identifierPattern.trailingTrivia

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ShorthandOperatorRule.swift
@@ -51,10 +51,10 @@ struct ShorthandOperatorRule: ConfigurationProviderRule, SwiftSyntaxRule {
 private extension ShorthandOperatorRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
-            guard node.operatorOperand.is(AssignmentExprSyntax.self),
+            guard node.operator.is(AssignmentExprSyntax.self),
                   let rightExpr = node.rightOperand.as(InfixOperatorExprSyntax.self),
-                  let binaryOperatorExpr = rightExpr.operatorOperand.as(BinaryOperatorExprSyntax.self),
-                  ShorthandOperatorRule.allOperators.contains(binaryOperatorExpr.operatorToken.text),
+                  let binaryOperatorExpr = rightExpr.operator.as(BinaryOperatorExprSyntax.self),
+                  ShorthandOperatorRule.allOperators.contains(binaryOperatorExpr.operator.text),
                   node.leftOperand.trimmedDescription == rightExpr.leftOperand.trimmedDescription
             else {
                 return
@@ -64,7 +64,7 @@ private extension ShorthandOperatorRule {
         }
 
         override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-            if let binaryOperator = node.identifier.binaryOperator,
+            if let binaryOperator = node.name.binaryOperator,
                case let shorthandOperators = ShorthandOperatorRule.allOperators.map({ $0 + "=" }),
                shorthandOperators.contains(binaryOperator) {
                 return .skipChildren

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
@@ -94,10 +94,10 @@ private extension SortedEnumCasesRule {
 
             let cases = node.memberBlock.members.compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
             let sortedCases = cases
-                .sorted(by: { $0.elements.first!.identifier.text < $1.elements.first!.identifier.text })
+                .sorted(by: { $0.elements.first!.name.text < $1.elements.first!.name.text })
 
             zip(sortedCases, cases).forEach { sortedCase, currentCase in
-                if sortedCase.elements.first?.identifier.text != currentCase.elements.first?.identifier.text {
+                if sortedCase.elements.first?.name.text != currentCase.elements.first?.name.text {
                     violations.append(currentCase.positionAfterSkippingLeadingTrivia)
                 }
             }
@@ -106,10 +106,10 @@ private extension SortedEnumCasesRule {
         }
 
         override func visitPost(_ node: EnumCaseDeclSyntax) {
-            let sortedElements = node.elements.sorted(by: { $0.identifier.text < $1.identifier.text })
+            let sortedElements = node.elements.sorted(by: { $0.name.text < $1.name.text })
 
             zip(sortedElements, node.elements).forEach { sortedElement, currentElement in
-                if sortedElement.identifier.text != currentElement.identifier.text {
+                if sortedElement.name.text != currentElement.name.text {
                     violations.append(currentElement.positionAfterSkippingLeadingTrivia)
                 }
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnusedOptionalBindingRule.swift
@@ -65,7 +65,7 @@ private extension ExprSyntax {
         if self.is(DiscardAssignmentExprSyntax.self) {
             return true
         } else if let tuple = self.as(TupleExprSyntax.self) {
-            return tuple.elementList.allSatisfy { elem in
+            return tuple.elements.allSatisfy { elem in
                 elem.expression.isDiscardExpression
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -27,11 +27,11 @@ private extension VerticalParameterAlignmentRule {
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {
-            violations.append(contentsOf: violations(for: node.signature.input.parameterList))
+            violations.append(contentsOf: violations(for: node.signature.parameterClause.parameters))
         }
 
         override func visitPost(_ node: InitializerDeclSyntax) {
-            violations.append(contentsOf: violations(for: node.signature.input.parameterList))
+            violations.append(contentsOf: violations(for: node.signature.parameterClause.parameters))
         }
 
         private func violations(for params: FunctionParameterListSyntax) -> [AbsolutePosition] {

--- a/Source/SwiftLintBuiltInRules/Visitors/BodyLengthRuleVisitor.swift
+++ b/Source/SwiftLintBuiltInRules/Visitors/BodyLengthRuleVisitor.swift
@@ -86,7 +86,7 @@ final class BodyLengthRuleVisitor<Parent: Rule>: ViolationsSyntaxVisitor {
             registerViolations(
                 leftBrace: body.leftBrace,
                 rightBrace: body.rightBrace,
-                violationNode: node.identifier
+                violationNode: node.name
             )
         }
     }

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
@@ -32,7 +32,7 @@ private let foldedSyntaxTreeCache = Cache { file -> SourceFileSyntax? in
         .as(SourceFileSyntax.self)
 }
 private let locationConverterCache = Cache { file -> SourceLocationConverter in
-    return SourceLocationConverter(file: file.path ?? "<nopath>", tree: file.syntaxTree)
+    return SourceLocationConverter(fileName: file.path ?? "<nopath>", tree: file.syntaxTree)
 }
 private let commandsCache = Cache { file -> [Command] in
     guard file.contents.contains("swiftlint:") else {

--- a/Source/SwiftLintCore/Extensions/SyntaxClassification+isComment.swift
+++ b/Source/SwiftLintCore/Extensions/SyntaxClassification+isComment.swift
@@ -7,8 +7,8 @@ public extension SyntaxClassification {
         case .lineComment, .docLineComment, .blockComment, .docBlockComment:
             return true
         case .none, .keyword, .identifier, .typeIdentifier, .operatorIdentifier, .dollarIdentifier, .integerLiteral,
-             .floatingLiteral, .stringLiteral, .stringInterpolationAnchor, .poundDirectiveKeyword, .buildConfigId,
-             .attribute, .objectLiteral, .editorPlaceholder, .regexLiteral:
+             .floatLiteral, .stringLiteral, .stringInterpolationAnchor, .poundDirective, .buildConfigId,
+             .attribute, .editorPlaceholder, .regexLiteral:
             return false
         }
     }

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -20,9 +20,9 @@ def swiftlint_repos(bzlmod = False):
 
     http_archive(
         name = "SwiftSyntax",
-        sha256 = "8c418e1782a53b588119ffbce3c8b03ed5d3f3e0faf9b093e2e74bc6ccf1e529",
-        strip_prefix = "swift-syntax-509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-09-a",
-        url = "https://github.com/apple/swift-syntax/archive/refs/tags/509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-09-a.tar.gz",
+        sha256 = "f2fae94020d84930d517c9ce86dfb8fd37db8a58a6ac9029bf00a3c9566b557f",
+        strip_prefix = "swift-syntax-509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-07-a",
+        url = "https://github.com/apple/swift-syntax/archive/refs/tags/509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-07-a.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Diff: https://github.com/apple/swift-syntax/compare/509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-09-a...509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-07-a

In this release, a lot of methods and names changed and are now deprecated. This PR updates them to use the recommended alternatives. Parts of the suggested API required some more changes besides simple renamings.

