### PR TITLE
Add strict configuration file setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@
 * Adds a `strict` configuration file setting, equivalent to the `--strict`
   command line option.
   [Martin Redington](https://github.com/mildm8nnered)
-  [#XXXX](https://github.com/realm/SwiftLint/issues/XXXX)
+  [#5226](https://github.com/realm/SwiftLint/issues/5226)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5215](https://github.com/realm/SwiftLint/issues/5215)
 
+* Adds a `strict` configuration file setting, equivalent to the `--strict`
+  command line option.
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#XXXX](https://github.com/realm/SwiftLint/issues/XXXX)
+
 #### Bug Fixes
 
 * Respect grapheme clusters in counting the number of characters in the `collection_alignment` rule.  

--- a/README.md
+++ b/README.md
@@ -518,6 +518,9 @@ excluded: # case-sensitive paths to ignore during linting. Takes precedence over
 # If true, SwiftLint will not fail if no lintable files are found.
 allow_zero_lintable_files: false
 
+# If true, SwiftLint will treat all warnings as errors.
+strict: false
+
 # configurable rules can be customized from this configuration file
 # binary rules can set their severity level
 force_cast: warning # implicitly

--- a/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
@@ -25,7 +25,8 @@ extension Configuration {
             warningThreshold: mergedWarningTreshold(with: childConfiguration),
             reporter: reporter,
             cachePath: cachePath,
-            allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles
+            allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles,
+            strict: childConfiguration.strict
         )
     }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -14,6 +14,7 @@ extension Configuration {
         case indentation = "indentation"
         case analyzerRules = "analyzer_rules"
         case allowZeroLintableFiles = "allow_zero_lintable_files"
+        case strict = "strict"
         case childConfig = "child_config"
         case parentConfig = "parent_config"
         case remoteConfigTimeout = "remote_timeout"
@@ -88,7 +89,8 @@ extension Configuration {
             reporter: dict[Key.reporter.rawValue] as? String ?? XcodeReporter.identifier,
             cachePath: cachePath ?? dict[Key.cachePath.rawValue] as? String,
             pinnedVersion: dict[Key.swiftlintVersion.rawValue].map { ($0 as? String) ?? String(describing: $0) },
-            allowZeroLintableFiles: dict[Key.allowZeroLintableFiles.rawValue] as? Bool ?? false
+            allowZeroLintableFiles: dict[Key.allowZeroLintableFiles.rawValue] as? Bool ?? false,
+            strict: dict[Key.strict.rawValue] as? Bool ?? false
         )
     }
 

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -35,6 +35,9 @@ public struct Configuration {
     /// Allow or disallow SwiftLint to exit successfully when passed only ignored or unlintable files.
     public let allowZeroLintableFiles: Bool
 
+    /// Treat warnings as errors
+    public let strict: Bool
+
     /// This value is `true` iff the `--config` parameter was used to specify (a) configuration file(s)
     /// In particular, this means that the value is also `true` if the `--config` parameter
     /// was used to explicitly specify the default `.swiftlint.yml` as the configuration file
@@ -69,7 +72,8 @@ public struct Configuration {
         warningThreshold: Int?,
         reporter: String,
         cachePath: String?,
-        allowZeroLintableFiles: Bool
+        allowZeroLintableFiles: Bool,
+        strict: Bool
     ) {
         self.rulesWrapper = rulesWrapper
         self.fileGraph = fileGraph
@@ -80,6 +84,7 @@ public struct Configuration {
         self.reporter = reporter
         self.cachePath = cachePath
         self.allowZeroLintableFiles = allowZeroLintableFiles
+        self.strict = strict
     }
 
     /// Creates a Configuration by copying an existing configuration.
@@ -96,6 +101,7 @@ public struct Configuration {
         basedOnCustomConfigurationFiles = configuration.basedOnCustomConfigurationFiles
         cachePath = configuration.cachePath
         allowZeroLintableFiles = configuration.allowZeroLintableFiles
+        strict = configuration.strict
     }
 
     /// Creates a `Configuration` by specifying its properties directly,
@@ -117,6 +123,7 @@ public struct Configuration {
     /// - parameter cachePath:              The location of the persisted cache to use whith this configuration.
     /// - parameter pinnedVersion:          The SwiftLint version defined in this configuration.
     /// - parameter allowZeroLintableFiles: Allow SwiftLint to exit successfully when passed ignored or unlintable files
+    /// - parameter strict:                 Treat warnings as errors
     @_spi(TestHelper)
     public init(
         rulesMode: RulesMode = .default(disabled: [], optIn: []),
@@ -130,7 +137,8 @@ public struct Configuration {
         reporter: String? = nil,
         cachePath: String? = nil,
         pinnedVersion: String? = nil,
-        allowZeroLintableFiles: Bool = false
+        allowZeroLintableFiles: Bool = false,
+        strict: Bool = false
     ) {
         if let pinnedVersion, pinnedVersion != Version.current.value {
             queuedPrintError(
@@ -155,7 +163,8 @@ public struct Configuration {
             warningThreshold: warningThreshold,
             reporter: reporter ?? XcodeReporter.identifier,
             cachePath: cachePath,
-            allowZeroLintableFiles: allowZeroLintableFiles
+            allowZeroLintableFiles: allowZeroLintableFiles,
+            strict: strict
         )
     }
 
@@ -259,6 +268,7 @@ extension Configuration: Hashable {
         hasher.combine(warningThreshold)
         hasher.combine(reporter)
         hasher.combine(allowZeroLintableFiles)
+        hasher.combine(strict)
         hasher.combine(basedOnCustomConfigurationFiles)
         hasher.combine(cachePath)
         hasher.combine(rules.map { type(of: $0).description.identifier })
@@ -275,7 +285,8 @@ extension Configuration: Hashable {
             lhs.cachePath == rhs.cachePath &&
             lhs.rules == rhs.rules &&
             lhs.fileGraph == rhs.fileGraph &&
-            lhs.allowZeroLintableFiles == rhs.allowZeroLintableFiles
+            lhs.allowZeroLintableFiles == rhs.allowZeroLintableFiles &&
+            lhs.strict == rhs.strict
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -56,6 +56,7 @@ class ConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(config.reporter, "xcode")
         XCTAssertEqual(reporterFrom(identifier: config.reporter).identifier, "xcode")
         XCTAssertFalse(config.allowZeroLintableFiles)
+        XCTAssertFalse(config.strict)
     }
 
     func testInitWithRelativePathAndRootPath() {
@@ -69,6 +70,7 @@ class ConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(config.indentation, expectedConfig.indentation)
         XCTAssertEqual(config.reporter, expectedConfig.reporter)
         XCTAssertTrue(config.allowZeroLintableFiles)
+        XCTAssertTrue(config.strict)
     }
 
     func testEnableAllRulesConfiguration() throws {
@@ -100,7 +102,7 @@ class ConfigurationTests: SwiftLintTestCase {
 
         let config = try Configuration(dict: ["only_rules": only, "custom_rules": customRules])
         guard let resultingCustomRules = config.rules.first(where: { $0 is CustomRules }) as? CustomRules
-            else {
+        else {
             XCTFail("Custom rules are expected to be present")
             return
         }
@@ -420,6 +422,11 @@ class ConfigurationTests: SwiftLintTestCase {
     func testAllowZeroLintableFiles() throws {
         let configuration = try Configuration(dict: ["allow_zero_lintable_files": true])
         XCTAssertTrue(configuration.allowZeroLintableFiles)
+    }
+
+    func testStrict() throws {
+        let configuration = try Configuration(dict: ["strict": true])
+        XCTAssertTrue(configuration.strict)
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/.swiftlint.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/.swiftlint.yml
@@ -7,3 +7,4 @@ excluded:
 line_length: 10000000000
 reporter: "json"
 allow_zero_lintable_files: true
+strict: true


### PR DESCRIPTION

Resolves #5220 

Adds a `strict` configuration file setting, equivalent to the `--strict` command line option.

If `--lenient` is passed on the command line, this will take precendence over the configuration file.

