### PR TITLE
Skip `switch` expressions used as child expressions in `switch_case_alignment` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5078](https://github.com/realm/SwiftLint/issues/5078)
 
+* Ignore `switch` expressions used in expression contexts in
+  `switch_case_alignment` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5191](https://github.com/realm/SwiftLint/issues/5191)
+
 * Fix bug in `prefer_self_in_static_references` rule that triggered on
   initializers of computed properties in classes when the property had an
   accessor block.  

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -39,6 +39,12 @@ struct SwitchCaseAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
                 case 1: 1
                 default: 2
             }
+            """),
+            Example("""
+            return switch i {
+                case 1: 1
+                default: 2
+            }
             """)
         ],
         triggeringExamples: Examples(indentedCases: false).triggeringExamples
@@ -61,7 +67,8 @@ extension SwitchCaseAlignmentRule {
         }
 
         override func visitPost(_ node: SwitchExprSyntax) {
-            if node.parent?.is(InitializerClauseSyntax.self) == true {
+            guard node.parent?.is(ExpressionStmtSyntax.self) == true else {
+                // Skip `switch` expressions used as part of other expressions for the time being.
                 return
             }
             let switchPosition = node.switchKeyword.positionAfterSkippingLeadingTrivia


### PR DESCRIPTION
Fixes #5191 as a generalization of #5080.