### PR TITLE
Removed `Image(systemName:)` special case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,11 @@
   when calling `NSNumber.init(value:)` directly.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#5172](https://github.com/realm/SwiftLint/issues/5172)
+* The `accessibility_label_for_image` rule will no longer ignore the
+  `Image(systemName:)` constructor, as many system images do not
+  have good accessibility labels.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5165](https://github.com/realm/SwiftLint/issues/5165)
 
 * The `no_magic_numbers` rule will not trigger for bitwise shift
   operations.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
   when calling `NSNumber.init(value:)` directly.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#5172](https://github.com/realm/SwiftLint/issues/5172)
+
 * The `accessibility_label_for_image` rule will no longer ignore the
   `Image(systemName:)` constructor, as many system images do not
   have good accessibility labels.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,16 +107,16 @@
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#5172](https://github.com/realm/SwiftLint/issues/5172)
 
+* The `no_magic_numbers` rule will not trigger for bitwise shift
+  operations.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5171](https://github.com/realm/SwiftLint/issues/5171)
+
 * The `accessibility_label_for_image` rule will no longer ignore the
   `Image(systemName:)` constructor, as many system images do not
   have good accessibility labels.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5165](https://github.com/realm/SwiftLint/issues/5165)
-
-* The `no_magic_numbers` rule will not trigger for bitwise shift
-  operations.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#5171](https://github.com/realm/SwiftLint/issues/5171)
 
 ## 0.52.4: Lid Switch
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -47,7 +47,7 @@ struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule, OptIn
 
             // If it's image, and does not hide from accessibility or provide a label, it's a violation.
             if dictionary.isImage {
-                if dictionary.isDecorativeOrLabeledOrSystemImage ||
+                if dictionary.isDecorativeOrLabeledImage ||
                   dictionary.hasAccessibilityHiddenModifier(in: file) ||
                     dictionary.hasAccessibilityLabelModifier(in: file) {
                     continue
@@ -101,15 +101,15 @@ private extension SourceKittenDictionary {
     }
 
     /// Whether or not the dictionary represents a SwiftUI Image using the `Image(decorative:)` constructor (hides
-    /// from a11y), or one of the `Image(_:label:)` or `Image(systemName:)` constructors (provides label).
-    var isDecorativeOrLabeledOrSystemImage: Bool {
+    /// from a11y), or the `Image(_:label:)` constructors (which provide labels).
+    var isDecorativeOrLabeledImage: Bool {
         guard isImage else {
             return false
         }
 
-        // Check for Image(decorative:), Image(_:label:), or Image(systemName:) constructor.
+        // Check for Image(decorative:) or Image(_:label:) constructor.
         if expressionKind == .call &&
-            enclosedArguments.contains(where: { ["decorative", "label", "systemName"].contains($0.name) }) {
+            enclosedArguments.contains(where: { ["decorative", "label"].contains($0.name) }) {
             return true
         }
 
@@ -118,7 +118,7 @@ private extension SourceKittenDictionary {
         // Image(decorative: "myImage").resizable().frame
         //     --> Image(decorative: "myImage").resizable
         //         --> Image
-        return substructure.contains(where: { $0.isDecorativeOrLabeledOrSystemImage })
+        return substructure.contains(where: { $0.isDecorativeOrLabeledImage })
     }
 
     /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityLabel(_:)`

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -10,13 +10,6 @@ internal struct AccessibilityLabelForImageRuleExamples {
         Example("""
         struct MyView: View {
             var body: some View {
-                Image(systemName: "circle.plus")
-            }
-        }
-        """),
-        Example("""
-        struct MyView: View {
-            var body: some View {
                 Image("my-image", label: Text("Alt text for my image"))
             }
         }
@@ -262,6 +255,13 @@ internal struct AccessibilityLabelForImageRuleExamples {
                         .renderingMode(.template)
                         .foregroundColor(.blue)
                 }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                ↓Image(systemName: "circle.plus")
             }
         }
         """)


### PR DESCRIPTION
Resolves #5165

The `Image(systemName:)` constructor will now trigger a violation, as many system images do not have good accessibility labels.
