### PR TITLE
README configuration section updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 * None.
 
 #### Enhancements
+* Update README configuration for new projects. The `included` used to have the old `Source` path, 
+  the new default is `Sources`.  
+  [chibombo](https://github.com/chibombo)
 
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@
 * None.
 
 #### Enhancements
-* Update README configuration for new projects. The `included` used to have the old `Source` path, 
-  the new default is `Sources`.  
-  [chibombo](https://github.com/chibombo)
 
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`

--- a/README.md
+++ b/README.md
@@ -507,13 +507,13 @@ analyzer_rules: # rules run by `swiftlint analyze`
   - explicit_self
 
 included: # case-sensitive paths to include during linting. `--path` is ignored if present
-  - Source
+  - Sources
 excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`
   - Carthage
   - Pods
-  - Source/ExcludedFolder
-  - Source/ExcludedFile.swift
-  - Source/*/ExcludedFile.swift # exclude files with a wildcard
+  - Sources/ExcludedFolder
+  - Sources/ExcludedFile.swift
+  - Sources/*/ExcludedFile.swift # exclude files with a wildcard
 
 # If true, SwiftLint will not fail if no lintable files are found.
 allow_zero_lintable_files: false

--- a/README_CN.md
+++ b/README_CN.md
@@ -431,12 +431,12 @@ opt_in_rules: # 一些规则仅仅是可选的
   # 可以通过执行如下指令来查找所有可用的规则:
   # swiftlint rules
 included: # 执行 linting 时包含的路径。如果出现这个 `--path` 会被忽略。
-  - Source
+  - Sources
 excluded: # 执行 linting 时忽略的路径。 优先级比 `included` 更高。
   - Carthage
   - Pods
-  - Source/ExcludedFolder
-  - Source/ExcludedFile.swift
+  - Sources/ExcludedFolder
+  - Sources/ExcludedFile.swift
 
 # 可配置的规则可以通过这个配置文件来自定义
 # 二进制规则可以设置他们的严格程度

--- a/README_KR.md
+++ b/README_KR.md
@@ -249,12 +249,12 @@ opt_in_rules: # 일부 룰은 옵트 인 형태로 제공
   - missing_docs
   # 사용 가능한 모든 룰은 swiftlint rules 명령으로 확인 가능
 included: # 린트 과정에 포함할 파일 경로. 이 항목이 존재하면 `--path`는 무시됨
-  - Source
+  - Sources
 excluded: # 린트 과정에서 무시할 파일 경로. `included`보다 우선순위 높음
   - Carthage
   - Pods
-  - Source/ExcludedFolder
-  - Source/ExcludedFile.swift
+  - Sources/ExcludedFolder
+  - Sources/ExcludedFile.swift
 
 # 설정 가능한 룰은 이 설정 파일에서 커스터마이징 가능
 # 경고나 에러 중 하나를 발생시키는 룰은 위반 수준을 설정 가능


### PR DESCRIPTION
## Context
When the developer creates a new Swift package project by default the code directory is `Sources` instead of `Source`.
### Why I modify the READMEs
- When some try to use the example as a first approach, the swiftlint command will fail because the path does exist. The `allow_zero_lintable_files: false` is causing this unexpected behavior.

We can accept the change for future developers or we can change the `allow_zero_lintable_files` rule to `true` in the example.
