### PR TITLE
Add examples for `superfluous_disable_command`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 #### Enhancements
 
+* Add examples for `superfluous_disable_command`.  
+  [laralove143](https://github.com/laralove143)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
+
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`
   is involved.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,6 @@
 
 #### Enhancements
 
-* Add examples for `superfluous_disable_command`.  
-  [laralove143](https://github.com/laralove143)
-  [#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
-
 * Show specific violation message for the `attributes` rule when the option
   `always_on_line_above` or `attributes_with_arguments_always_on_line_above`
   is involved.  

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -14,13 +14,13 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKi
         kind: .lint,
         nonTriggeringExamples: [
             Example("↓let abc:Void // swiftlint:disable:this colon"),
-            Example("↓// swiftlint:disable colon (If it is enabled in the configuration file"),
-            Example("↓// swiftlint:enable colon (If it is disabled in the configuration file")
+            Example("↓// swiftlint:disable colon (If it is enabled in the configuration file)"),
+            Example("↓// swiftlint:enable colon (If it is disabled in the configuration file)")
         ],
         triggeringExamples: [
             Example("↓let abc: Void // swiftlint:disable:this colon"),
-            Example("↓// swiftlint:disable colon (If it is disabled in the configuration file"),
-            Example("↓// swiftlint:enable colon (If it is enabled in the configuration file")
+            Example("↓// swiftlint:disable colon (If it is disabled in the configuration file)"),
+            Example("↓// swiftlint:enable colon (If it is enabled in the configuration file)")
         ]
     )
 

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -11,7 +11,7 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKi
             SwiftLint 'disable' commands are superfluous when the disabled rule would not have triggered a violation \
             in the disabled region. Use " - " if you wish to document a command.
             """,
-        kind: .lint
+        kind: .lint,
         nonTriggeringExamples: [
             Example("let abc:Void // swiftlint:disable:this colon"),
             Example("// swiftlint:disable colon (If it is enabled in the configuration file"),

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -13,14 +13,14 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKi
             """,
         kind: .lint,
         nonTriggeringExamples: [
-            Example("let abc:Void // swiftlint:disable:this colon"),
-            Example("// swiftlint:disable colon (If it is enabled in the configuration file"),
-            Example("// swiftlint:enable colon (If it is disabled in the configuration file")
+            Example("↓let abc:Void // swiftlint:disable:this colon"),
+            Example("↓// swiftlint:disable colon (If it is enabled in the configuration file"),
+            Example("↓// swiftlint:enable colon (If it is disabled in the configuration file")
         ],
         triggeringExamples: [
-            Example("let abc: Void // swiftlint:disable:this colon"),
-            Example("// swiftlint:disable colon (If it is disabled in the configuration file"),
-            Example("// swiftlint:enable colon (If it is enabled in the configuration file")
+            Example("↓let abc: Void // swiftlint:disable:this colon"),
+            Example("↓// swiftlint:disable colon (If it is disabled in the configuration file"),
+            Example("↓// swiftlint:enable colon (If it is enabled in the configuration file")
         ]
     )
 

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -12,6 +12,16 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKi
             in the disabled region. Use " - " if you wish to document a command.
             """,
         kind: .lint
+        nonTriggeringExamples: [
+            Example("let abc:Void // swiftlint:disable:this colon"),
+            Example("// swiftlint:disable colon (If it is enabled in the configuration file"),
+            Example("// swiftlint:enable colon (If it is disabled in the configuration file")
+        ],
+        triggeringExamples: [
+            Example("let abc: Void // swiftlint:disable:this colon"),
+            Example("// swiftlint:disable colon (If it is disabled in the configuration file"),
+            Example("// swiftlint:enable colon (If it is enabled in the configuration file")
+        ]
     )
 
     public func validate(file: SwiftLintFile) -> [StyleViolation] {

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -13,14 +13,20 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKi
             """,
         kind: .lint,
         nonTriggeringExamples: [
-            Example("↓let abc:Void // swiftlint:disable:this colon"),
-            Example("↓// swiftlint:disable colon (If it is enabled in the configuration file)"),
-            Example("↓// swiftlint:enable colon (If it is disabled in the configuration file)")
+            Example("let abc:Void // swiftlint:disable:this colon"),
+            Example("""
+                // swiftlint:disable colon
+                let abc:Void
+                // swiftlint:enable colon
+                """)
         ],
         triggeringExamples: [
-            Example("↓let abc: Void // swiftlint:disable:this colon"),
-            Example("↓// swiftlint:disable colon (If it is disabled in the configuration file)"),
-            Example("↓// swiftlint:enable colon (If it is enabled in the configuration file)")
+            Example("let abc: Void // swiftlint:disable:this colon"),
+            Example("""
+                // swiftlint:disable colon
+                let abc: Void
+                // swiftlint:enable colon
+                """)
         ]
     )
 


### PR DESCRIPTION
I'm not sure how to document the cases involving configuration files