### PR TITLE
Ignore the second operands of binary left shift operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,10 +103,7 @@
   when calling `NSNumber.init(value:)` directly.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#5172](https://github.com/realm/SwiftLint/issues/5172)
-* The `no_magic_numbers` rule will not trigger for the second operand of
-  bitwise left shift operations.  
-* The `no_magic_numbers` rule will not trigger for the either operand of
-  bitwise shift operations.  
+
 * The `no_magic_numbers` rule will not trigger for bitwise shift
   operations.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@
   bitwise left shift operations.  
 * The `no_magic_numbers` rule will not trigger for the either operand of
   bitwise shift operations.  
+* The `no_magic_numbers` rule will not trigger for bitwise shift
+  operations.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5171](https://github.com/realm/SwiftLint/issues/5171)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@
   when calling `NSNumber.init(value:)` directly.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#5172](https://github.com/realm/SwiftLint/issues/5172)
+* The `no_magic_numbers` rule will not trigger for the second operand of
+  bitwise left shift operations.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5171](https://github.com/realm/SwiftLint/issues/5171)
 
 ## 0.52.4: Lid Switch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@
   [#5172](https://github.com/realm/SwiftLint/issues/5172)
 * The `no_magic_numbers` rule will not trigger for the second operand of
   bitwise left shift operations.  
+* The `no_magic_numbers` rule will not trigger for the either operand of
+  bitwise shift operations.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5171](https://github.com/realm/SwiftLint/issues/5171)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -213,9 +213,8 @@ private extension ExprSyntaxProtocol {
         }
 
         let operatorIndex = siblings.index(after: siblings.startIndex)
-        if let tokenKind = siblings[operatorIndex].as(BinaryOperatorExprSyntax.self)?.operatorToken.tokenKind,
-           tokenKind == .binaryOperator("<<") || tokenKind == .binaryOperator(">>") {
-            return true
+        if let tokenKind = siblings[operatorIndex].as(BinaryOperatorExprSyntax.self)?.operatorToken.tokenKind {
+            return tokenKind == .binaryOperator("<<") || tokenKind == .binaryOperator(">>")
         }
 
         return false

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -205,20 +205,17 @@ private extension ExprSyntaxProtocol {
     }
 
     func isOperandOfBitwiseShiftOperation() -> Bool {
-        guard let siblings = parent?.as(ExprListSyntax.self)?.children(viewMode: .sourceAccurate) else {
+        guard
+            let siblings = parent?.as(ExprListSyntax.self)?.children(viewMode: .sourceAccurate),
+            siblings.count == 3
+        else {
             return false
         }
-        if siblings.count == 3 {
-            let index = siblings.index(after: siblings.startIndex)
-            if let tokenKind = siblings[index].as(BinaryOperatorExprSyntax.self)?.operatorToken.tokenKind {
-                if tokenKind == .binaryOperator("<<") || tokenKind == .binaryOperator(">>") {
-                    let lastIndex = siblings.index(after: index)
-                    let selfAsSyntax = self.as(Syntax.self)
-                    if siblings[siblings.startIndex] == selfAsSyntax || siblings[lastIndex] == selfAsSyntax {
-                        return true
-                    }
-                }
-            }
+
+        let operatorIndex = siblings.index(after: siblings.startIndex)
+        if let tokenKind = siblings[operatorIndex].as(BinaryOperatorExprSyntax.self)?.operatorToken.tokenKind,
+           tokenKind == .binaryOperator("<<") || tokenKind == .binaryOperator(">>") {
+            return true
         }
 
         return false


### PR DESCRIPTION
Resolves #5171, at least in part.

```
struct LogType: OptionSet {
    /// Returns the raw bitmask value of the option and satisfies the `RawRepresentable` protocol.
    public let rawValue: UInt
    public static let operatingSystem: LogType= LogType(rawValue: 1 << 0)
    public static let debugConsole: LogType= LogType(rawValue: 1 << 1)
    public static let file: LogType= LogType(rawValue: 1 << 2)
    public static let inMemory: LogType= LogType(rawValue: 1 << 3)
    public static let testing: LogType= ulogLogType(rawValue: 1 << 4)
    public static let visual: LogType= LogType(rawValue: 1 << 5)
    public static let reporting: LogType= LogType(rawValue: 1 << 6)
    public static let other: LogType= LogType(rawValue: 1 << 7)

    public init(rawValue: UInt) {
        self.rawValue = rawValue
    }
}
```

Will no longer generate any warnings. Only the left shift operator will receive this treatment, and only for its second operand.
