### PR TITLE
check string before command for `invalid_swiftlint_command` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5203](https://github.com/realm/SwiftLint/issues/5203)
 
+* Improved the reported location and reasons provided for issues
+  detected by the `invalid_seiftlint_command` rule.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5204](https://github.com/realm/SwiftLint/issues/5204)
+
 #### Bug Fixes
 
 * Fix false positive in `control_statement` rule that triggered on conditions

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
@@ -35,7 +35,7 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         validateBadPrefixViolations(file: file) + validateInvalidCommandViolations(file: file)
     }
-    
+
     private func validateBadPrefixViolations(file: SwiftLintFile) -> [StyleViolation] {
         (file.commands + file.invalidCommands).compactMap { command in
             if let precedingCharacter = command.precedingCharacter(in: file) {
@@ -52,7 +52,7 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
             return nil
         }
     }
-    
+
     private func validateInvalidCommandViolations(file: SwiftLintFile) -> [StyleViolation] {
         file.invalidCommands.map { command in
             let character = command.startingCharacterPosition(in: file)
@@ -78,7 +78,7 @@ private extension Command {
         }
         return position
     }
-    
+
     func precedingCharacter(in file: SwiftLintFile) -> String? {
         if let startingCharacterPosition = startingCharacterPosition(in: file), startingCharacterPosition > 2 {
             let line = file.lines[line - 1].content
@@ -86,7 +86,7 @@ private extension Command {
         }
         return nil
     }
-    
+
     func invalidReason() -> String? {
         if action == .invalid {
             return "swiftlint command does not have a valid action"

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
@@ -34,10 +34,10 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        validate(badPrefixViolationsIn: file) + validate(invalidCommandViolationsIn: file)
+        validateBadPrefixes(in: file) + validateInvalidCommands(in: file)
     }
 
-    private func validate(badPrefixViolationsIn file: SwiftLintFile) -> [StyleViolation] {
+    private func validateBadPrefixes(in file: SwiftLintFile) -> [StyleViolation] {
         (file.commands + file.invalidCommands).compactMap { command in
             if let precedingCharacter = command.precedingCharacter(in: file)?.trimmingCharacters(in: .whitespaces) {
                 if !precedingCharacter.isEmpty, precedingCharacter != "/", precedingCharacter != "*" {
@@ -58,7 +58,7 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
         }
     }
 
-    private func validate(invalidCommandViolationsIn file: SwiftLintFile) -> [StyleViolation] {
+    private func validateInvalidCommands(in file: SwiftLintFile) -> [StyleViolation] {
         file.invalidCommands.map { command in
             let character = command.startingCharacterPosition(in: file)
             let location = Location(file: file.path, line: command.line, character: character)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
@@ -44,7 +44,8 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
                     return StyleViolation(
                         ruleDescription: Self.description,
                         severity: configuration.severity,
-                        location: location
+                        location: location,
+                        reason: "swiftlint command should be preceded by whitespace or a comment character"
                     )
                 }
             }
@@ -59,7 +60,8 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
             return StyleViolation(
                 ruleDescription: Self.description,
                 severity: configuration.severity,
-                location: location
+                location: location,
+                reason: command.invalidReason() ?? Self.description.description
             )
         }
     }
@@ -81,6 +83,19 @@ private extension Command {
         if let startingCharacterPosition = startingCharacterPosition(in: file), startingCharacterPosition > 2 {
             let line = file.lines[line - 1].content
             return line.substring(from: startingCharacterPosition - 2, length: 1)
+        }
+        return nil
+    }
+    
+    func invalidReason() -> String? {
+        if action == .invalid {
+            return "swiftlint command does not have a valid action"
+        }
+        if modifier == .invalid {
+            return "swiftlint command does not have a valid modifier"
+        }
+        if ruleIdentifiers.isEmpty {
+            return "swiftlint command does not specify any rules"
         }
         return nil
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
@@ -11,7 +11,8 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
             Example("// swiftlint:enable unused_import"),
             Example("// swiftlint:disable:next unused_import"),
             Example("// swiftlint:disable:previous unused_import"),
-            Example("// swiftlint:disable:this unused_import")
+            Example("// swiftlint:disable:this unused_import"),
+            Example("//swiftlint:disable:this unused_import")
         ],
         triggeringExamples: [
             Example("// ↓swiftlint:"),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
@@ -40,7 +40,7 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
     private func validateBadPrefixes(in file: SwiftLintFile) -> [StyleViolation] {
         (file.commands + file.invalidCommands).compactMap { command in
             if let precedingCharacter = command.precedingCharacter(in: file)?.trimmingCharacters(in: .whitespaces) {
-                if !precedingCharacter.isEmpty, precedingCharacter != "/", precedingCharacter != "*" {
+                if !precedingCharacter.isEmpty, precedingCharacter != "/" {
                     let location = Location(
                         file: file.path,
                         line: command.line,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
@@ -34,14 +34,14 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        validateBadPrefixes(in: file) + validateInvalidCommands(in: file)
+        badPrefixViolations(in: file) + invalidCommandViolations(in: file)
     }
 
-    private func validateBadPrefixes(in file: SwiftLintFile) -> [StyleViolation] {
+    private func badPrefixViolations(in file: SwiftLintFile) -> [StyleViolation] {
         (file.commands + file.invalidCommands).compactMap { command in
             if let precedingCharacter = command.precedingCharacter(in: file)?.trimmingCharacters(in: .whitespaces) {
                 if !precedingCharacter.isEmpty, precedingCharacter != "/" {
-                    return violation(
+                    return styleViolation(
                         for: command,
                         in: file,
                         reason: "swiftlint command should be preceded by whitespace or a comment character"
@@ -52,13 +52,13 @@ struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
         }
     }
 
-    private func validateInvalidCommands(in file: SwiftLintFile) -> [StyleViolation] {
+    private func invalidCommandViolations(in file: SwiftLintFile) -> [StyleViolation] {
         file.invalidCommands.map { command in
-            violation(for: command, in: file, reason: command.invalidReason() ?? Self.description.description)
+            styleViolation(for: command, in: file, reason: command.invalidReason() ?? Self.description.description)
         }
     }
 
-    private func violation(for command: Command, in file: SwiftLintFile, reason: String) -> StyleViolation {
+    private func styleViolation(for command: Command, in file: SwiftLintFile, reason: String) -> StyleViolation {
         let character = command.startingCharacterPosition(in: file)
         return StyleViolation(
             ruleDescription: Self.description,


### PR DESCRIPTION

Some minor improvements to the `invalid_swiftlint_command` rule.

Location is now more accurate - we point to the start of the `swiftlint` command.

Separate reasons are now provided for invalid actions, modifier, or missing rules.

We now check whether `swiftlint` is preceded by whitespace or a comment `/` character, so `sswiftlint:disable some_rule` for example, would now generate a warning.

