### PR TITLE
Make `unneeded_break_in_switch` auto correctable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 
 #### Enhancements
 
+* Make `unneeded_break_in_switch` auto correctable.
+  [KS1019](https://github.com/KS1019/)
+  [5188](https://github.com/realm/SwiftLint/pull/5188)
+
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`
   is involved.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,8 @@
 
 #### Enhancements
 
-* Make `unneeded_break_in_switch` auto correctable.
+* Make `unneeded_break_in_switch` auto correctable.  
   [KS1019](https://github.com/KS1019/)
-  [5188](https://github.com/realm/SwiftLint/pull/5188)
 
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   [gibachan](https://github.com/gibachan)
   [#5233](https://github.com/realm/SwiftLint/pull/5233)
 
+* Make `unneeded_break_in_switch` auto correctable.  
+  [KS1019](https://github.com/KS1019/)
+
 #### Bug Fixes
 
 * Fix false positive in `unused_import` rule that triggered on 
@@ -51,9 +54,6 @@
 * None.
 
 #### Enhancements
-
-* Make `unneeded_break_in_switch` auto correctable.  
-  [KS1019](https://github.com/KS1019/)
 
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -78,8 +78,7 @@ struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule, ConfigurationProvi
 
 private final class UnneededBreakInSwitchRuleVisitor: ViolationsSyntaxVisitor {
     override func visitPost(_ node: SwitchCaseSyntax) {
-        guard node.containsUnneededBreak(),
-              let statement = node.statements.last else {
+        guard let statement = node.unneededBreak else {
             return
         }
 
@@ -98,8 +97,7 @@ private final class UnneededBreakInSwitchRewriter: SyntaxRewriter, ViolationsSyn
     }
 
     override func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
-        guard let statement = node.statements.last,
-              node.containsUnneededBreak(),
+        guard let statement = node.unneededBreak,
               !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) else {
             return super.visit(node)
         }
@@ -123,14 +121,14 @@ private final class UnneededBreakInSwitchRewriter: SyntaxRewriter, ViolationsSyn
 }
 
 private extension SwitchCaseSyntax {
-    func containsUnneededBreak() -> Bool {
+    var unneededBreak: CodeBlockItemSyntax? {
         guard statements.count > 1,
               let breakStatement = statements.last?.item.as(BreakStmtSyntax.self),
               breakStatement.label == nil else {
-            return false
+            return nil
         }
 
-        return true
+        return statements.last
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -49,14 +49,36 @@ struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule, ConfigurationProvi
         corrections: [
             embedInSwitch("something()\n    ↓break")
             : embedInSwitch("something()"),
-            embedInSwitch("something()\n    ↓break " + lineComment)
-            : embedInSwitch("something()\n     " + lineComment),
-            embedInSwitch("something()\n    ↓break\n" + blockComment)
-            : embedInSwitch("something()\n" + blockComment),
-            embedInSwitch("something()\n    ↓break " + docLineComment)
-            : embedInSwitch("something()\n     " + docLineComment),
-            embedInSwitch("something()\n    ↓break\n" + docBlockComment)
-            : embedInSwitch("something()\n" + docBlockComment),
+            embedInSwitch("something()\n    ↓break // line comment")
+            : embedInSwitch("something()\n     // line comment"),
+            embedInSwitch("""
+                something()
+                ↓break
+                /*
+                block comment
+                */
+                """)
+            : embedInSwitch("""
+                something()
+                /*
+                block comment
+                */
+                """),
+            embedInSwitch("something()\n    ↓break /// doc line comment")
+            : embedInSwitch("something()\n     /// doc line comment"),
+            embedInSwitch("""
+                something()
+                ↓break
+                ///
+                /// doc block comment
+                ///
+                """)
+            : embedInSwitch("""
+                something()
+                ///
+                /// doc block comment
+                ///
+                """),
             embedInSwitch("something()\n    ↓break", case: "default")
             : embedInSwitch("something()", case: "default"),
             embedInSwitch("something()\n    ↓break", case: "case .foo, .foo2 where condition")
@@ -142,19 +164,3 @@ private extension TriviaPiece {
         }
     }
 }
-
-private let lineComment = "// line comment"
-
-private let blockComment = """
-/*
-    block comment
-*/
-"""
-
-private let docLineComment = "/// doc line comment"
-
-private let docBlockComment = """
-///
-/// doc block comment
-///
-"""

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -119,7 +119,7 @@ private final class UnneededBreakInSwitchRewriter: SyntaxRewriter, ViolationsSyn
     }
 
     override func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
-        let stmts = node.statements.removingLast()
+        let stmts = CodeBlockItemListSyntax(node.statements.dropLast())
 
         guard let breakStatement = node.unneededBreak, let secondLast = stmts.last,
               !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -119,7 +119,9 @@ private final class UnneededBreakInSwitchRewriter: SyntaxRewriter, ViolationsSyn
     }
 
     override func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
-        guard let breakStatement = node.unneededBreak,
+        let stmts = node.statements.removingLast()
+
+        guard let breakStatement = node.unneededBreak, let secondLast = stmts.last,
               !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) else {
             return super.visit(node)
         }
@@ -127,9 +129,6 @@ private final class UnneededBreakInSwitchRewriter: SyntaxRewriter, ViolationsSyn
         correctionPositions.append(breakStatement.item.positionAfterSkippingLeadingTrivia)
 
         let trivia = breakStatement.item.leadingTrivia + breakStatement.item.trailingTrivia
-
-        let stmts = node.statements.removingLast()
-        let secondLast = stmts.last!
 
         let newNode = node
             .with(\.statements, stmts)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -119,14 +119,14 @@ private final class UnneededBreakInSwitchRewriter: SyntaxRewriter, ViolationsSyn
     }
 
     override func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
-        guard let statement = node.unneededBreak,
+        guard let breakStatement = node.unneededBreak,
               !node.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) else {
             return super.visit(node)
         }
 
-        correctionPositions.append(statement.item.positionAfterSkippingLeadingTrivia)
+        correctionPositions.append(breakStatement.item.positionAfterSkippingLeadingTrivia)
 
-        let trivia = statement.item.leadingTrivia + statement.item.trailingTrivia
+        let trivia = breakStatement.item.leadingTrivia + breakStatement.item.trailingTrivia
 
         let stmts = node.statements.removingLast()
         let secondLast = stmts.last!

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -115,11 +115,14 @@ private final class UnneededBreakInSwitchRewriter: SyntaxRewriter, ViolationsSyn
         let stmts = node.statements.removingLast()
         guard let secondLast = stmts.last else { return super.visit(node) }
 
-        return super.visit(
-            node.with(\.statements, stmts)
-                .with(\.statements.trailingTrivia, secondLast.item.trailingTrivia + trivia)
-                .trimmed { !$0.isComment }.formatted().as(SwitchCaseSyntax.self)!
-        )
+        let newNode = node
+            .with(\.statements, stmts)
+            .with(\.statements.trailingTrivia, secondLast.item.trailingTrivia + trivia)
+            .trimmed { !$0.isComment }
+            .formatted()
+            .as(SwitchCaseSyntax.self)!
+
+        return super.visit(newNode)
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -125,7 +125,7 @@ private final class UnneededBreakInSwitchRewriter: SyntaxRewriter, ViolationsSyn
 private extension SwitchCaseSyntax {
     func containsUnneededBreak() -> Bool {
         guard statements.count > 1,
-              let breakStatement = statements.last!.item.as(BreakStmtSyntax.self),
+              let breakStatement = statements.last?.item.as(BreakStmtSyntax.self),
               breakStatement.label == nil else {
             return false
         }


### PR DESCRIPTION
This PR adds `UnneededBreakInSwitchRewriter` and conformance to `SwiftSyntaxCorrectableRule` to `UnneededBreakInSwitchRule` making it autocorrectable.