### PR TITLE
`no_magic_numbers` rule should ignore 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5204](https://github.com/realm/SwiftLint/issues/5204)
 
+* 100 is no longer considered to be a magic number by the `no_magic_numbers`
+  rule.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5215](https://github.com/realm/SwiftLint/issues/5215)
+
 #### Bug Fixes
 
 * Fix false positive in `control_statement` rule that triggered on conditions

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -72,7 +72,8 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
             Example("let foo = 1 << 2"),
             Example("let foo = 1 >> 2"),
             Example("let foo = 2 >> 2"),
-            Example("let foo = 2 << 2")
+            Example("let foo = 2 << 2"),
+            Example("let a = b / 100.0"),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -167,7 +168,7 @@ private extension TokenSyntax {
         guard let number = Double(text.replacingOccurrences(of: "_", with: "")) else {
             return false
         }
-        if [0, 1].contains(number) {
+        if [0, 1, 100].contains(number) {
             return false
         }
         guard let grandparent = parent?.parent else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -73,7 +73,7 @@ struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule
             Example("let foo = 1 >> 2"),
             Example("let foo = 2 >> 2"),
             Example("let foo = 2 << 2"),
-            Example("let a = b / 100.0"),
+            Example("let a = b / 100.0")
         ],
         triggeringExamples: [
             Example("foo(↓321)"),


### PR DESCRIPTION
The `no_magic_numbers` rule now ignores 100

I didn't go for any power of 10, as 100 is 97% plus of the cases in one of my large codebases (100 = 4,000+ [includes user readable strings with 14 languages, which bumps it up a fair bit, but still indicative], 1,000 = 94, 10,000 = 12, 100,000 = 10, 1000,000 = 4).

Resolves #5185 
