### PR TITLE
Private SwiftUI State property rule now also applies to StateObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@
 
 #### Enhancements
 
-* Private SwiftUI State property rule now also applies to StateObject.  
-  [mt00chikin](https://github.com/mt00chikin)
-
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`
   is involved.  
@@ -39,7 +36,7 @@
   [SimplyDanny](https://github.com/SimplyDanny)
 
 * Add new `private_swiftui_state_property` opt-in rule to encourage setting 
-  SwiftUI `@State` properties to private.  
+  SwiftUI `@State` and `@StateObject` properties to private.  
   [mt00chikin](https://github.com/mt00chikin)
   [#3173](https://github.com/realm/SwiftLint/issues/3173)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 #### Enhancements
 
+* Private SwiftUI State property rule now also applies to StateObject.  
+  [mt00chikin](https://github.com/mt00chikin)
+
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`
   is involved.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -2,11 +2,14 @@ import SwiftSyntax
 
 /// Require that any state properties in SwiftUI be declared as private
 ///
-/// State and StateObject properties should only be accessible from inside a SwiftUI App, View, or Scene, or from methods called by it.
+/// State and StateObject properties should only be accessible
+/// from inside a SwiftUI App, View, or Scene, or from methods called by it.
 ///
-/// Per Apple's documentation on [State](https://developer.apple.com/documentation/swiftui/state) and [StateObject](https://developer.apple.com/documentation/swiftui/stateobject):
+/// Per Apple's documentation on [State](https://developer.apple.com/documentation/swiftui/state) a
+/// nd [StateObject](https://developer.apple.com/documentation/swiftui/stateobject):
 ///
-/// Declare state and state objects as private to prevent setting them from a memberwise initializer, which can conflict with the storage management that SwiftUI provides:
+/// Declare state and state objects as private to prevent setting them from a memberwise initializer,
+/// which can conflict with the storage management that SwiftUI provides:
 struct PrivateSwiftUIStatePropertyRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -15,7 +15,7 @@ struct PrivateSwiftUIStatePropertyRule: SwiftSyntaxRule, OptInRule, Configuratio
 
     static let description = RuleDescription(
         identifier: "private_swiftui_state",
-        name: "Private SwiftUI @State Properties",
+        name: "Private SwiftUI State Properties",
         description: "SwiftUI state properties should be private",
         kind: .lint,
         nonTriggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -5,8 +5,8 @@ import SwiftSyntax
 /// State and StateObject properties should only be accessible
 /// from inside a SwiftUI App, View, or Scene, or from methods called by it.
 ///
-/// Per Apple's documentation on [State](https://developer.apple.com/documentation/swiftui/state) a
-/// nd [StateObject](https://developer.apple.com/documentation/swiftui/stateobject):
+/// Per Apple's documentation on [State](https://developer.apple.com/documentation/swiftui/state)
+/// and [StateObject](https://developer.apple.com/documentation/swiftui/stateobject)
 ///
 /// Declare state and state objects as private to prevent setting them from a memberwise initializer,
 /// which can conflict with the storage management that SwiftUI provides:

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -15,8 +15,8 @@ struct PrivateSwiftUIStatePropertyRule: SwiftSyntaxRule, OptInRule, Configuratio
 
     static let description = RuleDescription(
         identifier: "private_swiftui_state",
-        name: "Private SwiftUI @State Properties",
-        description: "SwiftUI state properties should be private",
+        name: "Private SwiftUI State Properties",
+        description: "SwiftUI State and StateObject properties should be private",
         kind: .lint,
         nonTriggeringExamples: [
             Example("""

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -16,7 +16,7 @@ struct PrivateSwiftUIStatePropertyRule: SwiftSyntaxRule, OptInRule, Configuratio
     static let description = RuleDescription(
         identifier: "private_swiftui_state",
         name: "Private SwiftUI State Properties",
-        description: "SwiftUI State and StateObject properties should be private",
+        description: "SwiftUI state properties should be private",
         kind: .lint,
         nonTriggeringExamples: [
             Example("""
@@ -82,7 +82,7 @@ struct PrivateSwiftUIStatePropertyRule: SwiftSyntaxRule, OptInRule, Configuratio
             """),
             Example("""
             struct ContentView: View {
-                private @StateObject var model = DataModel()
+                @StateObject private var model = DataModel()
             }
             """),
             Example("""
@@ -241,7 +241,7 @@ private extension PrivateSwiftUIStatePropertyRule {
                 let decl = node.decl.as(VariableDeclSyntax.self),
                 let inheritanceClause = visitedTypeInheritances.peek() as? InheritanceClauseSyntax,
                 inheritanceClause.conformsToApplicableSwiftUIProtocol,
-                decl.attributes.hasStateAttribute || decl.attributes.hasStateObjectAttribute,
+                decl.attributes.hasStateAttribute,
                 !decl.modifiers.isPrivateOrFileprivate
             else {
                 return
@@ -271,7 +271,7 @@ private extension InheritedTypeListSyntax {
 }
 
 private extension AttributeListSyntax? {
-    /// Returns `true` if the attribute's identifier is equal to "State"
+    /// Returns `true` if the attribute's identifier is equal to `State` or `StateObject`
     var hasStateAttribute: Bool {
         guard let attributes = self else { return false }
 
@@ -281,21 +281,7 @@ private extension AttributeListSyntax? {
                 return false
             }
 
-            return identifier.name.text == "State"
-        }
-    }
-
-    /// Returns `true` if the attribute's identifier is equal to "StateObject"
-    var hasStateObjectAttribute: Bool {
-        guard let attributes = self else { return false }
-
-        return attributes.contains { attr in
-            guard let stateAttr = attr.as(AttributeSyntax.self),
-                  let identifier = stateAttr.attributeName.as(IdentifierTypeSyntax.self) else {
-                return false
-            }
-
-            return identifier.name.text == "StateObject"
+            return identifier.name.text == "State" || identifier.name.text == "StateObject"
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -15,7 +15,7 @@ struct PrivateSwiftUIStatePropertyRule: SwiftSyntaxRule, OptInRule, Configuratio
 
     static let description = RuleDescription(
         identifier: "private_swiftui_state",
-        name: "Private SwiftUI State Properties",
+        name: "Private SwiftUI @State Properties",
         description: "SwiftUI state properties should be private",
         kind: .lint,
         nonTriggeringExamples: [


### PR DESCRIPTION
This more closely aligns with Apple's recommended best practices for both State and StateObject. The `private_swiftui_state_property` rule will now ensure that both State and StateObject properties are private to prevent either from being set in a memberwise initializer, which can conflict with SwiftUI's storage management.

This addresses feedback requests from comments in https://github.com/realm/SwiftLint/pull/4769.