### PR TITLE
Preserve `@_exported` import statements in `unused_imports`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 #### Bug Fixes
 
 * Fix false positive in `unused_import` rule that triggered on 
-  `@_exported` imports which could break downstream modules even if removed.  
+  `@_exported` imports which could break downstream modules if removed.  
   [jszumski](https://github.com/jszumski)
   [#5242](https://github.com/realm/SwiftLint/pull/5242)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@
 
 #### Bug Fixes
 
-* None.
+* Fix false positive in `unused_import` rule that triggered on 
+  `@_exported` imports which could break downstream modules even if removed.  
+  [jszumski](https://github.com/jszumski)
+  [#5242](https://github.com/realm/SwiftLint/pull/5242)
 
 ## 0.53.0: Laundry List
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -185,7 +185,7 @@ private extension SwiftLintFile {
     func rangedAndSortedUnusedImports(of unusedImports: [String]) -> [(String, NSRange)] {
         return unusedImports
             .compactMap { module in
-                match(pattern: "^(@\\w+ +)?import +\(module)\\b.*?\n").first.map { (module, $0.0) }
+                match(pattern: "^(@(?!_exported)\\w+ +)?import +\(module)\\b.*?\n").first.map { (module, $0.0) }
             }
             .sorted(by: { $0.1.location < $1.1.location })
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRuleExamples.swift
@@ -16,6 +16,9 @@ struct UnusedImportRuleExamples {
         Example("""
         import UnknownModule
         func foo(error: Swift.Error) {}
+        """),
+        Example("""
+        @_exported import UnknownModule
         """)
     ] + nonTriggeringExamplesVersionAdditions
 
@@ -122,7 +125,7 @@ struct UnusedImportRuleExamples {
             dispatchMain()
             """),
         Example("""
-        ↓@_exported import Foundation
+        ↓@_implementationOnly import Foundation
         import Dispatch
         dispatchMain()
         """):


### PR DESCRIPTION
Preserve `@_exported` import statements even if unused to avoid breaking downstream modules depending on the re-exported module.