### PR TITLE
Support `switch` expressions in `switch_case_alignment` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,10 +103,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5078](https://github.com/realm/SwiftLint/issues/5078)
 
-* Ignore `switch` expressions used in expression contexts in
+* Support `switch` expressions used in expression contexts in
   `switch_case_alignment` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5191](https://github.com/realm/SwiftLint/issues/5191)
+  [#5227](https://github.com/realm/SwiftLint/issues/5272)
+  [#5080](https://github.com/realm/SwiftLint/issues/5080)
 
 * Fix bug in `prefer_self_in_static_references` rule that triggered on
   initializers of computed properties in classes when the property had an


### PR DESCRIPTION
The position of the closing brace now defines the alignment. Thanks to @robertmryan for the idea.

Fixes #5080, #5227 and #5191.