### PR TITLE
Enforce `any` on existential types

### DIFF
--- a/.sourcery/BuiltInRules.stencil
+++ b/.sourcery/BuiltInRules.stencil
@@ -1,5 +1,5 @@
 
 /// The rule list containing all available rules built into SwiftLint.
-public let builtInRules: [Rule.Type] = [
+public let builtInRules: [any Rule.Type] = [
 {% for rule in types.structs where rule.name|hasSuffix:"Rule" %}    {{ rule.name }}.self{% if not forloop.last %},{% endif %}
 {% endfor %}]

--- a/.sourcery/ReportersList.stencil
+++ b/.sourcery/ReportersList.stencil
@@ -1,6 +1,6 @@
 
 /// The reporters list containing all the reporters built into SwiftLint.
-public let reportersList: [Reporter.Type] = [
+public let reportersList: [any Reporter.Type] = [
 {% for reporter in types.structs where reporter.name|hasSuffix:"Reporter" %}
     {{ reporter.name }}.self{% if not forloop.last %},{% endif %}
 {% endfor %}

--- a/BUILD
+++ b/BUILD
@@ -6,7 +6,7 @@ load(
     "swift_compiler_plugin"
 )
 
-swiftFeatures = ["-enable-upcoming-feature", "ExistentialAny"]
+copts = ["-enable-upcoming-feature", "ExistentialAny"]
 
 # Targets
 
@@ -19,7 +19,7 @@ swift_library(
         "@SwiftSyntax//:SwiftCompilerPlugin_opt",
         "@SwiftSyntax//:SwiftSyntaxMacros_opt",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_compiler_plugin(
@@ -29,7 +29,7 @@ swift_compiler_plugin(
         "@SwiftSyntax//:SwiftCompilerPlugin_opt",
         "@SwiftSyntax//:SwiftSyntaxMacros_opt",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_library(
@@ -53,7 +53,7 @@ swift_library(
     plugins = [
         ":SwiftLintCoreMacros",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_library(
@@ -64,7 +64,7 @@ swift_library(
     deps = [
         ":SwiftLintCore",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_library(
@@ -92,7 +92,7 @@ swift_library(
         ":SwiftLintCore",
         ":SwiftLintExtraRules",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_library(
@@ -106,7 +106,7 @@ swift_library(
         "@sourcekitten_com_github_apple_swift_argument_parser//:ArgumentParser",
         "@swiftlint_com_github_scottrhoyt_swifty_text_table//:SwiftyTextTable",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_binary(
@@ -115,7 +115,7 @@ swift_binary(
     deps = [
         ":swiftlint.library",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 apple_universal_binary(

--- a/BUILD
+++ b/BUILD
@@ -6,6 +6,8 @@ load(
     "swift_compiler_plugin"
 )
 
+swiftFeatures = ["-enable-upcoming-feature", "ExistentialAny"]
+
 # Targets
 
 swift_library(
@@ -17,6 +19,7 @@ swift_library(
         "@SwiftSyntax//:SwiftCompilerPlugin_opt",
         "@SwiftSyntax//:SwiftSyntaxMacros_opt",
     ],
+    copts = swiftFeatures,
 )
 
 swift_compiler_plugin(
@@ -26,6 +29,7 @@ swift_compiler_plugin(
         "@SwiftSyntax//:SwiftCompilerPlugin_opt",
         "@SwiftSyntax//:SwiftSyntaxMacros_opt",
     ],
+    copts = swiftFeatures,
 )
 
 swift_library(
@@ -49,6 +53,7 @@ swift_library(
     plugins = [
         ":SwiftLintCoreMacros",
     ],
+    copts = swiftFeatures,
 )
 
 swift_library(
@@ -59,6 +64,7 @@ swift_library(
     deps = [
         ":SwiftLintCore",
     ],
+    copts = swiftFeatures,
 )
 
 swift_library(
@@ -86,6 +92,7 @@ swift_library(
         ":SwiftLintCore",
         ":SwiftLintExtraRules",
     ],
+    copts = swiftFeatures,
 )
 
 swift_library(
@@ -99,6 +106,7 @@ swift_library(
         "@sourcekitten_com_github_apple_swift_argument_parser//:ArgumentParser",
         "@swiftlint_com_github_scottrhoyt_swifty_text_table//:SwiftyTextTable",
     ],
+    copts = swiftFeatures,
 )
 
 swift_binary(
@@ -107,6 +115,7 @@ swift_binary(
     deps = [
         ":swiftlint.library",
     ],
+    copts = swiftFeatures,
 )
 
 apple_universal_binary(

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,10 @@
 import CompilerPluginSupport
 import PackageDescription
 
+let swiftFeatures: [SwiftSetting] = [
+    .enableUpcomingFeature("ExistentialAny")
+]
+
 let package = Package(
     name: "SwiftLint",
     platforms: [.macOS(.v12)],
@@ -35,13 +39,15 @@ let package = Package(
                 "CollectionConcurrencyKit",
                 "SwiftLintFramework",
                 "SwiftyTextTable",
-            ]
+            ],
+            swiftSettings: swiftFeatures
         ),
         .testTarget(
             name: "CLITests",
             dependencies: [
                 "swiftlint"
-            ]
+            ],
+            swiftSettings: swiftFeatures
         ),
         .target(
             name: "SwiftLintCore",
@@ -57,11 +63,13 @@ let package = Package(
                 .product(name: "SwiftyTextTable", package: "SwiftyTextTable"),
                 .product(name: "Yams", package: "Yams"),
                 "SwiftLintCoreMacros"
-            ]
+            ],
+            swiftSettings: swiftFeatures
         ),
         .target(
             name: "SwiftLintBuiltInRules",
-            dependencies: ["SwiftLintCore"]
+            dependencies: ["SwiftLintCore"],
+            swiftSettings: swiftFeatures
         ),
         .target(
             name: "SwiftLintExtraRules",
@@ -76,7 +84,8 @@ let package = Package(
                 // Workaround for https://github.com/apple/swift-package-manager/issues/6940:
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "CollectionConcurrencyKit"
-            ]
+            ],
+            swiftSettings: swiftFeatures
         ),
         .target(name: "DyldWarningWorkaround"),
         .target(
@@ -95,21 +104,24 @@ let package = Package(
             ],
             exclude: [
                 "Resources",
-            ]
+            ],
+            swiftSettings: swiftFeatures
         ),
         .testTarget(
             name: "GeneratedTests",
             dependencies: [
                 "SwiftLintFramework",
                 "SwiftLintTestHelpers"
-            ]
+            ],
+            swiftSettings: swiftFeatures
         ),
         .testTarget(
             name: "IntegrationTests",
             dependencies: [
                 "SwiftLintFramework",
                 "SwiftLintTestHelpers"
-            ]
+            ],
+            swiftSettings: swiftFeatures
         ),
         .testTarget(
             name: "ExtraRulesTests",
@@ -129,14 +141,16 @@ let package = Package(
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
             ],
-            path: "Source/SwiftLintCoreMacros"
+            path: "Source/SwiftLintCoreMacros",
+            swiftSettings: swiftFeatures
         ),
         .testTarget(
             name: "MacroTests",
             dependencies: [
                 "SwiftLintCoreMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-            ]
+            ],
+            swiftSettings: swiftFeatures
         ),
     ]
 )

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 /// The rule list containing all available rules built into SwiftLint.
-public let builtInRules: [Rule.Type] = [
+public let builtInRules: [any Rule.Type] = [
     AccessibilityLabelForImageRule.self,
     AccessibilityTraitForButtonRule.self,
     AnonymousArgumentInMultilineClosureRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -119,7 +119,7 @@ struct ConvenienceTypeRule: OptInRule, ConfigurationProviderRule {
 
 private extension ConvenienceTypeRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: StructDeclSyntax) {
             if hasViolation(
@@ -158,7 +158,7 @@ private extension ConvenienceTypeRule {
 }
 
 private class ConvenienceTypeCheckVisitor: ViolationsSyntaxVisitor {
-    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
     private(set) var canBeConvenienceType = true
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -81,7 +81,7 @@ struct ExplicitEnumRawValueRule: OptInRule, ConfigurationProviderRule {
 
 private extension ExplicitEnumRawValueRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: EnumCaseElementSyntax) {
             if node.rawValue == nil, node.enclosingEnum()?.supportsRawValues == true {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -173,7 +173,7 @@ struct ExplicitInitRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, 
         Visitor(viewMode: .sourceAccurate, includeBareInit: configuration.includeBareInit)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(locationConverter: file.locationConverter, disabledRegions: disabledRegions(file: file))
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -32,7 +32,7 @@ struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule {
 
 private extension ExplicitTopLevelACLRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: ClassDeclSyntax) {
             if hasViolation(modifiers: node.modifiers) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -78,7 +78,7 @@ private extension ExplicitTypeInterfaceRule {
     final class Visitor: ViolationsSyntaxVisitor {
         let configuration: ExplicitTypeInterfaceConfiguration
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         init(configuration: ExplicitTypeInterfaceConfiguration) {
             self.configuration = configuration

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -37,7 +37,7 @@ struct JoinedDefaultParameterRule: SwiftSyntaxCorrectableRule, ConfigurationProv
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -104,7 +104,7 @@ struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule, ConfigurationP
         LegacyFunctionRuleHelper.Visitor(legacyFunctions: Self.legacyFunctions)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         LegacyFunctionRuleHelper.Rewriter(
             legacyFunctions: Self.legacyFunctions,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
@@ -15,7 +15,7 @@ struct LegacyConstantRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule
         corrections: LegacyConstantRuleExamples.corrections
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -123,7 +123,7 @@ struct LegacyConstructorRule: SwiftSyntaxCorrectableRule, ConfigurationProviderR
                                                        "NSEdgeInsetsMake": "NSEdgeInsets",
                                                        "UIOffsetMake": "UIOffset"]
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -104,7 +104,7 @@ struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule, ConfigurationP
         LegacyFunctionRuleHelper.Visitor(legacyFunctions: Self.legacyFunctions)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         LegacyFunctionRuleHelper.Rewriter(
             legacyFunctions: Self.legacyFunctions,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -25,7 +25,7 @@ struct NoExtensionAccessModifierRule: OptInRule, ConfigurationProviderRule {
 
 private extension NoExtensionAccessModifierRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: ExtensionDeclSyntax) {
             let modifiers = node.modifiers

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -132,7 +132,7 @@ private extension NoMagicNumbersRule {
             collectViolation(forNode: node)
         }
 
-        private func collectViolation(forNode node: ExprSyntaxProtocol) {
+        private func collectViolation(forNode node: some ExprSyntaxProtocol) {
             if node.isMemberOfATestClass(testParentClasses) {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -35,7 +35,7 @@ struct PreferZeroOverExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule, Co
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -58,7 +58,7 @@ struct PrivateOverFilePrivateRule: ConfigurationProviderRule, SwiftSyntaxCorrect
         Visitor(validateExtensions: configuration.validateExtensions)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             validateExtensions: configuration.validateExtensions,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -22,7 +22,7 @@ struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule, Config
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -105,7 +105,7 @@ struct RedundantOptionalInitializationRule: SwiftSyntaxCorrectableRule, Configur
             """)
     ]
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -62,7 +62,7 @@ struct RedundantSetAccessControlRule: ConfigurationProviderRule {
 
 private extension RedundantSetAccessControlRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [FunctionDeclSyntax.self]
         }
 
@@ -120,7 +120,7 @@ private extension SyntaxProtocol {
 
 private extension DeclSyntax {
     var modifiers: DeclModifierListSyntax? {
-        self.asProtocol(WithModifiersSyntax.self)?.modifiers
+        self.asProtocol((any WithModifiersSyntax).self)?.modifiers
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
@@ -80,7 +80,7 @@ struct ShorthandOptionalBindingRule: OptInRule, SwiftSyntaxCorrectableRule, Conf
         deprecatedAliases: ["if_let_shadowing"]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
@@ -80,7 +80,7 @@ struct StaticOperatorRule: ConfigurationProviderRule, OptInRule {
 
 private extension StaticOperatorRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: FunctionDeclSyntax) {
             if node.isFreeFunction, node.isOperator {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -185,7 +185,7 @@ private extension StrictFilePrivateRule {
             violations.append(node.positionAfterSkippingLeadingTrivia)
         }
 
-        private func implementedTypesInDecl(of node: SyntaxProtocol?) -> [String] {
+        private func implementedTypesInDecl(of node: (any SyntaxProtocol)?) -> [String] {
             guard let node else {
                 queuedFatalError("Given node is nil. That should not happen.")
             }
@@ -216,7 +216,7 @@ private final class ProtocolCollector: ViolationsSyntaxVisitor {
     private(set) var protocols = [String: [ProtocolRequirementType]]()
     private var currentProtocolName: String = ""
 
-    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .allExcept(ProtocolDeclSyntax.self) }
+    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .allExcept(ProtocolDeclSyntax.self) }
 
     override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
         currentProtocolName = node.name.text

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -185,7 +185,7 @@ private extension StrictFilePrivateRule {
             violations.append(node.positionAfterSkippingLeadingTrivia)
         }
 
-        private func implementedTypesInDecl(of node: (any SyntaxProtocol)?) -> [String] {
+        private func implementedTypesInDecl(of node: (some SyntaxProtocol)?) -> [String] {
             guard let node else {
                 queuedFatalError("Given node is nil. That should not happen.")
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -217,7 +217,7 @@ private final class SyntacticSugarRuleVisitor: SyntaxVisitor {
         return nil
     }
 
-    private func violation(from node: SyntaxProtocol & SyntaxWithGenericClause) -> SyntacticSugarRuleViolation? {
+    private func violation(from node: some SyntaxProtocol & SyntaxWithGenericClause) -> SyntacticSugarRuleViolation? {
         guard
             let generic = node.genericArguments,
             let firstGenericType = generic.arguments.first,
@@ -256,7 +256,7 @@ private final class SyntacticSugarRuleVisitor: SyntaxVisitor {
 }
 
 private struct CorrectingContext {
-    let rule: Rule
+    let rule: any Rule
     let file: SwiftLintFile
     var contents: String
     var corrections: [Correction] = []

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -255,8 +255,8 @@ private final class SyntacticSugarRuleVisitor: SyntaxVisitor {
     }
 }
 
-private struct CorrectingContext {
-    let rule: any Rule
+private struct CorrectingContext<R: Rule> {
+    let rule: R
     let file: SwiftLintFile
     var contents: String
     var corrections: [Correction] = []

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
@@ -30,7 +30,7 @@ struct ToggleBoolRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, Op
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -25,7 +25,7 @@ struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule, ConfigurationProviderR
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -90,7 +90,7 @@ struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule, ConfigurationProvi
         Visitor(viewMode: .sourceAccurate)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -28,7 +28,7 @@ struct UnneededSynthesizedInitializerRule: SwiftSyntaxCorrectableRule, Configura
         corrections: UnneededSynthesizedInitializerRuleExamples.corrections
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)
@@ -38,7 +38,7 @@ struct UnneededSynthesizedInitializerRule: SwiftSyntaxCorrectableRule, Configura
 
 private extension UnneededSynthesizedInitializerRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(StructDeclSyntax.self, ClassDeclSyntax.self)
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -89,7 +89,7 @@ struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, SwiftSynta
         Visitor(viewMode: .sourceAccurate)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -43,7 +43,7 @@ struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule, Configurati
         return Visitor(viewMode: .sourceAccurate)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -114,7 +114,7 @@ struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule, ConfigurationPro
 private extension BalancedXCTestLifecycleRule {
     final class Visitor: ViolationsSyntaxVisitor {
         private let testParentClasses: Set<String>
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         init(viewMode: SyntaxTreeViewMode, testParentClasses: Set<String>) {
             self.testParentClasses = testParentClasses
@@ -138,7 +138,7 @@ private extension BalancedXCTestLifecycleRule {
 }
 
 private final class SetupTearDownVisitor: ViolationsSyntaxVisitor {
-    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
     private(set) var methods: Set<XCTMethod> = []
 
     override func visitPost(_ node: FunctionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -33,7 +33,7 @@ struct ClassDelegateProtocolRule: ConfigurationProviderRule {
 
 private extension ClassDelegateProtocolRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(ProtocolDeclSyntax.self)
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IBInspectableInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IBInspectableInExtensionRule.swift
@@ -28,7 +28,7 @@ struct IBInspectableInExtensionRule: ConfigurationProviderRule, OptInRule {
 
 private extension IBInspectableInExtensionRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(ExtensionDeclSyntax.self, VariableDeclSyntax.self)
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
@@ -81,7 +81,7 @@ struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, SwiftSyntax
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -16,7 +16,7 @@ struct NSObjectPreferIsEqualRule: ConfigurationProviderRule {
 
 private extension NSObjectPreferIsEqualRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .extensionsAndProtocols }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .extensionsAndProtocols }
 
         override func visitPost(_ node: FunctionDeclSyntax) {
             if node.isSelfEqualFunction, node.isInObjcClass {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverriddenSuperCallRule.swift
@@ -83,7 +83,7 @@ private extension OverriddenSuperCallRule {
     final class Visitor: ViolationsSyntaxVisitor {
         private let resolvedMethodNames: [String]
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [ProtocolDeclSyntax.self]
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
@@ -49,7 +49,7 @@ private extension OverrideInExtensionRule {
             super.init(viewMode: .sourceAccurate)
         }
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .allExcept(ExtensionDeclSyntax.self) }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .allExcept(ExtensionDeclSyntax.self) }
 
         override func visitPost(_ node: FunctionDeclSyntax) {
             if node.modifiers.contains(keyword: .override) {
@@ -77,7 +77,7 @@ private extension OverrideInExtensionRule {
 private class ClassNameCollectingVisitor: ViolationsSyntaxVisitor {
     private(set) var classNames: Set<String> = []
 
-    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
     override func visitPost(_ node: ClassDeclSyntax) {
         classNames.insert(node.name.text)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
@@ -18,7 +18,7 @@ private extension PrivateSubjectRule {
     final class Visitor: ViolationsSyntaxVisitor {
         private let subjectTypes: Set<String> = ["PassthroughSubject", "CurrentValueSubject"]
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [FunctionDeclSyntax.self, VariableDeclSyntax.self, SubscriptDeclSyntax.self, InitializerDeclSyntax.self]
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -197,7 +197,7 @@ struct PrivateSwiftUIStatePropertyRule: OptInRule, ConfigurationProviderRule {
 
 private extension PrivateSwiftUIStatePropertyRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [ProtocolDeclSyntax.self]
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
@@ -129,7 +129,7 @@ struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRul
         Visitor(configuration: configuration)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             configuration: configuration,
             locationConverter: file.locationConverter,
@@ -142,7 +142,7 @@ private extension PrivateUnitTestRule {
     final class Visitor: ViolationsSyntaxVisitor {
         private let configuration: PrivateUnitTestConfiguration
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         init(configuration: PrivateUnitTestConfiguration) {
             self.configuration = configuration

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedSuperRule.swift
@@ -79,7 +79,7 @@ private extension ProhibitedSuperRule {
     final class Visitor: ViolationsSyntaxVisitor {
         private let resolvedMethodNames: [String]
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [ProtocolDeclSyntax.self]
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -16,7 +16,7 @@ struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderRule {
 
 private extension QuickDiscouragedFocusedTestRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -16,7 +16,7 @@ struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderRule {
 
 private extension QuickDiscouragedPendingTestRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
@@ -82,7 +82,7 @@ private extension RequiredDeinitRule {
 private class DeinitVisitor: ViolationsSyntaxVisitor {
     private(set) var hasDeinit = false
 
-    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
     override func visitPost(_ node: DeinitializerDeclSyntax) {
         hasDeinit = true

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
@@ -28,7 +28,7 @@ struct StrongIBOutletRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -43,7 +43,7 @@ private extension TestCaseAccessibilityRule {
             super.init(viewMode: .sourceAccurate)
         }
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: ClassDeclSyntax) {
             guard !testParentClasses.isDisjoint(with: node.inheritedTypes) else {
@@ -66,7 +66,7 @@ private final class XCTestClassVisitor: ViolationsSyntaxVisitor {
         super.init(viewMode: .sourceAccurate)
     }
 
-    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
     override func visitPost(_ node: VariableDeclSyntax) {
         guard !node.modifiers.containsPrivateOrFileprivate(),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -79,7 +79,7 @@ struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
             }
     }
 
-    private func pointsToSystemMapType(pointee: [String: SourceKitRepresentable]) -> Bool {
+    private func pointsToSystemMapType(pointee: [String: any SourceKitRepresentable]) -> Bool {
         if let isSystem = pointee["key.is_system"], isSystem.isEqualTo(true),
            let name = pointee["key.name"], name.isEqualTo("map(_:)"),
            let typeName = pointee["key.typename"] as? String {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -23,7 +23,7 @@ struct UnneededOverrideRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRu
     }
 }
 
-private func simplify(_ node: any SyntaxProtocol) -> (any ExprSyntaxProtocol)? {
+private func simplify(_ node: some SyntaxProtocol) -> (any ExprSyntaxProtocol)? {
     if let expr = node.as(AwaitExprSyntax.self) {
         return expr.expression
     } else if let expr = node.as(TryExprSyntax.self) {
@@ -42,7 +42,7 @@ private func simplify(_ node: any SyntaxProtocol) -> (any ExprSyntaxProtocol)? {
     return nil
 }
 
-private func extractFunctionCallSyntax(_ node: any SyntaxProtocol) -> FunctionCallExprSyntax? {
+private func extractFunctionCallSyntax(_ node: some SyntaxProtocol) -> FunctionCallExprSyntax? {
     // Extract the function call from other expressions like try / await / return.
     // If this returns a non-super calling function that will get filtered out later
     var syntax = simplify(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -15,7 +15,7 @@ struct UnneededOverrideRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRu
         corrections: UnneededOverrideRuleExamples.corrections
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)
@@ -23,7 +23,7 @@ struct UnneededOverrideRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRu
     }
 }
 
-private func simplify(_ node: SyntaxProtocol) -> ExprSyntaxProtocol? {
+private func simplify(_ node: any SyntaxProtocol) -> (any ExprSyntaxProtocol)? {
     if let expr = node.as(AwaitExprSyntax.self) {
         return expr.expression
     } else if let expr = node.as(TryExprSyntax.self) {
@@ -42,7 +42,7 @@ private func simplify(_ node: SyntaxProtocol) -> ExprSyntaxProtocol? {
     return nil
 }
 
-private func extractFunctionCallSyntax(_ node: SyntaxProtocol) -> FunctionCallExprSyntax? {
+private func extractFunctionCallSyntax(_ node: any SyntaxProtocol) -> FunctionCallExprSyntax? {
     // Extract the function call from other expressions like try / await / return.
     // If this returns a non-super calling function that will get filtered out later
     var syntax = simplify(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
@@ -15,7 +15,7 @@ struct UnusedClosureParameterRule: SwiftSyntaxCorrectableRule, ConfigurationProv
         corrections: UnusedClosureParameterRuleExamples.corrections
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -84,7 +84,7 @@ struct UnusedControlFlowLabelRule: SwiftSyntaxCorrectableRule, ConfigurationProv
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -245,7 +245,7 @@ private extension SourceKittenDictionary {
     }
 
     func shouldSkipRelated(relatedUSRsToSkip: Set<String>) -> Bool {
-        return (value["key.related"] as? [[String: SourceKitRepresentable]])?
+        return (value["key.related"] as? [[String: any SourceKitRepresentable]])?
             .compactMap { SourceKittenDictionary($0).usr }
             .contains(where: relatedUSRsToSkip.contains) == true
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
@@ -131,7 +131,7 @@ struct UnusedSetterValueRule: ConfigurationProviderRule {
 
 private extension UnusedSetterValueRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: AccessorDeclSyntax) {
             guard node.accessorSpecifier.tokenKind == .keyword(.set) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ValidIBInspectableRule.swift
@@ -153,7 +153,7 @@ struct ValidIBInspectableRule: ConfigurationProviderRule {
 
 private extension ValidIBInspectableRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [FunctionDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [FunctionDeclSyntax.self] }
 
         override func visitPost(_ node: VariableDeclSyntax) {
             if node.isInstanceVariable, node.isIBInspectable, node.hasViolation {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
@@ -69,11 +69,7 @@ struct WeakDelegateRule: OptInRule, ConfigurationProviderRule {
 
 private extension WeakDelegateRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
-            [
-                ProtocolDeclSyntax.self
-            ]
-        }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: VariableDeclSyntax) {
             guard node.hasDelegateSuffix,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
@@ -22,7 +22,7 @@ struct ClosingBraceRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
@@ -50,7 +50,7 @@ struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule
         Visitor(locationConverter: file.locationConverter)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
@@ -72,7 +72,7 @@ struct ControlStatementRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRu
         ]
     )
 
-    func makeRewriter(file: SwiftLintCore.SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)
@@ -82,7 +82,7 @@ struct ControlStatementRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRu
 
 private extension ControlStatementRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: CatchClauseSyntax) {
             if node.catchItems.containSuperfluousParens == true {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
@@ -179,7 +179,7 @@ struct DirectReturnRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, 
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)
@@ -189,7 +189,7 @@ struct DirectReturnRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, 
 
 private extension DirectReturnRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ statements: CodeBlockItemListSyntax) {
             if let (binding, _) = statements.violation {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -112,7 +112,7 @@ struct EmptyEnumArgumentsRule: SwiftSyntaxCorrectableRule, ConfigurationProvider
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
@@ -32,7 +32,7 @@ struct EmptyParametersRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRul
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -45,7 +45,7 @@ struct EmptyParenthesesWithTrailingClosureRule: SwiftSyntaxCorrectableRule, Conf
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
@@ -46,7 +46,7 @@ struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRul
             return []
         }
 
-        let allCursorInfo: [[String: SourceKitRepresentable]]
+        let allCursorInfo: [[String: any SourceKitRepresentable]]
         do {
             let byteOffsets = try binaryOffsets(file: file, compilerArguments: compilerArguments)
             allCursorInfo = try file.allCursorInfo(compilerArguments: compilerArguments,
@@ -85,7 +85,7 @@ private let kindsToFind: Set = [
 
 private extension SwiftLintFile {
     func allCursorInfo(compilerArguments: [String], atByteOffsets byteOffsets: [ByteCount]) throws
-        -> [[String: SourceKitRepresentable]] {
+        -> [[String: any SourceKitRepresentable]] {
         return try byteOffsets.compactMap { offset in
             if isExplicitAccess(at: offset) { return nil }
             let cursorInfoRequest = Request.cursorInfoWithoutSymbolGraph(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
@@ -22,7 +22,7 @@ private extension ImplicitReturnRule {
     final class Visitor: ViolationsSyntaxVisitor {
         private let config: ConfigurationType
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         init(config: ConfigurationType) {
             self.config = config

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -188,7 +188,7 @@ private extension MultilineArgumentsBracketsRule {
             }
         }
 
-        private func hasLeadingNewline(_ syntax: SyntaxProtocol) -> Bool {
+        private func hasLeadingNewline(_ syntax: some SyntaxProtocol) -> Bool {
             syntax.leadingTrivia.contains(where: \.isNewline)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -44,7 +44,7 @@ struct NoSpaceInMethodCallRule: SwiftSyntaxCorrectableRule, ConfigurationProvide
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
@@ -106,7 +106,7 @@ private extension NonOverridableClassDeclarationRule {
 
         private var finalClassScope = Stack<Bool>()
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         init(configuration: NonOverridableClassDeclarationConfiguration) {
             self.configuration = configuration

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
@@ -29,7 +29,7 @@ struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule, Configuration
         Visitor(configuration: configuration)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             configuration: configuration,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -154,7 +154,7 @@ struct OptionalEnumCaseMatchingRule: SwiftSyntaxCorrectableRule, ConfigurationPr
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -106,7 +106,7 @@ struct PreferSelfTypeOverTypeOfSelfRule: SwiftSyntaxCorrectableRule, OptInRule, 
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -94,7 +94,7 @@ private extension PrefixedTopLevelConstantRule {
             super.init(viewMode: .sourceAccurate)
         }
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: VariableDeclSyntax) {
             guard node.bindingSpecifier.tokenKind == .keyword(.let) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -23,7 +23,7 @@ struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, SwiftSynta
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)
@@ -33,7 +33,7 @@ struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, SwiftSynta
 
 private extension ProtocolPropertyAccessorsOrderRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(ProtocolDeclSyntax.self, VariableDeclSyntax.self)
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -27,7 +27,7 @@ struct RedundantDiscardableLetRule: SwiftSyntaxCorrectableRule, ConfigurationPro
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
@@ -40,7 +40,7 @@ private extension RedundantSelfInClosureRule {
         private var functionCalls = Stack<FunctionCallType>()
         private var selfCaptures = Stack<SelfCaptureKind>()
 
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .extensionsAndProtocols }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .extensionsAndProtocols }
 
         override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
             typeDeclarations.push(.likeClass)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
@@ -50,7 +50,7 @@ struct SelfBindingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, O
         Visitor(bindIdentifier: configuration.bindIdentifier)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             bindIdentifier: configuration.bindIdentifier,
             locationConverter: file.locationConverter,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SingleTestClassRule.swift
@@ -66,7 +66,7 @@ struct SingleTestClassRule: SourceKitFreeRule, OptInRule, ConfigurationProviderR
 
 private class TestClassVisitor: ViolationsSyntaxVisitor {
     private let testParentClasses: Set<String>
-    override var skippableDeclarations: [DeclSyntaxProtocol.Type] { .all }
+    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
     init(viewMode: SyntaxTreeViewMode, testParentClasses: Set<String>) {
         self.testParentClasses = testParentClasses

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
@@ -80,8 +80,8 @@ struct SortedEnumCasesRule: ConfigurationProviderRule, OptInRule {
 
 private extension SortedEnumCasesRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] {
-            return .allExcept(EnumDeclSyntax.self)
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
+            .allExcept(EnumDeclSyntax.self)
         }
 
         override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
@@ -98,7 +98,7 @@ struct SuperfluousElseRule: ConfigurationProviderRule, OptInRule {
 
 private extension SuperfluousElseRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        override var skippableDeclarations: [DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: IfExprSyntax) {
             if node.violatesRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
@@ -54,7 +54,7 @@ struct TrailingCommaRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule 
         )
     }
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             mandatoryComma: configuration.mandatoryComma,
             locationConverter: file.locationConverter,
@@ -200,7 +200,7 @@ private extension TrailingCommaRule {
 }
 
 private extension SourceLocationConverter {
-    func isSingleLine(node: SyntaxProtocol) -> Bool {
+    func isSingleLine(node: any SyntaxProtocol) -> Bool {
         location(for: node.positionAfterSkippingLeadingTrivia).line ==
             location(for: node.endPositionBeforeTrailingTrivia).line
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
@@ -200,7 +200,7 @@ private extension TrailingCommaRule {
 }
 
 private extension SourceLocationConverter {
-    func isSingleLine(node: any SyntaxProtocol) -> Bool {
+    func isSingleLine(node: some SyntaxProtocol) -> Bool {
         location(for: node.positionAfterSkippingLeadingTrivia).line ==
             location(for: node.endPositionBeforeTrailingTrivia).line
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -73,7 +73,7 @@ struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, Swif
         ]
     )
 
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
             disabledRegions: disabledRegions(file: file)

--- a/Source/SwiftLintBuiltInRules/Visitors/BodyLengthRuleVisitor.swift
+++ b/Source/SwiftLintBuiltInRules/Visitors/BodyLengthRuleVisitor.swift
@@ -102,7 +102,7 @@ final class BodyLengthRuleVisitor<Parent: Rule>: ViolationsSyntaxVisitor {
     }
 
     private func registerViolations(
-        leftBrace: TokenSyntax, rightBrace: TokenSyntax, violationNode: SyntaxProtocol
+        leftBrace: TokenSyntax, rightBrace: TokenSyntax, violationNode: some SyntaxProtocol
     ) {
         let leftBracePosition = leftBrace.positionAfterSkippingLeadingTrivia
         let leftBraceLine = locationConverter.location(for: leftBracePosition).line

--- a/Source/SwiftLintCore/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintCore/Documentation/RuleDocumentation.swift
@@ -1,21 +1,21 @@
 /// User-facing documentation for a SwiftLint rule.
 struct RuleDocumentation {
-    private let ruleType: Rule.Type
+    private let ruleType: any Rule.Type
 
     /// If this rule is an opt-in rule.
-    var isOptInRule: Bool { ruleType is OptInRule.Type }
+    var isOptInRule: Bool { ruleType is any OptInRule.Type }
 
     /// If this rule is an analyzer rule.
-    var isAnalyzerRule: Bool { ruleType is AnalyzerRule.Type }
+    var isAnalyzerRule: Bool { ruleType is any AnalyzerRule.Type }
 
     /// If this rule is a linter rule.
     var isLinterRule: Bool { !isAnalyzerRule }
 
     /// If this rule uses SourceKit.
-    var usesSourceKit: Bool { !(ruleType is SourceKitFreeRule.Type) }
+    var usesSourceKit: Bool { !(ruleType is any SourceKitFreeRule.Type) }
 
     /// If this rule is disabled by default.
-    var isDisabledByDefault: Bool { ruleType is OptInRule.Type }
+    var isDisabledByDefault: Bool { ruleType is any OptInRule.Type }
 
     /// If this rule is enabled by default.
     var isEnabledByDefault: Bool { !isDisabledByDefault }
@@ -23,7 +23,7 @@ struct RuleDocumentation {
     /// Creates a RuleDocumentation instance from a Rule type.
     ///
     /// - parameter ruleType: A subtype of the `Rule` protocol to document.
-    init(_ ruleType: Rule.Type) {
+    init(_ ruleType: any Rule.Type) {
         self.ruleType = ruleType
     }
 
@@ -58,13 +58,13 @@ private func h1(_ text: String) -> String { "# \(text)" }
 
 private func h2(_ text: String) -> String { "## \(text)" }
 
-private func detailsSummary(_ rule: Rule) -> String {
+private func detailsSummary(_ rule: some Rule) -> String {
     let ruleDescription = """
         * **Identifier:** \(type(of: rule).description.identifier)
-        * **Enabled by default:** \(rule is OptInRule ? "No" : "Yes")
-        * **Supports autocorrection:** \(rule is CorrectableRule ? "Yes" : "No")
+        * **Enabled by default:** \(rule is any OptInRule ? "No" : "Yes")
+        * **Supports autocorrection:** \(rule is any CorrectableRule ? "Yes" : "No")
         * **Kind:** \(type(of: rule).description.kind)
-        * **Analyzer rule:** \(rule is AnalyzerRule ? "Yes" : "No")
+        * **Analyzer rule:** \(rule is any AnalyzerRule ? "Yes" : "No")
         * **Minimum Swift compiler version:** \(type(of: rule).description.minSwiftVersion.rawValue)
         """
     if rule.configurationDescription.hasContent {

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -36,7 +36,7 @@ extension Configuration {
         inPath path: String,
         forceExclude: Bool,
         excludeBy: ExcludeBy,
-        fileManager: LintableFileManager = FileManager.default
+        fileManager: some LintableFileManager = FileManager.default
     ) -> [String] {
         if fileManager.isFile(atPath: path) {
             if forceExclude {
@@ -108,7 +108,7 @@ extension Configuration {
     /// - parameter fileManager: The file manager to get child paths in a given parent location.
     ///
     /// - returns: The expanded excluded file paths.
-    public func excludedPaths(fileManager: LintableFileManager = FileManager.default) -> [String] {
+    public func excludedPaths(fileManager: some LintableFileManager = FileManager.default) -> [String] {
         return excludedPaths
             .flatMap(Glob.resolveGlob)
             .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -169,7 +169,7 @@ extension Configuration {
                 }
 
             case let .default(disabled: disabledRules, optIn: optInRules):
-                if rule is OptInRule.Type, Set(optInRules).isDisjoint(with: rule.description.allIdentifiers) {
+                if rule is any OptInRule.Type, Set(optInRules).isDisjoint(with: rule.description.allIdentifiers) {
                     Issue.genericWarning("\(message), but it is not enabled on '\(Key.optInRules.rawValue)'.").print()
                 } else if Set(disabledRules).isSuperset(of: rule.description.allIdentifiers) {
                     Issue.genericWarning("\(message), but it is disabled on '\(Key.disabledRules.rawValue)'.").print()
@@ -180,7 +180,7 @@ extension Configuration {
 
     private static func warnAboutMisplacedAnalyzerRules(optInRules: [String], ruleList: RuleList) {
         let analyzerRules = ruleList.list
-            .filter { $0.value.self is AnalyzerRule.Type }
+            .filter { $0.value.self is any AnalyzerRule.Type }
             .map(\.key)
         Set(analyzerRules).intersection(optInRules)
             .sorted()

--- a/Source/SwiftLintCore/Extensions/Configuration+Remote.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Remote.swift
@@ -69,7 +69,7 @@ internal extension Configuration.FileGraph.FilePath {
             }
 
             // Load from url
-            var taskResult: (Data?, URLResponse?, Error?)
+            var taskResult: (Data?, URLResponse?, (any Error)?)
             var taskDone = false
 
             // `.ephemeral` disables caching (which we don't want to be managed by the system)

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -4,7 +4,7 @@ public extension Configuration {
     /// - parameter ruleID: The identifier for the rule to look up.
     ///
     /// - returns: The rule for the specified ID, if configured in this configuration.
-    func configuredRule(forID ruleID: String) -> Rule? {
+    func configuredRule(forID ruleID: String) -> (any Rule)? {
         rules.first { rule in
             if type(of: rule).description.identifier == ruleID {
                 if let customRules = rule as? CustomRules {
@@ -65,7 +65,7 @@ public extension Configuration {
                 let effectiveOptInRules: [String]
                 if optInRules.contains(RuleIdentifier.all.stringRepresentation) {
                     let allOptInRules = RuleRegistry.shared.list.list.compactMap { ruleID, ruleType in
-                        ruleType is OptInRule.Type && !(ruleType is AnalyzerRule.Type) ? ruleID : nil
+                        ruleType is any OptInRule.Type && !(ruleType is any AnalyzerRule.Type) ? ruleID : nil
                     }
                     effectiveOptInRules = Array(Set(allOptInRules + optInRules))
                 } else {

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -18,12 +18,12 @@ internal extension Configuration {
             return Set(regularRuleIdentifiers + configurationCustomRulesIdentifiers)
         }
 
-        private var cachedResultingRules: [Rule]?
+        private var cachedResultingRules: [any Rule]?
         private let resultingRulesLock = NSLock()
 
         /// All rules enabled in this configuration,
         /// derived from rule mode (only / optIn - disabled) & existing rules
-        var resultingRules: [Rule] {
+        var resultingRules: [any Rule] {
             // Lock for thread-safety (that's also why this is not a lazy var)
             resultingRulesLock.lock()
             defer { resultingRulesLock.unlock() }
@@ -33,7 +33,7 @@ internal extension Configuration {
 
             // Calculate value
             let customRulesFilter: (RegexConfiguration<CustomRules>) -> (Bool)
-            var resultingRules = [Rule]()
+            var resultingRules = [any Rule]()
             switch mode {
             case .allEnabled:
                 customRulesFilter = { _ in true }
@@ -53,7 +53,7 @@ internal extension Configuration {
                 resultingRules = allRulesWrapped.filter { tuple in
                     let id = type(of: tuple.rule).description.identifier
                     return !disabledRuleIdentifiers.contains(id)
-                        && (!(tuple.rule is OptInRule) || optInRuleIdentifiers.contains(id))
+                        && (!(tuple.rule is any OptInRule) || optInRuleIdentifiers.contains(id))
                 }.map { $0.rule }
             }
 
@@ -288,7 +288,7 @@ internal extension Configuration {
             }
 
             let isOptInRule = allRulesWrapped
-                .first { type(of: $0.rule).description.identifier == identifier }?.rule is OptInRule
+                .first { type(of: $0.rule).description.identifier == identifier }?.rule is any OptInRule
             Self.isOptInRuleCache[identifier] = isOptInRule
             return isOptInRule
         }

--- a/Source/SwiftLintCore/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Dictionary+SwiftLint.swift
@@ -4,7 +4,7 @@ import SourceKittenFramework
 /// values.
 public struct SourceKittenDictionary {
     /// The underlying SourceKitten dictionary.
-    public let value: [String: SourceKitRepresentable]
+    public let value: [String: any SourceKitRepresentable]
     /// The cached substructure for this dictionary. Empty if there is no substructure.
     public let substructure: [SourceKittenDictionary]
 
@@ -21,11 +21,11 @@ public struct SourceKittenDictionary {
     /// Creates a SourceKitten dictionary given a `Dictionary<String, SourceKitRepresentable>` input.
     ///
     /// - parameter value: The input dictionary/
-    public init(_ value: [String: SourceKitRepresentable]) {
+    public init(_ value: [String: any SourceKitRepresentable]) {
         self.value = value
 
-        let substructure = value["key.substructure"] as? [SourceKitRepresentable] ?? []
-        self.substructure = substructure.compactMap { $0 as? [String: SourceKitRepresentable] }
+        let substructure = value["key.substructure"] as? [any SourceKitRepresentable] ?? []
+        self.substructure = substructure.compactMap { $0 as? [String: any SourceKitRepresentable] }
             .map(Self.init)
 
         let stringKind = value["key.kind"] as? String
@@ -136,20 +136,20 @@ public struct SourceKittenDictionary {
 
     /// The fully preserved SourceKitten dictionaries for all the attributes associated with this dictionary.
     public var swiftAttributes: [SourceKittenDictionary] {
-        let array = value["key.attributes"] as? [SourceKitRepresentable] ?? []
-        return array.compactMap { $0 as? [String: SourceKitRepresentable] }
+        let array = value["key.attributes"] as? [any SourceKitRepresentable] ?? []
+        return array.compactMap { $0 as? [String: any SourceKitRepresentable] }
             .map(Self.init)
     }
 
     public var elements: [SourceKittenDictionary] {
-        let elements = value["key.elements"] as? [SourceKitRepresentable] ?? []
-        return elements.compactMap { $0 as? [String: SourceKitRepresentable] }
+        let elements = value["key.elements"] as? [any SourceKitRepresentable] ?? []
+        return elements.compactMap { $0 as? [String: any SourceKitRepresentable] }
         .map(Self.init)
     }
 
     public var entities: [SourceKittenDictionary] {
-        let entities = value["key.entities"] as? [SourceKitRepresentable] ?? []
-        return entities.compactMap { $0 as? [String: SourceKitRepresentable] }
+        let entities = value["key.entities"] as? [any SourceKitRepresentable] ?? []
+        return entities.compactMap { $0 as? [String: any SourceKitRepresentable] }
             .map(Self.init)
     }
 
@@ -177,13 +177,13 @@ public struct SourceKittenDictionary {
     }
 
     public var inheritedTypes: [String] {
-        let array = value["key.inheritedtypes"] as? [SourceKitRepresentable] ?? []
+        let array = value["key.inheritedtypes"] as? [any SourceKitRepresentable] ?? []
         return array.compactMap { ($0 as? [String: String]).flatMap { $0["key.name"] } }
     }
 
     public var secondarySymbols: [SourceKittenDictionary] {
-        let array = value["key.secondary_symbols"] as? [SourceKitRepresentable] ?? []
-        return array.compactMap { $0 as? [String: SourceKitRepresentable] }
+        let array = value["key.secondary_symbols"] as? [any SourceKitRepresentable] ?? []
+        return array.compactMap { $0 as? [String: any SourceKitRepresentable] }
             .map(Self.init)
     }
 }

--- a/Source/SwiftLintCore/Extensions/Request+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Request+SwiftLint.swift
@@ -4,7 +4,7 @@ import SourceKittenFramework
 public extension Request {
     static let disableSourceKit = ProcessInfo.processInfo.environment["SWIFTLINT_DISABLE_SOURCEKIT"] != nil
 
-    func sendIfNotDisabled() throws -> [String: SourceKitRepresentable] {
+    func sendIfNotDisabled() throws -> [String: any SourceKitRepresentable] {
         guard !Self.disableSourceKit else {
             throw Self.Error.connectionInterrupted("SourceKit is disabled by `SWIFTLINT_DISABLE_SOURCEKIT`.")
         }

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
@@ -10,7 +10,7 @@ import SwiftParserDiagnostics
 import SwiftSyntax
 
 private typealias FileCacheKey = UUID
-private let responseCache = Cache { file -> [String: SourceKitRepresentable]? in
+private let responseCache = Cache { file -> [String: any SourceKitRepresentable]? in
     do {
         return try Request.editorOpen(file: file.file).sendIfNotDisabled()
     } catch let error as Request.Error {

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
@@ -267,7 +267,7 @@ extension SwiftLintFile {
         invalidateCache()
     }
 
-    public func ruleEnabled(violatingRanges: [NSRange], for rule: Rule) -> [NSRange] {
+    public func ruleEnabled(violatingRanges: [NSRange], for rule: some Rule) -> [NSRange] {
         let fileRegions = regions()
         if fileRegions.isEmpty { return violatingRanges }
         return violatingRanges.filter { range in
@@ -278,7 +278,7 @@ extension SwiftLintFile {
         }
     }
 
-    public func ruleEnabled(violatingRange: NSRange, for rule: Rule) -> NSRange? {
+    public func ruleEnabled(violatingRange: NSRange, for rule: some Rule) -> NSRange? {
         return ruleEnabled(violatingRanges: [violatingRange], for: rule).first
     }
 

--- a/Source/SwiftLintCore/Helpers/Stack.swift
+++ b/Source/SwiftLintCore/Helpers/Stack.swift
@@ -49,7 +49,7 @@ public struct Stack<Element> {
     }
 }
 
-extension Stack: CustomDebugStringConvertible where Element == CustomDebugStringConvertible {
+extension Stack: CustomDebugStringConvertible where Element: CustomDebugStringConvertible {
     public var debugDescription: String {
         let intermediateElements = count > 1 ? elements[1 ..< count - 1] : []
         return """

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -45,7 +45,7 @@ public struct Configuration {
 
     // MARK: Public Computed
     /// All rules enabled in this configuration
-    public var rules: [Rule] { rulesWrapper.resultingRules }
+    public var rules: [any Rule] { rulesWrapper.resultingRules }
 
     /// The root directory is the directory that included & excluded paths relate to.
     /// By default, the root directory is the current working directory,

--- a/Source/SwiftLintCore/Models/ConfigurationRuleWrapper.swift
+++ b/Source/SwiftLintCore/Models/ConfigurationRuleWrapper.swift
@@ -1,2 +1,2 @@
 @_spi(TestHelper)
-public typealias ConfigurationRuleWrapper = (rule: Rule, initializedWithNonEmptyConfiguration: Bool)
+public typealias ConfigurationRuleWrapper = (rule: any Rule, initializedWithNonEmptyConfiguration: Bool)

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -55,7 +55,7 @@ public enum Issue: LocalizedError, Equatable {
     /// - parameter error: Any `Error`.
     ///
     /// - returns: A `SwiftLintError.genericWarning` containig the message of the `error` argument.
-    static func wrap(error: Error) -> Self {
+    static func wrap(error: some Error) -> Self {
         error as? Issue ?? Self.genericWarning(error.localizedDescription)
     }
 

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -67,7 +67,7 @@ private extension Rule {
             return nil
         }
 
-        if !(self is SourceKitFreeRule) && file.sourcekitdFailed {
+        if !(self is any SourceKitFreeRule) && file.sourcekitdFailed {
             warnSourceKitFailedOnce()
             return nil
         }
@@ -128,7 +128,7 @@ public struct Linter {
     public let file: SwiftLintFile
     /// Whether or not this linter will be used to collect information from several files.
     public var isCollecting: Bool
-    fileprivate let rules: [Rule]
+    fileprivate let rules: [any Rule]
     fileprivate let cache: LinterCache?
     fileprivate let configuration: Configuration
     fileprivate let compilerArguments: [String]
@@ -147,13 +147,13 @@ public struct Linter {
         self.compilerArguments = compilerArguments
         let rules = configuration.rules.filter { rule in
             if compilerArguments.isEmpty {
-                return !(rule is AnalyzerRule)
+                return !(rule is any AnalyzerRule)
             } else {
-                return rule is AnalyzerRule
+                return rule is any AnalyzerRule
             }
         }
         self.rules = rules
-        self.isCollecting = rules.contains(where: { $0 is AnyCollectingRule })
+        self.isCollecting = rules.contains(where: { $0 is any AnyCollectingRule })
     }
 
     /// Returns a linter capable of checking for violations after running each rule's collection step.
@@ -175,7 +175,7 @@ public struct Linter {
 public struct CollectedLinter {
     /// The file to lint with this linter.
     public let file: SwiftLintFile
-    private let rules: [Rule]
+    private let rules: [any Rule]
     private let cache: LinterCache?
     private let configuration: Configuration
     private let compilerArguments: [String]
@@ -294,7 +294,7 @@ public struct CollectedLinter {
         }
 
         var corrections = [Correction]()
-        for rule in rules.compactMap({ $0 as? CorrectableRule }) {
+        for rule in rules.compactMap({ $0 as? any CorrectableRule }) {
             let newCorrections = rule.correct(file: file, using: storage, compilerArguments: compilerArguments)
             corrections += newCorrections
             if newCorrections.isNotEmpty, !file.isVirtual {

--- a/Source/SwiftLintCore/Models/LinterCache.swift
+++ b/Source/SwiftLintCore/Models/LinterCache.swift
@@ -28,11 +28,11 @@ public final class LinterCache {
     private let readCacheLock = NSLock()
     private var writeCache = Cache()
     private let writeCacheLock = NSLock()
-    internal let fileManager: LintableFileManager
+    internal let fileManager: any LintableFileManager
     private let location: URL?
     private let swiftVersion: SwiftVersion
 
-    internal init(fileManager: LintableFileManager = FileManager.default, swiftVersion: SwiftVersion = .current) {
+    internal init(fileManager: some LintableFileManager = FileManager.default, swiftVersion: SwiftVersion = .current) {
         location = nil
         self.fileManager = fileManager
         self.lazyReadCache = Cache()
@@ -43,14 +43,14 @@ public final class LinterCache {
     ///
     /// - parameter configuration: The SwiftLint configuration for which this cache will be used.
     /// - parameter fileManager:   The file manager to use to read lintable file information.
-    public init(configuration: Configuration, fileManager: LintableFileManager = FileManager.default) {
+    public init(configuration: Configuration, fileManager: some LintableFileManager = FileManager.default) {
         location = configuration.cacheURL
         lazyReadCache = Cache()
         self.fileManager = fileManager
         self.swiftVersion = .current
     }
 
-    private init(cache: Cache, location: URL?, fileManager: LintableFileManager, swiftVersion: SwiftVersion) {
+    private init(cache: Cache, location: URL?, fileManager: some LintableFileManager, swiftVersion: SwiftVersion) {
         self.lazyReadCache = cache
         self.location = location
         self.fileManager = fileManager

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -36,7 +36,7 @@ public struct Region: Equatable {
     /// - parameter rule: The rule whose status should be determined.
     ///
     /// - returns: True if the specified rule is enabled in this region.
-    public func isRuleEnabled(_ rule: Rule) -> Bool {
+    public func isRuleEnabled(_ rule: some Rule) -> Bool {
         return !isRuleDisabled(rule)
     }
 
@@ -45,7 +45,7 @@ public struct Region: Equatable {
     /// - parameter rule: The rule whose status should be determined.
     ///
     /// - returns: True if the specified rule is disabled in this region.
-    public func isRuleDisabled(_ rule: Rule) -> Bool {
+    public func isRuleDisabled(_ rule: some Rule) -> Bool {
         guard !disabledRuleIdentifiers.contains(.all) else {
             return true
         }
@@ -61,7 +61,7 @@ public struct Region: Equatable {
     /// - parameter rule: The rule to check.
     ///
     /// - returns: Deprecated rule aliases.
-    public func deprecatedAliasesDisabling(rule: Rule) -> Set<String> {
+    public func deprecatedAliasesDisabling(rule: some Rule) -> Set<String> {
         let identifiers = type(of: rule).description.deprecatedAliases
         return Set(disabledRuleIdentifiers.map { $0.stringRepresentation }).intersection(identifiers)
     }

--- a/Source/SwiftLintCore/Models/ReportersList.swift
+++ b/Source/SwiftLintCore/Models/ReportersList.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 /// The reporters list containing all the reporters built into SwiftLint.
-public let reportersList: [Reporter.Type] = [
+public let reportersList: [any Reporter.Type] = [
     CSVReporter.self,
     CheckstyleReporter.self,
     CodeClimateReporter.self,

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -55,7 +55,7 @@ public struct RuleConfigurationDescription: Equatable {
                 guard let codingKey = child.label, codingKey.starts(with: "_") else {
                     return nil
                 }
-                guard let element = child.value as? AnyConfigurationElement else {
+                guard let element = child.value as? any AnyConfigurationElement else {
                     return nil
                 }
                 return element.description

--- a/Source/SwiftLintCore/Models/RuleList.swift
+++ b/Source/SwiftLintCore/Models/RuleList.swift
@@ -1,13 +1,13 @@
 /// All possible rule list configuration errors.
 public enum RuleListError: Error {
     /// The rule list contains more than one configuration for the specified rule.
-    case duplicatedConfigurations(rule: Rule.Type)
+    case duplicatedConfigurations(rule: any Rule.Type)
 }
 
 /// A list of available SwiftLint rules.
 public struct RuleList {
     /// The rules contained in this list.
-    public let list: [String: Rule.Type]
+    public let list: [String: any Rule.Type]
     private let aliases: [String: String]
 
     // MARK: - Initializers
@@ -15,15 +15,15 @@ public struct RuleList {
     /// Creates a `RuleList` by specifying all its rules.
     ///
     /// - parameter rules: The rules to be contained in this list.
-    public init(rules: Rule.Type...) {
+    public init(rules: any Rule.Type...) {
         self.init(rules: rules)
     }
 
     /// Creates a `RuleList` by specifying all its rules.
     ///
     /// - parameter rules: The rules to be contained in this list.
-    public init(rules: [Rule.Type]) {
-        var tmpList = [String: Rule.Type]()
+    public init(rules: [any Rule.Type]) {
+        var tmpList = [String: any Rule.Type]()
         var tmpAliases = [String: String]()
 
         for rule in rules {

--- a/Source/SwiftLintCore/Models/RuleRegistry.swift
+++ b/Source/SwiftLintCore/Models/RuleRegistry.swift
@@ -1,6 +1,6 @@
 /// Container to register and look up SwiftLint rules.
 public final class RuleRegistry {
-    private var registeredRules = [Rule.Type]()
+    private var registeredRules = [any Rule.Type]()
 
     /// Shared rule registry instance.
     public static let shared = RuleRegistry()
@@ -17,7 +17,7 @@ public final class RuleRegistry {
     /// Register rules.
     ///
     /// - parameter rules: The rules to register.
-    public func register(rules: [Rule.Type]) {
+    public func register(rules: [any Rule.Type]) {
         registeredRules.append(contentsOf: rules)
     }
 
@@ -26,7 +26,7 @@ public final class RuleRegistry {
     /// - parameter id: The ID for the rule to look up.
     ///
     /// - returns: The rule matching the specified ID, if one was found.
-    public func rule(forID id: String) -> Rule.Type? {
+    public func rule(forID id: String) -> (any Rule.Type)? {
         return list.list[id]
     }
 }

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -152,7 +152,7 @@ public extension CollectingCorrectableRule where Self: AnalyzerRule {
 // MARK: - == Implementations
 
 /// :nodoc:
-public extension Array where Element == Rule {
+public extension Array where Element == any Rule {
     static func == (lhs: Array, rhs: Array) -> Bool {
         if lhs.count != rhs.count { return false }
         return !zip(lhs, rhs).contains { !$0.0.isEqualTo($0.1) }

--- a/Source/SwiftLintCore/Protocols/Reporter.swift
+++ b/Source/SwiftLintCore/Protocols/Reporter.swift
@@ -32,7 +32,7 @@ extension Reporter {
 /// - parameter identifier: The identifier corresponding to the reporter.
 ///
 /// - returns: The reporter type.
-public func reporterFrom(identifier: String) -> Reporter.Type {
+public func reporterFrom(identifier: String) -> any Reporter.Type {
     guard let reporter = reportersList.first(where: { $0.identifier == identifier }) else {
         queuedFatalError("No reporter with identifier '\(identifier)' available.")
     }

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -3,12 +3,15 @@ import SourceKittenFramework
 
 /// An executable value that can identify issues (violations) in Swift source code.
 public protocol Rule {
+    /// The rule's description type.
+    associatedtype Description: Documentable
+
     /// A verbose description of many of this rule's properties.
     static var description: RuleDescription { get }
 
     /// A description of how this rule has been configured to run. It can be built using the annotated result builder.
     @RuleConfigurationDescriptionBuilder
-    var configurationDescription: Documentable { get }
+    var configurationDescription: Description { get }
 
     /// A default initializer for rules. All rules need to be trivially initializable.
     init()
@@ -40,7 +43,7 @@ public protocol Rule {
     /// - parameter rule: The `rule` value to compare against.
     ///
     /// - returns: Whether or not the specified rule is equivalent to the current rule.
-    func isEqualTo(_ rule: Rule) -> Bool
+    func isEqualTo(_ rule: any Rule) -> Bool
 
     /// Collects information for the specified file in a storage object, to be analyzed by a `CollectedLinter`.
     ///
@@ -74,7 +77,7 @@ public extension Rule {
         return validate(file: file)
     }
 
-    func isEqualTo(_ rule: Rule) -> Bool {
+    func isEqualTo(_ rule: any Rule) -> Bool {
         return Self.description == type(of: rule).description
     }
 
@@ -85,7 +88,7 @@ public extension Rule {
     /// The cache description which will be used to determine if a previous
     /// cached value is still valid given the new cache value.
     var cacheDescription: String {
-        (self as? CacheDescriptionProvider)?.cacheDescription ?? configurationDescription.oneLiner()
+        (self as? any CacheDescriptionProvider)?.cacheDescription ?? configurationDescription.oneLiner()
     }
 }
 
@@ -112,14 +115,14 @@ public extension ConfigurationProviderRule {
         try self.configuration.apply(configuration: configuration)
     }
 
-    func isEqualTo(_ rule: Rule) -> Bool {
+    func isEqualTo(_ rule: any Rule) -> Bool {
         if let rule = rule as? Self {
             return configuration == rule.configuration
         }
         return false
     }
 
-    var configurationDescription: Documentable {
+    var configurationDescription: some Documentable {
         RuleConfigurationDescription.from(configuration: configuration)
     }
 }

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxCorrectableRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxCorrectableRule.swift
@@ -2,18 +2,21 @@ import SwiftSyntax
 
 /// A SwiftLint CorrectableRule that performs its corrections using a SwiftSyntax `SyntaxRewriter`.
 public protocol SwiftSyntaxCorrectableRule: SwiftSyntaxRule, CorrectableRule {
+    /// Type of the rewriter.
+    associatedtype RewriterType: ViolationsSyntaxRewriter
+
     /// Produce a `ViolationsSyntaxRewriter` for the given file.
     ///
     /// - parameter file: The file for which to produce the rewriter.
     ///
     /// - returns: A `ViolationsSyntaxRewriter` for the given file. May be `nil` in which case the rule visitor's
     ///            collected `violationCorrections` will be used.
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter?
+    func makeRewriter(file: SwiftLintFile) -> RewriterType?
 }
 
 public extension SwiftSyntaxCorrectableRule {
-    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter? {
-        nil
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
+        nil as NoOpRewriter?
     }
 
     func correct(file: SwiftLintFile) -> [Correction] {
@@ -66,4 +69,8 @@ public extension SwiftSyntaxCorrectableRule {
 public protocol ViolationsSyntaxRewriter: SyntaxRewriter {
     /// Positions in a source file where corrections were applied.
     var correctionPositions: [AbsolutePosition] { get }
+}
+
+private class NoOpRewriter: SyntaxRewriter, ViolationsSyntaxRewriter {
+    var correctionPositions = [AbsolutePosition]()
 }

--- a/Source/SwiftLintCore/Reporters/SummaryReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SummaryReporter.swift
@@ -68,8 +68,8 @@ private extension TextTable {
 
             addRow(values: [
                 ruleIdentifier,
-                rule is OptInRule.Type ? "yes" : "no",
-                rule is CorrectableRule.Type ? "yes" : "no",
+                rule is any OptInRule.Type ? "yes" : "no",
+                rule is any CorrectableRule.Type ? "yes" : "no",
                 rule == nil ? "yes" : "no",
                 numberOfWarnings.formattedString.leftPadded(forHeader: numberOfWarningsHeader),
                 numberOfErrors.formattedString.leftPadded(forHeader: numberOfErrorsHeader),

--- a/Source/SwiftLintCore/Rules/CoreRules.swift
+++ b/Source/SwiftLintCore/Rules/CoreRules.swift
@@ -1,5 +1,5 @@
 /// The rule list containing all available rules built into SwiftLintCore.
-public let coreRules: [Rule.Type] = [
+public let coreRules: [any Rule.Type] = [
     CustomRules.self,
     SuperfluousDisableCommandRule.self
 ]

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -35,7 +35,7 @@ public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKi
         return []
     }
 
-    func reason(for rule: Rule.Type) -> String {
+    func reason(for rule: (some Rule).Type) -> String {
         """
         SwiftLint rule '\(rule.description.identifier)' did not trigger a violation in the disabled region; \
         remove the disable command

--- a/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
@@ -9,7 +9,7 @@ open class ViolationsSyntaxVisitor: SyntaxVisitor {
     public var violationCorrections = [ViolationCorrection]()
 
     /// List of declaration types that shall be skipped while traversing the AST.
-    open var skippableDeclarations: [DeclSyntaxProtocol.Type] { [] }
+    open var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [] }
 
     override open func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
         skippableDeclarations.contains { $0 == ActorDeclSyntax.self } ? .skipChildren : .visitChildren
@@ -74,7 +74,7 @@ public struct ViolationCorrection {
     }
 }
 
-public extension Array where Element == DeclSyntaxProtocol.Type {
+public extension Array where Element == any DeclSyntaxProtocol.Type {
     /// All visitable declaration syntax types.
     static let all: Self = [
         ActorDeclSyntax.self,

--- a/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
+++ b/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
@@ -3,7 +3,7 @@ import SwiftSyntaxMacros
 
 @main
 struct SwiftLintCoreMacros: CompilerPlugin {
-    let providingMacros: [Macro.Type] = [
+    let providingMacros: [any Macro.Type] = [
         AutoApply.self,
         MakeAcceptableByConfigurationElement.self,
         SwiftSyntaxRule.self

--- a/Source/SwiftLintExtraRules/ExtraRules.swift
+++ b/Source/SwiftLintExtraRules/ExtraRules.swift
@@ -3,4 +3,4 @@
 /// This is an extension point for custom native rules for Bazel.
 ///
 /// - returns: Extra rules that are compiled with Bazel.
-public func extraRules() -> [Rule.Type] { [] }
+public func extraRules() -> [any Rule.Type] { [] }

--- a/Source/swiftlint/Commands/Reporters.swift
+++ b/Source/swiftlint/Commands/Reporters.swift
@@ -16,7 +16,7 @@ extension SwiftLint {
 // MARK: - SwiftyTextTable
 
 private extension TextTable {
-    init(reporters: [Reporter.Type]) {
+    init(reporters: [any Reporter.Type]) {
         let columns = [
             TextTableColumn(header: "identifier"),
             TextTableColumn(header: "description")

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftLintFramework
 import SwiftyTextTable
 
-private typealias SortedRules = [(String, Rule.Type)]
+private typealias SortedRules = [(String, any Rule.Type)]
 
 extension SwiftLint {
     struct Rules: ParsableCommand {
@@ -60,7 +60,7 @@ extension SwiftLint {
             ExitHelper.successfullyExit()
         }
 
-        private func printDescription(for ruleType: Rule.Type, with configuration: Configuration) {
+        private func printDescription(for ruleType: any Rule.Type, with configuration: Configuration) {
             let description = ruleType.description
 
             let rule = createInstance(of: ruleType, using: configuration, configure: !defaultConfig)
@@ -84,14 +84,15 @@ extension SwiftLint {
             }
         }
 
-        private func printConfig(for rule: Rule) {
+        private func printConfig(for rule: any Rule) {
             if rule.configurationDescription.hasContent {
                 print("\(type(of: rule).identifier):")
                 print(rule.configurationDescription.yaml().indent(by: 2))
             }
         }
 
-        private func createInstance(of ruleType: Rule.Type, using config: Configuration, configure: Bool) -> Rule {
+        private func createInstance(of ruleType: any Rule.Type, using config: Configuration,
+                                    configure: Bool) -> any Rule {
             configure
                 ? config.configuredRule(forID: ruleType.identifier) ?? ruleType.init()
                 : ruleType.init()
@@ -134,12 +135,12 @@ private extension TextTable {
             let configuredRule = configuration.configuredRule(forID: ruleID)
             addRow(values: [
                 ruleID,
-                (rule is OptInRule) ? "yes" : "no",
-                (rule is CorrectableRule) ? "yes" : "no",
+                (rule is any OptInRule) ? "yes" : "no",
+                (rule is any CorrectableRule) ? "yes" : "no",
                 configuredRule != nil ? "yes" : "no",
                 ruleType.description.kind.rawValue,
-                (rule is AnalyzerRule) ? "yes" : "no",
-                (rule is SourceKitFreeRule) ? "no" : "yes",
+                (rule is any AnalyzerRule) ? "yes" : "no",
+                (rule is any SourceKitFreeRule) ? "no" : "yes",
                 truncate((defaultConfig ? rule : configuredRule ?? rule).configurationDescription.oneLiner())
             ])
         }

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -266,7 +266,7 @@ private class LintOrAnalyzeResultBuilder {
     var violations = [StyleViolation]()
     let storage = RuleStorage()
     let configuration: Configuration
-    let reporter: Reporter.Type
+    let reporter: any Reporter.Type
     let cache: LinterCache?
     let options: LintOrAnalyzeOptions
 

--- a/Source/swiftlint/Helpers/RulesFilter.swift
+++ b/Source/swiftlint/Helpers/RulesFilter.swift
@@ -10,9 +10,9 @@ final class RulesFilter {
     }
 
     private let allRules: RuleList
-    private let enabledRules: [Rule]
+    private let enabledRules: [any Rule]
 
-    init(allRules: RuleList = RuleRegistry.shared.list, enabledRules: [Rule]) {
+    init(allRules: RuleList = RuleRegistry.shared.list, enabledRules: [any Rule]) {
         self.allRules = allRules
         self.enabledRules = enabledRules
     }
@@ -22,7 +22,7 @@ final class RulesFilter {
             return allRules
         }
 
-        let filtered: [Rule.Type] = allRules.list.compactMap { ruleID, ruleType in
+        let filtered: [any Rule.Type] = allRules.list.compactMap { ruleID, ruleType in
             let enabledRule = enabledRules.first { rule in
                 type(of: rule).description.identifier == ruleID
             }
@@ -34,7 +34,7 @@ final class RulesFilter {
             if excludingOptions.contains(.disabled) && !isRuleEnabled {
                 return nil
             }
-            if excludingOptions.contains(.uncorrectable) && !(ruleType is CorrectableRule.Type) {
+            if excludingOptions.contains(.uncorrectable) && !(ruleType is any CorrectableRule.Type) {
                 return nil
             }
 

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -2,7 +2,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
 
 exports_files(["BUILD"])
 
-swiftFeatures = ["-enable-upcoming-feature", "ExistentialAny"]
+copts = ["-enable-upcoming-feature", "ExistentialAny"]
 
 # CLITests
 
@@ -14,7 +14,7 @@ swift_library(
     deps = [
         "//:swiftlint.library",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_test(
@@ -34,7 +34,7 @@ swift_library(
         "//:SwiftLintCoreMacrosLib",
         "@SwiftSyntax//:SwiftSyntaxMacrosTestSupport_opt",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_test(
@@ -53,7 +53,7 @@ swift_library(
     deps = [
         "//:SwiftLintFramework",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 # SwiftLintFrameworkTests
@@ -88,7 +88,7 @@ swift_library(
     deps = [
         ":SwiftLintTestHelpers",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_test(
@@ -112,7 +112,7 @@ swift_library(
     deps = [
         ":SwiftLintTestHelpers",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_test(
@@ -131,7 +131,7 @@ swift_library(
     deps = [
         ":SwiftLintTestHelpers",
     ],
-    copts = swiftFeatures,
+    copts = copts,
 )
 
 swift_test(

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -2,6 +2,8 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
 
 exports_files(["BUILD"])
 
+swiftFeatures = ["-enable-upcoming-feature", "ExistentialAny"]
+
 # CLITests
 
 swift_library(
@@ -12,6 +14,7 @@ swift_library(
     deps = [
         "//:swiftlint.library",
     ],
+    copts = swiftFeatures,
 )
 
 swift_test(
@@ -31,6 +34,7 @@ swift_library(
         "//:SwiftLintCoreMacrosLib",
         "@SwiftSyntax//:SwiftSyntaxMacrosTestSupport_opt",
     ],
+    copts = swiftFeatures,
 )
 
 swift_test(
@@ -49,6 +53,7 @@ swift_library(
     deps = [
         "//:SwiftLintFramework",
     ],
+    copts = swiftFeatures,
 )
 
 # SwiftLintFrameworkTests
@@ -83,6 +88,7 @@ swift_library(
     deps = [
         ":SwiftLintTestHelpers",
     ],
+    copts = swiftFeatures,
 )
 
 swift_test(
@@ -106,6 +112,7 @@ swift_library(
     deps = [
         ":SwiftLintTestHelpers",
     ],
+    copts = swiftFeatures,
 )
 
 swift_test(
@@ -124,6 +131,7 @@ swift_library(
     deps = [
         ":SwiftLintTestHelpers",
     ],
+    copts = swiftFeatures,
 )
 
 swift_test(

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -12,7 +12,7 @@ final class RulesFilterTests: XCTestCase {
                 CorrectableRuleMock.self
             ]
         )
-        let enabledRules: [Rule] = [
+        let enabledRules: [any Rule] = [
             RuleMock1(),
             CorrectableRuleMock()
         ]
@@ -37,7 +37,7 @@ final class RulesFilterTests: XCTestCase {
                 CorrectableRuleMock.self
             ]
         )
-        let enabledRules: [Rule] = [
+        let enabledRules: [any Rule] = [
             RuleMock1(),
             CorrectableRuleMock()
         ]
@@ -62,7 +62,7 @@ final class RulesFilterTests: XCTestCase {
                 CorrectableRuleMock.self
             ]
         )
-        let enabledRules: [Rule] = [
+        let enabledRules: [any Rule] = [
             RuleMock1(),
             CorrectableRuleMock()
         ]
@@ -87,7 +87,7 @@ final class RulesFilterTests: XCTestCase {
                 CorrectableRuleMock.self
             ]
         )
-        let enabledRules: [Rule] = [
+        let enabledRules: [any Rule] = [
             RuleMock1(),
             CorrectableRuleMock()
         ]
@@ -112,7 +112,7 @@ final class RulesFilterTests: XCTestCase {
                 CorrectableRuleMock.self
             ]
         )
-        let enabledRules: [Rule] = [
+        let enabledRules: [any Rule] = [
             RuleMock1()
         ]
         let rulesFilter = RulesFilter(
@@ -132,7 +132,7 @@ final class RulesFilterTests: XCTestCase {
 // MARK: - Mocks
 
 private struct RuleMock1: Rule {
-    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
+    var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock1", name: "",
                                              description: "", kind: .style)
@@ -146,7 +146,7 @@ private struct RuleMock1: Rule {
 }
 
 private struct RuleMock2: Rule {
-    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
+    var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock2", name: "",
                                              description: "", kind: .style)
@@ -160,7 +160,7 @@ private struct RuleMock2: Rule {
 }
 
 private struct CorrectableRuleMock: CorrectableRule {
-    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
+    var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "CorrectableRuleMock", name: "",
                                              description: "", kind: .style)

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -115,7 +115,7 @@ class CollectingRuleTests: SwiftLintTestCase {
 private protocol MockCollectingRule: CollectingRule {}
 extension MockCollectingRule {
     @RuleConfigurationDescriptionBuilder
-    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
+    var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
     static var description: RuleDescription {
         return RuleDescription(identifier: "test_rule", name: "", description: "", kind: .lint)
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
@@ -84,7 +84,7 @@ internal extension ConfigurationTests {
 }
 
 struct RuleMock: Rule {
-    var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
+    var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock", name: "",
                                              description: "", kind: .style)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -337,7 +337,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 4 * 4)
         let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue((ruleType as Any) is OptInRule.Type)
+        XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(rulesMode: .default(
@@ -371,7 +371,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = BlanketDisableCommandRule.self
-        XCTAssertFalse(ruleType is OptInRule.Type)
+        XCTAssertFalse(ruleType is any OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(
@@ -403,7 +403,7 @@ extension ConfigurationTests {
         ]
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
-        XCTAssertTrue((ruleType as Any) is OptInRule.Type)
+        XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
         let parentConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
         for testCase in testCases {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 // swiftlint:disable file_length
 
-private let optInRules = RuleRegistry.shared.list.list.filter({ $0.1.init() is OptInRule }).map({ $0.0 })
+private let optInRules = RuleRegistry.shared.list.list.filter({ $0.1.init() is any OptInRule }).map({ $0.0 })
 
 class ConfigurationTests: SwiftLintTestCase {
     // MARK: Setup & Teardown

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -21,7 +21,7 @@ struct RuleWithLevelsMock: ConfigurationProviderRule {
 
 class RuleTests: SwiftLintTestCase {
     fileprivate struct RuleMock1: Rule {
-        var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
+        var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
         static let description = RuleDescription(identifier: "RuleMock1", name: "",
                                                  description: "", kind: .style)
 
@@ -34,7 +34,7 @@ class RuleTests: SwiftLintTestCase {
     }
 
     fileprivate struct RuleMock2: Rule {
-        var configurationDescription: Documentable { RuleConfigurationOption.noOptions }
+        var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
         static let description = RuleDescription(identifier: "RuleMock2", name: "",
                                                  description: "", kind: .style)
 

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -210,7 +210,7 @@ private extension Configuration {
         let file = SwiftLintFile.testFile(withContents: cleanedBefore, persistToDisk: true)
         // expectedLocations are needed to create before call `correct()`
         let expectedLocations = markerOffsets.map { Location(file: file, characterOffset: $0) }
-        let includeCompilerArguments = self.rules.contains(where: { $0 is AnalyzerRule })
+        let includeCompilerArguments = self.rules.contains(where: { $0 is any AnalyzerRule })
         let compilerArguments = includeCompilerArguments ? file.makeCompilerArguments() : []
         let storage = RuleStorage()
         let collecter = Linter(file: file, configuration: self, compilerArguments: compilerArguments)

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -3,7 +3,7 @@ load("@com_github_jpsim_sourcekitten//bazel:repos.bzl", "sourcekitten_repos")
 
 def _extra_swift_sources_impl(ctx):
     ctx.file("WORKSPACE", "")
-    ctx.file("empty.swift", "public func extraRules() -> [Rule.Type] { [] }")
+    ctx.file("empty.swift", "public func extraRules() -> [any Rule.Type] { [] }")
     label = ":empty"
     if ctx.attr.srcs:
         label = ctx.attr.srcs


### PR DESCRIPTION
This makes syntactically clear which types are rather expensive. `any` will be mandatory in Swift 6.

Especially on return types, existential types can be avoided by having generic protocols (adding an `associatedtype`). That has been done for `SwiftSyntaxCorrectableRule` and `Rule`.

@jpsim: Okay for you to enforce `any` in the Bazel and SPM builds?