### PR TITLE
Require Swift 5.9

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,8 @@ common --enable_bzlmod
 try-import %workspace%/ci.bazelrc
 try-import %workspace%/user.bazelrc
 
-build --macos_minimum_os=12.0 --host_macos_minimum_os=12.0
+build --macos_minimum_os=13.5 --host_macos_minimum_os=13.5
+build --xcode_version=15
 build --disk_cache=~/.bazel_cache
 build --experimental_remote_cache_compression
 build --experimental_remote_build_event_upload=minimal
@@ -13,3 +14,5 @@ build --swiftcopt=-warnings-as-errors
 build:release \
   --compilation_mode=opt \
   --features=swift.opt_uses_wmo
+
+test --xcode_version=15

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
   - label: "SwiftPM"
     commands:
       - echo "+++ Test"
-      - swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
+      - DEVELOPER_DIR=/Applications/Xcode-15.0.0.app/Contents/Developer swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
   - label: "Danger"
     commands:
       - echo "--- Install Bundler"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Breaking
 
+* SwiftLint now requires Swift 5.9 or higher to build.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [JP Simard](https://github.com/jpsim)
+
 * Hide all `Reporter`s from SwiftLint's' public interface.  
   [SimplyDanny](https://github.com/SimplyDanny)
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,9 +5,9 @@ module(
     repo_name = "SwiftLint",
 )
 
-bazel_dep(name = "platforms", version = "0.0.6")
-bazel_dep(name = "rules_apple", version = "2.4.1", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.9.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "rules_apple", version = "3.0.0", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_swift", version = "1.12.0", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "sourcekitten", version = "0.34.1", repo_name = "com_github_jpsim_sourcekitten")
 bazel_dep(name = "swift_argument_parser", version = "1.2.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "yams", version = "5.0.6", repo_name = "sourcekitten_com_github_jpsim_yams")

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ docker_image:
 	docker build --platform linux/amd64 --force-rm --tag swiftlint .
 
 docker_test:
-	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm swift:5.7-focal swift test --parallel
+	docker run -v `pwd`:`pwd` -w `pwd` --name swiftlint --rm swift:5.9-focal swift test --parallel
 
 docker_htop:
 	docker run --platform linux/amd64 -it --rm --pid=container:swiftlint terencewestphal/htop || reset

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
@@ -70,7 +70,10 @@ let package = Package(
             dependencies: [
                 "SwiftLintBuiltInRules",
                 "SwiftLintCore",
-                "SwiftLintExtraRules"
+                "SwiftLintExtraRules",
+                // Workaround for https://github.com/apple/swift-package-manager/issues/6940:
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "CollectionConcurrencyKit"
             ]
         ),
         .target(name: "DyldWarningWorkaround"),

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ running it.
 ### Installing from source:
 
 You can also build and install from source by cloning this project and running
-`make install` (Xcode 13.3 or later).
+`make install` (Xcode 15.0 or later).
 
 ### Using Bazel
 
 Put this in your `MODULE.bazel`:
 
 ```bzl
-bazel_dep(name = "swiftlint", version = "0.50.4", repo_name = "SwiftLint")
+bazel_dep(name = "swiftlint", version = "0.52.4", repo_name = "SwiftLint")
 ```
 
 Or put this in your `WORKSPACE`:
@@ -81,8 +81,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "f94e6dddf74739ef5cb30f000e13a2a613f6ebfa5e63588305a71fce8a8a9911",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/1.1.3/rules_apple.1.1.3.tar.gz",
+    sha256 = "390841dd5f8a85fc25776684f4793d56e21b098dfd7243cd145b9831e6ef8be6",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/2.4.1/rules_apple.2.4.1.tar.gz",
 )
 
 load(
@@ -108,8 +108,8 @@ swift_rules_extra_dependencies()
 
 http_archive(
     name = "SwiftLint",
-    sha256 = "7c454ff4abeeecdd9513f6293238a6d9f803b587eb93de147f9aa1be0d8337c4",
-    url = "https://github.com/realm/SwiftLint/releases/download/0.49.1/bazel.tar.gz",
+    sha256 = "c6ea58b9c72082cdc1ada4a2d48273ecc355896ed72204cedcc586b6ccb8aca6",
+    url = "https://github.com/realm/SwiftLint/releases/download/0.52.4/bazel.tar.gz",
 )
 
 load("@SwiftLint//bazel:repos.bzl", "swiftlint_repos")

--- a/Source/SwiftLintCore/Models/SwiftVersion.swift
+++ b/Source/SwiftLintCore/Models/SwiftVersion.swift
@@ -35,6 +35,8 @@ public extension SwiftVersion {
     static let fiveDotSeven = SwiftVersion(rawValue: "5.7.0")
     /// Swift 5.8.x - https://swift.org/download/#swift-58
     static let fiveDotEight = SwiftVersion(rawValue: "5.8.0")
+    /// Swift 5.9.x - https://swift.org/download/#swift-59
+    static let fiveDotNine = SwiftVersion(rawValue: "5.9.0")
 
     /// The current detected Swift compiler version, based on the currently accessible SourceKit version.
     ///

--- a/Source/swiftlint/Commands/SwiftLint.swift
+++ b/Source/swiftlint/Commands/SwiftLint.swift
@@ -2,6 +2,10 @@ import ArgumentParser
 import Foundation
 import SwiftLintFramework
 
+#if swift(<5.9)
+#error("SwiftLint requires Swift 5.9 or later to build")
+#endif
+
 @main
 struct SwiftLint: AsyncParsableCommand {
     static let configuration: CommandConfiguration = {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,14 +4,12 @@ trigger:
 jobs:
 - job: Linux
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   strategy:
     maxParallel: 10
     matrix:
-      swift57:
-        containerImage: swift:5.7
-      swift58:
-        containerImage: swift:5.8
+      swift59:
+        containerImage: swift:5.9
   container: $[ variables['containerImage'] ]
   steps:
     - script: swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
@@ -37,7 +35,7 @@ jobs:
   pool:
     vmImage: 'macOS-13'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_14.3.1.app
+    DEVELOPER_DIR: /Applications/Xcode_15.0.app
   steps:
     - script: bundle install --path vendor/bundle
       displayName: bundle install
@@ -50,7 +48,7 @@ jobs:
   pool:
     vmImage: 'macOS-13'
   variables:
-    DEVELOPER_DIR: /Applications/Xcode_14.3.1.app
+    DEVELOPER_DIR: /Applications/Xcode_15.0.app
   steps:
     - script: swift run swiftlint generate-docs
       displayName: Run swiftlint generate-docs


### PR DESCRIPTION
Historically, SwiftLint has supported compiling with older Swift versions for a while, but with the introduction of macros, we can't reasonably make use of them in a backwards-compatible way with Swift 5.8.

But also, with the fact that we've removed SwiftLintFramework as a package for consumers to integrate with (which to my knowledge, very few if any people ever used), supporting older Swift versions isn't as relevant anymore.

This will impact users who use the SwiftLint SwiftPM plugin though.