### PR TITLE
Fix `unused_import` when using a constructor defined transitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
   [jszumski](https://github.com/jszumski)
   [#5242](https://github.com/realm/SwiftLint/pull/5242)
 
+* Fix false positive in `unused_import` rule when using a constructor 
+  defined in a transitive module.  
+  [jszumski](https://github.com/jszumski)
+  [#5246](https://github.com/realm/SwiftLint/pull/5246)
+
 ## 0.53.0: Laundry List
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -177,6 +177,11 @@ private extension SwiftLintFile {
             }
 
             appendUsedImports(cursorInfo: cursorInfo, usrFragments: &usrFragments)
+
+            // also collect modules from secondary symbol usage if available
+            for secondaryInfo in cursorInfo.secondarySymbols {
+                appendUsedImports(cursorInfo: secondaryInfo, usrFragments: &usrFragments)
+            }
         }
 
         return (imports: imports, usrFragments: usrFragments)

--- a/Source/SwiftLintCore/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Dictionary+SwiftLint.swift
@@ -180,6 +180,12 @@ public struct SourceKittenDictionary {
         let array = value["key.inheritedtypes"] as? [SourceKitRepresentable] ?? []
         return array.compactMap { ($0 as? [String: String]).flatMap { $0["key.name"] } }
     }
+
+    public var secondarySymbols: [SourceKittenDictionary] {
+        let array = value["key.secondary_symbols"] as? [SourceKitRepresentable] ?? []
+        return array.compactMap { $0 as? [String: SourceKitRepresentable] }
+            .map(Self.init)
+    }
 }
 
 extension SourceKittenDictionary {


### PR DESCRIPTION
Fixes a false positive in `unused_import` when using a constructor defined in a transitive module.

https://github.com/apple/swift/commit/3ea9bed415526f1ed27affac6fe87c868941a376 added additional cursor info for the constructor in `key.secondary_symbols`.

## Example

```swift
// Module A
class Thing {}

// Module B
import ModuleA
extension Thing {
   init(model: [String: Any]) {}
}

// Module C
import ModuleA
import ModuleB // this gets marked as unused

let foo = Thing(model: ...)
```