### PR TITLE
Add `include_bare_init` option to `explicit_init` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,8 @@
   values for configurations being printed for a single rule or all rules.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
-* Add `include_bare_init` and `include_explicit_init` options to the
-  `explicit_init` rule. `include_bare_init` encourages using named
-  constructors over `.init()` and type inference.  
+* Add `include_bare_init` option to the `explicit_init` rule. `include_bare_init`
+  encourages using named constructors over `.init()` and type inference.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5203](https://github.com/realm/SwiftLint/issues/5203)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * Add `--default-config` option to `rules` command allowing to use default
   values for configurations being printed for a single rule or all rules.  
   [SimplyDanny](https://github.com/SimplyDanny)
+
 * Add `include_bare_init` and `include_explicit_init` options to the
   `explicit_init` rule. `include_bare_init` encourages using named
   constructors over `.init()` and type inference.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
   Bash, Zsh and fish.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
-* Add new `private_swiftui_state_property` opt-in rule to encourage setting 
+* Add new `private_swiftui_state_property` opt-in rule to encourage setting
   SwiftUI `@State` and `@StateObject` properties to private.  
   [mt00chikin](https://github.com/mt00chikin)
   [#3173](https://github.com/realm/SwiftLint/issues/3173)
@@ -53,10 +53,10 @@
   [keith](https://github.com/keith)
   [5139](https://github.com/realm/SwiftLint/pull/5139)
 
-* Show a rule's active YAML configuration in output of 
+* Show a rule's active YAML configuration in output of
   `swiftlint rules <rule>`.  
   [SimplyDanny](https://github.com/SimplyDanny)
-  
+
 * Add `invokeTest()` to `overridden_super_call` defaults.  
   [DylanBettermannDD](https://github.com/DylanBettermannDD)
 
@@ -67,6 +67,11 @@
 * Add `--default-config` option to `rules` command allowing to use default
   values for configurations being printed for a single rule or all rules.  
   [SimplyDanny](https://github.com/SimplyDanny)
+* Add `include_bare_init` and `include_explicit_init` options to the
+  `explicit_init` rule. `include_bare_init` encourages using named
+  constructors over `.init()` and type inference.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5203](https://github.com/realm/SwiftLint/issues/5203)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -178,10 +178,11 @@ struct ExplicitInitRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, 
     }
 
     func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        Rewriter(
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
+        guard configuration.includeExplicitInit else {
+            return nil
+        }
+
+        return Rewriter(locationConverter: file.locationConverter, disabledRegions: disabledRegions(file: file))
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -202,17 +202,13 @@ private extension ExplicitInitRule {
                 return
             }
 
-            if includeExplicitInit {
-                if let violationPosition = calledExpression.explicitInitPosition {
-                    violations.append(violationPosition)
-                }
+            if includeExplicitInit, let violationPosition = calledExpression.explicitInitPosition {
+                violations.append(violationPosition)
             }
 
-            if includeBareInit {
-                if let violationPosition = calledExpression.bareInitPosition {
-                    let reason = "Prefer named constructors over .init and type inference"
-                    violations.append(ReasonedRuleViolation(position: violationPosition, reason: reason))
-                }
+            if includeBareInit, let violationPosition = calledExpression.bareInitPosition {
+                let reason = "Prefer named constructors over .init and type inference"
+                violations.append(ReasonedRuleViolation(position: violationPosition, reason: reason))
             }
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -170,29 +170,19 @@ struct ExplicitInitRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, 
     )
 
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(
-            viewMode: .sourceAccurate,
-            includeExplicitInit: configuration.includeExplicitInit,
-            includeBareInit: configuration.includeBareInit
-        )
+        Visitor(viewMode: .sourceAccurate, includeBareInit: configuration.includeBareInit)
     }
 
     func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        guard configuration.includeExplicitInit else {
-            return nil
-        }
-
-        return Rewriter(locationConverter: file.locationConverter, disabledRegions: disabledRegions(file: file))
+        Rewriter(locationConverter: file.locationConverter, disabledRegions: disabledRegions(file: file))
     }
 }
 
 private extension ExplicitInitRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let includeExplicitInit: Bool
         private let includeBareInit: Bool
 
-        init(viewMode: SyntaxTreeViewMode, includeExplicitInit: Bool, includeBareInit: Bool) {
-            self.includeExplicitInit = includeExplicitInit
+        init(viewMode: SyntaxTreeViewMode, includeBareInit: Bool) {
             self.includeBareInit = includeBareInit
             super.init(viewMode: .sourceAccurate)
         }
@@ -202,7 +192,7 @@ private extension ExplicitInitRule {
                 return
             }
 
-            if includeExplicitInit, let violationPosition = calledExpression.explicitInitPosition {
+            if let violationPosition = calledExpression.explicitInitPosition {
                 violations.append(violationPosition)
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitInitConfiguration.swift
@@ -3,8 +3,6 @@ struct ExplicitInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
 
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(key: "include_explicit_init")
-    private(set) var includeExplicitInit = true
     @ConfigurationElement(key: "include_bare_init")
     private(set) var includeBareInit = false
 
@@ -15,10 +13,6 @@ struct ExplicitInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
 
         if let severityString = configuration[$severityConfiguration] as? String {
             try severityConfiguration.apply(configuration: severityString)
-        }
-
-        if let includeExplicitInit = configuration[$includeExplicitInit] as? Bool {
-            self.includeExplicitInit = includeExplicitInit
         }
 
         if let includeBareInit = configuration[$includeBareInit] as? Bool {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitInitConfiguration.swift
@@ -17,7 +17,12 @@ struct ExplicitInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
 
-        includeExplicitInit = configuration[$includeExplicitInit] as? Bool ?? true
-        includeBareInit = configuration[$includeBareInit] as? Bool ?? false
+        if let includeExplicitInit = configuration[$includeExplicitInit] as? Bool {
+            self.includeExplicitInit = includeExplicitInit
+        }
+
+        if let includeBareInit = configuration[$includeBareInit] as? Bool {
+            self.includeBareInit = includeBareInit
+        }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitInitConfiguration.swift
@@ -1,0 +1,23 @@
+struct ExplicitInitConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    typealias Parent = ExplicitInitRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "include_explicit_init")
+    private(set) var includeExplicitInit = true
+    @ConfigurationElement(key: "include_bare_init")
+    private(set) var includeBareInit = false
+
+    mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+        }
+
+        if let severityString = configuration[$severityConfiguration] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        includeExplicitInit = configuration[$includeExplicitInit] as? Bool ?? true
+        includeBareInit = configuration[$includeBareInit] as? Bool ?? false
+    }
+}

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -501,7 +501,7 @@ public extension SeverityConfiguration {
         guard let option = description.options.onlyElement?.value, case .symbol = option else {
             queuedFatalError(
                 """
-                Severity configurations must have exaclty one option that is a violation severity.
+                Severity configurations must have exactly one option that is a violation severity.
                 """
             )
         }

--- a/Tests/SwiftLintFrameworkTests/ExplicitInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitInitRuleTests.swift
@@ -4,10 +4,8 @@ class ExplicitInitRuleTests: SwiftLintTestCase {
     func testIncludeBareInit() {
         let nonTriggeringExamples = [
             Example("let foo = Foo()"),
-            Example("let foo = init()"),
-            Example("let foo = Foo.init()")
+            Example("let foo = init()")
         ] + ExplicitInitRule.description.nonTriggeringExamples
-          + ExplicitInitRule.description.triggeringExamples.map { $0.removingViolationMarkers() }
 
         let triggeringExamples = [
             Example("let foo: Foo = ↓.init()"),
@@ -20,6 +18,6 @@ class ExplicitInitRuleTests: SwiftLintTestCase {
             .with(triggeringExamples: triggeringExamples)
             .with(corrections: [:])
 
-        verifyRule(description, ruleConfiguration: ["include_explicit_init": false, "include_bare_init": true])
+        verifyRule(description, ruleConfiguration: ["include_bare_init": true])
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ExplicitInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitInitRuleTests.swift
@@ -1,0 +1,25 @@
+@testable import SwiftLintBuiltInRules
+
+class ExplicitInitRuleTests: SwiftLintTestCase {
+    func testIncludeBareInit() {
+        let nonTriggeringExamples = [
+            Example("let foo = Foo()"),
+            Example("let foo = init()"),
+            Example("let foo = Foo.init()")
+        ] + ExplicitInitRule.description.nonTriggeringExamples
+          + ExplicitInitRule.description.triggeringExamples.map { $0.removingViolationMarkers() }
+
+        let triggeringExamples = [
+            Example("let foo: Foo = ↓.init()"),
+            Example("let foo: [Foo] = [↓.init(), ↓.init()]"),
+            Example("foo(↓.init())")
+        ]
+
+        let description = ExplicitInitRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: [:])
+
+        verifyRule(description, ruleConfiguration: ["include_explicit_init": false, "include_bare_init": true])
+    }
+}


### PR DESCRIPTION
Adds `include_bare_init` option to the `explicit_init` rule.

This will produce violations where `.init` is called using type inference to determine the type.

For example:

```
let foo: Foo = ↓.init()
let foo: [Foo] = [↓.init(), ↓.init()]
foo(↓.init())
```

This option is off by default (as many code bases use the `.init` construct), and these violations are not correctable, as SwiftLint cannot infer the intended type.

Also adds an `include_explicit_init` option, on by default, which allows the original behavior of `explicit_init` to be suppressed, so that users can tune the rule's behavior to suit their particular use case. 

Replaces #5170, and resolves #2960
