### PR TITLE
Add option for `unneeded_override` to affect initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#4801](https://github.com/realm/SwiftLint/pull/4801)
 
+* Add `affect_initializers` option to allow `unneeded_override` rule
+  to affect initializers.  
+  [leonardosrodrigues0](https://github.com/leonardosrodrigues0)
+  [#5265](https://github.com/realm/SwiftLint/issues/5265)
+
 #### Bug Fixes
 
 * Ignore overridden functions with default parameters in the `unneeded_override`

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -3,7 +3,7 @@ import SwiftSyntaxBuilder
 
 @SwiftSyntaxRule(explicitRewriter: true)
 struct UnneededOverrideRule: Rule {
-    var configuration = SeverityConfiguration<Self>(.warning)
+    var configuration = UnneededOverrideRuleConfiguration()
 
     static let description = RuleDescription(
         identifier: "unneeded_override",
@@ -14,6 +14,137 @@ struct UnneededOverrideRule: Rule {
         triggeringExamples: UnneededOverrideRuleExamples.triggeringExamples,
         corrections: UnneededOverrideRuleExamples.corrections
     )
+}
+
+private extension UnneededOverrideRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            if node.isUnneededOverride {
+                self.violations.append(node.positionAfterSkippingLeadingTrivia)
+            }
+        }
+
+        override func visitPost(_ node: InitializerDeclSyntax) {
+            if configuration.affectInits && node.isUnneededOverride {
+                self.violations.append(node.positionAfterSkippingLeadingTrivia)
+            }
+        }
+    }
+
+    final class Rewriter: ViolationsSyntaxRewriter {
+        override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
+            guard node.isUnneededOverride else {
+                return super.visit(node)
+            }
+
+            return visitUnneededOverride(node)
+        }
+
+        override func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
+            guard node.isUnneededOverride else {
+                return super.visit(node)
+            }
+
+            return visitUnneededOverride(node)
+        }
+
+        private func visitUnneededOverride(_ node: some DeclSyntaxProtocol) -> DeclSyntax {
+            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            let expr: DeclSyntax = ""
+            return expr
+                .with(\.leadingTrivia, node.leadingTrivia)
+                .with(\.trailingTrivia, node.trailingTrivia)
+        }
+    }
+}
+
+private extension FunctionDeclSyntax {
+    var isUnneededOverride: Bool {
+        mayBeUnneededOverride(name: name.text)
+    }
+}
+
+private extension InitializerDeclSyntax {
+    var isUnneededOverride: Bool {
+        guard
+            optionalMark == nil, // init? can be overridden with init! and vice versa.
+            !modifiers.contains(keyword: .private) // An initializer can be hidden by overriding it.
+        else {
+            return false
+        }
+
+        return mayBeUnneededOverride(name: "init")
+    }
+}
+
+private protocol OverridableDecl: WithAttributesSyntax, WithModifiersSyntax {
+    var signature: FunctionSignatureSyntax { get }
+    var body: CodeBlockSyntax? { get }
+}
+
+private extension OverridableDecl {
+    /// Perform checks common to all overridable types of declarations.
+    func mayBeUnneededOverride(name: String) -> Bool {
+        guard modifiers.contains(keyword: .override), let statement = body?.statements.onlyElement else {
+            return false
+        }
+
+        // Assume having @available changes behavior.
+        if attributes.contains(attributeNamed: "available") {
+            return false
+        }
+
+        guard let call = extractFunctionCallSyntax(statement.item),
+            let member = call.calledExpression.as(MemberAccessExprSyntax.self),
+              member.base?.is(SuperExprSyntax.self) == true,
+              member.declName.baseName.text == name else {
+            return false
+        }
+
+        let declParameters = signature.parameterClause.parameters
+        if declParameters.contains(where: { $0.defaultValue != nil }) {
+            // Any default parameter might be a change to the super.
+            return false
+        }
+
+        // Assume any change in arguments passed means behavior was changed.
+        let expectedArguments = declParameters.map {
+            ($0.firstName.text == "_" ? "" : $0.firstName.text, $0.secondName?.text ?? $0.firstName.text)
+        }
+        let actualArguments = call.arguments.map {
+            ($0.label?.text ?? "", $0.expression.as(DeclReferenceExprSyntax.self)?.baseName.text ?? "")
+        }
+
+        guard expectedArguments.count == actualArguments.count else {
+            return false
+        }
+
+        for (lhs, rhs) in zip(expectedArguments, actualArguments) where lhs != rhs {
+            return false
+        }
+
+        return true
+    }
+}
+
+extension FunctionDeclSyntax: OverridableDecl {}
+
+extension InitializerDeclSyntax: OverridableDecl {}
+
+/// Extract the function call from other expressions like try / await / return.
+///
+/// If this returns a non-super calling function, it will get filtered out later.
+private func extractFunctionCallSyntax(_ node: some SyntaxProtocol) -> FunctionCallExprSyntax? {
+    var syntax = simplify(node)
+    while let nestedSyntax = syntax {
+        if nestedSyntax.as(FunctionCallExprSyntax.self) != nil {
+            break
+        }
+
+        syntax = simplify(nestedSyntax)
+    }
+
+    return syntax?.as(FunctionCallExprSyntax.self)
 }
 
 private func simplify(_ node: some SyntaxProtocol) -> (any ExprSyntaxProtocol)? {
@@ -33,86 +164,4 @@ private func simplify(_ node: some SyntaxProtocol) -> (any ExprSyntaxProtocol)? 
     }
 
     return nil
-}
-
-private func extractFunctionCallSyntax(_ node: some SyntaxProtocol) -> FunctionCallExprSyntax? {
-    // Extract the function call from other expressions like try / await / return.
-    // If this returns a non-super calling function, it will get filtered out later.
-    var syntax = simplify(node)
-    while let nestedSyntax = syntax {
-        if nestedSyntax.as(FunctionCallExprSyntax.self) != nil {
-            break
-        }
-
-        syntax = simplify(nestedSyntax)
-    }
-
-    return syntax?.as(FunctionCallExprSyntax.self)
-}
-
-private extension UnneededOverrideRule {
-    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
-        override func visitPost(_ node: FunctionDeclSyntax) {
-            if isUnneededOverride(node) {
-                self.violations.append(node.positionAfterSkippingLeadingTrivia)
-            }
-        }
-    }
-
-    final class Rewriter: ViolationsSyntaxRewriter {
-        override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
-            if isUnneededOverride(node) {
-                correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-                let expr: DeclSyntax = ""
-                return expr
-                    .with(\.leadingTrivia, node.leadingTrivia)
-                    .with(\.trailingTrivia, node.trailingTrivia)
-            }
-
-            return super.visit(node)
-        }
-    }
-}
-
-private func isUnneededOverride(_ node: FunctionDeclSyntax) -> Bool {
-    guard node.modifiers.contains(keyword: .override), let statement = node.body?.statements.onlyElement else {
-        return false
-    }
-
-    // Assume having @available changes behavior.
-    if node.attributes.contains(attributeNamed: "available") {
-        return false
-    }
-
-    let overridenFunctionName = node.name.text
-    guard let call = extractFunctionCallSyntax(statement.item),
-        let member = call.calledExpression.as(MemberAccessExprSyntax.self),
-          member.base?.is(SuperExprSyntax.self) == true,
-          member.declName.baseName.text == overridenFunctionName else {
-        return false
-    }
-
-    let declParameters = node.signature.parameterClause.parameters
-    if declParameters.contains(where: { $0.defaultValue != nil }) {
-        // Any default parameter might be a change to the super function.
-        return false
-    }
-
-    // Assume any change in arguments passed means behavior was changed.
-    let expectedArguments = declParameters.map {
-        ($0.firstName.text == "_" ? "" : $0.firstName.text, $0.secondName?.text ?? $0.firstName.text)
-    }
-    let actualArguments = call.arguments.map {
-        ($0.label?.text ?? "", $0.expression.as(DeclReferenceExprSyntax.self)?.baseName.text ?? "")
-    }
-
-    guard expectedArguments.count == actualArguments.count else {
-        return false
-    }
-
-    for (lhs, rhs) in zip(expectedArguments, actualArguments) where lhs != rhs {
-        return false
-    }
-
-    return true
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnneededOverrideRuleConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnneededOverrideRuleConfiguration.swift
@@ -1,0 +1,11 @@
+import SwiftLintCore
+
+@AutoApply
+struct UnneededOverrideRuleConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = UnneededOverrideRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "affect_initializers")
+    private(set) var affectInits = false
+}

--- a/Tests/SwiftLintFrameworkTests/UnneededOverrideRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnneededOverrideRuleTests.swift
@@ -1,0 +1,65 @@
+@testable import SwiftLintBuiltInRules
+
+class UnneededOverrideRuleTests: SwiftLintTestCase {
+    func testIncludeAffectInits() {
+        let nonTriggeringExamples = [
+            Example("""
+            override init() {
+                super.init(frame: .zero)
+            }
+            """),
+            Example("""
+            override init?() {
+                super.init()
+            }
+            """),
+            Example("""
+            override init!() {
+                super.init()
+            }
+            """),
+            Example("""
+            private override init() {
+                super.init()
+            }
+            """)
+        ] + UnneededOverrideRuleExamples.nonTriggeringExamples
+
+        let triggeringExamples = [
+            Example("""
+            class Foo {
+                ↓override init() {
+                    super.init()
+                }
+            }
+            """),
+            Example("""
+            class Foo {
+                ↓public override init(frame: CGRect) {
+                    super.init(frame: frame)
+                }
+            }
+            """)
+        ]
+
+        let corrections = [
+            Example("""
+            class Foo {
+                ↓override init(frame: CGRect) {
+                    super.init(frame: frame)
+                }
+            }
+            """): Example("""
+                          class Foo {
+                          }
+                          """)
+        ]
+
+        let description = UnneededOverrideRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: corrections)
+
+        verifyRule(description, ruleConfiguration: ["affect_initializers": true])
+    }
+}


### PR DESCRIPTION
## Changes

These changes add an `affect_initializers` option to `unneeded_override` rule . Closes #5265.

When the option is enabled, the overridden initializers are checked in the same way methods are. In addition, failable (`init?`) and implicitly unwrapped (`init!`) initializers never trigger the rule, as it is allowed to override one with the other and vice versa. Finally, `private` overrides also don't trigger the rule, as they can be used to hide the `super` initializer.

## Implementation

A new `OverridableDecl` protocol was built to allow both `FunctionDeclSyntax` and `InitializerDeclSyntax` to be checked using the same function. The check for `init` name on the member access expression was implemented by comparing directly to the `"init"` string, as it is done in `ExplicitInitRule`, `NSNumberInitAsFunctionReferenceRule` and `ReduceIntoRule`.