### PR TITLE
Stop generating tests for core rules

### DIFF
--- a/.sourcery/BuiltInRules.stencil
+++ b/.sourcery/BuiltInRules.stencil
@@ -1,5 +1,5 @@
 
 /// The rule list containing all available rules built into SwiftLint.
 public let builtInRules: [Rule.Type] = [
-{% for rule in types.structs where rule.name|hasSuffix:"Rule" or rule.name|hasSuffix:"Rules" %}    {{ rule.name }}.self{% if not forloop.last %},{% endif %}
+{% for rule in types.structs where rule.name|hasSuffix:"Rule" %}    {{ rule.name }}.self{% if not forloop.last %},{% endif %}
 {% endfor %}]

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ Source/SwiftLintCore/Models/ReportersList.swift: Source/SwiftLintCore/Reporters/
 	mv .sourcery/ReportersList.generated.swift Source/SwiftLintCore/Models/ReportersList.swift
 
 Tests/GeneratedTests/GeneratedTests.swift: Source/SwiftLint*/Rules/**/*.swift .sourcery/GeneratedTests.stencil
-	./tools/sourcery --sources Source/SwiftLintCore/Rules --sources Source/SwiftLintBuiltInRules/Rules --templates .sourcery/GeneratedTests.stencil --output .sourcery
+	./tools/sourcery --sources Source/SwiftLintBuiltInRules/Rules --templates .sourcery/GeneratedTests.stencil --output .sourcery
 	mv .sourcery/GeneratedTests.generated.swift Tests/GeneratedTests/GeneratedTests.swift
 
 test: clean_xcode

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1118,12 +1118,6 @@ class StrongIBOutletRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
-class SuperfluousDisableCommandRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(SuperfluousDisableCommandRule.description)
-    }
-}
-
 class SuperfluousElseRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SuperfluousElseRule.description)


### PR DESCRIPTION
Up to now, only `superfluous_disable_command` is concerned which doesn't contain examples anyway. If it provided some examples, they would not be testable in the same way as all the other rules.