### PR TITLE
Add `invokeTest()` to `overridden_super_call` defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@
   `swiftlint rules <rule>`.  
   [SimplyDanny](https://github.com/SimplyDanny)
 * Add `invokeTest()` to `overridden_super_call` defaults.
+* Add `invokeTest()` to `overridden_super_call` defaults.  
   [DylanBettermannDD](https://github.com/DylanBettermannDD)
-  [5192](https://github.com/realm/SwiftLint/pull/5192)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
 * Show a rule's active YAML configuration in output of 
   `swiftlint rules <rule>`.  
   [SimplyDanny](https://github.com/SimplyDanny)
+* Add `invokeTest()` to `overridden_super_call` defaults.
+  [DylanBettermannDD](https://github.com/DylanBettermannDD)
+  [5192](https://github.com/realm/SwiftLint/pull/5192)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 * Show a rule's active YAML configuration in output of 
   `swiftlint rules <rule>`.  
   [SimplyDanny](https://github.com/SimplyDanny)
-* Add `invokeTest()` to `overridden_super_call` defaults.
+  
 * Add `invokeTest()` to `overridden_super_call` defaults.  
   [DylanBettermannDD](https://github.com/DylanBettermannDD)
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -30,7 +30,9 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
         "viewDidDisappear(_:)",
         "viewDidLoad()",
         "viewWillAppear(_:)",
-        "viewWillDisappear(_:)"
+        "viewWillDisappear(_:)",
+        // XCTestCase
+        "invokeTest()",
     ]
 
     @ConfigurationElement(key: "severity")

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -32,7 +32,7 @@ struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration, Equatab
         "viewWillAppear(_:)",
         "viewWillDisappear(_:)",
         // XCTestCase
-        "invokeTest()",
+        "invokeTest()"
     ]
 
     @ConfigurationElement(key: "severity")


### PR DESCRIPTION
`invokeTest()` is the [recommended way](https://pointfreeco.github.io/swift-dependencies/main/documentation/dependencies/overridingdependencies) to override dependencies for an entire test case when using [swift-dependencies](https://github.com/pointfreeco/swift-dependencies).

Worth noting it's an Apple-provided API.

From the Testing section:
> Sometimes there is a dependency that you want to override in a particular way for the entire test case. For example, your feature may make extensive use of the [date](https://pointfreeco.github.io/swift-dependencies/main/documentation/dependencies/dependencyvalues/date) dependency and it may be cumbersome to override it in every test. Instead, it can be done a single time by overriding invokeTest in your test case class: