### PR TITLE
Add `only` configuration option to `todo` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@
 * Extend `implicitly_unwrapped_optional` rule with the new mode
   `weak_except_iboutlets` that only checks `weak` variables.  
   [Ricky Tan](https://github.com/rickytan)
+* Add `only` configuration option to `todo` rule.  
+  [gibachan](https://github.com/gibachan)
+  [#5233](https://github.com/realm/SwiftLint/pull/5233)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@
 
 #### Enhancements
 
-* None.
+* Add `only` configuration option to `todo` rule which allows to specify
+  whether the rule shall trigger on `TODO`s, `FIXME`s or both.  
+  [gibachan](https://github.com/gibachan)
+  [#5233](https://github.com/realm/SwiftLint/pull/5233)
 
 #### Bug Fixes
 
@@ -111,9 +114,6 @@
 * Extend `implicitly_unwrapped_optional` rule with the new mode
   `weak_except_iboutlets` that only checks `weak` variables.  
   [Ricky Tan](https://github.com/rickytan)
-* Add `only` configuration option to `todo` rule.  
-  [gibachan](https://github.com/gibachan)
-  [#5233](https://github.com/realm/SwiftLint/pull/5233)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
@@ -26,24 +26,24 @@ struct TodoRule: SwiftSyntaxRule, ConfigurationProviderRule {
     )
 
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(only: configuration.only)
+        Visitor(todoKeywords: configuration.only)
     }
 }
 
 private extension TodoRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let only: [TodoConfiguration.TodoKeyword]
+        private let todoKeywords: [TodoConfiguration.TodoKeyword]
 
-        init(only: [TodoConfiguration.TodoKeyword]) {
-            self.only = only
+        init(todoKeywords: [TodoConfiguration.TodoKeyword]) {
+            self.todoKeywords = todoKeywords
             super.init(viewMode: .sourceAccurate)
         }
 
         override func visitPost(_ node: TokenSyntax) {
             let leadingViolations = node.leadingTrivia.violations(offset: node.position,
-                                                                  for: only)
+                                                                  for: todoKeywords)
             let trailingViolations = node.trailingTrivia.violations(offset: node.endPositionBeforeTrailingTrivia,
-                                                                    for: only)
+                                                                    for: todoKeywords)
             violations.append(contentsOf: leadingViolations + trailingViolations)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
@@ -32,9 +32,9 @@ struct TodoRule: SwiftSyntaxRule, ConfigurationProviderRule {
 
 private extension TodoRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let only: [TodoKeyword]
+        private let only: [TodoConfiguration.TodoKeyword]
 
-        init(only: [TodoKeyword]) {
+        init(only: [TodoConfiguration.TodoKeyword]) {
             self.only = only
             super.init(viewMode: .sourceAccurate)
         }
@@ -49,7 +49,7 @@ private extension TodoRule {
 }
 
 private extension Trivia {
-    func violations(offset: AbsolutePosition, only: [TodoKeyword]) -> [ReasonedRuleViolation] {
+    func violations(offset: AbsolutePosition, only: [TodoConfiguration.TodoKeyword]) -> [ReasonedRuleViolation] {
         var position = offset
         var violations = [ReasonedRuleViolation]()
         for piece in self {
@@ -61,7 +61,7 @@ private extension Trivia {
 }
 
 private extension TriviaPiece {
-    func violations(offset: AbsolutePosition, only: [TodoKeyword]) -> [ReasonedRuleViolation] {
+    func violations(offset: AbsolutePosition, only: [TodoConfiguration.TodoKeyword]) -> [ReasonedRuleViolation] {
         switch self {
         case
                 .blockComment(let comment),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
@@ -70,8 +70,8 @@ private extension TriviaPiece {
                 .docLineComment(let comment):
 
             // Construct a regex string considering only keywords.
-            let availableKeywords = ["TODO", "FIXME"]
-            let searchKeywords = availableKeywords
+            let searchKeywords = TodoKeyword.allCases
+                .map { $0.rawValue }
                 .filter { onlyKeywords.contains($0) }
                 .joined(separator: "|")
             let matches = regex(#"\b((?:\#(searchKeywords))(?::|\b))"#)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
@@ -70,10 +70,7 @@ private extension TriviaPiece {
                 .docLineComment(let comment):
 
             // Construct a regex string considering only keywords.
-            let searchKeywords = TodoKeyword.allCases
-                .filter { only.contains($0) }
-                .map { $0.rawValue }
-                .joined(separator: "|")
+            let searchKeywords = only.map(\.rawValue).joined(separator: "|")
             let matches = regex(#"\b((?:\#(searchKeywords))(?::|\b))"#)
                 .matches(in: comment, range: comment.bridge().fullNSRange)
             return matches.reduce(into: []) { violations, match in

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
@@ -32,9 +32,9 @@ struct TodoRule: SwiftSyntaxRule, ConfigurationProviderRule {
 
 private extension TodoRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let onlyKeywords: Set<String>
+        private let onlyKeywords: [TodoKeyword]
 
-        init(onlyKeywords: Set<String>) {
+        init(onlyKeywords: [TodoKeyword]) {
             self.onlyKeywords = onlyKeywords
             super.init(viewMode: .sourceAccurate)
         }
@@ -49,7 +49,7 @@ private extension TodoRule {
 }
 
 private extension Trivia {
-    func violations(offset: AbsolutePosition, onlyKeywords: Set<String>) -> [ReasonedRuleViolation] {
+    func violations(offset: AbsolutePosition, onlyKeywords: [TodoKeyword]) -> [ReasonedRuleViolation] {
         var position = offset
         var violations = [ReasonedRuleViolation]()
         for piece in self {
@@ -61,7 +61,7 @@ private extension Trivia {
 }
 
 private extension TriviaPiece {
-    func violations(offset: AbsolutePosition, onlyKeywords: Set<String>) -> [ReasonedRuleViolation] {
+    func violations(offset: AbsolutePosition, onlyKeywords: [TodoKeyword]) -> [ReasonedRuleViolation] {
         switch self {
         case
                 .blockComment(let comment),
@@ -71,8 +71,8 @@ private extension TriviaPiece {
 
             // Construct a regex string considering only keywords.
             let searchKeywords = TodoKeyword.allCases
-                .map { $0.rawValue }
                 .filter { onlyKeywords.contains($0) }
+                .map { $0.rawValue }
                 .joined(separator: "|")
             let matches = regex(#"\b((?:\#(searchKeywords))(?::|\b))"#)
                 .matches(in: comment, range: comment.bridge().fullNSRange)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
@@ -13,7 +13,7 @@ struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "only")
-    private(set) var onlyKeywords: [TodoKeyword] = TodoKeyword.allCases
+    private(set) var only: [TodoKeyword] = TodoKeyword.allCases
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
@@ -24,8 +24,8 @@ struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
             try severityConfiguration.apply(configuration: severityString)
         }
 
-        if let onlyKeywords = configuration[$onlyKeywords] as? [String] {
-            self.onlyKeywords = onlyKeywords.compactMap { TodoKeyword(rawValue: $0) }
+        if let onlyStrings = configuration[$only] as? [String] {
+            self.only = onlyStrings.compactMap { TodoKeyword(rawValue: $0) }
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
@@ -1,14 +1,14 @@
 import SwiftLintCore
 
-enum TodoKeyword: String, CaseIterable, AcceptableByConfigurationElement {
-    case todo = "TODO"
-    case fixme = "FIXME"
-
-    func asOption() -> OptionType { .symbol(rawValue) }
-}
-
 struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TodoRule
+
+    enum TodoKeyword: String, CaseIterable, AcceptableByConfigurationElement {
+        case todo = "TODO"
+        case fixme = "FIXME"
+
+        func asOption() -> OptionType { .symbol(rawValue) }
+    }
 
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
@@ -1,0 +1,27 @@
+import SwiftLintCore
+
+struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
+    typealias Parent = TodoRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "only")
+    private(set) var onlyKeywords: Set<String> = [
+        "FIXME",
+        "TODO"
+    ]
+
+    mutating func apply(configuration: Any) throws {
+        guard let configuration = configuration as? [String: Any] else {
+            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+        }
+
+        if let severityString = configuration[$severityConfiguration] as? String {
+            try severityConfiguration.apply(configuration: severityString)
+        }
+
+        if let onlyKeywords = configuration[$onlyKeywords] as? [String] {
+            self.onlyKeywords = Set(onlyKeywords)
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
@@ -1,15 +1,17 @@
 import SwiftLintCore
 
+enum TodoKeyword: String, CaseIterable {
+    case todo = "TODO"
+    case fixme = "FIXME"
+}
+
 struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
     typealias Parent = TodoRule
 
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "only")
-    private(set) var onlyKeywords: Set<String> = [
-        "FIXME",
-        "TODO"
-    ]
+    private(set) var onlyKeywords: Set<String> = Set(TodoKeyword.allCases.map { $0.rawValue })
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
@@ -13,7 +13,7 @@ struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "only")
-    private(set) var only: [TodoKeyword] = TodoKeyword.allCases
+    private(set) var only = TodoKeyword.allCases
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
@@ -1,8 +1,10 @@
 import SwiftLintCore
 
-enum TodoKeyword: String, CaseIterable {
+enum TodoKeyword: String, CaseIterable, AcceptableByConfigurationElement {
     case todo = "TODO"
     case fixme = "FIXME"
+
+    func asOption() -> OptionType { .symbol(rawValue) }
 }
 
 struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
@@ -11,7 +13,7 @@ struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "only")
-    private(set) var onlyKeywords: Set<String> = Set(TodoKeyword.allCases.map { $0.rawValue })
+    private(set) var onlyKeywords: [TodoKeyword] = TodoKeyword.allCases
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
@@ -23,7 +25,7 @@ struct TodoConfiguration: SeverityBasedRuleConfiguration, Equatable {
         }
 
         if let onlyKeywords = configuration[$onlyKeywords] as? [String] {
-            self.onlyKeywords = Set(onlyKeywords)
+            self.onlyKeywords = onlyKeywords.compactMap { TodoKeyword(rawValue: $0) }
         }
     }
 }

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -20,8 +20,28 @@ class TodoRuleTests: SwiftLintTestCase {
         XCTAssertEqual(violations.first!.reason, "FIXMEs should be resolved (Implement)")
     }
 
-    private func violations(_ example: Example) -> [StyleViolation] {
-        let config = makeConfig(nil, TodoRule.description.identifier)!
+    func testOnlyFixMe() {
+        let example = Example("""
+            fatalError() // TODO: Implement todo
+            fatalError() // FIXME: Implement fixme
+        """)
+        let violations = self.violations(example, config: ["only": ["FIXME"]])
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "FIXMEs should be resolved (Implement fixme)")
+    }
+
+    func testOnlyTodo() {
+        let example = Example("""
+            fatalError() // TODO: Implement todo
+            fatalError() // FIXME: Implement fixme
+        """)
+        let violations = self.violations(example, config: ["only": ["TODO"]])
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first!.reason, "TODOs should be resolved (Implement todo)")
+    }
+
+    private func violations(_ example: Example, config: Any? = nil) -> [StyleViolation] {
+        let config = makeConfig(config, TodoRule.description.identifier)!
         return SwiftLintFrameworkTests.violations(example, config: config)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/realm/SwiftLint/issues/5232

This PR adds an `only` configuration option to the `todo` rule.
This option allows you to choose whether only FIXME or TODO will be warned.