### PR TITLE
[Bazel] Use the apple_support toolchain on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,11 @@ common --enable_bzlmod
 try-import %workspace%/ci.bazelrc
 try-import %workspace%/user.bazelrc
 
+build --enable_platform_specific_config
+build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --host_crosstool_top=@local_config_apple_cc//:toolchain
+
 build --macos_minimum_os=13.5 --host_macos_minimum_os=13.5
 build --disk_cache=~/.bazel_cache
 build --experimental_remote_cache_compression

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,13 +5,14 @@ module(
     repo_name = "SwiftLint",
 )
 
+bazel_dep(name = "apple_support", version = "1.10.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "rules_apple", version = "3.0.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_swift", version = "1.12.0", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "sourcekitten", version = "0.34.1", repo_name = "com_github_jpsim_sourcekitten")
+bazel_dep(name = "swift-syntax", version = "509.0.0.1", repo_name = "SwiftSyntax")
 bazel_dep(name = "swift_argument_parser", version = "1.2.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "yams", version = "5.0.6", repo_name = "sourcekitten_com_github_jpsim_yams")
-bazel_dep(name = "swift-syntax", version = "509.0.0.1", repo_name = "SwiftSyntax")
 
 swiftlint_repos = use_extension("//bazel:repos.bzl", "swiftlint_repos_bzlmod")
 use_repo(
@@ -23,6 +24,9 @@ use_repo(
 
 extra_rules = use_extension("//bazel:extensions.bzl", "extra_rules")
 use_repo(extra_rules, "swiftlint_extra_rules")
+
+apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
+use_repo(apple_cc_configure, "local_config_apple_cc")
 
 # Dev Dependencies
 


### PR DESCRIPTION
To silence some duplicate library linker warnings:
https://github.com/bazelbuild/apple_support/commit/9dada04856947bea40fc2620d1732f142ba91d41
