### PR TITLE
Added bare_init rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,6 +12,7 @@ opt_in_rules:
 disabled_rules:
   - anonymous_argument_in_multiline_closure
   - anyobject_protocol
+  - bare_init
   - closure_body_length
   - conditional_returns_on_newline
   - convenience_type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * Add `--default-config` option to `rules` command allowing to use default
   values for configurations being printed for a single rule or all rules.  
   [SimplyDanny](https://github.com/SimplyDanny)
+
 * Add new `bare_init` rule to encourage named constructors over
   `.init()` and type inference.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 * Add new `private_swiftui_state_property` opt-in rule to encourage setting 
   SwiftUI `@State` and `@StateObject` properties to private.  
+* Add new `private_swiftui_state_property` opt-in rule to encourage setting
+  SwiftUI `@State` properties to private.  
   [mt00chikin](https://github.com/mt00chikin)
   [#3173](https://github.com/realm/SwiftLint/issues/3173)
 
@@ -53,10 +55,10 @@
   [keith](https://github.com/keith)
   [5139](https://github.com/realm/SwiftLint/pull/5139)
 
-* Show a rule's active YAML configuration in output of 
+* Show a rule's active YAML configuration in output of
   `swiftlint rules <rule>`.  
   [SimplyDanny](https://github.com/SimplyDanny)
-  
+
 * Add `invokeTest()` to `overridden_super_call` defaults.  
   [DylanBettermannDD](https://github.com/DylanBettermannDD)
 
@@ -67,6 +69,10 @@
 * Add `--default-config` option to `rules` command allowing to use default
   values for configurations being printed for a single rule or all rules.  
   [SimplyDanny](https://github.com/SimplyDanny)
+* Add new `bare_init` rule to encourage named constructors over
+  `.init()` and type inference.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5170](https://github.com/realm/SwiftLint/issues/5170)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -10,6 +10,7 @@ public let builtInRules: [Rule.Type] = [
     ArrayInitRule.self,
     AttributesRule.self,
     BalancedXCTestLifecycleRule.self,
+    BareInitRule.self,
     BlanketDisableCommandRule.self,
     BlockBasedKVORule.self,
     CaptureVariableRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BareInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BareInitRule.swift
@@ -43,8 +43,8 @@ private extension BareInitRule {
 
 private extension MemberAccessExprSyntax {
     var bareInitPosition: AbsolutePosition? {
-        if base == nil, name.text == "init" {
-            return dot.positionAfterSkippingLeadingTrivia
+        if base == nil, declName.baseName.text == "init" {
+            return period.positionAfterSkippingLeadingTrivia
         } else {
             return nil
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BareInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BareInitRule.swift
@@ -7,11 +7,12 @@ struct BareInitRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
     static let description = RuleDescription(
         identifier: "bare_init",
         name: "Bare Init",
-        description: "Use named constructors over .init",
+        description: "Prefer named constructors over .init and type inference",
         kind: .idiomatic,
         nonTriggeringExamples: [
             Example("let foo = Foo()"),
-            Example("let foo = init()")
+            Example("let foo = init()"),
+            Example("let foo = Foo.init()")
         ],
         triggeringExamples: [
             Example("let foo: Foo = ↓.init()"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BareInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BareInitRule.swift
@@ -34,7 +34,7 @@ private extension BareInitRule {
             else {
                 return
             }
-            
+
             violations.append(violationPosition)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BareInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BareInitRule.swift
@@ -1,0 +1,51 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+struct BareInitRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "bare_init",
+        name: "Bare Init",
+        description: "Use named constructors over .init",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            Example("let foo = Foo()"),
+            Example("let foo = init()")
+        ],
+        triggeringExamples: [
+            Example("let foo: Foo = ↓.init()"),
+            Example("let foo: [Foo] = [↓.init(), ↓.init()]"),
+            Example("foo(↓.init())")
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+        Visitor(viewMode: .sourceAccurate)
+    }
+}
+
+private extension BareInitRule {
+    final class Visitor: ViolationsSyntaxVisitor {
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            guard
+                let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),
+                let violationPosition = calledExpression.bareInitPosition
+            else {
+                return
+            }
+            
+            violations.append(violationPosition)
+        }
+    }
+}
+
+private extension MemberAccessExprSyntax {
+    var bareInitPosition: AbsolutePosition? {
+        if base == nil, name.text == "init" {
+            return dot.positionAfterSkippingLeadingTrivia
+        } else {
+            return nil
+        }
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -50,6 +50,12 @@ class BalancedXCTestLifecycleRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class BareInitRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(BareInitRule.description)
+    }
+}
+
 class BlanketDisableCommandRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(BlanketDisableCommandRule.description)


### PR DESCRIPTION
Potentially resolves  #2960

I went for `bare_init`, as we already have an `explicit_init` rule.

Not massively happy with the name, so if anyone has a better suggestion ...

I did think of just adding a configuration option to `explicit_init` to extend its behavior, but then I would have needed another configuration flag to turn the rules normal behavior off, and a separate rule seemed easier.

Triggers a lot of violations in the open source samples, and in SwiftLint itself, as this is a very common construct, so I made it opt-in.
