### PR TITLE
Fix Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - jp/docker-swift-5.9
     tags:
       - '*'
 
@@ -33,7 +34,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       
-    - name: Login to Github registry
+    - name: Login to GitHub registry
       uses: docker/login-action@v1 
       with:
         username: ${{ github.actor }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - jp/docker-swift-5.9
     tags:
       - '*'
 


### PR DESCRIPTION
Swift 5.9 needs more dynamic libraries to be available, which grows the size of the final Docker image from 423MB to 449MB.