### PR TITLE
Let all rules be configurable

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct BlockBasedKVORule: ConfigurationProviderRule {
+struct BlockBasedKVORule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ConvenienceTypeRule: OptInRule, ConfigurationProviderRule {
+struct ConvenienceTypeRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DiscouragedAssertRule: OptInRule, ConfigurationProviderRule {
+struct DiscouragedAssertRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedNoneNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedNoneNameRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DiscouragedNoneNameRule: OptInRule, ConfigurationProviderRule {
+struct DiscouragedNoneNameRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule {
     var configuration = DiscouragedObjectLiteralConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DiscouragedOptionalBooleanRule: OptInRule, ConfigurationProviderRule {
+struct DiscouragedOptionalBooleanRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule, ConfigurationProviderRule {
+struct DiscouragedOptionalCollectionRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct DuplicateImportsRule: ConfigurationProviderRule, CorrectableRule {
+struct DuplicateImportsRule: CorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     // List of all possible import kinds

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitACLRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private typealias SourceKittenElement = SourceKittenDictionary
 
-struct ExplicitACLRule: OptInRule, ConfigurationProviderRule {
+struct ExplicitACLRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ExplicitEnumRawValueRule: OptInRule, ConfigurationProviderRule {
+struct ExplicitEnumRawValueRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-struct ExplicitInitRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct ExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = ExplicitInitConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ExplicitTopLevelACLRule: OptInRule, ConfigurationProviderRule {
+struct ExplicitTopLevelACLRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ExplicitTypeInterfaceRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+struct ExplicitTypeInterfaceRule: OptInRule, SwiftSyntaxRule {
     var configuration = ExplicitTypeInterfaceConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct ExtensionAccessModifierRule: ASTRule, ConfigurationProviderRule, OptInRule {
+struct ExtensionAccessModifierRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FallthroughRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct FallthroughRule: ConfigurationProviderRule, OptInRule {
+struct FallthroughRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct FatalErrorMessageRule: ConfigurationProviderRule, OptInRule {
+struct FatalErrorMessageRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FileNameNoSpaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FileNameNoSpaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct FileNameNoSpaceRule: ConfigurationProviderRule, OptInRule, SourceKitFreeRule {
+struct FileNameNoSpaceRule: OptInRule, SourceKitFreeRule {
     var configuration = FileNameNoSpaceConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FileNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FileNameRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct FileNameRule: ConfigurationProviderRule, OptInRule, SourceKitFreeRule {
+struct FileNameRule: OptInRule, SourceKitFreeRule {
     var configuration = FileNameConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForWhereRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ForWhereRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct ForWhereRule: SwiftSyntaxRule {
     var configuration = ForWhereConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceCastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceCastRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ForceCastRule: ConfigurationProviderRule, SwiftSyntaxRule {
+struct ForceCastRule: SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceTryRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceTryRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ForceTryRule: ConfigurationProviderRule {
+struct ForceTryRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRule {
+struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct FunctionDefaultParameterAtEndRule: ConfigurationProviderRule, OptInRule {
+struct FunctionDefaultParameterAtEndRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftSyntax
 
-struct GenericTypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct GenericTypeNameRule: SwiftSyntaxRule {
     var configuration = NameConfiguration<Self>(minLengthWarning: 1,
                                                 minLengthError: 0,
                                                 maxLengthWarning: 20,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, OptInRule {
     var configuration = ImplicitlyUnwrappedOptionalConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/IsDisjointRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/IsDisjointRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct IsDisjointRule: ConfigurationProviderRule {
+struct IsDisjointRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct JoinedDefaultParameterRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct JoinedDefaultParameterRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -1,4 +1,4 @@
-struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 @SwiftSyntaxRule
-struct LegacyConstantRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct LegacyConstantRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct LegacyConstructorRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct LegacyConstructorRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyHashingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct LegacyHashingRule: ConfigurationProviderRule {
+struct LegacyHashingRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule(foldExpressions: true)
-struct LegacyMultipleRule: OptInRule, ConfigurationProviderRule {
+struct LegacyMultipleRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -1,4 +1,4 @@
-struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -29,7 +29,7 @@ private let legacyObjcTypes = [
 ]
 
 @SwiftSyntaxRule
-struct LegacyObjcTypeRule: OptInRule, ConfigurationProviderRule {
+struct LegacyObjcTypeRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyRandomRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct LegacyRandomRule: ConfigurationProviderRule {
+struct LegacyRandomRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct NimbleOperatorRule: ConfigurationProviderRule, OptInRule, CorrectableRule {
+struct NimbleOperatorRule: OptInRule, CorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct NoExtensionAccessModifierRule: OptInRule, ConfigurationProviderRule {
+struct NoExtensionAccessModifierRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct NoFallthroughOnlyRule: ConfigurationProviderRule {
+struct NoFallthroughOnlyRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-struct NoGroupingExtensionRule: OptInRule, ConfigurationProviderRule {
+struct NoGroupingExtensionRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct NoMagicNumbersRule: SwiftSyntaxRule, OptInRule {
     var configuration = NoMagicNumbersConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ObjectLiteralRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+struct ObjectLiteralRule: SwiftSyntaxRule, OptInRule {
     var configuration = ObjectLiteralConfiguration<Self>()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct PatternMatchingKeywordsRule: ConfigurationProviderRule, OptInRule {
+struct PatternMatchingKeywordsRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferNimbleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferNimbleRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct PreferNimbleRule: OptInRule, ConfigurationProviderRule {
+struct PreferNimbleRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct PreferZeroOverExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
+struct PreferZeroOverExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct PrivateOverFilePrivateRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+struct PrivateOverFilePrivateRule: SwiftSyntaxCorrectableRule {
     var configuration = PrivateOverFilePrivateConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -5,7 +5,7 @@ private let attributeNamesImplyingObjc: Set<String> = [
     "IBAction", "IBOutlet", "IBInspectable", "GKInspectable", "IBDesignable", "NSManaged"
 ]
 
-struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
+struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct RedundantOptionalInitializationRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct RedundantOptionalInitializationRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct RedundantSetAccessControlRule: ConfigurationProviderRule {
+struct RedundantSetAccessControlRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct RedundantStringEnumValueRule: ConfigurationProviderRule {
+struct RedundantStringEnumValueRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule {
+struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct RedundantVoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableASTRule {
+struct RedundantVoidReturnRule: SubstitutionCorrectableASTRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ReturnValueFromVoidFunctionRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+struct ReturnValueFromVoidFunctionRule: OptInRule, SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ShorthandOptionalBindingRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct ShorthandOptionalBindingRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct StaticOperatorRule: ConfigurationProviderRule, OptInRule {
+struct StaticOperatorRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct StrictFilePrivateRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+struct StrictFilePrivateRule: OptInRule, SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-struct SyntacticSugarRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+struct SyntacticSugarRule: CorrectableRule, SourceKitFreeRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 @SwiftSyntaxRule
-struct ToggleBoolRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct ToggleBoolRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftSyntax
 
-struct TypeNameRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct TypeNameRule: SwiftSyntaxRule {
     var configuration = TypeNameConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableConditionRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct UnavailableConditionRule: ConfigurationProviderRule, SwiftSyntaxRule {
+struct UnavailableConditionRule: SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct UnavailableFunctionRule: ConfigurationProviderRule, OptInRule {
+struct UnavailableFunctionRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -12,7 +12,7 @@ private func embedInSwitch(
         """, file: file, line: line)
 }
 
-struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -14,7 +14,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct UnneededSynthesizedInitializerRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct UnneededSynthesizedInitializerRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct UntypedErrorInCatchRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+struct UntypedErrorInCatchRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct UnusedEnumeratedRule: ConfigurationProviderRule {
+struct UnusedEnumeratedRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct VoidFunctionInTernaryConditionRule: ConfigurationProviderRule, SwiftSyntaxRule {
+struct VoidFunctionInTernaryConditionRule: SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct XCTFailMessageRule: ConfigurationProviderRule {
+struct XCTFailMessageRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -1,7 +1,7 @@
 import SwiftOperators
 import SwiftSyntax
 
-struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule {
     var configuration = XCTSpecificMatcherConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -9,7 +9,7 @@ import SourceKittenFramework
 /// Known false negatives for Images declared as instance variables and containers that provide a label but are
 /// not accessibility elements. Known false positives for Images created in a separate function from where they
 /// have accessibility properties applied.
-struct AccessibilityLabelForImageRule: ASTRule, ConfigurationProviderRule, OptInRule {
+struct AccessibilityLabelForImageRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -7,7 +7,7 @@ import SourceKittenFramework
 /// element, you need to explicitly add the button or link trait. In most cases the button trait should be used, but for
 /// buttons that open a URL in an external browser we use the link trait instead. This rule attempts to catch uses of
 /// the SwiftUI `.onTapGesture` modifier where the `.isButton` or `.isLink` trait is not explicitly applied.
-struct AccessibilityTraitForButtonRule: ASTRule, ConfigurationProviderRule, OptInRule {
+struct AccessibilityTraitForButtonRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -9,7 +9,7 @@ private func warnDeprecatedOnce() {
     _ = warnDeprecatedOnceImpl
 }
 
-struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
+struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ArrayInitRule: ConfigurationProviderRule, OptInRule {
+struct ArrayInitRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule {
     var configuration = BalancedXCTestLifecycleConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -1,4 +1,4 @@
-struct BlanketDisableCommandRule: ConfigurationProviderRule {
+struct BlanketDisableCommandRule: Rule {
     var configuration = BlanketDisableCommandConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-struct CaptureVariableRule: ConfigurationProviderRule, AnalyzerRule, CollectingRule {
+struct CaptureVariableRule: AnalyzerRule, CollectingRule {
     struct Variable: Hashable {
         let usr: String
         let offset: ByteCount

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ClassDelegateProtocolRule: ConfigurationProviderRule {
+struct ClassDelegateProtocolRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CommentSpacingRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftIDEUtils
 
-struct CommentSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, SubstitutionCorrectableRule {
+struct CommentSpacingRule: SourceKitFreeRule, SubstitutionCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CompilerProtocolInitRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct CompilerProtocolInitRule: ConfigurationProviderRule {
+struct CompilerProtocolInitRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct DeploymentTargetRule: ConfigurationProviderRule, SwiftSyntaxRule {
+struct DeploymentTargetRule: SwiftSyntaxRule {
     fileprivate typealias Version = DeploymentTargetConfiguration.Version
     var configuration = DeploymentTargetConfiguration()
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DiscardedNotificationCenterObserverRule: ConfigurationProviderRule, OptInRule {
+struct DiscardedNotificationCenterObserverRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct DiscouragedDirectInitRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct DiscouragedDirectInitRule: SwiftSyntaxRule {
     var configuration = DiscouragedDirectInitConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateConditionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateConditionsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DuplicateConditionsRule: ConfigurationProviderRule {
+struct DuplicateConditionsRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DuplicateEnumCasesRule: ConfigurationProviderRule {
+struct DuplicateEnumCasesRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DuplicatedKeyInDictionaryLiteralRule: ConfigurationProviderRule {
+struct DuplicatedKeyInDictionaryLiteralRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DynamicInlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DynamicInlineRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DynamicInlineRule: ConfigurationProviderRule {
+struct DynamicInlineRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct EmptyXCTestMethodRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+struct EmptyXCTestMethodRule: OptInRule, SwiftSyntaxRule {
     var configuration = EmptyXCTestMethodConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ExpiringTodoRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct ExpiringTodoRule: ConfigurationProviderRule, OptInRule {
+struct ExpiringTodoRule: OptInRule {
     enum ExpiryViolationLevel {
         case approachingExpiry
         case expired

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IBInspectableInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IBInspectableInExtensionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct IBInspectableInExtensionRule: ConfigurationProviderRule, OptInRule {
+struct IBInspectableInExtensionRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule(foldExpressions: true)
-struct IdenticalOperandsRule: ConfigurationProviderRule, OptInRule {
+struct IdenticalOperandsRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     private static let operators = ["==", "!=", "===", "!==", ">", ">=", "<", "<="]

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
@@ -9,7 +9,7 @@ private func warnDeprecatedOnce() {
     _ = warnDeprecatedOnceImpl
 }
 
-struct InertDeferRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+struct InertDeferRule: SwiftSyntaxRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
@@ -1,4 +1,4 @@
-struct InvalidSwiftLintCommandRule: ConfigurationProviderRule {
+struct InvalidSwiftLintCommandRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
@@ -1,7 +1,7 @@
 import SwiftIDEUtils
 import SwiftSyntax
 
-struct LocalDocCommentRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+struct LocalDocCommentRule: SwiftSyntaxRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct LowerACLThanParentRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+struct LowerACLThanParentRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct MarkRule: CorrectableRule, ConfigurationProviderRule {
+struct MarkRule: CorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -43,7 +43,7 @@ private extension SwiftLintFile {
     }
 }
 
-struct MissingDocsRule: OptInRule, ConfigurationProviderRule {
+struct MissingDocsRule: OptInRule {
     init() {
         configuration = MissingDocsConfiguration()
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringKeyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringKeyRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct NSLocalizedStringKeyRule: OptInRule, ConfigurationProviderRule {
+struct NSLocalizedStringKeyRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct NSLocalizedStringRequireBundleRule: OptInRule, ConfigurationProviderRule {
+struct NSLocalizedStringRequireBundleRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSNumberInitAsFunctionReferenceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSNumberInitAsFunctionReferenceRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 // this rule exists due to a compiler bug: https://github.com/apple/swift/issues/51036
 @SwiftSyntaxRule
-struct NSNumberInitAsFunctionReferenceRule: ConfigurationProviderRule {
+struct NSNumberInitAsFunctionReferenceRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct NSObjectPreferIsEqualRule: ConfigurationProviderRule {
+struct NSObjectPreferIsEqualRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NotificationCenterDetachmentRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct NotificationCenterDetachmentRule: ConfigurationProviderRule {
+struct NotificationCenterDetachmentRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
@@ -1,6 +1,6 @@
 import SwiftIDEUtils
 
-struct OrphanedDocCommentRule: SourceKitFreeRule, ConfigurationProviderRule {
+struct OrphanedDocCommentRule: SourceKitFreeRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverriddenSuperCallRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct OverriddenSuperCallRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+struct OverriddenSuperCallRule: SwiftSyntaxRule, OptInRule {
     var configuration = OverriddenSuperCallConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct OverrideInExtensionRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+struct OverrideInExtensionRule: OptInRule, SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PeriodSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PeriodSpacingRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftIDEUtils
 
-struct PeriodSpacingRule: SourceKitFreeRule, ConfigurationProviderRule, OptInRule, SubstitutionCorrectableRule {
+struct PeriodSpacingRule: SourceKitFreeRule, OptInRule, SubstitutionCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateActionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct PrivateActionRule: OptInRule, ConfigurationProviderRule {
+struct PrivateActionRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct PrivateOutletRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct PrivateOutletRule: SwiftSyntaxRule, OptInRule {
     var configuration = PrivateOutletConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct PrivateSubjectRule: OptInRule, ConfigurationProviderRule {
+struct PrivateSubjectRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -11,7 +11,7 @@ import SwiftSyntax
 /// Declare state and state objects as private to prevent setting them from a memberwise initializer,
 /// which can conflict with the storage management that SwiftUI provides:
 @SwiftSyntaxRule
-struct PrivateSwiftUIStatePropertyRule: OptInRule, ConfigurationProviderRule {
+struct PrivateSwiftUIStatePropertyRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftSyntax
 
-struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
     var configuration = PrivateUnitTestConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ProhibitedInterfaceBuilderRule: ConfigurationProviderRule, OptInRule {
+struct ProhibitedInterfaceBuilderRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedSuperRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ProhibitedSuperRule: ConfigurationProviderRule, SwiftSyntaxRule, OptInRule {
+struct ProhibitedSuperRule: SwiftSyntaxRule, OptInRule {
     var configuration = ProhibitedSuperConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-struct QuickDiscouragedCallRule: OptInRule, ConfigurationProviderRule {
+struct QuickDiscouragedCallRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct QuickDiscouragedFocusedTestRule: OptInRule, ConfigurationProviderRule {
+struct QuickDiscouragedFocusedTestRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct QuickDiscouragedPendingTestRule: OptInRule, ConfigurationProviderRule {
+struct QuickDiscouragedPendingTestRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct RawValueForCamelCasedCodableEnumRule: OptInRule, ConfigurationProviderRule {
+struct RawValueForCamelCasedCodableEnumRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
@@ -7,7 +7,7 @@ import SwiftSyntax
 /// list of allocations. Even having an empty deinit method is useful to provide
 /// a place to put a breakpoint when chasing down leaks.
 @SwiftSyntaxRule
-struct RequiredDeinitRule: OptInRule, ConfigurationProviderRule {
+struct RequiredDeinitRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
@@ -67,7 +67,7 @@ import SwiftSyntax
 ///     case accountCreated
 /// }
 /// ````
-struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule {
     var configuration = RequiredEnumCaseConfiguration()
 
     private static let exampleConfiguration = [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/SelfInPropertyInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/SelfInPropertyInitializationRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct SelfInPropertyInitializationRule: ConfigurationProviderRule {
+struct SelfInPropertyInitializationRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct StrongIBOutletRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule, OptInRule {
+struct StrongIBOutletRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftSyntax
 
 struct TestCaseAccessibilityRule: SwiftSyntaxRule, OptInRule,
-                                         ConfigurationProviderRule, SubstitutionCorrectableRule {
+                                         SubstitutionCorrectableRule {
     var configuration = TestCaseAccessibilityConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftSyntax
 
-struct TodoRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct TodoRule: SwiftSyntaxRule {
     var configuration = TodoConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct TypesafeArrayInitRule: AnalyzerRule, ConfigurationProviderRule {
+struct TypesafeArrayInitRule: AnalyzerRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct UnhandledThrowingTaskRule: ConfigurationProviderRule, OptInRule {
+struct UnhandledThrowingTaskRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 @SwiftSyntaxRule
-struct UnneededOverrideRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+struct UnneededOverrideRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
@@ -9,7 +9,7 @@ private func warnDeprecatedOnce() {
     _ = warnDeprecatedOnceImpl
 }
 
-struct UnusedCaptureListRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+struct UnusedCaptureListRule: SwiftSyntaxRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 @SwiftSyntaxRule
-struct UnusedClosureParameterRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct UnusedClosureParameterRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct UnusedControlFlowLabelRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct UnusedControlFlowLabelRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct UnusedDeclarationRule: ConfigurationProviderRule, AnalyzerRule, CollectingRule {
+struct UnusedDeclarationRule: AnalyzerRule, CollectingRule {
     struct FileUSRs: Hashable {
         var referenced: Set<String>
         var declared: Set<DeclaredUSR>

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private let moduleToLog = ProcessInfo.processInfo.environment["SWIFTLINT_LOG_MODULE_USAGE"]
 
-struct UnusedImportRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
+struct UnusedImportRule: CorrectableRule, AnalyzerRule {
     var configuration = UnusedImportConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct UnusedSetterValueRule: ConfigurationProviderRule {
+struct UnusedSetterValueRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ValidIBInspectableRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ValidIBInspectableRule: ConfigurationProviderRule {
+struct ValidIBInspectableRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct WeakDelegateRule: OptInRule, ConfigurationProviderRule {
+struct WeakDelegateRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/YodaConditionRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct YodaConditionRule: OptInRule, ConfigurationProviderRule, SwiftSyntaxRule {
+struct YodaConditionRule: OptInRule, SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -1,4 +1,4 @@
-struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule, ConfigurationProviderRule {
+struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 30, error: 100)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/CyclomaticComplexityRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/CyclomaticComplexityRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct CyclomaticComplexityRule: ASTRule, ConfigurationProviderRule {
+struct CyclomaticComplexityRule: ASTRule {
     var configuration = CyclomaticComplexityConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 5, error: 6)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FileLengthRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-struct FileLengthRule: ConfigurationProviderRule {
+struct FileLengthRule: Rule {
     var configuration = FileLengthConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionBodyLengthRule.swift
@@ -1,4 +1,4 @@
-struct FunctionBodyLengthRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct FunctionBodyLengthRule: SwiftSyntaxRule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 50, error: 100)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionParameterCountRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct FunctionParameterCountRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct FunctionParameterCountRule: SwiftSyntaxRule {
     var configuration = FunctionParameterCountConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LargeTupleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LargeTupleRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct LargeTupleRule: SourceKitFreeRule, ConfigurationProviderRule {
+struct LargeTupleRule: SourceKitFreeRule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 2, error: 3)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct LineLengthRule: ConfigurationProviderRule {
+struct LineLengthRule: Rule {
     var configuration = LineLengthConfiguration()
 
     private let commentKinds = SyntaxKind.commentKinds

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-struct NestingRule: ConfigurationProviderRule {
+struct NestingRule: Rule {
     var configuration = NestingConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/TypeBodyLengthRule.swift
@@ -10,7 +10,7 @@ private func wrapExample(
                    repeatElement(template, count: count).joined() + "\(add)}\n", file: file, line: line)
 }
 
-struct TypeBodyLengthRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct TypeBodyLengthRule: SwiftSyntaxRule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 250, error: 350)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ContainsOverFilterCountRule: OptInRule, ConfigurationProviderRule {
+struct ContainsOverFilterCountRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ContainsOverFilterIsEmptyRule: OptInRule, ConfigurationProviderRule {
+struct ContainsOverFilterIsEmptyRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule(foldExpressions: true)
-struct ContainsOverFirstNotNilRule: OptInRule, ConfigurationProviderRule {
+struct ContainsOverFirstNotNilRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule(foldExpressions: true)
-struct ContainsOverRangeNilComparisonRule: OptInRule, ConfigurationProviderRule {
+struct ContainsOverRangeNilComparisonRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCollectionLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCollectionLiteralRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct EmptyCollectionLiteralRule: ConfigurationProviderRule, OptInRule {
+struct EmptyCollectionLiteralRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct EmptyCountRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+struct EmptyCountRule: OptInRule, SwiftSyntaxRule {
     var configuration = EmptyCountConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyStringRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct EmptyStringRule: ConfigurationProviderRule, OptInRule {
+struct EmptyStringRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FirstWhereRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct FirstWhereRule: OptInRule, ConfigurationProviderRule {
+struct FirstWhereRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FlatMapOverMapReduceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FlatMapOverMapReduceRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct FlatMapOverMapReduceRule: OptInRule, ConfigurationProviderRule {
+struct FlatMapOverMapReduceRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/LastWhereRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct LastWhereRule: OptInRule, ConfigurationProviderRule {
+struct LastWhereRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceBooleanRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceBooleanRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ReduceBooleanRule: ConfigurationProviderRule {
+struct ReduceBooleanRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceIntoRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ReduceIntoRule: ConfigurationProviderRule, OptInRule {
+struct ReduceIntoRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct SortedFirstLastRule: OptInRule, ConfigurationProviderRule {
+struct SortedFirstLastRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct AttributesRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct AttributesRule: SwiftSyntaxRule, OptInRule {
     var configuration = AttributesConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ClosingBraceRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct ClosingBraceRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct ClosureEndIndentationRule: Rule, OptInRule, ConfigurationProviderRule {
+struct ClosureEndIndentationRule: Rule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ClosureParameterPositionRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct ClosureParameterPositionRule: SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 // MARK: - ClosureSpacingRule
 
-struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct CollectionAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+struct CollectionAlignmentRule: SwiftSyntaxRule, OptInRule {
     var configuration = CollectionAlignmentConfiguration()
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ColonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ColonRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-struct ColonRule: SubstitutionCorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+struct ColonRule: SubstitutionCorrectableRule, SourceKitFreeRule {
     var configuration = ColonConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CommaInheritanceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CommaInheritanceRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule, ConfigurationProviderRule,
+struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule,
                                     SourceKitFreeRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CommaRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-struct CommaRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+struct CommaRule: CorrectableRule, SourceKitFreeRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ComputedAccessorsOrderRule: ConfigurationProviderRule, SwiftSyntaxRule {
+struct ComputedAccessorsOrderRule: SwiftSyntaxRule {
     var configuration = ComputedAccessorsOrderConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ConditionalReturnsOnNewlineRule: ConfigurationProviderRule, OptInRule, SwiftSyntaxRule {
+struct ConditionalReturnsOnNewlineRule: OptInRule, SwiftSyntaxRule {
     var configuration = ConditionalReturnsOnNewlineConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
@@ -2,7 +2,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ControlStatementRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+struct ControlStatementRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct DirectReturnRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct DirectReturnRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -24,7 +24,7 @@ private func wrapInFunc(_ str: String, file: StaticString = #file, line: UInt = 
 }
 
 @SwiftSyntaxRule
-struct EmptyEnumArgumentsRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct EmptyEnumArgumentsRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct EmptyParametersRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct EmptyParametersRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct EmptyParenthesesWithTrailingClosureRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct EmptyParenthesesWithTrailingClosureRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct ExplicitSelfRule: CorrectableRule, ConfigurationProviderRule, AnalyzerRule {
+struct ExplicitSelfRule: CorrectableRule, AnalyzerRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FileHeaderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct FileHeaderRule: ConfigurationProviderRule, OptInRule {
+struct FileHeaderRule: OptInRule {
     var configuration = FileHeaderConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FileTypesOrderRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private typealias FileTypeOffset = (fileType: FileTypesOrderConfiguration.FileType, offset: ByteCount)
 
-struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
+struct FileTypesOrderRule: OptInRule {
     var configuration = FileTypesOrderConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct IdentifierNameRule: ASTRule, ConfigurationProviderRule {
+struct IdentifierNameRule: ASTRule {
     var configuration = NameConfiguration<Self>(minLengthWarning: 3,
                                                 minLengthError: 2,
                                                 maxLengthWarning: 40,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ImplicitGetterRule: ConfigurationProviderRule, SwiftSyntaxRule {
+struct ImplicitGetterRule: SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct ImplicitReturnRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct ImplicitReturnRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = ImplicitReturnConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/InclusiveLanguageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/InclusiveLanguageRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct InclusiveLanguageRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct InclusiveLanguageRule: SwiftSyntaxRule {
     var configuration = InclusiveLanguageConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct IndentationWidthRule: ConfigurationProviderRule, OptInRule {
+struct IndentationWidthRule: OptInRule {
     // MARK: - Subtypes
     private enum Indentation: Equatable {
         case tabs(Int)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LeadingWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct LeadingWhitespaceRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+struct LeadingWhitespaceRule: CorrectableRule, SourceKitFreeRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct LetVarWhitespaceRule: ConfigurationProviderRule, OptInRule {
+struct LetVarWhitespaceRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct LiteralExpressionEndIndentationRule: Rule, ConfigurationProviderRule, OptInRule {
+struct LiteralExpressionEndIndentationRule: Rule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct ModifierOrderRule: ASTRule, OptInRule, ConfigurationProviderRule, CorrectableRule {
+struct ModifierOrderRule: ASTRule, OptInRule, CorrectableRule {
     var configuration = ModifierOrderConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct MultilineArgumentsBracketsRule: OptInRule, ConfigurationProviderRule {
+struct MultilineArgumentsBracketsRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct MultilineArgumentsRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct MultilineArgumentsRule: SwiftSyntaxRule, OptInRule {
     var configuration = MultilineArgumentsConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineFunctionChainsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct MultilineFunctionChainsRule: ASTRule, OptInRule, ConfigurationProviderRule {
+struct MultilineFunctionChainsRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct MultilineLiteralBracketsRule: ASTRule, OptInRule, ConfigurationProviderRule {
+struct MultilineLiteralBracketsRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersBracketsRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct MultilineParametersBracketsRule: OptInRule, ConfigurationProviderRule {
+struct MultilineParametersBracketsRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct MultilineParametersRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct MultilineParametersRule: SwiftSyntaxRule, OptInRule {
     var configuration = MultilineParametersConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct MultipleClosuresWithTrailingClosureRule: ConfigurationProviderRule {
+struct MultipleClosuresWithTrailingClosureRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct NoSpaceInMethodCallRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct NoSpaceInMethodCallRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct NonOverridableClassDeclarationRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct NonOverridableClassDeclarationRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = NonOverridableClassDeclarationConfiguration()
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftSyntax
 
-struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = NumberSeparatorConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
@@ -61,7 +61,7 @@ private extension SwiftLintFile {
     }
 }
 
-struct OpeningBraceRule: CorrectableRule, ConfigurationProviderRule {
+struct OpeningBraceRule: CorrectableRule {
     var configuration = OpeningBraceConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OperatorFunctionWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct OperatorFunctionWhitespaceRule: ConfigurationProviderRule {
+struct OperatorFunctionWhitespaceRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 import SwiftSyntax
 
-struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, SourceKitFreeRule {
     var configuration = OperatorUsageWhitespaceConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct OptionalEnumCaseMatchingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct OptionalEnumCaseMatchingRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct PreferSelfInStaticReferencesRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct PreferSelfInStaticReferencesRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct PreferSelfTypeOverTypeOfSelfRule: SwiftSyntaxCorrectableRule, OptInRule, ConfigurationProviderRule {
+struct PreferSelfTypeOverTypeOfSelfRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule, ConfigurationProviderRule {
+struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule {
     var configuration = PrefixedTopLevelConstantConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ProtocolPropertyAccessorsOrderRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule {
+struct ProtocolPropertyAccessorsOrderRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct RedundantDiscardableLetRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct RedundantDiscardableLetRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct RedundantSelfInClosureRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct RedundantSelfInClosureRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct ReturnArrowWhitespaceRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct ReturnArrowWhitespaceRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 // MARK: - SelfBindingRule
 
-struct SelfBindingRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule, OptInRule {
+struct SelfBindingRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SelfBindingConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ShorthandOperatorRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule(foldExpressions: true)
-struct ShorthandOperatorRule: ConfigurationProviderRule {
+struct ShorthandOperatorRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SingleTestClassRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct SingleTestClassRule: SourceKitFreeRule, OptInRule, ConfigurationProviderRule {
+struct SingleTestClassRule: SourceKitFreeRule, OptInRule {
     var configuration = SingleTestClassConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct SortedEnumCasesRule: ConfigurationProviderRule, OptInRule {
+struct SortedEnumCasesRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
@@ -52,7 +52,7 @@ private extension Sequence where Element == Line {
     }
 }
 
-struct SortedImportsRule: CorrectableRule, ConfigurationProviderRule, OptInRule {
+struct SortedImportsRule: CorrectableRule, OptInRule {
     var configuration = SortedImportsConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/StatementPositionRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct StatementPositionRule: CorrectableRule, ConfigurationProviderRule {
+struct StatementPositionRule: CorrectableRule {
     var configuration = StatementPositionConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct SuperfluousElseRule: ConfigurationProviderRule, OptInRule {
+struct SuperfluousElseRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct SwitchCaseAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct SwitchCaseAlignmentRule: SwiftSyntaxRule {
     var configuration = SwitchCaseAlignmentConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -8,7 +8,7 @@ private func wrapInSwitch(_ str: String, file: StaticString = #file, line: UInt 
     """, file: file, line: line)
 }
 
-struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, ConfigurationProviderRule, OptInRule {
+struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct TrailingClosureRule: OptInRule, ConfigurationProviderRule {
+struct TrailingClosureRule: OptInRule {
     var configuration = TrailingClosureConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct TrailingCommaRule: SwiftSyntaxCorrectableRule, ConfigurationProviderRule {
+struct TrailingCommaRule: SwiftSyntaxCorrectableRule {
     var configuration = TrailingCommaConfiguration()
 
     private static let triggeringExamples: [Example] = [

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingNewlineRule.swift
@@ -18,7 +18,7 @@ extension String {
     }
 }
 
-struct TrailingNewlineRule: CorrectableRule, ConfigurationProviderRule, SourceKitFreeRule {
+struct TrailingNewlineRule: CorrectableRule, SourceKitFreeRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct TrailingWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
+struct TrailingWhitespaceRule: CorrectableRule {
     var configuration = TrailingWhitespaceConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-struct TypeContentsOrderRule: ConfigurationProviderRule, OptInRule {
+struct TypeContentsOrderRule: OptInRule {
     private typealias TypeContentOffset = (typeContent: TypeContent, offset: ByteCount)
 
     var configuration = TypeContentsOrderConfiguration()

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 @SwiftSyntaxRule
-struct UnneededParenthesesInClosureArgumentRule: ConfigurationProviderRule, SwiftSyntaxCorrectableRule, OptInRule {
+struct UnneededParenthesesInClosureArgumentRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnusedOptionalBindingRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct UnusedOptionalBindingRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct UnusedOptionalBindingRule: SwiftSyntaxRule {
     var configuration = UnusedOptionalBindingConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -1,6 +1,6 @@
 import SourceKittenFramework
 
-struct VerticalParameterAlignmentOnCallRule: ASTRule, ConfigurationProviderRule, OptInRule {
+struct VerticalParameterAlignmentOnCallRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-struct VerticalParameterAlignmentRule: SwiftSyntaxRule, ConfigurationProviderRule {
+struct VerticalParameterAlignmentRule: SwiftSyntaxRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -7,7 +7,7 @@ private extension SwiftLintFile {
     }
 }
 
-struct VerticalWhitespaceBetweenCasesRule: ConfigurationProviderRule {
+struct VerticalWhitespaceBetweenCasesRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     private static let nonTriggeringExamples: [Example] = [

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct VerticalWhitespaceClosingBracesRule: CorrectableRule, OptInRule, ConfigurationProviderRule {
+struct VerticalWhitespaceClosingBracesRule: CorrectableRule, OptInRule {
     var configuration = VerticalWhitespaceClosingBracesConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -7,7 +7,7 @@ private extension SwiftLintFile {
     }
 }
 
-struct VerticalWhitespaceOpeningBracesRule: ConfigurationProviderRule {
+struct VerticalWhitespaceOpeningBracesRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     private static let nonTriggeringExamples = [

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private let defaultDescriptionReason = "Limit vertical whitespace to a single empty line"
 
-struct VerticalWhitespaceRule: CorrectableRule, ConfigurationProviderRule {
+struct VerticalWhitespaceRule: CorrectableRule {
     var configuration = VerticalWhitespaceConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VoidReturnRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct VoidReturnRule: ConfigurationProviderRule, SubstitutionCorrectableRule {
+struct VoidReturnRule: SubstitutionCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
@@ -28,8 +28,7 @@ public protocol SwiftSyntaxRule: SourceKitFreeRule {
     func preprocess(file: SwiftLintFile) -> SourceFileSyntax?
 }
 
-public extension SwiftSyntaxRule where Self: ConfigurationProviderRule,
-                                       ConfigurationType: SeverityBasedRuleConfiguration {
+public extension SwiftSyntaxRule where ConfigurationType: SeverityBasedRuleConfiguration {
     func makeViolation(file: SwiftLintFile, violation: ReasonedRuleViolation) -> StyleViolation {
         StyleViolation(
             ruleDescription: Self.description,

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -36,7 +36,7 @@ struct CustomRulesConfiguration: RuleConfiguration, CacheDescriptionProvider {
 
 // MARK: - CustomRules
 
-struct CustomRules: Rule, ConfigurationProviderRule, CacheDescriptionProvider {
+struct CustomRules: Rule, CacheDescriptionProvider {
     var cacheDescription: String {
         return configuration.cacheDescription
     }

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -1,5 +1,5 @@
 @_spi(TestHelper)
-public struct SuperfluousDisableCommandRule: ConfigurationProviderRule, SourceKitFreeRule {
+public struct SuperfluousDisableCommandRule: SourceKitFreeRule {
     public var configuration = SeverityConfiguration<Self>(.warning)
 
     public init() {}

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -132,6 +132,7 @@ final class RulesFilterTests: XCTestCase {
 // MARK: - Mocks
 
 private struct RuleMock1: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
     var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock1", name: "",
@@ -146,6 +147,7 @@ private struct RuleMock1: Rule {
 }
 
 private struct RuleMock2: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
     var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock2", name: "",
@@ -160,6 +162,7 @@ private struct RuleMock2: Rule {
 }
 
 private struct CorrectableRuleMock: CorrectableRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
     var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "CorrectableRuleMock", name: "",

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -7,6 +7,8 @@ import XCTest
 class CollectingRuleTests: SwiftLintTestCase {
     func testCollectsIntoStorage() {
         struct Spec: MockCollectingRule {
+            var configuration = SeverityConfiguration<Self>(.warning)
+
             func collectInfo(for file: SwiftLintFile) -> Int {
                 return 42
             }
@@ -22,6 +24,8 @@ class CollectingRuleTests: SwiftLintTestCase {
 
     func testCollectsAllFiles() {
         struct Spec: MockCollectingRule {
+            var configuration = SeverityConfiguration<Self>(.warning)
+
             func collectInfo(for file: SwiftLintFile) -> String {
                 return file.contents
             }
@@ -41,6 +45,8 @@ class CollectingRuleTests: SwiftLintTestCase {
 
     func testCollectsAnalyzerFiles() {
         struct Spec: MockCollectingRule, AnalyzerRule {
+            var configuration = SeverityConfiguration<Self>(.warning)
+
             func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> [String] {
                 return compilerArguments
             }
@@ -57,6 +63,8 @@ class CollectingRuleTests: SwiftLintTestCase {
 
     func testCorrects() {
         struct Spec: MockCollectingRule, CollectingCorrectableRule {
+            var configuration = SeverityConfiguration<Self>(.warning)
+
             func collectInfo(for file: SwiftLintFile) -> String {
                 return file.contents
             }
@@ -81,6 +89,8 @@ class CollectingRuleTests: SwiftLintTestCase {
         }
 
         struct AnalyzerSpec: MockCollectingRule, AnalyzerRule, CollectingCorrectableRule {
+            var configuration = SeverityConfiguration<Self>(.warning)
+
             func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> String {
                 return file.contents
             }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+Mock.swift
@@ -84,6 +84,7 @@ internal extension ConfigurationTests {
 }
 
 struct RuleMock: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
     var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
 
     static let description = RuleDescription(identifier: "RuleMock", name: "",

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -1,7 +1,7 @@
 import SwiftLintCore
 import XCTest
 
-struct RuleWithLevelsMock: ConfigurationProviderRule {
+struct RuleWithLevelsMock: Rule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 2, error: 3)
 
     static let description = RuleDescription(identifier: "severity_level_mock",
@@ -21,6 +21,7 @@ struct RuleWithLevelsMock: ConfigurationProviderRule {
 
 class RuleTests: SwiftLintTestCase {
     fileprivate struct RuleMock1: Rule {
+        var configuration = SeverityConfiguration<Self>(.warning)
         var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
         static let description = RuleDescription(identifier: "RuleMock1", name: "",
                                                  description: "", kind: .style)
@@ -34,6 +35,7 @@ class RuleTests: SwiftLintTestCase {
     }
 
     fileprivate struct RuleMock2: Rule {
+        var configuration = SeverityConfiguration<Self>(.warning)
         var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
         static let description = RuleDescription(identifier: "RuleMock2", name: "",
                                                  description: "", kind: .style)
@@ -46,7 +48,7 @@ class RuleTests: SwiftLintTestCase {
         }
     }
 
-    fileprivate struct RuleWithLevelsMock2: ConfigurationProviderRule {
+    fileprivate struct RuleWithLevelsMock2: Rule {
         var configuration = SeverityLevelsConfiguration<Self>(warning: 2, error: 3)
 
         static let description = RuleDescription(identifier: "violation_level_mock2",


### PR DESCRIPTION
`ConfigurationProviderRule` does not serve a purpose anymore as all rules are configurable (if only with a severity).

This is one more step to let `@SwiftSyntaxRule` generate even more boilerplate code by relying on the existence of a `configuration` variable that can be passed to a rule's `Visitor` and `Rewriter` automatically.